### PR TITLE
make isOpen a computed property

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -204,8 +204,10 @@ extension sockaddr_storage {
 /// This should not be created directly but one of its sub-classes should be used, like `ServerSocket` or `Socket`.
 class BaseSocket: Selectable {
 
-    private let descriptor: CInt
-    public private(set) var isOpen: Bool
+    private var descriptor: CInt
+    public var isOpen: Bool {
+        return descriptor >= 0
+    }
 
     func withUnsafeFileDescriptor<T>(_ body: (CInt) throws -> T) throws -> T {
         guard self.isOpen else {
@@ -283,8 +285,8 @@ class BaseSocket: Selectable {
     /// - parameters:
     ///     - descriptor: The file descriptor to wrap.
     init(descriptor: CInt) {
+        precondition(descriptor >= 0, "invalid file descriptor")
         self.descriptor = descriptor
-        self.isOpen = true
     }
 
     deinit {
@@ -381,7 +383,7 @@ class BaseSocket: Selectable {
             try Posix.close(descriptor: fd)
         }
 
-        self.isOpen = false
+        self.descriptor = -1
     }
 }
 


### PR DESCRIPTION
Motivation:

Reduce memory footprint of BaseSocket

Modifications:

- made isOpen a computed var from 'descriptor >= 0'
- BaseSocket init check precondition 'descriptor >= 0'

Result:

- isOpen no longer requires storage space
- close() sets descriptor to -1
- descriptor property changed from let to var
