### PR TITLE
Optional promotion bug

### DIFF
--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -584,7 +584,7 @@ final class Selector<R: Registration> {
             // in any case we only want what the user is currently registered for & what we got
             selectorEvent = selectorEvent.intersection(registration.interested)
 
-            guard selectorEvent != .none else {
+            guard selectorEvent != ._none else {
                 continue
             }
             try body((SelectorEvent(io: selectorEvent, registration: registration)))

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -532,7 +532,7 @@ final class Selector<R: Registration> {
                     // in any case we only want what the user is currently registered for & what we got
                     selectorEvent = selectorEvent.intersection(registration.interested)
 
-                    guard selectorEvent != .none else {
+                    guard selectorEvent != ._none else {
                         continue
                     }
 


### PR DESCRIPTION
Incorrect comparison due to optional promotion

### Motivation:
Fix comparison

### Modifications: 
Changed comparison to use _none

### Result:
Correct comparison 


