### PR TITLE
HTTPUpgradeHandler should accept Futures for upgraders.

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
@@ -37,6 +37,8 @@ extension HTTPUpgradeTestCase {
                 ("testUpgradeFiresUserEvent", testUpgradeFiresUserEvent),
                 ("testUpgraderCanRejectUpgradeForPersonalReasons", testUpgraderCanRejectUpgradeForPersonalReasons),
                 ("testUpgradeIsCaseInsensitive", testUpgradeIsCaseInsensitive),
+                ("testDelayedUpgradeBehaviour", testDelayedUpgradeBehaviour),
+                ("testBuffersInboundDataDuringDelayedUpgrade", testBuffersInboundDataDuringDelayedUpgrade),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Currently the HTTPUpgradeHandler does not allow for the protocol
upgraders to return EventLoopFuture objects. This leads to an
awkward scenario: it's essentially required that an upgrader be able
to synchronously change the pipeline to its satisfaction and prepare for
more bytes.

This is not really possible: ChannelPipeline.add(handler:) returns a
Future, which means that it is possible for this operation, at least
in principle, to not execute synchronously. This reality puts the
HTTPUpgradeHandler at odds with the reality of channel pipelines, and
cannot stand.

Modifications:

Give the HTTPProtocolUpgrader protocol to have upgrade() return an
EventLoopFuture<Void>, and update the HTTPServerUpgradeHandler to
appropriately handle the returned future by buffering until the future
completes.

Result:

It is no longer necessary to synchronously change the channel
pipeline during protocol upgrade.