### PR TITLE
HappyEyeballs should tolerate uncancellable tasks.

### DIFF
--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -406,12 +406,16 @@ internal class HappyEyeballsConnector {
 
         // Once we've completed, it's not impossible that we'll get state machine events for
         // some amounts of work. For example, we could get late DNS results and late connection
-        // notifications. We want to just quietly ignore these, as our transition into the complete
-        // state should have already sent cleanup messages to all of these things.
+        // notifications, and can also get late scheduled task callbacks. We want to just quietly
+        // ignore these, as our transition into the complete state should have already sent
+        // cleanup messages to all of these things.
         case (.complete, .resolverACompleted),
              (.complete, .resolverAAAACompleted),
              (.complete, .connectSuccess),
-             (.complete, .connectFailed):
+             (.complete, .connectFailed),
+             (.complete, .connectDelayElapsed),
+             (.complete, .connectTimeoutElapsed),
+             (.complete, .resolutionDelayElapsed):
             break
         default:
             fatalError("Invalid FSM transition attempt: state \(state), input \(input)")

--- a/Tests/NIOTests/HappyEyeballsTest+XCTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest+XCTest.swift
@@ -48,6 +48,8 @@ extension HappyEyeballsTest {
                 ("testLaterConnections", testLaterConnections),
                 ("testDelayedChannelCreation", testDelayedChannelCreation),
                 ("testChannelCreationFails", testChannelCreationFails),
+                ("testCancellationSyncWithConnectDelay", testCancellationSyncWithConnectDelay),
+                ("testCancellationSyncWithResolutionDelay", testCancellationSyncWithResolutionDelay),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

The HappyEyeballs state machine incorrectly assumed that it would always
be able to cancel any scheduled task that would execute on the event loop
that the state machine itself was running on. This is not accurate: if
the scheduled task is scheduled to execute at roughly the same time as
another callback into the state machine then it may be uncancellable.

Modifications:

Allowed the three scheduled tasks (connect timeout, connect delay, and
resolver delay) to fire in completed.

Result:

No fatalErrors in window conditions under high load

Resolves #187.