### PR TITLE
Add eventloop submitasync

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -205,7 +205,7 @@ public final class ServerBootstrap {
             return eventLoop.newFailedFuture(error: error)
         }
 
-        return eventLoop.submitAsync {
+        return eventLoop.submitFuture {
             return serverChannelInit(serverChannel).then {
                 serverChannel.pipeline.add(handler: AcceptHandler(childChannelInitializer: childChannelInit,
                                                                   childChannelOptions: childChannelOptions))
@@ -275,7 +275,7 @@ public final class ServerBootstrap {
             if childEventLoop === ctxEventLoop {
                 fireThroughPipeline(setupChildChannel())
             } else {
-                fireThroughPipeline(childEventLoop.submitAsync {
+                fireThroughPipeline(childEventLoop.submitFuture {
                     return setupChildChannel()
                 }.hopTo(eventLoop: ctxEventLoop))
             }
@@ -503,7 +503,7 @@ public final class ClientBootstrap {
         if eventLoop.inEventLoop {
             return setupChannel()
         } else {
-            return eventLoop.submitAsync(setupChannel)
+            return eventLoop.submitFuture(setupChannel)
         }
     }
 }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -205,7 +205,7 @@ public final class ServerBootstrap {
             return eventLoop.newFailedFuture(error: error)
         }
 
-        return eventLoop.submit {
+        return eventLoop.submitAsync {
             return serverChannelInit(serverChannel).then {
                 serverChannel.pipeline.add(handler: AcceptHandler(childChannelInitializer: childChannelInit,
                                                                   childChannelOptions: childChannelOptions))
@@ -219,8 +219,6 @@ public final class ServerBootstrap {
                 serverChannel.close0(error: error, mode: .all, promise: nil)
                 return eventLoop.newFailedFuture(error: error)
             }
-        }.then {
-            $0
         }
     }
 
@@ -277,9 +275,9 @@ public final class ServerBootstrap {
             if childEventLoop === ctxEventLoop {
                 fireThroughPipeline(setupChildChannel())
             } else {
-                fireThroughPipeline(childEventLoop.submit {
+                fireThroughPipeline(childEventLoop.submitAsync {
                     return setupChildChannel()
-                }.then { $0 }.hopTo(eventLoop: ctxEventLoop))
+                }.hopTo(eventLoop: ctxEventLoop))
             }
         }
 
@@ -505,7 +503,7 @@ public final class ClientBootstrap {
         if eventLoop.inEventLoop {
             return setupChannel()
         } else {
-            return eventLoop.submit(setupChannel).then { $0 }
+            return eventLoop.submitAsync(setupChannel)
         }
     }
 }

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -89,6 +89,13 @@ public protocol EventLoop: EventLoopGroup {
     ///     - task: The closure that will be submitted to the `EventLoop` for execution.
     /// - returns: `EventLoopFuture` that is notified once the task was executed.
     func submit<T>(_ task: @escaping () throws -> T) -> EventLoopFuture<T>
+    
+    /// Submit a given async task to start execution. Once the execution is complete the given async task has been started and the returned `EventLoopFuture` will be notified with the result of execution once the task is finished.
+    ///
+    /// - parameters:
+    ///     - asyncTask: The closure that will be submitted to the `EventLoop` to start execution.
+    /// - returns: `EventLoopFuture` that is notified once the task was executed.
+    func submitAsync<T>(_ asyncTask: @escaping () throws -> EventLoopFuture<T>) -> EventLoopFuture<T>
 
     /// Schedule a `task` that is executed by this `SelectableEventLoop` after the given amount of time.
     func scheduleTask<T>(in: TimeAmount, _ task: @escaping () throws -> T) -> Scheduled<T>
@@ -190,6 +197,10 @@ extension EventLoop {
         }
 
         return promise.futureResult
+    }
+    
+    public func submitAsync<T>(_ asyncTask: @escaping () throws -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+        return submit(asyncTask).then { $0 }
     }
 
     /// Creates and returns a new `EventLoopPromise` that will be notified using this `EventLoop` as execution `Thread`.

--- a/Tests/NIOTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOTests/AcceptBackoffHandlerTest.swift
@@ -256,7 +256,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
             serverChannel.pipeline.add(name: self.acceptHandlerName, handler: AcceptBackoffHandler(backoffProvider: backoffProvider))
         }.wait())
 
-        XCTAssertNoThrow(try eventLoop.submit {
+        XCTAssertNoThrow(try eventLoop.submitFuture {
             // this is pretty delicate at the moment:
             // `bind` must be _synchronously_ follow `register`, otherwise in our current implementation, `epoll` will
             // send us `EPOLLHUP`. To have it run synchronously, we need to invoke the `then` on the eventloop that the
@@ -264,7 +264,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
             serverChannel.register().then { () -> EventLoopFuture<()> in
                 return serverChannel.bind(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 0))
             }
-        }.wait().wait() as Void)
+        }.wait() as Void)
         return serverChannel
     }
 }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2123,7 +2123,7 @@ public class ChannelTests: XCTestCase {
 
         let allDone: EventLoopPromise<Void> = clientEL.newPromise()
 
-        XCTAssertNoThrow(try sc.eventLoop.submit {
+        XCTAssertNoThrow(try sc.eventLoop.submitFuture {
             // this is pretty delicate at the moment:
             // `bind` must be _synchronously_ follow `register`, otherwise in our current implementation, `epoll` will
             // send us `EPOLLHUP`. To have it run synchronously, we need to invoke the `then` on the eventloop that the
@@ -2134,7 +2134,7 @@ public class ChannelTests: XCTestCase {
             }.then {
                 sc.connect(to: serverChannel.localAddress!)
             }
-        }.wait().wait() as Void)
+        }.wait() as Void)
         XCTAssertNoThrow(try allDone.futureResult.wait())
         XCTAssertNoThrow(try sc.syncCloseAcceptingAlreadyClosed())
     }
