### PR TITLE
Add new, better helper method for configuring HTTP servers.

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -110,55 +110,6 @@ private protocol AnyHTTPDecoder: class {
     func popRequestMethod() -> HTTPMethod?
 }
 
-public extension ChannelPipeline {
-    /// Configure a `ChannelPipeline` for use as a HTTP server.
-    ///
-    /// - parameters:
-    ///     - first: Whether to add the HTTP server at the head of the channel pipeline,
-    ///         or at the tail.
-    ///     - supportPipelining: Whether your code can manually handle pipelined requests,
-    ///         or whether it needs requests serialized. If `false` (the default), this
-    ///         call will also insert a `HTTPServerPipelineHandler` to serialize HTTP
-    ///         requests.
-    /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
-    public func addHTTPServerHandlers(first: Bool = false, supportPipelining: Bool = false) -> EventLoopFuture<Void> {
-        return addHandlers(HTTPResponseEncoder(), HTTPRequestDecoder(), first: first)
-    }
-
-    /// Configure a `ChannelPipeline` for use as a HTTP client.
-    ///
-    /// - parameters:
-    ///     - first: Whether to add the HTTP client at the head of the channel pipeline,
-    ///              or at the tail.
-    /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
-    public func addHTTPClientHandlers(first: Bool = false) -> EventLoopFuture<Void> {
-        return addHandlers(HTTPRequestEncoder(), HTTPResponseDecoder(), first: first)
-    }
-
-    /// Configure a `ChannelPipeline` for use as a HTTP server that can perform a HTTP
-    /// upgrade to a non-HTTP protocol: that is, after upgrade the channel pipeline must
-    /// have none of the handlers added by this function in it.
-    ///
-    /// - parameters:
-    ///     - first: Whether to add the HTTP server at the head of the channel pipeline,
-    ///              or at the tail.
-    ///     - upgraders: The HTTP protocol upgraders to offer.
-    ///     - upgradeCompletionHandler: A block that will be fired when the HTTP upgrade is
-    ///                                 complete.
-    /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
-    public func addHTTPServerHandlersWithUpgrader(first: Bool = false,
-                                                  upgraders: [HTTPProtocolUpgrader],
-                                                  _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) -> EventLoopFuture<Void> {
-        let responseEncoder = HTTPResponseEncoder()
-        let requestDecoder = HTTPRequestDecoder()
-        let upgrader = HTTPServerUpgradeHandler(upgraders: upgraders,
-                                                httpEncoder: responseEncoder,
-                                                extraHTTPHandlers: [requestDecoder],
-                                                upgradeCompletionHandler: upgradeCompletionHandler)
-        return addHandlers(responseEncoder, requestDecoder, upgrader, first: first)
-    }
-}
-
 /// A `ChannelInboundHandler` used to decode HTTP requests. See the documentation
 /// on `HTTPDecoder` for more.
 ///

