### PR TITLE
fix optimiser problem triggered in BB.set(staticString:)

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -73,9 +73,9 @@ extension ByteBuffer {
     ///     - index: The index for the first serialized byte.
     /// - returns: The number of bytes written.
     public mutating func set(staticString string: StaticString, at index: Int) -> Int {
-        return string.withUTF8Buffer { ptr -> Int in
-            self.set(bytes: UnsafeRawBufferPointer(ptr), at: index)
-        }
+        // please do not replace the code below with code that uses `string.withUTF8Buffer { ... }` (see SR-7541)
+        return self.set(bytes: UnsafeRawBufferPointer(start: string.utf8Start,
+                                                      count: string.utf8CodeUnitCount), at: index)
     }
 
     // MARK: String APIs


### PR DESCRIPTION
Motivation:

There's a presumed optimiser bug which will trigger an allocation when
using `self` within `staticString.withUTF8Buffer { ... }` which makes it
cause an extra allocation.

Modifications:

use StaticString.utf8Start instead of withUTF8Buffer

Result:

less allocations

```
19:17:19 info: 1000_reqs_1_conn: allocations not freed: 0
19:17:19 info: 1000_reqs_1_conn: total number of mallocs: 51816
19:17:19 info: 1_reqs_1000_conn: allocations not freed: 0
19:17:19 info: 1_reqs_1000_conn: total number of mallocs: 866997
```

that kills a whopping 16(!!) allocations per request/response pair