### PR TITLE
Rename numThreads to numberOfThreads parameter.

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -273,7 +273,7 @@ public func swiftMain() -> Int {
         return numberOfRequests
     }
 
-    let group = MultiThreadedEventLoopGroup(numThreads: System.coreCount)
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
     defer {
         try! group.syncShutdownGracefully()
     }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -17,7 +17,7 @@
 /// Example:
 ///
 /// ```swift
-///     let group = MultiThreadedEventLoopGroup(numThreads: System.coreCount)
+///     let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 ///     let bootstrap = ServerBootstrap(group: group)
 ///         // Specify backlog and enable SO_REUSEADDR for the server itself
 ///         .serverChannelOption(ChannelOptions.backlog, value: 256)
@@ -316,7 +316,7 @@ private extension Channel {
 /// Example:
 ///
 /// ```swift
-///     let group = MultiThreadedEventLoopGroup(numThreads: 1)
+///     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 ///     let bootstrap = ClientBootstrap(group: group)
 ///         // Enable SO_REUSEADDR.
 ///         .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -514,7 +514,7 @@ public final class ClientBootstrap {
 /// Example:
 ///
 /// ```swift
-///     let group = MultiThreadedEventLoopGroup(numThreads: 1)
+///     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 ///     let bootstrap = DatagramBootstrap(group: group)
 ///         // Enable SO_REUSEADDR.
 ///         .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -693,13 +693,22 @@ final public class MultiThreadedEventLoopGroup: EventLoopGroup {
         return lock.withLock { _loop }
     }
 
+    /// Creates a `MultiThreadedEventLoopGroup` instance which uses `numberOfThreads`.
+    ///
+    /// - arguments:
+    ///     - numberOfThreads: The number of `Threads` to use.
+    public convenience init(numberOfThreads: Int) {
+        let initializers: [ThreadInitializer] = Array(repeating: { _ in }, count: numberOfThreads)
+        self.init(threadInitializers: initializers)
+    }
+    
     /// Creates a `MultiThreadedEventLoopGroup` instance which uses `numThreads`.
     ///
     /// - arguments:
     ///     - numThreads: The number of `Threads` to use.
+    @available(*, deprecated, renamed: "init(numberOfThreads:)")
     public convenience init(numThreads: Int) {
-        let initializers: [ThreadInitializer] = Array(repeating: { _ in }, count: numThreads)
-        self.init(threadInitializers: initializers)
+        self.init(numberOfThreads: numThreads)
     }
 
     /// Creates a `MultiThreadedEventLoopGroup` instance which uses the given `ThreadInitializer`s. One `Thread` per `ThreadInitializer` is created and used.

--- a/Sources/NIOChatClient/main.swift
+++ b/Sources/NIOChatClient/main.swift
@@ -33,7 +33,7 @@ private final class ChatHandler: ChannelInboundHandler {
     }
 }
 
-let group = MultiThreadedEventLoopGroup(numThreads: 1)
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
     .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -113,7 +113,7 @@ final class ChatHandler: ChannelInboundHandler {
 // connected clients. For this ChatHandler MUST be thread-safe!
 let chatHandler = ChatHandler()
 
-let group = MultiThreadedEventLoopGroup(numThreads: System.coreCount)
+let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -51,7 +51,7 @@ private final class EchoHandler: ChannelInboundHandler {
     }
 }
 
-let group = MultiThreadedEventLoopGroup(numThreads: 1)
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
     .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)

--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -39,7 +39,7 @@ private final class EchoHandler: ChannelInboundHandler {
         ctx.close(promise: nil)
     }
 }
-let group = MultiThreadedEventLoopGroup(numThreads: System.coreCount)
+let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -501,7 +501,7 @@ default:
     bindTarget = BindTo.ip(host: defaultHost, port: defaultPort)
 }
 
-let group = MultiThreadedEventLoopGroup(numThreads: System.coreCount)
+let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let threadPool = BlockingIOThreadPool(numberOfThreads: 6)
 threadPool.start()
 

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -111,7 +111,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
 }
 
 
-let group = MultiThreadedEventLoopGroup(numThreads: System.coreCount)
+let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 defer {
     try! group.syncShutdownGracefully()
 }

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -196,7 +196,7 @@ private final class WebSocketTimeHandler: ChannelInboundHandler {
     }
 }
 
