### PR TITLE
fix threading in testUpgradeWithUpgradePayloadInlineWithRequestWorks

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -894,9 +894,13 @@ class HTTPUpgradeTestCase: XCTestCase {
             upgraderCbFired = true
         }
         
-        let firstByteDonePromise: EventLoopPromise<Void> = EmbeddedEventLoop().newPromise()
-        let secondByteDonePromise: EventLoopPromise<Void> = EmbeddedEventLoop().newPromise()
-        let allDonePromise: EventLoopPromise<Void> = EmbeddedEventLoop().newPromise()
+        let promiseGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try promiseGroup.syncShutdownGracefully())
+        }
+        let firstByteDonePromise: EventLoopPromise<Void> = promiseGroup.next().newPromise()
+        let secondByteDonePromise: EventLoopPromise<Void> = promiseGroup.next().newPromise()
+        let allDonePromise: EventLoopPromise<Void> = promiseGroup.next().newPromise()
         let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
                                                                                     extraHandlers: []) { (ctx) in
                                                                                         // This is called before the upgrader gets called.


### PR DESCRIPTION
Motivation:

testUpgradeWithUpgradePayloadInlineWithRequestWorks used the
EmbeddedEventLoop to allocate some futures but setUpTestWithAutoremoval
spawns a MultiThreadedEventLoopGroup. Hence, threading was broken in the
test and this PR fixes it.

Modifications:

use a MultiThreadedEventLoopGroup instead of an EmbeddedEventLoop

Result:

tests pass in TSan again
