### PR TITLE
Make hopTo(eventLoop:) public.

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -935,7 +935,7 @@ extension EventLoopFuture {
     }
 }
 
-extension EventLoopFuture {
+public extension EventLoopFuture {
     /// Returns an `EventLoopFuture` that fires when this future completes, but executes its callbacks on the
     /// target event loop instead of the original one.
     ///
@@ -947,7 +947,7 @@ extension EventLoopFuture {
     /// - parameters:
     ///     - target: The `EventLoop` that the returned `EventLoopFuture` will run on.
     /// - returns: An `EventLoopFuture` whose callbacks run on `target` instead of the original loop.
-    func hopTo(eventLoop target: EventLoop) -> EventLoopFuture<T> {
+    public func hopTo(eventLoop target: EventLoop) -> EventLoopFuture<T> {
         if target === self.eventLoop {
             // We're already on that event loop, nothing to do here. Save an allocation.
             return self


### PR DESCRIPTION
Motivation:

When this method was originally introduced it was also intended as a
helper for external users, but we never made it public.

Modifications:

Make hopTo(eventLoop:) public.

Result:

Users will have an easier time managing their threads.
