### PR TITLE
Replaced @_inlineable and @_versioned with @usableFromInline

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -149,7 +149,7 @@ extension ByteBuffer {
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and returns the number of bytes it processed.
     /// - returns: The number of bytes read.
-    @_inlineable
+    @inlinable
     public mutating func readWithUnsafeReadableBytes(_ body: (UnsafeRawBufferPointer) throws -> Int) rethrows -> Int {
         let bytesRead = try self.withUnsafeReadableBytes(body)
         self._moveReaderIndex(forwardBy: bytesRead)
@@ -164,7 +164,7 @@ extension ByteBuffer {
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and returns the number of bytes it processed along with some other value.
     /// - returns: The value `fn` returned in the second tuple component.
-    @_inlineable
+    @inlinable
     public mutating func readWithUnsafeReadableBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> (Int, T)) rethrows -> T {
         let (bytesRead, ret) = try self.withUnsafeReadableBytes(body)
         self._moveReaderIndex(forwardBy: bytesRead)
@@ -179,7 +179,7 @@ extension ByteBuffer {
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and returns the number of bytes it processed.
     /// - returns: The number of bytes read.
-    @_inlineable
+    @inlinable
     public mutating func readWithUnsafeMutableReadableBytes(_ body: (UnsafeMutableRawBufferPointer) throws -> Int) rethrows -> Int {
         let bytesRead = try self.withUnsafeMutableReadableBytes(body)
         self._moveReaderIndex(forwardBy: bytesRead)
@@ -194,7 +194,7 @@ extension ByteBuffer {
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and returns the number of bytes it processed along with some other value.
     /// - returns: The value `fn` returned in the second tuple component.
-    @_inlineable
+    @inlinable
     public mutating func readWithUnsafeMutableReadableBytes<T>(_ body: (UnsafeMutableRawBufferPointer) throws -> (Int, T)) rethrows -> T {
         let (bytesRead, ret) = try self.withUnsafeMutableReadableBytes(body)
         self._moveReaderIndex(forwardBy: bytesRead)
@@ -234,7 +234,7 @@ extension ByteBuffer {
     ///     - bytes: A `Collection` of `UInt8` to be written.
     /// - returns: The number of bytes written or `bytes.count`.
     @discardableResult
-    @_inlineable
+    @inlinable
     public mutating func write<S: Sequence>(bytes: S) -> Int where S.Element == UInt8 {
         let written = set(bytes: bytes, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
@@ -248,7 +248,7 @@ extension ByteBuffer {
     ///     - bytes: A `ContiguousCollection` of `UInt8` to be written.
     /// - returns: The number of bytes written or `bytes.count`.
     @discardableResult
-    @_inlineable
+    @inlinable
     public mutating func write<S: ContiguousCollection>(bytes: S) -> Int where S.Element == UInt8 {
         let written = set(bytes: bytes, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)

--- a/Sources/NIO/ByteBuffer-int.swift
+++ b/Sources/NIO/ByteBuffer-int.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 extension ByteBuffer {
-    @_inlineable @_versioned
+    @usableFromInline
     func _toEndianness<T: FixedWidthInteger> (value: T, endianness: Endianness) -> T {
         switch endianness {
         case .little:
@@ -29,7 +29,7 @@ extension ByteBuffer {
     ///     - endianness: The endianness of the integer in this `ByteBuffer` (defaults to big endian).
     ///     - as: the desired `FixedWidthInteger` type (optional parameter)
     /// - returns: An integer value deserialized from this `ByteBuffer` or `nil` if there aren't enough bytes readable.
-    @_inlineable
+    @inlinable
     public mutating func readInteger<T: FixedWidthInteger>(endianness: Endianness = .big, as: T.Type = T.self) -> T? {
         guard self.readableBytes >= MemoryLayout<T>.size else {
             return nil
@@ -47,7 +47,7 @@ extension ByteBuffer {
     ///     - endianness: The endianness of the integer in this `ByteBuffer` (defaults to big endian).
     ///     - as: the desired `FixedWidthInteger` type (optional parameter)
     /// - returns: An integer value deserialized from this `ByteBuffer` or `nil` if the bytes of interest aren't contained in the `ByteBuffer`.
-    @_inlineable
+    @inlinable
     public func getInteger<T: FixedWidthInteger>(at index: Int, endianness: Endianness = Endianness.big, as: T.Type = T.self) -> T? {
         precondition(index >= 0, "index must not be negative")
         return self.withVeryUnsafeBytes { ptr in
@@ -70,7 +70,7 @@ extension ByteBuffer {
     ///     - endianness: The endianness to use, defaults to big endian.
     /// - returns: The number of bytes written.
     @discardableResult
-    @_inlineable
+    @inlinable
     public mutating func write<T: FixedWidthInteger>(integer: T, endianness: Endianness = .big, as: T.Type = T.self) -> Int {
         let bytesWritten = self.set(integer: integer, at: self.writerIndex, endianness: endianness)
         self._moveWriterIndex(forwardBy: bytesWritten)
@@ -85,7 +85,7 @@ extension ByteBuffer {
     ///     - endianness: The endianness to use, defaults to big endian.
     /// - returns: The number of bytes written.
     @discardableResult
-    @_inlineable
+    @inlinable
     public mutating func set<T: FixedWidthInteger>(integer: T, at index: Int, endianness: Endianness = .big, as: T.Type = T.self) -> Int {
         var value = _toEndianness(value: integer, endianness: endianness)
         return Swift.withUnsafeBytes(of: &value) { ptr in

--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -269,7 +269,7 @@ public extension ChannelCore {
     ///     - data: The `NIOAny` to unwrap.
     ///     - as: The type to extract from the `NIOAny`.
     /// - returns: The content of the `NIOAny`.
-    @_inlineable
+    @inlinable
     public func unwrapData<T>(_ data: NIOAny, as: T.Type = T.self) -> T {
         return data.forceAs()
     }

--- a/Sources/NIO/IntegerTypes.swift
+++ b/Sources/NIO/IntegerTypes.swift
@@ -15,12 +15,12 @@
 // MARK: _UInt24
 
 /// A 24-bit unsigned integer value type.
-@_versioned
+@usableFromInline
 struct _UInt24: ExpressibleByIntegerLiteral {
     typealias IntegerLiteralType = UInt16
 
-    @_versioned var b12: UInt16
-    @_versioned var b3: UInt8
+    @usableFromInline var b12: UInt16
+    @usableFromInline var b3: UInt8
 
     private init(b12: UInt16, b3: UInt8) {
         self.b12 = b12
@@ -84,9 +84,9 @@ extension _UInt24: CustomStringConvertible {
 struct _UInt56: ExpressibleByIntegerLiteral {
     typealias IntegerLiteralType = UInt32
 
-    @_versioned var b1234: UInt32
-    @_versioned var b56: UInt16
-    @_versioned var b7: UInt8
+    @usableFromInline var b1234: UInt32
+    @usableFromInline var b56: UInt16
+    @usableFromInline var b7: UInt8
 
     private init(b1234: UInt32, b56: UInt16, b7: UInt8) {
         self.b1234 = b1234

--- a/Sources/NIO/NIOAny.swift
+++ b/Sources/NIO/NIOAny.swift
@@ -43,24 +43,24 @@
 ///         }
 ///     }
 public struct NIOAny {
-    @_versioned
+    @usableFromInline
     /* private but _versioned */ let _storage: _NIOAny
 
     /// Wrap a value in a `NIOAny`. In most cases you should not create a `NIOAny` directly using this constructor.
     /// The abstraction that accepts values of type `NIOAny` must also provide a mechanism to do the wrapping. An
     /// example is a `ChannelInboundHandler` which provides `self.wrapInboundOut(aValueOfTypeInboundOut)`.
-    @_inlineable
+    @inlinable
     public init<T>(_ value: T) {
         self._storage = _NIOAny(value)
     }
 
-    @_versioned
+    @usableFromInline
     enum _NIOAny {
         case ioData(IOData)
         case bufferEnvelope(AddressedEnvelope<ByteBuffer>)
         case other(Any)
 
-        @_inlineable @_versioned
+        @usableFromInline
         init<T>(_ value: T) {
             switch value {
             case let value as ByteBuffer:
@@ -81,7 +81,7 @@ public struct NIOAny {
     /// Try unwrapping the wrapped message as `ByteBuffer`.
     ///
     /// returns: The wrapped `ByteBuffer` or `nil` if the wrapped message is not a `ByteBuffer`.
-    @_versioned @_inlineable
+    @usableFromInline
     func tryAsByteBuffer() -> ByteBuffer? {
         if case .ioData(.byteBuffer(let bb)) = self._storage {
             return bb
@@ -93,7 +93,7 @@ public struct NIOAny {
     /// Force unwrapping the wrapped message as `ByteBuffer`.
     ///
     /// returns: The wrapped `ByteBuffer` or crash if the wrapped message is not a `ByteBuffer`.
-    @_versioned @_inlineable
+    @usableFromInline
     func forceAsByteBuffer() -> ByteBuffer {
         if let v = tryAsByteBuffer() {
             return v
@@ -105,7 +105,7 @@ public struct NIOAny {
     /// Try unwrapping the wrapped message as `IOData`.
     ///
     /// returns: The wrapped `IOData` or `nil` if the wrapped message is not a `IOData`.
-    @_versioned @_inlineable
+    @usableFromInline
     func tryAsIOData() -> IOData? {
         if case .ioData(let data) = self._storage {
             return data
@@ -117,7 +117,7 @@ public struct NIOAny {
     /// Force unwrapping the wrapped message as `IOData`.
     ///
     /// returns: The wrapped `IOData` or crash if the wrapped message is not a `IOData`.
-    @_versioned @_inlineable
+    @usableFromInline
     func forceAsIOData() -> IOData {
         if let v = tryAsIOData() {
             return v
@@ -129,7 +129,7 @@ public struct NIOAny {
     /// Try unwrapping the wrapped message as `FileRegion`.
     ///
     /// returns: The wrapped `FileRegion` or `nil` if the wrapped message is not a `FileRegion`.
-    @_versioned @_inlineable
+    @usableFromInline
     func tryAsFileRegion() -> FileRegion? {
         if case .ioData(.fileRegion(let f)) = self._storage {
             return f
@@ -141,7 +141,7 @@ public struct NIOAny {
     /// Force unwrapping the wrapped message as `FileRegion`.
     ///
     /// returns: The wrapped `FileRegion` or crash if the wrapped message is not a `FileRegion`.
-    @_versioned @_inlineable
+    @usableFromInline
     func forceAsFileRegion() -> FileRegion {
         if let v = tryAsFileRegion() {
             return v
@@ -153,7 +153,7 @@ public struct NIOAny {
     /// Try unwrapping the wrapped message as `AddressedEnvelope<ByteBuffer>`.
     ///
     /// returns: The wrapped `AddressedEnvelope<ByteBuffer>` or `nil` if the wrapped message is not an `AddressedEnvelope<ByteBuffer>`.
-    @_versioned @_inlineable
+    @usableFromInline
     func tryAsByteEnvelope() -> AddressedEnvelope<ByteBuffer>? {
         if case .bufferEnvelope(let e) = self._storage {
             return e
@@ -165,7 +165,7 @@ public struct NIOAny {
     /// Force unwrapping the wrapped message as `AddressedEnvelope<ByteBuffer>`.
     ///
     /// returns: The wrapped `AddressedEnvelope<ByteBuffer>` or crash if the wrapped message is not an `AddressedEnvelope<ByteBuffer>`.
-    @_versioned @_inlineable
+    @usableFromInline
     func forceAsByteEnvelope() -> AddressedEnvelope<ByteBuffer> {
         if let e = tryAsByteEnvelope() {
             return e
@@ -177,7 +177,7 @@ public struct NIOAny {
     /// Try unwrapping the wrapped message as `T`.
     ///
     /// returns: The wrapped `T` or `nil` if the wrapped message is not a `T`.
-    @_versioned @_inlineable
+    @usableFromInline
     func tryAsOther<T>(type: T.Type = T.self) -> T? {
         if case .other(let any) = self._storage {
             return any as? T
@@ -189,7 +189,7 @@ public struct NIOAny {
     /// Force unwrapping the wrapped message as `T`.
     ///
     /// returns: The wrapped `T` or crash if the wrapped message is not a `T`.
-    @_versioned @_inlineable
+    @usableFromInline
     func forceAsOther<T>(type: T.Type = T.self) -> T {
         if let v = tryAsOther(type: type) {
             return v
@@ -201,7 +201,7 @@ public struct NIOAny {
     /// Force unwrapping the wrapped message as `T`.
     ///
     /// returns: The wrapped `T` or crash if the wrapped message is not a `T`.
-    @_versioned @_inlineable
+    @usableFromInline
     func forceAs<T>(type: T.Type = T.self) -> T {
         switch T.self {
         case let t where t == ByteBuffer.self:
@@ -220,7 +220,7 @@ public struct NIOAny {
     /// Try unwrapping the wrapped message as `T`.
     ///
     /// returns: The wrapped `T` or `nil` if the wrapped message is not a `T`.
-    @_versioned @_inlineable
+    @usableFromInline
     func tryAs<T>(type: T.Type = T.self) -> T? {
         switch T.self {
         case let t where t == ByteBuffer.self:
@@ -239,7 +239,7 @@ public struct NIOAny {
     /// Unwrap the wrapped message.
     ///
     /// returns: The wrapped message.
-    @_versioned @_inlineable
+    @usableFromInline
     func asAny() -> Any {
         switch self._storage {
         case .ioData(.byteBuffer(let bb)):

--- a/Sources/NIO/TypeAssistedChannelHandler.swift
+++ b/Sources/NIO/TypeAssistedChannelHandler.swift
@@ -20,13 +20,13 @@ public protocol _EmittingChannelHandler {
     associatedtype OutboundOut = Never
 
     /// Wrap the provided `OutboundOut` that will be passed to the next `ChannelOutboundHandler` by calling `ChannelHandlerContext.write`.
-    @_inlineable
+    @inlinable
     func wrapOutboundOut(_ value: OutboundOut) -> NIOAny
 }
 
 /// Default implementations for `_EmittingChannelHandler`.
 extension _EmittingChannelHandler {
-    @_inlineable
+    @inlinable
     public func wrapOutboundOut(_ value: OutboundOut) -> NIOAny {
         return NIOAny(value)
     }
@@ -43,22 +43,22 @@ public protocol ChannelInboundHandler: _ChannelInboundHandler, _EmittingChannelH
     associatedtype InboundOut = Never
 
     /// Unwrap the provided `NIOAny` that was passed to `channelRead`.
-    @_inlineable
+    @inlinable
     func unwrapInboundIn(_ value: NIOAny) -> InboundIn
 
     /// Wrap the provided `InboundOut` that will be passed to the next `ChannelInboundHandler` by calling `ChannelHandlerContext.fireChannelRead`.
-    @_inlineable
+    @inlinable
     func wrapInboundOut(_ value: InboundOut) -> NIOAny
 }
 
 /// Default implementations for `ChannelInboundHandler`.
 extension ChannelInboundHandler {
-    @_inlineable
+    @inlinable
     public func unwrapInboundIn(_ value: NIOAny) -> InboundIn {
         return value.forceAs()
     }
 
-    @_inlineable
+    @inlinable
     public func wrapInboundOut(_ value: InboundOut) -> NIOAny {
         return NIOAny(value)
     }
@@ -72,13 +72,13 @@ public protocol ChannelOutboundHandler: _ChannelOutboundHandler, _EmittingChanne
     associatedtype OutboundIn
 
     /// Unwrap the provided `NIOAny` that was passed to `write`.
-    @_inlineable
+    @inlinable
     func unwrapOutboundIn(_ value: NIOAny) -> OutboundIn
 }
 
 /// Default implementations for `ChannelOutboundHandler`.
 extension ChannelOutboundHandler {
-    @_inlineable
+    @inlinable
     public func unwrapOutboundIn(_ value: NIOAny) -> OutboundIn {
         return value.forceAs()
     }

--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -75,7 +75,7 @@ extension Lock {
     ///
     /// - Parameter body: The block to execute while holding the lock.
     /// - Returns: The value returned by the block.
-    @_inlineable
+    @inlinable
     public func withLock<T>(_ body: () throws -> T) rethrows -> T {
         self.lock()
         defer {
@@ -85,7 +85,7 @@ extension Lock {
     }
 
     // specialise Void return (for performance)
-    @_inlineable
+    @inlinable
     public func withLockVoid(_ body: () throws -> Void) rethrows -> Void {
         try self.withLock(body)
     }

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -30,7 +30,7 @@ import struct Foundation.Data
  */
 
 extension Data: ContiguousCollection {
-    @_inlineable
+    @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> R in
             try body(UnsafeRawBufferPointer(start: ptr, count: self.count))


### PR DESCRIPTION
Motivation:

swfit build generated the deprecated warnings for @_inlineable and @_versioned

Modifications:

Replaced @_inlineable and @_versioned with @usableFromInline

Result:

swift builds with no warnings

