### PR TITLE
Ensure we wait for the promise to succeed.

### DIFF
--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -391,6 +391,7 @@ class ChannelNotificationTest: XCTestCase {
         try clientChannel.writeAndFlush(buffer).then {
             clientChannel.close()
         }.wait()
+        try promise.futureResult.wait()
 
         try clientChannel.closeFuture.wait()
         try serverChannel.close().wait()


### PR DESCRIPTION
Motivation:

If we don't wait for the promise to succeed it may not be succeded
before we tear the loop down. This causes precondition failures.

Modifications:

We now always wait for the promise to succeed.

Result:

My tests will run.

Resolves #199