### PR TITLE
Make sure we create correct socket family.

### DIFF
--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -307,7 +307,7 @@ public class EventLoopTest : XCTestCase {
         let eventLoop = group.next()
         let assertHandler = AssertHandler()
         let serverSocket = try ServerBootstrap(group: group).bind(host: "localhost", port: 0).wait()
-        let channel = try SocketChannel(eventLoop: eventLoop as! SelectableEventLoop, protocolFamily: AF_INET)
+        let channel = try SocketChannel(eventLoop: eventLoop as! SelectableEventLoop, protocolFamily: serverSocket.localAddress!.protocolFamily)
         try channel.pipeline.add(handler: assertHandler).wait()
         _ = try channel.eventLoop.submit {
             channel.register().then {


### PR DESCRIPTION
Motivation:

If a server binds "localhost", and then we try to connect with an
AF_INET socket, then on macOS at least some of the time we will have
a protocol mismatch, as at least some of the time localhost will have
resolved to ::1 before 127.0.0.1.

That's bad.

Modifications:

Create a socket whose address family matches the server's.

Result:

This test will pass more often
