### PR TITLE
Add support for getting a handler of a given type.

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -412,6 +412,18 @@ public final class ChannelPipeline: ChannelInvoker {
         return context0({ $0.name == name })
     }
 
+    /// Returns the `ChannelHandlerContext` that belongs to a `ChannelHandler` of the given type.
+    ///
+    /// If multiple channel handlers of the same type are present in the pipeline, returns the context
+    /// belonging to the first such handler.
+    ///
+    /// - parameters:
+    ///     - handlerType: The type of the handler to search for.
+    /// - returns: the `EventLoopFuture` which will be notified once the the operation completes.
+    public func context<T>(handlerType: T.Type) -> EventLoopFuture<ChannelHandlerContext> {
+        return context0({ $0.handler is T })
+    }
+
     /// Find a `ChannelHandlerContext` in the `ChannelPipeline`.
     private func context0(_ body: @escaping ((ChannelHandlerContext) -> Bool)) -> EventLoopFuture<ChannelHandlerContext> {
         let promise: EventLoopPromise<ChannelHandlerContext> = eventLoop.newPromise()

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -41,6 +41,8 @@ extension ChannelPipelineTest {
                 ("testAddBeforeFirst", testAddBeforeFirst),
                 ("testAddAfterWhileClosed", testAddAfterWhileClosed),
                 ("testAddBeforeWhileClosed", testAddBeforeWhileClosed),
+                ("testFindHandlerByType", testFindHandlerByType),
+                ("testFindHandlerByTypeReturnsTheFirstOfItsType", testFindHandlerByTypeReturnsTheFirstOfItsType),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

It is often useful to find a handler of a given type even when you
aren't holding a reference to that handler. This patch allows us to
do that.

Modifications:

Add context(handlerType:) function to the channel pipeline.

Result:

Users can find handlers of a given type in a pipeline.
