### PR TITLE
Make clear generate_linux_tests must be run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,10 @@ We require that your commit messages match our template. The easiest way to do t
 
     git config commit.template dev/git.commit.template
 
-### Test on Linux
+### Make sure Tests work on Linux
 
-SwiftNIO uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not. For this reason, whenever you add new tests you will want to run a script that generates the hooks needed to run those tests on Linux, or our CI will complain that the tests are not all present on Linux. To do this, merely execute `ruby generate_linux_tests.rb` at the root of the package and check the changes it made.
+SwiftNIO uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not. 
+For this reason, whenever you add new tests **you have to run a script** that generates the hooks needed to run those tests on Linux, or our CI will complain that the tests are not all present on Linux. To do this, merely execute `ruby ./scripts/generate_linux_tests.rb` at the root of the package and check the changes it made.
 
 ## How to contribute your work
 


### PR DESCRIPTION
Motivation:

The path of the script to invoke was wrong,
also highlight that this is absolutely required
for a PR.

Modifications:

Some bold, some text, some proper path.

Result:

CI will be super happy as less people will
fail to generate proper Linux tests.

P.S.: FWIW, if there is a script that works, the CI should probably just run it in the first place.