### PR TITLE
don't just drop Channels on the floor if registration fails

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -396,7 +396,8 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
     }
 
     deinit {
-        assert(self.lifecycleManager.canBeDestroyed, "leak of open Channel")
+        assert(self.lifecycleManager.canBeDestroyed,
+               "leak of open Channel, state: \(String(describing: self.lifecycleManager))")
     }
 
     public final func localAddress0() throws -> SocketAddress {
@@ -791,7 +792,15 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         assert(self.eventLoop.inEventLoop)
         assert(self.isOpen)
         assert(!self.lifecycleManager.isActive)
-        register0(promise: nil)
+        let registerPromise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+        register0(promise: registerPromise)
+        registerPromise.futureResult.whenFailure { (_: Error) in
+            self.close(promise: nil)
+        }
+        if let promise = promise {
+            registerPromise.futureResult.cascadeFailure(promise: promise)
+        }
+
         if self.lifecycleManager.isPreRegistered {
             try! becomeFullyRegistered0()
             if self.lifecycleManager.isRegisteredFully {

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -71,6 +71,10 @@ extension ChannelTests {
                 ("testCloseInUnregister", testCloseInUnregister),
                 ("testLazyRegistrationWorksForServerSockets", testLazyRegistrationWorksForServerSockets),
                 ("testLazyRegistrationWorksForClientSockets", testLazyRegistrationWorksForClientSockets),
+                ("testFailedRegistrationOfClientSocket", testFailedRegistrationOfClientSocket),
+                ("testFailedRegistrationOfAcceptedSocket", testFailedRegistrationOfAcceptedSocket),
+                ("testFailedRegistrationOfServerSocket", testFailedRegistrationOfServerSocket),
+                ("testTryingToBindOnPortThatIsAlreadyBoundFailsButDoesNotCrash", testTryingToBindOnPortThatIsAlreadyBoundFailsButDoesNotCrash),
            ]
    }
 }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2360,6 +2360,106 @@ public class ChannelTests: XCTestCase {
         XCTAssertTrue(client.isActive)
         XCTAssertEqual(serverChannel.localAddress!, client.remoteAddress!)
     }
+
+    func testFailedRegistrationOfClientSocket() throws {
+        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        let serverChannel = try ServerBootstrap(group: group).bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try serverChannel.close().wait())
+        }
+        do {
+            let clientChannel = try ClientBootstrap(group: group)
+                .channelInitializer { channel in
+                    channel.pipeline.add(handler: FailRegistrationHandler())
+                }
+                .connect(to: serverChannel.localAddress!)
+                .wait()
+            XCTFail("shouldn't have reached this but got \(clientChannel)")
+        } catch FailRegistrationHandler.RegistrationFailedError.error {
+            // ok
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testFailedRegistrationOfAcceptedSocket() throws {
+        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        let serverChannel = try ServerBootstrap(group: group)
+            .childChannelInitializer { channel in
+                channel.pipeline.add(handler: FailRegistrationHandler())
+            }
+            .bind(host: "localhost", port: 0).wait()
+        defer {
+            XCTAssertNoThrow(try serverChannel.close().wait())
+        }
+        let clientChannel = try ClientBootstrap(group: group)
+            .connect(to: serverChannel.localAddress!)
+            .wait()
+        try clientChannel.closeFuture.wait()
+    }
+
+    func testFailedRegistrationOfServerSocket() throws {
+        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        do {
+            let serverChannel = try ServerBootstrap(group: group)
+                .serverChannelInitializer { channel in
+                    channel.pipeline.add(handler: FailRegistrationHandler())
+                }
+                .bind(host: "localhost", port: 0).wait()
+            XCTFail("shouldn't be reached")
+            XCTAssertNoThrow(try serverChannel.close().wait())
+        } catch FailRegistrationHandler.RegistrationFailedError.error {
+            // ok
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testTryingToBindOnPortThatIsAlreadyBoundFailsButDoesNotCrash() throws {
+        // this is a regression test for #417
+
+        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        let serverChannel1 = try! ServerBootstrap(group: group)
+            .bind(host: "localhost", port: 0)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try serverChannel1.close().wait())
+        }
+
+        do {
+            let serverChannel2 = try ServerBootstrap(group: group)
+                .bind(to: serverChannel1.localAddress!)
+                .wait()
+            XCTFail("shouldn't have succeeded, got two server channels on the same port: \(serverChannel1) and \(serverChannel2)")
+        } catch let e as IOError where e.errnoCode == EADDRINUSE {
+            // OK
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}
+
+fileprivate final class FailRegistrationHandler: ChannelOutboundHandler {
+    enum RegistrationFailedError: Error { case error }
+
+    typealias OutboundIn = Never
+
+    func register(ctx: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
+        promise!.fail(error: RegistrationFailedError.error)
+    }
 }
 
 fileprivate class VerifyConnectionFailureHandler: ChannelInboundHandler {

--- a/docker/docker-compose.1404.41.yaml
+++ b/docker/docker-compose.1404.41.yaml
@@ -17,7 +17,7 @@ services:
     image: swift-nio:14.04-4.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=776100
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=792100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
@@ -26,7 +26,7 @@ services:
     image: swift-nio:14.04-4.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=776100
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=792100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100

--- a/docker/docker-compose.1604.41.yaml
+++ b/docker/docker-compose.1604.41.yaml
@@ -16,7 +16,7 @@ services:
     image: swift-nio:16.04-4.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=777100
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=793100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
@@ -25,7 +25,7 @@ services:
     image: swift-nio:16.04-4.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=777100
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=793100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100


### PR DESCRIPTION
Motivation:

If registration of a Channel fails we need to close that Channel.
Previously we'd just drop it on the floor which triggers an assertion
that an open channel got leaked.

Modifications:

In cases where the Channel registration fails, we need to close that
channel.

Result:

No crashes if registration fails.
