### PR TITLE
Define ChannelDuplexHandler as a typealias

### DIFF
--- a/Sources/NIO/TypeAssistedChannelHandler.swift
+++ b/Sources/NIO/TypeAssistedChannelHandler.swift
@@ -77,4 +77,4 @@ extension ChannelOutboundHandler {
 }
 
 /// A combination of `ChannelInboundHandler` and `ChannelOutboundHandler`.
-public protocol ChannelDuplexHandler: ChannelInboundHandler, ChannelOutboundHandler { }
+public typealias ChannelDuplexHandler = ChannelInboundHandler & ChannelOutboundHandler


### PR DESCRIPTION
Change `ChannelDuplexHandler` from being its own protocol to being a typealias.

### Motivation:

This occurred to me when reading the recent commits.  It seems more "Swifty" to define a typealias rather than a new protocol.  This is the model used in [`Codable`](https://github.com/apple/swift/blob/5650f80937ad733ac6e16a4e6ec75d73cd849bae/stdlib/public/core/Codable.swift.gyb#L48), for example.

Maybe there is a good reason it wasn't a typealias though - I don't know.

### Modifications:

Change `ChannelDuplexHandler` from being its own protocol to being a typealias.

### Result:

No change to users of `ChannelDuplexHandler`.