### PR TITLE
silence warning

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -55,7 +55,7 @@ class HTTPDecoderLengthTest: XCTestCase {
 
     override func setUp() {
         self.channel = EmbeddedChannel()
-        self.loop = channel.eventLoop as! EmbeddedEventLoop
+        self.loop = (channel.eventLoop as! EmbeddedEventLoop)
     }
 
     override func tearDown() {

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -23,7 +23,7 @@ class HTTPDecoderTest: XCTestCase {
 
     override func setUp() {
         self.channel = EmbeddedChannel()
-        self.loop = channel.eventLoop as! EmbeddedEventLoop
+        self.loop = (channel.eventLoop as! EmbeddedEventLoop)
     }
 
     override func tearDown() {


### PR DESCRIPTION
Motivation:

Swift has a rather unhelpful warning

    warning: treating a forced downcast to 'EmbeddedEventLoop' as optional will never produce 'nil'

when assigning that to a variable of type `EmbeddedEventLoop!`. The
warning is accurate but obviously we know that can never be `nil`. The
way to silence this warning is to put parenthesis around the expression.

Modifications:

added parenthesis around force casts that are assigned to IUOs

Result:

fewer warnings with 4.2