-let group = MultiThreadedEventLoopGroup(numThreads: 1)
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
 let upgrader = WebSocketUpgrader(shouldUpgrade: { (head: HTTPRequestHead) in HTTPHeaders() },
                                  upgradePipelineHandler: { (channel: Channel, _: HTTPRequestHead) in

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -346,7 +346,7 @@ class HTTPServerClientTest : XCTestCase {
     }
 
     private func testSimpleGet(_ mode: SendMode) throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -404,7 +404,7 @@ class HTTPServerClientTest : XCTestCase {
     }
 
     private func testSimpleGetChunkedEncoding(_ mode: SendMode) throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -461,7 +461,7 @@ class HTTPServerClientTest : XCTestCase {
     }
 
     private func testSimpleGetTrailers(_ mode: SendMode) throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -520,7 +520,7 @@ class HTTPServerClientTest : XCTestCase {
     }
 
     func testMassiveResponse(_ mode: SendMode) throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -567,7 +567,7 @@ class HTTPServerClientTest : XCTestCase {
     }
 
     func testHead() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -613,7 +613,7 @@ class HTTPServerClientTest : XCTestCase {
     }
 
     func test204() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -659,7 +659,7 @@ class HTTPServerClientTest : XCTestCase {
 
     @available(*, deprecated, message: "Tests deprecated function addHTTPServerHandlers")
     func testDeprecatedPipelineConstruction() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -128,7 +128,7 @@ private func setUpTestWithAutoremoval(pipelining: Bool = false,
                                       upgraders: [HTTPProtocolUpgrader],
                                       extraHandlers: [ChannelHandler],
                                       _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) throws -> (EventLoopGroup, Channel, Channel, Channel) {
-    let group = MultiThreadedEventLoopGroup(numThreads: 1)
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     let (serverChannel, connectedServerChannelFuture) = try serverHTTPChannelWithAutoremoval(group: group,
                                                                                              pipelining: pipelining,
                                                                                              upgraders: upgraders,

--- a/Tests/NIOTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOTests/AcceptBackoffHandlerTest.swift
@@ -43,7 +43,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
     }
 
     private func assertBackoffRead(error: Int32) throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -79,7 +79,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
     }
 
     private func assertRemoval(read: Bool) throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -113,7 +113,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
     }
 
     public func testNotScheduleReadIfAlreadyScheduled() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -145,7 +145,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
     }
 
     public func testChannelInactiveCancelScheduled() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -194,7 +194,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
     }
 
     public func testSecondErrorUpdateScheduledRead() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -20,7 +20,7 @@ class BootstrapTest: XCTestCase {
         for numThreads in [1 /* everything on one event loop */,
                            2 /* some stuff has shared event loops */,
                            5 /* everything on a different event loop */] {
-            let group = MultiThreadedEventLoopGroup(numThreads: numThreads)
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: numThreads)
             defer {
                 XCTAssertNoThrow(try group.syncShutdownGracefully())
             }

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -286,7 +286,7 @@ class ChannelNotificationTest: XCTestCase {
     }
 
     func testNotificationOrder() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -328,7 +328,7 @@ class ChannelNotificationTest: XCTestCase {
 
     func testActiveBeforeChannelRead() throws {
         // Use two EventLoops to ensure the ServerSocketChannel and the SocketChannel are on different threads.
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -85,7 +85,7 @@ class ChannelLifecycleHandler: ChannelInboundHandler {
 
 public class ChannelTests: XCTestCase {
     func testBasicLifecycle() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -123,7 +123,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testManyManyWrites() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -152,7 +152,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testWritevLotsOfData() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -183,7 +183,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testParentsOfSocketChannels() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1056,7 +1056,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testSpecificConnectTimeout() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1081,7 +1081,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testGeneralConnectTimeout() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1106,7 +1106,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testCloseOutput() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1162,7 +1162,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testCloseInput() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1225,7 +1225,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testHalfClosure() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1329,7 +1329,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testRejectsInvalidData() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1369,7 +1369,7 @@ public class ChannelTests: XCTestCase {
         weak var weakServerChannel: Channel? = nil
         weak var weakServerChildChannel: Channel? = nil
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1428,7 +1428,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testAskForLocalAndRemoteAddressesAfterChannelIsClosed() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1458,7 +1458,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testReceiveAddressAfterAccept() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1531,7 +1531,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1572,7 +1572,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testNoChannelReadBeforeEOFIfNoAutoRead() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1617,7 +1617,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testCloseInEOFdChannelReadBehavesCorrectly() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1672,7 +1672,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testCloseInSameReadThatEOFGetsDelivered() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1724,7 +1724,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testEOFReceivedWithoutReadRequests() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1834,7 +1834,7 @@ public class ChannelTests: XCTestCase {
         }
 
         func runTest() throws {
-            let group = MultiThreadedEventLoopGroup(numThreads: System.coreCount)
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
             defer {
                 XCTAssertNoThrow(try group.syncShutdownGracefully())
             }
@@ -1915,7 +1915,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1986,7 +1986,7 @@ public class ChannelTests: XCTestCase {
                 XCTFail("unexpected error \(error)", file: file, line: line)
             }
         }
-        let elg = MultiThreadedEventLoopGroup(numThreads: 1)
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
         func withChannel(skipDatagram: Bool = false, skipStream: Bool = false, skipServerSocket: Bool = false, file: StaticString = #file, line: UInt = #line,  _ body: (Channel) throws -> Void) {
             XCTAssertNoThrow(try {
@@ -2100,7 +2100,7 @@ public class ChannelTests: XCTestCase {
                 self.allDone.succeed(result: ())
             }
         }
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2157,7 +2157,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2203,7 +2203,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2239,7 +2239,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testConnectWithECONNREFUSEDGetsTheRightError() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2276,7 +2276,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2318,7 +2318,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testLazyRegistrationWorksForServerSockets() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2338,7 +2338,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testLazyRegistrationWorksForClientSockets() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2362,7 +2362,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testFailedRegistrationOfClientSocket() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2386,7 +2386,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testFailedRegistrationOfAcceptedSocket() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2405,7 +2405,7 @@ public class ChannelTests: XCTestCase {
     }
 
     func testFailedRegistrationOfServerSocket() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -2427,7 +2427,7 @@ public class ChannelTests: XCTestCase {
     func testTryingToBindOnPortThatIsAlreadyBoundFailsButDoesNotCrash() throws {
         // this is a regression test for #417
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -98,7 +98,7 @@ final class DatagramChannelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        self.group = MultiThreadedEventLoopGroup(numThreads: 1)
+        self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.firstChannel = try! buildChannel(group: group)
         self.secondChannel = try! buildChannel(group: group)
     }
@@ -380,7 +380,7 @@ final class DatagramChannelTests: XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -35,7 +35,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testEcho() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -71,7 +71,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testLotsOfUnflushedWrites() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -104,7 +104,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testEchoUnixDomainSocket() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -147,7 +147,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testConnectUnixDomainSocket() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -189,7 +189,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testChannelActiveOnConnect() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -215,7 +215,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testWriteThenRead() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -406,7 +406,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testCloseInInactive() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
             defer {
                 XCTAssertNoThrow(try group.syncShutdownGracefully())
             }
@@ -440,7 +440,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testFlushOnEmpty() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -485,7 +485,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testWriteOnConnect() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -518,7 +518,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testWriteOnAccept() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -550,7 +550,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testWriteAfterChannelIsDead() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let dpGroup = DispatchGroup()
 
         dpGroup.enter()
@@ -587,7 +587,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testPendingReadProcessedAfterWriteError() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let dpGroup = DispatchGroup()
 
         dpGroup.enter()
@@ -703,7 +703,7 @@ class EchoServerClientTest : XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -730,7 +730,7 @@ class EchoServerClientTest : XCTestCase {
     func testPortNumbers() throws {
         var atLeastOneSucceeded = false
         for host in ["127.0.0.1", "::1"] {
-            let group = MultiThreadedEventLoopGroup(numThreads: 1)
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
             defer {
                 XCTAssertNoThrow(try group.syncShutdownGracefully())
             }
@@ -781,7 +781,7 @@ class EchoServerClientTest : XCTestCase {
     }
 
     func testConnectingToIPv4And6ButServerOnlyWaitsOnIPv4() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -35,7 +35,7 @@ class EventLoopFutureTest : XCTestCase {
 
     func testFoldWithMultipleEventLoops() throws {
         let nThreads = 3
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: nThreads)
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: nThreads)
         defer {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
@@ -440,7 +440,7 @@ class EventLoopFutureTest : XCTestCase {
 
     func testReduceIntoWithMultipleEventLoops() throws {
         let nThreads = 3
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: nThreads)
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: nThreads)
         defer {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
@@ -579,7 +579,7 @@ class EventLoopFutureTest : XCTestCase {
 
     func testEventLoopHoppingInThen() throws {
         let n = 20
-        let elg = MultiThreadedEventLoopGroup(numThreads: n)
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
         var prev: EventLoopFuture<Int> = elg.next().newSucceededFuture(result: 0)
         (1..<20).forEach { (i: Int) in
             let p: EventLoopPromise<Int> = elg.next().newPromise()
@@ -601,7 +601,7 @@ class EventLoopFutureTest : XCTestCase {
             case dummy
         }
         let n = 20
-        let elg = MultiThreadedEventLoopGroup(numThreads: n)
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
         var prev: EventLoopFuture<Int> = elg.next().newSucceededFuture(result: 0)
         (1..<n).forEach { (i: Int) in
             let p: EventLoopPromise<Int> = elg.next().newPromise()
@@ -634,7 +634,7 @@ class EventLoopFutureTest : XCTestCase {
 
     func testEventLoopHoppingAndAll() throws {
         let n = 20
-        let elg = MultiThreadedEventLoopGroup(numThreads: n)
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
         let ps = (0..<n).map { (_: Int) -> EventLoopPromise<Void> in
             elg.next().newPromise()
         }
@@ -651,8 +651,8 @@ class EventLoopFutureTest : XCTestCase {
     func testEventLoopHoppingAndAllWithFailures() throws {
         enum DummyError: Error { case dummy }
         let n = 20
-        let fireBackEl = MultiThreadedEventLoopGroup(numThreads: 1)
-        let elg = MultiThreadedEventLoopGroup(numThreads: n)
+        let fireBackEl = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
         let ps = (0..<n).map { (_: Int) -> EventLoopPromise<Void> in
             elg.next().newPromise()
         }
@@ -680,7 +680,7 @@ class EventLoopFutureTest : XCTestCase {
 
     func testFutureInVariousScenarios() throws {
         enum DummyError: Error { case dummy0; case dummy1 }
-        let elg = MultiThreadedEventLoopGroup(numThreads: 2)
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         let el1 = elg.next()
         let el2 = elg.next()
         precondition(el1 !== el2)
@@ -772,7 +772,7 @@ class EventLoopFutureTest : XCTestCase {
     }
 
     func testLoopHoppingHelperSuccess() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -791,7 +791,7 @@ class EventLoopFutureTest : XCTestCase {
     }
 
     func testLoopHoppingHelperFailure() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -815,7 +815,7 @@ class EventLoopFutureTest : XCTestCase {
     }
 
     func testLoopHoppingHelperNoHopping() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -21,7 +21,7 @@ public class EventLoopTest : XCTestCase {
     public func testSchedule() throws {
         let nanos = DispatchTime.now().uptimeNanoseconds
         let amount: TimeAmount = .seconds(1)
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
@@ -36,7 +36,7 @@ public class EventLoopTest : XCTestCase {
     public func testScheduleWithDelay() throws {
         let smallAmount: TimeAmount = .milliseconds(100)
         let longAmount: TimeAmount = .seconds(1)
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
@@ -69,7 +69,7 @@ public class EventLoopTest : XCTestCase {
     }
 
     public func testScheduleCancelled() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
@@ -96,7 +96,7 @@ public class EventLoopTest : XCTestCase {
         // Do not ignore intermittent failures in this test!
         let threads = 8
         let numBytes = 256
-        let group = MultiThreadedEventLoopGroup(numThreads: threads)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: threads)
 
         // Create a server channel.
         let serverChannel = try ServerBootstrap(group: group)
@@ -162,7 +162,7 @@ public class EventLoopTest : XCTestCase {
         let promiseQueue = DispatchQueue(label: "promiseQueue")
         var promises: [EventLoopPromise<Void>] = []
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             do {
                 try group.syncShutdownGracefully()
@@ -281,7 +281,7 @@ public class EventLoopTest : XCTestCase {
         }
 
         func assertCurrentEventLoop0() throws -> EventLoopHolder {
-            let group = MultiThreadedEventLoopGroup(numThreads: 2)
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
 
             let loop1 = group.next()
             let currentLoop1 = try loop1.submit {
@@ -317,7 +317,7 @@ public class EventLoopTest : XCTestCase {
     }
 
     public func testShutdownWhileScheduledTasksNotReady() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = group.next()
         _ = eventLoop.scheduleTask(in: .hours(1)) { }
         try group.syncShutdownGracefully()
@@ -336,7 +336,7 @@ public class EventLoopTest : XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = group.next()
         let assertHandler = AssertHandler()
         let serverSocket = try ServerBootstrap(group: group).bind(host: "localhost", port: 0).wait()
@@ -358,7 +358,7 @@ public class EventLoopTest : XCTestCase {
     public func testScheduleMultipleTasks() throws {
         let nanos = DispatchTime.now().uptimeNanoseconds
         let amount: TimeAmount = .seconds(1)
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -18,7 +18,7 @@ import XCTest
 class FileRegionTest : XCTestCase {
 
     func testWriteFileRegion() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -62,7 +62,7 @@ class FileRegionTest : XCTestCase {
     }
 
     func testWriteEmptyFileRegionDoesNotHang() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -101,7 +101,7 @@ class FileRegionTest : XCTestCase {
     }
 
     func testOutstandingFileRegionsWork() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/GetAddrInfoResolverTest.swift
+++ b/Tests/NIOTests/GetAddrInfoResolverTest.swift
@@ -18,7 +18,7 @@ import XCTest
 class GetaddrinfoResolverTest: XCTestCase {
 
     func testResolveNoDuplicatesV4() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -35,7 +35,7 @@ class GetaddrinfoResolverTest: XCTestCase {
     }
 
     func testResolveNoDuplicatesV6() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -34,7 +34,7 @@ class IdleStateHandlerTest : XCTestCase {
     }
 
     private func testIdle(_ handler: IdleStateHandler, _ writeToChannel: Bool, _ assertEventFn: @escaping (IdleStateHandler.IdleStateEvent) -> Bool) throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -25,7 +25,7 @@ class NonBlockingFileIOTest: XCTestCase {
     override func setUp() {
         super.setUp()
         self.allocator = ByteBufferAllocator()
-        self.group = MultiThreadedEventLoopGroup(numThreads: 1)
+        self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.threadPool = BlockingIOThreadPool(numberOfThreads: 6)
         self.threadPool.start()
         self.fileIO = NonBlockingFileIO(threadPool: threadPool)

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -328,7 +328,7 @@ class SelectorTest: XCTestCase {
                 }
             }
         }
-        let el = MultiThreadedEventLoopGroup(numThreads: 1).next()
+        let el = MultiThreadedEventLoopGroup(numberOfThreads: 1).next()
         defer {
             XCTAssertNoThrow(try el.syncShutdownGracefully())
         }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -30,7 +30,7 @@ private extension Array {
 public class SocketChannelTest : XCTestCase {
     /// Validate that channel options are applied asynchronously.
     public func testAsyncSetOption() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 2)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         // Create two channels with different event loops.
@@ -63,7 +63,7 @@ public class SocketChannelTest : XCTestCase {
     }
 
     public func testDelayedConnectSetsUpRemotePeerAddress() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverChannel = try ServerBootstrap(group: group)
@@ -140,7 +140,7 @@ public class SocketChannelTest : XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -170,7 +170,7 @@ public class SocketChannelTest : XCTestCase {
     }
 
     public func testSetGetOptionClosedServerSocketChannel() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         // Create two channels with different event loops.
@@ -197,7 +197,7 @@ public class SocketChannelTest : XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -235,7 +235,7 @@ public class SocketChannelTest : XCTestCase {
     }
 
     public func testWriteServerSocketChannel() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
@@ -250,7 +250,7 @@ public class SocketChannelTest : XCTestCase {
 
 
     public func testWriteAndFlushServerSocketChannel() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
@@ -264,7 +264,7 @@ public class SocketChannelTest : XCTestCase {
 
 
     public func testConnectServerSocketChannel() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
@@ -281,7 +281,7 @@ public class SocketChannelTest : XCTestCase {
     }
 
     public func testCloseDuringWriteFailure() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
@@ -311,7 +311,7 @@ public class SocketChannelTest : XCTestCase {
     }
 
     public func testWithConfiguredStreamSocket() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverSock = try Socket(protocolFamily: AF_INET, type: Posix.SOCK_STREAM)
@@ -338,7 +338,7 @@ public class SocketChannelTest : XCTestCase {
     }
 
     public func testWithConfiguredDatagramSocket() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverSock = try Socket(protocolFamily: AF_INET, type: Posix.SOCK_DGRAM)
@@ -389,7 +389,7 @@ public class SocketChannelTest : XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverChannel = try ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
@@ -491,7 +491,7 @@ public class SocketChannelTest : XCTestCase {
             }
         }
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let handler = AddressVerificationHandler(promise: group.next().newPromise())


### PR DESCRIPTION
Motivation:

We should be consistent with naming and also choose descriptive names.

Modifications:

- Deprecate old init method that uses numThreads
- Add new init with numberOfThreads param name
- Everywhere use the new init

Result:

More consistent and descriptive naming. Fixes https://github.com/apple/swift-nio/issues/432.
