### PR TITLE
Nil NIOHTTP1Server dynamic handlers

### DIFF
--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -388,6 +388,7 @@ private final class HTTPHandler: ChannelInboundHandler {
         if !self.keepAlive {
             promise!.futureResult.whenComplete { ctx.close(promise: nil) }
         }
+        self.handler = nil
 
         ctx.writeAndFlush(self.wrapOutboundOut(.end(trailers)), promise: promise)
     }


### PR DESCRIPTION
Fixes: #450

Make `NIOHTTP1Server` dynamic handlers non-sticky

### Motivation:

The server attaches a dynamic handler to requests and will keep passing data until the handlers are removed; which never happens.

### Modifications:

`nil` out the `handler` when `completeResponse` is called.

### Result:

When connections are reused we now get the correct dynamic handler for it instead of the previous one.
