### PR TITLE
EmbeddedChannel: make write not auto-flush & websockets: connection closed frame must be flushed

### DIFF
--- a/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
@@ -312,8 +312,8 @@ public final class WebSocketFrameDecoder: ByteToMessageDecoder {
         let frame = WebSocketFrame(fin: true,
                                    opcode: .connectionClose,
                                    data: data)
-        _ = ctx.write(self.wrapOutboundOut(frame)).then {
-            ctx.close()
+        ctx.writeAndFlush(self.wrapOutboundOut(frame)).whenComplete {
+            ctx.close(promise: nil)
         }
         ctx.fireErrorCaught(error)
     }

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
@@ -529,7 +529,7 @@ class HTTPResponseCompressorTest: XCTestCase {
         try sendRequest(acceptEncoding: nil, channel: channel)
         let head = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok)
         let writePromise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
-        channel.write(NIOAny(HTTPServerResponsePart.head(head)), promise: writePromise)
+        channel.writeAndFlush(NIOAny(HTTPServerResponsePart.head(head)), promise: writePromise)
         channel.pipeline.removeHandlers()
         try writePromise.futureResult.wait()
     }

--- a/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
@@ -136,8 +136,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         .channelRead(HTTPServerRequestPart.end(nil))])
 
         // Unblock by sending a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // Two requests should have made it through now.
         XCTAssertEqual(self.readRecorder.reads,
@@ -147,8 +147,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         .channelRead(HTTPServerRequestPart.end(nil))])
 
         // Now send the last response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // Now all three.
         XCTAssertEqual(self.readRecorder.reads,
@@ -176,8 +176,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Send a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // This should have automatically triggered a call to read(), but only one.
         XCTAssertEqual(self.readCounter.readCount, 2)
@@ -201,8 +201,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Send a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // This should have not triggered a call to read.
         XCTAssertEqual(self.readCounter.readCount, 1)
@@ -213,8 +213,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Now send in the last response, and see the read go through.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
         XCTAssertEqual(self.readCounter.readCount, 2)
     }
 
@@ -228,8 +228,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Now the server sends a response immediately.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // We're still moving forward and can read.
         XCTAssertEqual(self.readCounter.readCount, 1)
@@ -261,8 +261,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         .channelRead(HTTPServerRequestPart.end(nil))])
 
         // Unblock by sending a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // Two requests should have made it through now.
         XCTAssertEqual(self.readRecorder.reads,
@@ -272,8 +272,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         .channelRead(HTTPServerRequestPart.end(nil))])
 
         // Now send the last response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // Now the half-closure should be delivered.
         XCTAssertEqual(self.readRecorder.reads,
@@ -301,8 +301,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         .channelRead(HTTPServerRequestPart.end(nil))])
 
         // Unblock by sending a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // The second request head, followed by the half-close, should have made it through.
         XCTAssertEqual(self.readRecorder.reads,
@@ -331,15 +331,15 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Send a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // This should have not triggered a call to read.
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Now send in the last response. This should also not issue a read.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
         XCTAssertEqual(self.readCounter.readCount, 1)
     }
 
