### PR TITLE
Introduce HTTPHeaderName for faster header operations

### DIFF
--- a/IntegrationTests/tests_01_http/test_12_headers_too_large.sh
+++ b/IntegrationTests/tests_01_http/test_12_headers_too_large.sh
@@ -22,8 +22,8 @@ touch "$tmp/empty"
 cr=$(echo -e '\r')
 cat > "$tmp/headers_expected" <<EOF
 HTTP/1.1 400 Bad Request$cr
-Content-Length: 0$cr
-Connection: close$cr
+content-length: 0$cr
+connection: close$cr
 $cr
 EOF
 echo "FOO BAR" > "$htdocs/some_file.txt"
@@ -41,10 +41,10 @@ assert_equal_files "$tmp/empty" "$tmp/out"
 if ! grep -q 'HTTP/1.1 400 Bad Request' "$tmp/headers_actual"; then
     fail "couldn't find status line in response"
 fi
-if ! grep -q 'Content-Length: 0' "$tmp/headers_actual"; then
+if ! grep -q 'content-length: 0' "$tmp/headers_actual"; then
     fail "couldn't find content-length in response"
 fi
-if ! grep -q 'Connection: close' "$tmp/headers_actual"; then
+if ! grep -q 'connection: close' "$tmp/headers_actual"; then
     fail "couldn't find connection: close in response"
 fi
 

--- a/IntegrationTests/tests_01_http/test_14_strict_mode_assertion.sh
+++ b/IntegrationTests/tests_01_http/test_14_strict_mode_assertion.sh
@@ -24,11 +24,11 @@ echo -e 'GET / HTT\r\n\r\n' | nc -U "$socket" > "$tmp/actual"
 if ! grep -q 'HTTP/1.1 400 Bad Request' "$tmp/actual"; then
     fail "couldn't find status line in response"
 fi
-if ! grep -q 'Content-Length: 0' "$tmp/actual"; then
-    fail "couldn't find Content-Length in response"
+if ! grep -q 'content-length: 0' "$tmp/actual"; then
+    fail "couldn't find content-length in response"
 fi
-if ! grep -q 'Connection: close' "$tmp/actual"; then
-    fail "couldn't find Connection: close in response"
+if ! grep -q 'connection: close' "$tmp/actual"; then
+    fail "couldn't find connection: close in response"
 fi
 
 linecount=$(wc "$tmp/actual")

--- a/IntegrationTests/tests_01_http/test_18_close_with_no_keepalive.sh
+++ b/IntegrationTests/tests_01_http/test_18_close_with_no_keepalive.sh
@@ -23,12 +23,12 @@ socket=$(get_socket "$token")
 
 kill -0 $server_pid
 
-echo -e 'GET /dynamic/count-to-ten HTTP/1.1\r\nConnection: close\r\n\r\n' | \
+echo -e 'GET /dynamic/count-to-ten HTTP/1.1\r\nconnection: close\r\n\r\n' | \
     nc -U "$socket" > "$tmp/actual"
 backslash_r=$(echo -ne '\r')
 cat > "$tmp/expected" <<EOF
 HTTP/1.1 200 OK$backslash_r
-Connection: close$backslash_r
+connection: close$backslash_r
 transfer-encoding: chunked$backslash_r
 $backslash_r
 1$backslash_r

--- a/IntegrationTests/tests_01_http/test_22_http_1.0_keep_alive.sh
+++ b/IntegrationTests/tests_01_http/test_22_http_1.0_keep_alive.sh
@@ -19,6 +19,6 @@ token=$(create_token)
 start_server "$token"
 do_curl "$token" -H 'connection: keep-alive' -v --http1.0 \
     "http://foobar.com/dynamic/info" > "$tmp/out_actual" 2>&1
-grep -qi '< Connection: keep-alive' "$tmp/out_actual"
+grep -qi '< connection: keep-alive' "$tmp/out_actual"
 grep -qi '< HTTP/1.0 200 OK' "$tmp/out_actual"
 stop_server "$token"

