### PR TITLE
remove assertion that String.UTF8View doesn't underestimate count

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -386,7 +386,6 @@ public struct ByteBuffer {
         var (iterator, idx) = UnsafeMutableBufferPointer(start: base, count: underestimatedByteCount).initialize(from: bytes)
         assert(idx == underestimatedByteCount)
         while let b = iterator.next() {
-            assert(S.self != String.UTF8View.self)
             base = ensureCapacityAndReturnStorageBase(capacity: idx + 1)
             base[idx] = b
             idx += 1


### PR DESCRIPTION
Motivation:

I left an assertion that String.UTF8View's underestimatedCount is equal
to the actual count of UTF-8 code units. It's good to see that it never
failed so far so we can expect it to be really good which is important
for performance.
However, there's no problem if it does actually underestimate maybe for
some special kind of Strings. So the assertion really isn't meaningful.

Modifications:

Remove the assertion.

Result:

Most likely nothing but we will not crash on something that we
shouldn't crash on.
