### PR TITLE
fix Swift 4.2 compile error

### DIFF
--- a/Sources/NIO/PriorityQueue.swift
+++ b/Sources/NIO/PriorityQueue.swift
@@ -91,10 +91,10 @@ extension PriorityQueue {
   @available(*, deprecated, renamed: "Element")
   public typealias T = Element
   @available(*, deprecated, renamed: "PriorityQueue.Iterator")
-  public typealias PriorityQueueIterator<T: Comparable> = PriorityQueue<T>.Iterator
+  typealias PriorityQueueIterator<T: Comparable> = PriorityQueue<T>.Iterator
 }
 
 extension PriorityQueue.Iterator {
   @available(*, deprecated, renamed: "Element")
-  public typealias T = Element
+  typealias T = Element
 }


### PR DESCRIPTION
Motivation:

We had a public typealias for an internal type, that's an error now in
Swift 4.2.

Modifications:

make the typealias internal.

Result:

compiles in Swift 4.2
