### PR TITLE
Change initializer to public for HTTPRequestDecoder

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -152,7 +152,7 @@ public final class HTTPRequestDecoder: HTTPDecoder<HTTPServerRequestPart> {
     ///
     /// - parameters:
     ///     - leftOverBytesStrategy: the strategy to use when removing the decoder from the pipeline and an upgrade was detected
-    convenience init(leftOverBytesStrategy: RemoveAfterUpgradeStrategy) {
+    public convenience init(leftOverBytesStrategy: RemoveAfterUpgradeStrategy) {
         self.init(type: HTTPServerRequestPart.self, leftOverBytesStrategy: leftOverBytesStrategy)
     }
 }
@@ -196,7 +196,7 @@ public final class HTTPResponseDecoder: HTTPDecoder<HTTPClientResponsePart>, Cha
 }
 
 /// Strategy to use when a HTTPDecoder is removed from a pipeline after a HTTP upgrade was detected.
-enum RemoveAfterUpgradeStrategy {
+public enum RemoveAfterUpgradeStrategy {
     /// Forward all the remaining bytes that are currently buffered in the deccoder to the next handler in the pipeline.
     case forwardBytes
     /// Discard all the remaining bytes that are currently buffered in the decoder.

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -15,7 +15,7 @@
 import XCTest
 import Dispatch
 import NIO
-@testable import NIOHTTP1
+import NIOHTTP1
 
 class HTTPDecoderTest: XCTestCase {
     private var channel: EmbeddedChannel!


### PR DESCRIPTION
Motivation:

d53ee6dafc4d03a342aa32e79d5d282abc0c4f1a introduced a new constructor to HTTPRequestDecoder which allows to change the behaviour of handling left over bytes when an upgrade was detected and the decoder was removed. This was done as an internal init block as we wanted to to do as part of a patch release.

Modifications:

Change internal to public init

Result:

More flexible configuration possible.