### PR TITLE
Don't close ServerSocketChannel when accept fails with ECONNABORTED /…

### DIFF
--- a/Sources/NIO/ServerSocket.swift
+++ b/Sources/NIO/ServerSocket.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A server socket that can accept new connections.
-final class ServerSocket: BaseSocket {
+/* final but tests */ class ServerSocket: BaseSocket {
     public class func bootstrap(protocolFamily: Int32, host: String, port: Int) throws -> ServerSocket {
         let socket = try ServerSocket(protocolFamily: protocolFamily)
         try socket.bind(to: SocketAddress.newAddressResolving(host: host, port: port))

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -28,6 +28,12 @@ extension SocketChannelTest {
       return [
                 ("testAsyncSetOption", testAsyncSetOption),
                 ("testDelayedConnectSetsUpRemotePeerAddress", testDelayedConnectSetsUpRemotePeerAddress),
+                ("testAcceptFailsWithECONNABORTED", testAcceptFailsWithECONNABORTED),
+                ("testAcceptFailsWithEMFILE", testAcceptFailsWithEMFILE),
+                ("testAcceptFailsWithENFILE", testAcceptFailsWithENFILE),
+                ("testAcceptFailsWithENOBUFS", testAcceptFailsWithENOBUFS),
+                ("testAcceptFailsWithENOMEM", testAcceptFailsWithENOMEM),
+                ("testAcceptFailsWithEFAULT", testAcceptFailsWithEFAULT),
            ]
    }
 }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import NIO
+@testable import NIO
 import Dispatch
 import NIOConcurrencyHelpers
 
@@ -92,5 +92,75 @@ public class SocketChannelTest : XCTestCase {
         // setup causes us to get nil as the remote address, even though we connected (and we did, as these are all
         // up right now).
         remoteAddresses.assertAll { $0 != nil }
+    }
+    
+    public func testAcceptFailsWithECONNABORTED() throws {
+        try assertAcceptFails(error: ECONNABORTED, active: true)
+    }
+
+    public func testAcceptFailsWithEMFILE() throws {
+        try assertAcceptFails(error: EMFILE, active: true)
+    }
+    
+    public func testAcceptFailsWithENFILE() throws {
+        try assertAcceptFails(error: ENFILE, active: true)
+    }
+    
+    public func testAcceptFailsWithENOBUFS() throws {
+        try assertAcceptFails(error: ENOBUFS, active: true)
+    }
+    
+    public func testAcceptFailsWithENOMEM() throws {
+        try assertAcceptFails(error: ENOBUFS, active: true)
+    }
+    
+    public func testAcceptFailsWithEFAULT() throws {
+        try assertAcceptFails(error: EFAULT, active: false)
+    }
+    
+    private func assertAcceptFails(error: Int32, active: Bool) throws {
+        final class AcceptHandler: ChannelInboundHandler {
+            typealias InboundIn = Channel
+            typealias InboundOut = Channel
+            
+            func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+                XCTFail("Should not accept a Channel but got \(self.unwrapInboundIn(data))")
+            }
+        }
+        
+        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        class NonAcceptingServerSocket : ServerSocket {
+            private var error: Int32?
+            
+            init(error: Int32) throws {
+                self.error = error
+                try super.init(protocolFamily: AF_INET, setNonBlocking: true)
+            }
+            
+            override func accept(setNonBlocking: Bool) throws -> Socket? {
+                if let err = self.error {
+                    self.error = nil
+                    throw IOError(errnoCode: err, function: "accept")
+                }
+                return nil
+            }
+        }
+        let socket = try NonAcceptingServerSocket(error: error)
+        let serverChannel = try ServerSocketChannel(serverSocket: socket, eventLoop: group.next() as! SelectableEventLoop, group: group)
+        XCTAssertNoThrow(try serverChannel.register().wait())
+        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: AcceptHandler()).wait())
+        XCTAssertNoThrow(try serverChannel.bind(to: SocketAddress.init(ipAddress: "127.0.0.1", port: 0)).wait())
+    
+        XCTAssertEqual(active, try serverChannel.eventLoop.submit {
+            serverChannel.readable()
+            return serverChannel.isActive
+        }.wait())
+    
+        if active {
+            XCTAssertNoThrow(try serverChannel.close().wait())
+        }
     }
 }


### PR DESCRIPTION
… EMFILE / ENFILE, ENOBUFS. ENOMEM.

Motivation:

We should not close the server socket when accept fails with ECONNABORTED / EMFILE / ENFILE, ENOBUFS. ENOMEM as generally speaking these may be "recoverable" once some existing connections were closed for example. It's possible to implement a backoff strategy for these with a ChannelHandler.

Modifications:

- Special handle of ECONNABORTED / EMFILE / ENFILE, ENOBUFS. ENOMEM for ServerSocketChannel.

Result:

Not close servet socket for errors from which it is possible to recover.