### PR TITLE
Support user defined writability in Channels

### DIFF
--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -186,6 +186,36 @@ public enum AllowRemoteHalfClosureOption: ChannelOption {
     case const(())
 }
 
+/// `UserDefinedWritabilityOption` allows users to control the `isWritable` status of the channel aside from its
+/// normal calculation.  This is useful for handlers that need to have a say in when the channel is writable. For
+/// example, the traffic shaping handler needs to be able to disable writability at certain times and this option
+/// provides that capability.
+///
+/// There are 63 available flags and users must negotatiate an index on their own. The option carries the index
+/// of a specific flag to set and a value for the flag.
+public enum UserDefinedWritabilityOption: ChannelOption {
+    public typealias AssociatedValueType = Int
+    public typealias OptionType = Bool
+
+    case const(AssociatedValueType)
+
+    /// Create a new `UserDefinedWritabilityOption`.
+    ///
+    /// - parameters:
+    ///       - index: Index of the writability flag to set.
+    public init(index: Int) {
+        assert(index >= 1 && index < 64, "User defined writability indices must be one of 1..63")
+        self = .const(index)
+    }
+
+    public var value: Int {
+        switch self {
+        case .const(let index):
+            return index
+        }
+    }
+}
+
 /// Provides `ChannelOption`s to be used with a `Channel`, `Bootstrap` or `ServerBootstrap`.
 public struct ChannelOptions {
     /// - seealso: `SocketOption`.
@@ -217,4 +247,7 @@ public struct ChannelOptions {
 
     /// - seealso: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure = AllowRemoteHalfClosureOption.const(())
+
+    /// - seealso: `UserDefinedWritabilityOption`.
+    public static let userDefinedWritability = { (index: Int) -> UserDefinedWritabilityOption in .const(index) }
 }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -86,6 +86,11 @@ final class SocketChannel: BaseSocketChannel<Socket> {
             pendingWrites.writeSpinCount = value as! UInt
         case _ as WriteBufferWaterMarkOption:
             pendingWrites.waterMark = value as! WriteBufferWaterMark
+        case _ as UserDefinedWritabilityOption:
+            let index = option.value as! Int
+            if pendingWrites.setUserDefinedWritability(index: index, writable: value as! Bool) {
+                pipeline.fireChannelWritabilityChanged0()
+            }
         default:
             try super.setOption0(option: option, value: value)
         }
@@ -107,6 +112,9 @@ final class SocketChannel: BaseSocketChannel<Socket> {
             return pendingWrites.writeSpinCount as! T.OptionType
         case _ as WriteBufferWaterMarkOption:
             return pendingWrites.waterMark as! T.OptionType
+        case _ as UserDefinedWritabilityOption:
+            let index = option.value as! Int
+            return pendingWrites.getUserDefinedWritability(index: index) as! T.OptionType
         default:
             return try super.getOption0(option: option)
         }
@@ -556,6 +564,11 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             pendingWrites.writeSpinCount = value as! UInt
         case _ as WriteBufferWaterMarkOption:
             pendingWrites.waterMark = value as! WriteBufferWaterMark
+        case _ as UserDefinedWritabilityOption:
+            let index = option.value as! Int
+            if pendingWrites.setUserDefinedWritability(index: index, writable: value as! Bool) {
+                pipeline.fireChannelWritabilityChanged0()
+            }
         default:
             try super.setOption0(option: option, value: value)
         }
@@ -573,6 +586,9 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             return pendingWrites.writeSpinCount as! T.OptionType
         case _ as WriteBufferWaterMarkOption:
             return pendingWrites.waterMark as! T.OptionType
+        case _ as UserDefinedWritabilityOption:
+            let index = option.value as! Int
+            return pendingWrites.getUserDefinedWritability(index: index) as! T.OptionType
         default:
             return try super.getOption0(option: option)
         }


### PR DESCRIPTION
Mimics the user defined writability feature present in Netty’s `ChannelOutboundBuffer`.  

### Motivation:

Currently porting the traffic shaping features from Netty to Swift NIO.  Proper implementation of a  `ChannelTrafficShapingHandler` requires the ability to disable writability based on external factors.

### Modifications:

It adds the feature to `PendingWritesManager` for both stream & datagram sockets. Instead of exposing a reference to a `PendingWritesManager` interface/protocol in `Channel.unsafe` (as Netty does with `ChannelOutboundBuffer`) the `Channel`'s options feature (`getOption`/`setOption`) is used to allow setting the user defined writability of the `Channel` (which is forwarded to the `PendingWritesManager` internally).

### Result:

External handlers can control the writability of a channel without affecting the status calculated internally by the `Channel`s or `PendingWritesManager`s