### PR TITLE
Mount ~/.ssh into docker image

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
             args:
                 version: 4.0
         volumes:
+            - ~/.ssh:/root/.ssh
             - ..:/code
         working_dir: /code
 
@@ -17,6 +18,7 @@ services:
         image: swift-nio:latest
         command: swift test
         volumes:
+            - ~/.ssh:/root/.ssh
             - ..:/code
         working_dir: /code
 
@@ -28,6 +30,7 @@ services:
             - "9999:9999"
         command: swift run NIOEchoServer 0.0.0.0 9999
         volumes:
+            - ~/.ssh:/root/.ssh
             - ..:/code
         working_dir: /code
 
@@ -39,5 +42,6 @@ services:
             - "8888:8888"
         command: swift run NIOHTTP1Server 0.0.0.0 8888
         volumes:
+            - ~/.ssh:/root/.ssh
             - ..:/code
         working_dir: /code


### PR DESCRIPTION
Motivation:

We need to mount the ~/.ssh directory into the docker image as we use git@ to checkout our dependencies.

Modifications:

Use ~/.ssh as volume as well.

Result:

Be able to use docker images again.