### PR TITLE
write/set(integer:) should like read/getInteger have an option as: ar…

### DIFF
--- a/Sources/NIO/ByteBuffer-int.swift
+++ b/Sources/NIO/ByteBuffer-int.swift
@@ -67,7 +67,7 @@ extension ByteBuffer {
     ///     - endianness: The endianness to use, defaults to big endian.
     /// - returns: The number of bytes written.
     @discardableResult
-    public mutating func write<T: FixedWidthInteger>(integer: T, endianness: Endianness = .big) -> Int {
+    public mutating func write<T: FixedWidthInteger>(integer: T, endianness: Endianness = .big, as: T.Type = T.self) -> Int {
         let bytesWritten = self.set(integer: integer, at: self.writerIndex, endianness: endianness)
         self.moveWriterIndex(forwardBy: bytesWritten)
         return Int(bytesWritten)
@@ -81,7 +81,7 @@ extension ByteBuffer {
     ///     - endianness: The endianness to use, defaults to big endian.
     /// - returns: The number of bytes written.
     @discardableResult
-    public mutating func set<T: FixedWidthInteger>(integer: T, at index: Int, endianness: Endianness = .big) -> Int {
+    public mutating func set<T: FixedWidthInteger>(integer: T, at index: Int, endianness: Endianness = .big, as: T.Type = T.self) -> Int {
         var value = toEndianness(value: integer, endianness: endianness)
         return Swift.withUnsafeBytes(of: &value) { ptr in
             self.set(bytes: ptr, at: index)

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -109,6 +109,7 @@ extension ByteBufferTest {
                 ("testWeUseFastWriteForContiguousCollections", testWeUseFastWriteForContiguousCollections),
                 ("testUnderestimatingSequenceWorks", testUnderestimatingSequenceWorks),
                 ("testZeroSizeByteBufferResizes", testZeroSizeByteBufferResizes),
+                ("testSpecifyTypesAndEndiannessForIntegerMethods", testSpecifyTypesAndEndiannessForIntegerMethods),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -336,10 +336,10 @@ class ByteBufferTest: XCTestCase {
 
     func testDiscardReadBytes() throws {
         var buffer = allocator.buffer(capacity: 32)
-        buffer.write(integer: UInt8(1))
+        buffer.write(integer: 1, as: UInt8.self)
         buffer.write(integer: UInt8(2))
-        buffer.write(integer: UInt8(3))
-        buffer.write(integer: UInt8(4))
+        buffer.write(integer: 3 as UInt8)
+        buffer.write(integer: 4, as: UInt8.self)
         XCTAssertEqual(4, buffer.readableBytes)
         buffer.moveReaderIndex(forwardBy: 2)
         XCTAssertEqual(2, buffer.readableBytes)
@@ -1205,6 +1205,14 @@ class ByteBufferTest: XCTestCase {
         var buf = ByteBufferAllocator().buffer(capacity: 0)
         buf.write(staticString: "x")
         XCTAssertEqual(buf.writerIndex, 1)
+    }
+
+    func testSpecifyTypesAndEndiannessForIntegerMethods() {
+        self.buf.clear()
+        self.buf.write(integer: -1, endianness: .big, as: Int64.self)
+        XCTAssertEqual(-1, self.buf.readInteger(endianness: .big, as: Int64.self))
+        self.buf.set(integer: 0xdeadbeef, at: 0, endianness: .little, as: UInt64.self)
+        XCTAssertEqual(0xdeadbeef, self.buf.getInteger(at: 0, endianness: .little, as: UInt64.self))
     }
 }
 


### PR DESCRIPTION
…gument so types can be specified

Motivation:

Sometimes getting read/getInteger to guess the type correctly can be
annoying and it's handy to just say `as: UInt8.self` or similar. In
other cases it's not as the type is clear from the environment. This now
enables both, just like we already have for `write/set(integer:)`

Modifications:

added an `as: T.Type = T.self` argument which is optional as it has a
default

Result:

easier to use `ByteBuffer` interfaces
