### PR TITLE
Declare ThreadSpecificVariable public

### DIFF
--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -130,7 +130,7 @@ final class Thread {
 /// returned by `currentValue` is defined per thread.
 ///
 /// - note: `ThreadSpecificVariable` has reference semantics.
-internal struct ThreadSpecificVariable<T: AnyObject> {
+public struct ThreadSpecificVariable<T: AnyObject> {
     private let key: pthread_key_t
 
     /// Initialize a new `ThreadSpecificVariable` without a current value (`currentValue == nil`).


### PR DESCRIPTION
Motivation:

It's often useful for users to be able to store a thread-specific value (and so also EventLoop specific). We have ThreadSpecificVariable for this which was internal.

Modifications:

Change ThreadSpecificVariable to be public.

Result:

Fixes [#61].