### PR TITLE
workaround SR-6963

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -25,9 +25,9 @@ public protocol AppendableCollection: Collection {
 /// expansions from happening frequently. Expansions will always force an allocation and a copy to happen.
 public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     #if swift(>=4.2)
-    public typealias RangeType = Range
+    public typealias RangeType<Bound> = Range<Bound> where Bound: Strideable, Bound.Stride: SignedInteger
     #else
-    public typealias RangeType = CountableRange
+    public typealias RangeType<Bound> = CountableRange<Bound> where Bound: Strideable, Bound.Stride: SignedInteger
     #endif
     private var buffer: ContiguousArray<E?>
 

--- a/Sources/NIO/MarkedCircularBuffer.swift
+++ b/Sources/NIO/MarkedCircularBuffer.swift
@@ -19,9 +19,9 @@
 /// safe to write.
 public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     #if swift(>=4.2)
-    public typealias RangeType = Range
+    public typealias RangeType<Bound> = Range<Bound> where Bound: Strideable, Bound.Stride: SignedInteger
     #else
-    public typealias RangeType = CountableRange
+    public typealias RangeType<Bound> = CountableRange<Bound> where Bound: Strideable, Bound.Stride: SignedInteger
     #endif
 
     private var buffer: CircularBuffer<E>


### PR DESCRIPTION
Motivation:

SR-6963 is currently blocking builds with Swift 4.2 pre-releases, we
should work around it.

Modifications:

work around SR-6963.

Result:

- builds with 4.2 pre-release
- fixes #418 
