### PR TITLE
remove unnecessary UInt8 pointer binds

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -30,8 +30,7 @@ extension ByteBuffer {
         }
 
         return self.withVeryUnsafeBytes { ptr in
-            Array.init(UnsafeBufferPointer<UInt8>(start: ptr.baseAddress?.advanced(by: index).assumingMemoryBound(to: UInt8.self),
-                                                  count: length))
+            Array<UInt8>(ptr[index..<(index+length)])
         }
     }
 
@@ -118,8 +117,7 @@ extension ByteBuffer {
             guard index <= pointer.count - length else {
                 return nil
             }
-            return String(decoding: UnsafeBufferPointer(start: pointer.baseAddress?.assumingMemoryBound(to: UInt8.self).advanced(by: index), count: length),
-                          as: UTF8.self)
+            return String(decoding: pointer[index..<(index+length)], as: UTF8.self)
         }
     }
 

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -192,7 +192,7 @@ public struct NonBlockingFileIO {
                 let n = try buf.writeWithUnsafeMutableBytes { ptr in
                     let res = try fileHandle.withUnsafeFileDescriptor { descriptor in
                         try Posix.read(descriptor: descriptor,
-                                       pointer: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                                       pointer: ptr.baseAddress!,
                                        size: byteCount - bytesRead)
                     }
                     switch res {

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -314,7 +314,7 @@ internal enum Posix {
     }
 
     @inline(never)
-    public static func write(descriptor: CInt, pointer: UnsafePointer<UInt8>, size: Int) throws -> IOResult<Int> {
+    public static func write(descriptor: CInt, pointer: UnsafeRawPointer, size: Int) throws -> IOResult<Int> {
         return try wrapSyscallMayBlock {
             sysWrite(descriptor, pointer, size)
         }
@@ -328,7 +328,7 @@ internal enum Posix {
     }
 
     @inline(never)
-    public static func sendto(descriptor: CInt, pointer: UnsafePointer<UInt8>, size: size_t,
+    public static func sendto(descriptor: CInt, pointer: UnsafeRawPointer, size: size_t,
                               destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int> {
         return try wrapSyscallMayBlock {
             sysSendTo(descriptor, pointer, size, 0, destinationPtr, destinationSize)
@@ -336,14 +336,14 @@ internal enum Posix {
     }
 
     @inline(never)
-    public static func read(descriptor: CInt, pointer: UnsafeMutablePointer<UInt8>, size: size_t) throws -> IOResult<Int> {
+    public static func read(descriptor: CInt, pointer: UnsafeMutableRawPointer, size: size_t) throws -> IOResult<Int> {
         return try wrapSyscallMayBlock {
             sysRead(descriptor, pointer, size)
         }
     }
 
     @inline(never)
-    public static func recvfrom(descriptor: CInt, pointer: UnsafeMutablePointer<UInt8>, len: size_t, addr: UnsafeMutablePointer<sockaddr>, addrlen: UnsafeMutablePointer<socklen_t>) throws -> IOResult<ssize_t> {
+    public static func recvfrom(descriptor: CInt, pointer: UnsafeMutableRawPointer, len: size_t, addr: UnsafeMutablePointer<sockaddr>, addrlen: UnsafeMutablePointer<socklen_t>) throws -> IOResult<ssize_t> {
         return try wrapSyscallMayBlock {
             sysRecvFrom(descriptor, pointer, len, 0, addr, addrlen)
         }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -472,7 +472,7 @@ class ByteBufferTest: XCTestCase {
                 XCTAssertEqual(string.utf8.count, ptr.count)
 
                 for (idx, expected) in zip(0..<string.utf8.count, string.utf8) {
-                    let actual = ptr.baseAddress!.advanced(by: idx).assumingMemoryBound(to: UInt8.self).pointee
+                    let actual = ptr[idx]
                     XCTAssertEqual(expected, actual, "character at index \(idx) is \(actual) but should be \(expected)")
                 }
             }
@@ -636,7 +636,7 @@ class ByteBufferTest: XCTestCase {
         otherBuf?.withUnsafeReadableBytes { ptr in
             XCTAssertEqual(cap, ptr.count)
             for i in 0..<cap {
-                XCTAssertEqual(ptr.baseAddress!.assumingMemoryBound(to: UInt8.self)[i], UInt8(truncatingIfNeeded: i))
+                XCTAssertEqual(ptr[i], UInt8(truncatingIfNeeded: i))
             }
         }
     }
@@ -675,13 +675,13 @@ class ByteBufferTest: XCTestCase {
         buf!.withUnsafeReadableBytes { ptr in
             XCTAssertEqual(cap, ptr.count)
             for i in 0..<cap {
-                XCTAssertEqual(ptr.baseAddress!.assumingMemoryBound(to: UInt8.self)[i], 0)
+                XCTAssertEqual(ptr[i], 0)
             }
         }
         otherBuf!.withUnsafeReadableBytes { ptr in
             XCTAssertEqual(cap, ptr.count)
             for i in 0..<cap {
-                XCTAssertEqual(ptr.baseAddress!.assumingMemoryBound(to: UInt8.self)[i], UInt8(truncatingIfNeeded: i))
+                XCTAssertEqual(ptr[i], UInt8(truncatingIfNeeded: i))
             }
         }
     }


### PR DESCRIPTION
CC @atrick who pointed this out in [an Swift Evolution post](https://forums.swift.org/t/withunsafetypepunnedpointer/14540/5?u=johannesweiss). However I don't believe there are any correctness issues here in `ByteBuffer` regarding the types as we _do always_ bind the memory to `UInt8`s when we `assumeMemoryBound(to: UInt8.self)`.

Motivation:

The bytes that a Unsafe(Mutable)RawBufferPointers points to can be
accessed directly as `UInt8`s. We didn't know that so we bind
`ByteBuffer`s memory to `UInt8` so that we can access it as
`UnsafePointer<UInt8>` using `assumingMemoryBound(to: UInt8.self)` in
many places. Most of the time that is unnecessarily awkward and
unnecessary.

Modifications:

- remove some easy instances where we access an
  `UnsafeMutableBufferPointer` as `UnsafeBufferPointer<UInt8>` just to
  read some `UInt8`s.

Result:

less awkward looking code