### PR TITLE
fix minor unsafe pointer type assumption issue

### DIFF
--- a/Tests/NIOTests/SocketAddressTest.swift
+++ b/Tests/NIOTests/SocketAddressTest.swift
@@ -40,7 +40,7 @@ class SocketAddressTest: XCTestCase {
         #endif
         address.sin6_family = sa_family_t(AF_INET6)
         address.sin6_addr   = sampleIn6Addr.withUnsafeBytes {
-            $0.baseAddress!.assumingMemoryBound(to: in6_addr.self).pointee
+            $0.baseAddress!.bindMemory(to: in6_addr.self, capacity: 1).pointee
         }
 
         let s = address.addressDescription()


### PR DESCRIPTION
Motivation:

In a test we did `assumingMemoryBound(to: in6_addr.self)` for something
that was actually bound to `UInt8`. So we should use
`bindMemory(to: in6_addr.self, count: 1)` instead

Modifications:

replace one `assumingMemoryBound` by `bindMemory`

Result:

more memory correctness is good even for tests
