### PR TITLE
Ensure localAddress / remoteAddress are still accessible in channelIn…

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -681,9 +681,6 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
             p = nil
         }
 
-        // Fail all pending writes and so ensure all pending promises are notified
-        self.unsetCachedAddressesFromSocket()
-
         // Transition our internal state.
         let callouts = self.lifecycleManager.close(promise: p)
 
@@ -701,6 +698,9 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
             self.pipeline.removeHandlers()
 
             self.closePromise.succeed(result: ())
+
+            // Now reset the addresses as we notified all handlers / futures.
+            self.unsetCachedAddressesFromSocket()
         }
     }
 

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -43,6 +43,7 @@ extension SocketChannelTest {
                 ("testWithConfiguredStreamSocket", testWithConfiguredStreamSocket),
                 ("testWithConfiguredDatagramSocket", testWithConfiguredDatagramSocket),
                 ("testPendingConnectNotificationOrder", testPendingConnectNotificationOrder),
+                ("testLocalAndRemoteAddressNotNilInChannelInactiveAndHandlerRemoved", testLocalAndRemoteAddressNotNilInChannelInactiveAndHandlerRemoved),
            ]
    }
 }


### PR DESCRIPTION
…active / handlerRemoved

Motivation:

Often its useful to be still be able to access the local / remote address during channelInactive / handlerRemoved callbacks to for example log it. We should ensure its still accessible during it.

Modifications:

- Fallback to slow-path in ChannelHandlerContext.localAddress0 / remoteAddress0 if fast-path fails to try accessing the address via the cache.
- Clear cached addresses after all callbacks are run.
- Add unit test.

Result:

Be able to access addresses while handlers are notified.