### PR TITLE
TailChannelHandler does not need to implement _ChannelOutboundHandler

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -939,7 +939,7 @@ private extension CloseMode {
 }
 
 /// Special `ChannelInboundHandler` which will consume all inbound events.
-/* private but tests */ final class TailChannelHandler: _ChannelInboundHandler, _ChannelOutboundHandler {
+/* private but tests */ final class TailChannelHandler: _ChannelInboundHandler {
 
     static let name = "tail"
     static let sharedInstance = TailChannelHandler()


### PR DESCRIPTION
Motivation:

TailChannelHandler does not implement any _ChannelOutboundHandler methods and so has no need to conform to it.

Modifications:

Not implement _ChannelOutboundHandler for TailChannelHandler

Result:

More correct code