### PR TITLE
Add Package.resolved to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 Package.pins
 *.pem
 /docs
+Package.resolved


### PR DESCRIPTION
### Motivation:

In general, `Package.resolved` should not be checked in to version control.

### Modifications:

Add `Package.resolved` to `.gitignore`.

### Result:

`Package.resolved` no longer reported as Untracked by git.