### PR TITLE
Rename PriorityQueue's T to Element, and iterator to Iterator

### DIFF
--- a/Sources/NIOPriorityQueue/PriorityQueue.swift
+++ b/Sources/NIOPriorityQueue/PriorityQueue.swift
@@ -12,26 +12,26 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct PriorityQueue<T: Comparable> {
-    private var heap: Heap<T>
+public struct PriorityQueue<Element: Comparable> {
+    private var heap: Heap<Element>
 
     public init(ascending: Bool = false) {
         self.heap = Heap(type: ascending ? .minHeap : .maxHeap)
     }
 
-    public mutating func remove(_ key: T) {
+    public mutating func remove(_ key: Element) {
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
         _ = self.heap.remove(value: key)
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
     }
 
-    public mutating func push(_ key: T) {
+    public mutating func push(_ key: Element) {
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
         self.heap.append(key)
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
     }
 
-    public func peek() -> T? {
+    public func peek() -> Element? {
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
         return self.heap.storage.first
     }
@@ -41,7 +41,7 @@ public struct PriorityQueue<T: Comparable> {
         return self.heap.storage.isEmpty
     }
 
-    public mutating func pop() -> T? {
+    public mutating func pop() -> Element? {
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
         return self.heap.removeRoot()
     }
@@ -52,30 +52,26 @@ public struct PriorityQueue<T: Comparable> {
 }
 
 extension PriorityQueue: Equatable {
-    public static func ==(lhs: PriorityQueue<T>, rhs: PriorityQueue<T>) -> Bool {
+    public static func ==(lhs: PriorityQueue<Element>, rhs: PriorityQueue<Element>) -> Bool {
         return Array(lhs) == Array(rhs)
     }
 }
 
 extension PriorityQueue: Sequence {
-    public struct PriorityQueueIterator<T: Comparable>: IteratorProtocol {
-        public typealias Element = T
+    public struct Iterator: IteratorProtocol {
 
-        private var queue: PriorityQueue<T>
-        fileprivate init(queue: PriorityQueue<T>) {
+        private var queue: PriorityQueue<Element>
+        fileprivate init(queue: PriorityQueue<Element>) {
             self.queue = queue
         }
 
-        public mutating func next() -> T? {
+        public mutating func next() -> Element? {
             return self.queue.pop()
         }
     }
 
-    public typealias Element = T
-    public typealias Iterator = PriorityQueueIterator<T>
-
-    public func makeIterator() -> PriorityQueueIterator<Element> {
-        return PriorityQueueIterator(queue: self)
+    public func makeIterator() -> Iterator {
+        return Iterator(queue: self)
     }
 }
 
@@ -89,4 +85,16 @@ extension PriorityQueue: CustomStringConvertible {
     public var description: String {
         return "PriorityQueue(count: \(self.underestimatedCount)): \(Array(self))"
     }
+}
+
+extension PriorityQueue {
+  @available(*, deprecated, renamed: "Element")
+  public typealias T = Element
+  @available(*, deprecated, renamed: "PriorityQueue.Iterator")
+  public typealias PriorityQueueIterator<T: Comparable> = PriorityQueue<T>.Iterator
+}
+
+extension PriorityQueue.Iterator {
+  @available(*, deprecated, renamed: "Element")
+  public typealias T = Element
 }


### PR DESCRIPTION
Note, there are quite a few places where this could be applied, just floating this as a first trial to get feedback.

Motivation:

We've found following these conventions in the standard library simplifies the code significantly if you create a lot of generic types that conform to the std lib protocols.

Modifications:

Change the placeholder T to Element and remove now-unnecessary typealias.
Switch the name of the iterator to just Iterator, and have it re-use the outer type's Element placeholder. Remove now-unnecessary typealiases.

Result:

Should be a non-functional change.
