### PR TITLE
Support enumerating network interfaces.

### DIFF
--- a/Sources/NIO/Interfaces.swift
+++ b/Sources/NIO/Interfaces.swift
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//
+//  Interfaces.swift
+//  NIO
+//
+//  Created by Cory Benfield on 27/02/2018.
+//
+
+private extension ifaddrs {
+    var dstaddr: UnsafeMutablePointer<sockaddr>? {
+        #if os(Linux)
+        return self.ifa_ifu.ifu_dstaddr
+        #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        return self.ifa_dstaddr
+        #endif
+    }
+
+    var broadaddr: UnsafeMutablePointer<sockaddr>? {
+        #if os(Linux)
+        return self.ifa_ifu.ifu_broadaddr
+        #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        return self.ifa_dstaddr
+        #endif
+    }
+}
+
+/// A representation of a single network interface on a system.
+public final class NIONetworkInterface {
+    // This is a class because in almost all cases this will carry
+    // four structs that are backed by classes, and so will incur 4
+    // refcount operations each time it is copied.
+
+    /// The name of the network interface.
+    public let name: String
+
+    /// The address associated with the given network interface.
+    public let address: SocketAddress
+
+    /// The netmask associated with this address, if any.
+    public let netmask: SocketAddress?
+
+    /// The broadcast address associated with this socket interface, if it has one. Some
+    /// interfaces do not, especially those that have a `pointToPointDestinationAddress`.
+    public let broadcastAddress: SocketAddress?
+
+    /// The address of the peer on a point-to-point interface, if this is one. Some
+    /// interfaces do not have such an address: most of those have a `broadcastAddress`
+    /// instead.
+    public let pointToPointDestinationAddress: SocketAddress?
+
+    /// Create a brand new network interface.
+    ///
+    /// This constructor will fail if NIO does not understand the format of the underlying
+    /// socket address family. This is quite common: for example, Linux will return AF_PACKET
+    /// addressed interfaces on most platforms, which NIO does not currently understand.
+    internal init?(_ caddr: ifaddrs) {
+        self.name = String(cString: caddr.ifa_name)
+        guard let address = caddr.ifa_addr!.convert() else {
+            return nil
+        }
+        self.address = address
+
+        if let netmask = caddr.ifa_netmask {
+            self.netmask = netmask.convert()
+        } else {
+            self.netmask = nil
+        }
+
+        if (caddr.ifa_flags & UInt32(IFF_BROADCAST)) != 0, let addr = caddr.broadaddr {
+            self.broadcastAddress = addr.convert()
+            self.pointToPointDestinationAddress = nil
+        } else if (caddr.ifa_flags & UInt32(IFF_POINTOPOINT)) != 0, let addr = caddr.dstaddr {
+            self.broadcastAddress = nil
+            self.pointToPointDestinationAddress = addr.convert()
+        } else {
+            self.broadcastAddress = nil
+            self.pointToPointDestinationAddress = nil
+        }
+    }
+}
+
+extension NIONetworkInterface: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        let baseString = "Interface \(self.name): address \(self.address)"
+        let maskString = self.netmask != nil ? " netmask \(self.netmask!)" : ""
+        return baseString + maskString
+    }
+}
+
+extension NIONetworkInterface: Equatable {
+    public static func ==(lhs: NIONetworkInterface, rhs: NIONetworkInterface) -> Bool {
+        return lhs.name == rhs.name &&
+               lhs.address == rhs.address &&
+               lhs.netmask == rhs.netmask &&
+               lhs.broadcastAddress == rhs.broadcastAddress &&
+               lhs.pointToPointDestinationAddress == rhs.pointToPointDestinationAddress
+    }
+}

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -52,6 +52,8 @@ private let sysSendTo = sendto
 private let sysDup = dup
 private let sysGetpeername = getpeername
 private let sysGetsockname = getsockname
+private let sysGetifaddrs = getifaddrs
+private let sysFreeifaddrs = freeifaddrs
 private let sysAF_INET = AF_INET
 private let sysAF_INET6 = AF_INET6
 private let sysAF_UNIX = AF_UNIX
