### PR TITLE
canonical form for headers: fast path for 0 headers

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -412,6 +412,10 @@ public struct HTTPHeaders: CustomStringConvertible {
     public subscript(canonicalForm name: String) -> [String] {
         let result = self[name]
 
+        guard result.count > 0 else {
+            return []
+        }
+
         // It's not safe to split Set-Cookie on comma.
         guard name.lowercased() != "set-cookie" else {
             return result


### PR DESCRIPTION
Motivation:

It's quite common that someone asks for the canonical form of a header
and we don't have any header values. There's no need to do string
comparisons then, we can just return an empty array.

Modifications:

Check if we're asking for a header that isn't present and if so, just
return the empty array.

Result:

Should be ever so slightly faster.
