### PR TITLE
don't use _Nonnull for clang 3.6 (#147)

### DIFF
--- a/Sources/CNIOAtomics/include/c-atomics.h
+++ b/Sources/CNIOAtomics/include/c-atomics.h
@@ -16,6 +16,11 @@
 #include <inttypes.h>
 #include <stdint.h>
 
+#if __clang_major__ == 3 && __clang_minor__ <= 6
+/* clang 3.6 doesn't seem to know about _Nonnull yet */
+#define _Nonnull __attribute__((nonnull))
+#endif
+
 struct catmc_atomic__Bool;
 struct catmc_atomic__Bool * _Nonnull catmc_atomic__Bool_create(bool value);
 void catmc_atomic__Bool_destroy(struct catmc_atomic__Bool * _Nonnull atomic);


### PR DESCRIPTION
Motivation:

Clang 3.6 doesn't know about `_Nonnull` which breaks compilation for our
C atomics.

Modifications:

Defined `_Nonnull` as `__attribute__((nonnull))` which seems to already
be available before clang 3.7.

Result:

NIO compiles with clang 3.6 as the default C compiler.
