### PR TITLE
default example servers to use as many threads as cores

### DIFF
--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -39,7 +39,7 @@ private final class EchoHandler: ChannelInboundHandler {
         ctx.close(promise: nil)
     }
 }
-let group = MultiThreadedEventLoopGroup(numThreads: 1)
+let group = MultiThreadedEventLoopGroup(numThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -386,7 +386,7 @@ default:
     bindTarget = BindTo.ip(host: defaultHost, port: defaultPort)
 }
 
-let group = MultiThreadedEventLoopGroup(numThreads: 1)
+let group = MultiThreadedEventLoopGroup(numThreads: System.coreCount)
 let threadPool = BlockingIOThreadPool(numberOfThreads: 6)
 threadPool.start()
 


### PR DESCRIPTION
Motivation:

Our example servers used an arbitrary number of threads (the http one
just 1 :|) but `System.coreCount` is a much better default and also
demoes that API.

Modifications:

Changed the example servers to use `System.coreCount` threads.

Result:

Use more of the hardware you paid for.
