### PR TITLE
add 'tty: true' to the docker-compose file (#490)

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -37,12 +37,14 @@ services:
 
   echo:
     <<: *common
+    tty: true
     ports:
       - "9999:9999"
     command: /bin/bash -cl "swift run NIOEchoServer 0.0.0.0 9999"
 
   http:
     <<: *common
+    tty: true
     ports:
       - "8888:8888"
     command: /bin/bash -cl "swift run NIOHTTP1Server 0.0.0.0 8888"


### PR DESCRIPTION
Motivation:

swift-nio example projects (http, echo) don't print anything to the console when running inside docker container because of buffering issue.

Modifications:

Added tty: true to the docker-compose.yaml for http & echo.

Result:

Buffering issue is resolved. http & echo prints logs to the console.