### PR TITLE
[2.0] Remove decodeLast.

### DIFF
--- a/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
@@ -269,11 +269,6 @@ public final class WebSocketFrameDecoder: ByteToMessageDecoder {
         return .needMoreData
     }
 
-    public func decodeLast(ctx: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
-        // EOF is not semantic in WebSocket, so ignore this.
-        return .needMoreData
-    }
-
     /// Apply a number of validations to the incremental state, ensuring that the frame we're
     /// receiving is valid.
     private func validateState() throws {


### PR DESCRIPTION
Motivation:

decodeLast is nothing more or less than a bug magnet. It by default
assumes that it is safe to re-enter decode synchronously, despite its own
execution model ensuring that this is not the case. Additionally, it does
this quietly, without notifying most naive users of B2MD that the method
exists at all.

This is done to ensure that parsers successfully parse everything, but the
implementation is silly. In particular, it assumes that this uncommon
behaviour (needing to drain the parser on EOF) is sufficiently common
to justify burdening all implementations with it. Most protocol parsers
do not need to do anything special on EOF, because EOF is not a meaningful
signal for their protocol.

On top of this, B2MD does not even properly handle this behaviour becuase
it is not half-close aware. If a TCP half-close is received, B2MD will
not call decodeLast. Of course, protocols that treat EOF as semantic
are also the protocols that are most-likely to benefit from half-closure
support, meaning that the protocol types B2MD is working to support here
need custom code to work properly anyway.

Given that, and the long sequence of bugs caused by decodeLast, we should
remove it. In the extremely unusual case that EOF is semantic for the
protocol, users can reimplement something like decodeLast using
channelInactive and userInboundEventReceived.

Modifications:

Deleted decodeLast.

Result:

Fewer bugs. Happier users.

Resolves #108.
