### PR TITLE
Provide an iterator over the event loops of an EventLoopGroup

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -650,6 +650,42 @@ extension EventLoopGroup {
     }
 }
 
+/// An iterator over the `EventLoop`s of an `EventLoopGroup`.
+///
+/// Conforming to `Sequence`, the `EventLoopIterator` enables iterating over the `EventLoop`s of an `EventLoopGroup` using the `for-in` style.
+/// A common use-case of this is in performing per-`EventLoop` initializations before `BootStrap`ing.
+/// Example:
+///     ```swift
+///         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+///         for eventLoop in EventLoopIterator(group: group) {
+///             //do something on eventLoop
+///         }
+public struct EventLoopIterator: Sequence, IteratorProtocol {
+
+    private var eventLoopsIterator: IndexingIterator<[EventLoop]>
+
+    /// Create an `EventLoopIterator` for the `EventLoopGroup` `group`.
+    ///
+    /// - parameters:
+    ///     - group: The `EventLoopGroup` whose `EventLoop`s are to be iterated.
+    public init(group: EventLoopGroup) {
+        var eventLoops: [EventLoop] = []
+        let firstEventLoop = group.next()
+        eventLoops.append(firstEventLoop)
+        while true {
+            let nextEventLoop = group.next()
+            if nextEventLoop === firstEventLoop {
+                break
+            }
+            eventLoops.append(nextEventLoop)
+        }
+        self.eventLoopsIterator = eventLoops.makeIterator()
+    }
+
+    mutating public func next() -> EventLoop? {
+        return self.eventLoopsIterator.next()
+    }
+}
 /// Called per `Thread` that is created for an EventLoop to do custom initialization of the `Thread` before the actual `EventLoop` is run on it.
 typealias ThreadInitializer = (Thread) -> Void
 

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -38,6 +38,7 @@ extension EventLoopTest {
                 ("testShutdownWhileScheduledTasksNotReady", testShutdownWhileScheduledTasksNotReady),
                 ("testCloseFutureNotifiedBeforeUnblock", testCloseFutureNotifiedBeforeUnblock),
                 ("testScheduleMultipleTasks", testScheduleMultipleTasks),
+                ("testEventLoopIterator", testEventLoopIterator),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -396,4 +396,13 @@ public class EventLoopTest : XCTestCase {
         XCTAssertTrue(result.isEmpty)
 
     }
+
+    func testEventLoopIterator() {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        var count = 0
+        for _ in EventLoopIterator(group: eventLoopGroup) {
+            count += 1
+        }
+        XCTAssertEqual(count, System.coreCount)
+    }
 }


### PR DESCRIPTION
Provide an iterator over the event loops of an EventLoopGroup

### Motivation:

We might want to do certain initialisations on a per-event loop basis. Example: initialising `ThreadSpecificVariable`s. It would be handy to have an iterator over the event loops in an event loop group. See #497 

### Modifications:

Added a new public API class `EventLoopGroupIterator` implementing sequence. The challenges in making `EventLoopGroup` itself a sequence have been mentioned here: https://github.com/apple/swift-nio/issues/497#issuecomment-402107940

### Result:
 Something like this is possible:
```
let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)`
for eventLoop in EventLoopGroupIterator(for: eventLoopGroup) {
    //do something
}
```