### PR TITLE
[EventLoopFuture] Ensure client #file/#line are forwarded in `mapIfError`.

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -580,7 +580,9 @@ extension EventLoopFuture {
     ///         a new value lifted into a new `EventLoopFuture`.
     /// - returns: A future that will receive the recovered value.
     public func mapIfError(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) -> T) -> EventLoopFuture<T> {
-        return thenIfError { return EventLoopFuture<T>(eventLoop: self.eventLoop, result: callback($0), file: file, line: line) }
+        return thenIfError(file: file, line: line) {
+            return EventLoopFuture<T>(eventLoop: self.eventLoop, result: callback($0), file: file, line: line)
+        }
     }
 
 


### PR DESCRIPTION
[EventLoopFuture] Ensure client #file/#line are forwarded in `mapIfError`.

### Motivation:

This ensures that the client's context information will be propagated into
the promise which is implicitly created by thenIfError(). Without this, if
that promise leaked the client would only see information about where it was
allocated inside of NIO, which is not helpful.

### Modifications:

Propagate #file/#line.

### Result:

Client's will see a #file/#line in their code, rather than something like:

```
Fatal error: leaking promise created at (file: ".../.build/checkouts/swift-nio.git-bla/Sources/NIO/EventLoopFuture.swift", line: 583)
```
