### PR TITLE
don't leak pthread_keys

### DIFF
--- a/Tests/NIOTests/ThreadTest+XCTest.swift
+++ b/Tests/NIOTests/ThreadTest+XCTest.swift
@@ -36,6 +36,9 @@ extension ThreadTest {
                 ("testThreadSpecificDoesNotLeakIfReplacedWithNewValue", testThreadSpecificDoesNotLeakIfReplacedWithNewValue),
                 ("testSharingThreadSpecificVariableWorks", testSharingThreadSpecificVariableWorks),
                 ("testThreadSpecificInitWithValueWorks", testThreadSpecificInitWithValueWorks),
+                ("testThreadSpecificDoesNotLeakWhenOutOfScopeButThreadStillRunning", testThreadSpecificDoesNotLeakWhenOutOfScopeButThreadStillRunning),
+                ("testThreadSpecificDoesNotLeakIfThreadExitsWhilstSetOnMultipleThreads", testThreadSpecificDoesNotLeakIfThreadExitsWhilstSetOnMultipleThreads),
+                ("testThreadSpecificDoesNotLeakWhenOutOfScopeButSetOnMultipleThreads", testThreadSpecificDoesNotLeakWhenOutOfScopeButSetOnMultipleThreads),
            ]
    }
 }

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -28,6 +28,7 @@
 - Made `WebSocketOpcode` a struct. Removed `WebSocketOpcode.unknownControl` and
   `WebSocketOpcode.unknownNonControl` values: these should be replaced by
   simply instantiating `WebSocketOpcode` with the value.
+- `ThreadSpecificVariable` is now a `class` instead of a `struct`
 - `Channel.setOption(option:value:)` has been renamed `Channel.setOption(_:value:)`
 - `Channel.getOption(option:value:)` has been renamed `Channel.getOption(_:value:)`
 - `ChannelOption.AssociatedValueType` has been removed


### PR DESCRIPTION
- proposal that addresses #156, CC @toffaletti 
- this is _technically_ SemVer major as someone might write `import struct NIO.ThreadSpecificVariable` and after this patch it needs to be `import class NIO.ThreadSpecificVariable`

Motivation:

Previously we leaked `pthread_key`s as we only ever called
`pthread_key_create` but never `pthread_key_delete`. This patch fixes
that.

Modifications:

- made `ThreadSpecificVariable` a class (so we get lifecycle management
  through ARC)
- instead of just storing the value, store `Box<(ThreadSpecificVariable<T>, T)>`
  so we can control the lifecycle of the `ThreadSpecificVariable` as
  needed

Result:

We don't leak `pthread_key`s anymore.