### PR TITLE
ss18/pr0 typos

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -114,7 +114,7 @@ private func toIndex(_ value: Int) -> Index {
 ///     buf.set(integer: 17 as Int, at: 11)
 ///     let seventeen: Int = buf.getInteger(at: 11)
 ///
-/// If needed, `ByteBuffer` will automatically resize its storage to accomodate your `set` request.
+/// If needed, `ByteBuffer` will automatically resize its storage to accommodate your `set` request.
 ///
 /// ### Sequential Access
 /// `ByteBuffer` provides two properties which are indices into the `ByteBuffer` to support sequential access:

--- a/Sources/NIO/ChannelHandler.swift
+++ b/Sources/NIO/ChannelHandler.swift
@@ -169,7 +169,7 @@ public protocol _ChannelInboundHandler: ChannelHandler {
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny)
 
     /// Called when the `Channel` has completed its current read loop, either because no more data is available to read from the transport at this time, or because the `Channel` needs to yield to the event loop to process other I/O events for other `Channel`s.
-    /// If `ChannelOptions.autoRead` is `false` no futher read attempt will be made until `ChannelHandlerContext.read` or `Channel.read` is explicitly called.
+    /// If `ChannelOptions.autoRead` is `false` no further read attempt will be made until `ChannelHandlerContext.read` or `Channel.read` is explicitly called.
     ///
     /// This should call `ctx.fireChannelReadComplete` to forward the operation to the next `_ChannelInboundHandler` in the `ChannelPipeline` if you want to allow the next handler to also handle the event.
     ///

--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -122,7 +122,7 @@ extension ByteToMessageDecoder {
         }
     }
 
