### PR TITLE
Make Scheduled's constructor public.

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -23,7 +23,7 @@ public struct Scheduled<T> {
     private let promise: EventLoopPromise<T>
     private let cancellationTask: () -> Void
 
-    init(promise: EventLoopPromise<T>, cancellationTask: @escaping () -> Void) {
+    public init(promise: EventLoopPromise<T>, cancellationTask: @escaping () -> Void) {
         self.promise = promise
         promise.futureResult.whenFailure { error in
             guard let err = error as? EventLoopError else {


### PR DESCRIPTION
Motivation:

You need to be able to implement `EventLoop.scheduleTask` to implement
your own event loop. `EventLoop.scheduleTask` requires creating a
`Scheduled`. Currently, `Scheduled` has no public initializer.

Modifications:

Make `Scheduled`'s initializer public.

Result:

It will be possible to actually implement `EventLoop`.
