### PR TITLE
make contributors generator executable & change dir correctly

### DIFF
--- a/scripts/generate_contributors_list.sh
+++ b/scripts/generate_contributors_list.sh
@@ -15,7 +15,7 @@
 
 set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-contributors=$(git shortlog -es | cut -f2 | sed 's/^/- /')
+contributors=$( cd "$here"/.. && git shortlog -es | cut -f2 | sed 's/^/- /' )
 
 cat > "$here/../CONTRIBUTORS.txt" <<- EOF
 	For the purpose of tracking copyright, this is the list of individuals and


### PR DESCRIPTION
Motivation:

The script to generate the contributors list wasn't executable and
forgot to change to the correct directory before invoking `git`.

Modifications:

- make `scripts/generate_contributors_list.sh` executable
- correctly change directory before invoking git

Result:

it's now possible to invoke the script without explicitly running `bash`
and it's no longer important what directory one invokes the script from.