### PR TITLE
RFC: task queue

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -823,7 +823,7 @@ fileprivate class TaskQueue {
     }
     
     func removeReady(_ now: DispatchTime) -> ContiguousArray<() -> Void> {
-        precondition(thread.isCurrent)
+        assert(thread.isCurrent)
         var readyTasks = ContiguousArray<() -> Void>()
         while let task = scheduledTasks.peek(), task.readyIn(now) <= .nanoseconds(0) {
             readyTasks.append(task.task)
@@ -833,7 +833,7 @@ fileprivate class TaskQueue {
     }
     
     func coalesce() {
-        precondition(thread.isCurrent)
+        assert(thread.isCurrent)
         guard needCoalesce.exchange(with: false) else {
             return
         }


### PR DESCRIPTION
This was a bit of a failed experiment to remove futex syscall. I recalled after writing this that pthread_mutex only uses futex when there is contention, otherwise it is just an atomic CAS so EventLoop.taskLock wasn't the source of futex calls I was hunting down. However, there might be something salvageable here.

### Motivation:

I was trying to create a fast path for scheduler loop that avoided locking.

### Modifications:

- encapsulate scheduledTasks and taskLock into TaskQueue struct
- avoid locking when modifying scheduledTasks on the same thread as event loop is running
- limit locking to coalesce called in two places during SelectableEventLoop.run

### Result:

Unclear.