### PR TITLE
fix zero capacity ByteBuffer reallocs

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -270,7 +270,7 @@ public struct ByteBuffer {
 
         if self._slice.lowerBound + index + capacity > self._slice.upperBound {
             // double the capacity, we may want to use different strategies depending on the actual current capacity later on.
-            var newCapacity = toCapacity(self.capacity)
+            var newCapacity = max(1, toCapacity(self.capacity))
             
             // double the capacity until the requested capacity can be full-filled
             repeat {

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -108,6 +108,7 @@ extension ByteBufferTest {
                 ("testClearDoesNotDupeStorageIfTheresOnlyOneBuffer", testClearDoesNotDupeStorageIfTheresOnlyOneBuffer),
                 ("testWeUseFastWriteForContiguousCollections", testWeUseFastWriteForContiguousCollections),
                 ("testUnderestimatingSequenceWorks", testUnderestimatingSequenceWorks),
+                ("testZeroSizeByteBufferResizes", testZeroSizeByteBufferResizes),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1200,6 +1200,12 @@ class ByteBufferTest: XCTestCase {
             XCTAssertEqual(i, actual)
         }
     }
+
+    func testZeroSizeByteBufferResizes() {
+        var buf = ByteBufferAllocator().buffer(capacity: 0)
+        buf.write(staticString: "x")
+        XCTAssertEqual(buf.writerIndex, 1)
+    }
 }
 
 private enum AllocationExpectationState: Int {


### PR DESCRIPTION
Motivation:

We'd go into an infinite loop when trying to increase the capacity of a
0 capacity ByteBuffer *doh*. Thanks @vlm for reporting and writing the
test.

Modifications:

made sure ensureAvailableCapacity returns at least 1 if we don't have
enough capacity available.

Result:

0 capacity ByteBuffers resize now.