### PR TITLE
Made some HTTPHeaders API public, to use in NIOHPACK

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,6 +3,7 @@ Tomer Doron <tomerd@apple.com>
 Max Moiseev <moiseev@apple.com>
 Johannes Weiß <johannesweiss@apple.com>
 Adam Nemecek <adamnemecek@gmail.com>
+Jim Dovey <jimdovey@mac.com> <jdovey@linkedin.com>
 <bas@basbroek.nl> <BasThomas@users.noreply.github.com>
 <daniel_dunbar@apple.com> <daniel@zuster.org>
 <johannesweiss@apple.com> <github@tux4u.de>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -26,6 +26,7 @@ needs to be listed here.
 - Helge Heß <helge@alwaysrightinstitute.com>
 - Ian Partridge <i.partridge@uk.ibm.com>
 - Jason Toffaletti <toffaletti@gmail.com>
+- Jim Dovey <jimdovey@mac.com>
 - Johannes Weiß <johannesweiss@apple.com>
 - John Connolly <connoljo2@gmail.com>
 - Karim ElNaggar <karimfarid.naggar@gmail.com>

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -41,6 +41,8 @@ extension HTTPHeadersTest {
                 ("testKeepAliveStateHasClose", testKeepAliveStateHasClose),
                 ("testResolveNonContiguousHeaders", testResolveNonContiguousHeaders),
                 ("testStringBasedHTTPListHeaderIterator", testStringBasedHTTPListHeaderIterator),
+                ("testUnsafeBufferAccess", testUnsafeBufferAccess),
+                ("testCreateFromBufferAndLocations", testCreateFromBufferAndLocations),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -232,5 +232,67 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertEqual(String(decoding: currentToken!, as: UTF8.self), "close")
         currentToken = tokenSource.next()
         XCTAssertNil(currentToken)
+	}
+    
+    func testUnsafeBufferAccess() {
+        let originalHeaders = [ ("X-Header", "1"),
+                                ("X-SomeHeader", "3"),
+                                ("X-Header", "2")]
+        let originalHeadersString = "X-Header: 1\r\nX-SomeHeader: 3\r\nX-Header: 2\r\n"
+        var headers1 = HTTPHeaders(originalHeaders)
+        
+        // ensure we can access the underlying buffer and header locations
+        headers1.withUnsafeBufferAndIndices { (buf, locations, contiguous) in
+            XCTAssertTrue(contiguous)
+            XCTAssertEqual(locations.count, 3)
+            XCTAssertEqual(buf.readableBytes, originalHeadersString.utf8.count) // NB: String considers "\r\n" to be one character
+            
+            let str = buf.getString(at: 0, length: buf.readableBytes)
+            XCTAssertEqual(str, originalHeadersString)
+        }
+        
+        // remove a header
+        headers1.remove(name: "X-SomeHeader")
+        
+        // should no longer be contiguous
+        headers1.withUnsafeBufferAndIndices { (_, _, contiguous) in
+            XCTAssertFalse(contiguous)
+        }
+    }
+    
+    func testCreateFromBufferAndLocations() {
+        let originalHeaders = [ ("User-Agent", "1"),
+                                ("host", "2"),
+                                ("X-SOMETHING", "3"),
+                                ("X-Something", "4"),
+                                ("SET-COOKIE", "foo=bar"),
+                                ("Set-Cookie", "buz=cux")]
+        
+        // create our own buffer and location list
+        var buf = ByteBufferAllocator().buffer(capacity: 128)
+        var locations: [HTTPHeader] = []
+        for (name, value) in originalHeaders {
+            let nstart = buf.writerIndex
+            buf.write(string: name)
+            let nameLoc = HTTPHeaderIndex(start: nstart, length: buf.writerIndex - nstart)
+            buf.write(string: ": ")
+            
+            let vstart = buf.writerIndex
+            buf.write(string: value)
+            let valueLoc = HTTPHeaderIndex(start: vstart, length: buf.writerIndex - vstart)
+            buf.write(string: "\r\n")
+            
+            locations.append(HTTPHeader(name: nameLoc, value: valueLoc))
+        }
+        
+        // create HTTP headers
+        let headers = HTTPHeaders.createHeaderBlock(buffer: buf, headers: locations)
+        
+        // looking up headers value is case-insensitive
+        XCTAssertEqual(["1"], headers["User-Agent"])
+        XCTAssertEqual(["1"], headers["User-agent"])
+        XCTAssertEqual(["2"], headers["Host"])
+        XCTAssertEqual(["3", "4"], headers["X-Something"])
+        XCTAssertEqual(["foo=bar", "buz=cux"], headers["set-cookie"])
     }
 }


### PR DESCRIPTION
There's a public static creator which takes a ByteBuffer and array of `HTTPHeader` now, and the `buffer` and `headers` properties (and thus the `HTTPHeader` and `HTTPHeaderIndex` types) are public to support that.

### Motivation:

HTTP/2 adds an additional item to a header key/value pair: its indexability. By default, headers can be inserted into the HPACK header table index; sometimes this will be denied (common case is 'content-length' header, which is rarely going to be the same, and will just cause the table to purge more often than is really necessary). Additionally, a header may be marked as not only non-indexable but also non-rewritable by proxies. `HTTPHeaders` provides nowhere to store this, so the `HPACKHeaders` implementation referenced in https://github.com/apple/swift-nio-http2/pull/10 was created to add in that capability.

Now, given that we really want the HTTP version to be an implementation detail, we want to keep the HPACK details hidden, and would thus be using `HTTPHeaders` in client APIs. NIOHTTP2 already has a HTTP1-to-HTTP2 channel handler that translates between the two. Thus it behooves us to have the means to copy the actual key/value pairs between the two types without making a round-trip from UTF-8 bytes to UTF-16 `String`s. These changes allow NIOHPACK or NIOHTTP2 to implement that round-trip internally.

### Modifications:

- `HTTPHeader` and `HTTPHeaderIndex` types are now public.
- `HTTPHeaders.buffer` and `HTTPHeaders.headers` properties are now public.
- A new static method, `HTTPHeaders.createHeaderBlock(buffer:headers:)` was created to serve as a public means to create a `HTTPHeaders` from a `ByteBuffer` from outside NIOHTTP1. @Lukasa suggested this should be a static method rather than an initializer.

### Result:

Nothing in NIOHTTP1 changes in operation. All public types have documentation comments noting that they are only public for very specific reasons, and are not intended for general use. Once this is committed, NIOHPACK & NIOHTTP2 will be able to implement fast round-trips between `HTTPHeaders` and `HPACKHeaders`.