### PR TITLE
Make WriteBufferWaterMark be a struct and validate low and high water…

### DIFF
--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -139,7 +139,7 @@ final class DatagramChannelTests: XCTestCase {
     }
 
     func testDatagramChannelHasWatermark() throws {
-        _ = try self.firstChannel.setOption(option: ChannelOptions.writeBufferWaterMark, value: 1..<1024).wait()
+        _ = try self.firstChannel.setOption(option: ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 1, high: 1024)).wait()
 
         var buffer = self.firstChannel.allocator.buffer(capacity: 256)
         buffer.write(bytes: [UInt8](repeating: 5, count: 256))


### PR DESCRIPTION
…marks.

Motivation:

We used Range for WriteBufferWaterMark which did not do any validation of the low and high marks.

Modifications:

Make WriteBufferWaterMark a struct and validate low and high values

Result:

More correct impl for watermarks.