### PR TITLE
fix event loop hop between registration and activation of accepted ch…

### DIFF
--- a/IntegrationTests/tests_01_http/test_23_repeated_reqs_with_half_closure.sh
+++ b/IntegrationTests/tests_01_http/test_23_repeated_reqs_with_half_closure.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+source defines.sh
+
+token=$(create_token)
+start_server "$token"
+socket=$(get_socket "$token")
+echo -ne 'HTTP/1.1 200 OK\r\ncontent-length: 12\r\n\r\nHello World!' > "$tmp/expected"
+for f in $(seq 2000); do
+    echo -e 'GET / HTTP/1.1\r\n\r\n' | nc -w10 -U "$socket" > "$tmp/actual"
+    assert_equal_files "$tmp/expected" "$tmp/actual"
+done
+stop_server "$token"

--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -808,6 +808,11 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         assert(!self.lifecycleManager.hasSeenEOFNotification)
         self.lifecycleManager.hasSeenEOFNotification = true
 
+        // we can't be not active but still registered here; this would mean that we got a notification about a
+        // channel before we're ready to receive them.
+        assert(self.lifecycleManager.isActive || !self.lifecycleManager.isRegistered,
+               "illegal state: active: \(self.lifecycleManager.isActive), registered: \(self.lifecycleManager.isRegistered)")
+
         self.readEOF0()
 
         assert(!self.interestedEvent.contains(.read))

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -453,13 +453,15 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         assert(eventLoop.inEventLoop)
 
         let ch = data.forceAsOther() as SocketChannel
-        ch.register().thenThrowing {
-            guard ch.isOpen else {
-                throw ChannelError.ioOnClosedChannel
+        ch.eventLoop.execute {
+            ch.register().thenThrowing {
+                guard ch.isOpen else {
+                    throw ChannelError.ioOnClosedChannel
+                }
+                ch.becomeActive0(promise: nil)
+            }.whenFailure { error in
+                ch.close(promise: nil)
             }
-            ch.becomeActive0(promise: nil)
-        }.whenFailure { error in
-            ch.close(promise: nil)
         }
     }
 


### PR DESCRIPTION
…annels

Motivation:

Once again, we had an extra event loop hop between a channel
registration and its activation. Usually this shows up as `EPOLLHUP` but
not so for accepted channels. What happened instead is that we had a
small race window after we accepted a channel. It was in a state where
it was not marked active _yet_ and therefore we'd not read out its data
in case we received a `.readEOF`. That usually leads to a stale
connection. Fortunately it doesn't happen very often that the client
connects, immediately sends some data and then shuts the write end of
the socket.

Modifications:

prevent the event loop hop between registration and activation

Result:

will always read out the read buffer on .readEOF
