### PR TITLE
Added links to documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,16 @@ SwiftNIO aims to support all of the platforms where Swift is supported. Currentl
 
 ### Basic Architecture
 
-The basic building blocks of SwiftNIO are the following 6 types of objects:
+The basic building blocks of SwiftNIO are the following 8 types of objects:
 
-- `EventLoopGroup`, a protocol
-- `EventLoop`, a protocol
-- `Channel`, a protocol
-- `ChannelHandler`, a protocol
+- [`EventLoopGroup`][elg], a protocol
+- [`EventLoop`][el], a protocol
+- [`Channel`][c], a protocol
+- [`ChannelHandler`][ch], a protocol
 - `Bootstrap`, several related structures
-- `ByteBuffer`, a struct
-- `EventLoopPromise` and `EventLoopFuture`, two generic classes.
+- [`ByteBuffer`][bb], a struct
+- [`EventLoopFuture`][elf], a generic class
+- [`EventLoopPromise`][elp], a generic struct.
 
 All SwiftNIO applications are ultimately constructed of these various components.
 
@@ -42,71 +43,71 @@ The basic I/O primitive of SwiftNIO is the event loop. The event loop is an obje
 
 Event loops are gathered together into event loop *groups*. These groups provide a mechanism to distribute work around the event loops. For example, when listening for inbound connections the listening socket will be registered on one event loop. However, we don't want all connections that are accepted on that listening socket to be registered with the same event loop, as that would potentially overload one event loop while leaving the others empty. For that reason, the event loop group provides the ability to spread load across multiple event loops.
 
-In SwiftNIO today there is one `EventLoopGroup` implementation, and two `EventLoop` implementations. For production applications there is the `MultiThreadedEventLoopGroup`, an `EventLoopGroup` that creates a number of threads (using the POSIX `pthreads` library) and places one `SelectableEventLoop` on each one. The `SelectableEventLoop` is an event loop that uses a selector (either `kqueue` or `epoll` depending on the target system) to manage I/O events from file descriptors and to dispatch work. Additionally, there is the `EmbeddedEventLoop`, which is a dummy event loop that is used primarily for testing purposes.
+In SwiftNIO today there is one [`EventLoopGroup`][elg] implementation, and two [`EventLoop`][el] implementations. For production applications there is the [`MultiThreadedEventLoopGroup`][mtelg], an [`EventLoopGroup`][elg] that creates a number of threads (using the POSIX [`pthreads`][pthreads] library) and places one `SelectableEventLoop` on each one. The `SelectableEventLoop` is an event loop that uses a selector (either [`kqueue`][kqueue] or [`epoll`][epoll] depending on the target system) to manage I/O events from file descriptors and to dispatch work. Additionally, there is the [`EmbeddedEventLoop`][eel], which is a dummy event loop that is used primarily for testing purposes.
 
-`EventLoop`s have a number of important properties. Most vitally, they are the way all work gets done in SwiftNIO applications. In order to ensure thread-safety, any work that wants to be done on almost any of the other objects in SwiftNIO must be dispatched via an `EventLoop`. `EventLoop` objects own almost all the other objects in a SwiftNIO application, and understanding their execution model is critical for building high-performance SwiftNIO applications.
+[`EventLoop`][el]s have a number of important properties. Most vitally, they are the way all work gets done in SwiftNIO applications. In order to ensure thread-safety, any work that wants to be done on almost any of the other objects in SwiftNIO must be dispatched via an [`EventLoop`][el]. [`EventLoop`][el] objects own almost all the other objects in a SwiftNIO application, and understanding their execution model is critical for building high-performance SwiftNIO applications.
 
 #### Channels, Channel Handlers, Channel Pipelines, and Channel Contexts
 
