### PR TITLE
explain why typealias is complicated

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -24,6 +24,7 @@ public protocol AppendableCollection: Collection {
 /// will automatically expand if more elements than `initialRingCapacity` are stored, it's advantageous to prevent
 /// expansions from happening frequently. Expansions will always force an allocation and a copy to happen.
 public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
+    // this typealias is so complicated because of SR-6963, when that's fixed we can drop the generic parameters and the where clause
     #if swift(>=4.2)
     public typealias RangeType<Bound> = Range<Bound> where Bound: Strideable, Bound.Stride: SignedInteger
     #else

--- a/Sources/NIO/MarkedCircularBuffer.swift
+++ b/Sources/NIO/MarkedCircularBuffer.swift
@@ -18,6 +18,7 @@
 /// writes and mark how far through the buffer the user has flushed, and therefore how far through the buffer is
 /// safe to write.
 public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollection {
+    // this typealias is so complicated because of SR-6963, when that's fixed we can drop the generic parameters and the where clause
     #if swift(>=4.2)
     public typealias RangeType<Bound> = Range<Bound> where Bound: Strideable, Bound.Stride: SignedInteger
     #else


### PR DESCRIPTION
CC @BasThomas , forgot to address your comment before merge.

Motivation:

We should explain why this typealias

    public typealias RangeType<Bound> = CountableRange<Bound> where Bound: Strideable, Bound.Stride: SignedInteger

isn't just

    public typealias RangeType = CountableRange

and that's because SR-6963.

Modifications:

added a comment explaining why

Result:

code easier to read
