### PR TITLE
Fix warnings in tests.

### DIFF
--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -317,7 +317,7 @@ class ChannelNotificationTest: XCTestCase {
         buffer.write(string: "test")
 
 
-        while let result = try? channel.writeAndFlush(buffer).wait() {
+        while (try? channel.writeAndFlush(buffer).wait()) != nil {
             // Just write in a loop until it fails to ensure we detect the closed connection in a timely manner.
         }
         try channel.closeFuture.wait()

--- a/Tests/NIOTests/EmbeddedEventLoopTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest.swift
@@ -300,7 +300,7 @@ public class EmbeddedEventLoopTest: XCTestCase {
         }
 
         // Finally schedule a task for 10ns.
-        loop.scheduleTask(in: .nanoseconds(10)) {
+        _ = loop.scheduleTask(in: .nanoseconds(10)) {
             XCTAssertEqual(orderingCounter, 5)
             orderingCounter = 6
         }


### PR DESCRIPTION
Motivation:

When running swift test two warnings were printed.

Modifications:

- Signal that we want to ignore the return value
- Use boolean test in the while loop

Result:

Cleaner build