### PR TITLE
work bug in latest Swift 4.1 with closures taking `()` (SR-7191)

### DIFF
--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -282,7 +282,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                                                 }
                                                 return ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buffer))))
                                             }
-                    f.then { (_: Void) -> EventLoopFuture<Void> in
+                    f.then { () -> EventLoopFuture<Void> in
                         let p: EventLoopPromise<Void> = ctx.eventLoop.newPromise()
                         self.completeResponse(ctx, trailers: nil, promise: p)
                         return p.futureResult
@@ -304,7 +304,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                 case .sendfile:
                     ctx.write(self.wrapOutboundOut(.head(response))).then {
                         ctx.writeAndFlush(self.wrapOutboundOut(.body(.fileRegion(region))))
-                    }.then { (_: Void) in
+                    }.then {
                         let p: EventLoopPromise<Void> = ctx.eventLoop.newPromise()
                         self.completeResponse(ctx, trailers: nil, promise: p)
                         return p.futureResult

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -1463,7 +1463,7 @@ public class ChannelTests: XCTestCase {
             public func expectRead(loop: EventLoop) -> EventLoopFuture<Void> {
                 return loop.submit {
                     self.waitingForReadPromise = loop.newPromise()
-                }.then { (_: Void) in
+                }.then {
                     self.waitingForReadPromise!.futureResult
                 }
             }


### PR DESCRIPTION
Motivation:

In a few instances, we have code that ignores a `()` argument in a
closure with this syntax:

    { (_: Void) in

whilst that's a bit odd, it shouldn't be wrong and Swift 4.0.x is also
totally happy with it. The latest Swift 4.1 candidates however are not
and also there's a better way of spelling this:

    { () in

and in some cases even just

    {

Modifications:

Removed instances of `{ (_: Void) in`

Result:

Compiles with `swift-4.1-DEVELOPMENT-SNAPSHOT-2018-03-12-a`. The bug is filed as [SR-7191](https://bugs.swift.org/browse/SR-7191)