### PR TITLE
Fix ConditionLock bug.

### DIFF
--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -143,10 +143,7 @@ public final class ConditionLock<T: Equatable> {
     ///     to have before acquiring the lock.
     public func lock(whenValue wantedValue: T) {
         self.lock()
-        while true {
-            if self._value == wantedValue {
-                break
-            }
+        while self._value != wantedValue {
             let err = pthread_cond_wait(self.cond, self.mutex.mutex)
             precondition(err == 0, "pthread_cond_wait error \(err)")
         }
@@ -176,10 +173,7 @@ public final class ConditionLock<T: Equatable> {
                                   tv_nsec: Int(allNSecs % nsecPerSec))
         assert(timeoutAbs.tv_nsec >= 0 && timeoutAbs.tv_nsec < Int(nsecPerSec))
         assert(timeoutAbs.tv_sec >= curTime.tv_sec)
-        while true {
-            if self._value == wantedValue {
-                return true
-            }
+        while self._value != wantedValue {
             switch pthread_cond_timedwait(self.cond, self.mutex.mutex, &timeoutAbs) {
             case 0:
                 continue
@@ -190,6 +184,7 @@ public final class ConditionLock<T: Equatable> {
                 fatalError("caught error \(e) when calling pthread_cond_timedwait")
             }
         }
+        return true
     }
 
     /// Release the lock, setting the state variable to `newValue`.
@@ -197,9 +192,10 @@ public final class ConditionLock<T: Equatable> {
     /// - Parameter newValue: The value to give to the state variable when we
     ///     release the lock.
     public func unlock(withValue newValue: T) {
+        self.lock()
         self._value = newValue
-        self.unlock()
         let r = pthread_cond_broadcast(self.cond)
         precondition(r == 0)
+        self.unlock()
     }
 }


### PR DESCRIPTION
### This is a bugfix PR.

In Sources/NIOConcurrencyHelpers/lock.swift, the implementation of `lock(whenValue)` and `unlock(withValue)` may have some issues.

### Motivation:
[Line 150](https://github.com/apple/swift-nio/blob/master/Sources/NIOConcurrencyHelpers/lock.swift#L150)
```
            let err = pthread_cond_wait(self.cond, self.mutex.mutex)
```
will unlock the mutex temporarily, then `unlock(withValue)` should lock mutex first before modify the value, it seems like an obvious bug? or it's just my misunderstand?

### Modifications:

rewrite the `unlock(withValue)` method. 
Pseudocode:
``` 
lock()
self.value = newValue
pthread_cond_broadcast(cond)
unlock()
```

Any issue?
