### PR TITLE
Add missing doc for the ChannelOutboundInvoker extension.

### DIFF
--- a/Sources/NIO/ChannelInvoker.swift
+++ b/Sources/NIO/ChannelInvoker.swift
@@ -132,6 +132,10 @@ public protocol ChannelOutboundInvoker {
     var eventLoop: EventLoop { get }
 }
 
+/// Default implementations for `ChannelOutboundInvoker` methods. Each method that returns a `EventLoopFuture` will just do the following:
+///     - create a new `EventLoopPromise<Void>`
+///     - call the corresponding method that takes a `EventLoopPromise<Void>`
+///     - return `EventLoopPromise.futureResult`
 extension ChannelOutboundInvoker {
     public func register() -> EventLoopFuture<Void> {
         let promise = newPromise()


### PR DESCRIPTION
Motivation:

ChannelOutboundInvoker exntesion has no docs.

Modifications:

Add docs.

Result:

More docs FTW.