### PR TITLE
Suppress compiler warnings in release mode.

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -312,7 +312,7 @@ public final class EventLoopFuture<T> {
         self.value = value
         self._fulfilled = Atomic(value: value != nil)
 
-        if _isDebugAssertConfiguration() {
+        debugOnly {
             if let me = eventLoop as? SelectableEventLoop {
                 me.promiseCreationStoreAdd(future: self, file: file, line: line)
             }
@@ -335,13 +335,15 @@ public final class EventLoopFuture<T> {
     }
 
     deinit {
-        if _isDebugAssertConfiguration(), let eventLoop = self.eventLoop as? SelectableEventLoop {
-            let creation = eventLoop.promiseCreationStoreRemove(future: self)
-            if !fulfilled {
-                fatalError("leaking promise created at \(creation)", file: creation.file, line: creation.line)
+        debugOnly {
+            if let eventLoop = self.eventLoop as? SelectableEventLoop {
+                let creation = eventLoop.promiseCreationStoreRemove(future: self)
+                if !fulfilled {
+                    fatalError("leaking promise created at \(creation)", file: creation.file, line: creation.line)
+                }
+            } else {
+                precondition(fulfilled, "leaking an unfulfilled Promise")
             }
-        } else {
-            precondition(fulfilled, "leaking an unfulfilled Promise")
         }
     }
 }

--- a/Sources/NIO/Utilities.swift
+++ b/Sources/NIO/Utilities.swift
@@ -28,6 +28,15 @@ private func darwinCoreCount() -> Int {
 }
 #endif
 
+/// A utility function that runs the body code only in debug builds, without
+/// emitting compiler warnings.
+///
+/// This is currently the only way to do this in Swift: see
+/// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
+internal func debugOnly(_ body: () -> Void) {
+    assert({ body(); return true }())
+}
+
 /// Allows to "box" another value.
 final class Box<T> {
     let value: T


### PR DESCRIPTION
Motivation:

There's no reason for us to emit compiler warnings.

Modifications:

Remove use of _isDebugAssertConfiguration to guard code, instead
use a hand-rolled hacky solution on top of assert.

Result:

Fewer warnings, more sadness.

Resolves #178.