### PR TITLE
use accept4 and SOCK_NONBLOCK on Linux

### DIFF
--- a/Sources/CNIOLinux/include/c_nio_linux.h
+++ b/Sources/CNIOLinux/include/c_nio_linux.h
@@ -51,6 +51,9 @@ int CNIOLinux_recvmmsg(int sockfd, CNIOLinux_mmsghdr *msgvec, unsigned int vlen,
 int CNIOLinux_pthread_setname_np(pthread_t thread, const char *name);
 int CNIOLinux_pthread_getname_np(pthread_t thread, char *name, size_t len);
 
+// Non-standard socket stuff.
+int CNIOLinux_accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags);
+
 // Thread affinity stuff.
 int CNIOLinux_pthread_setaffinity_np(pthread_t thread, size_t cpusetsize, const cpu_set_t *cpuset);
 int CNIOLinux_pthread_getaffinity_np(pthread_t thread, size_t cpusetsize, cpu_set_t *cpuset);

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -34,6 +34,10 @@ int CNIOLinux_recvmmsg(int sockfd, CNIOLinux_mmsghdr *msgvec, unsigned int vlen,
     return recvmmsg(sockfd, (struct mmsghdr *)msgvec, vlen, flags, timeout);
 }
 
+int CNIOLinux_accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags) {
+    return accept4(sockfd, addr, addrlen, flags);
+}
+
 int CNIOLinux_pthread_setname_np(pthread_t thread, const char *name) {
     return pthread_setname_np(thread, name);
 }

--- a/Sources/NIO/Linux.swift
+++ b/Sources/NIO/Linux.swift
@@ -95,4 +95,22 @@ internal enum Epoll {
         }
     }
 }
+
+internal enum Linux {
+    static let SOCK_CLOEXEC = Int32(bitPattern: Glibc.SOCK_CLOEXEC.rawValue)
+    static let SOCK_NONBLOCK = Int32(bitPattern: Glibc.SOCK_NONBLOCK.rawValue)
+
+    @inline(never)
+    public static func accept4(descriptor: CInt, addr: UnsafeMutablePointer<sockaddr>, len: UnsafeMutablePointer<socklen_t>, flags: Int32) throws -> CInt? {
+        let result: IOResult<CInt> = try wrapSyscallMayBlock {
+            CNIOLinux.CNIOLinux_accept4(descriptor, addr, len, flags)
+        }
+        switch result {
+        case .processed(let fd):
+            return fd
+        default:
+            return nil
+        }
+    }
+}
 #endif

--- a/Sources/NIO/ServerSocket.swift
+++ b/Sources/NIO/ServerSocket.swift
@@ -25,9 +25,10 @@ final class ServerSocket: BaseSocket {
     ///
     /// - parameters:
     ///     - protocolFamily: The protocol family to use (usually `AF_INET6` or `AF_INET`).
+    ///     - setNonBlocking: Set non-blocking mode on the socket.
     /// - throws: An `IOError` if creation of the socket failed.
-    init(protocolFamily: Int32) throws {
-        let sock = try BaseSocket.newSocket(protocolFamily: protocolFamily, type: Posix.SOCK_STREAM)
+    init(protocolFamily: Int32, setNonBlocking: Bool = false) throws {
+        let sock = try BaseSocket.newSocket(protocolFamily: protocolFamily, type: Posix.SOCK_STREAM, setNonBlocking: setNonBlocking)
         super.init(descriptor: sock)
     }
 
@@ -44,23 +45,41 @@ final class ServerSocket: BaseSocket {
 
     /// Accept a new connection
     ///
+    /// - parameters:
+    ///     - setNonBlocking: set non-blocking mode on the returned `Socket`. On Linux this will use accept4 with SOCK_NONBLOCK to save a system call.
     /// - returns: A `Socket` once a new connection was established or `nil` if this `ServerSocket` is in non-blocking mode and there is no new connection that can be accepted when this method is called.
     /// - throws: An `IOError` if the operation failed.
-    func accept() throws -> Socket? {
+    func accept(setNonBlocking: Bool = false) throws -> Socket? {
         return try withUnsafeFileDescriptor { fd in
             var acceptAddr = sockaddr_in()
             var addrSize = socklen_t(MemoryLayout<sockaddr_in>.size)
 
-            let result = try withUnsafeMutablePointer(to: &acceptAddr) { ptr in
+            let result = try withUnsafeMutablePointer(to: &acceptAddr) { (ptr) throws -> CInt? in
                 try ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
-                    try Posix.accept(descriptor: fd, addr: ptr, len: &addrSize)
+                    #if os(Linux)
+                    let flags: Int32
+                    if setNonBlocking {
+                        flags = Linux.SOCK_NONBLOCK
+                    } else {
+                        flags = 0
+                    }
+                    return try Linux.accept4(descriptor: fd, addr: ptr, len: &addrSize, flags: flags)
+                    #else
+                    return try Posix.accept(descriptor: fd, addr: ptr, len: &addrSize)
+                    #endif
                 }
             }
 
             guard let fd = result else {
                 return nil
             }
-            return Socket(descriptor: fd)
+            let sock = Socket(descriptor: fd)
+            #if !os(Linux)
+            if setNonBlocking {
+                try sock.setNonBlocking()
+            }
+            #endif
+            return sock
         }
     }
 }

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -31,9 +31,10 @@ final class Socket: BaseSocket {
     /// - parameters:
     ///     - protocolFamily: The protocol family to use (usually `AF_INET6` or `AF_INET`).
     ///     - type: The type of the socket to create.
+    ///     - setNonBlocking: Set non-blocking mode on the socket.
     /// - throws: An `IOError` if creation of the socket failed.
-    init(protocolFamily: CInt, type: CInt) throws {
-        let sock = try BaseSocket.newSocket(protocolFamily: protocolFamily, type: type)
+    init(protocolFamily: CInt, type: CInt, setNonBlocking: Bool = false) throws {
+        let sock = try BaseSocket.newSocket(protocolFamily: protocolFamily, type: type, setNonBlocking: setNonBlocking)
         super.init(descriptor: sock)
     }
 


### PR DESCRIPTION
Motivation:

Reduce system calls on Linux required for configuring sockets as
nonblocking.

Modifications:

- expose accept4 as CNIOLinux_accept4
- add Linux internal enum for exposing Linux specific API
- wrap CNIOLinux_accept4 with Linux.accept4
- expose SOCK_NONBLOCK and SOCK_CLOEXEC on Linux
- ServerSocket.accept take flags parameter and pass flags to accept4
- SocketChannel uses SOCK_NONBLOCK instead of setNonBlocking

Result:

Servers and clients on Linux will use fewer system calls creating new sockets.
