### PR TITLE
fix errors received when holding messages in HTTPServerPipelineHandler

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest+XCTest.swift
@@ -28,6 +28,8 @@ extension HTTPServerProtocolErrorHandlerTest {
       return [
                 ("testHandlesBasicErrors", testHandlesBasicErrors),
                 ("testIgnoresNonParserErrors", testIgnoresNonParserErrors),
+                ("testDoesNotSendAResponseIfResponseHasAlreadyStarted", testDoesNotSendAResponseIfResponseHasAlreadyStarted),
+                ("testCanHandleErrorsWhenResponseHasStarted", testCanHandleErrorsWhenResponseHasStarted),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -66,4 +66,77 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
 
         XCTAssertNoThrow(try channel.finish())
     }
+    
+    func testDoesNotSendAResponseIfResponseHasAlreadyStarted() throws {
+        let channel = EmbeddedChannel()
+        XCTAssertNoThrow(try channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false, withErrorHandling: true).wait())
+        let res = HTTPServerResponsePart.head(.init(version: HTTPVersion(major: 1, minor: 1),
+                                                    status: .ok,
+                                                    headers: .init([("Content-Length", "0")])))
+        XCTAssertNoThrow(try channel.writeAndFlush(res).wait())
+        // now we have started a response but it's not complete yet, let's inject a parser error
+        channel.pipeline.fireErrorCaught(HTTPParserError.invalidEOFState)
+        var allOutbound = channel.readAllOutboundBuffers()
+        let allOutboundString = allOutbound.readString(length: allOutbound.readableBytes)
+        // there should be no HTTP/1.1 400 or anything in here
+        XCTAssertEqual("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n", allOutboundString)
+    }
+
+    func testCanHandleErrorsWhenResponseHasStarted() throws {
+        enum NextExpectedState {
+            case head
+            case end
+            case none
+        }
+        class DelayWriteHandler: ChannelInboundHandler {
+            typealias InboundIn = HTTPServerRequestPart
+            typealias OutboundOut = HTTPServerResponsePart
+            
+            private var nextExpected: NextExpectedState = .head
+            
+            func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+                let req = self.unwrapInboundIn(data)
+                switch req {
+                case .head:
+                    XCTAssertEqual(.head, self.nextExpected)
+                    self.nextExpected = .end
+                    let res = HTTPServerResponsePart.head(.init(version: HTTPVersion(major: 1, minor: 1),
+                                                                status: .ok,
+                                                                headers: .init([("Content-Length", "0")])))
+                    ctx.writeAndFlush(self.wrapOutboundOut(res), promise: nil)
+                default:
+                    XCTAssertEqual(.end, self.nextExpected)
+                    self.nextExpected = .none
+                }
+            }
+            
+            
+        }
+        let channel = EmbeddedChannel()
+        XCTAssertNoThrow(try channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).then {
+            channel.pipeline.add(handler: DelayWriteHandler())
+        }.wait())
+        
+        var buffer = channel.allocator.buffer(capacity: 1024)
+        buffer.write(staticString: "GET / HTTP/1.1\r\n\r\nGET / HTTP/1.1\r\n\r\nGET / HT")
+        XCTAssertNoThrow(try channel.writeInbound(buffer))
+        XCTAssertNoThrow(try channel.close().wait())
+        (channel.eventLoop as! EmbeddedEventLoop).run()
+        
+        // The channel should be closed at this stage.
+        XCTAssertNoThrow(try channel.closeFuture.wait())
+        
+        // We expect exactly one ByteBuffer in the output.
+        guard case .some(.byteBuffer(var written)) = channel.readOutbound() else {
+            XCTFail("No writes")
+            return
+        }
+        
+        XCTAssertNil(channel.readOutbound())
+        
+        // Check the response.
+        assertResponseIs(response: written.readString(length: written.readableBytes)!,
+                         expectedResponseLine: "HTTP/1.1 200 OK",
+                         expectedResponseHeaders: ["Content-Length: 0"])
+    }
 }


### PR DESCRIPTION
Motivation:

We had a bug which is happens in the combination of these states:
- we held a request in the pipelining handler (because we're procesing a
  previous one)
- a http handler error happened whilst a response's `.head` had already
  been sent (but not yet the `.end`)
- the HTTPServerProtocolErrors handler is in use

That would lead to this situation:
- the error isn't held by the pipelining handler
- the error handler then just sends a full response (`.head` and `.end`)
  but the actual http server already send a `.head`. So all in all, we
  sent `.head`, `.head`, `.end` which is illegal
- the pipelining handler didn't notice this and beause it saw an `.end`
  it would send through the next requst
- now the http server handler is in the situation that it gets `.head`,
  `.head` too (which is illegal)

Modifications:

- hold HTTP errors in the pipelining handler too

Result:

- more correctness
