### PR TITLE
Support for initializing off the system file descriptors

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -718,6 +718,14 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         }
     }
 
+    public final func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
+        assert(self.eventLoop.inEventLoop)
+        assert(self.isOpen)
+        assert(!self.lifecycleManager.isActive)
+        register0(promise: nil)
+        becomeActive0(promise: promise)
+    }
+
     public final func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
         promise?.succeed(result: ())
     }

--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -30,6 +30,11 @@ public protocol ChannelCore: class {
     ///     - promise: The `EventLoopPromise` which should be notified once the operation completes, or nil if no notification should take place.
     func register0(promise: EventLoopPromise<Void>?)
 
+    /// Register channel as already connected or bound socket.
+    /// - parameters:
+    ///     - promise: The `EventLoopPromise` which should be notified once the operation completes, or nil if no notification should take place.
+    func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?)
+
     /// Bind to a `SocketAddress`.
     ///
     /// - parameters:
@@ -203,6 +208,10 @@ extension Channel {
 
     public func register(promise: EventLoopPromise<Void>?) {
         pipeline.register(promise: promise)
+    }
+
+    public func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
+        promise?.fail(error: ChannelError.operationUnsupported)
     }
 
     public func triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {

--- a/Sources/NIO/DeadChannel.swift
+++ b/Sources/NIO/DeadChannel.swift
@@ -28,6 +28,10 @@ private final class DeadChannelCore: ChannelCore {
         promise?.fail(error: ChannelError.ioOnClosedChannel)
     }
 
+    func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
+        promise?.fail(error: ChannelError.ioOnClosedChannel)
+    }
+
     func bind0(to: SocketAddress, promise: EventLoopPromise<Void>?) {
         promise?.fail(error: ChannelError.ioOnClosedChannel)
     }

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -203,6 +203,12 @@ class EmbeddedChannelCore: ChannelCore {
         pipeline.fireChannelRegistered0()
     }
 
+    func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
+        isActive = true
+        register0(promise: promise)
+        pipeline.fireChannelActive0()
+    }
+
     func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         guard let data = data.tryAsIOData() else {
             promise?.fail(error: ChannelError.writeDataUnsupported)

--- a/Sources/NIO/ServerSocket.swift
+++ b/Sources/NIO/ServerSocket.swift
@@ -32,6 +32,19 @@
         super.init(descriptor: sock)
     }
 
+    /// Create a new instance.
+    ///
+    /// - parameters:
+    ///     - descriptor: The _Unix file descriptor_ representing the bound socket.
+    ///     - setNonBlocking: Set non-blocking mode on the socket.
+    /// - throws: An `IOError` if socket is invalid.
+    init(descriptor: CInt, setNonBlocking: Bool = false) throws {
+        super.init(descriptor: descriptor)
+        if setNonBlocking {
+            try self.setNonBlocking()
+        }
+    }
+
     /// Start to listen for new connections.
     ///
     /// - parameters:

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -38,6 +38,19 @@ public typealias IOVector = iovec
         super.init(descriptor: sock)
     }
 
+    /// Create a new instance out of an already established socket.
+    ///
+    /// - parameters:
+    ///     - descriptor: The existing socket descriptor.
+    ///     - setNonBlocking: Set non-blocking mode on the socket.
+    /// - throws: An `IOError` if could not change the socket into non-blocking
+    init(descriptor: CInt, setNonBlocking: Bool) throws {
+        super.init(descriptor: descriptor)
+        if setNonBlocking {
+            try self.setNonBlocking()
+        }
+    }
+
     /// Create a new instance.
     ///
     /// The ownership of the passed in descriptor is transferred to this class. A user must call `close` to close the underlying
@@ -45,7 +58,7 @@ public typealias IOVector = iovec
     ///
     /// - parameters:
     ///     - descriptor: The file descriptor to wrap.
-    override init(descriptor: Int32) {
+    override init(descriptor: CInt) {
         super.init(descriptor: descriptor)
     }
 

--- a/Tests/NIOTests/CustomChannelTests.swift
+++ b/Tests/NIOTests/CustomChannelTests.swift
@@ -37,6 +37,10 @@ private class IntChannelCore: ChannelCore {
         promise?.fail(error: NotImplementedError())
     }
 
+    func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
+        promise?.fail(error: NotImplementedError())
+    }
+
     func bind0(to: SocketAddress, promise: EventLoopPromise<Void>?) {
         promise?.fail(error: NotImplementedError())
     }

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -40,6 +40,8 @@ extension SocketChannelTest {
                 ("testWriteAndFlushServerSocketChannel", testWriteAndFlushServerSocketChannel),
                 ("testConnectServerSocketChannel", testConnectServerSocketChannel),
                 ("testCloseDuringWriteFailure", testCloseDuringWriteFailure),
+                ("testWithConfiguredStreamSocket", testWithConfiguredStreamSocket),
+                ("testWithConfiguredDatagramSocket", testWithConfiguredDatagramSocket),
            ]
    }
 }


### PR DESCRIPTION
### Motivation:

In some contexts it is important to be able to pass file descriptors around instead of specifying the particular host and port. This allows removing certain windows for race conditions, and has positive security implications.

### Modifications:

 * Added `withConnectedSocket(descriptor:)` call to the `ClientBootstrap` that can be used to create a new `Channel` out of existing file descriptor representing the connected socket.

 * Added `withBoundSocket(descriptor:)` call to the `ServerBootstrap`.

 * Added appropriate testing for both.

### Result:

Allows initializing `Channel`s off the existing file descriptors.
