### PR TITLE
make ChannelPipeline.init public

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -662,8 +662,13 @@ public final class ChannelPipeline: ChannelInvoker {
         return eventLoop.inEventLoop
     }
 
-    // Only executed from Channel
-    init (channel: Channel) {
+    /// Create `ChannelPipeline` for a given `Channel`. This method should never be called by the end-user
+    /// directly: it is only intended for use with custom `Channel` implementations. Users should always use
+    /// `channel.pipeline` to access the `ChannelPipeline` for a `Channel`.
+    ///
+    /// - parameters:
+    ///    - channel: The `Channel` this `ChannelPipeline` is created for.
+    public init(channel: Channel) {
         self._channel = channel
         self.eventLoop = channel.eventLoop
 


### PR DESCRIPTION
Motivation:

There are a few network protocols that are best implemented with child
`Channel`s. And given that those child `Channels` need a
`ChannelPipeline` the init for `ChannelPipeline` should be public.
Otherwise these protocols can only be sensibly implemented in the core
`NIO` module which is unfair.

Modifications:

make `ChannelPipeline.init` public

Result:

modules other than `NIO` can implement child `Channel`s.
