### PR TITLE
Update EmbeddedChannel state before notify connect and close promise.

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -175,10 +175,10 @@ class EmbeddedChannelCore: ChannelCore {
             return
         }
         isOpen = false
+        isActive = false
         promise?.succeed(result: ())
 
         // As we called register() in the constructor of EmbeddedChannel we also need to ensure we call unregistered here.
-        isActive = false
         pipeline.fireChannelInactive0()
         pipeline.fireChannelUnregistered0()
 
@@ -194,8 +194,8 @@ class EmbeddedChannelCore: ChannelCore {
     }
 
     func connect0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.succeed(result: ())
         isActive = true
+        promise?.succeed(result: ())
         pipeline.fireChannelActive0()
     }
 

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -35,6 +35,7 @@ extension EmbeddedChannelTest {
                 ("testEmbeddedLifecycle", testEmbeddedLifecycle),
                 ("testEmbeddedChannelAndPipelineAndChannelCoreShareTheEventLoop", testEmbeddedChannelAndPipelineAndChannelCoreShareTheEventLoop),
                 ("testSendingIncorrectDataOnEmbeddedChannel", testSendingIncorrectDataOnEmbeddedChannel),
+                ("testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires", testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

We need to update isActive before notify the promises of connect and close to correctly refect Channel.isActive in callbacks.

Modifications:

- Correctly update isActive before notify promises.
- Add unit test.

Result:

Correct Channel state in callbacks.