--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -101,25 +101,25 @@ private enum BodyFraming {
 private func sanitizeTransportHeaders(hasBody: HTTPMethod.HasBody, headers: inout HTTPHeaders, version: HTTPVersion) -> BodyFraming {
     switch hasBody {
     case .no:
-        headers.remove(name: "content-length")
-        headers.remove(name: "transfer-encoding")
+        headers.remove(name: .contentLength)
+        headers.remove(name: .transferEncoding)
         return .neither
     case .yes:
-        if headers.contains(name: "content-length") {
+        if headers.contains(name: .contentLength) {
             return .contentLength
         }
         if version.major == 1 && version.minor >= 1 {
-            headers.replaceOrAdd(name: "transfer-encoding", value: "chunked")
+            headers.replaceOrAdd(name: .transferEncoding, value: "chunked")
             return .chunked
         } else {
             return .neither
         }
     case .unlikely:
-        if headers.contains(name: "content-length") {
+        if headers.contains(name: .contentLength) {
             return .contentLength
         }
         if version.major == 1 && version.minor >= 1 {
-            return headers["transfer-encoding"].first == "chunked" ? .chunked : .neither
+            return headers[.transferEncoding].first == "chunked" ? .chunked : .neither
         }
         return .neither
     }

--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -104,7 +104,7 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler {
 
     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         if case .head(let requestHead) = unwrapInboundIn(data) {
-            acceptQueue.append(requestHead.headers[canonicalForm: "accept-encoding"])
+            acceptQueue.append(requestHead.headers[canonicalForm: .acceptEncoding])
         }
 
         ctx.fireChannelRead(data)
@@ -120,7 +120,7 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler {
                 return
             }
 
-            responseHead.headers.add(name: "Content-Encoding", value: algorithm!.rawValue)
+            responseHead.headers.add(name: .contentEncoding, value: algorithm!.rawValue)
             initializeEncoder(encoding: algorithm!)
             pendingResponse.bufferResponseHead(responseHead)
             chainPromise(promise)
@@ -342,11 +342,11 @@ private struct PartialHTTPResponse {
 
         let body = compressBody(compressor: &compressor, allocator: allocator, flag: flag)
         if let bodyLength = body?.readableBytes, isCompleteResponse && bodyLength > 0 {
-            head!.headers.remove(name: "transfer-encoding")
-            head!.headers.replaceOrAdd(name: "content-length", value: "\(bodyLength)")
+            head!.headers.remove(name: .transferEncoding )
+            head!.headers.replaceOrAdd(name: .contentLength, value: "\(bodyLength)")
         } else if head != nil && head!.status.mayHaveResponseBody {
-            head!.headers.remove(name: "content-length")
-            head!.headers.replaceOrAdd(name: "transfer-encoding", value: "chunked")
+            head!.headers.remove(name: .contentLength)
+            head!.headers.replaceOrAdd(name: .transferEncoding, value: "chunked")
         }
 
         let response = (head, body, end)

--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -43,7 +43,7 @@ public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler {
         // A side note here: we cannot block or do any delayed work. ByteToMessageDecoder is going
         // to come along and close the channel right after we return from this function.
         if !self.hasUnterminatedResponse {
-            let headers = HTTPHeaders([("Connection", "close"), ("Content-Length", "0")])
+            let headers = HTTPHeaders([(.connection, "close"), (.contentLength, "0")])
             let head = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .badRequest, headers: headers)
             ctx.write(self.wrapOutboundOut(.head(head)), promise: nil)
             ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)

--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -156,7 +156,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
 
         // Ok, we have a HTTP request. Check if it's an upgrade. If it's not, we want to pass it on and remove ourselves
         // from the channel pipeline.
-        let requestedProtocols = request.headers[canonicalForm: "upgrade"]
+        let requestedProtocols = request.headers[canonicalForm: .upgrade]
         guard requestedProtocols.count > 0 else {
             notUpgrading(ctx: ctx, data: data)
             return
@@ -170,7 +170,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
 
     /// The core of the upgrade handling logic.
     private func handleUpgrade(ctx: ChannelHandlerContext, request: HTTPRequestHead, requestedProtocols: [String]) -> Bool {
-        let connectionHeader = Set(request.headers[canonicalForm: "connection"].map { $0.lowercased() })
+        let connectionHeader = Set(request.headers[canonicalForm: .connection].map { $0.lowercased() })
         let allHeaderNames = Set(request.headers.map { $0.name.lowercased() })
 
         for proto in requestedProtocols {
@@ -251,7 +251,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
 
     /// Builds the initial mandatory HTTP headers for HTTP ugprade responses.
     private func buildUpgradeHeaders(`protocol`: String) -> HTTPHeaders {
-        return HTTPHeaders([("connection", "upgrade"), ("upgrade", `protocol`)])
+        return HTTPHeaders([(.connection, "upgrade"), (.upgrade, `protocol`)])
     }
 
     /// Removes the given channel handler from the channel pipeline.

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -73,9 +73,9 @@ private final class HTTPHandler: ChannelInboundHandler {
         }
 
         var headers = HTTPHeaders()
-        headers.add(name: "Content-Type", value: "text/html")
-        headers.add(name: "Content-Length", value: String(self.responseBody.readableBytes))
-        headers.add(name: "Connection", value: "close")
+        headers.add(name: .contentType, value: "text/html")
+        headers.add(name: .contentLength, value: String(self.responseBody.readableBytes))
+        headers.add(name: .connection, value: "close")
         let responseHead = HTTPResponseHead(version: .init(major: 1, minor: 1),
                                     status: .ok,
                                     headers: headers)
@@ -89,8 +89,8 @@ private final class HTTPHandler: ChannelInboundHandler {
 
     private func respond405(ctx: ChannelHandlerContext) {
         var headers = HTTPHeaders()
-        headers.add(name: "Connection", value: "close")
-        headers.add(name: "Content-Length", value: "0")
+        headers.add(name: .connection, value: "close")
+        headers.add(name: .contentLength, value: "0")
         let head = HTTPResponseHead(version: .init(major: 1, minor: 1),
                                     status: .methodNotAllowed,
                                     headers: headers)

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -35,6 +35,7 @@ extension HTTPHeadersTest {
                 ("testTrimWhitespaceWorksOnOnlyWhitespace", testTrimWhitespaceWorksOnOnlyWhitespace),
                 ("testTrimWorksWithCharactersInTheMiddleAndWhitespaceAround", testTrimWorksWithCharactersInTheMiddleAndWhitespaceAround),
                 ("testContains", testContains),
+                ("testHTTPHeaderName", testHTTPHeaderName),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -143,4 +143,18 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertTrue(headers.contains(name: "X-Header"))
         XCTAssertFalse(headers.contains(name: "X-NonExistingHeader"))
     }
+
+    func testHTTPHeaderName() {
+        var headers = HTTPHeaders()
+        headers.add(name: .contentLength, value: "1")
+        headers.add(name: "Transfer-Encoding", value: "chunked")
+
+        XCTAssertTrue(headers.contains(name: .contentLength))
+        XCTAssertTrue(headers.contains(name: "Content-Length"))
+        XCTAssertTrue(headers.contains(name: .transferEncoding))
+        XCTAssertTrue(headers.contains(name: "Transfer-Encoding"))
+
+        XCTAssertEqual(headers[.contentLength], ["1"])
+        XCTAssertEqual(headers[.transferEncoding], ["chunked"])
+    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -44,7 +44,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         // Check the response.
         assertResponseIs(response: written.readString(length: written.readableBytes)!,
                          expectedResponseLine: "HTTP/1.1 400 Bad Request",
-                         expectedResponseHeaders: ["Connection: close", "Content-Length: 0"])
+                         expectedResponseHeaders: ["connection: close", "content-length: 0"])
     }
 
     func testIgnoresNonParserErrors() throws {


### PR DESCRIPTION
Motivation:

Most HTTP header names are well known and so we can optimize for them.

Modification:

- Introduce HTTPHeaderName and also expose common used names via static lets.
- Add unit test

Result:

Less overhead when acting on headers