### PR TITLE
Make NIO compile on iOS - wrap sendfile() in #if's that match the import

### DIFF
--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -378,7 +378,7 @@ internal enum Posix {
                     }
                     return result
                 #else
-                    let badOS = { fatalError("unsupported OS") }()
+                    fatalError("unsupported OS")
                 #endif
             }
             return .processed(Int(written))

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -363,12 +363,12 @@ internal enum Posix {
         var written: off_t = 0
         do {
             _ = try wrapSyscall { () -> ssize_t in
-                #if os(macOS)
+                #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
                     var w: off_t = off_t(count)
                     let result: CInt = Darwin.sendfile(fd, descriptor, offset, &w, nil, 0)
                     written = w
                     return ssize_t(result)
-                #else
+                #elseif os(Linux) || os(FreeBSD) || os(Android)
                     var off: off_t = offset
                     let result: ssize_t = Glibc.sendfile(descriptor, fd, &off, count)
                     if result >= 0 {
@@ -377,6 +377,8 @@ internal enum Posix {
                         written = 0
                     }
                     return result
+                #else
+                    let badOS = { fatalError("unsupported OS") }()
                 #endif
             }
             return .processed(Int(written))


### PR DESCRIPTION
### Motivation:

NIO doesn't compile on iOS. Which I'd like to do.

### Modifications:

The `#if`'s used to protect the syscall do not match the `#if`'s used to `import`. Specifically the Darwin branch only applied to macOS, not watchOS nor homePodOS.

### Result:

NIO compiles on iOS. Thanks to NIO iPhone's can serve 100k RpS and will replace the IBM servers in the datacenter.