### PR TITLE
raise Ubuntu 16.04 allocation limit by 1 allocation

### DIFF
--- a/docker/docker-compose.1604.41.yaml
+++ b/docker/docker-compose.1604.41.yaml
@@ -16,7 +16,7 @@ services:
     image: swift-nio:16.04-4.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=718100
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=719100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
@@ -25,7 +25,7 @@ services:
     image: swift-nio:16.04-4.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=718100
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=719100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100


### PR DESCRIPTION
Motivation:

We knew since before that on Ubuntu 16.04 we have one more allocation
per connection that on 14.04 (presumably due to resolver differences or
something in the system). When I last updated the allocation limits
however I forgot that...

Modifications:

- raise 16.04 allocation limit by 1 allocation

Result:

- integration tests should pass on 16.04