-    /// Call `decodeLast` before forward the event throught the pipeline.
+    /// Call `decodeLast` before forward the event through the pipeline.
     public func channelInactive(ctx: ChannelHandlerContext) {
         if var buffer = cumulationBuffer {
             ctx.withThrowingToFireErrorAndClose {

--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -108,7 +108,7 @@ extension ByteToMessageDecoder {
         }
 
         ctx.withThrowingToFireErrorAndClose {
-            // Running decode method until either the user returned `.needMoreData` or an error occured.
+            // Running decode method until either the user returned `.needMoreData` or an error occurred.
             while try decode(ctx: ctx, buffer: &buffer) == .`continue` && buffer.readableBytes > 0 { }
         }
 
@@ -126,7 +126,7 @@ extension ByteToMessageDecoder {
     public func channelInactive(ctx: ChannelHandlerContext) {
         if var buffer = cumulationBuffer {
             ctx.withThrowingToFireErrorAndClose {
-                // Running decodeLast method until either the user returned `.needMoreData` or an error occured.
+                // Running decodeLast method until either the user returned `.needMoreData` or an error occurred.
                 while try decodeLast(ctx: ctx, buffer: &buffer)  == .`continue` && buffer.readableBytes > 0 { }
             }
 

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -44,7 +44,7 @@ extension EmbeddedScheduledTask: Comparable {
 /// kinds of mocking.
 ///
 /// - warning: Unlike `SelectableEventLoop`, `EmbeddedEventLoop` **is not thread-safe**. This
-///     is becuase it is intended to be run in the thread that instantiated it. Users are
+///     is because it is intended to be run in the thread that instantiated it. Users are
 ///     responsible for ensuring they never call into the `EmbeddedEventLoop` in an
 ///     unsynchronized fashion.
 public class EmbeddedEventLoop: EventLoop {

--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -17,7 +17,7 @@
 // The natural implementation of RFC 8305 is to use an explicit FSM, and this module does so. However,
 // it doesn't use the natural Swift idiom for an FSM of using an enum with mutating methods. The reason
 // for this is that the RFC 8305 FSM here needs to trigger a number of concurrent asynchronous operations,
-// each of which will register callbacks that attempt to mutate `self`. This gets tricky fast, becuase enums
+// each of which will register callbacks that attempt to mutate `self`. This gets tricky fast, because enums
 // are value types, while all of these callbacks need to trigger state transitions on the same underlying
 // state machine.
 //

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -61,7 +61,7 @@ public struct NonBlockingFileIO {
     /// times, delivering `chunkSize` bytes each time. If less than `fileRegion.readableBytes` bytes can be read from the file,
     /// `chunkHandler` will be called less often with the last invocation possibly being of less than `chunkSize` bytes.
     ///
-    /// The allocation and reading of a subsequent chunk will only be attempted when `chunkHandler` suceeds.
+    /// The allocation and reading of a subsequent chunk will only be attempted when `chunkHandler` succeeds.
     ///
     /// - parameters:
     ///   - fileRegion: The file region to read.
@@ -99,7 +99,7 @@ public struct NonBlockingFileIO {
     /// times, delivering `chunkSize` bytes each time. If less than `byteCount` bytes can be read from `descriptor`,
     /// `chunkHandler` will be called less often with the last invocation possibly being of less than `chunkSize` bytes.
     ///
-    /// The allocation and reading of a subsequent chunk will only be attempted when `chunkHandler` suceeds.
+    /// The allocation and reading of a subsequent chunk will only be attempted when `chunkHandler` succeeds.
     ///
     /// - note: `readChunked(fileRegion:chunkSize:allocator:eventLoop:chunkHandler:)` should be preferred as it uses `FileRegion` object instead of raw `FileHandle`s.
     ///

--- a/Sources/NIO/PendingDatagramWritesManager.swift
+++ b/Sources/NIO/PendingDatagramWritesManager.swift
@@ -22,7 +22,7 @@ private struct PendingDatagramWrite {
     /// and then returns the length.
     ///
     /// This copying is an annoyance, but one way or another this copy will have to happen as
-    /// we do not want to expose the backing socket address to libc in case it mutates it. Becuase
+    /// we do not want to expose the backing socket address to libc in case it mutates it. Because
     /// we are using a box to store the underlying sockaddr, if libc ever did mess with that data
     /// it will screw any other values pointing to that box. That would be a pretty bad scene. And
     /// in most cases we're not copying large values here: only for UDS does this become a problem.
@@ -341,7 +341,7 @@ extension PendingDatagramWritesState {
 /// value. The most important purpose of this object is to call `sendto` or `sendmmsg` depending on the writes held and
 /// the availability of the functions.
 final class PendingDatagramWritesManager: PendingWritesManager {
-    /// Storage for mmsghdr strutures. Only present on Linux becuase Darwin does not support
+    /// Storage for mmsghdr strutures. Only present on Linux because Darwin does not support
     /// gathering datagram writes.
     private var msgs: UnsafeMutableBufferPointer<MMsgHdr>
 

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -514,10 +514,10 @@ internal extension Selector where R == NIORegistration {
 
 /// The strategy used for the `Selector`.
 enum SelectorStrategy {
-    /// Block until there is some IO ready to be processed or the `Selector` is explictly woken up.
+    /// Block until there is some IO ready to be processed or the `Selector` is explicitly woken up.
     case block
 
-    /// Block until there is some IO ready to be processed, the `Selector` is explictly woken up or the given `TimeAmount` elapsed.
+    /// Block until there is some IO ready to be processed, the `Selector` is explicitly woken up or the given `TimeAmount` elapsed.
     case blockUntilTimeout(TimeAmount)
 
     /// Try to select all ready IO at this point in time without blocking at all.

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -219,7 +219,7 @@ final class DatagramChannelTests: XCTestCase {
         // switches.
         _ = try self.firstChannel.eventLoop.submit {
             let myPromise: EventLoopPromise<()> = self.firstChannel.eventLoop.newPromise()
-            // For datagrams this buffer cannot be very large, becuase if it's larger than the path MTU it
+            // For datagrams this buffer cannot be very large, because if it's larger than the path MTU it
             // will cause EMSGSIZE.
             let bufferSize = 1024 * 5
             var buffer = self.firstChannel.allocator.buffer(capacity: bufferSize)

--- a/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
@@ -124,7 +124,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
     }
 
     public func testFramesWith64BitLengthsRoundTrip() throws {
-        // We need a new decoder channel here, becuase the max length would otherwise trigger an error.
+        // We need a new decoder channel here, because the max length would otherwise trigger an error.
         _ = try! self.decoderChannel.finish()
         self.decoderChannel = EmbeddedChannel()
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: WebSocketFrameDecoder(maxFrameSize: 80000)).wait())


### PR DESCRIPTION
Minor typos in comments.

### Modifications:

accomodate -> accommodate
becuase -> because
futher -> further
explictly -> explicitly
occured -> occurred
throught -> through
suceeds -> succeeds

Found with: https://github.com/ss18/grep-typos
