### PR TITLE
properly destroy pthread mutex and cond

### DIFF
--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -42,6 +42,8 @@ public final class Lock {
     }
 
     deinit {
+        let err = pthread_mutex_destroy(self.mutex)
+        precondition(err == 0)
         mutex.deallocate()
     }
 
@@ -107,6 +109,8 @@ public final class ConditionLock<T: Equatable> {
     }
 
     deinit {
+        let err = pthread_cond_destroy(self.cond)
+        precondition(err == 0)
         self.cond.deallocate()
     }
 


### PR DESCRIPTION
properly destroy pthread mutex and cond

### Motivation:

properly destroy pthread mutex and cond

### Modifications:

- call pthread_mutex_destroy in Lock deinit
- call pthread_cond_destroy in ConditionLock deinit

### Result:

Lock and ConditionLock deinit may crash if locks are still in use.