### PR TITLE
Iterating over the EventLoops from EventLoopGroups

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -127,6 +127,32 @@ public final class RepeatedTask {
         self.reschedule()
     }
 }
+
+/// An iterator over the `EventLoop`s forming an `EventLoopGroup`.
+///
+/// Usually returned by an `EventLoopGroup`'s `makeIterator()` method.
+///
+///     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+///     group.makeIterator()?.forEach { loop in
+///         // Do something with each loop
+///     }
+///
+public struct EventLoopIterator: Sequence, IteratorProtocol {
+    public typealias Element = EventLoop
+    private var eventLoops: IndexingIterator<[EventLoop]>
+
+    internal init(_ eventLoops: [EventLoop]) {
+        self.eventLoops = eventLoops.makeIterator()
+    }
+
+    /// Advances to the next `EventLoop` and returns it, or `nil` if no next element exists.
+    ///
+    /// - returns: The next `EventLoop` if a next element exists; otherwise, `nil`.
+    public mutating func next() -> EventLoop? {
+        return self.eventLoops.next()
+    }
+}
+
 /// An EventLoop processes IO / tasks in an endless loop for `Channel`s until it's closed.
 ///
 /// Usually multiple `Channel`s share the same `EventLoop` for processing IO / tasks and so share the same processing `Thread`.
@@ -332,6 +358,14 @@ extension EventLoop {
         let repeated = RepeatedTask(interval: delay, eventLoop: self, task: task)
         repeated.begin(in: initialDelay)
         return repeated
+    }
+
+    /// Returns an `EventLoopIterator` over this `EventLoop`.
+    ///
+    /// - note: The return value of `makeIterator` is currently optional as requiring it would be SemVer major. From NIO 2.0.0 on it will return a non-optional iterator.
+    /// - returns: `EventLoopIterator`
+    public func makeIterator() -> EventLoopIterator? {
+        return EventLoopIterator([self])
     }
 }
 
@@ -733,6 +767,12 @@ public protocol EventLoopGroup: class {
     /// The virtue of this function is to shut the event loop down. To work around that we call back on a DispatchQueue
     /// instead.
     func shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void)
+
+    /// Returns an `EventLoopIterator` over the `EventLoop`s in this `EventLoopGroup`.
+    ///
+    /// - note: The return value of `makeIterator` is currently optional as requiring it would be SemVer major. From NIO 2.0.0 on it will return a non-optional iterator.
+    /// - returns: `EventLoopIterator`
+    func makeIterator() -> EventLoopIterator?
 }
 
 extension EventLoopGroup {
@@ -758,6 +798,10 @@ extension EventLoopGroup {
                 throw error
             }
         }
+    }
+
+    public func makeIterator() -> EventLoopIterator? {
+        return nil
     }
 }
 
