### PR TITLE
Remove busywork left over from flush promises.

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -170,7 +170,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
 
     /// Mark a flush point. This is called when flush is received, and instructs
     /// the implementation to record the flush.
-    func markFlushPoint(promise: EventLoopPromise<Void>?) {
+    func markFlushPoint() {
         fatalError("this must be overridden by sub class")
     }
 
@@ -408,7 +408,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
             return
         }
 
-        self.markFlushPoint(promise: nil)
+        self.markFlushPoint()
 
         if !isWritePending() && flushNow() == .register {
             registerForWritable()

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -252,7 +252,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
         }
     }
 
-    override func markFlushPoint(promise: EventLoopPromise<Void>?) {
+    override func markFlushPoint() {
         // Even if writable() will be called later by the EventLoop we still need to mark the flush checkpoint so we are sure all the flushed messages
         // are actually written once writable() is called.
         self.pendingWrites.markFlushCheckpoint()
@@ -441,8 +441,8 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         promise?.fail(error: ChannelError.operationUnsupported)
     }
 
-    override func markFlushPoint(promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.operationUnsupported)
+    override func markFlushPoint() {
+        // We do nothing here: flushes are no-ops.
     }
 
     override func flushNow() -> IONotificationState {
@@ -616,7 +616,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
     /// Mark a flush point. This is called when flush is received, and instructs
     /// the implementation to record the flush.
-    override func markFlushPoint(promise: EventLoopPromise<Void>?) {
+    override func markFlushPoint() {
         // Even if writable() will be called later by the EventLoop we still need to mark the flush checkpoint so we are sure all the flushed messages
         // are actually written once writable() is called.
         self.pendingWrites.markFlushCheckpoint()


### PR DESCRIPTION
Motivation:

The Socket channels and PendingDatagramWritesManager had a bunch of
overhead left over from when they were handling flush promises. This was
only adding to code complexity and perf cost.

Modifications:

Removed the promise label in markPendingWritePoint.

Reworked the code to stop expecting write promises in
PendingDatagramWritesManager.

Result:

Smaller, faster code.
