### PR TITLE
Restore unary initializer for HTTPHeaders

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -257,7 +257,18 @@ public struct HTTPHeaders: CustomStringConvertible {
     /// - parameters
     ///     - headers: An initial set of headers to use to populate the header block.
     ///     - allocator: The allocator to use to allocate the underlying storage.
-    public init(_ headers: [(String, String)] = [], allocator: ByteBufferAllocator = ByteBufferAllocator()) {
+    public init(_ headers: [(String, String)] = []) {
+        // Note: this initializer exists becuase of https://bugs.swift.org/browse/SR-7415.
+        // Otherwise we'd only have the one below with a default argument for `allocator`.
+        self.init(headers, allocator: ByteBufferAllocator())
+    }
+
+    /// Construct a `HTTPHeaders` structure.
+    ///
+    /// - parameters
+    ///     - headers: An initial set of headers to use to populate the header block.
+    ///     - allocator: The allocator to use to allocate the underlying storage.
+    public init(_ headers: [(String, String)] = [], allocator: ByteBufferAllocator) {
         // Reserve enough space in the array to hold all indices.
         var array: [HTTPHeader] = []
         array.reserveCapacity(headers.count)


### PR DESCRIPTION
Motivation:

The Swift compiler seems to get very nervous when variadic inits
are used for types that have constructors with optional values. In
general we're not worried about breaking downstream consumers'
extensions when we update our code, but in this case we break the
ability to conform HTTPHeaders to ExpressibleByDictionaryLiteral,
which is a bit annoying. See https://bugs.swift.org/browse/SR-7415
for more details.

For 1.5.0 we should conform HTTPHeaders ourselves, but until that
time we can restore anyone who was conforming HTTPHeaders to
ExpressibleByDictionaryLiteral by restoring the old unary initializer
and delegating it to the new one. This presents an effect that is
equivalent to the old behaviour, but is new.

As a side note, in general it's a bad idea to conform types that you
do not own to standard library protocols. NIO reserves the right to
add conformances to our types in any Semver Minor release, so having
that conformance in your own code risks breakage without a Semver
Major patch bump. Please be aware.

Modifications:

Restored the unary initializer for HTTPHeaders.

Result:

Less breakage, more happiness.