@@ -2289,14 +2289,14 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        XCTAssertNoThrow(try sc.eventLoop.submit {
+        XCTAssertNoThrow(try sc.eventLoop.submitFuture {
             sc.register().then {
                 sc.connect(to: serverChannel.localAddress!)
             }
-        }.wait().wait() as Void)
+        }.wait() as Void)
 
         do {
-            try sc.eventLoop.submit { () -> EventLoopFuture<Void> in
+            try sc.eventLoop.submitFuture { () -> EventLoopFuture<Void> in
                 let p: EventLoopPromise<Void> = sc.eventLoop.newPromise()
                 // this callback must be attached before we call the close
                 let f = p.futureResult.map {
@@ -2307,7 +2307,7 @@ public class ChannelTests: XCTestCase {
                 }
                 sc.close(promise: p)
                 return f
-            }.wait().wait()
+            }.wait()
             XCTFail("shouldn't be reached")
         } catch ChannelError.alreadyClosed {
             // ok

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -38,6 +38,9 @@ extension EventLoopTest {
                 ("testShutdownWhileScheduledTasksNotReady", testShutdownWhileScheduledTasksNotReady),
                 ("testCloseFutureNotifiedBeforeUnblock", testCloseFutureNotifiedBeforeUnblock),
                 ("testScheduleMultipleTasks", testScheduleMultipleTasks),
+                ("testSubmitFutureTaskSuccess", testSubmitFutureTaskSuccess),
+                ("testSubmitFutureTaskFailure", testSubmitFutureTaskFailure),
+                ("testSubmitFutureWhichDoesFailOnEventLoopShutdown", testSubmitFutureWhichDoesFailOnEventLoopShutdown),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -406,7 +406,7 @@ public class EventLoopTest : XCTestCase {
             taskEventLoop.submit { 42 }
         }
         
-        let future = submissionEventLoop.submitAsync(asyncTask)
+        let future = submissionEventLoop.submitFuture(asyncTask)
         
         let result = try future.wait()
         XCTAssert(future.isFulfilled)
@@ -423,7 +423,7 @@ public class EventLoopTest : XCTestCase {
             taskEventLoop.submit { throw E() }
         }
         
-        let future = submissionEventLoop.submitAsync(asyncTask)
+        let future = submissionEventLoop.submitFuture(asyncTask)
         
         do {
             _ = try future.wait()

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -430,8 +430,8 @@ public class EventLoopTest : XCTestCase {
             XCTFail("should've thrown an error")
         } catch _ as E {
             /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        } catch {
+            XCTFail("error of wrong type \(error)")
         }
     }
     
@@ -454,8 +454,8 @@ public class EventLoopTest : XCTestCase {
             _ = try future.wait()
         } catch EventLoopError.shutdown {
             /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        } catch {
+            XCTFail("error of wrong type \(error)")
         }
     }
 }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -148,13 +148,13 @@ public class SocketChannelTest : XCTestCase {
         let serverChannel = try ServerSocketChannel(serverSocket: socket, eventLoop: group.next() as! SelectableEventLoop, group: group)
         let promise: EventLoopPromise<IOError> = serverChannel.eventLoop.newPromise()
 
-        XCTAssertNoThrow(try serverChannel.eventLoop.submit {
+        XCTAssertNoThrow(try serverChannel.eventLoop.submitFuture {
             serverChannel.pipeline.add(handler: AcceptHandler(promise)).then {
                 serverChannel.register()
             }.then {
                 serverChannel.bind(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 0))
             }
-        }.wait().wait() as Void)
+        }.wait() as Void)
 
         XCTAssertEqual(active, try serverChannel.eventLoop.submit {
             serverChannel.readable()
@@ -428,7 +428,7 @@ public class SocketChannelTest : XCTestCase {
 
         // We need to call submit {...} here to ensure then {...} is called while on the EventLoop already to not have
         // a ECONNRESET sneak in.
-        XCTAssertNoThrow(try channel.eventLoop.submit {
+        XCTAssertNoThrow(try channel.eventLoop.submitFuture {
             channel.register().map { () -> Void in
                 channel.connect(to: serverChannel.localAddress!, promise: connectPromise)
             }.map { () -> Void in
@@ -437,7 +437,7 @@ public class SocketChannelTest : XCTestCase {
                 // before we have the chance to register it for .write.
                 channel.close(promise: closePromise)
             }
-        }.wait().wait() as Void)
+        }.wait() as Void)
 
         do {
             try connectPromise.futureResult.wait()


### PR DESCRIPTION
Implement #426

### Motivation:

Dealing with double futures is annoying when working with `EventLoop.submit(task)` when the task itself returns an `EventLoopFuture`, so we provide a new function to deal with tasks that return an `EventLoopFuture<T>`

### Modifications:

1- Add a new function  `func submitAsync<T>(_ asyncTask: @escaping () throws -> EventLoopFuture<T>) -> EventLoopFuture<T>`

2- Clean up the workarounds from #424

### Result:

less `.then { $0 }` in code base