### PR TITLE
Don't re-arm timerfd each epoll_wait

### DIFF
--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
+
 private enum SelectorLifecycleState {
     case open
     case closing
@@ -50,6 +52,7 @@ final class Selector<R: Registration> {
     private typealias EventType = Epoll.epoll_event
     private let eventfd: Int32
     private let timerfd: Int32
+    private var earliestTimer: UInt64 = UInt64.max
     #else
     private typealias EventType = kevent
     #endif
@@ -352,9 +355,17 @@ final class Selector<R: Registration> {
         case .now:
             ready = Int(try Epoll.epoll_wait(epfd: self.fd, events: events, maxevents: Int32(eventsCapacity), timeout: 0))
         case .blockUntilTimeout(let timeAmount):
-            var ts = itimerspec()
-            ts.it_value = timespec(timeAmount: timeAmount)
-            try TimerFd.timerfd_settime(fd: timerfd, flags: 0, newValue: &ts, oldValue: nil)
+            // Only call timerfd_settime if we not already scheduled one that will cover it.
+            // This guards against calling timerfd_settime if not needed as this is generally speaking
+            // expensive.
+            let next = DispatchTime.now().uptimeNanoseconds + UInt64(timeAmount.nanoseconds)
+            if next < self.earliestTimer {
+                self.earliestTimer = next
+
+                var ts = itimerspec()
+                ts.it_value = timespec(timeAmount: timeAmount)
+                try TimerFd.timerfd_settime(fd: timerfd, flags: 0, newValue: &ts, oldValue: nil)
+            }
             fallthrough
         case .block:
             ready = Int(try Epoll.epoll_wait(epfd: self.fd, events: events, maxevents: Int32(eventsCapacity), timeout: -1))
@@ -372,6 +383,9 @@ final class Selector<R: Registration> {
                 var val: UInt = 0
                 // We are not interested in the result
                 _ = Glibc.read(timerfd, &val, MemoryLayout<UInt>.size)
+
+                // Processed the earliest set timer so reset it.
+                self.earliestTimer = UInt64.max
             default:
                 // If the registration is not in the Map anymore we deregistered it during the processing of whenReady(...). In this case just skip it.
                 if let registration = registrations[Int(ev.data.fd)] {

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -37,6 +37,7 @@ extension EventLoopTest {
                 ("testCurrentEventLoop", testCurrentEventLoop),
                 ("testShutdownWhileScheduledTasksNotReady", testShutdownWhileScheduledTasksNotReady),
                 ("testCloseFutureNotifiedBeforeUnblock", testCloseFutureNotifiedBeforeUnblock),
+                ("testScheduleMultipleTasks", testScheduleMultipleTasks),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When calling Selector.whenReady(...) and using a SelectorStrategy.blockUntil(...) we may end up re-arm the timerfd each time even if the wakeup time did not change.
This is expensive and can be avoided in most situations.

Modifications:

Keep track of the earliest scheduled timer and only schedule a new one if it would fire sooner.

Result:

Less overhead when using epoll and timers.