### PR TITLE
Remove unsafe assert on Linux

### DIFF
--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -152,18 +152,6 @@ final class Selector<R: Registration> {
         }
     }
 
-    private func ensureFDNotRegisteredOnEpoll(_ fd: CInt) -> Bool {
-        var ev = Epoll.epoll_event()
-        do {
-            _ = try Epoll.epoll_ctl(epfd: self.fd, op: Epoll.EPOLL_CTL_DEL, fd: fd, event: &ev)
-        } catch let ioError as IOError {
-            return ioError.errnoCode == Epoll.ENOENT
-        } catch {
-            // Just ignore any other error.
-        }
-        return true
-    }
-
 #else
     private func toKQueueTimeSpec(strategy: SelectorStrategy) -> timespec? {
         switch strategy {
@@ -392,8 +380,6 @@ final class Selector<R: Registration> {
                             readable: (ev.events & Epoll.EPOLLIN.rawValue) != 0 || (ev.events & Epoll.EPOLLERR.rawValue) != 0 || (ev.events & Epoll.EPOLLRDHUP.rawValue) != 0,
                             writable: (ev.events & Epoll.EPOLLOUT.rawValue) != 0 || (ev.events & Epoll.EPOLLERR.rawValue) != 0 || (ev.events & Epoll.EPOLLRDHUP.rawValue) != 0,
                             registration: registration))
-                } else {
-                    assert(ensureFDNotRegisteredOnEpoll(ev.data.fd), "No registration found for \(ev.data.fd), but still registered on epoll.")
                 }
             }
         }

--- a/Tests/NIOTests/SelectorTest+XCTest.swift
+++ b/Tests/NIOTests/SelectorTest+XCTest.swift
@@ -27,6 +27,7 @@ extension SelectorTest {
    static var allTests : [(String, (SelectorTest) -> () throws -> Void)] {
       return [
                 ("testDeregisterWhileProcessingEvents", testDeregisterWhileProcessingEvents),
+                ("testDeregisterAndCloseWhileProcessingEvents", testDeregisterAndCloseWhileProcessingEvents),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

b8055f74672622f5f06abc13f37b630ff9ccb312 added some code to guard against the case when a fd is deregistered while processing ready events. On Linux it also added an assert which tried to verify that the fd in question is not registered anymore via epoll. The problem here is that it may also be closed which will have epoll_ctl fail with EBADF

Modifications:

Remove assert and add test-case which would have triggered the assert.

Result:

No more assertion error on linux.