### PR TITLE
Correctly account for writes of all datagrams.

### DIFF
--- a/Sources/CNIODarwin/shim.c
+++ b/Sources/CNIODarwin/shim.c
@@ -39,7 +39,7 @@ int CNIODarwin_sendmmsg(int sockfd, CNIODarwin_mmsghdr *msgvec, unsigned int vle
         }
 
         // Send succeeded, save off the bytes written.
-        msgvec->msg_len = sendAmount;
+        msgvec[i].msg_len = sendAmount;
     }
 
     // If we dropped out, we sent everything.

--- a/Tests/NIOTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOTests/DatagramChannelTests+XCTest.swift
@@ -40,6 +40,7 @@ extension DatagramChannelTests {
                 ("testRecvFromFailsWithENOMEM", testRecvFromFailsWithENOMEM),
                 ("testRecvFromFailsWithEFAULT", testRecvFromFailsWithEFAULT),
                 ("testSetGetOptionClosedDatagramChannel", testSetGetOptionClosedDatagramChannel),
+                ("testWritesAreAccountedCorrectly", testWritesAreAccountedCorrectly),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

The Darwin gathering datagram writes shim incorrectly placed the
"bytes written" amount into the first slot in the array for every write.
This had the effect of incorrectly accounting for the amount of bytes
written for literally every element of a vector write. Not good.

Modifications:

Correctly account for each vector write element.

Result:

Lower risk of preconditions in incorrect situations, better accounting
of written bytes.
