### PR TITLE
Fix warning during compiling tests.

### DIFF
--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -358,7 +358,7 @@ class SelectorTest: XCTestCase {
                         return channel
                     }
                 }
-        }.wait().forEach { return try! $0.wait() } as Void)
+        }.wait().forEach { XCTAssertNoThrow(try $0.wait()) } as Void)
         XCTAssertNoThrow(try everythingWasReadPromise.futureResult.wait())
         XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(fileURLWithPath: tempDir)))
     }


### PR DESCRIPTION
Motivation:

When compiling the tests the following warning is printed:

swift-nio/Tests/NIOTests/SelectorTest.swift:361:43: warning: result of call to 'wait()' is unused
        }.wait().forEach { return try! $0.wait() } as Void)

Modifications:

Ignore return value to silent the compiler warnings.

Result:

No more warnings.