### PR TITLE
Make removeHandlers public.

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -273,6 +273,19 @@ public extension ChannelCore {
     public func unwrapData<T>(_ data: NIOAny, as: T.Type = T.self) -> T {
         return data.forceAs()
     }
+
+    /// Removes the `ChannelHandler`s from the `ChannelPipeline` belonging to `channel`, and
+    /// closes that `ChannelPipeline`.
+    ///
+    /// This method is intended for use when writing custom `ChannelCore` implementations.
+    /// This can be called from `close0` to tear down the `ChannelPipeline` when closure is
+    /// complete.
+    ///
+    /// - parameters:
+    ///     - channel: The `Channel` whose `ChannelPipeline` will be closed.
+    public func removeHandlers(channel: Channel) {
+        channel.pipeline.removeHandlers()
+    }
 }
 
 /// An error that can occur on `Channel` operations.

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -499,7 +499,10 @@ public final class ChannelPipeline: ChannelInvoker {
         return name
     }
 
-    /// Remove all the `ChannelHandler`s from the `ChannelPipeline` and destroy these. This method must only be called from within the `EventLoop`.
+    /// Remove all the `ChannelHandler`s from the `ChannelPipeline` and destroy these.
+    ///
+    /// This method must only be called from within the `EventLoop`. It should only be called from a `ChannelCore`
+    /// implementation. Once called, the `ChannelPipeline` is no longer active and cannot be used again.
     func removeHandlers() {
         assert(eventLoop.inEventLoop)
 


### PR DESCRIPTION
Motivation:

If ChannelPipeline.removeHandlers is internal it is extremely difficult
to implement a correct ChannelCore.

Modifications:

Make ChannelPipeline.removeHandlers public.

Result:

Easier to implement ChannelCore.
