### PR TITLE
Correctly update cached addresses for accepted Channels.

### DIFF
--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -206,6 +206,9 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         self.active.store(false)
         self.recvAllocator = recvAllocator
         self._pipeline = ChannelPipeline(channel: self)
+        // As the socket may already be connected we should ensure we start with the correct addresses cached.
+        self.localAddressCached.store(Box(try? socket.localAddress()))
+        self.remoteAddressCached.store(Box(try? socket.remoteAddress()))
     }
 
     deinit {

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -55,6 +55,7 @@ extension ChannelTests {
                 ("testRejectsInvalidData", testRejectsInvalidData),
                 ("testWeDontCrashIfChannelReleasesBeforePipeline", testWeDontCrashIfChannelReleasesBeforePipeline),
                 ("testAskForLocalAndRemoteAddressesAfterChannelIsClosed", testAskForLocalAndRemoteAddressesAfterChannelIsClosed),
+                ("testReceiveAddressAfterAccept", testReceiveAddressAfterAccept),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

We missed to correctly update the cached remote and local addresses for accepted Channels. Because of this localAddress and remoteAddr always returned nil.

Modifications:

- Update cached addresses when constructing SocketChannel from existing Socket.
- Add testcase

Result:

Fixes [#97].