### PR TITLE
better descriptions for HTTP{Response,Request}Head and HTTPVersion

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -1372,3 +1372,21 @@ extension HTTPResponseStatus: Equatable {
         }
     }
 }
+
+extension HTTPRequestHead: CustomStringConvertible {
+    public var description: String {
+        return "HTTPRequestHead { method: \(self.method), uri: \"\(self.uri)\", version: \(self.version), headers: \(self.headers) }"
+    }
+}
+
+extension HTTPResponseHead: CustomStringConvertible {
+    public var description: String {
+        return "HTTPResponseHead { version: \(self.version), status: \(self.status), headers: \(self.headers) }"
+    }
+}
+
+extension HTTPVersion: CustomStringConvertible {
+    public var description: String {
+        return "HTTP/\(self.major).\(self.minor)"
+    }
+}


### PR DESCRIPTION
Motivation:

We recently changed the backing for the HTTP request and response
objects so that the URI string was no longer visible in
`request.description`. This patch fixes that and prints a format like
this:

    HTTPRequestHead { method: GET, uri: "/", version: HTTP/1.1, headers: [("Host", "localhost:8888"), ("User-Agent", "curl/7.54.0"), ("Accept", "*/*")] }

and

    HTTPResponseHead { version: HTTP/1.1, status: ok, headers: [("content-length", "12")] }

Modifications:

improved the HTTP request/response descriptions

Result:

debugging is easier
