### PR TITLE
Implement lazy headers parsing

### DIFF
--- a/IntegrationTests/tests_01_http/test_12_headers_too_large.sh
+++ b/IntegrationTests/tests_01_http/test_12_headers_too_large.sh
@@ -22,8 +22,8 @@ touch "$tmp/empty"
 cr=$(echo -e '\r')
 cat > "$tmp/headers_expected" <<EOF
 HTTP/1.1 400 Bad Request$cr
-content-length: 0$cr
-connection: close$cr
+Content-Length: 0$cr
+Connection: close$cr
 $cr
 EOF
 echo "FOO BAR" > "$htdocs/some_file.txt"
@@ -41,10 +41,10 @@ assert_equal_files "$tmp/empty" "$tmp/out"
 if ! grep -q 'HTTP/1.1 400 Bad Request' "$tmp/headers_actual"; then
     fail "couldn't find status line in response"
 fi
-if ! grep -q 'content-length: 0' "$tmp/headers_actual"; then
+if ! grep -q 'Content-Length: 0' "$tmp/headers_actual"; then
     fail "couldn't find content-length in response"
 fi
-if ! grep -q 'connection: close' "$tmp/headers_actual"; then
+if ! grep -q 'Connection: close' "$tmp/headers_actual"; then
     fail "couldn't find connection: close in response"
 fi
 

--- a/IntegrationTests/tests_01_http/test_14_strict_mode_assertion.sh
+++ b/IntegrationTests/tests_01_http/test_14_strict_mode_assertion.sh
@@ -24,11 +24,11 @@ echo -e 'GET / HTT\r\n\r\n' | nc -U "$socket" > "$tmp/actual"
 if ! grep -q 'HTTP/1.1 400 Bad Request' "$tmp/actual"; then
     fail "couldn't find status line in response"
 fi
-if ! grep -q 'content-length: 0' "$tmp/actual"; then
-    fail "couldn't find content-length in response"
+if ! grep -q 'Content-Length: 0' "$tmp/actual"; then
+    fail "couldn't find Content-Length in response"
 fi
