### PR TITLE
Correctly fail EventLoopFuture for unsupported operations on ServerSo…

### DIFF
--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -436,6 +436,18 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
             ch.close(promise: nil)
         }
     }
+
+    override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
+        promise?.fail(error: ChannelError.operationUnsupported)
+    }
+
+    override func markFlushPoint(promise: EventLoopPromise<Void>?) {
+        promise?.fail(error: ChannelError.operationUnsupported)
+    }
+
+    override func flushNow() -> IONotificationState {
+        return IONotificationState.unregister
+    }
 }
 
 /// A channel used with datagram sockets.

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -36,6 +36,9 @@ extension SocketChannelTest {
                 ("testAcceptFailsWithEFAULT", testAcceptFailsWithEFAULT),
                 ("testSetGetOptionClosedServerSocketChannel", testSetGetOptionClosedServerSocketChannel),
                 ("testConnect", testConnect),
+                ("testWriteServerSocketChannel", testWriteServerSocketChannel),
+                ("testWriteAndFlushServerSocketChannel", testWriteAndFlushServerSocketChannel),
+                ("testConnectServerSocketChannel", testConnectServerSocketChannel),
            ]
    }
 }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -219,4 +219,46 @@ public class SocketChannelTest : XCTestCase {
         try channel.closeFuture.wait()
         try promise.futureResult.wait()
     }
+
+    public func testWriteServerSocketChannel() throws {
+        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
+
+        let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
+        do {
+            try serverChannel.write("test").wait()
+        } catch let err as ChannelError where err == .operationUnsupported {
+            // expected
+        }
+        try serverChannel.close().wait()
+    }
+
+
+    public func testWriteAndFlushServerSocketChannel() throws {
+        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
+
+        let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
+        do {
+            try serverChannel.writeAndFlush("test").wait()
+        } catch let err as ChannelError where err == .operationUnsupported {
+            // expected
+        }
+        try serverChannel.close().wait()
+    }
+
+    
+    public func testConnectServerSocketChannel() throws {
+        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
+
+        let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
+        do {
+            try serverChannel.connect(to: serverChannel.localAddress!).wait()
+        } catch let err as ChannelError where err == .operationUnsupported {
+            // expected
+        }
+        try serverChannel.close().wait()
+    }
+
 }


### PR DESCRIPTION
…cketChannel

Motivation:

ServerSocketChannel should just fail the EventLoopFuture for unsupported operations and not crash.

Modifications:

- Correctly fail the EventLoopFuture for unsupported operations
- Add unit test.

Result:

No more crashes when users invoke unsupported operations.