### PR TITLE
Don't call to user code before reconciling Channel state.

### DIFF
--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -39,6 +39,7 @@ extension SocketChannelTest {
                 ("testWriteServerSocketChannel", testWriteServerSocketChannel),
                 ("testWriteAndFlushServerSocketChannel", testWriteAndFlushServerSocketChannel),
                 ("testConnectServerSocketChannel", testConnectServerSocketChannel),
+                ("testCloseDuringWriteFailure", testCloseDuringWriteFailure),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Callouts to user code allows the user to make calls that re-enter
channel code. In the case of channel closure, we could call out to the
user before the channel knew it was completely closed, which would
trigger a safety assertion (in debug mode) or hit a fatalError
(in release mode).

Modifications:

Reconciled channel state before we call out to user code.
Added a test for this case.

Result:

Fewer crashes, better channel state management.

Resolves #307.