### PR TITLE
typo: ChannnelDuplexHandler should be ChannelDuplexHandler

### DIFF
--- a/Sources/NIO/ChannelHandlers.swift
+++ b/Sources/NIO/ChannelHandlers.swift
@@ -21,7 +21,7 @@ import struct Dispatch.DispatchTime
  ChannelHandler implementation which enforces back-pressure by stopping to read from the remote peer when it cannot write back fast enough.
  It will start reading again once pending data was written.
 */
-public class BackPressureHandler: ChannnelDuplexHandler {
+public class BackPressureHandler: ChannelDuplexHandler {
     public typealias OutboundIn = NIOAny
     public typealias InboundIn = ByteBuffer
     public typealias InboundOut = ByteBuffer
@@ -65,7 +65,7 @@ public class BackPressureHandler: ChannnelDuplexHandler {
 }
 
 /// Triggers an IdleStateEvent when a Channel has not performed read, write, or both operation for a while.
-public class IdleStateHandler: ChannnelDuplexHandler {
+public class IdleStateHandler: ChannelDuplexHandler {
     public typealias InboundIn = NIOAny
     public typealias InboundOut = NIOAny
     public typealias OutboundIn = NIOAny

--- a/Sources/NIO/TypeAssistedChannelHandler.swift
+++ b/Sources/NIO/TypeAssistedChannelHandler.swift
@@ -77,4 +77,4 @@ extension ChannelOutboundHandler {
 }
 
 /// A combination of `ChannelInboundHandler` and `ChannelOutboundHandler`.
-public protocol ChannnelDuplexHandler: ChannelInboundHandler, ChannelOutboundHandler { }
+public protocol ChannelDuplexHandler: ChannelInboundHandler, ChannelOutboundHandler { }

--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -56,7 +56,7 @@ private func qValueFromHeader(_ text: String) -> Float {
 /// ahead-of-time instead of dynamically, could be a waste of CPU time and latency for relatively minimal
 /// benefit. This channel handler should be present in the pipeline only for dynamically-generated and
 /// highly-compressible content, which will see the biggest benefits from streaming compression.
-public final class HTTPResponseCompressor: ChannnelDuplexHandler {
+public final class HTTPResponseCompressor: ChannelDuplexHandler {
     public typealias InboundIn = HTTPServerRequestPart
     public typealias InboundOut = HTTPServerRequestPart
     public typealias OutboundIn = HTTPServerResponsePart

--- a/Tests/NIOTests/TypeAssistedChannelHandlerTests.swift
+++ b/Tests/NIOTests/TypeAssistedChannelHandlerTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 class TypeAssistedChannelHandlerTest: XCTestCase {
     func testCanDefineBothInboundAndOutbound() throws {
-        class TestClass: ChannnelDuplexHandler {
+        class TestClass: ChannelDuplexHandler {
             public typealias OutboundIn = ByteBuffer
             public typealias OutboundOut = ByteBuffer
             public typealias InboundIn = ByteBuffer


### PR DESCRIPTION
Introduced in 613998ba9ec15f52537ab697e87b8cfcfbafe136.

### Motivation:

Typos in public API are bad.

### Modifications:

Fix the typo.

### Result:

Nicer public API.
