### PR TITLE
Explicitly define constants through Posix and import errno.h

### DIFF
--- a/Sources/CNIOLinux/include/c_nio_linux.h
+++ b/Sources/CNIOLinux/include/c_nio_linux.h
@@ -21,6 +21,7 @@
 #include <sys/sysinfo.h>
 #include <sys/socket.h>
 #include <sched.h>
+#include <errno.h>
 
 
 // Some explanation is required here.

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -141,11 +141,11 @@ enum Shutdown {
     fileprivate var cValue: CInt {
         switch self {
         case .RD:
-            return CInt(SHUT_RD)
+            return CInt(Posix.SHUT_RD)
         case .WR:
-            return CInt(SHUT_WR)
+            return CInt(Posix.SHUT_WR)
         case .RDWR:
-            return CInt(SHUT_RDWR)
+            return CInt(Posix.SHUT_RDWR)
         }
     }
 }
@@ -155,13 +155,18 @@ internal enum Posix {
     static let SOCK_STREAM: CInt = CInt(Darwin.SOCK_STREAM)
     static let SOCK_DGRAM: CInt = CInt(Darwin.SOCK_DGRAM)
     static let IPPROTO_TCP: CInt = CInt(Darwin.IPPROTO_TCP)
-
     static let UIO_MAXIOV: Int = 1024
+    static let SHUT_RD: CInt = CInt(Darwin.SHUT_RD)
+    static let SHUT_WR: CInt = CInt(Darwin.SHUT_WR)
+    static let SHUT_RDWR: CInt = CInt(Darwin.SHUT_RDWR)
 #elseif os(Linux) || os(FreeBSD) || os(Android)
     static let SOCK_STREAM: CInt = CInt(Glibc.SOCK_STREAM.rawValue)
     static let SOCK_DGRAM: CInt = CInt(Glibc.SOCK_DGRAM.rawValue)
     static let IPPROTO_TCP: CInt = CInt(Glibc.IPPROTO_TCP)
     static let UIO_MAXIOV: Int = Int(Glibc.UIO_MAXIOV)
+    static let SHUT_RD: CInt = CInt(Glibc.SHUT_RD)
+    static let SHUT_WR: CInt = CInt(Glibc.SHUT_WR)
+    static let SHUT_RDWR: CInt = CInt(Glibc.SHUT_RDWR)
 #else
     static var SOCK_STREAM: CInt {
         fatalError("unsupported OS")


### PR DESCRIPTION
Explicitly define constants through Posix and import errno.h

### Motivation:

We implicitly depend on errno's `ENOENT` in Linux.swift, but don't explicitly import errno.h.

Similarly, in some cases the compiler can be confused as to where `SHUT_*` come from, so make them an exported value from `Posix` instead.

### Result:

Compiles successfully on Linux and Darwin.