### PR TITLE
Do not try to use the resolver if ip string is used when connect

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -311,6 +311,11 @@ public final class ClientBootstrap {
     ///     - port: The port to connect to.
     /// - returns: An `EventLoopFuture<Channel>` to deliver the `Channel` when connected.
     public func connect(host: String, port: Int) -> EventLoopFuture<Channel> {
+        // First check if the given "host" was actual an ipaddress and if so use it directly without
+        // even try to use the resolver.
+        if let address = try? SocketAddress(ipAddress: host, port: UInt16(port)) {
+            return connect(to: address)
+        }
         let loop = self.group.next()
         let connector = HappyEyeballsConnector(resolver: resolver ?? GetaddrinfoResolver(loop: loop),
                                                loop: loop,

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -57,6 +57,8 @@ extension ChannelTests {
                 ("testAskForLocalAndRemoteAddressesAfterChannelIsClosed", testAskForLocalAndRemoteAddressesAfterChannelIsClosed),
                 ("testReceiveAddressAfterAccept", testReceiveAddressAfterAccept),
                 ("testWeDontJamSocketsInANoIOState", testWeDontJamSocketsInANoIOState),
+                ("testBootstrapNoResolverUsedWhenIPUsed", testBootstrapNoResolverUsedWhenIPUsed),
+                ("testBootstrapResolverUsedWhenHostnameUsed", testBootstrapResolverUsedWhenHostnameUsed),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

We should not try to use the resolver if an ip is given as host string when connect the remote peer.

Modifications:

Add check if ip is used and if so not use the resolver.

Result:

Fast-path for the case of ip address usage when connect.