### PR TITLE
fix EventLoop-hopping thens (#51)

### DIFF
--- a/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
@@ -36,6 +36,8 @@ extension EventLoopFutureTest {
                 ("testThenIfErrorThrowingWhichDoesNotThrow", testThenIfErrorThrowingWhichDoesNotThrow),
                 ("testThenIfErrorThrowingWhichDoesThrow", testThenIfErrorThrowingWhichDoesThrow),
                 ("testOrderOfFutureCompletion", testOrderOfFutureCompletion),
+                ("testEventLoopHoppingInThen", testEventLoopHoppingInThen),
+                ("testEventLoopHoppingInThenWithFailures", testEventLoopHoppingInThenWithFailures),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously if we'd futureOnEL1.then { ... in futureInEL2 } we'd forget
to hop from EL1 to EL2 which is bad. Shout out to @tanner0101 for
reporting!

Modifications:

Hop from one EventLoop to another if needed.

Result:

thens between Futures of different EventLoops now correctly switch
EventLoops.
