### PR TITLE
[MERGE-WHEN-PUBLIC] Use https for dependency so no SSH login is needed.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,7 @@ let package = Package(
         .library(name: "NIOConcurrencyHelpers", targets: ["NIOConcurrencyHelpers"]),
     ],
     dependencies: [
-        .package(url: "git@github.com:apple/swift-nio-zlib-support.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-zlib-support.git", from: "1.0.0"),
     ],
     targets: targets
 )


### PR DESCRIPTION
Motivation:

We should just use https for our dependency so the user not need to have a github user at all and no ssh configured.

Modifications:

Just use https

Result:

Easier to use and consume SwiftNIO