### PR TITLE
Add support for HTTP Response Status 418

### DIFF
--- a/Sources/CNIOHTTPParser/include/c_nio_http_parser.h
+++ b/Sources/CNIOHTTPParser/include/c_nio_http_parser.h
@@ -133,6 +133,7 @@ typedef int (*http_cb) (http_parser*);
   XX(415, UNSUPPORTED_MEDIA_TYPE,          Unsupported Media Type)          \
   XX(416, RANGE_NOT_SATISFIABLE,           Range Not Satisfiable)           \
   XX(417, EXPECTATION_FAILED,              Expectation Failed)              \
+  XX(418, I_AM_A_TEAPOT,                   I am a Teapot)                   \
   XX(421, MISDIRECTED_REQUEST,             Misdirected Request)             \
   XX(422, UNPROCESSABLE_ENTITY,            Unprocessable Entity)            \
   XX(423, LOCKED,                          Locked)                          \

--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -275,6 +275,8 @@ private extension ByteBuffer {
             self.write(staticString: "HTTP/1.0 416 Range Not Satisfiable\r\n")
         case (1, 0, .expectationFailed):
             self.write(staticString: "HTTP/1.0 417 Expectation Failed\r\n")
+        case (1, 0, .amTeapot):
+            self.write(staticString: "HTTP/1.0 418 I'm a Teapot\r\n")
         case (1, 0, .misdirectedRequest):
             self.write(staticString: "HTTP/1.0 421 Misdirected Request\r\n")
         case (1, 0, .unprocessableEntity):
@@ -399,6 +401,8 @@ private extension ByteBuffer {
             self.write(staticString: "HTTP/1.1 416 Request Range Not Satisified\r\n")
         case (1, 1, .expectationFailed):
             self.write(staticString: "HTTP/1.1 417 Expectation Failed\r\n")
+        case (1, 1, .amTeapot):
+            self.write(staticString: "HTTP/1.1 418 Expectation Failed\r\n")
         case (1, 1, .misdirectedRequest):
             self.write(staticString: "HTTP/1.1 421 Misdirected Request\r\n")
         case (1, 1, .unprocessableEntity):

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -421,11 +421,11 @@ public struct HTTPHeaders: CustomStringConvertible {
             self.add(name: key, value: value)
         }
     }
-    
+
     private func isConnectionHeader(_ header: HTTPHeaderIndex) -> Bool {
          return self.buffer.equalCaseInsensitiveASCII(view: "connection".utf8, at: header)
     }
-    
+
     /// Add a header name/value pair to the block.
     ///
     /// This method is strictly additive: if there are other values for the given header name
@@ -446,11 +446,11 @@ public struct HTTPHeaders: CustomStringConvertible {
         self._storage.buffer.write(staticString: headerSeparator)
         let valueStart = self.buffer.writerIndex
         let valueLength = self._storage.buffer.write(string: value)!
-        
+
         let nameIdx = HTTPHeaderIndex(start: nameStart, length: nameLength)
         self._storage.headers.append(HTTPHeader(name: nameIdx, value: HTTPHeaderIndex(start: valueStart, length: valueLength)))
         self._storage.buffer.write(staticString: crlf)
-        
+
         if self.isConnectionHeader(nameIdx) {
             self._storage.keepAliveState = .unknown
         }
@@ -491,7 +491,7 @@ public struct HTTPHeaders: CustomStringConvertible {
             let header = self.headers[idx]
             if self.buffer.equalCaseInsensitiveASCII(view: utf8, at: header.name) {
                 array.append(idx)
-                
+
                 if self.isConnectionHeader(header.name) {
                     self._storage.keepAliveState = .unknown
                 }
@@ -1011,6 +1011,8 @@ extension HTTPResponseStatus {
                 return 416
             case .expectationFailed:
                 return 417
+            case .amTeapot:
+                return 418
             case .misdirectedRequest:
                 return 421
             case .unprocessableEntity:
@@ -1139,6 +1141,8 @@ extension HTTPResponseStatus {
                 return "Range Not Satisfiable"
             case .expectationFailed:
                 return "Expectation Failed"
+            case .amTeapot:
+                return "I'm a Teapot"
             case .misdirectedRequest:
                 return "Misdirected Request"
             case .unprocessableEntity:
@@ -1240,6 +1244,7 @@ public enum HTTPResponseStatus {
     case unsupportedMediaType
     case rangeNotSatisfiable
     case expectationFailed
+    case isTeapot
 
     // 5xx
     case misdirectedRequest
@@ -1362,6 +1367,8 @@ public enum HTTPResponseStatus {
             self = .rangeNotSatisfiable
         case 417:
             self = .expectationFailed
+        case 418:
+            self = .amTeapot
         case 421:
             self = .misdirectedRequest
         case 422:

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -1244,7 +1244,7 @@ public enum HTTPResponseStatus {
     case unsupportedMediaType
     case rangeNotSatisfiable
     case expectationFailed
-    case isTeapot
+    case amTeapot
 
     // 5xx
     case misdirectedRequest


### PR DESCRIPTION
_Add support for HTTP Response Status 418_

### Motivation:

_In a recent project of my own, I had cause to use error code 418 only to find that it had not been implemented._

### Modifications:

_Addition of  `.amTeapot` case for `HTTPResponseStatus`_

### Result:

_Developers can now support 418 status responses_
