### PR TITLE
channelRead should never be triggered if autoRead is false.

### DIFF
--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -148,7 +148,7 @@ final class Selector<R: Registration> {
         case .all:
             return Epoll.EPOLLIN.rawValue | Epoll.EPOLLOUT.rawValue | Epoll.EPOLLERR.rawValue | Epoll.EPOLLRDHUP.rawValue
         case .none:
-            return Epoll.EPOLLERR.rawValue | Epoll.EPOLLRDHUP.rawValue
+            return Epoll.EPOLLERR.rawValue
         }
     }
 #else

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -520,10 +520,12 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
 
         // Was not registered yet so do it now.
         do {
-            try self.safeRegister(interested: .read)
+            // We always register with interested .none and will just trigger readIfNeeded0() later to re-register if needed.
+            try self.safeRegister(interested: .none)
             neverRegistered = false
             promise?.succeed(result: ())
             pipeline.fireChannelRegistered0()
+            readIfNeeded0()
         } catch {
             promise?.fail(error: error)
         }

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -57,6 +57,8 @@ extension ChannelTests {
                 ("testAskForLocalAndRemoteAddressesAfterChannelIsClosed", testAskForLocalAndRemoteAddressesAfterChannelIsClosed),
                 ("testReceiveAddressAfterAccept", testReceiveAddressAfterAccept),
                 ("testWeDontJamSocketsInANoIOState", testWeDontJamSocketsInANoIOState),
+                ("testNoChannelReadIfNoAutoRead", testNoChannelReadIfNoAutoRead),
+                ("testEOFOnlyReceivedOnceReadRequested", testEOFOnlyReceivedOnceReadRequested),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

At the moment its possible that channelRead is triggered even if autoRead is never changed to true and no read() is triggered.

Modifications:

- Correctly take autoRead / pendingRead into account when register with the Selector
- Only set SelectorEvent.writable to true if EPOLLRDHUP or EPOLLERR is set. This allows us to detect connection-reset by try to call write(...). We also set SelectorEvent.readable before which would also still trigger a read in this scenario which is unexpected.
- Add test case.

Result:

Fixes https://github.com/apple/swift-nio/issues/160.