### PR TITLE
Don't require casing to match in the HTTP upgrade header.

### DIFF
--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -125,7 +125,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
                 continue
             }
 
-            let requiredHeaders = Set(upgrader.requiredUpgradeHeaders)
+            let requiredHeaders = Set(upgrader.requiredUpgradeHeaders.map { $0.lowercased() })
             guard requiredHeaders.isSubset(of: allHeaderNames) && requiredHeaders.isSubset(of: connectionHeader) else {
                 continue
             }

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
@@ -36,6 +36,7 @@ extension HTTPUpgradeTestCase {
                 ("testUpgradeRespectsClientPreference", testUpgradeRespectsClientPreference),
                 ("testUpgradeFiresUserEvent", testUpgradeFiresUserEvent),
                 ("testUpgraderCanRejectUpgradeForPersonalReasons", testUpgraderCanRejectUpgradeForPersonalReasons),
+                ("testUpgradeIsCaseInsensitive", testUpgradeIsCaseInsensitive),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

The HTTP upgrade handler should not require that we case-match with
the mandatory headers.

Modifications:

Treat all headers as lowercase.

Result:

Upgrade is easier.