### PR TITLE
Remove management of flush promises from PDWM.

### DIFF
--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -1237,7 +1237,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     override fileprivate func markFlushPoint(promise: EventLoopPromise<Void>?) {
         // Even if writable() will be called later by the EventLoop we still need to mark the flush checkpoint so we are sure all the flushed messages
         // are actually written once writable() is called.
-        self.pendingWrites.markFlushCheckpoint(promise: promise)
+        self.pendingWrites.markFlushCheckpoint()
     }
 
     /// Called when closing, to instruct the specific implementation to discard all pending

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests+XCTest.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests+XCTest.swift
@@ -33,7 +33,6 @@ extension PendingDatagramWritesManagerTests {
                 ("testPendingWritesCancellationWorksCorrectly", testPendingWritesCancellationWorksCorrectly),
                 ("testPendingWritesNoMoreThanWritevLimitIsWritten", testPendingWritesNoMoreThanWritevLimitIsWritten),
                 ("testPendingWritesNoMoreThanWritevLimitIsWrittenInOneMassiveChunk", testPendingWritesNoMoreThanWritevLimitIsWrittenInOneMassiveChunk),
-                ("testPendingWritesFlushPromiseWorksWithoutWritePromises", testPendingWritesFlushPromiseWorksWithoutWritePromises),
                 ("testPendingWritesWorksWithManyEmptyWrites", testPendingWritesWorksWithManyEmptyWrites),
                 ("testPendingWritesCloseDuringVectorWrite", testPendingWritesCloseDuringVectorWrite),
                 ("testPendingWritesMoreThanWritevIOVectorLimit", testPendingWritesMoreThanWritevIOVectorLimit),


### PR DESCRIPTION
Motivation:

A substantial chunk of code complexity exists in the PDWM to manage
flush promises. This complexity is no longer justified now that we
don't bother with them.

Modifications:

Removed much of the complexity of the PDWM handling of flush promises.

Result:

Simpler, easier to understand code.