### PR TITLE
Set Swift version to 4.0.3 in Docker configuration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN cd $HOME/.curl && ./configure --with-ssl && make && make install && cd -
 RUN ldconfig
 
 # swift
-ARG version=4.0.2
+ARG version=4.0.3
 RUN mkdir $HOME/.swift
 RUN wget -q https://swift.org/builds/swift-${version}-release/ubuntu1404/swift-${version}-RELEASE/swift-${version}-RELEASE-ubuntu14.04.tar.gz -O $HOME/swift.tar.gz
 RUN tar xzf $HOME/swift.tar.gz --directory $HOME/.swift --strip-components=1


### PR DESCRIPTION
Motivation:
In order to target the latest version of Swift and address this issue https://github.com/apple/swift-nio/issues/83

Modifications:
Set the Swift version to the latest (4.0.3)

Result:
Uniform version of Swift across the Ubuntu Docker image and a passing
test suite on all target platforms