### PR TITLE
improve license header checking

### DIFF
--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -1,10 +1,24 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 set -eu
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 printf "=> Checking linux tests... "
 FIRST_OUT="$(git status --porcelain)"
-ruby scripts/generate_linux_tests.rb > /dev/null
+ruby "$here/../scripts/generate_linux_tests.rb" > /dev/null
 SECOND_OUT="$(git status --porcelain)"
 if [[ "$FIRST_OUT" != "$SECOND_OUT" ]]; then
   printf "\033[0;31mmissing changes!\033[0m\n"
@@ -15,11 +29,74 @@ else
 fi
 
 printf "=> Checking license headers... "
-NON_LICENSED_FILES="$(grep --include=\*.swift --exclude-dir=.build -rL "Licensed under Apache License v2.0" .)"
-if [[ -n "$NON_LICENSED_FILES" ]]; then
-  printf "\033[0;31mmissing headers!\033[0m\n"
-  printf "$NON_LICENSED_FILES\n"
-  exit 1
-else
-  printf "\033[0;32mokay.\033[0m\n"
-fi
+tmp=$(mktemp /tmp/.swift-nio-sanity_XXXXXX)
+
+for language in swift-or-c bash; do
+  declare -a matching_files
+  declare -a exceptions
+  expections=( )
+  matching_files=( -name '*' )
+  case "$language" in
+      swift-or-c)
+        exceptions=( -name c_nio_http_parser.c -o -name c_nio_http_parser.h -o -name cpp_magic.h -o -name Package.swift )
+        matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
+        cat > "$tmp" <<"EOF"
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+EOF
+        ;;
+      bash)
+        matching_files=( -name '*.sh' )
+        cat > "$tmp" <<"EOF"
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+EOF
+      ;;
+    *)
+      echo >&2 "ERROR: unknown language '$language'"
+      ;;
+  esac
+
+  expected_lines=$(cat "$tmp" | wc -l)
+  expected_sha=$(cat "$tmp" | shasum)
+
+  (
+    cd "$here/.."
+    find . \
+      \( \! -path './.build/*' -a \
+      \( "${matching_files[@]}" \) -a \
+      \( \! \( "${exceptions[@]}" \) \) \) | while read line; do
+      if [[ "$(cat "$line" | head -n $expected_lines | shasum)" != "$expected_sha" ]]; then
+        printf "\033[0;31mmissing headers in file '$line'!\033[0m\n"
+        diff -u <(cat "$line" | head -n $expected_lines) "$tmp"
+        exit 1
+      fi
+    done
+    printf "\033[0;32mokay.\033[0m\n"
+  )
+done
+
+rm "$tmp"


### PR DESCRIPTION
Motivation:

We need license headers at the top of all files but we didn't
automatically check for it in all source files.

Modifications:

Check for the full licensing header in all files (Swift, C & Shell).

Result:

If we're missing a licensing header a PR won't turn green.