### PR TITLE
make allocation counter test fail on error in subshell

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_allocation_counts_for_http1.sh
+++ b/IntegrationTests/tests_04_performance/test_01_allocation_counts_for_http1.sh
@@ -22,6 +22,7 @@ cp -R "test_01_resources/template"/* "$tmp/"
 nio_root="$PWD/../.."
 
 (
+set -eu
 cd "$tmp"
 
 function make_git_commit_all() {


### PR DESCRIPTION
Motivation:

In shell, subshells don't inherit the shell flags (such as `set -eu`)
and therefore need to set them again. The allocation counter test uses a
subshell but forgot to `set -eu` in the subshell.

Modifications:

`set -eu` in the subshell for the allocation counter tests.

Result:

if there's an error building the test program the test now fails.
