### PR TITLE
Our sample HTTP server should respect HTTP keep-alive.

### DIFF
--- a/IntegrationTests/tests_01_http/test_18_close_with_no_keepalive.sh
+++ b/IntegrationTests/tests_01_http/test_18_close_with_no_keepalive.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+source defines.sh
+
+token=$(create_token)
+start_server "$token"
+htdocs=$(get_htdocs "$token")
+server_pid=$(get_server_pid "$token")
+socket=$(get_socket "$token")
+
+kill -0 $server_pid
+
+echo -e 'GET /dynamic/count-to-ten HTTP/1.1\r\nConnection: close\r\n\r\n' | \
+    nc -U "$socket" > "$tmp/actual"
+backslash_r=$(echo -ne '\r')
+cat > "$tmp/expected" <<EOF
+HTTP/1.1 200 OK$backslash_r
+transfer-encoding: chunked$backslash_r
+$backslash_r
+1$backslash_r
+1$backslash_r
+1$backslash_r
+2$backslash_r
+1$backslash_r
+3$backslash_r
+1$backslash_r
+4$backslash_r
+1$backslash_r
+5$backslash_r
+1$backslash_r
+6$backslash_r
+1$backslash_r
+7$backslash_r
+1$backslash_r
+8$backslash_r
+1$backslash_r
+9$backslash_r
+2$backslash_r
+10$backslash_r
+0$backslash_r
+$backslash_r
+EOF
+assert_equal_files "$tmp/expected" "$tmp/actual"
+stop_server "$token"

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -41,8 +41,30 @@ private final class HTTPHandler: ChannelInboundHandler {
     public typealias InboundIn = HTTPServerRequestPart
     public typealias OutboundOut = HTTPServerResponsePart
 
+    private enum State {
+        case idle
+        case waitingForRequestBody
+        case sendingResponse
+
+        mutating func requestReceived() {
+            precondition(self == .idle, "Invalid state for request received: \(self)")
+            self = .waitingForRequestBody
+        }
+
+        mutating func requestComplete() {
+            precondition(self == .waitingForRequestBody, "Invalid state for request complete: \(self)")
+            self = .sendingResponse
+        }
+
+        mutating func responseComplete() {
+            precondition(self == .sendingResponse, "Invalid state for response complete: \(self)")
+            self = .idle
+        }
+    }
+
     private var buffer: ByteBuffer! = nil
     private var keepAlive = false
+    private var state = State.idle
     private let htdocsPath: String
 
     private var infoSavedRequestHead: HTTPRequestHead?
@@ -64,9 +86,13 @@ private final class HTTPHandler: ChannelInboundHandler {
         case .head(let request):
             self.infoSavedRequestHead = request
             self.infoSavedBodyBytes = 0
+            self.keepAlive = request.isKeepAlive
+            self.state.requestReceived()
         case .body(buffer: let buf):
             self.infoSavedBodyBytes += buf.readableBytes
         case .end(_):
+            self.state.requestComplete()
+
             let response = """
             HTTP method: \(self.infoSavedRequestHead!.method)\r
             URL: \(self.infoSavedRequestHead!.uri)\r
@@ -81,7 +107,7 @@ private final class HTTPHandler: ChannelInboundHandler {
             headers.add(name: "Content-Length", value: "\(response.utf8.count)")
             ctx.write(self.wrapOutboundOut(.head(HTTPResponseHead(version: self.infoSavedRequestHead!.version, status: .ok, headers: headers))), promise: nil)
             ctx.write(self.wrapOutboundOut(.body(.byteBuffer(self.buffer))), promise: nil)
-            ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+            self.completeResponse(ctx, trailers: nil, promise: nil)
         }
     }
 
@@ -92,6 +118,8 @@ private final class HTTPHandler: ChannelInboundHandler {
     func handleEcho(ctx: ChannelHandlerContext, request: HTTPServerRequestPart, balloonInMemory: Bool = false) {
         switch request {
         case .head(let request):
+            self.keepAlive = request.isKeepAlive
+            self.state.requestReceived()
             if balloonInMemory {
                 self.buffer.clear()
             } else {
@@ -104,14 +132,15 @@ private final class HTTPHandler: ChannelInboundHandler {
                 ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buf))), promise: nil)
             }
         case .end(_):
+            self.state.requestComplete()
             if balloonInMemory {
                 var headers = HTTPHeaders()
                 headers.add(name: "Content-Length", value: "\(self.buffer.readableBytes)")
                 ctx.write(self.wrapOutboundOut(.head(HTTPResponseHead(version: HTTPVersion(major: 1, minor: 0), status: .ok, headers: headers))), promise: nil)
                 ctx.write(self.wrapOutboundOut(.body(.byteBuffer(self.buffer))), promise: nil)
-                ctx.write(self.wrapOutboundOut(.end(nil)), promise: nil)
+                self.completeResponse(ctx, trailers: nil, promise: nil)
             } else {
-                ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+                self.completeResponse(ctx, trailers: nil, promise: nil)
             }
         }
     }
@@ -119,10 +148,13 @@ private final class HTTPHandler: ChannelInboundHandler {
     func handleJustWrite(ctx: ChannelHandlerContext, request: HTTPServerRequestPart, statusCode: HTTPResponseStatus = .ok, string: String, trailer: (String, String)? = nil, delay: TimeAmount = .nanoseconds(0)) {
         switch request {
         case .head(let request):
+            self.keepAlive = request.isKeepAlive
+            self.state.requestReceived()
             ctx.writeAndFlush(self.wrapOutboundOut(.head(.init(version: request.version, status: .ok))), promise: nil)
         case .body(buffer: _):
             ()
         case .end(_):
+            self.state.requestComplete()
             _ = ctx.eventLoop.scheduleTask(in: delay) { () -> Void in
                 var buf = ctx.channel.allocator.buffer(capacity: string.utf8.count)
                 buf.write(string: string)
@@ -132,7 +164,8 @@ private final class HTTPHandler: ChannelInboundHandler {
                     trailers = HTTPHeaders()
                     trailers?.add(name: trailer.0, value: trailer.1)
                 }
-                ctx.writeAndFlush(self.wrapOutboundOut(.end(trailers)), promise: nil)
+
+                self.completeResponse(ctx, trailers: trailers, promise: nil)
             }
         }
     }
@@ -140,7 +173,9 @@ private final class HTTPHandler: ChannelInboundHandler {
     func handleContinuousWrites(ctx: ChannelHandlerContext, request: HTTPServerRequestPart) {
         switch request {
         case .head(let request):
+            self.keepAlive = request.isKeepAlive
             self.continuousCount = 0
+            self.state.requestReceived()
             func doNext() {
                 self.buffer.clear()
                 self.continuousCount += 1
@@ -148,11 +183,13 @@ private final class HTTPHandler: ChannelInboundHandler {
                 ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(self.buffer)))).map {
                     _ = ctx.eventLoop.scheduleTask(in: .milliseconds(400), doNext)
                 }.whenFailure { (_: Error) in
-                    ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+                    self.completeResponse(ctx, trailers: nil, promise: nil)
                 }
             }
             ctx.writeAndFlush(self.wrapOutboundOut(.head(HTTPResponseHead(version: request.version, status: .ok))), promise: nil)
             doNext()
+        case .end:
+            self.state.requestComplete()
         default:
             ()
         }
@@ -161,7 +198,9 @@ private final class HTTPHandler: ChannelInboundHandler {
     func handleMultipleWrites(ctx: ChannelHandlerContext, request: HTTPServerRequestPart, strings: [String], delay: TimeAmount) {
         switch request {
         case .head(let request):
+            self.keepAlive = request.isKeepAlive
             self.continuousCount = 0
+            self.state.requestReceived()
             func doNext() {
                 self.buffer.clear()
                 self.buffer.write(string: strings[self.continuousCount])
@@ -169,15 +208,17 @@ private final class HTTPHandler: ChannelInboundHandler {
                     if self.continuousCount < strings.count - 1 {
                         _ = ctx.eventLoop.scheduleTask(in: delay, doNext)
                     } else {
-                        ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+                        self.completeResponse(ctx, trailers: nil, promise: nil)
                     }
                 }
                 self.continuousCount += 1
             }
             ctx.writeAndFlush(self.wrapOutboundOut(.head(HTTPResponseHead(version: request.version, status: .ok))), promise: nil)
             doNext()
+        case .end:
+            self.state.requestComplete()
         default:
-            ()
+            break
         }
     }
 
@@ -198,7 +239,7 @@ private final class HTTPHandler: ChannelInboundHandler {
         case "/dynamic/continuous":
             return self.handleContinuousWrites
         case "/dynamic/count-to-ten":
-            return { self.handleMultipleWrites(ctx: $0, request: $1, strings: (1...10).map { "\($0)\r\n" }, delay: .milliseconds(100)) }
+            return { self.handleMultipleWrites(ctx: $0, request: $1, strings: (1...10).map { "\($0)" }, delay: .milliseconds(100)) }
         case "/dynamic/client-ip":
             return { ctx, req in self.handleJustWrite(ctx: ctx, request: req, string: "\(ctx.remoteAddress.debugDescription)") }
         default:
@@ -211,10 +252,12 @@ private final class HTTPHandler: ChannelInboundHandler {
 
         switch request {
         case .head(let request):
+            self.keepAlive = request.isKeepAlive
+            self.state.requestReceived()
             guard !request.uri.containsDotDot() else {
                 let response = HTTPResponseHead(version: request.version, status: .forbidden)
                 ctx.write(self.wrapOutboundOut(.head(response)), promise: nil)
-                ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+                self.completeResponse(ctx, trailers: nil, promise: nil)
                 return
             }
             let path = self.htdocsPath + "/" + path
@@ -229,7 +272,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                 switch ioMethod {
                 case .nonblockingFileIO:
                     var responseStarted = false
-                    self.fileIO.readChunked(fileRegion: region,
+                    let f = self.fileIO.readChunked(fileRegion: region,
                                             chunkSize: 32 * 1024,
                                             allocator: ctx.channel.allocator,
                                             eventLoop: ctx.eventLoop) { buffer in
@@ -238,27 +281,33 @@ private final class HTTPHandler: ChannelInboundHandler {
                                                     ctx.write(self.wrapOutboundOut(.head(response)), promise: nil)
                                                 }
                                                 return ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buffer))))
-                        }.then {
-                            ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)))
-                        }.thenIfError { error in
-                            if !responseStarted {
-                                let response = HTTPResponseHead(version: request.version, status: .ok)
-                                ctx.write(self.wrapOutboundOut(.head(response)), promise: nil)
-                                var buffer = ctx.channel.allocator.buffer(capacity: 100)
-                                buffer.write(string: "fail: \(error)")
-                                ctx.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
-                                return ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)))
-                            } else {
-                                return ctx.close()
-                            }
-                        }.whenComplete {
-                            _ = try? file.close()
+                                            }
+                    f.then { (_: Void) -> EventLoopFuture<Void> in
+                        let p: EventLoopPromise<Void> = ctx.eventLoop.newPromise()
+                        self.completeResponse(ctx, trailers: nil, promise: p)
+                        return p.futureResult
+                    }.thenIfError { error in
+                        if !responseStarted {
+                            let response = HTTPResponseHead(version: request.version, status: .ok)
+                            ctx.write(self.wrapOutboundOut(.head(response)), promise: nil)
+                            var buffer = ctx.channel.allocator.buffer(capacity: 100)
+                            buffer.write(string: "fail: \(error)")
+                            ctx.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+                            self.state.responseComplete()
+                            return ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)))
+                        } else {
+                            return ctx.close()
                         }
+                    }.whenComplete {
+                        _ = try? file.close()
+                    }
                 case .sendfile:
                     ctx.write(self.wrapOutboundOut(.head(response))).then {
                         ctx.writeAndFlush(self.wrapOutboundOut(.body(.fileRegion(region))))
-                    }.then {
-                        ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)))
+                    }.then { (_: Void) in
+                        let p: EventLoopPromise<Void> = ctx.eventLoop.newPromise()
+                        self.completeResponse(ctx, trailers: nil, promise: p)
+                        return p.futureResult
                     }.thenIfError { (_: Error) in
                         ctx.close()
                     }.whenComplete {
@@ -290,9 +339,19 @@ private final class HTTPHandler: ChannelInboundHandler {
                 ctx.channel.close(promise: nil)
             }
         case .end(_):
-            ()
+            self.state.requestComplete()
         default:
             fatalError("oh noes: \(request)")
+        }
+    }
+
+    private func completeResponse(_ ctx: ChannelHandlerContext, trailers: HTTPHeaders?, promise: EventLoopPromise<Void>?) {
+        self.state.responseComplete()
+        let promise = self.keepAlive ? promise : (promise ?? ctx.eventLoop.newPromise())
+        ctx.writeAndFlush(self.wrapOutboundOut(.end(trailers)), promise: promise)
+
+        if !self.keepAlive {
+            promise!.futureResult.whenComplete { ctx.close(promise: nil) }
         }
     }
 
@@ -305,8 +364,6 @@ private final class HTTPHandler: ChannelInboundHandler {
 
         switch reqPart {
         case .head(let request):
-            keepAlive = request.isKeepAlive
-
             if request.uri.unicodeScalars.starts(with: "/dynamic".unicodeScalars) {
                 self.handler = self.dynamicHandler(request: request)
                 self.handler!(ctx, reqPart)
@@ -321,6 +378,9 @@ private final class HTTPHandler: ChannelInboundHandler {
                 return
             }
 
+            self.keepAlive = request.isKeepAlive
+            self.state.requestReceived()
+
             var responseHead = HTTPResponseHead(version: request.version, status: HTTPResponseStatus.ok)
             responseHead.headers.add(name: "content-length", value: "12")
             let response = HTTPServerResponsePart.head(responseHead)
@@ -328,16 +388,10 @@ private final class HTTPHandler: ChannelInboundHandler {
         case .body:
             break
         case .end:
+            self.state.requestComplete()
             let content = HTTPServerResponsePart.body(.byteBuffer(buffer!.slice()))
             ctx.write(self.wrapOutboundOut(content), promise: nil)
-
-            if keepAlive {
-                ctx.write(self.wrapOutboundOut(HTTPServerResponsePart.end(nil)), promise: nil)
-            } else {
-                ctx.write(self.wrapOutboundOut(HTTPServerResponsePart.end(nil))).whenComplete {
-                    ctx.close(promise: nil)
-                }
-            }
+            self.completeResponse(ctx, trailers: nil, promise: nil)
         }
     }
 
@@ -348,6 +402,24 @@ private final class HTTPHandler: ChannelInboundHandler {
     func handlerAdded(ctx: ChannelHandlerContext) {
         self.buffer = ctx.channel.allocator.buffer(capacity: 12)
         self.buffer.write(staticString: "Hello World!")
+    }
+
+    func userInboundEventTriggered(ctx: ChannelHandlerContext, event: Any) {
+        switch event {
+        case let evt as ChannelEvent where evt == ChannelEvent.inputClosed:
+            // The remote peer half-closed the channel. At this time, any
+            // outstanding response will now get the channel closed, and
+            // if we are idle or waiting for a request body to finish we
+            // will close the channel immediately.
+            switch self.state {
+            case .idle, .waitingForRequestBody:
+                ctx.close(promise: nil)
+            case .sendingResponse:
+                self.keepAlive = false
+            }
+        default:
+            ctx.fireUserInboundEventTriggered(event)
+        }
     }
 }
 
@@ -407,6 +479,7 @@ let bootstrap = ServerBootstrap(group: group)
     .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
     .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+    .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
 
 defer {
     try! group.syncShutdownGracefully()


### PR DESCRIPTION
Motivation:

Currently our HTTP server almost always just assumes that keep-alive is enabled. It really shouldn't, it should validate more carefully. Additionally, it mishandles TCP half-close in a way that breaks with netcat.

Modifications:

Added keep-alive tracking to all handlers and ensured that connections will be closed after a response to a keep-alive request has been sent. Also add support for handling TCP half-close.

Result:

Non-keep-alive connections will be closed by the server in all cases. Half-closed connections will be appropriately managed.