### PR TITLE
Add support for adding handlers at arbitrary pipeline locations

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -162,19 +162,136 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - first: `true` to add this handler to the front of the `ChannelPipeline`, `false to add it last
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was added.
     public func add(name: String? = nil, handler: ChannelHandler, first: Bool = false) -> EventLoopFuture<Void> {
-        let promise: EventLoopPromise<Void> = eventLoop.newPromise()
-        if eventLoop.inEventLoop {
-            add0(name: name, handler: handler, first: first, promise: promise)
-        } else {
-            eventLoop.execute {
-                self.add0(name: name, handler: handler, first: first, promise: promise)
+        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+
+        func _add() {
+            if self.destroyed {
+                promise.fail(error: ChannelError.ioOnClosedChannel)
+                return
+            }
+
+            if first {
+                self.add0(name: name, handler: handler, relativeContext: head!, operation: self.add0(context:after:), promise: promise)
+            } else {
+                self.add0(name: name, handler: handler, relativeContext: tail!, operation: self.add0(context:before:), promise: promise)
             }
         }
+
+        if self.eventLoop.inEventLoop {
+            _add()
+        } else {
+            self.eventLoop.execute {
+                _add()
+            }
+        }
+
         return promise.futureResult
     }
 
-    /// Add the handler to the `ChannelPipeline`. This operation must only be called when within the `EventLoop` thread.
-    private func add0(name: String?, handler: ChannelHandler, first: Bool, promise: EventLoopPromise<Void>) {
+    /// Add a `ChannelHandler` to the `ChannelPipeline` immediately after a `ChannelHandler` that is already present
+    /// in the `ChannelPipeline`.
+    ///
+    /// - parameters:
+    ///     - name: The name to use for the `ChannelHandler` when its added. If none is specified, a name will be
+    ///         automatically generated.
+    ///     - handler: The `ChannelHandler` to add.
+    ///     - after: The pre-existing `ChannelHandler` that `handler` should be inserted immediately after.
+    /// - returns: An `EventLoopFuture` that will be notified when the `ChannelHandler` is added.
+    public func add(name: String? = nil, handler: ChannelHandler, after: ChannelHandler) -> EventLoopFuture<Void> {
+        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+
+        if self.eventLoop.inEventLoop {
+            self.add0(name: name, handler: handler, relativeHandler: after, operation: self.add0(context:after:), promise: promise)
+        } else {
+            self.eventLoop.execute {
+                self.add0(name: name, handler: handler, relativeHandler: after, operation: self.add0(context:after:), promise: promise)
+            }
+        }
+
+        return promise.futureResult
+    }
+
+    /// Add a `ChannelHandler` to the `ChannelPipeline` immediately before a `ChannelHandler` that is already present
+    /// in the `ChannelPipeline`.
+    ///
+    /// - parameters:
+    ///     - name: The name to use for the `ChannelHandler` when its added. If none is specified, a name will be
+    ///         automatically generated.
+    ///     - handler: The `ChannelHandler` to add.
+    ///     - after: The pre-existing `ChannelHandler` that `handler` should be inserted immediately before.
+    /// - returns: An `EventLoopFuture` that will be notified when the `ChannelHandler` is added.
+    public func add(name: String? = nil, handler: ChannelHandler, before: ChannelHandler) -> EventLoopFuture<Void> {
+        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+
+        if self.eventLoop.inEventLoop {
+            self.add0(name: name, handler: handler, relativeHandler: before, operation: self.add0(context:before:), promise: promise)
+        } else {
+            self.eventLoop.execute {
+                self.add0(name: name, handler: handler, relativeHandler: before, operation: self.add0(context:before:), promise: promise)
+            }
+        }
+
+        return promise.futureResult
+    }
+
+    /// Synchronously add a `ChannelHandler` to the pipeline, relative to another `ChannelHandler`,
+    /// where the insertion is done by a specific operation.
+    ///
+    /// May only be called from on the event loop.
+    ///
+    /// This will search the pipeline for `relativeHandler` and, if it cannot find it, will fail
+    /// `promise` with `ChannelPipelineError.notFound`.
+    ///
+    /// - parameters:
+    ///     - name: The name to use for the `ChannelHandler` when its added. If none is specified, a name will be
+    ///         automatically generated.
+    ///     - handler: The `ChannelHandler` to add.
+    ///     - relativeHandler: The `ChannelHandler` already in the `ChannelPipeline` that `handler` will be
+    ///         inserted relative to.
+    ///     - operation: A callback that will insert `handler` relative to `relativeHandler`.
+    ///     - promise: An `EventLoopPromise<Void>` that will fire when the operation is complete, or will fire with
+    ///         an error if it could not be completed.
+    private func add0(name: String?,
+                      handler: ChannelHandler,
+                      relativeHandler: ChannelHandler,
+                      operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void,
+                      promise: EventLoopPromise<Void>) {
+        assert(eventLoop.inEventLoop)
+        if self.destroyed {
+            promise.fail(error: ChannelError.ioOnClosedChannel)
+            return
+        }
+
+        guard let ctx = self.contextForPredicate0({ $0.handler === relativeHandler }) else {
+            promise.fail(error: ChannelPipelineError.notFound)
+            return
+        }
+
+        self.add0(name: name, handler: handler, relativeContext: ctx, operation: operation, promise: promise)
+    }
+
+    /// Synchronously add a `ChannelHandler` to the pipeline, relative to a `ChannelHandlerContext`,
+    /// where the insertion is done by a specific operation.
+    ///
+    /// May only be called from on the event loop.
+    ///
+    /// This method is more efficient than the one that takes a `relativeHandler` as it does not need to
+    /// search the pipeline for the insertion point. It should be used whenever possible.
+    ///
+    /// - parameters:
+    ///     - name: The name to use for the `ChannelHandler` when its added. If none is specified, a name will be
+    ///         automatically generated.
+    ///     - handler: The `ChannelHandler` to add.
+    ///     - relativeContext: The `ChannelHandlerContext` already in the `ChannelPipeline` that `handler` will be
+    ///         inserted relative to.
+    ///     - operation: A callback that will insert `handler` relative to `relativeHandler`.
+    ///     - promise: An `EventLoopPromise<Void>` that will fire when the operation is complete, or will fire with
+    ///         an error if it could not be completed.
+    private func add0(name: String?,
+                      handler: ChannelHandler,
+                      relativeContext: ChannelHandlerContext,
+                      operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void,
+                      promise: EventLoopPromise<Void>) {
         assert(eventLoop.inEventLoop)
 
         if destroyed {
@@ -183,28 +300,53 @@ public final class ChannelPipeline: ChannelInvoker {
         }
 
         let ctx = ChannelHandlerContext(name: name ?? nextName(), handler: handler, pipeline: self)
-        if first {
-            let next = self.head?.next
-            ctx.prev = self.head
-            ctx.next = next
-            head?.next = ctx
-            next?.prev = ctx
-        } else {
-            let prev = self.tail?.prev
-            ctx.prev = prev
-            ctx.next = self.tail
-            tail?.prev = ctx
-            prev?.next = ctx
-        }
+        operation(ctx, relativeContext)
 
         do {
             try ctx.invokeHandlerAdded()
             promise.succeed(result: ())
         } catch let err {
             remove0(ctx: ctx, promise: nil)
-
             promise.fail(error: err)
         }
+    }
+
+    /// Synchronously add a single new `ChannelHandlerContext` after one that currently exists in the
+    /// pipeline.
+    ///
+    /// Must be called from within the event loop thread, as it synchronously manipulates the
+    /// `ChannelHandlerContext`s on the `ChannelPipeline`.
+    ///
+    /// - parameters:
+    ///     - new: The `ChannelHandlerContext` to add to the pipeline.
+    ///     - existing: The `ChannelHandlerContext` that `new` will be added after.
+    private func add0(context new: ChannelHandlerContext, after existing: ChannelHandlerContext) {
+        assert(eventLoop.inEventLoop)
+
+        let next = existing.next
+        new.prev = existing
+        new.next = next
+        existing.next = new
+        next?.prev = new
+    }
+
+    /// Synchronously add a single new `ChannelHandlerContext` before one that currently exists in the
+    /// pipeline.
+    ///
+    /// Must be called from within the event loop thread, as it synchronously manipulates the
+    /// `ChannelHandlerContext`s on the `ChannelPipeline`.
+    ///
+    /// - parameters:
+    ///     - new: The `ChannelHandlerContext` to add to the pipeline.
+    ///     - existing: The `ChannelHandlerContext` that `new` will be added before.
+    private func add0(context new: ChannelHandlerContext, before existing: ChannelHandlerContext) {
+        assert(eventLoop.inEventLoop)
+
+        let prev = existing.prev
+        new.prev = prev
+        new.next = existing
+        existing.prev = new
+        prev?.next = new
     }
 
     /// Remove a `ChannelHandler` from the `ChannelPipeline`.
@@ -275,16 +417,13 @@ public final class ChannelPipeline: ChannelInvoker {
         let promise: EventLoopPromise<ChannelHandlerContext> = eventLoop.newPromise()
 
         func _context0() {
-            var curCtx: ChannelHandlerContext? = self.head
-            while let ctx = curCtx {
-                if body(ctx) {
-                    promise.succeed(result: ctx)
-                    return
-                }
-                curCtx = ctx.next
+            if let ctx = self.contextForPredicate0(body) {
+                promise.succeed(result: ctx)
+            } else {
+                promise.fail(error: ChannelPipelineError.notFound)
             }
-            promise.fail(error: ChannelPipelineError.notFound)
         }
+
         if eventLoop.inEventLoop {
             _context0()
         } else {
@@ -293,6 +432,18 @@ public final class ChannelPipeline: ChannelInvoker {
             }
         }
         return promise.futureResult
+    }
+
+    private func contextForPredicate0(_ body: @escaping((ChannelHandlerContext) -> Bool)) -> ChannelHandlerContext? {
+        var curCtx: ChannelHandlerContext? = self.head
+        while let ctx = curCtx {
+            if body(ctx) {
+                return ctx
+            }
+            curCtx = ctx.next
+        }
+
+        return nil
     }
 
     /// Remove a `ChannelHandlerContext` from the `ChannelPipeline`. Must only be called from within the `EventLoop`.
@@ -676,8 +827,6 @@ public final class ChannelPipeline: ChannelInvoker {
         self.tail = ChannelHandlerContext(name: "tail", handler: TailChannelHandler.sharedInstance, pipeline: self)
         self.head?.next = self.tail
         self.tail?.prev = self.head
-        self.tail?.prev = self.head
-        self.head?.next = self.tail
     }
 }
 

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -35,6 +35,12 @@ extension ChannelPipelineTest {
                 ("testOutboundNextForInboundOnlyIsCorrect", testOutboundNextForInboundOnlyIsCorrect),
                 ("testChannelInfrastructureIsNotLeaked", testChannelInfrastructureIsNotLeaked),
                 ("testAddingHandlersFirstWorks", testAddingHandlersFirstWorks),
+                ("testAddAfter", testAddAfter),
+                ("testAddBefore", testAddBefore),
+                ("testAddAfterLast", testAddAfterLast),
+                ("testAddBeforeFirst", testAddBeforeFirst),
+                ("testAddAfterWhileClosed", testAddAfterWhileClosed),
+                ("testAddBeforeWhileClosed", testAddBeforeWhileClosed),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Currently we only supporting adding channel handlers at the front
or the end of the pipeline. This is potentially a bit frustrating:
it becomes impossible to insert handlers relative to a specific
point in the pipeline, which limits users ability to code generic
pipeline modification operations.

Modifications:

Added two new methods to ChannelPipeline, specifically
add(handler:before:) and add(handler:after:). Also performed a
substantial internal refactoring of the ChannelPipeline handler
adding code to ensure that all operations go through the same
logical path, redefining add(handler:first:) in terms of adding
either before tail or after head.

Result:

Users will be able to insert channel handlers at any point in a
ChannelPipeline, so long as they are able to point at a handler
already in that pipeline.