### PR TITLE
Use case-insensitive protocol names for indexing the upgraders dictionary

### DIFF
--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -94,7 +94,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
     public init(upgraders: [HTTPProtocolUpgrader], httpEncoder: HTTPResponseEncoder?, httpDecoder: HTTPRequestDecoder?, upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) {
         var upgraderMap = [String: HTTPProtocolUpgrader]()
         for upgrader in upgraders {
-            upgraderMap[upgrader.supportedProtocol] = upgrader
+            upgraderMap[upgrader.supportedProtocol.lowercased()] = upgrader
         }
         self.upgraders = upgraderMap
         self.upgradeCompletionHandler = upgradeCompletionHandler
@@ -121,7 +121,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
     public init(upgraders: [HTTPProtocolUpgrader], httpEncoder: HTTPResponseEncoder, extraHTTPHandlers: [ChannelHandler], upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) {
         var upgraderMap = [String: HTTPProtocolUpgrader]()
         for upgrader in upgraders {
-            upgraderMap[upgrader.supportedProtocol] = upgrader
+            upgraderMap[upgrader.supportedProtocol.lowercased()] = upgrader
         }
         self.upgraders = upgraderMap
         self.upgradeCompletionHandler = upgradeCompletionHandler

--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -187,7 +187,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
         let allHeaderNames = Set(request.headers.map { $0.name.lowercased() })
 
         for proto in requestedProtocols {
-            guard let upgrader = upgraders[proto] else {
+            guard let upgrader = upgraders[proto.lowercased()] else {
                 continue
             }
 

--- a/Tests/NIOWebSocketTests/EndToEndTests+XCTest.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests+XCTest.swift
@@ -27,6 +27,7 @@ extension EndToEndTests {
    static var allTests : [(String, (EndToEndTests) -> () throws -> Void)] {
       return [
                 ("testBasicUpgradeDance", testBasicUpgradeDance),
+                ("testUpgradeWithProtocolName", testUpgradeWithProtocolName),
                 ("testCanRejectUpgrade", testCanRejectUpgrade),
                 ("testRequiresVersion13", testRequiresVersion13),
                 ("testRequiresVersionHeader", testRequiresVersionHeader),


### PR DESCRIPTION
**Motivation** 

`handleUpgrade(ctx: ChannelHandlerContext, request: HTTPRequestHead, requestedProtocols: [String])` in `HTTPServerUpgradeHandler` upgrades a request only if the `Upgrade` header of the request is `websocket` protocol. For `Websocket` protocol, it fails. For indexing the upgraders, case-insensitive protocol names should be used.

**Modifications:**

```
 for proto in requestedProtocols {
            guard let upgrader = upgraders[proto.lowercased()] else {
                continue
            }
```
Here, all the protocols in the `requestedProtocols` are lowercased before indexing the upgraders dictionary.

