### PR TITLE
Annotate global constants that refer to C functions with @convention(c)

### DIFF
--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -31,41 +31,41 @@ let badOS = { fatalError("unsupported OS") }()
 #endif
 
 // Declare aliases to share more code and not need to repeat #if #else blocks
-private let sysClose = close
-private let sysShutdown = shutdown
-private let sysBind = bind
-private let sysFcntl: (CInt, CInt, CInt) -> CInt = fcntl
-private let sysSocket = socket
-private let sysSetsockopt = setsockopt
-private let sysGetsockopt = getsockopt
-private let sysListen = listen
-private let sysAccept = accept
-private let sysConnect = connect
-private let sysOpen: (UnsafePointer<CChar>, CInt) -> CInt = open
-private let sysOpenWithMode: (UnsafePointer<CChar>, CInt, mode_t) -> CInt = open
-private let sysWrite = write
-private let sysWritev = writev
-private let sysRead = read
-private let sysLseek = lseek
-private let sysRecvFrom = recvfrom
-private let sysSendTo = sendto
-private let sysDup = dup
-private let sysGetpeername = getpeername
-private let sysGetsockname = getsockname
-private let sysGetifaddrs = getifaddrs
-private let sysFreeifaddrs = freeifaddrs
+private let sysClose: @convention(c) (CInt) -> CInt = close
+private let sysShutdown: @convention(c) (CInt, CInt) -> CInt = shutdown
+private let sysBind: @convention(c) (CInt, UnsafePointer<sockaddr>?, socklen_t) -> CInt = bind
+private let sysFcntl: @convention(c) (CInt, CInt, CInt) -> CInt = fcntl
+private let sysSocket: @convention(c) (CInt, CInt, CInt) -> CInt = socket
+private let sysSetsockopt: @convention(c) (CInt, CInt, CInt, UnsafeRawPointer?, socklen_t) -> CInt = setsockopt
+private let sysGetsockopt: @convention(c) (CInt, CInt, CInt, UnsafeMutableRawPointer?, UnsafeMutablePointer<socklen_t>?) -> CInt = getsockopt
+private let sysListen: @convention(c) (CInt, CInt) -> CInt = listen
+private let sysAccept: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = accept
+private let sysConnect: @convention(c) (CInt, UnsafePointer<sockaddr>?, socklen_t) -> CInt = connect
+private let sysOpen: @convention(c) (UnsafePointer<CChar>, CInt) -> CInt = open
+private let sysOpenWithMode: @convention(c) (UnsafePointer<CChar>, CInt, mode_t) -> CInt = open
+private let sysWrite: @convention(c) (CInt, UnsafeRawPointer?, CLong) -> CLong = write
+private let sysWritev: @convention(c) (Int32, UnsafePointer<iovec>?, CInt) -> CLong = writev
+private let sysRead: @convention(c) (CInt, UnsafeMutableRawPointer?, CLong) -> CLong = read
+private let sysLseek: @convention(c) (CInt, off_t, CInt) -> off_t = lseek
+private let sysRecvFrom: @convention(c) (CInt, UnsafeMutableRawPointer?, CLong, CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CLong = recvfrom
+private let sysSendTo: @convention(c) (CInt, UnsafeRawPointer?, CLong, CInt, UnsafePointer<sockaddr>?, socklen_t) -> CLong = sendto
+private let sysDup: @convention(c) (CInt) -> CInt = dup
+private let sysGetpeername: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = getpeername
+private let sysGetsockname: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = getsockname
+private let sysGetifaddrs: @convention(c) (UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>?) -> CInt = getifaddrs
+private let sysFreeifaddrs: @convention(c) (UnsafeMutablePointer<ifaddrs>?) -> Void = freeifaddrs
 private let sysAF_INET = AF_INET
 private let sysAF_INET6 = AF_INET6
 private let sysAF_UNIX = AF_UNIX
-private let sysInet_ntop = inet_ntop
+private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>! = inet_ntop
 
 #if os(Linux)
-private let sysSendMmsg = CNIOLinux_sendmmsg
-private let sysRecvMmsg = CNIOLinux_recvmmsg
+private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIOLinux_mmsghdr>?, CUnsignedInt, CInt) -> CInt = CNIOLinux_sendmmsg
+private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIOLinux_mmsghdr>?, CUnsignedInt, CInt, UnsafeMutablePointer<timespec>?) -> CInt  = CNIOLinux_recvmmsg
 #else
 private let sysKevent = kevent
-private let sysSendMmsg = CNIODarwin_sendmmsg
-private let sysRecvMmsg = CNIODarwin_recvmmsg
+private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_mmsghdr>?, CUnsignedInt, CInt) -> CInt = CNIODarwin_sendmmsg
+private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_mmsghdr>?, CUnsignedInt, CInt, UnsafeMutablePointer<timespec>?) -> CInt = CNIODarwin_recvmmsg
 #endif
 
 private func isBlacklistedErrno(_ code: Int32) -> Bool {


### PR DESCRIPTION
### Motivation:

This fixes https://github.com/apple/swift-nio/issues/206.

Also see: https://bugs.swift.org/browse/SR-7242.

### Modifications:

Annotated global constants that refer to C functions with `@convention(c), and added explcit types.

### Results:

https://bugs.swift.org/browse/SR-7242 is worked around.