### PR TITLE
Add WebSocketUpgrader to channel config

### DIFF
--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -210,7 +210,7 @@ let bootstrap = ServerBootstrap(group: group)
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
-        let config: HTTPUpgradeConfiguration = (upgraders: [], completionHandler: { _ in })
+        let config: HTTPUpgradeConfiguration = (upgraders: [ upgrader ], completionHandler: { _ in })
         return channel.pipeline.configureHTTPServerPipeline(withServerUpgrade: config).then {
             channel.pipeline.add(handler: HTTPHandler())
         }


### PR DESCRIPTION
### Motivation:

The NIOWebSocketServer demo works wayyy better, when it actually configures the WebSocketUpgrader.

### Modifications:

This adds the `upgrader` to the `HTTPUpgradeConfiguration`.

### Result:

The demo will actually perform something web-sockety.

### P.S.

You should have a test for that!
