### PR TITLE
Fix test code on linux

### DIFF
--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -208,7 +208,7 @@ public class EventLoopTest : XCTestCase {
                 t.affinity = set
                 XCTAssertEqual(set, t.affinity)
             }
-            let threads: [ThreadInitializer] = [fn, body]
+            let threads: [ThreadInitializer] = [body, body]
         
             let group = MultiThreadedEventLoopGroup(threadInitializers: threads)
         


### PR DESCRIPTION
Motivation:

73a805c7f6c96aa19a2c5b7b6a529616a028e16c did some changes but missed to rename one variable. This broke the build on linux.

Modifications:

Rename fn to body.

Result:

Builds again on linux.