### PR TITLE
Ensure we always call Channel.close() if a channel is fired through t…

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -794,6 +794,10 @@ public final class ChannelPipeline: ChannelInvoker {
     func fireChannelRead0(_ data: NIOAny) {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelRead(data)
+        } else if let channel: Channel = data.tryAs() {
+            // If fireChannelRead0 was called with a `Channel` wrapped (as done by our ServerSocketChannel) we need to ensure we close
+            // it if there is no way to intercept it by te user.
+            channel.close(promise: nil)
         }
     }
 


### PR DESCRIPTION
…he ChannelPipeline and the pipeline is already destroyed.

Motivation:

If a Channel is closed we also destroy the ChannelPipeline. For this we remove all handlers from it. The problem is that once this is done there is no more posibility for the user to intercept the fireChannelRead(...) and so Channels may leak if these are passed into it (as done by ServerSocketChannel).

Modifications:

Close the Channel when the pipeline was destroyed already.

Result:

No more leaks of Channels accepted by ServerSocketChannel.