@@ -411,6 +413,13 @@ internal enum Posix {
     public static func getsockname(socket: CInt, address: UnsafeMutablePointer<sockaddr>, addressLength: UnsafeMutablePointer<socklen_t>) throws {
         _ = try wrapSyscall {
             return sysGetsockname(socket, address, addressLength)
+        }
+    }
+
+    @inline(never)
+    public static func getifaddrs(_ addrs: UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>) throws {
+        _ = try wrapSyscall {
+            sysGetifaddrs(addrs)
         }
     }
 

--- a/Sources/NIO/Utilities.swift
+++ b/Sources/NIO/Utilities.swift
@@ -51,4 +51,32 @@ public enum System {
         return darwinCoreCount()
         #endif
     }
+
+    /// A utility function that enumerates the available network interfaces on this machine.
+    ///
+    /// This function returns values that are true for a brief snapshot in time. These results can
+    /// change, and the returned values will not change to reflect them. This function must be called
+    /// again to get new results.
+    ///
+    /// - returns: An array of network interfaces available on this machine.
+    /// - throws: If an error is encountered while enumerating interfaces.
+    public static func enumerateInterfaces() throws -> [NIONetworkInterface] {
+        var interface: UnsafeMutablePointer<ifaddrs>? = nil
+        try Posix.getifaddrs(&interface)
+        let originalInterface = interface
+        defer {
+            freeifaddrs(originalInterface)
+        }
+
+        var results: [NIONetworkInterface] = []
+        results.reserveCapacity(12)  // Arbitrary choice.
+        while let concreteInterface = interface {
+            if let nioInterface = NIONetworkInterface(concreteInterface.pointee) {
+                results.append(nioInterface)
+            }
+            interface = concreteInterface.pointee.ifa_next
+        }
+
+        return results
+    }
 }

--- a/Tests/NIOTests/UtilitiesTest+XCTest.swift
+++ b/Tests/NIOTests/UtilitiesTest+XCTest.swift
@@ -27,6 +27,7 @@ extension UtilitiesTest {
    static var allTests : [(String, (UtilitiesTest) -> () throws -> Void)] {
       return [
                 ("testCoreCountWorks", testCoreCountWorks),
+                ("testEnumeratingInterfaces", testEnumeratingInterfaces),
            ]
    }
 }

--- a/Tests/NIOTests/UtilitiesTest.swift
+++ b/Tests/NIOTests/UtilitiesTest.swift
@@ -19,4 +19,32 @@ class UtilitiesTest: XCTestCase {
     func testCoreCountWorks() {
         XCTAssertGreaterThan(System.coreCount, 0)
     }
+
+    func testEnumeratingInterfaces() throws {
+        // This is a tricky test, because we can't really assert much and expect this
+        // to pass on all systems. The best we can do is assume there is a loopback:
+        // maybe an IPv4 one, maybe an IPv6 one, but there will be one. We look for
+        // both.
+        let interfaces = try System.enumerateInterfaces()
+        XCTAssertGreaterThan(interfaces.count, 0)
+
+        var ipv4LoopbackPresent = false
+        var ipv6LoopbackPresent = false
+
+        for interface in interfaces {
+            if try interface.address == SocketAddress(ipAddress: "127.0.0.1", port: 0) {
+                ipv4LoopbackPresent = true
+                XCTAssertEqual(interface.netmask, try SocketAddress(ipAddress: "255.0.0.0", port: 0))
+                XCTAssertNil(interface.broadcastAddress)
+                XCTAssertNil(interface.pointToPointDestinationAddress)
+            } else if try interface.address == SocketAddress(ipAddress: "::1", port: 0) {
+                ipv6LoopbackPresent = true
+                XCTAssertEqual(interface.netmask, try SocketAddress(ipAddress: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", port: 0))
+                XCTAssertNil(interface.broadcastAddress)
+                XCTAssertNil(interface.pointToPointDestinationAddress)
+            }
+        }
+
+        XCTAssertTrue(ipv4LoopbackPresent || ipv6LoopbackPresent)
+    }
 }


### PR DESCRIPTION
Motivation:

When writing programs that use networks, particularly if you want to
perform multicast joins, it's extremely important to be able to query
network interfaces and get results.

Modifications:

Add support for querying interfaces using getifaddrs and wrap those query
results in a Swift class.

Result:

Users will be able to enumerate the interfaces on their machine.