### PR TITLE
add HTTPURI for more performant uri access

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -19,7 +19,7 @@ private struct HTTPParserState {
     var dataAwaitingState: DataAwaitingState = .messageBegin
     var currentNameIndex: HTTPHeaderIndex?
     var currentHeaders: [HTTPHeader]
-    var currentURI: HTTPURIStorage?
+    var currentURI: HTTPURI._Storage?
     var currentStatus: String?
     var slice: (readerIndex: Int, length: Int)?
     var readerIndexAdjustment = 0

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -19,7 +19,7 @@ private struct HTTPParserState {
     var dataAwaitingState: DataAwaitingState = .messageBegin
     var currentNameIndex: HTTPHeaderIndex?
     var currentHeaders: [HTTPHeader]
-    var currentURI: URI?
+    var currentURI: HTTPURIStorage?
     var currentStatus: String?
     var slice: (readerIndex: Int, length: Int)?
     var readerIndexAdjustment = 0
@@ -202,7 +202,7 @@ public class HTTPDecoder<HTTPMessageT>: ByteToMessageDecoder, AnyHTTPDecoder {
     private func newRequestHead(_ parser: UnsafeMutablePointer<http_parser>!) -> HTTPRequestHead {
         let method = HTTPMethod.from(httpParserMethod: http_method(rawValue: parser.pointee.method))
         let version = HTTPVersion(major: parser.pointee.http_major, minor: parser.pointee.http_minor)
-        let request = HTTPRequestHead(version: version, method: method, rawURI: state.currentURI!, headers: HTTPHeaders(buffer: cumulationBuffer!, headers: state.currentHeaders))
+        let request = HTTPRequestHead(version: version, method: method, rawURI: .init(storage: state.currentURI!), headers: HTTPHeaders(buffer: cumulationBuffer!, headers: state.currentHeaders))
         self.state.currentHeaders.removeAll(keepingCapacity: true)
         return request
     }

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -127,11 +127,17 @@ public struct HTTPRequestHead: Equatable {
 /// Represents a the URI component of an `HTTPRequestHead`. Allows the URI
 /// to be accessed as a `String` or as raw bytes.
 public struct HTTPURI: ExpressibleByStringLiteral {
+    /// Internal representation of a URI
+    enum _Storage {
+        case string(String)
+        case byteBuffer(ByteBuffer)
+    }
+
     /// Internal storage.
-    var storage: HTTPURIStorage
+    private var storage: _Storage
 
     /// Internal init.
-    internal init(storage: HTTPURIStorage) {
+    internal init(storage: _Storage) {
         self.storage = storage
     }
 
@@ -165,12 +171,6 @@ public struct HTTPURI: ExpressibleByStringLiteral {
             storage = .string(newValue)
         }
     }
-}
-
-/// Internal representation of a URI
-enum HTTPURIStorage {
-    case string(String)
-    case byteBuffer(ByteBuffer)
 }
 
 /// The parts of a complete HTTP message, either request or response.

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -68,7 +68,6 @@ public struct HTTPRequestHead: Equatable {
     }
 
     /// The URI string used on this request.
-    /// See `url`.
     public var uri: String {
         get {
             return rawURI.string
@@ -104,7 +103,7 @@ public struct HTTPRequestHead: Equatable {
     ///
     /// - Parameter version: The version for this HTTP request.
     /// - Parameter method: The HTTP method for this request.
-    /// - Parameter url: The HTTPURI used on this request.
+    /// - Parameter rawURI: The HTTPURI used on this request.
     public init(version: HTTPVersion, method: HTTPMethod, rawURI: HTTPURI) {
         self.init(version: version, method: method, rawURI: rawURI, headers: HTTPHeaders())
     }
@@ -113,7 +112,7 @@ public struct HTTPRequestHead: Equatable {
     ///
     /// - Parameter version: The version for this HTTP request.
     /// - Parameter method: The HTTP method for this request.
-    /// - Parameter rawURI: The URI used on this request.
+    /// - Parameter rawURI: The HTTPURI used on this request.
     /// - Parameter headers: The headers for this HTTP request.
     init(version: HTTPVersion, method: HTTPMethod, rawURI: HTTPURI, headers: HTTPHeaders) {
         self.headers = headers
@@ -149,7 +148,7 @@ public struct HTTPURI: ExpressibleByStringLiteral {
             // cString + utf8 codeunit count -> raw buffer pointer
             return s.withCString { closure(.init(start: .init($0), count: s.utf8.count)) }
         case .byteBuffer(let b):
-            /// point to readable byte region
+            // point to readable byte region
             return b.withUnsafeReadableBytes(closure)
         }
     }

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -124,7 +124,7 @@ public struct HTTPRequestHead: Equatable {
     }
 }
 
-/// Represents a the URI component of an `HTTPRequestHead`. Allows the URI
+/// Represents the URI component of an `HTTPRequestHead`. Allows the URI
 /// to be accessed as a `String` or as raw bytes.
 public struct HTTPURI: ExpressibleByStringLiteral {
     /// Internal representation of a URI


### PR DESCRIPTION
Motivation:

Currently the only way to access a request head's uri is via a computed property that converts it to a String. The internal storage however is usually a byte buffer. Being able to access the uri bytes without going through String would be a performance win.

Modifications:

Removed URI in favor or HTTPURI and internal HTTPURIStorage

Result:

HTTP URI can be accessed more performantly.

See https://github.com/apple/swift-nio/issues/342