### PR TITLE
Typo: writte => written

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -514,7 +514,7 @@ public struct ByteBuffer {
         return Int(self._readerIndex)
     }
 
-    /// The write index or the number of bytes previously writte to this `ByteBuffer`. `writerIndex` is `0` for a
+    /// The write index or the number of bytes previously written to this `ByteBuffer`. `writerIndex` is `0` for a
     /// newly allocated `ByteBuffer`.
     public var writerIndex: Int {
         return Int(self._writerIndex)


### PR DESCRIPTION
Changed the word `writte` to `written`

### Motivation:

While it is important to keep the reader alert at all times and test his attention to a comment, I still prefer to apply correct spelling. Kids may be reading this!

### Modifications:

- `mate Sources/NIO/ByteBuffer-core.swift`
- ⌘-f, then typed "writte " three times to fight auto correction, enter
- cursor-right, entered `n`
- ⌘-s to save

### Result:

This specific comment now has proper spelling, something people expect from an Apple project (along proper typography and project icons).