### PR TITLE
EmbeddedChannel should call fireChannelRegistered(...) when register(...) is called.

### DIFF
--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -88,12 +88,12 @@ class EmbeddedChannelTest: XCTestCase {
     }
 
     func testEmbeddedLifecycle() throws {
-        let channel = EmbeddedChannel()
         let handler = ChannelLifecycleHandler()
         XCTAssertEqual(handler.currentState, .unregistered)
 
-        _ = try channel.pipeline.add(handler: handler).wait()
-        XCTAssertEqual(handler.currentState, .unregistered)
+        let channel = EmbeddedChannel(handler: handler)
+
+        XCTAssertEqual(handler.currentState, .registered)
         XCTAssertFalse(channel.isActive)
 
         _ = try channel.connect(to: try SocketAddress(unixDomainSocketPath: "/fake")).wait()


### PR DESCRIPTION
    Motivation:

    At the moment EmbeddedChannel calls fireChannelRegistered() when connect(...) is called. This is not correct, as it should be done when register(...) is called.

    Modifications:

    - Correctly call `fireChannelRegistered(...)` when register(...) is called
    - Simplify init of EmbeddedChannel
    - Fix EmbeddedChannelTest

    Result:

    Correct invocation of methods.