### PR TITLE
introduce ByteBufferView

### DIFF
--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A read-only view into a portion of a `ByteBuffer`.
+///
+/// A `ByteBufferView` is useful whenever a `Collection where Element == UInt8` representing a portion of a
+/// `ByteBuffer` is needed.
+public struct ByteBufferView: ContiguousCollection, RandomAccessCollection {
+    public typealias Element = UInt8
+    public typealias Index = Int
+    public typealias SubSequence = ByteBufferView
+
+    private let buffer: ByteBuffer
+    private let range: Range<Index>
+
+    internal init(buffer: ByteBuffer, range: Range<Index>) {
+        precondition(range.lowerBound >= 0 && range.upperBound < buffer.capacity)
+        self.buffer = buffer
+        self.range = range
+    }
+
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try self.buffer.withVeryUnsafeBytes { ptr in
+            try body(UnsafeRawBufferPointer.init(start: ptr.baseAddress!.advanced(by: self.range.lowerBound),
+                                                 count: self.range.count))
+        }
+    }
+
+    public var startIndex: Index {
+        return self.range.lowerBound
+    }
+
+    public var endIndex: Index {
+        return self.range.upperBound
+    }
+
+    public func index(after i: Index) -> Index {
+        return i + 1
+    }
+
+    public subscript(position: Index) -> UInt8 {
+        guard position >= self.range.lowerBound && position < self.range.upperBound else {
+            preconditionFailure("index \(position) out of range")
+        }
+        return self.buffer.getInteger(at: position)!
+    }
+
+    public subscript(range: Range<Index>) -> ByteBufferView {
+        return ByteBufferView(buffer: self.buffer, range: range)
+    }
+}
+
+public extension ByteBuffer {
+    /// A view into the readable bytes of the `ByteBuffer`.
+    public var readableBytesView: ByteBufferView {
+        return ByteBufferView(buffer: self, range: self.readerIndex ..< self.readerIndex + self.readableBytes)
+    }
+
+    /// Returns a view into some portion of a `ByteBuffer`.
+    ///
+    /// - parameters:
+    ///   - index: The index the view should start at
+    ///   - length: The length of the view (in bytes)
+    /// - returns A view into a portion of a `ByteBuffer`.
+    public func viewBytes(at index: Int, length: Int) -> ByteBufferView {
+        return ByteBufferView(buffer: self, range: index ..< index+length)
+    }
+}

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -116,6 +116,11 @@ extension ByteBufferTest {
                 ("testDiscardReadBytesOnConsumedBuffer", testDiscardReadBytesOnConsumedBuffer),
                 ("testDumpBytesFormat", testDumpBytesFormat),
                 ("testStaticStringCategorySubscript", testStaticStringCategorySubscript),
+                ("testReadableBytesView", testReadableBytesView),
+                ("testReadableBytesViewNoReadableBytes", testReadableBytesViewNoReadableBytes),
+                ("testBytesView", testBytesView),
+                ("testViewsStartIndexIsStable", testViewsStartIndexIsStable),
+                ("testSlicesOfByteBufferViewsAreByteBufferViews", testSlicesOfByteBufferViewsAreByteBufferViews),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1356,6 +1356,53 @@ class ByteBufferTest: XCTestCase {
         XCTAssertEqual("h".utf8.first!, s[0])
         XCTAssertEqual("o".utf8.first!, s[4])
     }
+
+    func testReadableBytesView() throws {
+        self.buf.clear()
+        self.buf.write(string: "hello world 012345678")
+        XCTAssertEqual("hello ", self.buf.readString(length: 6))
+        self.buf.moveWriterIndex(to: self.buf.writerIndex - 10)
+        XCTAssertEqual("world", String(decoding: self.buf.readableBytesView, as: UTF8.self))
+        XCTAssertEqual("world", self.buf.readString(length: self.buf.readableBytes))
+    }
+
+    func testReadableBytesViewNoReadableBytes() throws {
+        self.buf.clear()
+        let view = self.buf.readableBytesView
+        XCTAssertEqual(0, view.count)
+    }
+
+    func testBytesView() throws {
+        self.buf.clear()
+        self.buf.write(string: "hello world 012345678")
+
+        XCTAssertEqual(String(decoding: self.buf.viewBytes(at: self.buf.readerIndex,
+                                                           length: self.buf.writerIndex - self.buf.readerIndex),
+                              as: UTF8.self),
+                       self.buf.getString(at: self.buf.readerIndex, length: self.buf.readableBytes))
+        XCTAssertEqual(Array(self.buf.viewBytes(at: 0, length: 0)), [])
+        XCTAssertEqual(Array("hello world 012345678".utf8),
+                       Array(self.buf.viewBytes(at: 0, length: self.buf.readableBytes)))
+    }
+
+    func testViewsStartIndexIsStable() throws {
+        self.buf.write(string: "hello")
+        let view = self.buf.viewBytes(at: 1, length: 3)
+        XCTAssertEqual(1, view.startIndex)
+        XCTAssertEqual(3, view.count)
+        XCTAssertEqual(4, view.endIndex)
+        XCTAssertEqual("ell", String(decoding: view, as: UTF8.self))
+    }
+
+    func testSlicesOfByteBufferViewsAreByteBufferViews() throws {
+        self.buf.write(string: "hello")
+        let view: ByteBufferView = self.buf.viewBytes(at: 1, length: 3)
+        XCTAssertEqual("ell", String(decoding: view, as: UTF8.self))
+        let viewSlice: ByteBufferView = view[view.startIndex + 1 ..< view.endIndex]
+        XCTAssertEqual("ll", String(decoding: viewSlice, as: UTF8.self))
+        XCTAssertEqual("l", String(decoding: viewSlice.dropFirst(), as: UTF8.self))
+        XCTAssertEqual("", String(decoding: viewSlice.dropFirst().dropLast(), as: UTF8.self))
+    }
 }
 
 private enum AllocationExpectationState: Int {


### PR DESCRIPTION
RFC: @normanmaurer / @Lukasa / @moiseev / @airspeedswift 

Motivation:

Sometimes it would be handy to have ByteBuffers conform to a
`Collection` where `Element == UInt8`. ByteBuffer however has multiple
modes how to operate so it would be wrong to have say the readable bytes
be the ByteBuffer's collection.
Therefore it would be nice to have a view into a `ByteBuffer` which is a
`Collection where Element == UInt8`. This introduces these.

Modifications:

- add `ByteBufferView`
- add `ByteBuffer.readableBytesView`
- add `ByteBuffer.viewBytes(range: ...)`

Result:

- easier to work with `ByteBuffer`s in the Swift ecosystem.
