### PR TITLE
two missing @_inlineables

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -624,6 +624,7 @@ extension ByteBuffer: CustomStringConvertible {
 
 /// A `Collection` that is contiguously layed out in memory and can therefore be duplicated using `memcpy`.
 public protocol ContiguousCollection: Collection {
+    @_inlineable
     func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
 }
 

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -30,6 +30,7 @@ import struct Foundation.Data
  */
 
 extension Data: ContiguousCollection {
+    @_inlineable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> R in
             try body(UnsafeRawBufferPointer(start: ptr, count: self.count))


### PR DESCRIPTION
Motivation:

@_inlineable is important for at least all performance sensitive
functions that use generics and/or closures.

Modifications:

added two missing @_inlineable

Result:

fewer allocations (not measurable because https://bugs.swift.org/browse/SR-7542)
