### PR TITLE
Support faster copying of potentially discontiguous data.

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -255,6 +255,20 @@ extension ByteBuffer {
         return written
     }
 
+    /// Write `compositeBytes`, a `CompositeCollection` of `UInt8` into this `ByteBuffer`. Moves the writer index forward by the number of bytes written.
+    /// This method is likely more efficient than the one operating on plain `Collection` as it will use `memcpy` to copy as many bytes as possible in one go.
+    ///
+    /// - parameters:
+    ///     - bytes: A `CompositeCollection` of `UInt8` to be written.
+    /// - returns: The number of bytes written or `bytes.count`.
+    @discardableResult
+    @_inlineable
+    public mutating func write<S: CompositeCollection>(compositeBytes: S) -> Int where S.Element == UInt8 {
+        let written = self.set(compositeBytes: compositeBytes, at: self.writerIndex)
+        self._moveWriterIndex(forwardBy: written)
+        return written
+    }
+
     /// Slice the readable bytes off this `ByteBuffer` without modifying the reader index. This method will return a
     /// `ByteBuffer` sharing the underlying storage with the `ByteBuffer` the method was invoked on. The returned
     /// `ByteBuffer` will contain the bytes in the range `readerIndex..<writerIndex` of the original `ByteBuffer`.

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -14,6 +14,7 @@
 
 import NIO
 import struct Foundation.Data
+import struct Dispatch.DispatchData
 
 /*
  * This is NIO's `NIOFoundationCompat` module which at the moment only adds `ByteBuffer` utility methods
@@ -35,6 +36,20 @@ extension Data: ContiguousCollection {
         return try self.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> R in
             try body(UnsafeRawBufferPointer(start: ptr, count: self.count))
         }
+    }
+}
+
+extension Data: CompositeCollection {
+    @_inlineable
+    public func forEachContiguousByteChunk(_ block: (UnsafeBufferPointer<UInt8>) -> Void) {
+        self.enumerateBytes { srcPtr, _, _ in block(srcPtr) }
+    }
+}
+
+extension DispatchData: CompositeCollection {
+    @_inlineable
+    public func forEachContiguousByteChunk(_ block: (UnsafeBufferPointer<UInt8>) -> Void) {
+        self.enumerateBytes { srcPtr, _, _ in block(srcPtr) }
     }
 }
 

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -123,6 +123,8 @@ extension ByteBufferTest {
                 ("testBytesView", testBytesView),
                 ("testViewsStartIndexIsStable", testViewsStartIndexIsStable),
                 ("testSlicesOfByteBufferViewsAreByteBufferViews", testSlicesOfByteBufferViewsAreByteBufferViews),
+                ("testCopyingDispatchDatas", testCopyingDispatchDatas),
+                ("testCopyingContiguousDataAsIfItWereDiscontiguous", testCopyingContiguousDataAsIfItWereDiscontiguous),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Data and DispatchData have the potential of being discontiguous:
hiding the fact that they're made up of multiple contiguous chunks of
memory where each of those chunks is separated from the rest.

Currently these are copied in less-efficient mechanisms. Data is copied
via ContiguousCollection: while some Datas are, if the Data is
non-contiguous then ContiguousCollection will actually copy each byte
twice: once to make them contiguous, and then again to move them into the
ByteBuffer.

DispatchData, on the other hand, is treated like any other Sequence of
bytes, which potentially leads to extremely poor copying times, even
though a DispatchData could usually be copied in a small number of memcpy
calls.

This patch improves performance when writing these data types by using their
enumerateBytes methods to obtain a view of what chunks of their memory are
contiguous.

Modifications:

Defined a new CompositeCollection protocol.
Conformed Data and DispatchData to that protocol.
Implemented new ByteBuffer.set(compositeBytes:at:) and ByteBuffer.write(compositeBytes:at:) methods.

Result:

Improved performance when writing Data and DispatchData types.
