### PR TITLE
make enums containing ByteBuffer fit in three words

### DIFF
--- a/Sources/NIO/FileRegion.swift
+++ b/Sources/NIO/FileRegion.swift
@@ -28,11 +28,23 @@ public struct FileRegion {
     /// The `FileHandle` that is used by this `FileRegion`.
     public let fileHandle: FileHandle
 
+    private let _endIndex: UInt64
+    private var _readerIndex: _UInt56
+
     /// The current reader index of this `FileRegion`
-    private(set) public var readerIndex: Int
+    private(set) public var readerIndex: Int {
+        get {
+            return Int(self._readerIndex)
+        }
+        set {
+            self._readerIndex = _UInt56(newValue)
+        }
+    }
 
     /// The end index of this `FileRegion`.
-    public let endIndex: Int
+    public var endIndex: Int {
+        return Int(self._endIndex)
+    }
 
     /// Create a new `FileRegion` from an open `FileHandle`.
     ///
@@ -44,8 +56,8 @@ public struct FileRegion {
         precondition(readerIndex <= endIndex, "readerIndex(\(readerIndex) must be <= endIndex(\(endIndex).")
 
         self.fileHandle = fileHandle
-        self.readerIndex = readerIndex
-        self.endIndex = endIndex
+        self._readerIndex = _UInt56(readerIndex)
+        self._endIndex = UInt64(endIndex)
     }
 
     /// The number of readable bytes within this FileRegion (taking the `readerIndex` and `endIndex` into account).

--- a/Sources/NIO/IntegerTypes.swift
+++ b/Sources/NIO/IntegerTypes.swift
@@ -1,0 +1,137 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: _UInt24
+
+/// A 24-bit unsigned integer value type.
+@_versioned
+struct _UInt24: ExpressibleByIntegerLiteral {
+    typealias IntegerLiteralType = UInt16
+    
+    @_versioned var b12: UInt16
+    @_versioned var b3: UInt8
+    
+    private init(b12: UInt16, b3: UInt8) {
+        self.b12 = b12
+        self.b3 = b3
+    }
+    
+    init(integerLiteral value: UInt16) {
+        self.init(b12: value, b3: 0)
+    }
+    
+    static let bitWidth: Int = 24
+    
+    static var max: _UInt24 {
+        return .init(b12: .max, b3: .max)
+    }
+    
+    static let min: _UInt24 = 0
+}
+
+extension UInt32 {
+    init(_ value: _UInt24) {
+        var newValue: UInt32 = 0
+        newValue  = UInt32(value.b12)
+        newValue |= UInt32(value.b3) << 16
+        self = newValue
+    }
+}
+
+extension Int {
+    init(_ value: _UInt24) {
+        var newValue: Int = 0
+        newValue  = Int(value.b12)
+        newValue |= Int(value.b3) << 16
+        self = newValue
+    }
+}
+
+extension _UInt24 {
+    init(_ value: UInt32) {
+        assert(value & 0xff_00_00_00 == 0, "value \(value) too large for _UInt24")
+        self.b12 = UInt16(truncatingIfNeeded: value & 0xff_ff)
+        self.b3  =  UInt8(value >> 16)
+    }
+}
+
+extension _UInt24: Equatable {
+    static func ==(_ lhs: _UInt24, _ rhs: _UInt24) -> Bool {
+        return lhs.b12 == rhs.b12 && lhs.b3 == rhs.b3
+    }
+}
+
+// MARK: _UInt56
+
+/// A 56-bit unsigned integer value type.
+struct _UInt56: ExpressibleByIntegerLiteral {
+    typealias IntegerLiteralType = UInt32
+    
+    @_versioned var b1234: UInt32
+    @_versioned var b56: UInt16
+    @_versioned var b7: UInt8
+    
+    private init(b1234: UInt32, b56: UInt16, b7: UInt8) {
+        self.b1234 = b1234
+        self.b56 = b56
+        self.b7 = b7
+    }
+    
+    init(integerLiteral value: UInt32) {
+        self.init(b1234: value, b56: 0, b7: 0)
+    }
+    
+    static let bitWidth: Int = 56
+    
+    static var max: _UInt56 {
+        return .init(b1234: .max, b56: .max, b7: .max)
+    }
+    
+    static let min: _UInt56 = 0
+}
+
+extension _UInt56 {
+    init(_ value: UInt64) {
+        assert(value & 0xff_00_00_00_00_00_00_00 == 0, "value \(value) too large for _UInt56")
+        self.init(b1234: UInt32(truncatingIfNeeded: (value &          0xff_ff_ff_ff) >> 0 ),
+                  b56:   UInt16(truncatingIfNeeded: (value &    0xff_ff_00_00_00_00) >> 32),
+                  b7:     UInt8(                     value                           >> 48))
+    }
+    
+    init(_ value: Int) {
+        self.init(UInt64(value))
+    }
+}
+
+extension UInt64 {
+    init(_ value: _UInt56) {
+        var newValue: UInt64 = 0
+        newValue  = UInt64(value.b1234)
+        newValue |= UInt64(value.b56  ) << 32
+        newValue |= UInt64(value.b7   ) << 48
+        self = newValue
+    }
+}
+
+extension Int {
+    init(_ value: _UInt56) {
+        self = Int(UInt64(value))
+    }
+}
+
+extension _UInt56: Equatable {
+    static func ==(_ lhs: _UInt56, _ rhs: _UInt56) -> Bool {
+        return lhs.b1234 == rhs.b1234 && lhs.b56 == rhs.b56 && lhs.b7 == rhs.b7
+    }
+}

--- a/Sources/NIO/NIOAny.swift
+++ b/Sources/NIO/NIOAny.swift
@@ -49,15 +49,18 @@ public struct NIOAny {
     /// Wrap a value in a `NIOAny`. In most cases you should not create a `NIOAny` directly using this constructor.
     /// The abstraction that accepts values of type `NIOAny` must also provide a mechanism to do the wrapping. An
     /// example is a `ChannelInboundHandler` which provides `self.wrapInboundOut(aValueOfTypeInboundOut)`.
+    @_inlineable
     public init<T>(_ value: T) {
         self._storage = _NIOAny(value)
     }
 
+    @_versioned
     enum _NIOAny {
         case ioData(IOData)
         case bufferEnvelope(AddressedEnvelope<ByteBuffer>)
         case other(Any)
 
+        @_inlineable @_versioned
         init<T>(_ value: T) {
             switch value {
             case let value as ByteBuffer:

--- a/Sources/NIO/TypeAssistedChannelHandler.swift
+++ b/Sources/NIO/TypeAssistedChannelHandler.swift
@@ -20,11 +20,13 @@ public protocol _EmittingChannelHandler {
     associatedtype OutboundOut = Never
 
     /// Wrap the provided `OutboundOut` that will be passed to the next `ChannelOutboundHandler` by calling `ChannelHandlerContext.write`.
+    @_inlineable
     func wrapOutboundOut(_ value: OutboundOut) -> NIOAny
 }
 
 /// Default implementations for `_EmittingChannelHandler`.
 extension _EmittingChannelHandler {
+    @_inlineable
     public func wrapOutboundOut(_ value: OutboundOut) -> NIOAny {
         return NIOAny(value)
     }
@@ -41,18 +43,22 @@ public protocol ChannelInboundHandler: _ChannelInboundHandler, _EmittingChannelH
     associatedtype InboundOut = Never
 
     /// Unwrap the provided `NIOAny` that was passed to `channelRead`.
+    @_inlineable
     func unwrapInboundIn(_ value: NIOAny) -> InboundIn
 
     /// Wrap the provided `InboundOut` that will be passed to the next `ChannelInboundHandler` by calling `ChannelHandlerContext.fireChannelRead`.
+    @_inlineable
     func wrapInboundOut(_ value: InboundOut) -> NIOAny
 }
 
 /// Default implementations for `ChannelInboundHandler`.
 extension ChannelInboundHandler {
+    @_inlineable
     public func unwrapInboundIn(_ value: NIOAny) -> InboundIn {
         return value.forceAs()
     }
 
+    @_inlineable
     public func wrapInboundOut(_ value: InboundOut) -> NIOAny {
         return NIOAny(value)
     }
@@ -66,11 +72,13 @@ public protocol ChannelOutboundHandler: _ChannelOutboundHandler, _EmittingChanne
     associatedtype OutboundIn
 
     /// Unwrap the provided `NIOAny` that was passed to `write`.
+    @_inlineable
     func unwrapOutboundIn(_ value: NIOAny) -> OutboundIn
 }
 
 /// Default implementations for `ChannelOutboundHandler`.
 extension ChannelOutboundHandler {
+    @_inlineable
     public func unwrapOutboundIn(_ value: NIOAny) -> OutboundIn {
         return value.forceAs()
     }

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -110,6 +110,9 @@ extension ByteBufferTest {
                 ("testUnderestimatingSequenceWorks", testUnderestimatingSequenceWorks),
                 ("testZeroSizeByteBufferResizes", testZeroSizeByteBufferResizes),
                 ("testSpecifyTypesAndEndiannessForIntegerMethods", testSpecifyTypesAndEndiannessForIntegerMethods),
+                ("testByteBufferFitsInACoupleOfEnums", testByteBufferFitsInACoupleOfEnums),
+                ("testLargeSliceBegin16MBIsOkayAndDoesNotCopy", testLargeSliceBegin16MBIsOkayAndDoesNotCopy),
+                ("testLargeSliceBeginMoreThan16MBIsOkay", testLargeSliceBeginMoreThan16MBIsOkay),
            ]
    }
 }

--- a/Tests/NIOTests/FileRegionTest+XCTest.swift
+++ b/Tests/NIOTests/FileRegionTest+XCTest.swift
@@ -32,6 +32,9 @@ extension FileRegionTest {
                 ("testWholeFileFileRegion", testWholeFileFileRegion),
                 ("testWholeEmptyFileFileRegion", testWholeEmptyFileFileRegion),
                 ("testFileRegionDuplicatesShareSeekPointer", testFileRegionDuplicatesShareSeekPointer),
+                ("testMassiveFileRegionThatJustAboutWorks", testMassiveFileRegionThatJustAboutWorks),
+                ("testMassiveFileRegionReaderIndexWorks", testMassiveFileRegionReaderIndexWorks),
+                ("testFileRegionAndIODataFitsInACoupleOfEnums", testFileRegionAndIODataFitsInACoupleOfEnums),
            ]
    }
 }


### PR DESCRIPTION
CC @tanner0101 & @helje5 

only really makes sense together with #351

Motivation:

NIO's dynamic pipeline comes with one performance caveat: If your type
isn't specialised in NIOAny (only types in the NIO module can be) and
it's over 3 words (24 bytes on 64-bit platforms), you'll suffer an
allocation for every time you box it in NIOAny. Very unfortunately, both
ByteBuffer and FileRegion were exactly 3 words wide which means that any
enum containing those would be wider than 3 words. Worse, both
HTTP{Request,Response}Head contained types that were wider than 3 words.
The best solution to this problem is to shrink ByteBuffer and FileRegion
to just under 3 words and that's exactly what this PR is doing. That is
slightly tricky as ByteBuffer was already bit packed fairly well
(reader/writer indices & slice begin/end were stored as a UInt32). The
trick we employ now is to store the slice beginning in a UInt24 and the
file region reader index in a UInt56. That saves one byte for both
ByteBuffer and FileRegion with very moderate tradeoffs: The reader index
in a file now needs to be within 64 PiB (peta bytes) and a byte buffer
slice beginning must start within 16 MiB (mega bytes). Note: The
reader/writer indices as well as slice ends are _not_ affected and can
still be within 4 GiB. Clearly no one would care about the restrictions
for FileRegions in the real world but we might hit the ByteBuffer slice
beginning limit in which case the slice would be copied out. But
given that slices are mostly used to slice off headers in network
protocols, 16 MiB should be _plenty_.

Norman was kind enough to measure the perf differences:

master (before this PR):
```
$ wrk -c 256 -d 10s -t 4 -s ~/Downloads/pipeline-many.lua -H "X-Host: SomeValue" -H "Host: swiftnio.io" -H "ThereAreEvenMoreHeaders: AndMoreValues" http://localhost:8888
Running 10s test @ http://localhost:8888
  4 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    93.02ms  158.13ms   1.97s    93.07%
    Req/Sec   112.79k    26.05k  258.75k    84.50%
  4501098 requests in 10.04s, 214.63MB read
  Socket errors: connect 0, read 111, write 0, timeout 89
Requests/sec: 448485.61
Transfer/sec:     21.39MB
```

after this PR:
```
$ wrk -c 256 -d 10s -t 4 -s ~/Downloads/pipeline-many.lua -H "X-Host: SomeValue" -H "Host: swiftnio.io" -H "ThereAreEvenMoreHeaders: AndMoreValues" http://localhost:8888
Running 10s test @ http://localhost:8888
  4 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   107.53ms  206.56ms   1.99s    90.55%
    Req/Sec   124.15k    26.56k  290.41k    89.25%
  4952904 requests in 10.03s, 236.17MB read
  Socket errors: connect 0, read 161, write 0, timeout 22
Requests/sec: 493852.65
Transfer/sec:     23.55MB
```

so we see a nice 10% improvement and allocations go down by 2, too:

```
23:21:44 info: 1000_reqs_1_conn: allocations not freed: 0
23:21:44 info: 1000_reqs_1_conn: total number of mallocs: 67832
```

from

```
19:08:57 info: 1000_reqs_1_conn: allocations not freed: 0
19:08:57 info: 1000_reqs_1_conn: total number of mallocs: 69834
```


Modifications:

- shrank ByteBuffer by 1 byte, making it 23 bytes in total
- shrank FileRegion by 1 byte, making it 23 bytes in total
- CoW boxed parts of HTTP{Request,Response}Head to make them fit within 2 words
- added @_inlineable to NIOAny where appropriate to not suffer boxed existentials in different places
- added tests for the new edge cases

Result:

- more speed
- fewer allocations