### PR TITLE
Add FileDescriptor protocol and implement it for FileHandle / BaseSocket

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -181,10 +181,10 @@ extension sockaddr_storage {
 /// This should not be created directly but one of its sub-classes should be used, like `ServerSocket` or `Socket`.
 class BaseSocket: Selectable {
 
-    private let descriptor: Int32
+    private let descriptor: CInt
     public private(set) var isOpen: Bool
     
-    func withUnsafeFileDescriptor<T>(_ body: (Int32) throws -> T) throws -> T {
+    func withUnsafeFileDescriptor<T>(_ body: (CInt) throws -> T) throws -> T {
         guard self.isOpen else {
             throw IOError(errnoCode: EBADF, reason: "file descriptor already closed!")
         }
@@ -259,7 +259,7 @@ class BaseSocket: Selectable {
     ///
     /// - parameters:
     ///     - descriptor: The file descriptor to wrap.
-    init(descriptor: Int32) {
+    init(descriptor: CInt) {
         self.descriptor = descriptor
         self.isOpen = true
     }

--- a/Sources/NIO/FileDescriptor.swift
+++ b/Sources/NIO/FileDescriptor.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public protocol FileDescriptor {
+    
+    /// Will be called with the file descriptor if still open, if not it will
+    /// throw an `IOError`.
+    ///
+    /// The ownership of the file descriptor must not escape the `body` as it's completely managed by the
+    /// implementation of the `FileDescriptor` protocol.
+    ///
+    /// - parameters:
+    ///     - body: The closure to execute if the `FileDescriptor` is still open.
+    /// - throws: If either the `FileDescriptor` was closed before or the closure throws by itself.
+    func withUnsafeFileDescriptor<T>(_ body: (CInt) throws -> T) throws -> T
+    
+    /// `true` if this `FileDescriptor` is open (which means it was not closed yet).
+    var isOpen: Bool { get }
+    
+    /// Close this `FileDescriptor`.
+    func close() throws
+}

--- a/Sources/NIO/FileRegion.swift
+++ b/Sources/NIO/FileRegion.swift
@@ -67,7 +67,7 @@ extension FileRegion {
     /// - parameters:
     ///     - fileHandle: An open `FileHandle` to the file.
     public init(fileHandle: FileHandle) throws {
-        let eof = try fileHandle.withDescriptor { (fd: CInt) throws -> off_t in
+        let eof = try fileHandle.withUnsafeFileDescriptor { (fd: CInt) throws -> off_t in
             let eof = try Posix.lseek(descriptor: fd, offset: 0, whence: SEEK_END)
             try Posix.lseek(descriptor: fd, offset: 0, whence: SEEK_SET)
             return eof

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -77,7 +77,7 @@ public struct NonBlockingFileIO {
                             chunkHandler: @escaping (ByteBuffer) -> EventLoopFuture<()>) -> EventLoopFuture<()> {
         do {
             let readableBytes = fileRegion.readableBytes
-            try fileRegion.fileHandle.withDescriptor { descriptor in
+            try fileRegion.fileHandle.withUnsafeFileDescriptor { descriptor in
                 _ = try Posix.lseek(descriptor: descriptor, offset: off_t(fileRegion.readerIndex), whence: SEEK_SET)
             }
             return self.readChunked(fileHandle: fileRegion.fileHandle,
@@ -154,7 +154,7 @@ public struct NonBlockingFileIO {
     public func read(fileRegion: FileRegion, allocator: ByteBufferAllocator, eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
         do {
             let readableBytes = fileRegion.readableBytes
-            try fileRegion.fileHandle.withDescriptor { descriptor in
+            try fileRegion.fileHandle.withUnsafeFileDescriptor { descriptor in
                 _ = try Posix.lseek(descriptor: descriptor, offset: off_t(fileRegion.readerIndex), whence: SEEK_SET)
             }
             return self.read(fileHandle: fileRegion.fileHandle,
@@ -197,7 +197,7 @@ public struct NonBlockingFileIO {
             while bytesRead < byteCount {
                 do {
                     let n = try buf.writeWithUnsafeMutableBytes { ptr in
-                        let res = try fileHandle.withDescriptor { descriptor in
+                        let res = try fileHandle.withUnsafeFileDescriptor { descriptor in
                             try Posix.read(descriptor: descriptor,
                                                      pointer: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self),
                                                      size: byteCount - bytesRead)

--- a/Sources/NIO/PendingWritesManager.swift
+++ b/Sources/NIO/PendingWritesManager.swift
@@ -383,7 +383,7 @@ final class PendingStreamWritesManager: PendingWritesManager {
         case .fileRegion(let file):
             let readerIndex = file.readerIndex
             let endIndex = file.endIndex
-            return try file.fileHandle.withDescriptor { fd in
+            return try file.fileHandle.withUnsafeFileDescriptor { fd in
                 self.didWrite(itemCount: 1, result: try operation(fd, readerIndex, endIndex))
             }
         case .byteBuffer:

--- a/Sources/NIO/Selectable.swift
+++ b/Sources/NIO/Selectable.swift
@@ -15,19 +15,5 @@
 /// Represents a selectable resource which can be registered to a `Selector` to be notified once there are some events ready for it.
 ///
 /// - warning: `Selectable`s are not thread-safe, only to be used on the appropriate `EventLoop`.
-protocol Selectable {
-    
-    /// Will be called with the file descriptor of the `Selectable` if still open, if not it will
-    /// throw an `IOError`.
-    ///
-    /// - parameters:
-    ///     - body: The closure to execute if the `Selectable` is still open.
-    /// - throws: If either the `Selectable` was closed before or the closure throws by itself.
-    func withUnsafeFileDescriptor<T>(_ body: (Int32) throws -> T) throws -> T
-
-    /// `true` if this `Selectable` is open (which means it was not closed yet).
-    var isOpen: Bool { get }
-
-    /// Close this `Selectable` (and so its file descriptor).
-    func close() throws
+protocol Selectable: FileDescriptor {
 }

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -196,11 +196,11 @@ class FileRegionTest : XCTestCase {
 
             var fr1Bytes: [UInt8] = Array(repeating: 0, count: 5)
             var fr2Bytes = fr1Bytes
-            try fh1.withDescriptor { fd in
+            try fh1.withUnsafeFileDescriptor { fd in
                 let r = try Posix.read(descriptor: fd, pointer: &fr1Bytes, size: 5)
                 XCTAssertEqual(r, IOResult<Int>.processed(5))
             }
-            try fh2.withDescriptor { fd in
+            try fh2.withUnsafeFileDescriptor { fd in
                 let r = try Posix.read(descriptor: fd, pointer: &fr2Bytes, size: 5)
                 XCTAssertEqual(r, IOResult<Int>.processed(5))
             }

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -111,7 +111,7 @@ class NonBlockingFileIOTest: XCTestCase {
 
             do {
                 try self.eventLoop.submit {
-                    try writeFH.withDescriptor { writeFD in
+                    try writeFH.withUnsafeFileDescriptor { writeFD in
                         _ = try Posix.write(descriptor: writeFD, pointer: "X", size: 1)
                     }
                     try writeFH.close()
@@ -277,7 +277,7 @@ class NonBlockingFileIOTest: XCTestCase {
                 for i in 0..<10 {
                     // this construction will cause 'read' to repeatedly return with 1 byte read
                     try self.eventLoop.scheduleTask(in: .milliseconds(50)) {
-                        try writeFH.withDescriptor { writeFD in
+                        try writeFH.withUnsafeFileDescriptor { writeFD in
                             _ = try Posix.write(descriptor: writeFD, pointer: "\(i)", size: 1)
                         }
                     }.futureResult.wait()
@@ -340,7 +340,7 @@ class NonBlockingFileIOTest: XCTestCase {
                 for i in 0..<10 {
                     // this construction will cause 'read' to repeatedly return with 1 byte read
                     try self.eventLoop.scheduleTask(in: .milliseconds(50)) {
-                        try writeFH.withDescriptor { writeFD in
+                        try writeFH.withUnsafeFileDescriptor { writeFD in
                             _ = try Posix.write(descriptor: writeFD, pointer: "\(i)", size: 1)
                         }
                     }.futureResult.wait()
@@ -379,7 +379,7 @@ class NonBlockingFileIOTest: XCTestCase {
 
     func testFileRegionReadFromPipeFails() throws {
         try withPipe { readFH, writeFH in
-            try! writeFH.withDescriptor { writeFD in
+            try! writeFH.withUnsafeFileDescriptor { writeFD in
                 _ = try! Posix.write(descriptor: writeFD, pointer: "ABC", size: 3)
             }
             let fr = FileRegion(fileHandle: readFH, readerIndex: 1, endIndex: 2)
@@ -404,7 +404,7 @@ class NonBlockingFileIOTest: XCTestCase {
     func testReadFromNonBlockingPipeFails() throws {
         try withPipe { readFH, writeFH in
             do {
-                try readFH.withDescriptor { readFD in
+                try readFH.withUnsafeFileDescriptor { readFD in
                     try Posix.fcntl(descriptor: readFD, command: F_SETFL, value: O_NONBLOCK)
                 }
                 try self.fileIO.readChunked(fileHandle: readFH,

--- a/Tests/NIOTests/SystemTest.swift
+++ b/Tests/NIOTests/SystemTest.swift
@@ -26,7 +26,7 @@ class SystemTest: XCTestCase {
             var randomBytes: UInt8 = 42
             do {
                 _ = try withUnsafePointer(to: &randomBytes) { ptr in
-                    try readFD.withDescriptor { readFD in
+                    try readFD.withUnsafeFileDescriptor { readFD in
                         try Posix.setsockopt(socket: readFD, level: -1, optionName: -1, optionValue: ptr, optionLen: 0)
                     }
                 }


### PR DESCRIPTION
Motivation:

FileHandle and BaseSocket should implement a common protocol as these are both "based" on file descriptors

Modifications:

- Add FileDescriptor protocol
- Implement it for FileHandler and BaseSocket

Result:

Better code structure