### PR TITLE
Download curl from https endpoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 
 #RUN apt-get install -y curl
 RUN apt-get install -y build-essential libssl-dev
 RUN mkdir $HOME/.curl
-RUN wget -q http://curl.haxx.se/download/curl-7.50.3.tar.gz -O $HOME/curl.tar.gz
+RUN wget -q https://curl.haxx.se/download/curl-7.50.3.tar.gz -O $HOME/curl.tar.gz
 RUN tar xzf $HOME/curl.tar.gz --directory $HOME/.curl --strip-components=1
 RUN cd $HOME/.curl && ./configure --with-ssl && make && make install && cd -
 RUN ldconfig


### PR DESCRIPTION
Currently the Dockerfile pulls curl from and http endpoint. This change switches that to use https

### Motivation:

This is a modest but easy win to make the curl download more secure

### Modifications:

1 character addition to swap the curl host from http to https

### Result:

With this in place, users who run the Dockerfile will be more confident that the file the receive purporting to be curl will, in fact, be curl
