### PR TITLE
Disallow adding ChannelHandlers with the same name to the ChannelPipeline

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -299,6 +299,15 @@ public final class ChannelPipeline: ChannelInvoker {
             return
         }
 
+        /// The user provided a name let us ensure we not clash.
+        if let n = name {
+            let found = self.contextForPredicate0 { $0.name == n }
+            if found != nil {
+                promise.fail(error: ChannelPipelineError.duplicatedName)
+                return
+            }
+        }
+
         let ctx = ChannelHandlerContext(name: name ?? nextName(), handler: handler, pipeline: self)
         operation(ctx, relativeContext)
 
@@ -988,6 +997,8 @@ public enum ChannelPipelineError: Error {
     case alreadyRemoved
     /// `ChannelHandler` was not found.
     case notFound
+    /// `ChannelHandler` with the name already exists in the `ChannelPipeline`.
+    case duplicatedName
 }
 
 /// Every `ChannelHandler` has -- when added to a `ChannelPipeline` -- a corresponding `ChannelHandlerContext` which is

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -45,6 +45,7 @@ extension ChannelPipelineTest {
                 ("testFindHandlerByTypeReturnsTheFirstOfItsType", testFindHandlerByTypeReturnsTheFirstOfItsType),
                 ("testContextForHeadOrTail", testContextForHeadOrTail),
                 ("testRemoveHeadOrTail", testRemoveHeadOrTail),
+                ("testAddWithSameNameFails", testAddWithSameNameFails),
            ]
    }
 }

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -678,4 +678,46 @@ class ChannelPipelineTest: XCTestCase {
             /// expected
         }
     }
+
+    func testAddWithSameNameFails() throws {
+        class TestHandler: ChannelInboundHandler {
+            typealias InboundIn = Any
+        }
+
+        let channel = EmbeddedChannel()
+
+        defer {
+            XCTAssertFalse(try channel.finish())
+        }
+
+        let handler = TestHandler()
+        try channel.pipeline.add(name: "handler", handler: handler).wait()
+
+        do {
+            try channel.pipeline.add(name: "handler", handler: TestHandler(), first: true).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .duplicatedName {
+            /// expected
+        }
+
+        do {
+            try channel.pipeline.add(name: "handler", handler: TestHandler(), first: false).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .duplicatedName {
+            /// expected
+        }
+        do {
+            try channel.pipeline.add(name: "handler", handler: TestHandler(), after: handler).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .duplicatedName {
+            /// expected
+        }
+
+        do {
+            try channel.pipeline.add(name: "handler", handler: TestHandler(), before: handler).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .duplicatedName {
+            /// expected
+        }
+    }
 }


### PR DESCRIPTION
    Motivation:

    We should not allow to add ChannelHandlers with the same name to the ChannelPipeline as these should be usable to uniqly identify ChannelHandlers.

    Modifications:

    - Dissallow adding ChannelHandlers with the same name to the ChannelPipeline
    - Add unit tests.

    Result:

    More robust ChannelPipeline.