### PR TITLE
make _UInt24 and _UInt56 printable

### DIFF
--- a/Sources/NIO/IntegerTypes.swift
+++ b/Sources/NIO/IntegerTypes.swift
@@ -72,6 +72,12 @@ extension _UInt24: Equatable {
     }
 }
 
+extension _UInt24: CustomStringConvertible {
+    var description: String {
+        return Int(self).description
+    }
+}
+
 // MARK: _UInt56
 
 /// A 56-bit unsigned integer value type.
@@ -133,5 +139,11 @@ extension Int {
 extension _UInt56: Equatable {
     static func ==(_ lhs: _UInt56, _ rhs: _UInt56) -> Bool {
         return lhs.b1234 == rhs.b1234 && lhs.b56 == rhs.b56 && lhs.b7 == rhs.b7
+    }
+}
+
+extension _UInt56: CustomStringConvertible {
+    var description: String {
+        return UInt64(self).description
     }
 }

--- a/Tests/NIOTests/IntegerTypesTest+XCTest.swift
+++ b/Tests/NIOTests/IntegerTypesTest+XCTest.swift
@@ -32,6 +32,8 @@ extension IntegerTypesTest {
                 ("testNextPowerOfTwoOfThree", testNextPowerOfTwoOfThree),
                 ("testNextPowerOfTwoOfFour", testNextPowerOfTwoOfFour),
                 ("testNextPowerOfTwoOfFive", testNextPowerOfTwoOfFive),
+                ("testDescriptionUInt24", testDescriptionUInt24),
+                ("testDescriptionUInt56", testDescriptionUInt56),
            ]
    }
 }

--- a/Tests/NIOTests/IntegerTypesTest.swift
+++ b/Tests/NIOTests/IntegerTypesTest.swift
@@ -81,4 +81,20 @@ public class IntegerTypesTest: XCTestCase {
         XCTAssertEqual(8, (5 as Int32).nextPowerOf2())
         XCTAssertEqual(8, (5 as Int64).nextPowerOf2())
     }
+
+    func testDescriptionUInt24() {
+        XCTAssertEqual("0", _UInt24.min.description)
+        XCTAssertEqual("16777215", _UInt24.max.description)
+        XCTAssertEqual("12345678", _UInt24(12345678).description)
+        XCTAssertEqual("1", _UInt24(1).description)
+        XCTAssertEqual("8388608", _UInt24(1 << 23).description)
+    }
+
+    func testDescriptionUInt56() {
+        XCTAssertEqual("0", _UInt56.min.description)
+        XCTAssertEqual("72057594037927935", _UInt56.max.description)
+        XCTAssertEqual("12345678901234567", _UInt56(12345678901234567 as UInt64).description)
+        XCTAssertEqual("1", _UInt56(1).description)
+        XCTAssertEqual("36028797018963968", _UInt56(1 << 55).description)
+    }
 }


### PR DESCRIPTION
Motivation:

_UInt24 and _UInt56 didn't have a CustomStringConvertible conformance
which this patch is adding.

Modifications:

add CustomStringConvertible instances.

Result:

easier to debug stuff
