### PR TITLE
Correctly update remote peer address on delayed connect.

### DIFF
--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -549,6 +549,9 @@ class BaseSocketChannel<T : BaseSocket> : SelectableChannel, ChannelCore {
 
         if let connectPromise = pendingConnect {
             pendingConnect = nil
+
+            // We already know what the local address is.
+            self.updateCachedAddressesFromSocket(updateLocal: false, updateRemote: true)
             executeAndComplete(connectPromise) {
                 try finishConnectSocket()
             }
@@ -632,7 +635,8 @@ class BaseSocketChannel<T : BaseSocket> : SelectableChannel, ChannelCore {
         }
         do {
             if try !connectSocket(to: address) {
-                self.updateCachedAddressesFromSocket()
+                // We aren't connected, we'll get the remote address later.
+                self.updateCachedAddressesFromSocket(updateLocal: true, updateRemote: false)
                 if promise != nil {
                     pendingConnect = promise
                 } else {

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -27,6 +27,7 @@ extension SocketChannelTest {
    static var allTests : [(String, (SocketChannelTest) -> () throws -> Void)] {
       return [
                 ("testAsyncSetOption", testAsyncSetOption),
+                ("testDelayedConnectSetsUpRemotePeerAddress", testDelayedConnectSetsUpRemotePeerAddress),
            ]
    }
 }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -16,6 +16,17 @@ import NIO
 import Dispatch
 import NIOConcurrencyHelpers
 
+private extension Array {
+    /// A helper function that asserts that a predicate is true for all elements.
+    func assertAll(_ predicate: (Element) -> Bool) {
+        self.enumerated().forEach { (index: Int, element: Element) in
+            if !predicate(element) {
+                XCTFail("Entry \(index) failed predicate, contents: \(element)")
+            }
+        }
+    }
+}
+
 public class SocketChannelTest : XCTestCase {
     /// Validate that channel options are applied asynchronously.
     public func testAsyncSetOption() throws {
@@ -49,5 +60,37 @@ public class SocketChannelTest : XCTestCase {
         }
         try futureA.wait()
         try futureB.wait()
+    }
+
+    public func testDelayedConnectSetsUpRemotePeerAddress() throws {
+        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
+
+        let serverChannel = try ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+            .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .bind(host: "127.0.0.1", port: 0).wait()
+
+        // The goal of this test is to try to trigger at least one channel to have connection setup that is not
+        // instantaneous. Due to the design of NIO this is not really observable to us, and due to the complex
+        // overlapping interactions between SYN queues and loopback interfaces in modern kernels it's not
+        // trivial to trigger this behaviour. The easiest thing we can do here is to try to slow the kernel down
+        // enough that a connection eventually is delayed. To do this we're going to submit 50 connections more
+        // or less at once.
+        var clientConnectionFutures: [EventLoopFuture<Channel>] = []
+        clientConnectionFutures.reserveCapacity(50)
+        let clientBootstrap = ClientBootstrap(group: group)
+
+        for _ in 0..<50 {
+            let conn = clientBootstrap.connect(to: serverChannel.localAddress!)
+            clientConnectionFutures.append(conn)
+        }
+
+        let remoteAddresses = try clientConnectionFutures.map { try $0.wait() }.map { $0.remoteAddress }
+
+        // Now we want to check that they're all the same. The bug we're catching here is one where delayed connection
+        // setup causes us to get nil as the remote address, even though we connected (and we did, as these are all
+        // up right now).
+        remoteAddresses.assertAll { $0 != nil }
     }
 }


### PR DESCRIPTION
Motivation:

When the connect() call does not complete synchronously we were not
updating the peer IP address when it finally did complete. This meant
that any channel that didn't connect synchronously (in the real world,
almost all of them) would not correctly see the remote peer IP.

Modifications:

Update the cached addresses on delayed connect.

Result:

Connected channels will see the correct remote IP.