### PR TITLE
add license headers for shell scripts

### DIFF
--- a/IntegrationTests/plugin_echo.sh
+++ b/IntegrationTests/plugin_echo.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 function plugin_echo_test_suite_begin() {
     echo "Running test suite '$1'"

--- a/IntegrationTests/plugin_junit_xml.sh
+++ b/IntegrationTests/plugin_junit_xml.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 junit_testsuite_time=0
 

--- a/IntegrationTests/run-single-test.sh
+++ b/IntegrationTests/run-single-test.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 (
 # this sub-shell is where the actual test is run

--- a/IntegrationTests/run-tests.sh
+++ b/IntegrationTests/run-tests.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 set -eu
 

--- a/IntegrationTests/test_functions.sh
+++ b/IntegrationTests/test_functions.sh
@@ -1,3 +1,17 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 function fail() {
     echo >&2 "FAILURE: $*"
     false

--- a/IntegrationTests/tests_01_http/SKIP_test_12_headers_too_large.sh
+++ b/IntegrationTests/tests_01_http/SKIP_test_12_headers_too_large.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/SKIP_test_13_http_pipelining.sh
+++ b/IntegrationTests/tests_01_http/SKIP_test_13_http_pipelining.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/SKIP_test_14_strict_mode_assertion.sh
+++ b/IntegrationTests/tests_01_http/SKIP_test_14_strict_mode_assertion.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/defines.sh
+++ b/IntegrationTests/tests_01_http/defines.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 function server_lsof() {
     lsof -a -d 0-1024 -p "$1"

--- a/IntegrationTests/tests_01_http/test_01_get_file.sh
+++ b/IntegrationTests/tests_01_http/test_01_get_file.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_02_get_random_bytes.sh
+++ b/IntegrationTests/tests_01_http/test_02_get_random_bytes.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_03_post_random_bytes.sh
+++ b/IntegrationTests/tests_01_http/test_03_post_random_bytes.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_04_keep_alive_works.sh
+++ b/IntegrationTests/tests_01_http/test_04_keep_alive_works.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_05_repeated_reqs_work.sh
+++ b/IntegrationTests/tests_01_http/test_05_repeated_reqs_work.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_06_http_1.0.sh
+++ b/IntegrationTests/tests_01_http/test_06_http_1.0.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_07_headers_work.sh
+++ b/IntegrationTests/tests_01_http/test_07_headers_work.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_08_survive_signals.sh
+++ b/IntegrationTests/tests_01_http/test_08_survive_signals.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_09_curl_happy_with_trailers.sh
+++ b/IntegrationTests/tests_01_http/test_09_curl_happy_with_trailers.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_10_connection_drop_in_body_ok.sh
+++ b/IntegrationTests/tests_01_http/test_10_connection_drop_in_body_ok.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_11_res_body_streaming.sh
+++ b/IntegrationTests/tests_01_http/test_11_res_body_streaming.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_15_post_in_chunked_encoding.sh
+++ b/IntegrationTests/tests_01_http/test_15_post_in_chunked_encoding.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_16_tcp_client_ip.sh
+++ b/IntegrationTests/tests_01_http/test_16_tcp_client_ip.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_17_serve_massive_sparse_file.sh
+++ b/IntegrationTests/tests_01_http/test_17_serve_massive_sparse_file.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_01_http/test_18_close_with_no_keepalive.sh
+++ b/IntegrationTests/tests_01_http/test_18_close_with_no_keepalive.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/IntegrationTests/tests_02_syscall_wrappers/defines.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/defines.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 set -eu
 

--- a/IntegrationTests/tests_02_syscall_wrappers/test_01_syscall_wrapper_fast.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_01_syscall_wrapper_fast.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 set -eu
 

--- a/IntegrationTests/tests_02_syscall_wrappers/test_02_blacklisted_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_02_blacklisted_errnos.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 set -eu
 

--- a/IntegrationTests/tests_03_linker_things/defines.sh
+++ b/IntegrationTests/tests_03_linker_things/defines.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 swift build
 bin_path=$(swift build --show-bin-path)

--- a/IntegrationTests/tests_03_linker_things/test_01_check_we_do_not_link_Foundation.sh
+++ b/IntegrationTests/tests_03_linker_things/test_01_check_we_do_not_link_Foundation.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 source defines.sh
 

--- a/Sources/CNIOHTTPParser/update_and_patch_http_parser.sh
+++ b/Sources/CNIOHTTPParser/update_and_patch_http_parser.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 set -eu
 

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 set -e
 

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 mkdir -p .build # for the junit.xml file
 ./IntegrationTests/run-tests.sh --junit-xml .build/junit-sh-tests.xml


### PR DESCRIPTION
Motivation:

Our shell scripts didn't have license headers but they should.

Modifications:

Add licensing headers to all shell scripts

Result:

Licensing clear for shell scripts too.