-While `EventLoop`s are critical to the way SwiftNIO works, most users will not interact with them substantially beyond asking them to create `EventLoopPromise`s and to schedule work. The parts of a SwiftNIO application most users will spend the most time interacting with are `Channel`s and `ChannelHandler`s.
+While [`EventLoop`][el]s are critical to the way SwiftNIO works, most users will not interact with them substantially beyond asking them to create [`EventLoopPromise`][elp]s and to schedule work. The parts of a SwiftNIO application most users will spend the most time interacting with are [`Channel`][c]s and [`ChannelHandler`][ch]s.
 
-Almost every file descriptor that a user interacts with in a SwiftNIO program is associated with a single `Channel`. The `Channel` owns this file descriptor, and is responsible for managing its lifetime. It is also responsible for processing inbound and outbound events on that file descriptor: whenever the event loop has an event that corresponds to a file descriptor, it will notify the `Channel` that owns that file descriptor.
+Almost every file descriptor that a user interacts with in a SwiftNIO program is associated with a single [`Channel`][c]. The [`Channel`][c] owns this file descriptor, and is responsible for managing its lifetime. It is also responsible for processing inbound and outbound events on that file descriptor: whenever the event loop has an event that corresponds to a file descriptor, it will notify the [`Channel`][c] that owns that file descriptor.
 
-`Channel`s by themselves, however, are not useful. After all, it is a rare application that doesn't want to do anything with the data it sends or receives on a socket! So the other important part of the `Channel` is the `ChannelPipeline`.
+[`Channel`][c]s by themselves, however, are not useful. After all, it is a rare application that doesn't want to do anything with the data it sends or receives on a socket! So the other important part of the [`Channel`][c] is the [`ChannelPipeline`][cp].
 
-A `ChannelPipeline` is a sequence of objects, called `ChannelHandler`s, that process events on a `Channel`. The `ChannelHandler`s process these events one after another, in order, mutating and transforming events as they go. This can be thought of as a data processing pipeline; hence the name `ChannelPipeline`.
+A [`ChannelPipeline`][cp] is a sequence of objects, called [`ChannelHandler`][ch]s, that process events on a [`Channel`][c]. The [`ChannelHandler`][ch]s process these events one after another, in order, mutating and transforming events as they go. This can be thought of as a data processing pipeline; hence the name [`ChannelPipeline`][cp].
 
-All `ChannelHandler`s are either Inbound or Outbound handlers, or both. Inbound handlers process "inbound" events: events like reading data from a socket, reading socket close, or other kinds of events initiated by remote peers. Outbound handlers process "outbound" events, such as writes, connection attempts, and local socket closes.
+All [`ChannelHandler`][ch]s are either Inbound or Outbound handlers, or both. Inbound handlers process "inbound" events: events like reading data from a socket, reading socket close, or other kinds of events initiated by remote peers. Outbound handlers process "outbound" events, such as writes, connection attempts, and local socket closes.
 
 Each handler processes the events in order. For example, read events are passed from the front of the pipeline to the back, one handler at a time, while write events are passed from the back of the pipeline to the front. Each handler may, at any time, generate either inbound or outbound events that will be sent to the next handler in whichever direction is appropriate. This allows handlers to split up reads, coalesce writes, delay connection attempts, and generally perform arbitrary transformations of events.
 
-In general, `ChannelHandler`s are designed to be highly re-usable components. This means they tend to be designed to be as small as possible, performing one specific data transformation. This allows handlers to be composed together in novel and flexible ways, which helps with code reuse and encapsulation.
+In general, [`ChannelHandler`][ch]s are designed to be highly re-usable components. This means they tend to be designed to be as small as possible, performing one specific data transformation. This allows handlers to be composed together in novel and flexible ways, which helps with code reuse and encapsulation.
 
