### PR TITLE
Synchronous connection failures must close channels.

### DIFF
--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -66,6 +66,7 @@ extension ChannelTests {
                 ("testAppropriateAndInappropriateOperationsForUnregisteredSockets", testAppropriateAndInappropriateOperationsForUnregisteredSockets),
                 ("testCloseSocketWhenReadErrorWasReceivedAndMakeSureNoReadCompleteArrives", testCloseSocketWhenReadErrorWasReceivedAndMakeSureNoReadCompleteArrives),
                 ("testSocketFailingAsyncCorrectlyTearsTheChannelDownAndDoesntCrash", testSocketFailingAsyncCorrectlyTearsTheChannelDownAndDoesntCrash),
+                ("testSocketErroringSynchronouslyCorrectlyTearsTheChannelDown", testSocketErroringSynchronouslyCorrectlyTearsTheChannelDown),
            ]
    }
 }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -262,10 +262,14 @@ public class SocketChannelTest : XCTestCase {
         let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
         do {
             try serverChannel.connect(to: serverChannel.localAddress!).wait()
+            XCTFail("Did not throw")
+            XCTAssertNoThrow(try serverChannel.close().wait())
         } catch let err as ChannelError where err == .operationUnsupported {
-            // expected
+            // expected, no close here as the channel is already closed.
+        } catch {
+            XCTFail("Unexpected error \(error)")
+            XCTAssertNoThrow(try serverChannel.close().wait())
         }
-        try serverChannel.close().wait()
     }
 
     public func testCloseDuringWriteFailure() throws {


### PR DESCRIPTION
Motivation:

When a connect() call returns an error other than EINPROGRESS, we
currently leave the FD registered and don't close the channel. This is
wrong, we should take this as a signal to close the socket immediately,
rathern than letting the selector tell us this FD is dead: after all,
we know it's dead.

Modifications:

Call `close0()` in synchronous connect failures.

Result:

Faster failures!
Resolves #322.