### PR TITLE
workaround 'Network is unreachable' errors in new CI

### DIFF
--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -1073,6 +1073,10 @@ public class ChannelTests: XCTestCase {
             } else {
                 XCTFail()
             }
+        } catch let err as IOError where err.errnoCode == ENETDOWN || err.errnoCode == ENETUNREACH {
+            // we need to accept those too unfortunately
+        } catch {
+            XCTFail("unexpected error \(error)")
         }
     }
 
@@ -1094,6 +1098,10 @@ public class ChannelTests: XCTestCase {
             } else {
                 XCTFail()
             }
+        } catch let err as IOError where err.errnoCode == ENETDOWN || err.errnoCode == ENETUNREACH {
+            // we need to accept those too unfortunately
+        } catch {
+            XCTFail("unexpected error \(error)")
         }
     }
 


### PR DESCRIPTION
Motivation:

In the new CI, ChannelTests.testGeneral/SpecificConnectTimeout often fails with

```
error: ChannelTests.testGeneralConnectTimeout : threw error "connection reset (error set): Network is unreachable (errno: 101) "
```

It's not a great test but this just works around it by saying that if
the network's down that's fine too.

Modifications:

also accept ENETDOWN and ENETUNREACH

Result:

tests should pass in new CI.
