### PR TITLE
Use correct errno value (ENOMEM) in testAcceptFailsWithENOMEM

### DIFF
--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -111,7 +111,7 @@ public class SocketChannelTest : XCTestCase {
     }
     
     public func testAcceptFailsWithENOMEM() throws {
-        try assertAcceptFails(error: ENOBUFS, active: true)
+        try assertAcceptFails(error: ENOMEM, active: true)
     }
     
     public func testAcceptFailsWithEFAULT() throws {


### PR DESCRIPTION
Motivation:

We didnt use ENOMEM as errno value in testAcceptFailsWithENOMEM.

Modifications:

Use ENOMEM

Result:

Correct test.