### PR TITLE
Let Upgrade handler remove other HTTP handlers.

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -153,7 +153,7 @@ public extension ChannelPipeline {
         let requestDecoder = HTTPRequestDecoder()
         let upgrader = HTTPServerUpgradeHandler(upgraders: upgraders,
                                                 httpEncoder: responseEncoder,
-                                                httpDecoder: requestDecoder,
+                                                extraHTTPHandlers: [requestDecoder],
                                                 upgradeCompletionHandler: upgradeCompletionHandler)
         return addHandlers(responseEncoder, requestDecoder, upgrader, first: first)
     }


### PR DESCRIPTION
Motivation:

The HTTP pipeline may contain other HTTP protocol specific handlers,
beyond just the ones that the upgrade handler knows explicitly. It should
be possible to get the upgrade handler to remove those at the right time.

Modifications:

Add extra support for removing handlers.

Result:

It'll be possible for the HTTP upgrade logic to remove things like the
pipelining handler at upgrade time.