--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+/// Configuration required to configure a HTTP pipeline for upgrade.
+///
+/// See the documentation for `HTTPServerUpgradeHandler` for details on these
+/// properties.
+public typealias HTTPUpgradeConfiguration = (upgraders: [HTTPProtocolUpgrader], completionHandler: (ChannelHandlerContext) -> Void)
+
+public extension ChannelPipeline {
+    /// Configure a `ChannelPipeline` for use as a HTTP server.
+    ///
+    /// - parameters:
+    ///     - first: Whether to add the HTTP server at the head of the channel pipeline,
+    ///              or at the tail.
+    /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    @available(*, deprecated, message: "Please use configureHTTPServerPipeline")
+    public func addHTTPServerHandlers(first: Bool = false) -> EventLoopFuture<Void> {
+        return addHandlers(HTTPResponseEncoder(), HTTPRequestDecoder(), first: first)
+    }
+
+    /// Configure a `ChannelPipeline` for use as a HTTP client.
+    ///
+    /// - parameters:
+    ///     - first: Whether to add the HTTP client at the head of the channel pipeline,
+    ///              or at the tail.
+    /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    public func addHTTPClientHandlers(first: Bool = false) -> EventLoopFuture<Void> {
+        return addHandlers(HTTPRequestEncoder(), HTTPResponseDecoder(), first: first)
+    }
+
+    /// Configure a `ChannelPipeline` for use as a HTTP server that can perform a HTTP
+    /// upgrade to a non-HTTP protocol: that is, after upgrade the channel pipeline must
+    /// have none of the handlers added by this function in it.
+    ///
+    /// - parameters:
+    ///     - first: Whether to add the HTTP server at the head of the channel pipeline,
+    ///              or at the tail.
+    ///     - upgraders: The HTTP protocol upgraders to offer.
+    ///     - upgradeCompletionHandler: A block that will be fired when the HTTP upgrade is
+    ///                                 complete.
+    /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    @available(*, deprecated, message: "Please use configureHTTPServerPipeline")
+    public func addHTTPServerHandlersWithUpgrader(first: Bool = false,
+                                                  upgraders: [HTTPProtocolUpgrader],
+                                                  _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) -> EventLoopFuture<Void> {
+        let responseEncoder = HTTPResponseEncoder()
+        let requestDecoder = HTTPRequestDecoder()
+        let upgrader = HTTPServerUpgradeHandler(upgraders: upgraders,
+                                                httpEncoder: responseEncoder,
+                                                extraHTTPHandlers: [requestDecoder],
+                                                upgradeCompletionHandler: upgradeCompletionHandler)
+        return addHandlers(responseEncoder, requestDecoder, upgrader, first: first)
+    }
+
+    /// Configure a `ChannelPipeline` for use as a HTTP server.
+    ///
+    /// This function knows how to set up all first-party HTTP channel handlers appropriately
+    /// for server use. It supports the following features:
+    ///
+    /// 1. Providing assistance handling clients that pipeline HTTP requests, using the
+    ///     `HTTPServerPipelineHandler`.
+    /// 2. Supporting HTTP upgrade, using the `HTTPServerUpgradeHandler`.
+    ///
+    /// This method will likely be extended in future with more support for other first-party
+    /// features.
+    ///
+    /// - parameters:
+    ///     - first: Whether to add the HTTP server at the head of the channel pipeline,
+    ///         or at the tail.
+    ///     - pipelining: Whether to provide assistance handling HTTP clients that pipeline
+    ///         their requests. Defaults to `true`. If `false`, users will need to handle
+    ///         clients that pipeline themselves.
+    ///     - upgrade: Whether to add a `HTTPServerUpgradeHandler` to the pipeline, configured for
+    ///         HTTP upgrade. Defaults to `nil`, which will not add the handler to the pipeline. If
+    ///         provided should be a tuple of an array of `HTTPProtocolUpgrader` and the upgrade
+    ///         completion handler. See the documentation on `HTTPServerUpgradeHandler` for more
+    ///         details.
+    /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    public func configureHTTPServerPipeline(first: Bool = false,
+                                            withPipeliningAssistance pipelining: Bool = true,
+                                            withServerUpgrade upgrade: HTTPUpgradeConfiguration? = nil) -> EventLoopFuture<Void> {
+        let responseEncoder = HTTPResponseEncoder()
+        let requestDecoder = HTTPRequestDecoder()
+
+        var handlers: [ChannelHandler] = [responseEncoder, requestDecoder]
+
+        if pipelining {
+            handlers.append(HTTPServerPipelineHandler())
+        }
+
+        if let (upgraders, completionHandler) = upgrade {
+            let upgrader = HTTPServerUpgradeHandler(upgraders: upgraders,
+                                                    httpEncoder: responseEncoder,
+                                                    extraHTTPHandlers: Array(handlers.dropFirst()),
+                                                    upgradeCompletionHandler: completionHandler)
+            handlers.append(upgrader)
+        }
+
+        return self.addHandlers(handlers, first: first)
+    }
+}
+

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -471,9 +471,7 @@ let bootstrap = ServerBootstrap(group: group)
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
-        channel.pipeline.addHTTPServerHandlers().then {
-            channel.pipeline.add(handler: HTTPServerPipelineHandler())
-        }.then {
+        channel.pipeline.configureHTTPServerPipeline().then {
             channel.pipeline.add(handler: HTTPHandler(fileIO: fileIO, htdocsPath: htdocs))
         }
     }

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -210,7 +210,8 @@ let bootstrap = ServerBootstrap(group: group)
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
-        channel.pipeline.addHTTPServerHandlersWithUpgrader(upgraders: [upgrader]) { _ in }.then {
+        let config: HTTPUpgradeConfiguration = (upgraders: [], completionHandler: { _ in })
+        return channel.pipeline.configureHTTPServerPipeline(withServerUpgrade: config).then {
             channel.pipeline.add(handler: HTTPHandler())
         }
     }

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest+XCTest.swift
@@ -36,6 +36,7 @@ extension HTTPServerClientTest {
                 ("testMassiveResponseFileRegion", testMassiveResponseFileRegion),
                 ("testHead", testHead),
                 ("test204", test204),
+                ("testDeprecatedPipelineConstruction", testDeprecatedPipelineConstruction),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
@@ -39,6 +39,8 @@ extension HTTPUpgradeTestCase {
                 ("testUpgradeIsCaseInsensitive", testUpgradeIsCaseInsensitive),
                 ("testDelayedUpgradeBehaviour", testDelayedUpgradeBehaviour),
                 ("testBuffersInboundDataDuringDelayedUpgrade", testBuffersInboundDataDuringDelayedUpgrade),
+                ("testRemovesAllHTTPRelatedHandlersAfterUpgrade", testRemovesAllHTTPRelatedHandlersAfterUpgrade),
+                ("testBasicUpgradePipelineMutation", testBasicUpgradePipelineMutation),
            ]
    }
 }

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -99,7 +99,8 @@ class EndToEndTests: XCTestCase {
     func createTestFixtures(upgraders: [WebSocketUpgrader]) -> (loop: EmbeddedEventLoop, serverChannel: EmbeddedChannel, clientChannel: EmbeddedChannel) {
         let loop = EmbeddedEventLoop()
         let serverChannel = EmbeddedChannel(loop: loop)
-        XCTAssertNoThrow(try serverChannel.pipeline.addHTTPServerHandlersWithUpgrader(upgraders: upgraders, { (ctx: ChannelHandlerContext) in }).wait())
+        let upgradeConfig = (upgraders: upgraders as [HTTPProtocolUpgrader], completionHandler: { (ctx: ChannelHandlerContext) in } )
+        XCTAssertNoThrow(try serverChannel.pipeline.configureHTTPServerPipeline(withServerUpgrade: upgradeConfig).wait())
         let clientChannel = EmbeddedChannel(loop: loop)
         return (loop: loop, serverChannel: serverChannel, clientChannel: clientChannel)
     }


### PR DESCRIPTION
Motivation:

The current HTTP server helpers are not modular, meaning that each
time we add a new first-party HTTP handler we need to add a brand new
method. Additionally, they do not currently compose, so if you want
assistance with HTTP pipelining *and* to support HTTP upgrade you are
out of luck.

Modifications:

Deprecate the two existing server helpers.

Add a new server helper that can be extended to support all of the
possible features that users may want in their HTTP pipelines.

Result:

Users will have a single place to go that can be used to configure
their HTTP server pipeline, and that understands how the different
handlers fit together in a complete pipeline.