-if ! grep -q 'connection: close' "$tmp/actual"; then
-    fail "couldn't find connection: close in response"
+if ! grep -q 'Connection: close' "$tmp/actual"; then
+    fail "couldn't find Connection: close in response"
 fi
 
 linecount=$(wc "$tmp/actual")

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -24,8 +24,13 @@ public struct HTTPRequestHead: Equatable {
     /// The HTTP method for this request.
     public let method: HTTPMethod
 
+    // Internal representation of the URI.
+    private let rawURI: URI
+
     /// The URI used on this request.
-    public let uri: String
+    public var uri: String {
+        return String(uri: rawURI)
+    }
 
     /// The version for this HTTP request.
     public let version: HTTPVersion
@@ -39,27 +44,41 @@ public struct HTTPRequestHead: Equatable {
     /// - Parameter method: The HTTP method for this request.
     /// - Parameter uri: The URI used on this request.
     public init(version: HTTPVersion, method: HTTPMethod, uri: String) {
-        self.version = version
-        self.method = method
-        self.uri = uri
-        self.headers = HTTPHeaders()
+        self.init(version: version, method: method, rawURI: .string(uri), headers: HTTPHeaders())
     }
 
     /// Create a `HTTPRequestHead`
     ///
     /// - Parameter version: The version for this HTTP request.
     /// - Parameter method: The HTTP method for this request.
-    /// - Parameter uri: The URI used on this request.
+    /// - Parameter rawURI: The URI used on this request.
     /// - Parameter headers: The headers for this HTTP request.
-    init(version: HTTPVersion, method: HTTPMethod, uri: String, headers: HTTPHeaders) {
+    init(version: HTTPVersion, method: HTTPMethod, rawURI: URI, headers: HTTPHeaders) {
         self.version = version
         self.method = method
-        self.uri = uri
+        self.rawURI = rawURI
         self.headers = headers
     }
 
     public static func ==(lhs: HTTPRequestHead, rhs: HTTPRequestHead) -> Bool {
         return lhs.method == rhs.method && lhs.uri == rhs.uri && lhs.version == rhs.version && lhs.headers == rhs.headers
+    }
+}
+
+/// Internal representation of a URI
+enum URI {
+    case string(String)
+    case byteBuffer(ByteBuffer)
+}
+
+private extension String {
+    init(uri: URI) {
+        switch uri {
+        case .string(let string):
+            self = string
+        case .byteBuffer(let buffer):
+            self = buffer.getString(at: buffer.readerIndex, length: buffer.readableBytes)!
+        }
     }
 }
 
@@ -145,8 +164,43 @@ public struct HTTPResponseHead: Equatable {
     }
 }
 
-fileprivate typealias HTTPHeadersStorage = [String: [(String, String)]] // [lowerCasedName: [(originalCaseName, value)]
+/// The Index for a header name or value that points into the underlying `ByteBuffer`.
+struct HTTPHeaderIndex {
+    let start: Int
+    let length: Int
+}
 
+/// Struct which holds name, value pairs.
+struct HTTPHeader {
+    let name: HTTPHeaderIndex
+    let value: HTTPHeaderIndex
+}
+
+private extension ByteBuffer {
+    func equalCaseInsensitiveASCII(view: String.UTF8View, at index: HTTPHeaderIndex) -> Bool {
+        guard view.count == index.length else {
+            return false
+        }
+        return withVeryUnsafeBytes { buffer in
+            // This should never happens as we control when this is called. Adding an assert to ensure this.
+            assert(index.start <= self.capacity - index.length)
+            let address = buffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            for (idx, byte) in view.enumerated() {
+                guard byte.isASCII && address.advanced(by: index.start + idx).pointee & 0xdf == byte & 0xdf else {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+}
+
+
+private extension UInt8 {
+    var isASCII: Bool {
+        return self <= 127
+    }
+}
 
 
 /// A representation of a block of HTTP header fields.
@@ -163,26 +217,55 @@ fileprivate typealias HTTPHeadersStorage = [String: [(String, String)]] // [lowe
 /// can be represented appropriately.
 public struct HTTPHeaders: CustomStringConvertible {
 
-    // [lowerCasedName: [(originalCaseName, value)]
-    private var storage: HTTPHeadersStorage = HTTPHeadersStorage()
-    public var description: String { return storage.description }
+    // Because we use CoW implementations HTTPHeaders is also CoW
+    private var buffer: ByteBuffer
+    private var headers: [HTTPHeader]
+    private var continuous: Bool = true
 
-    // This is expressly *not* public because it doesn't do anything sensible:
-    // it doesn't return the number of header fields in the structure, just the number
-    // of unique header names. That's not really a useful question to ask, but we need it
-    // in NIOHTTP1 so we're adding it internally. At some point this type should be made
-    // to conform to Collection, and when that's done we can add something a bit more sensible.
-    var count: Int {
-        return storage.count
+    /// Returns the `String` for the given `HTTPHeaderIndex`.
+    ///
+    /// - parameters:
+    ///     - idx: The index into the underlying storage.
+    /// - returns: The value.
+    private func string(idx: HTTPHeaderIndex) -> String {
+        return self.buffer.getString(at: idx.start, length: idx.length)!
+    }
+
+    /// Return all names.
+    fileprivate var names: [HTTPHeaderIndex] {
+        return self.headers.map { $0.name }
+    }
+
+    public var description: String {
+        var headersArray: [(String, String)] = []
+        headersArray.reserveCapacity(self.headers.count)
+
+        for h in self.headers {
+            headersArray.append((self.string(idx: h.name), self.string(idx: h.value)))
+        }
+        return headersArray.description
+    }
+
+    /// Constructor used by our decoder to construct headers without the need of converting bytes to string.
+    init(buffer: ByteBuffer, headers: [HTTPHeader]) {
+        self.buffer = buffer
+        self.headers = headers
     }
 
     /// Construct a `HTTPHeaders` structure.
     ///
-    /// - Parameter headers: An initial set of headers to use to populate the
-    ///     header block.
-    public init(_ headers: [(String, String)] = []) {
+    /// - parameters
+    ///     - headers: An initial set of headers to use to populate the header block.
+    ///     - allocator: The allocator to use to allocate the underlying storage.
+    public init(_ headers: [(String, String)] = [], allocator: ByteBufferAllocator = ByteBufferAllocator()) {
+        // Reserve enough space in the array to hold all indices.
+        var array: [HTTPHeader] = []
+        array.reserveCapacity(headers.count)
+
+        self.init(buffer: allocator.buffer(capacity: 256), headers: array)
+
         for (key, value) in headers {
-            add(name: key, value: value)
+            self.add(name: key, value: value)
         }
     }
 
@@ -197,8 +280,14 @@ public struct HTTPHeaders: CustomStringConvertible {
     //      recommended.
     /// - Parameter value: The header field value to add for the given name.
     public mutating func add(name: String, value: String) {
-        let keyLower = name.lowercased()
-        storage[keyLower] = (storage[keyLower] ?? [])  + [(name, value)]
+        precondition(!name.utf8.contains(where: { !$0.isASCII }), "name must be ASCII")
+        let nameStart = self.buffer.writerIndex
+        let nameLength = self.buffer.write(string: name)!
+        self.buffer.write(staticString: headerSeparator)
+        let valueStart = self.buffer.writerIndex
+        let valueLength = self.buffer.write(string: value)!
+        self.headers.append(HTTPHeader(name: HTTPHeaderIndex(start: nameStart, length: nameLength), value: HTTPHeaderIndex(start: valueStart, length: valueLength)))
+        self.buffer.write(staticString: crlf)
     }
 
     /// Add a header name/value pair to the block, replacing any previous values for the
@@ -215,8 +304,8 @@ public struct HTTPHeaders: CustomStringConvertible {
     //      recommended.
     /// - Parameter value: The header field value to add for the given name.
     public mutating func replaceOrAdd(name: String, value: String) {
-        let keyLower = name.lowercased()
-        storage[keyLower] = [(name, value)]
+        self.remove(name: name)
+        self.add(name: name, value: value)
     }
 
     /// Remove all values for a given header name from the block.
@@ -225,7 +314,28 @@ public struct HTTPHeaders: CustomStringConvertible {
     ///
     /// - Parameter name: The name of the header field to remove from the block.
     public mutating func remove(name: String) {
-        self.storage[name.lowercased()] = nil
+        guard !self.headers.isEmpty else {
+            return
+        }
+
+        let utf8 = name.utf8
+        var array: [Int] = []
+        // We scan from the back to the front so we can remove the subranges with as less overhead as possible.
+        for idx in stride(from: self.headers.count - 1, to: -1, by: -1) {
+            let header = self.headers[idx]
+            if self.buffer.equalCaseInsensitiveASCII(view: utf8, at: header.name) {
+                array.append(idx)
+            }
+        }
+
+        guard !array.isEmpty else {
+            return
+        }
+
+        array.forEach {
+            self.headers.remove(at: $0)
+        }
+        self.continuous = false
     }
 
     /// Retrieve all of the values for a give header field name from the block.
@@ -240,51 +350,59 @@ public struct HTTPHeaders: CustomStringConvertible {
     /// - Parameter name: The header field name whose values are to be retrieved.
     /// - Returns: A list of the values for that header field name.
     public subscript(name: String) -> [String] {
-        if let result = storage[name.lowercased()] {
-            return result.map { tuple in tuple.1 }
+        guard !self.headers.isEmpty else {
+            return []
         }
-        return []
+
+        let utf8 = name.utf8
+        var array: [String] = []
+        for header in self.headers {
+            if self.buffer.equalCaseInsensitiveASCII(view: utf8, at: header.name) {
+                array.append(self.string(idx: header.value))
+            }
+        }
+        return array
+    }
+
+    /// Checks if a header is present
+    ///
+    /// - parameters:
+    ///     - name: The name of the header
+    //  - returns: `true` if a header with the name (and value) exists, `false` otherwise.
+    public func contains(name: String) -> Bool {
+        guard !self.headers.isEmpty else {
+            return false
+        }
+
+        let utf8 = name.utf8
+        for header in self.headers {
+            if self.buffer.equalCaseInsensitiveASCII(view: utf8, at: header.name) {
+                return true
+            }
+        }
+        return false
     }
 
     /// Serializes this HTTP header block to bytes suitable for writing to the wire.
     ///
     /// - Parameter buffer: A buffer to write the serialized bytes into. Will increment
     ///     the writer index of this buffer.
-    func write(buffer: inout ByteBuffer) {
-        for (key, values) in storage {
-            if key != "set-cookie" {
-                writeListHeaderValues(buffer: &buffer, key: key, values: values)
-            } else {
-                writeSequentialHeaderValues(buffer: &buffer, key: key, values: values)
+    func write(into: inout ByteBuffer) {
+        if self.continuous {
+            // Declare an extra variable so we not affect the readerIndex of the buffer itself.
+            var buf = self.buffer
+            into.write(buffer: &buf)
+        } else {
+            // slow-path....
+            // TODO: This can still be improved to write as many continuous data as possible and just skip over stuff that was removed.
+            for header in self.headers {
+                let fieldLength = (header.value.start + header.value.length) - header.name.start
+                var header = self.buffer.getSlice(at: header.name.start, length: fieldLength)!
+                into.write(buffer: &header)
+                into.write(staticString: crlf)
             }
         }
-        buffer.write(staticString: crlf)
-    }
-
-    /// Used for most HTTP headers, which can be represented as a single line joined by commas.
-    private func writeListHeaderValues(buffer: inout ByteBuffer, key: String, values: [(String, String)]) {
-        buffer.write(string: key)
-        buffer.write(staticString: headerSeparator)
-
-        var writerIndex = buffer.writerIndex
-        for (_, value) in values {
-            buffer.write(string: value)
-            writerIndex = buffer.writerIndex
-            buffer.write(staticString: ",")
-        }
-        // Discard last ,
-        buffer.moveWriterIndex(to: writerIndex)
-        buffer.write(staticString: crlf)
-    }
-
-    /// Used for HTTP headers that cannot be joined with commas, e.g. set-cookie.
-    private func writeSequentialHeaderValues(buffer: inout ByteBuffer, key: String, values: [(String, String)]) {
-        for (_, value) in values {
-            buffer.write(string: key)
-            buffer.write(staticString: headerSeparator)
-            buffer.write(string: value)
-            buffer.write(staticString: crlf)
-        }
+        into.write(staticString: crlf)
     }
     
     @available(*, deprecated, message: "getCanonicalForm has been changed to a subscript: headers[canonicalForm: name]")
@@ -300,16 +418,14 @@ public struct HTTPHeaders: CustomStringConvertible {
     /// - Parameter name: The header field name whose values are to be retrieved.
     /// - Returns: A list of the values for that header field name.
     public subscript(canonicalForm name: String) -> [String] {
+        let result = self[name]
+
         // It's not safe to split Set-Cookie on comma.
-        let queryName = name.lowercased()
-        if queryName == "set-cookie" {
-            return self[name]
+        guard name.lowercased() != "set-cookie" else {
+            return result
         }
 
-        if let result = storage[queryName] {
-            return result.flatMap { tuple in tuple.1.split(separator: ",").map { String($0.trimWhitespace()) } }
-        }
-        return []
+        return result.flatMap { $0.split(separator: ",").map { String($0.trimWhitespace()) } }
     }
 }
 
@@ -321,33 +437,19 @@ extension HTTPHeaders: Sequence {
     /// This iterator will return each value for a given header name separately. That
     /// means that `name` is not guaranteed to be unique in a given block of headers.
     public struct Iterator: IteratorProtocol {
-        private var storageIterator: HTTPHeadersStorage.Iterator
-        private var valuesIterator: Array<(String, String)>.Iterator?
+        private var headerParts: Array<(String, String)>.Iterator
 
-        fileprivate init(wrapping: HTTPHeadersStorage.Iterator) {
-            self.storageIterator = wrapping
+        fileprivate init(headerParts: Array<(String, String)>.Iterator) {
+            self.headerParts = headerParts
         }
 
         public mutating func next() -> Element? {
-            // If we're already iterating an entry in the dict, grab the next one
-            if let nextValues = valuesIterator?.next() {
-                return nextValues
-            } else {
-                // If there's nothing left in this array, clear the iterator
-                valuesIterator = nil
-            }
-
-            if let entry = storageIterator.next() {
-                valuesIterator = entry.value.makeIterator()
-                return next()
-            } else {
-                return nil
-            }
+            return headerParts.next()
         }
     }  
 
     public func makeIterator() -> Iterator {
-        return Iterator(wrapping: storage.makeIterator())
+        return Iterator(headerParts: headers.map { (self.string(idx: $0.name), self.string(idx: $0.value)) }.makeIterator())
     }
 }
 
@@ -389,16 +491,21 @@ private extension Substring {
 
 extension HTTPHeaders: Equatable {
     public static func ==(lhs: HTTPHeaders, rhs: HTTPHeaders) -> Bool {
-        if lhs.storage.count != rhs.storage.count {
+        guard lhs.headers.count == rhs.headers.count else {
             return false
         }
-        for (k, v) in lhs.storage {
-            if let rv = rhs.storage[k], rv.map({ $0.1 }) == v.map({ $0.1 }) {
-                continue
-            } else {
+        let lhsNames = Set(lhs.names.map { lhs.string(idx: $0).lowercased() })
+        let rhsNames = Set(rhs.names.map { rhs.string(idx: $0).lowercased() })
+        guard lhsNames == rhsNames else {
+            return false
+        }
+
+        for name in lhsNames {
+            guard lhs[name].sorted() == rhs[name].sorted() else {
                 return false
             }
         }
+
         return true
     }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -34,6 +34,7 @@ extension HTTPHeadersTest {
                 ("testTrimWhitespaceWorksOnEmptyString", testTrimWhitespaceWorksOnEmptyString),
                 ("testTrimWhitespaceWorksOnOnlyWhitespace", testTrimWhitespaceWorksOnOnlyWhitespace),
                 ("testTrimWorksWithCharactersInTheMiddleAndWhitespaceAround", testTrimWorksWithCharactersInTheMiddleAndWhitespaceAround),
+                ("testContains", testContains),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -61,14 +61,15 @@ class HTTPHeadersTest : XCTestCase {
         let headers = HTTPHeaders(originalHeaders)
         let channel = EmbeddedChannel()
         var buffer = channel.allocator.buffer(capacity: 1024)
-        headers.write(buffer: &buffer)
+        headers.write(into: &buffer)
 
         let writtenBytes = buffer.getString(at: buffer.readerIndex, length: buffer.readableBytes)!
-        XCTAssertTrue(writtenBytes.contains("user-agent: 1\r\n"))
+        XCTAssertTrue(writtenBytes.contains("User-Agent: 1\r\n"))
         XCTAssertTrue(writtenBytes.contains("host: 2\r\n"))
-        XCTAssertTrue(writtenBytes.contains("x-something: 3,4\r\n"))
-        XCTAssertTrue(writtenBytes.contains("set-cookie: foo=bar\r\n"))
-        XCTAssertTrue(writtenBytes.contains("set-cookie: buz=cux\r\n"))
+        XCTAssertTrue(writtenBytes.contains("X-SOMETHING: 3\r\n"))
+        XCTAssertTrue(writtenBytes.contains("X-Something: 4\r\n"))
+        XCTAssertTrue(writtenBytes.contains("SET-COOKIE: foo=bar\r\n"))
+        XCTAssertTrue(writtenBytes.contains("Set-Cookie: buz=cux\r\n"))
 
         XCTAssertFalse(try channel.finish())
     }
@@ -132,4 +133,14 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertEqual(expected, actual)
     }
 
+    func testContains() {
+        let originalHeaders = [ ("X-Header", "1"),
+                                ("X-SomeHeader", "3"),
+                                ("X-Header", "2")]
+
+        let headers = HTTPHeaders(originalHeaders)
+        XCTAssertTrue(headers.contains(name: "x-header"))
+        XCTAssertTrue(headers.contains(name: "X-Header"))
+        XCTAssertFalse(headers.contains(name: "X-NonExistingHeader"))
+    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
@@ -48,7 +48,7 @@ class HTTPResponseEncoderTests: XCTestCase {
     func testNoAutoHeadersForCustom1XX() throws {
         let headers = HTTPHeaders([("Link", "</styles.css>; rel=preload; as=style")])
         let writtenData = sendResponse(withStatus: .custom(code: 103, reasonPhrase: "Early Hints"), andHeaders: headers)
-        writtenData.assertContainsOnly("HTTP/1.1 103 Early Hints\r\nlink: </styles.css>; rel=preload; as=style\r\n\r\n")
+        writtenData.assertContainsOnly("HTTP/1.1 103 Early Hints\r\nLink: </styles.css>; rel=preload; as=style\r\n\r\n")
     }
 
     func testNoAutoHeadersFor204() throws {
@@ -65,7 +65,7 @@ class HTTPResponseEncoderTests: XCTestCase {
     func testNoContentLengthHeadersForCustom1XX() throws {
         let headers = HTTPHeaders([("Link", "</styles.css>; rel=preload; as=style"), ("content-length", "0")])
         let writtenData = sendResponse(withStatus: .custom(code: 103, reasonPhrase: "Early Hints"), andHeaders: headers)
-        writtenData.assertContainsOnly("HTTP/1.1 103 Early Hints\r\nlink: </styles.css>; rel=preload; as=style\r\n\r\n")
+        writtenData.assertContainsOnly("HTTP/1.1 103 Early Hints\r\nLink: </styles.css>; rel=preload; as=style\r\n\r\n")
     }
 
     func testNoContentLengthHeadersFor204() throws {
@@ -83,7 +83,7 @@ class HTTPResponseEncoderTests: XCTestCase {
     func testNoTransferEncodingHeadersForCustom1XX() throws {
         let headers = HTTPHeaders([("Link", "</styles.css>; rel=preload; as=style"), ("transfer-encoding", "chunked")])
         let writtenData = sendResponse(withStatus: .custom(code: 103, reasonPhrase: "Early Hints"), andHeaders: headers)
-        writtenData.assertContainsOnly("HTTP/1.1 103 Early Hints\r\nlink: </styles.css>; rel=preload; as=style\r\n\r\n")
+        writtenData.assertContainsOnly("HTTP/1.1 103 Early Hints\r\nLink: </styles.css>; rel=preload; as=style\r\n\r\n")
     }
 
     func testNoTransferEncodingHeadersFor204() throws {

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -44,7 +44,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         // Check the response.
         assertResponseIs(response: written.readString(length: written.readableBytes)!,
                          expectedResponseLine: "HTTP/1.1 400 Bad Request",
-                         expectedResponseHeaders: ["connection: close", "content-length: 0"])
+                         expectedResponseHeaders: ["Connection: close", "Content-Length: 0"])
     }
 
     func testIgnoresNonParserErrors() throws {

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -399,7 +399,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                             expectedResponseHeaders: ["x-upgrade-complete: true", "upgrade: myproto", "connection: upgrade"])
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(result: ())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
@@ -504,7 +504,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                             expectedResponseHeaders: ["x-upgrade-complete: true", "upgrade: myproto", "connection: upgrade"])
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(result: ())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
@@ -548,7 +548,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                             expectedResponseHeaders: ["x-upgrade-complete: true", "upgrade: myproto", "connection: upgrade"])
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(result: ())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
@@ -609,7 +609,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                             expectedResponseHeaders: ["x-upgrade-complete: true", "upgrade: myproto", "connection: upgrade"])
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(result: ())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
@@ -655,7 +655,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                             expectedResponseHeaders: ["x-upgrade-complete: true", "upgrade: myproto", "connection: upgrade"])
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(result: ())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
@@ -689,7 +689,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                             expectedResponseHeaders: ["x-upgrade-complete: true", "upgrade: myproto", "connection: upgrade"])
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(result: ())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
@@ -732,7 +732,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                             expectedResponseHeaders: ["x-upgrade-complete: true", "upgrade: myproto", "connection: upgrade"])
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(result: ())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -127,7 +127,7 @@ class EndToEndTests: XCTestCase {
         let receivedResponse = client.readAllInboundBuffers().allAsString()
         assertResponseIs(response: receivedResponse,
                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["upgrade: websocket", "sec-websocket-accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "connection: upgrade"])
+                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
     }
 
     func testCanRejectUpgrade() throws {
@@ -267,7 +267,7 @@ class EndToEndTests: XCTestCase {
         let receivedResponse = client.readAllInboundBuffers().allAsString()
         assertResponseIs(response: receivedResponse,
                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["upgrade: websocket", "sec-websocket-accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "connection: upgrade", "testheader: TestValue"])
+                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade", "TestHeader: TestValue"])
     }
 
     func testMayRegisterMultipleWebSocketEndpoints() throws {
@@ -298,7 +298,7 @@ class EndToEndTests: XCTestCase {
         let receivedResponse = client.readAllInboundBuffers().allAsString()
         assertResponseIs(response: receivedResponse,
                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["upgrade: websocket", "sec-websocket-accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "connection: upgrade", "target: third"])
+                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade", "Target: third"])
     }
 
     func testSendAFewFrames() throws {
@@ -322,7 +322,7 @@ class EndToEndTests: XCTestCase {
         let receivedResponse = client.readAllInboundBuffers().allAsString()
         assertResponseIs(response: receivedResponse,
                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["upgrade: websocket", "sec-websocket-accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "connection: upgrade"])
+                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
 
         // Put a frame encoder in the client pipeline.
         XCTAssertNoThrow(try client.pipeline.add(handler: WebSocketFrameEncoder()).wait())


### PR DESCRIPTION
Motivation:

We are currently parsing each header eagly which means we need to convert from bytes to String frequently. The reality is that most of the times the user is not really interested in all the headers and so it is kind of wasteful to do so.

Modification:

Rewrite our internal storage of HTTPHeaders to use a ByteBuffer as internal storage and so only parse headers on demand.

Result:

Less overhead for parsing headers.