### PR TITLE
non-blocking versions of file open/stat

### DIFF
--- a/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
@@ -45,6 +45,9 @@ extension NonBlockingFileIOTest {
                 ("testFileRegionReadFromPipeFails", testFileRegionReadFromPipeFails),
                 ("testReadFromNonBlockingPipeFails", testReadFromNonBlockingPipeFails),
                 ("testSeekPointerIsSetToFront", testSeekPointerIsSetToFront),
+                ("testFileOpenWorks", testFileOpenWorks),
+                ("testFileOpenWorksWithEmptyFile", testFileOpenWorksWithEmptyFile),
+                ("testFileOpenFails", testFileOpenFails),
            ]
    }
 }


### PR DESCRIPTION
addresses #185. This is a first draft to discuss the API.

Motivation:

Opening a file, seeking it or querying its size (or other information)
is blocking on UNIX so `NonBlockingFileIO` should support that too.

Modifications:

Added a method to `NonBlockingFileIO` which lets the user open a file
without blocking the calling thread.

Result:

Less blocking is good :)
