### PR TITLE
just set 127.0.0.1 as localhost's IPv4 address

### DIFF
--- a/IntegrationTests/tests_01_http/defines.sh
+++ b/IntegrationTests/tests_01_http/defines.sh
@@ -36,7 +36,7 @@ function start_server() {
         port="0"
         tok_type=""
         maybe_host="localhost"
-        maybe_nio_host="$(host -4 -t a "$maybe_host" | tr ' ' '\n' | tail -1)"
+        maybe_nio_host="127.0.0.1"
     fi
 
     mkdir "$tmp/htdocs"


### PR DESCRIPTION
this was reported somewhere but I can't find the issue now, @tomerd can you remember?

Motivation:

Previously we tried to use `host` to determine localhost's IPv4 address.
That didn't work reliably in Docker and sometimes on macOS. Let's just
fix this to 127.0.0.1.

Modifications:

Hardcode localhost's IPv4 address as 127.0.0.1.

Result:

More stable test_16_tcp_client_ip
