### PR TITLE
Correctly shutdown EventLoopGroup during tests.

### DIFF
--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -384,6 +384,9 @@ class EventLoopFutureTest : XCTestCase {
 
     func testLoopHoppingHelperSuccess() throws {
         let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
         let loop1 = group.next()
         let loop2 = group.next()
         XCTAssertFalse(loop1 === loop2)
@@ -400,6 +403,10 @@ class EventLoopFutureTest : XCTestCase {
 
     func testLoopHoppingHelperFailure() throws {
         let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
         let loop1 = group.next()
         let loop2 = group.next()
         XCTAssertFalse(loop1 === loop2)
@@ -420,6 +427,9 @@ class EventLoopFutureTest : XCTestCase {
 
     func testLoopHoppingHelperNoHopping() throws {
         let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
         let loop1 = group.next()
         let loop2 = group.next()
         XCTAssertFalse(loop1 === loop2)


### PR DESCRIPTION
Motivation:

320561f4371d32c74a12158d2e18f220703fe32c added a few tests which missed to correctly shutdown the EventLoopGroup

Modifications:

Add code to shutdown group

Result:

Correctly release resources during tests.