### PR TITLE
rename HTTPHeaders.getCanonicalForm to subject and improve efficiency

### DIFF
--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -104,7 +104,7 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler {
 
     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         if case .head(let requestHead) = unwrapInboundIn(data) {
-            acceptQueue.append(requestHead.headers.getCanonicalForm("accept-encoding"))
+            acceptQueue.append(requestHead.headers[canonicalForm: "accept-encoding"])
         }
 
         ctx.fireChannelRead(data)

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -286,6 +286,11 @@ public struct HTTPHeaders: CustomStringConvertible {
             buffer.write(staticString: crlf)
         }
     }
+    
+    @available(*, deprecated, message: "getCanonicalForm has been changed to a subscript: headers[canonicalForm: name]")
+    public func getCanonicalForm(_ name: String) -> [String] {
+        return self[canonicalForm: name]
+    }
 
     /// Retrieves the header values for the given header field in "canonical form": that is,
     /// splitting them on commas as extensively as possible such that multiple values received on the
@@ -294,7 +299,7 @@ public struct HTTPHeaders: CustomStringConvertible {
     ///
     /// - Parameter name: The header field name whose values are to be retrieved.
     /// - Returns: A list of the values for that header field name.
-    public func getCanonicalForm(_ name: String) -> [String] {
+    public subscript(canonicalForm name: String) -> [String] {
         // It's not safe to split Set-Cookie on comma.
         let queryName = name.lowercased()
         if queryName == "set-cookie" {
@@ -302,7 +307,7 @@ public struct HTTPHeaders: CustomStringConvertible {
         }
 
         if let result = storage[queryName] {
-            return result.map { tuple in tuple.1.split(separator: ",").map { String($0.trimWhitespace()) } }.reduce([], +)
+            return result.flatMap { tuple in tuple.1.split(separator: ",").map { String($0.trimWhitespace()) } }
         }
         return []
     }

--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -156,7 +156,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
 
         // Ok, we have a HTTP request. Check if it's an upgrade. If it's not, we want to pass it on and remove ourselves
         // from the channel pipeline.
-        let requestedProtocols = request.headers.getCanonicalForm("upgrade")
+        let requestedProtocols = request.headers[canonicalForm: "upgrade"]
         guard requestedProtocols.count > 0 else {
             notUpgrading(ctx: ctx, data: data)
             return
@@ -170,7 +170,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
 
     /// The core of the upgrade handling logic.
     private func handleUpgrade(ctx: ChannelHandlerContext, request: HTTPRequestHead, requestedProtocols: [String]) -> Bool {
-        let connectionHeader = Set(request.headers.getCanonicalForm("connection").map { $0.lowercased() })
+        let connectionHeader = Set(request.headers[canonicalForm: "connection"].map { $0.lowercased() })
         let allHeaderNames = Set(request.headers.map { $0.name.lowercased() })
 
         for proto in requestedProtocols {

--- a/Sources/NIOWebSocket/WebSocketUpgrader.swift
+++ b/Sources/NIOWebSocket/WebSocketUpgrader.swift
@@ -30,7 +30,7 @@ public enum NIOWebSocketUpgradeError: Error {
 
 fileprivate extension HTTPHeaders {
     fileprivate func nonListHeader(_ name: String) throws -> String {
-        let fields = self.getCanonicalForm(name)
+        let fields = self[canonicalForm: name]
         guard fields.count == 1 else {
             throw NIOWebSocketUpgradeError.invalidUpgradeHeader
         }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -80,10 +80,10 @@ class HTTPHeadersTest : XCTestCase {
                                 ("X-Something", "5")]
 
         let headers = HTTPHeaders(originalHeaders)
-        XCTAssertEqual(headers.getCanonicalForm("user-agent"), ["1"])
-        XCTAssertEqual(headers.getCanonicalForm("host"), ["2"])
-        XCTAssertEqual(headers.getCanonicalForm("x-something"), ["3", "4", "5"])
-        XCTAssertEqual(headers.getCanonicalForm("foo"), [])
+        XCTAssertEqual(headers[canonicalForm: "user-agent"], ["1"])
+        XCTAssertEqual(headers[canonicalForm: "host"], ["2"])
+        XCTAssertEqual(headers[canonicalForm: "x-something"], ["3", "4", "5"])
+        XCTAssertEqual(headers[canonicalForm: "foo"], [])
     }
 
     func testSubscriptDoesntSplitHeaders() {
@@ -106,10 +106,10 @@ class HTTPHeadersTest : XCTestCase {
                                 ("Set-Cookie", "buz=cux; expires=Fri, 13 Oct 2017 21:21:41 GMT")]
 
         let headers = HTTPHeaders(originalHeaders)
-        XCTAssertEqual(headers.getCanonicalForm("user-agent"), ["1"])
-        XCTAssertEqual(headers.getCanonicalForm("host"), ["2"])
-        XCTAssertEqual(headers.getCanonicalForm("set-cookie"), ["foo=bar; expires=Sun, 17-Mar-2013 13:49:50 GMT",
-                                                                "buz=cux; expires=Fri, 13 Oct 2017 21:21:41 GMT"])
+        XCTAssertEqual(headers[canonicalForm: "user-agent"], ["1"])
+        XCTAssertEqual(headers[canonicalForm: "host"], ["2"])
+        XCTAssertEqual(headers[canonicalForm: "set-cookie"], ["foo=bar; expires=Sun, 17-Mar-2013 13:49:50 GMT",
+                                                              "buz=cux; expires=Fri, 13 Oct 2017 21:21:41 GMT"])
     }
 
     func testTrimWhitespaceWorksOnEmptyString() {

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
@@ -255,15 +255,15 @@ class HTTPResponseCompressorTest: XCTestCase {
         let compressedResponse = data.0
         var compressedChunks = data.1
         var compressedBody = compressedChunks[0].merge(compressedChunks[1...])
-        XCTAssertEqual(compressedResponse.headers.getCanonicalForm("content-encoding"), ["deflate"])
+        XCTAssertEqual(compressedResponse.headers[canonicalForm: "content-encoding"], ["deflate"])
 
         switch writeStrategy {
         case .once:
-            XCTAssertEqual(compressedResponse.headers.getCanonicalForm("content-length"), ["\(compressedBody.readableBytes)"])
-            XCTAssertEqual(compressedResponse.headers.getCanonicalForm("transfer-encoding"), [])
+            XCTAssertEqual(compressedResponse.headers[canonicalForm: "content-length"], ["\(compressedBody.readableBytes)"])
+            XCTAssertEqual(compressedResponse.headers[canonicalForm: "transfer-encoding"], [])
         case .intermittentFlushes:
-            XCTAssertEqual(compressedResponse.headers.getCanonicalForm("content-length"), [])
-            XCTAssertEqual(compressedResponse.headers.getCanonicalForm("transfer-encoding"), ["chunked"])
+            XCTAssertEqual(compressedResponse.headers[canonicalForm: "content-length"], [])
+            XCTAssertEqual(compressedResponse.headers[canonicalForm: "transfer-encoding"], ["chunked"])
         }
 
         assertDecompressedResponseMatches(responseData: &compressedBody,
@@ -292,15 +292,15 @@ class HTTPResponseCompressorTest: XCTestCase {
         let compressedResponse = data.0
         var compressedChunks = data.1
         var compressedBody = compressedChunks[0].merge(compressedChunks[1...])
-        XCTAssertEqual(compressedResponse.headers.getCanonicalForm("content-encoding"), ["gzip"])
+        XCTAssertEqual(compressedResponse.headers[canonicalForm: "content-encoding"], ["gzip"])
 
         switch writeStrategy {
         case .once:
-            XCTAssertEqual(compressedResponse.headers.getCanonicalForm("content-length"), ["\(compressedBody.readableBytes)"])
-            XCTAssertEqual(compressedResponse.headers.getCanonicalForm("transfer-encoding"), [])
+            XCTAssertEqual(compressedResponse.headers[canonicalForm: "content-length"], ["\(compressedBody.readableBytes)"])
+            XCTAssertEqual(compressedResponse.headers[canonicalForm: "transfer-encoding"], [])
         case .intermittentFlushes:
-            XCTAssertEqual(compressedResponse.headers.getCanonicalForm("content-length"), [])
-            XCTAssertEqual(compressedResponse.headers.getCanonicalForm("transfer-encoding"), ["chunked"])
+            XCTAssertEqual(compressedResponse.headers[canonicalForm: "content-length"], [])
+            XCTAssertEqual(compressedResponse.headers[canonicalForm: "transfer-encoding"], ["chunked"])
         }
 
         assertDecompressedResponseMatches(responseData: &compressedBody,
@@ -329,7 +329,7 @@ class HTTPResponseCompressorTest: XCTestCase {
         let compressedResponse = data.0
         var compressedChunks = data.1
         let uncompressedBody = compressedChunks[0].merge(compressedChunks[1...])
-        XCTAssertEqual(compressedResponse.headers.getCanonicalForm("content-encoding"), [])
+        XCTAssertEqual(compressedResponse.headers[canonicalForm: "content-encoding"], [])
         XCTAssertEqual(uncompressedBody.readableBytes, 2048)
         XCTAssertEqual(uncompressedBody, bodyBuffer)
     }


### PR DESCRIPTION
Motivation:

HTTPHeaders had an unusual API for Swift: `getCanonicalForm(String)` which is
better suited as a subscript `[canonicalForm: String]`.
Also the implementation was needlessly inefficient.

Modifications:

- renamed HTTPHeaders.getCanonicalForm to HTTPHeaders[canonicalForm]
- improved efficiency by replacing anti-pattern
  Array.map { ...  }.reduce(+, []) by flatMap

Result:

more Swift in both meanings

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
