### PR TITLE
Revert "make isOpen a computed property"

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -204,10 +204,8 @@ extension sockaddr_storage {
 /// This should not be created directly but one of its sub-classes should be used, like `ServerSocket` or `Socket`.
 class BaseSocket: Selectable {
 
-    private var descriptor: CInt
-    public var isOpen: Bool {
-        return descriptor >= 0
-    }
+    private let descriptor: CInt
+    public private(set) var isOpen: Bool
 
     func withUnsafeFileDescriptor<T>(_ body: (CInt) throws -> T) throws -> T {
         guard self.isOpen else {
@@ -285,8 +283,8 @@ class BaseSocket: Selectable {
     /// - parameters:
     ///     - descriptor: The file descriptor to wrap.
     init(descriptor: CInt) {
-        precondition(descriptor >= 0, "invalid file descriptor")
         self.descriptor = descriptor
+        self.isOpen = true
     }
 
     deinit {
@@ -383,7 +381,7 @@ class BaseSocket: Selectable {
             try Posix.close(descriptor: fd)
         }
 
-        self.descriptor = -1
+        self.isOpen = false
     }
 }
 

--- a/Sources/NIO/FileHandle.swift
+++ b/Sources/NIO/FileHandle.swift
@@ -23,17 +23,14 @@
 ///
 /// - warning: `FileHandle` objects are not thread-safe and are mutable. They also cannot be fully thread-safe as they refer to a global underlying file descriptor.
 public final class FileHandle: FileDescriptor {
-    private var descriptor: CInt
-
-    public var isOpen: Bool {
-        return descriptor >= 0
-    }
+    public private(set) var isOpen: Bool
+    private let descriptor: CInt
 
     /// Create a `FileHandle` taking ownership of `descriptor`. You must call `FileHandle.close` or `FileHandle.takeDescriptorOwnership` before
     /// this object can be safely released.
     public init(descriptor: CInt) {
-        precondition(descriptor >= 0, "invalid file descriptor")
         self.descriptor = descriptor
+        self.isOpen = true
     }
 
     deinit {
@@ -63,16 +60,16 @@ public final class FileHandle: FileDescriptor {
             throw IOError(errnoCode: EBADF, reason: "can't close file (as it's not open anymore).")
         }
 
-        let savedDescriptor = self.descriptor
-        self.descriptor = -1
-        return savedDescriptor
+        self.isOpen = false
+        return self.descriptor
     }
 
     public func close() throws {
         try withUnsafeFileDescriptor { fd in
             try Posix.close(descriptor: fd)
         }
-        self.descriptor = -1
+
+        self.isOpen = false
     }
 
     public func withUnsafeFileDescriptor<T>(_ body: (CInt) throws -> T) throws -> T {

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -165,13 +165,15 @@ class ChannelPipelineTest: XCTestCase {
 
         XCTAssertTrue(loop.inEventLoop)
         do {
-            try withPipe { (readFH, writeFH) in
-                let fr = FileRegion(fileHandle: writeFH, readerIndex: 0, endIndex: 0)
-                try channel.writeOutbound(fr)
-                loop.run()
-                XCTFail("we ran but an error should have been thrown")
-                return [readFH, writeFH]
+            let handle = FileHandle(descriptor: -1)
+            let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 0)
+            defer {
+                // fake descriptor, so shouldn't be closed.
+                XCTAssertNoThrow(try handle.takeDescriptorOwnership())
             }
+            try channel.writeOutbound(fr)
+            loop.run()
+            XCTFail("we ran but an error should have been thrown")
         } catch let err as ChannelError {
             XCTAssertEqual(err, .ioOnClosedChannel)
         }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 @testable import NIO
 
+
 class ChannelLifecycleHandler: ChannelInboundHandler {
     public typealias InboundIn = Any
 
@@ -596,30 +597,32 @@ public class ChannelTests: XCTestCase {
             let numberOfWrites = Int(1 /* first write */ + pwm.writeSpinCount /* the spins */ + 1 /* so one byte remains at the end */)
             buffer.clear()
             buffer.write(bytes: Array<UInt8>(repeating: 0xff, count: 1))
-            try withPipe { (readFH, writeFH) in
-                let fileRegion = FileRegion(fileHandle: writeFH, readerIndex: 0, endIndex: 1)
-                let ps: [EventLoopPromise<()>] = (0..<numberOfWrites).map { _ in el.newPromise() }
-                (0..<numberOfWrites).forEach { i in
-                    _ = pwm.add(data: i % 2 == 0 ? .byteBuffer(buffer) : .fileRegion(fileRegion), promise: ps[i])
-                }
-                pwm.markFlushCheckpoint()
-
-                let expectedPromiseStates = Array((1...numberOfWrites).reversed()).map { n in
-                    Array(repeating: true, count: numberOfWrites - n + 1) + Array(repeating: false, count: n - 1)
-                }
-                /* below, we'll write 1 byte at a time. So the number of bytes offered should decrease by one.
-                 The write operation should be repeated until we did it 1 + spin count times and then return `.writtenPartially`.
-                 After that, one byte will remain */
-                let result = try assertExpectedWritability(pendingWritesManager: pwm,
-                                                           promises: ps,
-                                                           expectedSingleWritabilities: Array(repeating: 1, count: numberOfWrites / 2),
-                                                           expectedVectorWritabilities: nil,
-                                                           expectedFileWritabilities: Array(repeating: (0, 1), count: numberOfWrites / 2),
-                                                           returns: Array(repeating: .processed(1), count: numberOfWrites),
-                                                           promiseStates: expectedPromiseStates)
-                XCTAssertEqual(.writtenCompletely, result)
-                return [readFH, writeFH]
+            let handle = FileHandle(descriptor: -1)
+            defer {
+                /* fake file handle, so don't actually close */
+                XCTAssertNoThrow(try handle.takeDescriptorOwnership())
             }
+            let fileRegion = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 1)
+            let ps: [EventLoopPromise<()>] = (0..<numberOfWrites).map { _ in el.newPromise() }
+            (0..<numberOfWrites).forEach { i in
+                _ = pwm.add(data: i % 2 == 0 ? .byteBuffer(buffer) : .fileRegion(fileRegion), promise: ps[i])
+            }
+            pwm.markFlushCheckpoint()
+
+            let expectedPromiseStates = Array((1...numberOfWrites).reversed()).map { n in
+                Array(repeating: true, count: numberOfWrites - n + 1) + Array(repeating: false, count: n - 1)
+            }
+            /* below, we'll write 1 byte at a time. So the number of bytes offered should decrease by one.
+             The write operation should be repeated until we did it 1 + spin count times and then return `.writtenPartially`.
+             After that, one byte will remain */
+            let result = try assertExpectedWritability(pendingWritesManager: pwm,
+                                                       promises: ps,
+                                                       expectedSingleWritabilities: Array(repeating: 1, count: numberOfWrites / 2),
+                                                       expectedVectorWritabilities: nil,
+                                                       expectedFileWritabilities: Array(repeating: (0, 1), count: numberOfWrites / 2),
+                                                       returns: Array(repeating: .processed(1), count: numberOfWrites),
+                                                       promiseStates: expectedPromiseStates)
+            XCTAssertEqual(.writtenCompletely, result)
         }
     }
 
@@ -733,43 +736,48 @@ public class ChannelTests: XCTestCase {
         let el = EmbeddedEventLoop()
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<()>] = (0..<2).map { (_: Int) in el.newPromise() }
-            try withSocketpair { ( fh1, fh2) in
-                let fr1 = FileRegion(fileHandle: fh1, readerIndex: 12, endIndex: 14)
-                let fr2 = FileRegion(fileHandle: fh2, readerIndex: 0, endIndex: 2)
-                _ = pwm.add(data: .fileRegion(fr1), promise: ps[0])
-                pwm.markFlushCheckpoint()
-                _ = pwm.add(data: .fileRegion(fr2), promise: ps[1])
 
-                var result = try assertExpectedWritability(pendingWritesManager: pwm,
-                                                           promises: ps,
-                                                           expectedSingleWritabilities: nil,
-                                                           expectedVectorWritabilities: nil,
-                                                           expectedFileWritabilities: [(12, 14)],
-                                                           returns: [.processed(2)],
-                                                           promiseStates: [[true, false]])
-                XCTAssertEqual(.writtenCompletely, result)
-
-                result = try assertExpectedWritability(pendingWritesManager: pwm,
-                                                       promises: ps,
-                                                       expectedSingleWritabilities: nil,
-                                                       expectedVectorWritabilities: nil,
-                                                       expectedFileWritabilities: nil,
-                                                       returns: [],
-                                                       promiseStates: [[true, false]])
-                XCTAssertEqual(.writtenCompletely, result)
-
-                pwm.markFlushCheckpoint()
-
-                result = try assertExpectedWritability(pendingWritesManager: pwm,
-                                                       promises: ps,
-                                                       expectedSingleWritabilities: nil,
-                                                       expectedVectorWritabilities: nil,
-                                                       expectedFileWritabilities: [(0, 2), (1, 2)],
-                                                       returns: [.processed(1), .processed(1)],
-                                                       promiseStates: [[true, false], [true, true]])
-                XCTAssertEqual(.writtenCompletely, result)
-                return [fh1, fh2]
+            let fh1 = FileHandle(descriptor: -1)
+            let fh2 = FileHandle(descriptor: -2)
+            let fr1 = FileRegion(fileHandle: fh1, readerIndex: 12, endIndex: 14)
+            let fr2 = FileRegion(fileHandle: fh2, readerIndex: 0, endIndex: 2)
+            defer {
+                // fake descriptors, so shouldn't be closed.
+                XCTAssertNoThrow(try fh1.takeDescriptorOwnership())
+                XCTAssertNoThrow(try fh2.takeDescriptorOwnership())
             }
+            _ = pwm.add(data: .fileRegion(fr1), promise: ps[0])
+            pwm.markFlushCheckpoint()
+            _ = pwm.add(data: .fileRegion(fr2), promise: ps[1])
+
+            var result = try assertExpectedWritability(pendingWritesManager: pwm,
+                                                   promises: ps,
+                                                   expectedSingleWritabilities: nil,
+                                                   expectedVectorWritabilities: nil,
+                                                   expectedFileWritabilities: [(12, 14)],
+                                                   returns: [.processed(2)],
+                                                   promiseStates: [[true, false]])
+            XCTAssertEqual(.writtenCompletely, result)
+
+            result = try assertExpectedWritability(pendingWritesManager: pwm,
+                                               promises: ps,
+                                               expectedSingleWritabilities: nil,
+                                               expectedVectorWritabilities: nil,
+                                               expectedFileWritabilities: nil,
+                                               returns: [],
+                                               promiseStates: [[true, false]])
+            XCTAssertEqual(.writtenCompletely, result)
+
+            pwm.markFlushCheckpoint()
+
+            result = try assertExpectedWritability(pendingWritesManager: pwm,
+                                               promises: ps,
+                                               expectedSingleWritabilities: nil,
+                                               expectedVectorWritabilities: nil,
+                                               expectedFileWritabilities: [(0, 2), (1, 2)],
+                                               returns: [.processed(1), .processed(1)],
+                                               promiseStates: [[true, false], [true, true]])
+            XCTAssertEqual(.writtenCompletely, result)
         }
     }
 
@@ -777,22 +785,24 @@ public class ChannelTests: XCTestCase {
         let el = EmbeddedEventLoop()
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<()>] = (0..<1).map { (_: Int) in el.newPromise() }
-            try withPipe { (readFH, writeFH) in
-                let fr = FileRegion(fileHandle: writeFH, readerIndex: 99, endIndex: 99)
-                _ = pwm.add(data: .fileRegion(fr), promise: ps[0])
-                pwm.markFlushCheckpoint()
 
-                let result = try assertExpectedWritability(pendingWritesManager: pwm,
-                                                           promises: ps,
-                                                           expectedSingleWritabilities: nil,
-                                                           expectedVectorWritabilities: nil,
-                                                           expectedFileWritabilities: [(99, 99)],
-                                                           returns: [.processed(0)],
-                                                           promiseStates: [[true]])
-                XCTAssertEqual(.writtenCompletely, result)
-                return [readFH, writeFH]
+            let fh = FileHandle(descriptor: -1)
+            let fr = FileRegion(fileHandle: fh, readerIndex: 99, endIndex: 99)
+            defer {
+                // fake descriptor, so shouldn't be closed.
+                XCTAssertNoThrow(try fh.takeDescriptorOwnership())
             }
+            _ = pwm.add(data: .fileRegion(fr), promise: ps[0])
+            pwm.markFlushCheckpoint()
 
+            let result = try assertExpectedWritability(pendingWritesManager: pwm,
+                                                   promises: ps,
+                                                   expectedSingleWritabilities: nil,
+                                                   expectedVectorWritabilities: nil,
+                                                   expectedFileWritabilities: [(99, 99)],
+                                                   returns: [.processed(0)],
+                                                   promiseStates: [[true]])
+            XCTAssertEqual(.writtenCompletely, result)
         }
     }
 
@@ -804,45 +814,50 @@ public class ChannelTests: XCTestCase {
 
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<()>] = (0..<5).map { (_: Int) in el.newPromise() }
-            try withSocketpair { (fh1, fh2) in
-                let fr1 = FileRegion(fileHandle: fh1, readerIndex: 99, endIndex: 99)
-                let fr2 = FileRegion(fileHandle: fh1, readerIndex: 0, endIndex: 10)
 
-                _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
-                _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
-                _ = pwm.add(data: .fileRegion(fr1), promise: ps[2])
-                _ = pwm.add(data: .byteBuffer(buffer), promise: ps[3])
-                _ = pwm.add(data: .fileRegion(fr2), promise: ps[4])
-
-                pwm.markFlushCheckpoint()
-
-                var result = try assertExpectedWritability(pendingWritesManager: pwm,
-                                                           promises: ps,
-                                                           expectedSingleWritabilities: [4, 3, 2, 1],
-                                                           expectedVectorWritabilities: [[4, 4]],
-                                                           expectedFileWritabilities: [(99, 99), (0, 10), (3, 10), (6, 10)],
-                                                           returns: [.processed(8), .processed(0), .processed(1), .processed(1), .processed(1), .processed(1), .wouldBlock(3), .processed(3), .wouldBlock(0)],
-                                                           promiseStates: [[true, true, false, false, false],
-                                                                           [true, true, true, false, false],
-                                                                           [true, true, true, false, false],
-                                                                           [true, true, true, false, false],
-                                                                           [true, true, true, false, false],
-                                                                           [true, true, true, true, false],
-                                                                           [true, true, true, true, false],
-                                                                           [true, true, true, true, false],
-                                                                           [true, true, true, true, false]])
-                XCTAssertEqual(.couldNotWriteEverything, result)
-
-                result = try assertExpectedWritability(pendingWritesManager: pwm,
-                                                       promises: ps,
-                                                       expectedSingleWritabilities: nil,
-                                                       expectedVectorWritabilities: nil,
-                                                       expectedFileWritabilities: [(6, 10)],
-                                                       returns: [.processed(4)],
-                                                       promiseStates: [[true, true, true, true, true]])
-                XCTAssertEqual(.writtenCompletely, result)
-                return [fh1, fh2]
+            let fh1 = FileHandle(descriptor: -1)
+            let fh2 = FileHandle(descriptor: -1)
+            let fr1 = FileRegion(fileHandle: fh1, readerIndex: 99, endIndex: 99)
+            let fr2 = FileRegion(fileHandle: fh1, readerIndex: 0, endIndex: 10)
+            defer {
+                // fake descriptors, so shouldn't be closed.
+                XCTAssertNoThrow(try fh1.takeDescriptorOwnership())
+                XCTAssertNoThrow(try fh2.takeDescriptorOwnership())
             }
+
+            _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
+            _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
+            _ = pwm.add(data: .fileRegion(fr1), promise: ps[2])
+            _ = pwm.add(data: .byteBuffer(buffer), promise: ps[3])
+            _ = pwm.add(data: .fileRegion(fr2), promise: ps[4])
+
+            pwm.markFlushCheckpoint()
+
+            var result = try assertExpectedWritability(pendingWritesManager: pwm,
+                                                   promises: ps,
+                                                   expectedSingleWritabilities: [4, 3, 2, 1],
+                                                   expectedVectorWritabilities: [[4, 4]],
+                                                   expectedFileWritabilities: [(99, 99), (0, 10), (3, 10), (6, 10)],
+                                                   returns: [.processed(8), .processed(0), .processed(1), .processed(1), .processed(1), .processed(1), .wouldBlock(3), .processed(3), .wouldBlock(0)],
+                                                   promiseStates: [[true, true, false, false, false],
+                                                                   [true, true, true, false, false],
+                                                                   [true, true, true, false, false],
+                                                                   [true, true, true, false, false],
+                                                                   [true, true, true, false, false],
+                                                                   [true, true, true, true, false],
+                                                                   [true, true, true, true, false],
+                                                                   [true, true, true, true, false],
+                                                                   [true, true, true, true, false]])
+            XCTAssertEqual(.couldNotWriteEverything, result)
+
+            result = try assertExpectedWritability(pendingWritesManager: pwm,
+                                               promises: ps,
+                                               expectedSingleWritabilities: nil,
+                                               expectedVectorWritabilities: nil,
+                                               expectedFileWritabilities: [(6, 10)],
+                                               returns: [.processed(4)],
+                                               promiseStates: [[true, true, true, true, true]])
+            XCTAssertEqual(.writtenCompletely, result)
         }
     }
 
@@ -875,6 +890,7 @@ public class ChannelTests: XCTestCase {
 
             _ = pwm.add(data: .byteBuffer(emptyBuffer), promise: ps[2])
 
+
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                    promises: ps,
                                                    expectedSingleWritabilities: nil,
@@ -896,6 +912,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertEqual(.writtenCompletely, result)
         }
     }
+
 
     func testPendingWritesWorksWithManyEmptyWrites() throws {
         let el = EmbeddedEventLoop()
@@ -999,22 +1016,25 @@ public class ChannelTests: XCTestCase {
         let el = EmbeddedEventLoop()
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<()>] = (0..<1).map { (_: Int) in el.newPromise() }
-            try withPipe { (readFH, writeFH) in
-                let fr = FileRegion(fileHandle: writeFH, readerIndex: 0, endIndex: 8192)
 
-                _ = pwm.add(data: .fileRegion(fr), promise: ps[0])
-                pwm.markFlushCheckpoint()
-
-                let result = try assertExpectedWritability(pendingWritesManager: pwm,
-                                                           promises: ps,
-                                                           expectedSingleWritabilities: nil,
-                                                           expectedVectorWritabilities: nil,
-                                                           expectedFileWritabilities: [(0, 8192)],
-                                                           returns: [.wouldBlock(8192)],
-                                                           promiseStates: [[true]])
-                XCTAssertEqual(.writtenCompletely, result)
-                return [readFH, writeFH]
+            let fh = FileHandle(descriptor: -1)
+            let fr = FileRegion(fileHandle: fh, readerIndex: 0, endIndex: 8192)
+            defer {
+                // fake descriptor, so shouldn't be closed.
+                XCTAssertNoThrow(try fh.takeDescriptorOwnership())
             }
+
+            _ = pwm.add(data: .fileRegion(fr), promise: ps[0])
+            pwm.markFlushCheckpoint()
+
+            let result = try assertExpectedWritability(pendingWritesManager: pwm,
+                                                   promises: ps,
+                                                   expectedSingleWritabilities: nil,
+                                                   expectedVectorWritabilities: nil,
+                                                   expectedFileWritabilities: [(0, 8192)],
+                                                   returns: [.wouldBlock(8192)],
+                                                   promiseStates: [[true]])
+            XCTAssertEqual(.writtenCompletely, result)
         }
     }
 
@@ -1130,7 +1150,7 @@ public class ChannelTests: XCTestCase {
         try server.bind(to: SocketAddress.newAddressResolving(host: "127.0.0.1", port: 0))
         try server.listen()
 
-        class VerifyNoReadHandler: ChannelInboundHandler {
+        class VerifyNoReadHandler : ChannelInboundHandler {
             typealias InboundIn = ByteBuffer
 
             public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
@@ -1382,6 +1402,7 @@ public class ChannelTests: XCTestCase {
 
         let clientChannel = try ClientBootstrap(group: group)
             .connect(to: serverChannel.localAddress!).wait()
+
 
         // Start shutting stuff down.
         try serverChannel.syncCloseAcceptingAlreadyClosed()


### PR DESCRIPTION
Reverts apple/swift-nio#123

/cc @toffaletti 

I just noticed that #123 was not actually SemVer patch, but was SemVer major, because it changed the behaviour of a public initializer of public class. We should back this out because we don't *need* that change right this second.

@toffaletti, I'd like to propose that you re-open that PR and that we split it into two parts. The first part will be the change to `BaseSocket`, and the test changes. The second part would be the change to `FileRegion`. That will allow us to keep the `FileRegion` change easy to merge for 2.0, but get the majority of the hairy changes out of the way.

While we're here, @weissi suggested a nice improvement to the test changes: rather than change everything to use named pipes or socketpairs, why not use an arbitrary somewhat large integer (0xBADF, for example) that is highly unlikely to be a valid file descriptor. That will keep the current semantic of using `-1`.