### PR TITLE
Allow to create ByteBufferView of all bytes in a ByteBuffer

### DIFF
--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -25,7 +25,7 @@ public struct ByteBufferView: ContiguousCollection, RandomAccessCollection {
     private let range: Range<Index>
 
     internal init(buffer: ByteBuffer, range: Range<Index>) {
-        precondition(range.lowerBound >= 0 && range.upperBound < buffer.capacity)
+        precondition(range.lowerBound >= 0 && range.upperBound <= buffer.capacity)
         self.buffer = buffer
         self.range = range
     }

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -123,6 +123,7 @@ extension ByteBufferTest {
                 ("testBytesView", testBytesView),
                 ("testViewsStartIndexIsStable", testViewsStartIndexIsStable),
                 ("testSlicesOfByteBufferViewsAreByteBufferViews", testSlicesOfByteBufferViewsAreByteBufferViews),
+                ("testReadableBufferViewRangeEqualCapacity", testReadableBufferViewRangeEqualCapacity),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1437,6 +1437,14 @@ class ByteBufferTest: XCTestCase {
         XCTAssertEqual("l", String(decoding: viewSlice.dropFirst(), as: UTF8.self))
         XCTAssertEqual("", String(decoding: viewSlice.dropFirst().dropLast(), as: UTF8.self))
     }
+    
+    func testReadableBufferViewRangeEqualCapacity() throws {
+        self.buf.clear()
+        self.buf.moveWriterIndex(forwardBy: buf.capacity)
+        let view = self.buf.readableBytesView
+        let viewSlice: ByteBufferView = view[view.startIndex ..< view.endIndex]
+        XCTAssertEqual(buf.readableBytes, viewSlice.count)
+    }
 }
 
 private enum AllocationExpectationState: Int {


### PR DESCRIPTION
Motivation:

We used an incorrect precondition and so it would be hit if someone tried to create a ByteBufferView add all bytes in a ByteBuffer.

Modifications:

Allow upperBound up to capacity

Result:

Fixes https://github.com/apple/swift-nio/issues/482.