### PR TITLE
propagate socket errors on .reset

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -798,7 +798,27 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
     // the `reset` event.
     final func reset() {
         self.readEOF()
-        self.close0(error: ChannelError.eof, mode: .all, promise: nil)
+
+        if self.socket.isOpen {
+            assert(self.lifecycleManager.isRegistered)
+            let error: IOError
+            // if the socket is still registered (and therefore open), let's try to get the actual socket error from the socket
+            do {
+                let result: Int32 = try self.socket.getOption(level: SOL_SOCKET, name: SO_ERROR)
+                if result != 0 {
+                    // we have a socket error, let's forward
+                    // this path will be executed on Linux (EPOLLERR) & Darwin (ev.fflags != 0)
+                    error = IOError(errnoCode: result, reason: "connection reset (error set)")
+                } else {
+                    // we don't have a socket error, this must be connection reset without an error then
+                    // this path should only be executed on Linux (EPOLLHUP, no EPOLLERR)
+                    error = IOError(errnoCode: ECONNRESET, reason: "connection reset (no error set)")
+                }
+                self.close0(error: error, mode: .all, promise: nil)
+            } catch {
+                self.close0(error: error, mode: .all, promise: nil)
+            }
+        }
         assert(!self.lifecycleManager.isRegistered)
     }
 

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -67,6 +67,7 @@ extension ChannelTests {
                 ("testCloseSocketWhenReadErrorWasReceivedAndMakeSureNoReadCompleteArrives", testCloseSocketWhenReadErrorWasReceivedAndMakeSureNoReadCompleteArrives),
                 ("testSocketFailingAsyncCorrectlyTearsTheChannelDownAndDoesntCrash", testSocketFailingAsyncCorrectlyTearsTheChannelDownAndDoesntCrash),
                 ("testSocketErroringSynchronouslyCorrectlyTearsTheChannelDown", testSocketErroringSynchronouslyCorrectlyTearsTheChannelDown),
+                ("testConnectWithECONNREFUSEDGetsTheRightError", testConnectWithECONNREFUSEDGetsTheRightError),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Since #286, we do eagerly detect connection resets which is good. To
resolve the situation we first try to read everything off the socket. If
something fails there, everything is good and the client gets the
correct error. If that however doesn't lead to any errors, we would
close the connection with `error: ChannelError.eof` which the client
would then see for example on a connect that happened to get
`ECONNRESET` or `ECONNREFUSED`. That's not right so these situations are
fixed here.

Modifications:

- on reset, try to get the socket error if any
- if no socket error was detected, we send a `ECONNRESET` because we
  know we have been reset but not why and didn't encounter any errors
- write tests for these situations

Result:

connection resets that don't hit any other errors will now see the
correct error
