### PR TITLE
alloc counter test: better recursive malloc

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_allocation_counts_for_http1.sh
+++ b/IntegrationTests/tests_04_performance/test_01_allocation_counts_for_http1.sh
@@ -55,7 +55,7 @@ make_git_commit_all
 cd ..
 
 "$swift_bin" package edit --path "$nio_root" swift-nio
-"$swift_bin" run -c release > "$tmp/output"
+"$swift_bin" run -c release | tee "$tmp/output"
 )
 
 for test in 1000_reqs_1_conn 1_reqs_1000_conn; do


### PR DESCRIPTION
Motivation:

The allocation counter integration tests previously used a pretty crude
malloc implementation for the case that malloc is needed whilst we
resolve malloc from libc using dlsym. This implements a much better
version and also allows us to actually use free. Previously we just
leaked all the memory (which is okay as its just a test but in
constrained environments this wouldn't scale as we might actually run
out of memory). The reason we used to leak the memory is that given a
pointer we couldn't figure out if that pointer was alloated using libc's
malloc or our crude malloc implementation so we didn't know how to free.
The new version fixes that as all the pointers vended from
recursive_malloc live in one global block. That makes it trivial to
check if a given pointer is allocated by recursive_malloc (lives in that
block) or libc's malloc (doesn't live in the recursive_malloc block).

Modifications:

- implemented a better recursive_malloc function
- make the allocation counter test actually free memory that can be
  freed

Result:

Less memory use in the allocation counter test.
