### PR TITLE
Fix issue #110, IPv6 address desc contains 0 bytes

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -32,7 +32,7 @@ private func descriptionForAddress(family: CInt, bytes: UnsafeRawPointer, length
                              addressDescription: addressBytesPtr.baseAddress!,
                              addressDescriptionLength: socklen_t(byteCount))
         return addressBytesPtr.baseAddress!.withMemoryRebound(to: UInt8.self, capacity: byteCount) { addressBytesPtr -> String in
-            return String(decoding: UnsafeBufferPointer<UInt8>(start: addressBytesPtr, count: byteCount), as: Unicode.ASCII.self)
+            return String(cString: addressBytesPtr)
         }
     }
 }


### PR DESCRIPTION
### Motivation:

Fix for issue #110, .description on IPv6 addresses
return a String with 0 codepoints in it, like so:

  [IPv6]::1<NUL><NUL><NUL>....lots..

### Modifications:

Use String(cString:) instead of decode, which doesn't
care about \0-cstr terminators.

### Result:

Issue fixed, everything is awesome, everyone is happy.
