### PR TITLE
Remove Channel.open and rename Selectable.open to isOpen

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -182,10 +182,10 @@ extension sockaddr_storage {
 class BaseSocket: Selectable {
 
     private let descriptor: Int32
-    public private(set) var open: Bool
+    public private(set) var isOpen: Bool
     
     func withUnsafeFileDescriptor<T>(_ body: (Int32) throws -> T) throws -> T {
-        guard self.open else {
+        guard self.isOpen else {
             throw IOError(errnoCode: EBADF, reason: "file descriptor already closed!")
         }
         return try body(descriptor)
@@ -261,11 +261,11 @@ class BaseSocket: Selectable {
     ///     - descriptor: The file descriptor to wrap.
     init(descriptor: Int32) {
         self.descriptor = descriptor
-        self.open = true
+        self.isOpen = true
     }
 
     deinit {
-        assert(!self.open, "leak of open BaseSocket")
+        assert(!self.isOpen, "leak of open BaseSocket")
     }
     
     /// Set the socket as non-blocking.
@@ -358,7 +358,7 @@ class BaseSocket: Selectable {
             try Posix.close(descriptor: fd)
         }
 
-        self.open = false
+        self.isOpen = false
     }
 }
 

--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -164,18 +164,13 @@ internal protocol SelectableChannel: Channel {
     func registrationFor(interested: IOEvent) -> NIORegistration
 }
 
+/// Default implementations which will start on the head of the `ChannelPipeline`.
 extension Channel {
-    public var open: Bool {
-        return !closeFuture.fulfilled
-    }
-
+    
     public func bind(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         pipeline.bind(to: address, promise: promise)
     }
-
-    // Methods invoked from the HeadHandler of the ChannelPipeline
-    // By default, just pass through to pipeline
-
+    
     public func connect(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         pipeline.connect(to: address, promise: promise)
     }

--- a/Sources/NIO/Selectable.swift
+++ b/Sources/NIO/Selectable.swift
@@ -26,7 +26,7 @@ protocol Selectable {
     func withUnsafeFileDescriptor<T>(_ body: (Int32) throws -> T) throws -> T
 
     /// `true` if this `Selectable` is open (which means it was not closed yet).
-    var open: Bool { get }
+    var isOpen: Bool { get }
 
     /// Close this `Selectable` (and so its file descriptor).
     func close() throws

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -293,7 +293,6 @@ final class Selector<R: Registration> {
         guard self.lifecycleState == .open else {
             throw IOError(errnoCode: EBADF, reason: "can't re-register on selector as it's \(self.lifecycleState).")
         }
-        
         try selectable.withUnsafeFileDescriptor { fd in
             var reg = registrations[Int(fd)]!
             
@@ -321,7 +320,6 @@ final class Selector<R: Registration> {
         guard self.lifecycleState == .open else {
             throw IOError(errnoCode: EBADF, reason: "can't deregister from selector as it's \(self.lifecycleState).")
         }
-        
         try selectable.withUnsafeFileDescriptor { fd in
             guard let reg = registrations.removeValue(forKey: Int(fd)) else {
                 return

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -214,7 +214,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
 
     public final func localAddress0() throws -> SocketAddress {
         assert(self.eventLoop.inEventLoop)
-        guard self.open else {
+        guard self.isOpen else {
             throw ChannelError.ioOnClosedChannel
         }
         return try self.socket.localAddress()
@@ -222,7 +222,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
 
     public final func remoteAddress0() throws -> SocketAddress {
         assert(self.eventLoop.inEventLoop)
-        guard self.open else {
+        guard self.isOpen else {
             throw ChannelError.ioOnClosedChannel
         }
         return try self.socket.remoteAddress()


### PR DESCRIPTION
   Motivation:

    Channel.open was not really needed as for our use-case Selectable already provides everything we need. Also how we used Channel.open in some scenarios was not really correct.

    Modifications:

    - Remove extension method.
    - Rename property
    - Remove out-dated comment.
    - Fix usage of open

    Result:

    More clear and correct API