### PR TITLE
workaround ab (ApacheBench) in keep-alive mode

### DIFF
--- a/IntegrationTests/tests_01_http/test_18_close_with_no_keepalive.sh
+++ b/IntegrationTests/tests_01_http/test_18_close_with_no_keepalive.sh
@@ -28,6 +28,7 @@ echo -e 'GET /dynamic/count-to-ten HTTP/1.1\r\nConnection: close\r\n\r\n' | \
 backslash_r=$(echo -ne '\r')
 cat > "$tmp/expected" <<EOF
 HTTP/1.1 200 OK$backslash_r
+Connection: close$backslash_r
 transfer-encoding: chunked$backslash_r
 $backslash_r
 1$backslash_r

--- a/IntegrationTests/tests_01_http/test_22_http_1.0_keep_alive.sh
+++ b/IntegrationTests/tests_01_http/test_22_http_1.0_keep_alive.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+source defines.sh
+
+token=$(create_token)
+start_server "$token"
+do_curl "$token" -H 'connection: keep-alive' -v --http1.0 \
+    "http://foobar.com/dynamic/info" > "$tmp/out_actual" 2>&1
+grep -qi '< Connection: keep-alive' "$tmp/out_actual"
+grep -qi '< HTTP/1.0 200 OK' "$tmp/out_actual"
+stop_server "$token"


### PR DESCRIPTION
Motivation:

`ab -k` behaves weirdly: it'll send an HTTP/1.0 request with keep-alive set
but stops doing anything at all if the server doesn't also set Connection: keep-alive
which our example HTTP1Server didn't do.

Modifications:

In the HTTP1Server example if we receive an HTTP/1.0 request with
Connection: keep-alive, we'll now set keep-alive too.

Result:

ab -k doesn't get stuck anymore.
