### PR TITLE
fix closed accepting Channels in closed ServerSocketChannels

### DIFF
--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -59,6 +59,7 @@ extension ChannelTests {
                 ("testWeDontJamSocketsInANoIOState", testWeDontJamSocketsInANoIOState),
                 ("testNoChannelReadIfNoAutoRead", testNoChannelReadIfNoAutoRead),
                 ("testEOFOnlyReceivedOnceReadRequested", testEOFOnlyReceivedOnceReadRequested),
+                ("testAcceptsAfterCloseDontCauseIssues", testAcceptsAfterCloseDontCauseIssues),
            ]
    }
 }


### PR DESCRIPTION
many thanks to @vlm for reporting 💯

Motivation:

For servers NIO had a race where when you start tearing down the
`ServerSocketChannel` and at roughly the same time a client connects, we
would not fully bring that channel up, nor tear it down. That lead to
open channels being deallocated which leads to a crash as that's an
illegal state.

Modifications:

Made sure newly accepted channels get closed if the
`ServerSocketChannel` is already clsing.

Result:

No crashes anymore when a client connects to a closing server.