### PR TITLE
Make IdleStateHandler.IdleStateEvent public

### DIFF
--- a/Sources/NIO/ChannelHandlers.swift
+++ b/Sources/NIO/ChannelHandlers.swift
@@ -159,7 +159,8 @@ public class IdleStateHandler: ChannelDuplexHandler {
     public typealias OutboundIn = NIOAny
     public typealias OutboundOut = NIOAny
 
-    enum IdleStateEvent {
+    ///A user event triggered by IdleStateHandler when a Channel is idle.
+    public enum IdleStateEvent {
         /// Will be triggered when no write was performed for the specified amount of time
         case write
         /// Will be triggered when no read was performed for the specified amount of time


### PR DESCRIPTION
IdleStateHandler.IdleStateEvent is currently internal. Make it public.

### Motivation:

The IdleStateEvent is delivered to the user via`public func userInboundEventTriggered(ctx: ChannelHandlerContext, event: Any)`. In this method, it must be possible to have a check on the type of `event`. `IdleStateEvent` must be public.

### Modifications:
Change access level of `IdleStateHandler.IdleStateEvent` to `public`.

### Result:

IdleStateEvent will become a part of the NIO API.