### PR TITLE
fixed doc comment `ByteBuffer#readString(length: Int)` 

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -123,7 +123,7 @@ extension ByteBuffer {
         }
     }
 
-    /// Read `length` bytes off this `ByteBuffer`, decoding it as `String` using the UTF-8 encoding. Does not move the reader index.
+    /// Read `length` bytes off this `ByteBuffer`, decoding it as `String` using the UTF-8 encoding. Move the reader index forward by `length`.
     ///
     /// - parameters:
     ///     - length: The number of bytes making up the string.


### PR DESCRIPTION
Fixed Doc per discussion with @Lukasa.

### Motivation:

The accuracy of documentation so developers such as myself using `swift-nio` will be able to use the method `ByteBuffer#readString(length: Int)` with confidence, was the motivation for this patch.

### Modifications:

Changed the doc comment, to indicate that the aforementioned method is documented correctly.

### Result:

Applying this patch does not change the code base logically, it only changes the documentation.
