### PR TITLE
Remove the promise-handling from the PWM.

### DIFF
--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -936,7 +936,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
     override func markFlushPoint(promise: EventLoopPromise<Void>?) {
         // Even if writable() will be called later by the EventLoop we still need to mark the flush checkpoint so we are sure all the flushed messages
         // are actually written once writable() is called.
-        self.pendingWrites.markFlushCheckpoint(promise: promise)
+        self.pendingWrites.markFlushCheckpoint()
     }
 
     override func cancelWritesOnClose(error: Error) {

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -42,7 +42,6 @@ extension ChannelTests {
                 ("testPendingWritesFileRegion", testPendingWritesFileRegion),
                 ("testPendingWritesEmptyFileRegion", testPendingWritesEmptyFileRegion),
                 ("testPendingWritesInterleavedBuffersAndFiles", testPendingWritesInterleavedBuffersAndFiles),
-                ("testPendingWritesFlushPromiseWorksWithoutWritePromises", testPendingWritesFlushPromiseWorksWithoutWritePromises),
                 ("testTwoFlushedNonEmptyWritesFollowedByUnflushedEmpty", testTwoFlushedNonEmptyWritesFollowedByUnflushedEmpty),
                 ("testPendingWritesWorksWithManyEmptyWrites", testPendingWritesWorksWithManyEmptyWrites),
                 ("testPendingWritesCloseDuringVectorWrite", testPendingWritesCloseDuringVectorWrite),


### PR DESCRIPTION
Motivation:

We no longer have flush promises, so the PWM no longer needs to
handle them.

Modifications:

Removed all flush promise handling from the PWM and associated
tests.

Result:

Less code, more clarity.