### PR TITLE
Improve Linux test gen script to match current format.

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// LinuxMain.swift
-///
+//
+// LinuxMain.swift
+//
 import XCTest
 
 ///
@@ -59,13 +59,13 @@ import XCTest
          testCase(IdleStateHandlerTest.allTests),
          testCase(MarkedCircularBufferTests.allTests),
          testCase(MessageToByteEncoderTest.allTests),
+         testCase(NIOConcurrencyHelpersTests.allTests),
          testCase(NonBlockingFileIOTest.allTests),
          testCase(PendingDatagramWritesManagerTests.allTests),
          testCase(PriorityQueueTest.allTests),
          testCase(SniHandlerTest.allTests),
          testCase(SocketAddressTest.allTests),
          testCase(SocketChannelTest.allTests),
-         testCase(NIOConcurrencyHelpersTests.allTests),
          testCase(SystemTest.allTests),
          testCase(ThreadTest.allTests),
          testCase(TypeAssistedChannelHandlerTest.allTests),

--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests+XCTest.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// NIOConcurrencyHelpersTests+XCTest.swift
-///
+//
+// NIOConcurrencyHelpersTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// HTTPHeadersTest+XCTest.swift
-///
+//
+// HTTPHeadersTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// HTTPRequestEncoderTest+XCTest.swift
-///
+//
+// HTTPRequestEncoderTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// HTTPResponseCompressorTest+XCTest.swift
-///
+//
+// HTTPResponseCompressorTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// HTTPResponseEncoderTest+XCTest.swift
-///
+//
+// HTTPResponseEncoderTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// HTTPServerClientTest+XCTest.swift
-///
+//
+// HTTPServerClientTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOHTTP1Tests/HTTPTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// HTTPTest+XCTest.swift
-///
+//
+// HTTPTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// HTTPUpgradeTests+XCTest.swift
-///
+//
+// HTTPUpgradeTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOPriorityQueueTests/HeapTests+XCTest.swift
+++ b/Tests/NIOPriorityQueueTests/HeapTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// HeapTests+XCTest.swift
-///
+//
+// HeapTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOPriorityQueueTests/PriorityQueueTests+XCTest.swift
+++ b/Tests/NIOPriorityQueueTests/PriorityQueueTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// PriorityQueueTests+XCTest.swift
-///
+//
+// PriorityQueueTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests+XCTest.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// ApplicationProtocolNegotiationHandlerTests+XCTest.swift
-///
+//
+// ApplicationProtocolNegotiationHandlerTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTLSTests/SNIHandlerTests+XCTest.swift
+++ b/Tests/NIOTLSTests/SNIHandlerTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// SniHandlerTests+XCTest.swift
-///
+//
+// SNIHandlerTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/BaseObjectsTest+XCTest.swift
+++ b/Tests/NIOTests/BaseObjectsTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// BaseObjectsTest+XCTest.swift
-///
+//
+// BaseObjectsTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/BlockingIOThreadPoolTest+XCTest.swift
+++ b/Tests/NIOTests/BlockingIOThreadPoolTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// BlockingIOThreadPoolTest+XCTest.swift
-///
+//
+// BlockingIOThreadPoolTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// ByteBufferTest+XCTest.swift
-///
+//
+// ByteBufferTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// ChannelPipelineTest+XCTest.swift
-///
+//
+// ChannelPipelineTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// ChannelTests+XCTest.swift
-///
+//
+// ChannelTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/CircularBufferTests+XCTest.swift
+++ b/Tests/NIOTests/CircularBufferTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// CircularBufferTests+XCTest.swift
-///
+//
+// CircularBufferTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// CodecTest+XCTest.swift
-///
+//
+// CodecTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/CompositeErrorTests+XCTest.swift
+++ b/Tests/NIOTests/CompositeErrorTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// CompositeErrorTests+XCTest.swift
-///
+//
+// CompositeErrorTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOTests/DatagramChannelTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// DatagramChannelTests+XCTest.swift
-///
+//
+// DatagramChannelTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/EchoServerClientTest+XCTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// EchoServerClientTest+XCTest.swift
-///
+//
+// EchoServerClientTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// EmbeddedChannelTest+XCTest.swift
-///
+//
+// EmbeddedChannelTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// EmbeddedEventLoopTest+XCTest.swift
-///
+//
+// EmbeddedEventLoopTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// EventLoopFutureTest+XCTest.swift
-///
+//
+// EventLoopFutureTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// EventLoopTest+XCTest.swift
-///
+//
+// EventLoopTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/FileRegionTest+XCTest.swift
+++ b/Tests/NIOTests/FileRegionTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// FileRegionTest+XCTest.swift
-///
+//
+// FileRegionTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/HappyEyeballsTest+XCTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// HappyEyeballsTest+XCTest.swift
-///
+//
+// HappyEyeballsTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/IdleStateHandlerTest+XCTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// IdleStateHandlerTest+XCTest.swift
-///
+//
+// IdleStateHandlerTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/MarkedCircularBufferTests+XCTest.swift
+++ b/Tests/NIOTests/MarkedCircularBufferTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// MarkedCircularBufferTests+XCTest.swift
-///
+//
+// MarkedCircularBufferTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// NonBlockingFileIOTest+XCTest.swift
-///
+//
+// NonBlockingFileIOTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests+XCTest.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// PendingDatagramWritesManagerTests+XCTest.swift
-///
+//
+// PendingDatagramWritesManagerTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/RecvByteBufAllocatorTest+XCTest.swift
+++ b/Tests/NIOTests/RecvByteBufAllocatorTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// RecvByteBufAllocatorTest+XCTest.swift
-///
+//
+// RecvByteBufAllocatorTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/SocketAddressTest+XCTest.swift
+++ b/Tests/NIOTests/SocketAddressTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// SocketAddressTest+XCTest.swift
-///
+//
+// SocketAddressTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// SocketChannelTest+XCTest.swift
-///
+//
+// SocketChannelTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/SystemTest+XCTest.swift
+++ b/Tests/NIOTests/SystemTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// SystemTest+XCTest.swift
-///
+//
+// SystemTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/ThreadTest+XCTest.swift
+++ b/Tests/NIOTests/ThreadTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// ThreadTest+XCTest.swift
-///
+//
+// ThreadTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/TypeAssistedChannelHandlerTests+XCTest.swift
+++ b/Tests/NIOTests/TypeAssistedChannelHandlerTests+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// TypeAssistedChannelHandlerTests+XCTest.swift
-///
+//
+// TypeAssistedChannelHandlerTests+XCTest.swift
+//
 import XCTest
 
 ///

--- a/Tests/NIOTests/UtilitiesTest+XCTest.swift
+++ b/Tests/NIOTests/UtilitiesTest+XCTest.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-///
-/// UtilitiesTest+XCTest.swift
-///
+//
+// UtilitiesTest+XCTest.swift
+//
 import XCTest
 
 ///

--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -32,9 +32,22 @@ include FileUtils
 #
 def header(fileName)
     string = <<-eos
-///
-/// <FileName>
-///
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//
+// <FileName>
+//
 import XCTest
 
 ///


### PR DESCRIPTION
Motivation:

Right now the test gen script will rewrite every file. Not ideal!

Modifications:

Added the license header, and made the follow-on comment match that
style.

Result:

Test files will look the same when running this script as they do
now.