### PR TITLE
Nest HTTPHeaderIterator inside HTTPHeader, un-erase makeIterator()

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -148,35 +148,6 @@ public struct HTTPResponseHead: Equatable {
 fileprivate typealias HTTPHeadersStorage = [String: [(String, String)]] // [lowerCasedName: [(originalCaseName, value)]
 
 
-/// An iterator of HTTP header fields.
-///
-/// This iterator will return each value for a given header name separately. That
-/// means that `name` is not guaranteed to be unique in a given block of headers.
-struct HTTPHeadersIterator: IteratorProtocol {
-    fileprivate var storageIterator: HTTPHeadersStorage.Iterator
-    fileprivate var valuesIterator: Array<(String, String)>.Iterator?
-
-    fileprivate init(wrapping: HTTPHeadersStorage.Iterator) {
-        self.storageIterator = wrapping
-    }
-
-    mutating func next() -> (name: String, value: String)? {
-        // If we're already iterating an entry in the dict, grab the next one
-        if let nextValues = valuesIterator?.next() {
-            return nextValues
-        } else {
-            // If there's nothing left in this array, clear the iterator
-            valuesIterator = nil
-        }
-
-        if let entry = storageIterator.next() {
-            valuesIterator = entry.value.makeIterator()
-            return next()
-        } else {
-            return nil
-        }
-    }
-}
 
 /// A representation of a block of HTTP header fields.
 ///
@@ -190,7 +161,7 @@ struct HTTPHeadersIterator: IteratorProtocol {
 /// field when needed. It also supports recomposing headers to a maximally joined
 /// or split representation, such that header fields that are able to be repeated
 /// can be represented appropriately.
-public struct HTTPHeaders: Sequence, CustomStringConvertible {
+public struct HTTPHeaders: CustomStringConvertible {
 
     // [lowerCasedName: [(originalCaseName, value)]
     private var storage: HTTPHeadersStorage = HTTPHeadersStorage()
@@ -316,10 +287,6 @@ public struct HTTPHeaders: Sequence, CustomStringConvertible {
         }
     }
 
-    public func makeIterator() -> AnyIterator<(name: String, value: String)> {
-        return AnyIterator(HTTPHeadersIterator(wrapping: storage.makeIterator()))
-    }
-
     /// Retrieves the header values for the given header field in "canonical form": that is,
     /// splitting them on commas as extensively as possible such that multiple values received on the
     /// one line are returned as separate entries. Also respects the fact that Set-Cookie should not
@@ -339,6 +306,55 @@ public struct HTTPHeaders: Sequence, CustomStringConvertible {
         }
         return []
     }
+}
+
+extension HTTPHeaders: Sequence {
+    public typealias Element = (name: String, value: String)
+  
+    /// An iterator of HTTP header fields.
+    ///
+    /// This iterator will return each value for a given header name separately. That
+    /// means that `name` is not guaranteed to be unique in a given block of headers.
+    public struct Iterator: IteratorProtocol {
+        private var storageIterator: HTTPHeadersStorage.Iterator
+        private var valuesIterator: Array<(String, String)>.Iterator?
+
+        fileprivate init(wrapping: HTTPHeadersStorage.Iterator) {
+            self.storageIterator = wrapping
+        }
+
+        public mutating func next() -> Element? {
+            // If we're already iterating an entry in the dict, grab the next one
+            if let nextValues = valuesIterator?.next() {
+                return nextValues
+            } else {
+                // If there's nothing left in this array, clear the iterator
+                valuesIterator = nil
+            }
+
+            if let entry = storageIterator.next() {
+                valuesIterator = entry.value.makeIterator()
+                return next()
+            } else {
+                return nil
+            }
+        }
+    }  
+
+    public func makeIterator() -> Iterator {
+        return Iterator(wrapping: storage.makeIterator())
+    }
+}
+
+// Dance to ensure that this version of makeIterator(), which returns
+// an AnyIterator, is only called when forced through type context.
+protocol _DeprecateHTTPHeaderIterator: Sequence { }
+extension HTTPHeaders: _DeprecateHTTPHeaderIterator { }
+extension _DeprecateHTTPHeaderIterator {
+  @available(*, deprecated, message: "Please use the HTTPHeaders.Iterator type")
+  func makeIterator() -> AnyIterator<Element> {
+    return AnyIterator(makeIterator() as Iterator)
+  }  
 }
 
 /* private but tests */ internal extension Character {


### PR DESCRIPTION
Similar to #91 and #93, but in this case the un-nested iterator was already internal, but there was use of a type-erased `AnyIterator` that seems like it could be eliminated. @weissi do you know the background for the type-erasure? Anything I'm missing?

Motivation:

Simplifies the code by putting the iterator in HTTPHeader's namespace.

Additionally, removing the type erasure should result in more performant code as `AnyIterator` is an optimization barrier. The type erasure did not appear to be adding an abstraction benefit.

Modifications:

Nested (internal) type `HTTPHeaderIterator` as `HTTPHeader.Iterator`
Explicit rather than inferred types for `Element` and `Iterator`.
Eliminated `AnyIterator` wrapper from `makeIterator()`
Added lower-priority version that still returns `AnyIterator` for source compatibility purposes.

Result:

Unless caller was explicitly typing the iterator, should have no noticeable impact other than performance.