### PR TITLE
Added class for LineBasedFrameDecoder - GitHub issue #473

### DIFF
--- a/Sources/NIO/LineBasedFrameDecoder.swift
+++ b/Sources/NIO/LineBasedFrameDecoder.swift
@@ -1,0 +1,50 @@
+//
+//  LineBasedFrameDecoder.swift
+//  NIO
+//
+//  Created by Edward Arenberg on 6/8/18.
+//
+
+/// An inbound `ChannelHandler` that strips newlines from an inbound stream.
+///
+/// I added my LineBasedFrameDecoder into the channel.pipeline of the NIOEchoServer (main.swift)
+/// Finding a crash in the creation of the ByteBufferView:
+///
+///  ByteBuffer generates its readableBytesView:
+///   public var readableBytesView: ByteBufferView {
+///     return ByteBufferView(buffer: self, range: self.readerIndex ..< self.readerIndex + self.readableBytes)
+///   }
+///
+///  ByteBufferView init fails the precondition below.
+///  range = 0..<N   range.upperBounds == N   buffer.capacity == N
+///   internal init(buffer: ByteBuffer, range: Range<Index>) {
+///     precondition(range.lowerBound >= 0 && range.upperBound < buffer.capacity)
+///     self.buffer = buffer
+///     self.range = range
+///   }
+///
+///
+
+
+public final class LineBasedFrameDecoder : ByteToMessageDecoder {
+    public typealias InboundIn = ByteBuffer
+    public typealias InboundOut = ByteBuffer
+    
+    public var cumulationBuffer: ByteBuffer?
+
+    public init() { }
+        
+    public func decode(ctx: ChannelHandlerContext, buffer: inout ByteBuffer) -> DecodingState {
+        let newLine = "\n".utf8.first!
+        
+        if let idx = buffer.readableBytesView.firstIndex(of: newLine) {
+            if let buf = buffer.readSlice(length: idx) {
+                ctx.fireChannelRead(self.wrapInboundOut(buf))
+                buffer.moveReaderIndex(forwardBy: 1)    // Skip newline
+                return .continue
+            }
+        }
+        
+        return .needMoreData
+    }
+}

--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -49,7 +49,9 @@ let bootstrap = ServerBootstrap(group: group)
     .childChannelInitializer { channel in
         // Ensure we don't read faster then we can write by adding the BackPressureHandler into the pipeline.
         channel.pipeline.add(handler: BackPressureHandler()).then { v in
-            channel.pipeline.add(handler: EchoHandler())
+            channel.pipeline.add(handler:LineBasedFrameDecoder()).then { v in
+                channel.pipeline.add(handler: EchoHandler())
+            }
         }
     }
 


### PR DESCRIPTION
Added LineBasedFrameDecoder class

### Motivation:

GitHub Issue #473 

### Modifications:

Added the class LineBasedFrameDecoder.swift and modified NIOEchoServer main.swift to include it in the pipeline.

### Result:

Newlines will be stripped from input text passed through the decoder, with each line output as a ByteBuffer stripped of the newline.


### Notes:

It was working for a little while and I changed the run scheme, and set the scheme back, and it started failing as detailed below:

/// I added my LineBasedFrameDecoder into the channel.pipeline of the NIOEchoServer (main.swift)
/// Finding a crash in the creation of the ByteBufferView:
///
///  ByteBuffer generates its readableBytesView:
///   public var readableBytesView: ByteBufferView {
///     return ByteBufferView(buffer: self, range: self.readerIndex ..< self.readerIndex + self.readableBytes)
///   }
///
///  ByteBufferView init fails the precondition below.
///  range = 0..<N ,  range.upperBounds == N ,  buffer.capacity == N
///
///   internal init(buffer: ByteBuffer, range: Range<Index>) {
///     precondition(range.lowerBound >= 0 && range.upperBound < buffer.capacity)
///     self.buffer = buffer
///     self.range = range
///   }
