### PR TITLE
Wait for test cleanup.

### DIFF
--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -653,7 +653,7 @@ class EchoServerClientTest : XCTestCase {
             }.bind(host: "127.0.0.1", port: 0).wait()
 
         defer {
-            _ = serverChannel.close()
+            XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
 
         let clientChannel = try ClientBootstrap(group: group)
@@ -666,7 +666,7 @@ class EchoServerClientTest : XCTestCase {
                 }
             }.connect(to: serverChannel.localAddress!).wait()
         defer {
-            _ = clientChannel.close()
+            XCTAssertNoThrow(try clientChannel.syncCloseAcceptingAlreadyClosed())
         }
         dpGroup.wait()
 


### PR DESCRIPTION
Motivation:

The current test function does not wait for the futures from close to
return, and so they may in principle be leaked. This obscures errors that
the test might hit with precondition failures.

Modifications:

Changed the defer statements to wait for the futures.

Result:

Fewer spurious test failures.
