### PR TITLE
lower allocation limits

### DIFF
--- a/docker/docker-compose.1404.41.yaml
+++ b/docker/docker-compose.1404.41.yaml
@@ -16,19 +16,19 @@ services:
   integration-tests:
     image: swift-nio:14.04-4.1
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=52000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=867500
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=5000
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3500
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=776100
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   test:
     image: swift-nio:14.04-4.1
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=52000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=867500
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=5000
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3500
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=776100
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   echo:

--- a/docker/docker-compose.1604.41.yaml
+++ b/docker/docker-compose.1604.41.yaml
@@ -15,19 +15,19 @@ services:
   integration-tests:
     image: swift-nio:16.04-4.1
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=52000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=868500
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=5000
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3500
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=777100
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   test:
     image: swift-nio:16.04-4.1
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=52000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=868500
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=5000
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3500
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=777100
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   echo:


### PR DESCRIPTION
Motivation:

We reduced allocations again, let's reset the limits.

Modifications:

lowed a bunch of limits to

      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=776100
      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100

Result:

tighter limits should find regressions more easily
