### PR TITLE
Remove return when possible.

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -32,7 +32,7 @@ private func descriptionForAddress(family: CInt, bytes: UnsafeRawPointer, length
                              addressDescription: addressBytesPtr.baseAddress!,
                              addressDescriptionLength: socklen_t(byteCount))
         return addressBytesPtr.baseAddress!.withMemoryRebound(to: UInt8.self, capacity: byteCount) { addressBytesPtr -> String in
-            return String(cString: addressBytesPtr)
+            String(cString: addressBytesPtr)
         }
     }
 }

--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -74,7 +74,7 @@ extension ByteBuffer {
     /// - returns: The number of bytes written.
     public mutating func set(staticString string: StaticString, at index: Int) -> Int {
         return string.withUTF8Buffer { ptr -> Int in
-            return self.set(bytes: UnsafeRawBufferPointer(ptr), at: index)
+            self.set(bytes: UnsafeRawBufferPointer(ptr), at: index)
         }
     }
 

--- a/Sources/NIO/Linux.swift
+++ b/Sources/NIO/Linux.swift
@@ -91,7 +91,7 @@ internal enum Epoll {
     @inline(never)
     public static func epoll_wait(epfd: Int32, events: UnsafeMutablePointer<epoll_event>, maxevents: Int32, timeout: Int32) throws -> Int32 {
         return try wrapSyscall {
-            return CNIOLinux.epoll_wait(epfd, events, maxevents, timeout)
+            CNIOLinux.epoll_wait(epfd, events, maxevents, timeout)
         }
     }
 }

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -125,7 +125,7 @@ public struct NonBlockingFileIO {
                 let readSize = remainingReads > 1 ? chunkSize : lastReadSize
                 assert(readSize > 0)
                 return self.read(fileHandle: fileHandle, byteCount: readSize, allocator: allocator, eventLoop: eventLoop).then { buffer in
-                    return chunkHandler(buffer).then { () -> EventLoopFuture<()> in
+                    chunkHandler(buffer).then { () -> EventLoopFuture<()> in
                         assert(eventLoop.inEventLoop)
                         return _read(remainingReads: remainingReads - 1)
                     }

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -248,11 +248,11 @@ public enum SocketAddress: CustomStringConvertible {
             switch info.pointee.ai_family {
             case AF_INET:
                 return info.pointee.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { ptr in
-                    return .v4(.init(address: ptr.pointee, host: host))
+                    .v4(.init(address: ptr.pointee, host: host))
                 }
             case AF_INET6:
                 return info.pointee.ai_addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { ptr in
-                    return .v6(.init(address: ptr.pointee, host: host))
+                    .v6(.init(address: ptr.pointee, host: host))
                 }
             default:
                 throw SocketAddressError.unsupported

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -1256,7 +1256,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             return try self.socket.sendto(pointer: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), size: ptr.count,
                                           destinationPtr: destinationPtr, destinationSize: destinationSize)
         }, vectorWriteOperation: { msgs in
-            return try self.socket.sendmmsg(msgs: msgs)
+            try self.socket.sendmmsg(msgs: msgs)
         })
         if result.writable {
             // writable again

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -440,7 +440,7 @@ internal enum KQueue {
     @inline(never)
     public static func kevent(kq: CInt, changelist: UnsafePointer<kevent>?, nchanges: CInt, eventlist: UnsafeMutablePointer<kevent>?, nevents: CInt, timeout: UnsafePointer<Darwin.timespec>?) throws -> CInt {
         return try wrapSyscall {
-            return sysKevent(kq, changelist, nchanges, eventlist, nevents, timeout)
+            sysKevent(kq, changelist, nchanges, eventlist, nevents, timeout)
         }
     }
 }

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -32,7 +32,7 @@ import struct Foundation.Data
 extension Data: ContiguousCollection {
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> R in
-            return try body(UnsafeRawBufferPointer(start: ptr, count: self.count))
+            try body(UnsafeRawBufferPointer(start: ptr, count: self.count))
         }
     }
 }

--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
@@ -120,7 +120,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let continuePromise: EventLoopPromise<Void> = loop.newPromise()
 
         let handler = ApplicationProtocolNegotiationHandler { result in
-            return continuePromise.futureResult
+            continuePromise.futureResult
         }
 
         try channel.pipeline.add(handler: handler).wait()
@@ -151,7 +151,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let continuePromise: EventLoopPromise<Void> = loop.newPromise()
 
         let handler = ApplicationProtocolNegotiationHandler { result in
-            return continuePromise.futureResult
+            continuePromise.futureResult
         }
         let readCompleteHandler = ReadCompletedHandler()
 
@@ -178,7 +178,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let continuePromise: EventLoopPromise<Void> = loop.newPromise()
 
         let handler = ApplicationProtocolNegotiationHandler { result in
-            return continuePromise.futureResult
+            continuePromise.futureResult
         }
         let readCompleteHandler = ReadCompletedHandler()
 

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -87,7 +87,7 @@ class ChannelPipelineTest: XCTestCase {
 
         _ = try channel.pipeline.add(handler: NoBindAllowed()).wait()
         _ = try channel.pipeline.add(handler: TestChannelOutboundHandler<ByteBuffer, ByteBuffer> { data in
-            return data
+            data
         }).wait()
 
         _ = try channel.connect(to: sa).wait()

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -553,7 +553,7 @@ public class ChannelTests: XCTestCase {
              `[[1, 1, 1, 1], [1, 1, 1], [1, 1], [1]]`
              */
             let expectedVectorWrites = Array((2...numberOfBytes).reversed()).map { n in
-                return Array(repeating: 1, count: n)
+                Array(repeating: 1, count: n)
             }
 
             /* this will create an `Array` like this (for `numberOfBytes == 4`)
@@ -659,8 +659,8 @@ public class ChannelTests: XCTestCase {
     /// Test that with a few massive buffers, we don't offer more than we should to `writev` if the individual chunks fit.
     func testPendingWritesNoMoreThanWritevLimitIsWritten() throws {
         let el = EmbeddedEventLoop()
-        let alloc = ByteBufferAllocator(hookedMalloc: { _ in return UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)! },
-                                        hookedRealloc: { _, _ in return UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)! },
+        let alloc = ByteBufferAllocator(hookedMalloc: { _ in UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)! },
+                                        hookedRealloc: { _, _ in UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)! },
                                         hookedFree: { _ in },
                                         hookedMemcpy: { _, _, _ in })
         /* each buffer is half the writev limit */
@@ -691,8 +691,8 @@ public class ChannelTests: XCTestCase {
     /// Test that with a massive buffers (bigger than writev size), we don't offer more than we should to `writev`.
     func testPendingWritesNoMoreThanWritevLimitIsWrittenInOneMassiveChunk() throws {
         let el = EmbeddedEventLoop()
-        let alloc = ByteBufferAllocator(hookedMalloc: { _ in return UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)! },
-                                        hookedRealloc: { _, _ in return UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)! },
+        let alloc = ByteBufferAllocator(hookedMalloc: { _ in UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)! },
+                                        hookedRealloc: { _, _ in UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)! },
                                         hookedFree: { _ in },
                                         hookedMemcpy: { _, _, _ in })
         /* each buffer is half the writev limit */
@@ -1097,8 +1097,8 @@ public class ChannelTests: XCTestCase {
         let verificationHandler = ShutdownVerificationHandler(shutdownEvent: .output, promise: group.next().newPromise())
         let future = ClientBootstrap(group: group)
             .channelInitializer { channel in
-                return channel.pipeline.add(handler: verificationHandler).then {
-                    return channel.pipeline.add(handler: byteCountingHandler)
+                channel.pipeline.add(handler: verificationHandler).then {
+                    channel.pipeline.add(handler: byteCountingHandler)
                 }
             }
             .connect(to: try! server.localAddress())
@@ -1161,8 +1161,8 @@ public class ChannelTests: XCTestCase {
         let verificationHandler = ShutdownVerificationHandler(shutdownEvent: .input, promise: group.next().newPromise())
         let future = ClientBootstrap(group: group)
             .channelInitializer { channel in
-                return channel.pipeline.add(handler: VerifyNoReadHandler()).then {
-                    return channel.pipeline.add(handler: verificationHandler)
+                channel.pipeline.add(handler: VerifyNoReadHandler()).then {
+                    channel.pipeline.add(handler: verificationHandler)
                 }
             }
             .connect(to: try! server.localAddress())
@@ -1216,7 +1216,7 @@ public class ChannelTests: XCTestCase {
 
         let future = ClientBootstrap(group: group)
             .channelInitializer { channel in
-                return channel.pipeline.add(handler: verificationHandler)
+                channel.pipeline.add(handler: verificationHandler)
             }
             .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
             .connect(to: try! server.localAddress())
@@ -1464,7 +1464,7 @@ public class ChannelTests: XCTestCase {
                 return loop.submit {
                     self.waitingForReadPromise = loop.newPromise()
                 }.then { (_: Void) in
-                    return self.waitingForReadPromise!.futureResult
+                    self.waitingForReadPromise!.futureResult
                 }
             }
 

--- a/Tests/NIOTests/EmbeddedEventLoopTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest.swift
@@ -194,7 +194,7 @@ public class EmbeddedEventLoopTest: XCTestCase {
     func testScheduledTasksFuturesFire() throws {
         var fired = false
         let loop = EmbeddedEventLoop()
-        let task = loop.scheduleTask(in: .nanoseconds(5)) { return true }
+        let task = loop.scheduleTask(in: .nanoseconds(5)) { true }
         task.futureResult.whenSuccess { fired = $0 }
 
         loop.advanceTime(by: .nanoseconds(4))

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -26,7 +26,7 @@ public class EventLoopTest : XCTestCase {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
         let value = try eventLoopGroup.next().scheduleTask(in: amount) {
-            return true
+            true
         }.futureResult.wait()
 
         XCTAssertTrue(DispatchTime.now().uptimeNanoseconds - nanos >= amount.nanoseconds)
@@ -50,11 +50,11 @@ public class EventLoopTest : XCTestCase {
         // Now, schedule two tasks: one that takes a while, one that doesn't.
         let nanos = DispatchTime.now().uptimeNanoseconds
         let longFuture = eventLoopGroup.next().scheduleTask(in: longAmount) {
-            return true
+            true
         }.futureResult
 
         _ = try eventLoopGroup.next().scheduleTask(in: smallAmount) {
-            return true
+            true
         }.futureResult.wait()
 
         // Ok, the short one has happened. Now we should try connecting them. This connect should happen
@@ -83,7 +83,7 @@ public class EventLoopTest : XCTestCase {
         let nanos = DispatchTime.now().uptimeNanoseconds
         let amount: TimeAmount = .seconds(2)
         let value = try eventLoopGroup.next().scheduleTask(in: amount) {
-            return true
+            true
         }.futureResult.wait()
 
         XCTAssertTrue(DispatchTime.now().uptimeNanoseconds - nanos >= amount.nanoseconds)
@@ -221,7 +221,7 @@ public class EventLoopTest : XCTestCase {
             let group = MultiThreadedEventLoopGroup(pinnedCPUIds: [0])
             let eventLoop = group.next()
             let set = try eventLoop.submit {
-                return NIO.Thread.current.affinity
+                NIO.Thread.current.affinity
             }.wait()
 
             XCTAssertEqual(LinuxCPUSet(0), set)

--- a/Tests/NIOTests/SocketAddressTest.swift
+++ b/Tests/NIOTests/SocketAddressTest.swift
@@ -128,15 +128,15 @@ class SocketAddressTest: XCTestCase {
 
         var firstCopy = firstIPAddress.withMutableSockAddr { (addr, size) -> sockaddr_in in
             XCTAssertEqual(size, MemoryLayout<sockaddr_in>.size)
-            return addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { return $0.pointee }
+            return addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee }
         }
         var secondCopy = secondIPAddress.withMutableSockAddr { (addr, size) -> sockaddr_in6 in
             XCTAssertEqual(size, MemoryLayout<sockaddr_in6>.size)
-            return addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { return $0.pointee }
+            return addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { $0.pointee }
         }
         var thirdCopy = thirdIPAddress.withMutableSockAddr { (addr, size) -> sockaddr_un in
             XCTAssertEqual(size, MemoryLayout<sockaddr_un>.size)
-            return addr.withMemoryRebound(to: sockaddr_un.self, capacity: 1) { return $0.pointee }
+            return addr.withMemoryRebound(to: sockaddr_un.self, capacity: 1) { $0.pointee }
         }
 
         XCTAssertEqual(memcmp(&firstIPAddress, &firstCopy, MemoryLayout<sockaddr_in>.size), 0)


### PR DESCRIPTION
Motivation:

We can cleanup the code by removing return keywords in closures sometimes.

Modifications:

Remove return when possible.

Result:

Cleaner code.