### PR TITLE
Change class func to static on Thread.

### DIFF
--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -76,7 +76,7 @@ final class Thread {
     /// - arguments:
     ///     - name: The name of the `Thread` or `nil` if no specific name should be set.
     ///     - body: The function to execute within the spawned `Thread`.
-    class func spawnAndRun(name: String? = nil, body: @escaping (Thread) -> Void) {
+    static func spawnAndRun(name: String? = nil, body: @escaping (Thread) -> Void) {
         // Unfortunally the pthread_create method take a different first argument depending on if its on linux or macOS, so ensure we use the correct one.
         #if os(Linux)
             var pt: pthread_t = pthread_t()


### PR DESCRIPTION
Change class func to static on Thread.

### Motivation:
Thread is declared final, so I believe spawnAndRun should be static.

### Modifications:
Change class func to static

### Result:
More consistent code, and spawnAndRun is statically dispatched.
