### PR TITLE
Minor typo: becuase -> because

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -606,7 +606,7 @@ public class HTTPDecoder<HTTPMessageT>: ByteToMessageDecoder, AnyHTTPDecoder {
         // We don't need the cumulation buffer, if we're holding it.
         self.cumulationBuffer = nil
 
-        // No check to state.currentError becuase, if we hit it before, we already threw that
+        // No check to state.currentError because, if we hit it before, we already threw that
         // error. This never calls any of the callbacks that set that field anyway. Instead we
         // just check if the errno is set and throw.
         let httpError = self.parser.http_errno

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -366,7 +366,7 @@ public struct HTTPHeaders: CustomStringConvertible {
     ///     - headers: An initial set of headers to use to populate the header block.
     ///     - allocator: The allocator to use to allocate the underlying storage.
     public init(_ headers: [(String, String)] = []) {
-        // Note: this initializer exists becuase of https://bugs.swift.org/browse/SR-7415.
+        // Note: this initializer exists because of https://bugs.swift.org/browse/SR-7415.
         // Otherwise we'd only have the one below with a default argument for `allocator`.
         self.init(headers, allocator: ByteBufferAllocator())
     }

--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -138,7 +138,7 @@ class HTTPDecoderLengthTest: XCTestCase {
 
         // We now want to send a HTTP/1.1 response. This response has no content-length, no transfer-encoding,
         // is not a response to a HEAD request, is not a 2XX response to CONNECT, and is not 1XX, 204, or 304.
-        // That means, per RFC 7230 § 3.3.3, the body is framed by EOF. Becuase this is a response, that EOF
+        // That means, per RFC 7230 § 3.3.3, the body is framed by EOF. Because this is a response, that EOF
         // may be transmitted by channelInactive.
         let response = "HTTP/\(version.major).\(version.minor) 200 OK\r\nServer: example\r\n\r\n"
         XCTAssertNoThrow(try channel.writeInbound(IOData.byteBuffer(ByteBuffer(string: response))))


### PR DESCRIPTION
As per title, just a few minor typos of the word `because`.

https://github.com/apple/swift-nio/issues/393