### PR TITLE
Fixes build issue on 4.1

### DIFF
--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -57,7 +57,7 @@ private let sysFreeifaddrs: @convention(c) (UnsafeMutablePointer<ifaddrs>?) -> V
 private let sysAF_INET = AF_INET
 private let sysAF_INET6 = AF_INET6
 private let sysAF_UNIX = AF_UNIX
-private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>! = inet_ntop
+private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
 
 #if os(Linux)
 private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIOLinux_mmsghdr>?, CUnsignedInt, CInt) -> CInt = CNIOLinux_sendmmsg

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -145,7 +145,7 @@ private final class WebSocketTimeHandler: ChannelInboundHandler {
         buffer.write(string: "\(theTime)")
 
         let frame = WebSocketFrame(fin: true, opcode: .text, data: buffer)
-        ctx.writeAndFlush(self.wrapOutboundOut(frame)).map { (_: Void) in
+        ctx.writeAndFlush(self.wrapOutboundOut(frame)).map { _ in
             _ = ctx.eventLoop.scheduleTask(in: .seconds(1), { self.sendTime(ctx: ctx) })
         }.whenFailure { (_: Error) in
             ctx.close(promise: nil)

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -145,7 +145,7 @@ private final class WebSocketTimeHandler: ChannelInboundHandler {
         buffer.write(string: "\(theTime)")
 
         let frame = WebSocketFrame(fin: true, opcode: .text, data: buffer)
-        ctx.writeAndFlush(self.wrapOutboundOut(frame)).map { _ in
+        ctx.writeAndFlush(self.wrapOutboundOut(frame)).map {
             _ = ctx.eventLoop.scheduleTask(in: .seconds(1), { self.sendTime(ctx: ctx) })
         }.whenFailure { (_: Error) in
             ctx.close(promise: nil)


### PR DESCRIPTION
Fix build warning in library and build error in WebSocketServer when building with Swift 4.1

### Motivation:

Resolves #228 

### Modifications:

Remove type information in empty closure fixed build warning with compiler suggestion

### Result:

No API changes, no issues building on 4.1!