### PR TITLE
Track Future allocations in CI.

### DIFF
--- a/docker/docker-compose.1404.41.yaml
+++ b/docker/docker-compose.1404.41.yaml
@@ -20,6 +20,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=867500
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=5000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3500
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   test:
     image: swift-nio:14.04-4.1
@@ -28,6 +29,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=867500
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=5000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3500
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   echo:
     image: swift-nio:14.04-4.1

--- a/docker/docker-compose.1604.41.yaml
+++ b/docker/docker-compose.1604.41.yaml
@@ -19,6 +19,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=868500
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=5000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3500
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   test:
     image: swift-nio:16.04-4.1
@@ -27,6 +28,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=868500
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=5000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3500
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   echo:
     image: swift-nio:16.04-4.1


### PR DESCRIPTION
Motivation:

We don't want to regress the number of heap allocations we perform.

Modifications:

Added appropriate environment variables to Docker files.

Result:

Things go bang if we regress Future allocation counts.
