### PR TITLE
Changed EventLoop{Future,Promise}<()> occurances to EventLoop{Future,Promise}<Void> (#211)

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -55,8 +55,8 @@ public final class ServerBootstrap {
 
     private let group: EventLoopGroup
     private let childGroup: EventLoopGroup
-    private var serverChannelInit: ((Channel) -> EventLoopFuture<()>)?
-    private var childChannelInit: ((Channel) -> EventLoopFuture<()>)?
+    private var serverChannelInit: ((Channel) -> EventLoopFuture<Void>)?
+    private var childChannelInit: ((Channel) -> EventLoopFuture<Void>)?
     private var serverChannelOptions = ChannelOptionStorage()
     private var childChannelOptions = ChannelOptionStorage()
 
@@ -87,7 +87,7 @@ public final class ServerBootstrap {
     ///
     /// - parameters:
     ///     - initializer: A closure that initializes the provided `Channel`.
-    public func serverChannelInitializer(_ initializer: @escaping (Channel) -> EventLoopFuture<()>) -> Self {
+    public func serverChannelInitializer(_ initializer: @escaping (Channel) -> EventLoopFuture<Void>) -> Self {
         self.serverChannelInit = initializer
         return self
     }
@@ -99,7 +99,7 @@ public final class ServerBootstrap {
     ///
     /// - parameters:
     ///     - initializer: A closure that initializes the provided `Channel`.
-    public func childChannelInitializer(_ initializer: @escaping (Channel) -> EventLoopFuture<()>) -> Self {
+    public func childChannelInitializer(_ initializer: @escaping (Channel) -> EventLoopFuture<Void>) -> Self {
         self.childChannelInit = initializer
         return self
     }
@@ -199,10 +199,10 @@ public final class ServerBootstrap {
     private class AcceptHandler: ChannelInboundHandler {
         public typealias InboundIn = SocketChannel
 
-        private let childChannelInit: ((Channel) -> EventLoopFuture<()>)?
+        private let childChannelInit: ((Channel) -> EventLoopFuture<Void>)?
         private let childChannelOptions: ChannelOptionStorage
 
-        init(childChannelInitializer: ((Channel) -> EventLoopFuture<()>)?, childChannelOptions: ChannelOptionStorage) {
+        init(childChannelInitializer: ((Channel) -> EventLoopFuture<Void>)?, childChannelOptions: ChannelOptionStorage) {
             self.childChannelInit = childChannelInitializer
             self.childChannelOptions = childChannelOptions
         }
@@ -214,7 +214,7 @@ public final class ServerBootstrap {
             self.childChannelOptions.applyAll(channel: accepted).hopTo(eventLoop: ctx.eventLoop).then {
                 assert(ctx.eventLoop.inEventLoop)
                 return childChannelInit(accepted)
-            }.then { () -> EventLoopFuture<()> in
+            }.then { () -> EventLoopFuture<Void> in
                 assert(ctx.eventLoop.inEventLoop)
                 guard !ctx.pipeline.destroyed else {
                     return accepted.close().thenThrowing {
@@ -268,7 +268,7 @@ public final class ServerBootstrap {
 public final class ClientBootstrap {
 
     private let group: EventLoopGroup
-    private var channelInitializer: ((Channel) -> EventLoopFuture<()>)?
+    private var channelInitializer: ((Channel) -> EventLoopFuture<Void>)?
     private var channelOptions = ChannelOptionStorage()
     private var connectTimeout: TimeAmount = TimeAmount.seconds(10)
     private var resolver: Resolver?
@@ -288,7 +288,7 @@ public final class ClientBootstrap {
     ///
     /// - parameters:
     ///     - handler: A closure that initializes the provided `Channel`.
-    public func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<()>) -> Self {
+    public func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self {
         self.channelInitializer = handler
         return self
     }
@@ -427,7 +427,7 @@ public final class ClientBootstrap {
 public final class DatagramBootstrap {
 
     private let group: EventLoopGroup
-    private var channelInitializer: ((Channel) -> EventLoopFuture<()>)?
+    private var channelInitializer: ((Channel) -> EventLoopFuture<Void>)?
     private var channelOptions = ChannelOptionStorage()
 
     /// Create a `DatagramBootstrap` on the `EventLoopGroup` `group`.
@@ -443,7 +443,7 @@ public final class DatagramBootstrap {
     ///
     /// - parameters:
     ///     - handler: A closure that initializes the provided `Channel`.
-    public func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<()>) -> Self {
+    public func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self {
         self.channelInitializer = handler
         return self
     }

--- a/Sources/NIO/DeadChannel.swift
+++ b/Sources/NIO/DeadChannel.swift
@@ -75,7 +75,7 @@ internal final class DeadChannel: Channel {
     let eventLoop: EventLoop
     let pipeline: ChannelPipeline
 
-    public var closeFuture: EventLoopFuture<()> {
+    public var closeFuture: EventLoopFuture<Void> {
         return self.eventLoop.newSucceededFuture(result: ())
     }
 

--- a/Sources/NIO/PendingWritesManager.swift
+++ b/Sources/NIO/PendingWritesManager.swift
@@ -120,7 +120,7 @@ private struct PendingStreamWritesState {
     ///
     /// - returns: The `EventLoopPromise` of the write or `nil` if none was provided. The promise needs to be fulfilled by the caller.
     ///
-    private mutating func fullyWrittenFirst() -> EventLoopPromise<()>? {
+    private mutating func fullyWrittenFirst() -> EventLoopPromise<Void>? {
         self.chunks -= 1
         let first = self.pendingWrites.removeFirst()
         self.subtractOutstanding(bytes: first.data.readableBytes)
@@ -184,7 +184,7 @@ private struct PendingStreamWritesState {
     ///     - writeResult: The result of the write operation.
     /// - returns: A closure that the caller _needs_ to run which will fulfill the promises of the writes and a `OneWriteOperationResult` which indicates if we could write everything or not.
     public mutating func didWrite(itemCount: Int, result writeResult: IOResult<Int>) -> (() -> Void, OneWriteOperationResult) {
-        var promises: [EventLoopPromise<()>] = []
+        var promises: [EventLoopPromise<Void>] = []
         let fulfillPromises = { promises.forEach { $0.succeed(result: ()) } }
 
         switch writeResult {
@@ -225,7 +225,7 @@ private struct PendingStreamWritesState {
     ///
     /// - returns: A closure that the caller _needs_ to run which will fulfill the promises.
     public mutating func failAll(error: Error) -> (() -> Void) {
-        var promises: [EventLoopPromise<()>] = []
+        var promises: [EventLoopPromise<Void>] = []
         promises.reserveCapacity(self.pendingWrites.count)
         while !self.pendingWrites.isEmpty {
             if let p = self.fullyWrittenFirst() {

--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -15,12 +15,12 @@
 import NIO
 
 private func writeChunk(wrapOutboundOut: (IOData) -> NIOAny, ctx: ChannelHandlerContext, isChunked: Bool, chunk: IOData, promise: EventLoopPromise<Void>?) {
-    let (mW1, mW2, mW3): (EventLoopPromise<()>?, EventLoopPromise<()>?, EventLoopPromise<()>?)
+    let (mW1, mW2, mW3): (EventLoopPromise<Void>?, EventLoopPromise<Void>?, EventLoopPromise<Void>?)
 
     switch (isChunked, promise) {
     case (true, .some(let p)):
         /* chunked encoding and the user's interested: we need three promises and need to cascade into the users promise */
-        let (w1, w2, w3) = (ctx.eventLoop.newPromise() as EventLoopPromise<()>, ctx.eventLoop.newPromise() as EventLoopPromise<()>, ctx.eventLoop.newPromise() as EventLoopPromise<()>)
+        let (w1, w2, w3) = (ctx.eventLoop.newPromise() as EventLoopPromise<Void>, ctx.eventLoop.newPromise() as EventLoopPromise<Void>, ctx.eventLoop.newPromise() as EventLoopPromise<Void>)
         w1.futureResult.and(w2.futureResult).and(w3.futureResult).map { (_: ((((), ()), ()))) in }.cascade(promise: p)
         (mW1, mW2, mW3) = (w1, w2, w3)
     case (false, .some(let p)):

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -73,7 +73,7 @@ private final class HTTPHandler: ChannelInboundHandler {
     private var continuousCount: Int = 0
 
     private var handler: ((ChannelHandlerContext, HTTPServerRequestPart) -> Void)?
-    private var handlerFuture: EventLoopFuture<()>?
+    private var handlerFuture: EventLoopFuture<Void>?
     private let fileIO: NonBlockingFileIO
 
     public init(fileIO: NonBlockingFileIO, htdocsPath: String) {

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -242,7 +242,7 @@ public class ChannelTests: XCTestCase {
     ///     - returns: The return values of the fakes write operations (both single and vector).
     ///     - promiseStates: The states of the promises _after_ the write operations are done.
     func assertExpectedWritability(pendingWritesManager pwm: PendingStreamWritesManager,
-                                   promises: [EventLoopPromise<()>],
+                                   promises: [EventLoopPromise<Void>],
                                    expectedSingleWritabilities: [Int]?,
                                    expectedVectorWritabilities: [[Int]]?,
                                    expectedFileWritabilities: [(Int, Int)]?,
@@ -365,7 +365,7 @@ public class ChannelTests: XCTestCase {
 
         try withPendingStreamWritesManager { pwm in
             buffer.clear()
-            let ps: [EventLoopPromise<()>] = (0..<2).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.newPromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
 
             XCTAssertFalse(pwm.isEmpty)
@@ -421,7 +421,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -457,7 +457,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<4).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<4).map { (_: Int) in el.newPromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[2])
@@ -505,7 +505,7 @@ public class ChannelTests: XCTestCase {
             let numberOfBytes = Int(1 /* first write */ + pwm.writeSpinCount /* the spins */ + 1 /* so one byte remains at the end */)
             buffer.clear()
             buffer.write(bytes: Array<UInt8>(repeating: 0xff, count: numberOfBytes))
-            let ps: [EventLoopPromise<()>] = (0..<1).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.newPromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             pwm.markFlushCheckpoint()
 
@@ -543,8 +543,8 @@ public class ChannelTests: XCTestCase {
             let numberOfBytes = Int(1 /* first write */ + pwm.writeSpinCount /* the spins */ + 1 /* so one byte remains at the end */)
             buffer.clear()
             buffer.write(bytes: [0xff] as [UInt8])
-            let ps: [EventLoopPromise<()>] = (0..<numberOfBytes).map { (_: Int) in
-                let p: EventLoopPromise<()> = el.newPromise()
+            let ps: [EventLoopPromise<Void>] = (0..<numberOfBytes).map { (_: Int) in
+                let p: EventLoopPromise<Void> = el.newPromise()
                 _ = pwm.add(data: .byteBuffer(buffer), promise: p)
                 return p
             }
@@ -604,7 +604,7 @@ public class ChannelTests: XCTestCase {
                 XCTAssertNoThrow(try handle.takeDescriptorOwnership())
             }
             let fileRegion = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 1)
-            let ps: [EventLoopPromise<()>] = (0..<numberOfWrites).map { _ in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<numberOfWrites).map { _ in el.newPromise() }
             (0..<numberOfWrites).forEach { i in
                 _ = pwm.add(data: i % 2 == 0 ? .byteBuffer(buffer) : .fileRegion(fileRegion), promise: ps[i])
             }
@@ -636,7 +636,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -671,7 +671,7 @@ public class ChannelTests: XCTestCase {
         buffer.moveWriterIndex(to: halfTheWriteVLimit)
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             /* add 1.5x the writev limit */
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
@@ -703,7 +703,7 @@ public class ChannelTests: XCTestCase {
         buffer.moveWriterIndex(to: biggerThanWriteV)
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             /* add 1.5x the writev limit */
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
@@ -736,7 +736,7 @@ public class ChannelTests: XCTestCase {
     func testPendingWritesFileRegion() throws {
         let el = EmbeddedEventLoop()
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<2).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.newPromise() }
 
             let fh1 = FileHandle(descriptor: -1)
             let fh2 = FileHandle(descriptor: -2)
@@ -785,7 +785,7 @@ public class ChannelTests: XCTestCase {
     func testPendingWritesEmptyFileRegion() throws {
         let el = EmbeddedEventLoop()
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<1).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.newPromise() }
 
             let fh = FileHandle(descriptor: -1)
             let fr = FileRegion(fileHandle: fh, readerIndex: 99, endIndex: 99)
@@ -814,7 +814,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<5).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<5).map { (_: Int) in el.newPromise() }
 
             let fh1 = FileHandle(descriptor: -1)
             let fh2 = FileHandle(descriptor: -1)
@@ -870,7 +870,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
 
             pwm.markFlushCheckpoint()
 
@@ -921,7 +921,7 @@ public class ChannelTests: XCTestCase {
         let emptyBuffer = alloc.buffer(capacity: 12)
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             _ = pwm.add(data: .byteBuffer(emptyBuffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(emptyBuffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -956,7 +956,7 @@ public class ChannelTests: XCTestCase {
         buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -987,7 +987,7 @@ public class ChannelTests: XCTestCase {
         buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.newPromise() }
             ps.forEach { p in
                 _ = pwm.add(data: .byteBuffer(buffer), promise: p)
             }
@@ -1016,7 +1016,7 @@ public class ChannelTests: XCTestCase {
     func testPendingWritesIsHappyWhenSendfileReturnsWouldBlockButWroteFully() throws {
         let el = EmbeddedEventLoop()
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<1).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.newPromise() }
 
             let fh = FileHandle(descriptor: -1)
             let fr = FileRegion(fileHandle: fh, readerIndex: 0, endIndex: 8192)
@@ -1643,7 +1643,7 @@ public class ChannelTests: XCTestCase {
                 XCTAssertTrue(removed != nil)
             }
 
-            func closeAll() -> [EventLoopFuture<()>] {
+            func closeAll() -> [EventLoopFuture<Void>] {
                 return q.sync { self.channels.values }.map { channel in
                     channel.close()
                 }
@@ -1732,9 +1732,9 @@ public class ChannelTests: XCTestCase {
         }
         class ReadDoesNotHappen: ChannelInboundHandler {
             typealias InboundIn = Any
-            private let hasRegisteredPromise: EventLoopPromise<()>
-            private let hasUnregisteredPromise: EventLoopPromise<()>
-            private let hasReadPromise: EventLoopPromise<()>
+            private let hasRegisteredPromise: EventLoopPromise<Void>
+            private let hasUnregisteredPromise: EventLoopPromise<Void>
+            private let hasReadPromise: EventLoopPromise<Void>
             enum State {
                 case start
                 case registered
@@ -1742,7 +1742,7 @@ public class ChannelTests: XCTestCase {
                 case read
             }
             private var state: State = .start
-            init(hasRegisteredPromise: EventLoopPromise<()>, hasUnregisteredPromise: EventLoopPromise<()>, hasReadPromise: EventLoopPromise<()>) {
+            init(hasRegisteredPromise: EventLoopPromise<Void>, hasUnregisteredPromise: EventLoopPromise<Void>, hasReadPromise: EventLoopPromise<Void>) {
                 self.hasRegisteredPromise = hasRegisteredPromise
                 self.hasUnregisteredPromise = hasUnregisteredPromise
                 self.hasReadPromise = hasReadPromise
@@ -1779,9 +1779,9 @@ public class ChannelTests: XCTestCase {
             typealias InboundIn = Any
             typealias OutboundOut = ByteBuffer
 
-            private let writeDonePromise: EventLoopPromise<()>
+            private let writeDonePromise: EventLoopPromise<Void>
 
-            init(writeDonePromise: EventLoopPromise<()>) {
+            init(writeDonePromise: EventLoopPromise<Void>) {
                 self.writeDonePromise = writeDonePromise
             }
 
@@ -1792,10 +1792,10 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let serverWriteHappenedPromise: EventLoopPromise<()> = serverEL.next().newPromise()
-        let clientHasRegistered: EventLoopPromise<()> = serverEL.next().newPromise()
-        let clientHasUnregistered: EventLoopPromise<()> = serverEL.next().newPromise()
-        let clientHasRead: EventLoopPromise<()> = serverEL.next().newPromise()
+        let serverWriteHappenedPromise: EventLoopPromise<Void> = serverEL.next().newPromise()
+        let clientHasRegistered: EventLoopPromise<Void> = serverEL.next().newPromise()
+        let clientHasUnregistered: EventLoopPromise<Void> = serverEL.next().newPromise()
+        let clientHasRead: EventLoopPromise<Void> = serverEL.next().newPromise()
 
         let bootstrap = try ServerBootstrap(group: serverEL)
             .childChannelInitializer { channel in

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -110,12 +110,12 @@ final class DatagramChannelTests: XCTestCase {
         var buffer = firstChannel.allocator.buffer(capacity: 256)
         buffer.write(staticString: "hello, world!")
         let writeData = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
-        var writeFutures: [EventLoopFuture<()>] = []
+        var writeFutures: [EventLoopFuture<Void>] = []
         for _ in 0..<5 {
             writeFutures.append(self.firstChannel.write(NIOAny(writeData)))
         }
         self.firstChannel.flush()
-        XCTAssertNoThrow(try EventLoopFuture<()>.andAll(writeFutures, eventLoop: self.firstChannel.eventLoop).wait())
+        XCTAssertNoThrow(try EventLoopFuture<Void>.andAll(writeFutures, eventLoop: self.firstChannel.eventLoop).wait())
 
         let reads = try self.secondChannel.waitForDatagrams(count: 5)
 
@@ -155,7 +155,7 @@ final class DatagramChannelTests: XCTestCase {
             XCTAssertTrue(writable)
         }
 
-        let lastWritePromise: EventLoopPromise<()> = self.firstChannel.eventLoop.newPromise()
+        let lastWritePromise: EventLoopPromise<Void> = self.firstChannel.eventLoop.newPromise()
         // The last write will push us over the edge.
         var writable: Bool = try self.firstChannel.eventLoop.submit {
             self.firstChannel.write(NIOAny(writeData), promise: lastWritePromise)
@@ -197,14 +197,14 @@ final class DatagramChannelTests: XCTestCase {
         // We're going to try to write loads, and loads, and loads of data. In this case, one more
         // write than the iovecs max.
 
-        var overall: EventLoopFuture<()> = self.firstChannel.eventLoop.newSucceededFuture(result: ())
+        var overall: EventLoopFuture<Void> = self.firstChannel.eventLoop.newSucceededFuture(result: ())
         for _ in 0...Socket.writevLimitIOVectors {
-            let myPromise: EventLoopPromise<()> = self.firstChannel.eventLoop.newPromise()
+            let myPromise: EventLoopPromise<Void> = self.firstChannel.eventLoop.newPromise()
             var buffer = self.firstChannel.allocator.buffer(capacity: 1)
             buffer.write(string: "a")
             let envelope = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
             self.firstChannel.write(NIOAny(envelope), promise: myPromise)
-            overall = EventLoopFuture<()>.andAll([overall, myPromise.futureResult], eventLoop: self.firstChannel.eventLoop)
+            overall = EventLoopFuture<Void>.andAll([overall, myPromise.futureResult], eventLoop: self.firstChannel.eventLoop)
         }
         self.firstChannel.flush()
         XCTAssertNoThrow(try overall.wait())
@@ -218,7 +218,7 @@ final class DatagramChannelTests: XCTestCase {
         // We defer this work to the background thread because otherwise it incurs an enormous number of context
         // switches.
         _ = try self.firstChannel.eventLoop.submit {
-            let myPromise: EventLoopPromise<()> = self.firstChannel.eventLoop.newPromise()
+            let myPromise: EventLoopPromise<Void> = self.firstChannel.eventLoop.newPromise()
             // For datagrams this buffer cannot be very large, because if it's larger than the path MTU it
             // will cause EMSGSIZE.
             let bufferSize = 1024 * 5
@@ -232,7 +232,7 @@ final class DatagramChannelTests: XCTestCase {
             var written = 0
             while written <= Int(INT32_MAX) {
                 self.firstChannel.write(NIOAny(envelope), promise: myPromise)
-                overall = EventLoopFuture<()>.andAll([overall, myPromise.futureResult], eventLoop: self.firstChannel.eventLoop)
+                overall = EventLoopFuture<Void>.andAll([overall, myPromise.futureResult], eventLoop: self.firstChannel.eventLoop)
                 written += bufferSize
                 datagrams += 1
             }

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -331,11 +331,11 @@ class EchoServerClientTest : XCTestCase {
         typealias InboundIn = Never
         let alreadyClosedInChannelInactive = Atomic<Bool>(value: false)
         let alreadyClosedInChannelUnregistered = Atomic<Bool>(value: false)
-        let channelUnregisteredPromise: EventLoopPromise<()>
-        let channelInactivePromise: EventLoopPromise<()>
+        let channelUnregisteredPromise: EventLoopPromise<Void>
+        let channelInactivePromise: EventLoopPromise<Void>
 
-        public init(channelUnregisteredPromise: EventLoopPromise<()>,
-                    channelInactivePromise: EventLoopPromise<()>) {
+        public init(channelUnregisteredPromise: EventLoopPromise<Void>,
+                    channelInactivePromise: EventLoopPromise<Void>) {
             self.channelUnregisteredPromise = channelUnregisteredPromise
             self.channelInactivePromise = channelInactivePromise
         }
@@ -411,8 +411,8 @@ class EchoServerClientTest : XCTestCase {
                 XCTAssertNoThrow(try group.syncShutdownGracefully())
             }
 
-        let inactivePromise = group.next().newPromise() as EventLoopPromise<()>
-        let unregistredPromise = group.next().newPromise() as EventLoopPromise<()>
+        let inactivePromise = group.next().newPromise() as EventLoopPromise<Void>
+        let unregistredPromise = group.next().newPromise() as EventLoopPromise<Void>
         let handler = CloseInInActiveAndUnregisteredChannelHandler(channelUnregisteredPromise: unregistredPromise,
                                                                    channelInactivePromise: inactivePromise)
 

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -91,7 +91,7 @@ class FileRegionTest : XCTestCase {
             }
             try "".write(toFile: filePath, atomically: false, encoding: .ascii)
 
-            var futures: [EventLoopFuture<()>] = []
+            var futures: [EventLoopFuture<Void>] = []
             for _ in 0..<10 {
                 futures.append(clientChannel.write(NIOAny(fr)))
             }

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
@@ -104,7 +104,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
     ///     - returns: The return values of the fakes write operations (both single and vector).
     ///     - promiseStates: The states of the promises _after_ the write operations are done.
     private func assertExpectedWritability(pendingWritesManager pwm: PendingDatagramWritesManager,
-                                           promises: [EventLoopPromise<()>],
+                                           promises: [EventLoopPromise<Void>],
                                            expectedSingleWritabilities: [(Int, SocketAddress)]?,
                                            expectedVectorWritabilities: [[(Int, SocketAddress)]]?,
                                            returns: [FakeWriteResult],
@@ -231,7 +231,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
 
         try withPendingDatagramWritesManager { pwm in
             buffer.clear()
-            let ps: [EventLoopPromise<()>] = (0..<2).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.newPromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
 
             XCTAssertFalse(pwm.isEmpty)
@@ -286,7 +286,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: firstAddress, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: secondAddress, data: buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -322,7 +322,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<4).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<4).map { (_: Int) in el.newPromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: firstAddress, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: secondAddress, data: buffer), promise: ps[1])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: firstAddress, data: buffer), promise: ps[2])
@@ -371,9 +371,9 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         buffer.write(bytes: Array<UInt8>(repeating: 0xff, count: 12))
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0...pwm.writeSpinCount+1).map { (_: UInt) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0...pwm.writeSpinCount+1).map { (_: UInt) in el.newPromise() }
             ps.forEach { _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: $0) }
-            let maxVectorWritabilities = ps.map { (_: EventLoopPromise<()>) in (buffer.readableBytes, address) }
+            let maxVectorWritabilities = ps.map { (_: EventLoopPromise<Void>) in (buffer.readableBytes, address) }
             let actualVectorWritabilities = maxVectorWritabilities.indices.dropLast().map { Array(maxVectorWritabilities[$0...]) }
             let actualPromiseStates = ps.indices.dropFirst().map { Array(repeating: true, count: $0) + Array(repeating: false, count: ps.count - $0) }
 
@@ -410,7 +410,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -445,7 +445,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 65535)
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             /* add 1.5x the writev limit */
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[1])
@@ -477,7 +477,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         buffer.moveWriterIndex(to: biggerThanWriteV)
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             /* add 1.5x the writev limit */
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
             buffer.moveReaderIndex(to: 100)
@@ -520,7 +520,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 80)
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: emptyBuffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: emptyBuffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -554,7 +554,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -585,7 +585,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<()>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.newPromise() }
             ps.forEach { p in
                 _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: p)
             }


### PR DESCRIPTION
### Motivation:

Fix inconsistency of <Void> and <()> occurances in the codebase. (fixes #211)

### Modifications:

Changed EventLoop{Future,Promise}<()> occurances to EventLoop{Future,Promise}<Void>

### Result:

Consistent code style for EventLoopPromise and EventLoopFuture. 

All tests have been passed.