### PR TITLE
don't crash if non-socket is provided to withConnectedSocket

### DIFF
--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -43,6 +43,7 @@ extension SocketChannelTest {
                 ("testWithConfiguredStreamSocket", testWithConfiguredStreamSocket),
                 ("testWithConfiguredDatagramSocket", testWithConfiguredDatagramSocket),
                 ("testPendingConnectNotificationOrder", testPendingConnectNotificationOrder),
+                ("testWithConnectedBogusSocket", testWithConnectedBogusSocket),
            ]
    }
 }


### PR DESCRIPTION
CC @vlm I can't add you as a reviewer for some reason but it'd be great if you could have a look.

Motivation:

If the registration of a file descriptor passed to `withConnectedSocket`
failed, we previously crashed in an assertion as we couldn't activate
the channel.

Modifications:

Check if registration succeeds or fails and only activate if
registration succeeded.

Result:

Less crashes for users that try odd stuff.
