### PR TITLE
update getting started guide to use git ssh address

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SwiftNIO aims to support all of the platforms where Swift is supported. Currentl
 
 * Ubuntu 14.04+
 * macOS 10.12+
-    
+
 ### Basic Architecture
 
 The basic building blocks of SwiftNIO are the following 6 types of objects:
@@ -131,7 +131,7 @@ The following projects contain useful protocol implementations that do not live 
 SwiftNIO primarily uses [SwiftPM](https://swift.org/package-manager/) as its build tool, so we recommend using that as well. If you want to depend on SwiftNIO in your own project, it's as simple as adding a `dependencies` clause to your `Package.swift`:
 
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "1.0.0")
+        .package(url: "git@github.com:apple/swift-nio.git", from: "1.0.0")
     ]
 
 and then adding the appropriate SwiftNIO module(s) to your target dependencies.
@@ -172,5 +172,3 @@ To do that, first `cd docker` and then run the following commands:
 ## Developing SwiftNIO
 
 For the most part, SwiftNIO development is as straightforward as any other SwiftPM project. With that said, we do have a few processes that are worth understanding before you contribute. For details, please see `CONTRIBUTING.md` in this repository.
-
-


### PR DESCRIPTION
Motivation:

consistency with other examples

Modifications:

use git ssh address in Package.swift example

Result:

more consistent with other getting started guides