### PR TITLE
It should be possible to open a DatagramChannel without binding it.

### DIFF
--- a/Tests/NIOTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOTests/DatagramChannelTests+XCTest.swift
@@ -40,6 +40,7 @@ extension DatagramChannelTests {
                 ("testRecvFromFailsWithENOMEM", testRecvFromFailsWithENOMEM),
                 ("testRecvFromFailsWithEFAULT", testRecvFromFailsWithEFAULT),
                 ("testSetGetOptionClosedDatagramChannel", testSetGetOptionClosedDatagramChannel),
+                ("testOpenWithoutBind", testOpenWithoutBind),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

If someone wants to just send data via a DatagramChannel it should be possible to do so without binding it.

Modifications:

- Add DatagramChannel.open() which allows to open a DatagramChannel without binding it first.
- Add unit test

Result:

Be able to send data as datagram without binding the DatagramChannel