### PR TITLE
run integration tests in info mode

### DIFF
--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -14,4 +14,4 @@
 ##===----------------------------------------------------------------------===##
 
 mkdir -p .build # for the junit.xml file
-./IntegrationTests/run-tests.sh --junit-xml .build/junit-sh-tests.xml
+./IntegrationTests/run-tests.sh --junit-xml .build/junit-sh-tests.xml -i


### PR DESCRIPTION
Motivation:

The integration tests' info mode lets us see the number of allocations
the did, that's great.

Modifications:

run integration tests in info mode

Result:

mode information
