### PR TITLE
improve BlockingIOThreadPool docs

### DIFF
--- a/Sources/NIO/BlockingIOThreadPool.swift
+++ b/Sources/NIO/BlockingIOThreadPool.swift
@@ -16,7 +16,21 @@ import Dispatch
 import NIOConcurrencyHelpers
 
 
-/// A thread pool that should be used for blocking IO.
+/// A thread pool that should be used if some (kernel thread) blocking work
+/// needs to be performed for which no non-blocking API exists.
+///
+/// When using NIO it is crucial not to block any of the `EventLoop`s as that
+/// leads to slow downs or stalls of arbitrary other work. Unfortunately though
+/// there are tasks that applications need to achieve for which no non-blocking
+/// APIs exist. In those cases `BlockingIOThreadPool` can be used but should be
+/// treated as a last resort.
+///
+/// - note: The prime example for missing non-blocking APIs is file IO on UNIX.
+///   The OS does not provide a usable and truly non-blocking API but with
+///   `NonBlockingFileIO` NIO provides a high-level API for file IO that should
+///   be preferred to running blocking file IO system calls directly on
+///   `BlockingIOThreadPool`. Under the covers `NonBlockingFileIO` will use
+///   `BlockingIOThreadPool` on all currently supported platforms though.
 public final class BlockingIOThreadPool {
 
     /// The state of the `WorkItem`.


### PR DESCRIPTION
Motivation:

The BlockingIOThreadPool were very sparse which is improved here.

Modifications:

The existing docs didn't really help much if you didn't already know why
you'd need an extra thread pool for blocking work.

Result:

docs more clear on when to use BlockingIOThreadPool
