### PR TITLE
base variadic ChannelPipeline.addHandlers off of an array accepting version

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -676,6 +676,39 @@ public final class ChannelPipeline: ChannelInvoker {
     }
 }
 
+extension ChannelPipeline {
+    /// Adds the provided channel handlers to the pipeline in the order given, taking account
+    /// of the behaviour of `ChannelHandler.add(first:)`.
+    ///
+    /// - parameters:
+    ///     - handlers: The array of `ChannelHandler`s to be added.
+    ///     - first: If `true`, the supplied `ChannelHandler`s will be added to the front of the pipeline.
+    ///              If `false`, they will be added to the back.
+    ///
+    /// - returns: A future that will be completed when all of the supplied `ChannelHandler`s were added.
+    public func addHandlers(_ handlers: [ChannelHandler], first: Bool) -> EventLoopFuture<Void> {
+        var handlers = handlers
+        if first {
+            handlers = handlers.reversed()
+        }
+
+        return EventLoopFuture<Void>.andAll(handlers.map { add(handler: $0) }, eventLoop: eventLoop)
+    }
+
+    /// Adds the provided channel handlers to the pipeline in the order given, taking account
+    /// of the behaviour of `ChannelHandler.add(first:)`.
+    ///
+    /// - parameters:
+    ///     - handlers: One or more `ChannelHandler`s to be added.
+    ///     - first: If `true`, the supplied `ChannelHandler`s will be added to the front of the pipeline.
+    ///              If `false`, they will be added to the back.
+    ///
+    /// - returns: A future that will be completed when all of the supplied `ChannelHandler`s were added.
+    public func addHandlers(_ handlers: ChannelHandler..., first: Bool) -> EventLoopFuture<Void> {
+        return addHandlers(handlers, first: first)
+    }
+}
+
 /// Special `ChannelHandler` that forwards all events to the `Channel.Unsafe` implementation.
 private final class HeadChannelHandler: _ChannelOutboundHandler {
 

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -153,17 +153,6 @@ public extension ChannelPipeline {
                                                 upgradeCompletionHandler: upgradeCompletionHandler)
         return addHandlers(responseEncoder, requestDecoder, upgrader, first: first)
     }
-
-    /// Adds the provided channel handlers to the pipeline in the order given, taking account
-    /// of the behaviour of `ChannelHandler.add(first:)`.
-    private func addHandlers(_ handlers: ChannelHandler..., first: Bool) -> EventLoopFuture<Void> {
-        var handlers = handlers
-        if first {
-            handlers = handlers.reversed()
-        }
-
-        return EventLoopFuture<Void>.andAll(handlers.map { add(handler: $0) }, eventLoop: eventLoop)
-    }
 }
 
 /// A `ChannelInboundHandler` used to decode HTTP requests. See the documentation


### PR DESCRIPTION
Publicizes variadic `ChannelPipeline.addHandler` method and provides an array accepting version as well.

### Motivation:

This method is useful for creating extensions to add handlers similar to what Swift NIO offers w/ HTTP. For example:

```swift
extension ChannelPipeline {
    func addPostgreSQLClientHandlers(first: Bool = false) -> EventLoopFuture<Void> {
        return addHandlers(PostgreSQLMessageEncoder(), PostgreSQLMessageDecoder(), first: first)
    }
```

### Modifications:

Publicized one method and added another public array accepting version.
