### PR TITLE
Replace precondition with assert when checks for an implementation bug.

### DIFF
--- a/Sources/NIO/MarkedCircularBuffer.swift
+++ b/Sources/NIO/MarkedCircularBuffer.swift
@@ -21,6 +21,10 @@ public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollec
     private var buffer: CircularBuffer<E>
     private var markedIndex: Int = -1 /* negative: nothing marked */
 
+    /// Create a new instance.
+    ///
+    /// - paramaters:
+    ///     - initialRingCapacity: The initial capacity of the internal storage.
     public init(initialRingCapacity: Int) {
         self.buffer = CircularBuffer(initialRingCapacity: initialRingCapacity)
     }
@@ -91,7 +95,7 @@ public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollec
         if count > 0 {
             self.markedIndex = count - 1
         } else {
-            assert(self.markedIndex == -1)
+            assert(self.markedIndex == -1, "marked index is \(self.markedIndex)")
         }
     }
 
@@ -121,7 +125,7 @@ public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollec
     /// Returns tre if the buffer has been marked at all.
     public func hasMark() -> Bool {
         if self.markedIndex < 0 {
-            precondition(self.markedIndex == -1)
+            assert(self.markedIndex == -1, "marked index is \(self.markedIndex)")
             return false
         } else {
             return true


### PR DESCRIPTION
Motivation:

We used precondition for a few cases where it really checks for our own implementation. We should use assert here as there is nothing the user really can do to trigger it.

Modifications:

Replace precondition with assert.

Result:

Less overhead when in release mode and more correct in general.