### PR TITLE
Correctly expose backward-compat shim for header iterator.

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -348,11 +348,11 @@ extension HTTPHeaders: Sequence {
 
 // Dance to ensure that this version of makeIterator(), which returns
 // an AnyIterator, is only called when forced through type context.
-protocol _DeprecateHTTPHeaderIterator: Sequence { }
+public protocol _DeprecateHTTPHeaderIterator: Sequence { }
 extension HTTPHeaders: _DeprecateHTTPHeaderIterator { }
-extension _DeprecateHTTPHeaderIterator {
+public extension _DeprecateHTTPHeaderIterator {
   @available(*, deprecated, message: "Please use the HTTPHeaders.Iterator type")
-  func makeIterator() -> AnyIterator<Element> {
+  public func makeIterator() -> AnyIterator<Element> {
     return AnyIterator(makeIterator() as Iterator)
   }  
 }


### PR DESCRIPTION
Motivation:

header iterator that could be used to keep access to the iterator with
type erasure. However, it was accidentally made internal, and therefore
useless.

Modifications:

Made the shim public.

Result:

Users can actually upgrade their systems.
