### PR TITLE
Added a sample NIO Web Framework project implementing basic Routing a…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,8 @@ var targets: [PackageDescription.Target] = [
                 dependencies: ["NIOHTTP1", "NIOFoundationCompat"]),
     .testTarget(name: "NIOTLSTests",
                 dependencies: ["NIO", "NIOTLS", "NIOFoundationCompat"]),
+    .target(name: "NIOWebFramework",
+            dependencies: ["NIO", "NIOHTTP1"]),
 ]
 
 let package = Package(
@@ -66,6 +68,7 @@ let package = Package(
         .executable(name: "NIOChatServer", targets: ["NIOChatServer"]),
         .executable(name: "NIOChatClient", targets: ["NIOChatClient"]),
         .executable(name: "NIOHTTP1Server", targets: ["NIOHTTP1Server"]),
+        .executable(name: "NIOWebFramework", targets: ["NIOWebFramework"]),
         .library(name: "NIO", targets: ["NIO"]),
         .library(name: "NIOTLS", targets: ["NIOTLS"]),
         .library(name: "NIOHTTP1", targets: ["NIOHTTP1"]),

--- a/Sources/NIOWebFramework/Handler.swift
+++ b/Sources/NIOWebFramework/Handler.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import NIO
+import NIOHTTP1
+
+class Handler: ChannelInboundHandler {
+    private enum FileIOMethod {
+        case sendfile
+        case nonblockingFileIO
+    }
+    public typealias InboundIn = HTTPServerRequestPart
+    public typealias OutboundOut = HTTPServerResponsePart
+    
+    private var requestUri: String?
+    private var keepAlive = false
+    
+    private let fileIO: NonBlockingFileIO
+    private let router: Router
+    
+    public init(fileIO: NonBlockingFileIO, router: Router) {
+        self.fileIO = fileIO
+        self.router = router
+    }
+    
+    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+        let reqPart = self.unwrapInboundIn(data)
+        
+        switch reqPart {
+        case .head(let request):
+            keepAlive = request.isKeepAlive
+            var buffer: ByteBuffer
+            
+            if let routerHandler = router.routingTable[request.uri] {
+                let responseBody = routerHandler.respond()
+                
+                buffer = ctx.channel.allocator.buffer(capacity: responseBody.lengthOfBytes(using: String.Encoding.utf8))
+                buffer.write(string: responseBody)
+            }
+            else {
+                buffer = ctx.channel.allocator.buffer(capacity: 5)
+                buffer.write(staticString: "ERROR")
+            }
+                
+            var responseHead = HTTPResponseHead(version: request.version, status: HTTPResponseStatus.ok)
+            responseHead.headers.add(name: "content-length", value: String(buffer.readableBytes))
+            let response = HTTPServerResponsePart.head(responseHead)
+            ctx.write(self.wrapOutboundOut(response), promise: nil)
+            
+            let content = HTTPServerResponsePart.body(.byteBuffer(buffer.slice()))
+            ctx.write(self.wrapOutboundOut(content), promise: nil)
+        case .body:
+            break
+        case .end:
+            if keepAlive {
+                ctx.write(self.wrapOutboundOut(HTTPServerResponsePart.end(nil)), promise: nil)
+            } else {
+                ctx.write(self.wrapOutboundOut(HTTPServerResponsePart.end(nil))).whenComplete {
+                    ctx.close(promise: nil)
+                }
+            }
+        }
+    }
+    
+    func channelReadComplete(ctx: ChannelHandlerContext) {
+        ctx.flush()
+    }
+}

--- a/Sources/NIOWebFramework/Router.swift
+++ b/Sources/NIOWebFramework/Router.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+public protocol Responder {
+    func respond() -> String
+}
+
+public struct RouteResponder<T>: Responder where T: Encodable
+{
+    public typealias Handler = () -> T
+    
+    public let handler: Handler
+    
+    public init(handler: @escaping Handler) {
+        self.handler = handler
+    }
+    
+    public func respond() -> String {
+        let encodable = handler()
+        let data = try! JSONEncoder().encode(encodable)
+        return String(data: data, encoding: .utf8)!
+    }
+}
+
+class Router {
+    var routingTable = [String : Responder]()
+    
+    func get<T: Encodable>(_ route: String, handler: @escaping () -> T) {
+        let rr = RouteResponder<T>(handler: handler)
+        routingTable[route] = rr
+    }
+}

--- a/Sources/NIOWebFramework/Server.swift
+++ b/Sources/NIOWebFramework/Server.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import NIO
+import NIOHTTP1
+
+class Server {
+    var host: String
+    var port: Int
+    var group: MultiThreadedEventLoopGroup
+    var threadPool: BlockingIOThreadPool
+    var fileIO: NonBlockingFileIO
+    var router: Router
+
+    init(host: String, port: Int, with router: Router, eventLoopThreads: Int = 1, poolThreads: Int = 6) {
+        self.host = host
+        self.port = port
+        self.router = router
+        
+        group = MultiThreadedEventLoopGroup(numThreads: eventLoopThreads)
+        threadPool = BlockingIOThreadPool(numberOfThreads: poolThreads)
+        threadPool.start()
+
+        fileIO = NonBlockingFileIO(threadPool: threadPool)
+    }
+    
+    
+    func run() {
+        do {
+            let bootstrap = ServerBootstrap(group: group)
+                // Specify backlog and enable SO_REUSEADDR for the server itself
+                .serverChannelOption(ChannelOptions.backlog, value: 256)
+                .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+                
+                // Set the handlers that are applied to the accepted Channels
+                .childChannelInitializer { channel in
+                    channel.pipeline.addHTTPServerHandlers().then {
+                        channel.pipeline.add(handler: Handler(fileIO: self.fileIO, router: self.router))
+                    }
+                }
+                
+                // Enable TCP_NODELAY and SO_REUSEADDR for the accepted Channels
+                .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+                .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+                .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+
+            let channel = try bootstrap.bind(host: host, port: port).wait()
+            
+            print("Server started and listening on \(channel.localAddress!)")
+            
+            // This will never unblock as we don't close the ServerChannel
+            try channel.closeFuture.wait()
+        }
+        catch {
+            print("Error starting server")
+        }
+    }
+}

--- a/Sources/NIOWebFramework/main.swift
+++ b/Sources/NIOWebFramework/main.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+struct User : Codable {
+    let firstName: String
+    let lastName: String
+    let id: Int
+}
+
+let users = [User(firstName: "John", lastName: "Doe", id: 0),
+             User(firstName: "Jane", lastName: "Doe", id: 1)]
+
+let router = Router()
+
+router.get("/users") {
+    return users
+}
+
+router.get("/user/0") {
+    return users[0]
+}
+
+let server = Server(host: "::1", port: 8888, with: router)
+
+server.run()
+
+print("Server closed")


### PR DESCRIPTION
Added a sample NIO Web Framework project implementing basic Routing and Server functionality with Codable support

### Motivation:

Provide a sample about how to easily integrate swift-nio on existing Swift Web Frameworks or just build a new one

### Modifications:

No modifications other than Package.swift to add the new sample project target

### Result:

Sample usage:

import Foundation

struct User : Codable {
    let name: String
    let id: Int
}

let users = [User(name: "John", id: 0), User(name: "Jane", id: 1)]

let router = Router()

router.get("/users") {
    return users
}

let server = Server(host: "::1", port: 8888, with: router)

server.run()