@@ -356,8 +356,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         .channelRead(HTTPServerRequestPart.end(nil))])
 
         // Unblock by sending a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // Two requests should have made it through now. Still no half-closure.
         XCTAssertEqual(self.readRecorder.reads,
@@ -495,8 +495,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         .channelRead(HTTPServerRequestPart.end(nil))])
 
         // Now send a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // No further events should have happened.
         XCTAssertEqual(self.readRecorder.reads,
@@ -520,8 +520,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
 
         // Now send a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         // still missing the request .end
         XCTAssertTrue(self.channel.isActive)
@@ -552,8 +552,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
 
         // Now send a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         XCTAssertFalse(self.channel.isActive)
 
@@ -577,14 +577,14 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         .channelRead(HTTPServerRequestPart.end(nil))])
 
         // Now send the response .head.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
 
         XCTAssertTrue(self.channel.isActive)
         self.channel.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
         XCTAssertTrue(self.channel.isActive)
 
         // Now send the response .end.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
         XCTAssertFalse(self.channel.isActive)
 
         XCTAssertEqual([HTTPServerResponsePart.head(self.responseHead),
@@ -603,7 +603,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                        [.channelRead(HTTPServerRequestPart.head(self.requestHead))])
 
         // Now send the response .head.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
 
         XCTAssertTrue(self.channel.isActive)
         self.channel.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
@@ -618,7 +618,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
 
         // Response .end.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
         XCTAssertFalse(self.channel.isActive)
 
         XCTAssertEqual([HTTPServerResponsePart.head(self.responseHead),
@@ -639,14 +639,14 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                        [.channelRead(HTTPServerRequestPart.head(self.requestHead))])
 
         // Now send the response .head.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
 
         XCTAssertTrue(self.channel.isActive)
         self.channel.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
         XCTAssertTrue(self.channel.isActive)
 
         // Response .end.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
         XCTAssertTrue(self.channel.isActive)
 
         // Request .end.
@@ -685,8 +685,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
 
         // Now send a response.
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.write(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
 
         XCTAssertFalse(self.channel.isActive)
 

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -265,7 +265,7 @@ class ChannelPipelineTest: XCTestCase {
 
             func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
                 let data = self.unwrapInboundIn(data)
-                ctx.write(self.wrapOutboundOut(data.map { $0 * -1 }), promise: nil)
+                ctx.writeAndFlush(self.wrapOutboundOut(data.map { $0 * -1 }), promise: nil)
                 ctx.fireChannelRead(self.wrapInboundOut(data))
             }
         }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -1410,7 +1410,7 @@ public class ChannelTests: XCTestCase {
             try pipeline.eventLoop.submit { () -> Channel in
                 XCTAssertTrue(pipeline.channel is DeadChannel)
                 return pipeline.channel
-            }.wait().write(NIOAny(())).wait()
+            }.wait().writeAndFlush(NIOAny(())).wait()
             XCTFail("shouldn't have been reached")
         } catch let e as ChannelError where e == .ioOnClosedChannel {
             // OK

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -36,6 +36,7 @@ extension EmbeddedChannelTest {
                 ("testEmbeddedChannelAndPipelineAndChannelCoreShareTheEventLoop", testEmbeddedChannelAndPipelineAndChannelCoreShareTheEventLoop),
                 ("testSendingIncorrectDataOnEmbeddedChannel", testSendingIncorrectDataOnEmbeddedChannel),
                 ("testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires", testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires),
+                ("testWriteWithoutFlushDoesNotWrite", testWriteWithoutFlushDoesNotWrite),
            ]
    }
 }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -240,7 +240,8 @@ public class SocketChannelTest : XCTestCase {
 
         let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
         do {
-            try serverChannel.write("test").wait()
+            try serverChannel.writeAndFlush("test").wait()
+            XCTFail("did not throw")
         } catch let err as ChannelError where err == .operationUnsupported {
             // expected
         }

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -38,7 +38,7 @@ extension EmbeddedChannel {
     func writeString(_ string: String) -> EventLoopFuture<Void> {
         var buffer = self.allocator.buffer(capacity: string.utf8.count)
         buffer.write(string: string)
-        return self.write(buffer)
+        return self.writeAndFlush(buffer)
     }
 }
 
@@ -332,10 +332,10 @@ class EndToEndTests: XCTestCase {
 
         // Let's send a frame or two, to confirm that this works.
         let dataFrame = WebSocketFrame(fin: true, opcode: .binary, data: data)
-        XCTAssertNoThrow(try client.write(dataFrame).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(dataFrame).wait())
 
         let pingFrame = WebSocketFrame(fin: true, opcode: .ping, data: client.allocator.buffer(capacity: 0))
-        XCTAssertNoThrow(try client.write(pingFrame).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(pingFrame).wait())
         interactInMemory(client, server)
 
         XCTAssertEqual(recorder.frames, [dataFrame, pingFrame])

--- a/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
@@ -77,7 +77,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
     }
 
     private func frameForFrame(_ frame: WebSocketFrame) -> WebSocketFrame? {
-        self.encoderChannel.write(frame, promise: nil)
+        self.encoderChannel.writeAndFlush(frame, promise: nil)
 
         while case .some(.byteBuffer(let d)) = self.encoderChannel.readOutbound() {
             XCTAssertNoThrow(try self.decoderChannel.writeInbound(d))

--- a/Tests/NIOWebSocketTests/WebSocketFrameEncoderTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameEncoderTest.swift
@@ -49,7 +49,7 @@ public class WebSocketFrameEncoderTest: XCTestCase {
     }
 
     private func assertFrameEncodes(frame: WebSocketFrame, expectedBytes: [UInt8]) {
-        self.channel.write(frame, promise: nil)
+        self.channel.writeAndFlush(frame, promise: nil)
         let writtenBytes = self.channel.readAllOutboundBytes()
         XCTAssertEqual(writtenBytes, expectedBytes)
     }
@@ -75,7 +75,7 @@ public class WebSocketFrameEncoderTest: XCTestCase {
         self.buffer.write(bytes: dataBytes)
 
         let frame = WebSocketFrame(fin: true, opcode: .binary, data: self.buffer)
-        self.channel.write(frame, promise: nil)
+        self.channel.writeAndFlush(frame, promise: nil)
 
         let writtenBytes = self.channel.readAllOutboundBytes()
         let expectedBytes: [UInt8] = [0x82, 0x7F, 0, 0, 0, 0, 0, 1, 0, 0]


### PR DESCRIPTION
# THIS CONTAINS TWO COMMITS, PLEASE DON'T SQUASH AND MERGE

## part 1

EmbeddedChannel: make write not auto-flush
Motivation:

EmbeddedChannel just treated all `write`s as flushed. That's not a good
idea as all real channels obviously only actually write the bytes when
flushed. This changes that behaviour for `EmbeddedChannel`.

Modifications:

- make `write` only write to a buffer
- make `flush` then actually pretend to write the bytes

Result:

- EmbeddedChannel behaves more realisticly


## part 2

websockets: connection closed frame must be flushed
Motivation:

Because EmbeddedChannel used to treat all writes as flushed the test
that tested that we do send out the WebSockets connection close frame
didn't actually test the right thing. Now that EmbeddedChannel behaves
more realisticly, this test actually fails.

This fixes the bug and the test that tests that a WebSockets connection
is successfully torn down after an error occured.

Modifications:

- use `writeAndFlush` to send out the connection close frame.

Result:

WebSockets connection actually gets closed on error.
