### PR TITLE
make Channel lifecycle statemachine explicit

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -280,6 +280,13 @@ public enum ChannelError: Error {
     case writeHostUnreachable
 }
 
+/// This should be inside of `ChannelError` but we keep it separate to not break API.
+// TODO: For 2.0: bring this inside of `ChannelError`
+public enum ChannelLifecycleError: Error {
+    /// An operation that was inappropriate given the current `Channel` state was attempted.
+    case inappropriateOperationForState
+}
+
 extension ChannelError: Equatable {
     public static func ==(lhs: ChannelError, rhs: ChannelError) -> Bool {
         switch (lhs, rhs) {

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -823,6 +823,7 @@ public final class ChannelPipeline: ChannelInvoker {
     }
 
     func fireErrorCaught0(error: Error) {
+        assert((error as? ChannelError).map { $0 != .eof } ?? true)
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeErrorCaught(error)
         }

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -519,6 +519,14 @@ internal extension Selector where R == NIORegistration {
             case .datagramChannel(let chan, _):
                 return closeChannel(chan)
             }
+        }.map { future in
+            future.thenIfErrorThrowing { error in
+                if let error = error as? ChannelError, error == .alreadyClosed {
+                    return ()
+                } else {
+                    throw error
+                }
+            }
         }
 
         guard futures.count > 0 else {

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -61,6 +61,8 @@ extension ChannelTests {
                 ("testEOFOnlyReceivedOnceReadRequested", testEOFOnlyReceivedOnceReadRequested),
                 ("testAcceptsAfterCloseDontCauseIssues", testAcceptsAfterCloseDontCauseIssues),
                 ("testChannelReadsDoesNotHappenAfterRegistration", testChannelReadsDoesNotHappenAfterRegistration),
+                ("testAppropriateAndInappropriateOperationsForUnregisteredSockets", testAppropriateAndInappropriateOperationsForUnregisteredSockets),
+                ("testCloseSocketWhenReadErrorWasReceivedAndMakeSureNoReadCompleteArrives", testCloseSocketWhenReadErrorWasReceivedAndMakeSureNoReadCompleteArrives),
            ]
    }
 }


### PR DESCRIPTION
@normanmaurer / @Lukasa this is a preview of what I'm working on. It passes tests, also happy with some monkey channel test which previously used to crash stuff a lot. But we should have a chat what we want to do in which situations. Also CC @vlm .

Motivation:

We had a lot of problems with the Channel lifecycle statemachine as it
wasn't explicit, this fixes this. Additionally, it asserts a lot more.

Modifications:

- made Channel lifecycle statemachine explicit
- lots of asserts

Result:

- hopefully the state machine works better
- the asserts should guide our way to work on in corner cases as well
