### PR TITLE
Fixed minor typos and updated force unwraps.

### DIFF
--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -99,7 +99,6 @@ extension ByteToMessageDecoder {
     /// Calls `decode` until there is nothing left to decode.
     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         var buffer = self.unwrapInboundIn(data)
-        
         if self.cumulationBuffer != nil {
             self.cumulationBuffer!.write(buffer: &buffer)
             buffer = self.cumulationBuffer!

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -322,7 +322,7 @@ public struct EventLoopPromise<T> {
 ///
 /// This means that for any `EventLoopFuture` that your code did not create itself (via
 /// `EventLoopPromise.futureResult`), use of `hopTo` is **strongly encouraged** to help guarantee thread-safety. It
-/// should only be elided when thread-safety is proved to be not needed.
+/// should only be elided when thread-safety is provably not needed.
 ///
 /// The "thread affinity" of `EventLoopFuture`s is critical to writing safe, performant concurrent code without
 /// boilerplate. It allows you to avoid needing to write or use locks in your own code, instead using the natural

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -177,11 +177,10 @@ let channel = try { () -> Channel in
     }
 }()
 
-if let localAddress = channel.localAddress {
-    print("ChatServer started and listening on \(localAddress)")
-} else {
-    print("ChatServer started but the address could not be determined.")
+guard let localAddress = channel.localAddress else {
+    fatalError("Address was unable to bind. Please check that the socket was not closed or that the address family was understood.")
 }
+print("Server started and listening on \(localAddress)")
 
 // This will never unblock as we don't close the ServerChannel.
 try channel.closeFuture.wait()

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -498,11 +498,10 @@ let channel = try { () -> Channel in
     }
 }()
 
-if let localAddress = channel.localAddress {
-    print("Server started and listening on \(localAddress), htdocs path \(htdocs)")
-} else {
-    print("Server started but the address could not be determined, htdocs path \(htdocs)")
+guard let localAddress = channel.localAddress else {
+    fatalError("Address was unable to bind. Please check that the socket was not closed or that the address family was understood.")
 }
+print("Server started and listening on \(localAddress), htdocs path \(htdocs)")
 
 // This will never unblock as we don't close the ServerChannel
 try channel.closeFuture.wait()

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -264,11 +264,10 @@ let channel = try { () -> Channel in
     }
 }()
 
-if let localAddress = channel.localAddress {
-    print("Server started and listening on \(localAddress)")
-} else {
-    print("Server started but the address could not be determined.")
+guard let localAddress = channel.localAddress else {
+    fatalError("Address was unable to bind. Please check that the socket was not closed or that the address family was understood.")
 }
+print("Server started and listening on \(localAddress)")
 
 // This will never unblock as we don't close the ServerChannel
 try channel.closeFuture.wait()


### PR DESCRIPTION
Motivation:

I wanted to make sure that I fixed the minor typos and that I addressed
the feedback that was provided to me in regards to force unwrapping.
I also wanted to make sure my error messages were accurate.

Modifications:

Fixed a few minor typos and updated the force unwrap error messages.

Result:

Fixed typos and guard statements with accurate error messages.

