### PR TITLE
Don't close DatagramChannel when recvfrom fails with ECONNREFUSED / E…

### DIFF
--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -16,7 +16,7 @@
 public typealias IOVector = iovec
 
 // TODO: scattering support
-final class Socket: BaseSocket {
+/* final but tests */ class Socket: BaseSocket {
 
     /// The maximum number of bytes to write per `writev` call.
     static var writevLimitBytes: Int {

--- a/Tests/NIOTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOTests/DatagramChannelTests+XCTest.swift
@@ -36,6 +36,9 @@ extension DatagramChannelTests {
                 ("testLargeWritesFail", testLargeWritesFail),
                 ("testOneLargeWriteDoesntPreventOthersWriting", testOneLargeWriteDoesntPreventOthersWriting),
                 ("testClosingBeforeFlushFailsAllWrites", testClosingBeforeFlushFailsAllWrites),
+                ("testRecvFromFailsWithECONNREFUSED", testRecvFromFailsWithECONNREFUSED),
+                ("testRecvFromFailsWithENOMEM", testRecvFromFailsWithENOMEM),
+                ("testRecvFromFailsWithEFAULT", testRecvFromFailsWithEFAULT),
            ]
    }
 }


### PR DESCRIPTION
…NOMEM

Motivation:

We should not close the DatagramChannel when recvfrom fails with ECONNREFUSED / ENOMEM. The former may be caused by a previous sendto and the other may be recoverable by just stop reading for some time.

Modifications:

- Special handle ECONNREFUSED and ENOMEN to not close the channel.
- Add unit tests

Result:

More robust datagram support.