### PR TITLE
Not do any precondition range checks when moving the reader / writer …

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -47,7 +47,7 @@ extension ByteBuffer {
             return nil
         }
         defer {
-            self.moveReaderIndex(forwardBy: length)
+            self._moveReaderIndex(forwardBy: length)
         }
         return self.getBytes(at: self.readerIndex, length: length)! /* must work, enough readable bytes */
     }
@@ -62,7 +62,7 @@ extension ByteBuffer {
     @discardableResult
     public mutating func write(staticString string: StaticString) -> Int {
         let written = self.set(staticString: string, at: self.writerIndex)
-        self.moveWriterIndex(forwardBy: written)
+        self._moveWriterIndex(forwardBy: written)
         return written
     }
 
@@ -87,7 +87,7 @@ extension ByteBuffer {
     @discardableResult
     public mutating func write(string: String) -> Int? {
         if let written = self.set(string: string, at: self.writerIndex) {
-            self.moveWriterIndex(forwardBy: written)
+            self._moveWriterIndex(forwardBy: written)
             return written
         } else {
             return nil
@@ -134,7 +134,7 @@ extension ByteBuffer {
             return nil
         }
         defer {
-            self.moveReaderIndex(forwardBy: length)
+            self._moveReaderIndex(forwardBy: length)
         }
         return self.getString(at: self.readerIndex, length: length)! /* must work, enough readable bytes */
     }
@@ -152,7 +152,7 @@ extension ByteBuffer {
     @_inlineable
     public mutating func readWithUnsafeReadableBytes(_ body: (UnsafeRawBufferPointer) throws -> Int) rethrows -> Int {
         let bytesRead = try self.withUnsafeReadableBytes(body)
-        self.moveReaderIndex(forwardBy: bytesRead)
+        self._moveReaderIndex(forwardBy: bytesRead)
         return bytesRead
     }
 
@@ -167,7 +167,7 @@ extension ByteBuffer {
     @_inlineable
     public mutating func readWithUnsafeReadableBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> (Int, T)) rethrows -> T {
         let (bytesRead, ret) = try self.withUnsafeReadableBytes(body)
-        self.moveReaderIndex(forwardBy: bytesRead)
+        self._moveReaderIndex(forwardBy: bytesRead)
         return ret
     }
 
@@ -182,7 +182,7 @@ extension ByteBuffer {
     @_inlineable
     public mutating func readWithUnsafeMutableReadableBytes(_ body: (UnsafeMutableRawBufferPointer) throws -> Int) rethrows -> Int {
         let bytesRead = try self.withUnsafeMutableReadableBytes(body)
-        self.moveReaderIndex(forwardBy: bytesRead)
+        self._moveReaderIndex(forwardBy: bytesRead)
         return bytesRead
     }
 
@@ -197,7 +197,7 @@ extension ByteBuffer {
     @_inlineable
     public mutating func readWithUnsafeMutableReadableBytes<T>(_ body: (UnsafeMutableRawBufferPointer) throws -> (Int, T)) rethrows -> T {
         let (bytesRead, ret) = try self.withUnsafeMutableReadableBytes(body)
-        self.moveReaderIndex(forwardBy: bytesRead)
+        self._moveReaderIndex(forwardBy: bytesRead)
         return ret
     }
 
@@ -223,8 +223,8 @@ extension ByteBuffer {
     @discardableResult
     public mutating func write(buffer: inout ByteBuffer) -> Int {
         let written = set(buffer: buffer, at: writerIndex)
-        self.moveWriterIndex(forwardBy: written)
-        buffer.moveReaderIndex(forwardBy: written)
+        self._moveWriterIndex(forwardBy: written)
+        buffer._moveReaderIndex(forwardBy: written)
         return written
     }
 
@@ -237,7 +237,7 @@ extension ByteBuffer {
     @_inlineable
     public mutating func write<S: Sequence>(bytes: S) -> Int where S.Element == UInt8 {
         let written = set(bytes: bytes, at: self.writerIndex)
-        self.moveWriterIndex(forwardBy: written)
+        self._moveWriterIndex(forwardBy: written)
         return written
     }
 
@@ -251,7 +251,7 @@ extension ByteBuffer {
     @_inlineable
     public mutating func write<S: ContiguousCollection>(bytes: S) -> Int where S.Element == UInt8 {
         let written = set(bytes: bytes, at: self.writerIndex)
-        self.moveWriterIndex(forwardBy: written)
+        self._moveWriterIndex(forwardBy: written)
         return written
     }
 
@@ -281,7 +281,7 @@ extension ByteBuffer {
         }
 
         let buffer = self.getSlice(at: readerIndex, length: length)! /* must work, enough readable bytes */
-        self.moveReaderIndex(forwardBy: length)
+        self._moveReaderIndex(forwardBy: length)
         return buffer
     }
 }

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -325,15 +325,28 @@ public struct ByteBuffer {
 
     // MARK: Internal API
 
-    private mutating func _moveReaderIndex(to newIndex: Index) {
+    @_inlineable @_versioned
+    mutating func _moveReaderIndex(to newIndex: Index) {
         assert(newIndex >= 0 && newIndex <= writerIndex)
         self._readerIndex = newIndex
+    }
+
+    @_inlineable @_versioned
+    mutating func _moveReaderIndex(forwardBy offset: Int) {
+        let newIndex = self._readerIndex + _toIndex(offset)
+        self._moveReaderIndex(to: newIndex)
     }
 
     @_inlineable @_versioned
     mutating func _moveWriterIndex(to newIndex: Index) {
         assert(newIndex >= 0 && newIndex <= _toCapacity(self._slice.count))
         self._writerIndex = newIndex
+    }
+
+    @_inlineable @_versioned
+    mutating func _moveWriterIndex(forwardBy offset: Int) {
+        let newIndex = self._writerIndex + _toIndex(offset)
+        self._moveWriterIndex(to: newIndex)
     }
 
     @_inlineable @_versioned
@@ -536,7 +549,7 @@ public struct ByteBuffer {
         }
         var new = self
         new._slice = _ByteBufferSlice(sliceStartIndex ..< self._slice.lowerBound + index+length)
-        new.moveReaderIndex(to: 0)
+        new._moveReaderIndex(to: 0)
         new._moveWriterIndex(to: length)
         return new
     }
@@ -555,7 +568,7 @@ public struct ByteBuffer {
                 .copyMemory(from: self._storage.bytes.advanced(by: Int(self._slice.lowerBound + self._readerIndex)),
                             byteCount: self.readableBytes)
             let indexShift = self._readerIndex
-            self.moveReaderIndex(to: 0)
+            self._moveReaderIndex(to: 0)
             self._moveWriterIndex(to: self._writerIndex - indexShift)
         } else {
             self._copyStorageAndRebase(extraCapacity: 0, resetIndices: true)
@@ -585,8 +598,8 @@ public struct ByteBuffer {
         if !isKnownUniquelyReferenced(&self._storage) {
             self._storage = self._storage.allocateStorage()
         }
-        self.moveWriterIndex(to: 0)
-        self.moveReaderIndex(to: 0)
+        self._moveWriterIndex(to: 0)
+        self._moveReaderIndex(to: 0)
     }
 }
 

--- a/Sources/NIO/ByteBuffer-int.swift
+++ b/Sources/NIO/ByteBuffer-int.swift
@@ -36,7 +36,7 @@ extension ByteBuffer {
         }
 
         let value: T = self.getInteger(at: self.readerIndex, endianness: endianness)! /* must work as we have enough bytes */
-        self.moveReaderIndex(forwardBy: MemoryLayout<T>.size)
+        self._moveReaderIndex(forwardBy: MemoryLayout<T>.size)
         return value
     }
 
@@ -73,7 +73,7 @@ extension ByteBuffer {
     @_inlineable
     public mutating func write<T: FixedWidthInteger>(integer: T, endianness: Endianness = .big, as: T.Type = T.self) -> Int {
         let bytesWritten = self.set(integer: integer, at: self.writerIndex, endianness: endianness)
-        self.moveWriterIndex(forwardBy: bytesWritten)
+        self._moveWriterIndex(forwardBy: bytesWritten)
         return Int(bytesWritten)
     }
 


### PR DESCRIPTION
…index from within our methods of ByteBuffer.

Motivation:

We should not need to do any precondition range changes when we change the reader / writer index within our ByteBuffer methods as we know the index is valid. Beside this we already have asserts in place.

Modifications:

Add missing _ methods to adjust the reader / writer index and make use of these.

Result:

Less range checks within our ByteBuffer methods.