### PR TITLE
fix massive race in testBootstrapsCallInitializersOnCorrectEventLoop

### DIFF
--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -54,6 +54,8 @@ class BootstrapTest: XCTestCase {
             defer {
                 XCTAssertNoThrow(try client.syncCloseAcceptingAlreadyClosed())
             }
+            XCTAssertNoThrow(try childChannelDone.futureResult.wait())
+            XCTAssertNoThrow(try serverChannelDone.futureResult.wait())
         }
     }
 }


### PR DESCRIPTION
Motivation:

testBootstrapsCallInitializersOnCorrectEventLoop had a massive race
condition, we'd never wait for childChannelDone and serverChannelDone to
actually be fulfilled which could lead to leaked promises. No idea why
this didn't fail more often.

Modifications:

Wait for futures to be fulfilled to make sure we don't leak the
promises.

Result:

tests more stable.