### PR TITLE
shrink HTTP{Request,Response}Head by CoW boxing them

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest+XCTest.swift
@@ -34,6 +34,8 @@ extension HTTPTest {
                 ("test1ByteHTTPBody", test1ByteHTTPBody),
                 ("testHTTPPipeliningWithBody", testHTTPPipeliningWithBody),
                 ("testChunkedBody", testChunkedBody),
+                ("testHTTPRequestHeadCoWWorks", testHTTPRequestHeadCoWWorks),
+                ("testHTTPResponseHeadCoWWorks", testHTTPResponseHeadCoWWorks),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest.swift
@@ -206,4 +206,62 @@ class HTTPTest: XCTestCase {
         trailers.add(name: "Something", value: "Else")
         try checkHTTPRequest(HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .POST, uri: "/"), body: "100", trailers: trailers)
     }
+
+    func testHTTPRequestHeadCoWWorks() throws {
+        let headers = HTTPHeaders([("foo", "bar")])
+        var httpReq = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/uri")
+        httpReq.headers = headers
+
+        var modVersion = httpReq
+        modVersion.version = HTTPVersion(major: 2, minor: 0)
+        XCTAssertEqual(HTTPVersion(major: 1, minor: 1), httpReq.version)
+        XCTAssertEqual(HTTPVersion(major: 2, minor: 0), modVersion.version)
+
+        var modMethod = httpReq
+        modMethod.method = .POST
+        XCTAssertEqual(.GET, httpReq.method)
+        XCTAssertEqual(.POST, modMethod.method)
+
+        var modURI = httpReq
+        modURI.uri = "/changed"
+        XCTAssertEqual("/uri", httpReq.uri)
+        XCTAssertEqual("/changed", modURI.uri)
+
+        var modHeaders = httpReq
+        modHeaders.headers.add(name: "qux", value: "quux")
+        XCTAssertEqual(httpReq.headers, headers)
+        XCTAssertNotEqual(httpReq, modHeaders)
+        modHeaders.headers.remove(name: "foo")
+        XCTAssertEqual(httpReq.headers, headers)
+        XCTAssertNotEqual(httpReq, modHeaders)
+        modHeaders.headers.remove(name: "qux")
+        modHeaders.headers.add(name: "foo", value: "bar")
+        XCTAssertEqual(httpReq, modHeaders)
+    }
+
+    func testHTTPResponseHeadCoWWorks() throws {
+        let headers = HTTPHeaders([("foo", "bar")])
+        let httpRes = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok, headers: headers)
+
+        var modVersion = httpRes
+        modVersion.version = HTTPVersion(major: 2, minor: 0)
+        XCTAssertEqual(HTTPVersion(major: 1, minor: 1), httpRes.version)
+        XCTAssertEqual(HTTPVersion(major: 2, minor: 0), modVersion.version)
+
+        var modStatus = httpRes
+        modStatus.status = .notFound
+        XCTAssertEqual(.ok, httpRes.status)
+        XCTAssertEqual(.notFound, modStatus.status)
+
+        var modHeaders = httpRes
+        modHeaders.headers.add(name: "qux", value: "quux")
+        XCTAssertEqual(httpRes.headers, headers)
+        XCTAssertNotEqual(httpRes, modHeaders)
+        modHeaders.headers.remove(name: "foo")
+        XCTAssertEqual(httpRes.headers, headers)
+        XCTAssertNotEqual(httpRes, modHeaders)
+        modHeaders.headers.remove(name: "qux")
+        modHeaders.headers.add(name: "foo", value: "bar")
+        XCTAssertEqual(httpRes, modHeaders)
+    }
 }


### PR DESCRIPTION
only really makes sense with #349 

Motivation:

HTTP{Request,Response}Head were too large even with a less than 3 word
ByteBuffer, this shrinks them box CoW boxing them. Should also reduce
ARC traffic when passing around a bunch.

Modifications:

CoW box HTTP{Request,Response}Head

Result:

fewer existential containers created, more performance
