### PR TITLE
fewer warnings for 4.2 in 4.2 mode

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -292,7 +292,13 @@ public struct ByteBuffer {
     private mutating func _copyStorageAndRebase(capacity: Capacity, resetIndices: Bool = false) {
         let indexRebaseAmount = resetIndices ? self._readerIndex : 0
         let storageRebaseAmount = self._slice.lowerBound + indexRebaseAmount
-        let newSlice = Range(storageRebaseAmount ..< min(storageRebaseAmount + _toCapacity(self._slice.count), self._slice.upperBound, storageRebaseAmount + capacity))
+        let _newSlice = storageRebaseAmount ..< min(storageRebaseAmount + _toCapacity(self._slice.count), self._slice.upperBound, storageRebaseAmount + capacity)
+        #if swift(>=4.2)
+        // no need for the conversion anymore
+        let newSlice = _newSlice
+        #else
+        let newSlice = Range(_newSlice)
+        #endif
         self._storage = self._storage.reallocSlice(newSlice, capacity: capacity)
         self._moveReaderIndex(to: self._readerIndex - indexRebaseAmount)
         self._moveWriterIndex(to: self._writerIndex - indexRebaseAmount)


### PR DESCRIPTION
Motivation:

Minus [SR-7578](https://bugs.swift.org/browse/SR-7578) which will be
fixed soon, we should then compile warning-free in `-swift-version 4`
mode which is good.
However, we should also be as warning-free as possible in
`-swift-version 4.2`. This is not entirely possible because of
`@_inlineable` vs `@inlinable` but we can address the other warnings.

Modifications:

- make `CountableRange` vs `Range` (which used to be separate types but
  are now the same) work warning-free Swift 4.[01] and Swift 4.2

Result:

Fewer warnings.

test this the following way:

    # make sure you have a Swift 4.2 compiler installed as `swift`
    rm -rf .build && swift build -Xswiftc -swift-version -Xswiftc 4.2 2>&1 | grep warning: | grep -v -e "'@_versioned' has been renamed to '@usableFromInline'" -e "'@_inlineable' has been renamed to '@inlinable'"