### PR TITLE
Avoid delivering websocket frames twice on EOF.

### DIFF
--- a/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
@@ -269,6 +269,11 @@ public final class WebSocketFrameDecoder: ByteToMessageDecoder {
         return .needMoreData
     }
 
+    public func decodeLast(ctx: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
+        // EOF is not semantic in WebSocket, so ignore this.
+        return .needMoreData
+    }
+
     /// Apply a number of validations to the incremental state, ensuring that the frame we're
     /// receiving is valid.
     private func validateState() throws {

--- a/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest+XCTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest+XCTest.swift
@@ -38,6 +38,7 @@ extension WebSocketFrameDecoderTest {
                 ("testDecoderRejectsFragmentedControlFrames", testDecoderRejectsFragmentedControlFrames),
                 ("testDecoderRejectsMultibyteControlFrameLengths", testDecoderRejectsMultibyteControlFrameLengths),
                 ("testIgnoresFurtherDataAfterRejectedFrame", testIgnoresFurtherDataAfterRejectedFrame),
+                ("testClosingSynchronouslyOnChannelRead", testClosingSynchronouslyOnChannelRead),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Unfortunately as a result of #108 the WebSocketFrameDecoder can emit a
WebSocketFrame more than once if the user closes the connection in
channelRead, or any other callback while decode() is on the call stack.
This is obviously less than ideal, as it can allow multiple delivery of
frames.

Modifications:

Given WebSocketFrameDecoder a no-op implementation of decodeLast.

Result:

No multi-delivery of frames.