-`ChannelHandler`s are able to keep track of where they are in a `ChannelPipeline` by using a `ChannelHandlerContext`. These objects contain references to the previous and next channel handler in the pipeline, ensuring that it is always possible for a `ChannelHandler` to emit events while it remains in a pipeline.
+[`ChannelHandler`][ch]s are able to keep track of where they are in a [`ChannelPipeline`][cp] by using a [`ChannelHandlerContext`][chc]. These objects contain references to the previous and next channel handler in the pipeline, ensuring that it is always possible for a [`ChannelHandler`][ch] to emit events while it remains in a pipeline.
 
-SwiftNIO ships with many `ChannelHandler`s built in that provide useful functionality, such as HTTP parsing. In addition, high-performance applications will want to provide as much of their logic as possible in `ChannelHandler`s, as it helps avoid problems with context switching.
+SwiftNIO ships with many [`ChannelHandler`][ch]s built in that provide useful functionality, such as HTTP parsing. In addition, high-performance applications will want to provide as much of their logic as possible in [`ChannelHandler`][ch]s, as it helps avoid problems with context switching.
 
-Additionally, SwiftNIO ships with a few `Channel` implementations. In particular, it ships with `ServerSocketChannel`, a `Channel` for sockets that accept inbound connections; `SocketChannel`, a `Channel` for TCP connections; `DatagramChannel`, a `Channel` for UDP sockets; and `EmbeddedChannel`, a `Channel` primarily used for testing.
+Additionally, SwiftNIO ships with a few [`Channel`][c] implementations. In particular, it ships with `ServerSocketChannel`, a [`Channel`][c] for sockets that accept inbound connections; `SocketChannel`, a [`Channel`][c] for TCP connections; `DatagramChannel`, a [`Channel`][c] for UDP sockets; and [`EmbeddedChannel`][ec], a [`Channel`][c] primarily used for testing.
 
 ##### A Note on Blocking
 
-One of the important notes about `ChannelPipeline`s is that they are not thread-safe. This is very important for writing SwiftNIO applications, as it allows you to write much simpler `ChannelHandler`s in the knowledge that they will not require synchronization.
+One of the important notes about [`ChannelPipeline`][cp]s is that they are not thread-safe. This is very important for writing SwiftNIO applications, as it allows you to write much simpler [`ChannelHandler`][ch]s in the knowledge that they will not require synchronization.
 
-However, this is achieved by dispatching all code on the `ChannelPipeline` on the same thread as the `EventLoop`. This means that, as a general rule, `ChannelHandler`s **must not** call blocking code without dispatching it to a background thread. If a `ChannelHandler` blocks for any reason, all `Channel`s attached to the parent `EventLoop` will be unable to progress until the blocking call completes.
+However, this is achieved by dispatching all code on the [`ChannelPipeline`][cp] on the same thread as the [`EventLoop`][el]. This means that, as a general rule, [`ChannelHandler`][ch]s **must not** call blocking code without dispatching it to a background thread. If a [`ChannelHandler`][ch] blocks for any reason, all [`Channel`][c]s attached to the parent [`EventLoop`][el] will be unable to progress until the blocking call completes.
 
 This is a common concern while writing SwiftNIO applications. If it is useful to write code in a blocking style, it is highly recommended that you dispatch work to a different thread when you're done with it in your pipeline.
 
 #### Bootstrap
 
-While it is possible to configure and register `Channel`s with `EventLoop`s directly, it is generally more useful to have a higher-level abstraction to handle this work.
+While it is possible to configure and register [`Channel`][c]s with [`EventLoop`][el]s directly, it is generally more useful to have a higher-level abstraction to handle this work.
 
 For this reason, SwiftNIO ships a number of `Bootstrap` objects whose purpose is to streamline the creation of channels. Some `Bootstrap` objects also provide other functionality, such as support for Happy Eyeballs for making TCP connection attempts.
 
