### PR TITLE
implement lazy selector registration

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -344,6 +344,12 @@ internal final class SelectableEventLoop: EventLoop {
         _addresses.deallocate()
     }
 
+    /// Is this `SelectableEventLoop` still open (ie. not shutting down or shut down)
+    internal var isOpen: Bool {
+        assert(self.inEventLoop)
+        return self.lifecycleState == .open
+    }
+
     /// Register the given `SelectableChannel` with this `SelectableEventLoop`. After this point all I/O for the `SelectableChannel` will be processed by this `SelectableEventLoop` until it
     /// is deregistered by calling `deregister`.
     public func register<C: SelectableChannel>(channel: C) throws {

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -69,6 +69,8 @@ extension ChannelTests {
                 ("testSocketErroringSynchronouslyCorrectlyTearsTheChannelDown", testSocketErroringSynchronouslyCorrectlyTearsTheChannelDown),
                 ("testConnectWithECONNREFUSEDGetsTheRightError", testConnectWithECONNREFUSEDGetsTheRightError),
                 ("testCloseInUnregister", testCloseInUnregister),
+                ("testLazyRegistrationWorksForServerSockets", testLazyRegistrationWorksForServerSockets),
+                ("testLazyRegistrationWorksForClientSockets", testLazyRegistrationWorksForClientSockets),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously we would eagerly register any fd with the selector
(epoll/kqueue) which works well with kqueue. With epoll however, you'll
get `EPOLLHUP` immediately if you supplied a socket that hasn't had
connect/bind called on it.
We got away with this because we took quite a bit of care to always make
sure we call connect/bind pretty much immediately after we registered
it.  And crucially before we ever asked the selector to tell us about
new events.

Modifications:

made selector registration lazy (when we try activating the channel by
calling connect/bind)

Result:

the user can now register and connect whenever they feel like it, fixes #380 