### PR TITLE
Add Selectable.withUnsafeFileDescriptor and use it through the code.

### DIFF
--- a/Sources/NIO/Selectable.swift
+++ b/Sources/NIO/Selectable.swift
@@ -17,12 +17,17 @@
 /// - warning: `Selectable`s are not thread-safe, only to be used on the appropriate `EventLoop`.
 protocol Selectable {
     
-    /// The file descriptor itself.
-    var descriptor: Int32 { get }
+    /// Will be called with the file descriptor of the `Selectable` if still open, if not it will
+    /// throw an `IOError`.
+    ///
+    /// - parameters:
+    ///     - fn: The closure to execute if the `Selectable` is still open.
+    /// - throws: If either the `Selectable` was closed before or the closure throws by itself.
+    func withUnsafeFileDescriptor<T>(_ fn: (Int32) throws -> T) throws -> T
 
     /// `true` if this `Selectable` is open (which means it was not closed yet).
     var open: Bool { get }
 
-    /// Close this `Selectable` (and so its `descriptor`).
+    /// Close this `Selectable` (and so its file descriptor).
     func close() throws
 }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -1283,18 +1283,18 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
 extension SocketChannel: CustomStringConvertible {
     var description: String {
-        return "SocketChannel { descriptor = \(self.selectable.descriptor), localAddress = \(self.localAddress.debugDescription), remoteAddress = \(self.remoteAddress.debugDescription) }"
+        return "SocketChannel { selectable = \(self.selectable), localAddress = \(self.localAddress.debugDescription), remoteAddress = \(self.remoteAddress.debugDescription) }"
     }
 }
 
 extension ServerSocketChannel: CustomStringConvertible {
     var description: String {
-        return "ServerSocketChannel { descriptor = \(self.selectable.descriptor), localAddress = \(self.localAddress.debugDescription), remoteAddress = \(self.remoteAddress.debugDescription) }"
+        return "ServerSocketChannel { selectable = \(self.selectable), localAddress = \(self.localAddress.debugDescription), remoteAddress = \(self.remoteAddress.debugDescription) }"
     }
 }
 
 extension DatagramChannel: CustomStringConvertible {
     var description: String {
-        return "DatagramChannel { descriptor = \(self.selectable.descriptor), localAddress = \(self.localAddress.debugDescription), remoteAddress = \(self.remoteAddress.debugDescription) }"
+        return "DatagramChannel { selectable = \(self.selectable), localAddress = \(self.localAddress.debugDescription), remoteAddress = \(self.remoteAddress.debugDescription) }"
     }
 }


### PR DESCRIPTION
Motivation:

We missed to check if the file descriptor is still open in ServerSocket before we act on it. We can remove a lot of complexity by just providing a withUnsafeFileDescriptor which will do this for us and use it through out the code-base.

Modifications:

Introduce withUnsafeFileDescriptor and use it to ensure we always only act on open Selectables.

Result:

More correct code.