-Currently SwiftNIO ships with three `Bootstrap` objects: `ServerBootstrap`, for bootstrapping listening channels; `ClientBootstrap`, for bootstrapping client TCP channels; and `DatagramBootstrap` for bootstrapping UDP channels.
+Currently SwiftNIO ships with three `Bootstrap` objects: [`ServerBootstrap`](https://apple.github.io/swift-nio/docs/current/NIO/Classes/ServerBootstrap.html), for bootstrapping listening channels; [`ClientBootstrap`](https://apple.github.io/swift-nio/docs/current/NIO/Classes/ClientBootstrap.html), for bootstrapping client TCP channels; and [`DatagramBootstrap`](https://apple.github.io/swift-nio/docs/current/NIO/Classes/DatagramBootstrap.html) for bootstrapping UDP channels.
 
 #### ByteBuffer
 
 The majority of the work in a SwiftNIO application involves shuffling buffers of bytes around. At the very least, data is sent and received to and from the network in the form of buffers of bytes. For this reason it's very important to have a high-performance data structure that is optimized for the kind of work SwiftNIO applications perform.
 
-For this reason, SwiftNIO provides `ByteBuffer`, a fast copy-on-write byte buffer that forms a key building block of most SwiftNIO applications.
+For this reason, SwiftNIO provides [`ByteBuffer`][bb], a fast copy-on-write byte buffer that forms a key building block of most SwiftNIO applications.
 
-`ByteBuffer` provides a number of useful features, and in addition provides a number of hooks to use it in an "unsafe" mode. This turns off bounds checking for improved performance, at the cost of potentially opening your application up to memory correctness problems.
+[`ByteBuffer`][bb] provides a number of useful features, and in addition provides a number of hooks to use it in an "unsafe" mode. This turns off bounds checking for improved performance, at the cost of potentially opening your application up to memory correctness problems.
 
-In general, it is highly recommended that you use the `ByteBuffer` in its safe mode at all times.
+In general, it is highly recommended that you use the [`ByteBuffer`][bb] in its safe mode at all times.
 
-For more details on the API of `ByteBuffer`, please see our API documentation, linked below.
+For more details on the API of [`ByteBuffer`][bb], please see our API documentation, linked below.
 
 #### Promises and Futures
 
-One major difference between writing concurrent code and writing synchronous code is that not all actions will complete immediately. For example, when you write data on a channel, it is possible that the event loop will not be able to immediately flush that write out to the network. For this reason, SwiftNIO provides `EventLoopPromise<T>` and `EventLoopFuture<T>` to manage operations that complete *asynchronously*.
+One major difference between writing concurrent code and writing synchronous code is that not all actions will complete immediately. For example, when you write data on a channel, it is possible that the event loop will not be able to immediately flush that write out to the network. For this reason, SwiftNIO provides [`EventLoopPromise<T>`][elp] and [`EventLoopFuture<T>`][elf] to manage operations that complete *asynchronously*.
 
-An `EventLoopFuture<T>` is essentially a container for the return value of a function that will be populated *at some time in the future*. Each `EventLoopFuture<T>` has a corresponding `EventLoopPromise<T>`, which is the object that the result will be put into. When the promise is succeeded, the future will be fulfilled.
+An [`EventLoopFuture<T>`][elf] is essentially a container for the return value of a function that will be populated *at some time in the future*. Each [`EventLoopFuture<T>`][elf] has a corresponding [`EventLoopPromise<T>`][elp], which is the object that the result will be put into. When the promise is succeeded, the future will be fulfilled.
 
-If you had to poll the future to detect when it completed that would be quite inefficient, so `EventLoopFuture<T>` is designed to have managed callbacks. Essentially, you can hang callbacks off the future that will be executed when a result is available. The `EventLoopFuture<T>` will even carefully arrange the scheduling to ensure that these callbacks always execute on the event loop that initially created the promise, which helps ensure that you don't need too much synchronization around `EventLoopFuture<T>` callbacks.
+If you had to poll the future to detect when it completed that would be quite inefficient, so [`EventLoopFuture<T>`][elf] is designed to have managed callbacks. Essentially, you can hang callbacks off the future that will be executed when a result is available. The [`EventLoopFuture<T>`][elf] will even carefully arrange the scheduling to ensure that these callbacks always execute on the event loop that initially created the promise, which helps ensure that you don't need too much synchronization around [`EventLoopFuture<T>`][elf] callbacks.
 
-Another important topic for consideration is the difference between how the promise passed to `close` works as opposed to `closeFuture` on a `Channel`. For example, the promise passed into `close` will succeed after the `Channel` is closed down but before the `ChannelPipeline` is completely cleared out. This will allow you to take action on the `ChannelPipeline` before it is completely cleared out, if needed. If it is desired to wait for the `Channel` to close down and the `ChannelPipeline` to be cleared out without any futher action, then the better option would be to wait for the `closeFuture` to succeed.
+Another important topic for consideration is the difference between how the promise passed to `close` works as opposed to `closeFuture` on a [`Channel`][c]. For example, the promise passed into `close` will succeed after the [`Channel`][c] is closed down but before the [`ChannelPipeline`][cp] is completely cleared out. This will allow you to take action on the [`ChannelPipeline`][cp] before it is completely cleared out, if needed. If it is desired to wait for the [`Channel`][c] to close down and the [`ChannelPipeline`][cp] to be cleared out without any futher action, then the better option would be to wait for the `closeFuture` to succeed.
 
-There are several functions for applying callbacks to `EventLoopFuture<T>`, depending on how and when you want them to execute. Details of these functions is left to the API documentation.
+There are several functions for applying callbacks to [`EventLoopFuture<T>`][elf], depending on how and when you want them to execute. Details of these functions is left to the API documentation.
 
 ### Design Philosophy
 
@@ -201,3 +202,19 @@ First make sure you have [Docker](https://www.docker.com/community-edition) inst
 ## Developing SwiftNIO
 
 For the most part, SwiftNIO development is as straightforward as any other SwiftPM project. With that said, we do have a few processes that are worth understanding before you contribute. For details, please see `CONTRIBUTING.md` in this repository.
+
+[ch]: https://apple.github.io/swift-nio/docs/current/NIO/Protocols/ChannelHandler.html
+[c]: https://apple.github.io/swift-nio/docs/current/NIO/Protocols/Channel.html
+[chc]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/ChannelHandlerContext.html
+[ec]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/EmbeddedChannel.html
+[el]: https://apple.github.io/swift-nio/docs/current/NIO/Protocols/EventLoop.html
+[eel]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/EmbeddedEventLoop.html
+[elg]: https://apple.github.io/swift-nio/docs/current/NIO/Protocols/EventLoopGroup.html
+[bb]: https://apple.github.io/swift-nio/docs/current/NIO/Structs/ByteBuffer.html
+[elf]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/EventLoopFuture.html
+[elp]: https://apple.github.io/swift-nio/docs/current/NIO/Structs/EventLoopPromise.html
+[cp]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/ChannelPipeline.html
+[mtelg]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/MultiThreadedEventLoopGroup.html
+[pthreads]: https://en.wikipedia.org/wiki/POSIX_Threads
+[kqueue]: https://en.wikipedia.org/wiki/Kqueue
+[epoll]: https://en.wikipedia.org/wiki/Epoll


### PR DESCRIPTION
### Motivation:

For newcomers that start to explore SwiftNIO on GitHub, the first thing they stumble upon is `README.md`. This file contains a high level description of the framework and mentions a few types that are important when getting started. Adding links from these types to the generated HTML documentation reduces possible friction and makes it easier for newcomers to grasp fundamental building blocks of SwiftNIO.

### Modifications:

- Added Markdown links from first use of types in README.md to generated documentation at https://apple.github.io/swift-nio/
- Added Wikipedia links for few important concepts: `pthreads`, `kqueue`, `epoll`

### Result:

Easier navigation from `README.md` to related documentation.