@@ -841,6 +885,14 @@ final public class MultiThreadedEventLoopGroup: EventLoopGroup {
     /// - returns: The current `EventLoop` for the calling thread or `nil` if none is assigned to the thread.
     public static var currentEventLoop: EventLoop? {
         return threadSpecificEventLoop.currentValue
+    }
+
+    /// Returns an `EventLoopIterator` over the `EventLoop`s in this `MultiThreadedEventLoopGroup`.
+    ///
+    /// - note: The return value of `makeIterator` is currently optional as requiring it would be SemVer major. From NIO 2.0.0 on it will return a non-optional iterator.
+    /// - returns: `EventLoopIterator`
+    public func makeIterator() -> EventLoopIterator? {
+        return EventLoopIterator(self.eventLoops)
     }
 
     public func next() -> EventLoop {

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -35,6 +35,7 @@ extension EventLoopTest {
                 ("testScheduleRepeatedTaskToNotRetainEventLoop", testScheduleRepeatedTaskToNotRetainEventLoop),
                 ("testEventLoopGroupMakeIterator", testEventLoopGroupMakeIterator),
                 ("testEventLoopMakeIterator", testEventLoopMakeIterator),
+                ("testDummyEventLoopGroupMakeIterator", testDummyEventLoopGroupMakeIterator),
                 ("testMultipleShutdown", testMultipleShutdown),
                 ("testShuttingDownFailsRegistration", testShuttingDownFailsRegistration),
                 ("testEventLoopThreads", testEventLoopThreads),

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -33,6 +33,8 @@ extension EventLoopTest {
                 ("testScheduleRepeatedTaskCancelFromDifferentThread", testScheduleRepeatedTaskCancelFromDifferentThread),
                 ("testScheduleRepeatedTaskToNotRetainRepeatedTask", testScheduleRepeatedTaskToNotRetainRepeatedTask),
                 ("testScheduleRepeatedTaskToNotRetainEventLoop", testScheduleRepeatedTaskToNotRetainEventLoop),
+                ("testEventLoopGroupMakeIterator", testEventLoopGroupMakeIterator),
+                ("testEventLoopMakeIterator", testEventLoopMakeIterator),
                 ("testMultipleShutdown", testMultipleShutdown),
                 ("testShuttingDownFailsRegistration", testShuttingDownFailsRegistration),
                 ("testEventLoopThreads", testEventLoopThreads),

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -173,6 +173,54 @@ public class EventLoopTest : XCTestCase {
         XCTAssertNil(weakEventLoop)
     }
 
+    public func testEventLoopGroupMakeIterator() throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer {
+            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+        }
+
+        var counter = 0
+        var innerCounter = 0
+        eventLoopGroup.makeIterator()?.forEach { loop in
+            counter += 1
+            loop.makeIterator()?.forEach { _ in
+                innerCounter += 1
+            }
+        }
+
+        XCTAssertEqual(counter, System.coreCount)
+        XCTAssertEqual(innerCounter, System.coreCount)
+    }
+
+    public func testEventLoopMakeIterator() throws {
+        let eventLoop = EmbeddedEventLoop()
+        var iterator = eventLoop.makeIterator()
+        defer {
+            XCTAssertNoThrow(try eventLoop.syncShutdownGracefully())
+        }
+
+        var counter = 0
+        iterator?.forEach { loop in
+            XCTAssertTrue(loop === eventLoop)
+            counter += 1
+        }
+
+        XCTAssertEqual(counter, 1)
+    }
+
+    public func testDummyEventLoopGroupMakeIterator() throws {
+        class DummyEventLoopGroup: EventLoopGroup {
+            func shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) { }
+
+            func next() -> EventLoop {
+                return EmbeddedEventLoop()
+            }
+        }
+
+        let dummyEventLoopGroup = DummyEventLoopGroup()
+        XCTAssertNil(dummyEventLoopGroup.makeIterator())
+    }
+
     public func testMultipleShutdown() throws {
         // This test catches a regression that causes it to intermittently fail: it reveals bugs in synchronous shutdown.
         // Do not ignore intermittent failures in this test!


### PR DESCRIPTION
Provide a way to iterate over the event loops of an `EventLoopGroup`

### Motivation:

For some use cases, it might be necessary to access the underlying event loops. See https://github.com/apple/swift-nio/issues/497.

### Modifications:

Added a property requirement to the `EventLoopGroup` protocol.

### Result:

The event loops are now accessible from the outside.

### Alternative Implementation:
Another approach is to create a separate struct for the iterator and pass in the event loop array. This hides the implementation from the ELG.

```swift
public struct EventLoopIterator: Sequence, IteratorProtocol {
    public typealias Element = EventLoop
    private var eventLoops: IndexingIterator<[EventLoop]>
    
    internal init(_ eventLoops: [EventLoop]) {
        self.eventLoops = eventLoops.makeIterator()
    }
    
    public mutating func next() -> EventLoop? {
        return self.eventLoops.next()
    }
}

public protocol EventLoopGroup: class {
    // ....
    func makeIterator() -> EventLoopIterator
}

extension EventLoop {
    public func makeIterator() -> EventLoopIterator {
        return EventLoopIterator([self])
    }
}

extension MultiThreadedEventLoopGroup {
    public func makeIterator() -> EventLoopIterator {
        return EventLoopIterator(self.eventLoops)
    }
}
```
