### PR TITLE
Dissallow access and removal of Head and Tail ChannelHandlers

### DIFF
--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -43,6 +43,8 @@ extension ChannelPipelineTest {
                 ("testAddBeforeWhileClosed", testAddBeforeWhileClosed),
                 ("testFindHandlerByType", testFindHandlerByType),
                 ("testFindHandlerByTypeReturnsTheFirstOfItsType", testFindHandlerByTypeReturnsTheFirstOfItsType),
+                ("testContextForHeadOrTail", testContextForHeadOrTail),
+                ("testRemoveHeadOrTail", testRemoveHeadOrTail),
            ]
    }
 }

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -620,4 +620,62 @@ class ChannelPipelineTest: XCTestCase {
         XCTAssertTrue(try h1 === channel.pipeline.context(handlerType: TestHandler.self).wait().handler)
         XCTAssertFalse(try h2 === channel.pipeline.context(handlerType: TestHandler.self).wait().handler)
     }
+
+    func testContextForHeadOrTail() throws {
+        let channel = EmbeddedChannel()
+
+        defer {
+            XCTAssertFalse(try channel.finish())
+        }
+
+        do {
+            _ = try channel.pipeline.context(name: HeadChannelHandler.name).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .notFound {
+            /// expected
+        }
+
+        do {
+            _ = try channel.pipeline.context(handlerType: HeadChannelHandler.self).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .notFound {
+            /// expected
+        }
+
+        do {
+            _ = try channel.pipeline.context(name: TailChannelHandler.name).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .notFound {
+            /// expected
+        }
+
+        do {
+            _ = try channel.pipeline.context(handlerType: TailChannelHandler.self).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .notFound {
+            /// expected
+        }
+    }
+
+    func testRemoveHeadOrTail() throws {
+        let channel = EmbeddedChannel()
+
+        defer {
+            XCTAssertFalse(try channel.finish())
+        }
+
+        do {
+            _ = try channel.pipeline.remove(name: HeadChannelHandler.name).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .notFound {
+            /// expected
+        }
+
+        do {
+            _ = try channel.pipeline.remove(name: TailChannelHandler.name).wait()
+            XCTFail()
+        } catch let err as ChannelPipelineError where err == .notFound {
+            /// expected
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

The Head and Tail ChannelHandlers should not be accessible as these are implementation details of the ChannelPipeline and removal of these will even make the whole ChannelPipeline not work anymore.

Modifications:

- Make it impossible to access / removal the Head and Tail ChannelHandlers
- Exclude the Head and Tail ChannelHandler from the debug String
- Add unit tests.

Result:

More robust ChannelPipeline.