### PR TITLE
add a ByteBuffer allocation test

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_allocation_counts_for_http1.sh
+++ b/IntegrationTests/tests_04_performance/test_01_allocation_counts_for_http1.sh
@@ -58,7 +58,7 @@ cd ..
 "$swift_bin" run -c release | tee "$tmp/output"
 )
 
-for test in 1000_reqs_1_conn 1_reqs_1000_conn ping_pong_1000_reqs_1_conn; do
+for test in 1000_reqs_1_conn 1_reqs_1000_conn ping_pong_1000_reqs_1_conn bytebuffer_lots_of_rw; do
     cat "$tmp/output"  # helps debugging
     total_allocations=$(grep "^$test.total_allocations:" "$tmp/output" | cut -d: -f2 | sed 's/ //g')
     not_freed_allocations=$(grep "^$test.remaining_allocations:" "$tmp/output" | cut -d: -f2 | sed 's/ //g')


### PR DESCRIPTION
Motivation:

We had a few issues with ByteBuffer methods allocating without us
knowing, the only way to make sure we don't regress is obviously a test.

Modifications:

add a ByteBuffer allocation counter test

Result:

less room for regressions.