### PR TITLE
fix some Swift 4.2 warnings

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -658,10 +658,9 @@ extension StaticString: Collection {
     public var endIndex: Index { return self.utf8CodeUnitCount }
     public func index(after i: Index) -> Index { return i + 1 }
 
-    public subscript(position: Int) -> StaticString.Element {
-        get {
-            return self[position]
-        }
+    public subscript(position: Int) -> UInt8 {
+        precondition(position < self.utf8CodeUnitCount, "index \(position) out of bounds")
+        return self.utf8Start.advanced(by: position).pointee
     }
 }
 

--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -24,6 +24,11 @@ public protocol AppendableCollection: Collection {
 /// will automatically expand if more elements than `initialRingCapacity` are stored, it's advantageous to prevent
 /// expansions from happening frequently. Expansions will always force an allocation and a copy to happen.
 public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
+    #if swift(>=4.2)
+    public typealias RangeType = Range
+    #else
+    public typealias RangeType = CountableRange
+    #endif
     private var buffer: ContiguousArray<E?>
 
     /// The index into the buffer of the first item
@@ -168,7 +173,7 @@ public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     }
 
     /// Return all valid indices of the ring.
-    public var indices: CountableRange<Int> {
+    public var indices: RangeType<Int> {
         return 0..<self.count
     }
 

--- a/Sources/NIO/MarkedCircularBuffer.swift
+++ b/Sources/NIO/MarkedCircularBuffer.swift
@@ -18,6 +18,12 @@
 /// writes and mark how far through the buffer the user has flushed, and therefore how far through the buffer is
 /// safe to write.
 public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollection {
+    #if swift(>=4.2)
+    public typealias RangeType = Range
+    #else
+    public typealias RangeType = CountableRange
+    #endif
+
     private var buffer: CircularBuffer<E>
     private var markedIndex: Int = -1 /* negative: nothing marked */
 
@@ -71,7 +77,7 @@ public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollec
     }
 
     /// The valid indices into the buffer.
-    public var indices: CountableRange<Int> {
+    public var indices: RangeType<Int> {
         return self.buffer.indices
     }
 

--- a/Sources/NIOPriorityQueue/Heap.swift
+++ b/Sources/NIOPriorityQueue/Heap.swift
@@ -183,6 +183,7 @@ internal struct Heap<T: Comparable> {
 
 @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
 extension Heap: CustomDebugStringConvertible {
+    @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
     public var debugDescription: String {
         guard self.storage.count > 0 else {
             return "<empty heap>"
@@ -266,6 +267,7 @@ extension Heap: Sequence {
         return self.storage.count
     }
 
+    @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
     func makeIterator() -> HeapIterator<T> {
         return HeapIterator(heap: self)
     }

--- a/Sources/NIOPriorityQueue/PriorityQueue.swift
+++ b/Sources/NIOPriorityQueue/PriorityQueue.swift
@@ -54,6 +54,7 @@ public struct PriorityQueue<Element: Comparable> {
 
 @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
 extension PriorityQueue: Equatable {
+    @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
     public static func ==(lhs: PriorityQueue, rhs: PriorityQueue) -> Bool {
         return lhs.count == rhs.count && lhs.elementsEqual(rhs)
     }
@@ -63,16 +64,21 @@ extension PriorityQueue: Equatable {
 extension PriorityQueue: Sequence {
     public struct Iterator: IteratorProtocol {
 
+        @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
         private var queue: PriorityQueue<Element>
+        
+        @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
         fileprivate init(queue: PriorityQueue<Element>) {
             self.queue = queue
         }
 
+        @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
         public mutating func next() -> Element? {
             return self.queue.pop()
         }
     }
 
+    @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
     public func makeIterator() -> Iterator {
         return Iterator(queue: self)
     }
@@ -80,6 +86,7 @@ extension PriorityQueue: Sequence {
 
 @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
 public extension PriorityQueue {
+    @available(*, deprecated, message: "The NIOPriorityQueue module is deprecated and will be removed in the next major release.")
     public var count: Int {
         return self.heap.count
     }

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -115,6 +115,7 @@ extension ByteBufferTest {
                 ("testLargeSliceBeginMoreThan16MBIsOkay", testLargeSliceBeginMoreThan16MBIsOkay),
                 ("testDiscardReadBytesOnConsumedBuffer", testDiscardReadBytesOnConsumedBuffer),
                 ("testDumpBytesFormat", testDumpBytesFormat),
+                ("testStaticStringCategorySubscript", testStaticStringCategorySubscript),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1349,6 +1349,12 @@ class ByteBufferTest: XCTestCase {
                        "e0 e1 e2 e3 e4 e5 e6 e7 e8 e9 ea eb ec ed ee ef f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff ]"
         XCTAssertEqual(expected, actual)
     }
+
+    func testStaticStringCategorySubscript() throws {
+        let s: StaticString = "hello"
+        XCTAssertEqual("h".utf8.first!, s[0])
+        XCTAssertEqual("o".utf8.first!, s[4])
+    }
 }
 
 private enum AllocationExpectationState: Int {


### PR DESCRIPTION
Motivation:

Warnings are bad.

Modifications:

Changed things that still work in 4.0/4.1 but are warnings in 4.2 to
improved versions.

Result:

less warnings on the upcoming 4.2
