### PR TITLE
Add support to obtain the current EventLoop

### DIFF
--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -34,6 +34,7 @@ extension EventLoopTest {
                 ("testEventLoopThreads", testEventLoopThreads),
                 ("testEventLoopPinned", testEventLoopPinned),
                 ("testEventLoopPinnedCPUIdsConstructor", testEventLoopPinnedCPUIdsConstructor),
+                ("testCurrentEventLoop", testCurrentEventLoop),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

In certain cases it would be useful to be able to access the current EventLoop (which is tied to a thread).

Modifications:

- Add MultiThreadEventLoopGroup.currentEventLoop
- Add tests

Result:

Fixes [#59]