### PR TITLE
Ensure fireChannelActive(...) is always called before fireChannelRead(...)

### DIFF
--- a/Tests/NIOTests/ChannelNotificationTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest+XCTest.swift
@@ -27,6 +27,7 @@ extension ChannelNotificationTest {
    static var allTests : [(String, (ChannelNotificationTest) -> () throws -> Void)] {
       return [
                 ("testNotificationOrder", testNotificationOrder),
+                ("testActiveBeforeChannelRead", testActiveBeforeChannelRead),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

fireChannelActive(...) must always be called before fireChannelRead(...) which was not the cause all of the times as once ChannelOptions were applied to the accepted SocketChannel it was possible that read0() was called during this. This would then lead to an assert error as it tried to reregister on the Selector before we ever registered.

Modifications:

- Ensure we only try to reregister once we have registered to the Selector
- Only trigger read0() or pauseRead0() if the autoRead value actually changed
- Add unit test

Result:

Correct order of events and no crashes.