### PR TITLE
Fix possible endless loop when shutdown SelectableEventLoop

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -473,7 +473,7 @@ internal final class SelectableEventLoop: EventLoop {
             tasksLock.unlock()
 
             // Fail all the scheduled tasks.
-            while let task = tasksCopy.first {
+            for task in tasksCopy {
                 task.fail(error: EventLoopError.shutdown)
             }
         }
@@ -522,13 +522,11 @@ internal final class SelectableEventLoop: EventLoop {
                 }
 
                 // Execute all the tasks that were summited
-                while let task = tasksCopy.first {
+                for task in tasksCopy {
                     /* for macOS: in case any calls we make to Foundation put objects into an autoreleasepool */
                     withAutoReleasePool {
                         task()
                     }
-
-                    _ = tasksCopy.removeFirst()
                 }
             }
         }

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -35,6 +35,7 @@ extension EventLoopTest {
                 ("testEventLoopPinned", testEventLoopPinned),
                 ("testEventLoopPinnedCPUIdsConstructor", testEventLoopPinnedCPUIdsConstructor),
                 ("testCurrentEventLoop", testCurrentEventLoop),
+                ("testShutdownWhileScheduledTasksNotReady", testShutdownWhileScheduledTasksNotReady),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -272,4 +272,11 @@ public class EventLoopTest : XCTestCase {
             tries += 1
         }
     }
+
+    public func testShutdownWhileScheduledTasksNotReady() throws {
+        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let eventLoop = group.next()
+        _ = eventLoop.scheduleTask(in: .hours(1)) { }
+        try group.syncShutdownGracefully()
+    }
 }


### PR DESCRIPTION
Motivation:

When the SelectableEventLoop is shutdown it will process a defer block in which we tried to fail all scheduled tasks that were not processed yet. The problem here was that we incorrectly not dropped the processed task and so ended in an endless loop which prevent the defer block to complete.

Beside this how we processed the scheduled tasks that were ready for execution was quite in-efficient as we always called removeFirst() which will most likely case a memory copy to move the elements around.

Modifications:

- Correctly fail all scheduled tasks without end up in an endless loop
- Use a for each loop to reduce overhead of processing ready tasks.

Result:

It's always possible to shutdown a SelectableEventLoop and less overhead when processing ready tasks.