### PR TITLE
Add better guards again re-entrance in ByteToMessageDecoder

### DIFF
--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -31,6 +31,8 @@ extension ByteToMessageDecoderTest {
                 ("testDecoderIsNotQuadratic", testDecoderIsNotQuadratic),
                 ("testMemoryIsReclaimedIfMostIsConsumed", testMemoryIsReclaimedIfMostIsConsumed),
                 ("testMemoryIsReclaimedIfLotsIsAvailable", testMemoryIsReclaimedIfLotsIsAvailable),
+                ("testDecoderReentranceChannelRead", testDecoderReentranceChannelRead),
+                ("testDecoderWriteIntoCumulationBuffer", testDecoderWriteIntoCumulationBuffer),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When the ByteToMessageDecoder re-entranced in its decode(...) / decodeLast(...) methods it could be possible that the ordering of processing and so the seen bytes are mixed.

Modifications:

- Refresh the buffer on each loop iteration and update the cumulationBuffers indicies.

Result:

More robust code.