### PR TITLE
Added write function to NonBlockingFileIO

### DIFF
--- a/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
@@ -45,6 +45,7 @@ extension NonBlockingFileIOTest {
                 ("testFileRegionReadFromPipeFails", testFileRegionReadFromPipeFails),
                 ("testReadFromNonBlockingPipeFails", testReadFromNonBlockingPipeFails),
                 ("testSeekPointerIsSetToFront", testSeekPointerIsSetToFront),
+                ("testWriting", testWriting),
                 ("testFileOpenWorks", testFileOpenWorks),
                 ("testFileOpenWorksWithEmptyFile", testFileOpenWorksWithEmptyFile),
                 ("testFileOpenFails", testFileOpenFails),

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -450,6 +450,27 @@ class NonBlockingFileIOTest: XCTestCase {
         XCTAssertEqual(2, numCalls)
     }
 
+    func testWriting() throws {
+        var buffer = allocator.buffer(capacity: 3)
+        buffer.write(staticString: "123")
+
+        try withTemporaryFile(content: "") { (fileHandle, path) in
+            try self.fileIO.write(fileHandle: fileHandle,
+                                  buffer: buffer,
+                                  eventLoop: self.eventLoop).wait()
+            let offset = try fileHandle.withUnsafeFileDescriptor {
+                try Posix.lseek(descriptor: $0, offset: 0, whence: SEEK_SET)
+            }
+            XCTAssertEqual(offset, 0)
+
+            let readBuffer = try self.fileIO.read(fileHandle: fileHandle,
+                                                  byteCount: 3,
+                                                  allocator: self.allocator,
+                                                  eventLoop: self.eventLoop).wait()
+            XCTAssertEqual(readBuffer.getString(at: 0, length: 3), "123")
+        }
+    }
+
     func testFileOpenWorks() throws {
         let content = "123"
         try withTemporaryFile(content: content) { (fileHandle, path) -> Void in


### PR DESCRIPTION
### Motivation:

`NonBlockingFileIO` currently provides multiple read functions, but no functions to write to a `FileHandle` in an asynchronous non-blocking way.

### Modifications:

`NonBlockingFileIO` struct now has simple basic `write` function that supports writing from a `ByteBuffer` to a `FileHandle`. Added `testWriting()` to `NonBlockingFileIOTest`.

### Result:

`NonBlockingFileIO` now has a basic building block for asynchronous non-blocking writes.

Resolves #406.