### PR TITLE
Create ISSUE_TEMPLATE.md

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+### Expected behavior
+_[what you expected to happen]_
+
+### Actual behavior
+_[what actually happened]_
+
+### Steps to reproduce
+
+1. ...
+2. ...
+
+### If possible, minimal yet complete reproducer code (or URL to code)
+
+_[anything to help us reproducing the issue]_
+
+### SwiftNIO version/commit hash
+
+_[the SwiftNIO tag/commit hash]_
+
+### Swift & OS version (output of `swift --version && uname -a`)


### PR DESCRIPTION
Added ISSUE_TEMPLATE.md
Motivation:

It's great if the GitHub issues come prefilled with a template.

Modifications:

Added a template very similiar to the commit one but md.

Result:

hopefully issues that are easier to action :)