### PR TITLE
Fix docker-compose docs for running the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Alternatively, you may want to develop or test with `docker-compose`.
 
 To do that, first `cd docker` and then run the following commands:
 
-- `docker-compose test`
+- `docker-compose up test`
 
   Will create a base image with Swift 4.0 (if missing), compile SwiftNIO and run the tests
 


### PR DESCRIPTION
Motivation:

We missed the "up" argument in our docs.

Modifications:

Fix doc about running tests via docker-compose.

Result:

More correct docs.