### PR TITLE
allow some cool down time after allocation measurements [SHOULD FIX TEST FAILURES]

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -100,9 +100,8 @@ public func swiftMain() -> Int {
         func measureOne(_ fn: () -> Int) -> [String: Int] {
             AtomicCounter.reset_free_counter()
             AtomicCounter.reset_malloc_counter()
-            //autoreleasepool {
-                _ = fn()
-            //}
+            _ = fn()
+            usleep(100_000) // allocs/frees happen on multiple threads, allow some cool down time
             let frees = AtomicCounter.read_free_counter()
             let mallocs = AtomicCounter.read_malloc_counter()
             return ["total_allocations": mallocs,


### PR DESCRIPTION
Motivation:

We have code running on multiple threads and certain allocations/frees
happen for example after a promise has been fulfilled. We can't
deterministically wait for that so the only thing we can do is sleep a
little and wait...

Modifications:

Added a 100ms delay after an allocation counted test run.

Result:

Hopefully we don't see this again:

    ["total_allocations": 322051, "remaining_allocations": 24], ["total_allocations": 322051, "remaining_allocations": -24]

where the first test run had 24 allocations that weren't freed and the
second one on the other hand had 24 frees for allocations that "didn't
happen"...
