### PR TITLE
fix integration tests on Darwin

### DIFF
--- a/IntegrationTests/tests_02_syscall_wrappers/defines.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/defines.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eu
+
+function make_package() {
+    cat > "$tmpdir/syscallwrapper/Package.swift" <<"EOF"
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "syscallwrapper",
+    dependencies: [],
+    targets: [
+        .target(
+            name: "syscallwrapper",
+            dependencies: ["CNIOLinux", "CNIODarwin"]),
+        .target(
+            name: "CNIOLinux",
+            dependencies: []),
+        .target(
+            name: "CNIODarwin",
+            dependencies: []),
+    ]
+)
+EOF
+    cp "$here/../../Tests/NIOTests/SystemCallWrapperHelpers.swift" \
+        "$here/../../Sources/NIO/System.swift" \
+        "$here/../../Sources/NIO/IO.swift" \
+        "$tmpdir/syscallwrapper/Sources/syscallwrapper"
+    ln -s "$here/../../Sources/CNIOLinux" "$tmpdir/syscallwrapper/Sources"
+    ln -s "$here/../../Sources/CNIODarwin" "$tmpdir/syscallwrapper/Sources"
+}

--- a/IntegrationTests/tests_02_syscall_wrappers/test_01_syscall_wrapper_fast.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_01_syscall_wrapper_fast.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+source defines.sh
+
 swift_binary=swift
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -25,31 +27,8 @@ public typealias IOVector = iovec
 runStandalone()
 EOF
 
-cat > "$tmpdir/syscallwrapper/Package.swift" <<"EOF"
-// swift-tools-version:4.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+make_package
 
-import PackageDescription
-
-let package = Package(
-    name: "syscallwrapper",
-    dependencies: [],
-    targets: [
-        .target(
-            name: "syscallwrapper",
-            dependencies: ["CNIOLinux"]),
-        .target(
-            name: "CNIOLinux",
-            dependencies: []),
-    ]
-)
-EOF
-
-cp "$here/../../Tests/NIOTests/SystemCallWrapperHelpers.swift" \
-    "$here/../../Sources/NIO/System.swift" \
-    "$here/../../Sources/NIO/IO.swift" \
-    "$tmpdir/syscallwrapper/Sources/syscallwrapper"
-ln -s "$here/../../Sources/CNIOLinux" "$tmpdir/syscallwrapper/Sources"
 "$swift_binary" run -c release -Xswiftc -DRUNNING_INTEGRATION_TESTS
 
 rm -rf "$tmpdir"

--- a/IntegrationTests/tests_02_syscall_wrappers/test_02_blacklisted_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_02_blacklisted_errnos.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+source defines.sh
+
 swift_binary=swift
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -43,31 +45,8 @@ _ = try? withUnsafePointer(to: &whatevs) { ptr in
 exit(42)
 EOF
 
-cat > "$tmpdir/syscallwrapper/Package.swift" <<"EOF"
-// swift-tools-version:4.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+make_package
 
-import PackageDescription
-
-let package = Package(
-    name: "syscallwrapper",
-    dependencies: [],
-    targets: [
-        .target(
-            name: "syscallwrapper",
-            dependencies: ["CNIOLinux"]),
-        .target(
-            name: "CNIOLinux",
-            dependencies: []),
-    ]
-)
-EOF
-
-cp "$here/../../Tests/NIOTests/SystemCallWrapperHelpers.swift" \
-    "$here/../../Sources/NIO/System.swift" \
-    "$here/../../Sources/NIO/IO.swift" \
-    "$tmpdir/syscallwrapper/Sources/syscallwrapper"
-ln -s "$here/../../Sources/CNIOLinux" "$tmpdir/syscallwrapper/Sources"
 for mode in debug release; do
     for error in EFAULT EBADF; do
         temp_file="$tmp/stderr"


### PR DESCRIPTION
Motivation:

The integration tests didn't work on Darwin anymore as the `CNIODarwin`
module wasn't included in their build.

Modifications:

Included the `CNIODarwin` module, just like `CNIOLinux`.

Result:

integration tests run on Darwin