### PR TITLE
fixed #202

### DIFF
--- a/Sources/NIO/ChannelInvoker.swift
+++ b/Sources/NIO/ChannelInvoker.swift
@@ -179,8 +179,8 @@ extension ChannelOutboundInvoker {
         return promise.futureResult
     }
 
-    private func newPromise() -> EventLoopPromise<Void> {
-        return eventLoop.newPromise()
+    private func newPromise(file: StaticString = #file, line: UInt = #line) -> EventLoopPromise<Void> {
+        return eventLoop.newPromise(file: file, line: line)
     }
 }
 


### PR DESCRIPTION
Introduced some new parameters.

### Motivation:

I just wanted to fix #202 :)

### Modifications:

Created new parameters for the file and line newPromise method inside ChannelOutboundInvoker.

### Result:

File and line numbers are now passed to the eventLoop object, all unit tests have been passed.
