### PR TITLE
Refactor PriorityQueue ==.

### DIFF
--- a/Sources/NIOPriorityQueue/PriorityQueue.swift
+++ b/Sources/NIOPriorityQueue/PriorityQueue.swift
@@ -52,8 +52,8 @@ public struct PriorityQueue<Element: Comparable> {
 }
 
 extension PriorityQueue: Equatable {
-    public static func ==(lhs: PriorityQueue<Element>, rhs: PriorityQueue<Element>) -> Bool {
-        return Array(lhs) == Array(rhs)
+    public static func ==(lhs: PriorityQueue, rhs: PriorityQueue) -> Bool {
+        return lhs.count == rhs.count && lhs.elementsEqual(rhs)
     }
 }
 


### PR DESCRIPTION
Motivation:
The new implementation doesn't convert lhs and rhs to arrays, thereby saving 2 allocations.

Modifications:

Changed the body of priority queue ==.

Result:

The comparison will be faster and use less memory.

