### PR TITLE
improve documentation for ByteBuffer.get* methods

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -18,6 +18,13 @@ extension ByteBuffer {
 
     /// Get `length` bytes starting at `index` and return the result as `[UInt8]`. This will not change the reader index.
     ///
+    /// - note: Please consider using `readBytes` which is a safer alternative that automatically maintains the
+    ///         `readerIndex` and won't allow you to read uninitialized memory.
+    /// - warning: This method allows the user to read any of the bytes in the `ByteBuffer`'s storage, including
+    ///           _uninitialized_ ones. To use this API in a safe way the user needs to make sure all the requested
+    ///           bytes have been written before and are therefore initialized. Note that bytes between (including)
+    ///           `readerIndex` and (excluding) `writerIndex` are always initialized by contract and therefore must be
+    ///           safe to read.
     /// - parameters:
     ///     - index: The starting index of the bytes of interest into the `ByteBuffer`.
     ///     - length: The number of bytes of interest.
@@ -106,6 +113,13 @@ extension ByteBuffer {
 
     /// Get the string at `index` from this `ByteBuffer` decoding using the UTF-8 encoding. Does not move the reader index.
     ///
+    /// - note: Please consider using `readString` which is a safer alternative that automatically maintains the
+    ///         `readerIndex` and won't allow you to read uninitialized memory.
+    /// - warning: This method allows the user to read any of the bytes in the `ByteBuffer`'s storage, including
+    ///           _uninitialized_ ones. To use this API in a safe way the user needs to make sure all the requested
+    ///           bytes have been written before and are therefore initialized. Note that bytes between (including)
+    ///           `readerIndex` and (excluding) `writerIndex` are always initialized by contract and therefore must be
+    ///           safe to read.
     /// - parameters:
     ///     - index: The starting index into `ByteBuffer` containing the string of interest.
     ///     - length: The number of bytes making up the string.

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -200,7 +200,7 @@ public struct ByteBufferAllocator {
 /// Each method that is prefixed with `get` is considered "unsafe" as it allows the user to read uninitialized memory if the `index` or `index + length` points outside of the previous written
 /// range of the `ByteBuffer`. Because of this it's strongly advised to prefer the usage of methods that start with the `read` prefix and only use the `get` prefixed methods if there is a strong reason
 /// for doing so. In any case, if you use the `get` prefixed methods you are responsible for ensuring that you do not reach into uninitialized memory by taking the `readableBytes` and `readerIndex` into
-/// account, and ensuring that you have previously written into the area covered by the `index itself.
+/// account, and ensuring that you have previously written into the area covered by the `index` itself.
 public struct ByteBuffer {
     typealias Slice = _ByteBufferSlice
     typealias Allocator = ByteBufferAllocator
@@ -545,6 +545,13 @@ public struct ByteBuffer {
     /// will correspond to index `0` in the returned `ByteBuffer`.
     /// The `readerIndex` of the returned `ByteBuffer` will be `0`, the `writerIndex` will be `length`.
     ///
+    /// - note: Please consider using `readSlice` which is a safer alternative that automatically maintains the
+    ///         `readerIndex` and won't allow you to slice off uninitialized memory.
+    /// - warning: This method allows the user to slice out any of the bytes in the `ByteBuffer`'s storage, including
+    ///           _uninitialized_ ones. To use this API in a safe way the user needs to make sure all the requested
+    ///           bytes have been written before and are therefore initialized. Note that bytes between (including)
+    ///           `readerIndex` and (excluding) `writerIndex` are always initialized by contract and therefore must be
+    ///           safe to read.
     /// - parameters:
     ///     - index: The index the requested slice starts at.
     ///     - length: The length of the requested slice.
@@ -722,6 +729,12 @@ extension ByteBuffer {
     }
 
     /// Move the reader index forward by `offset` bytes.
+    ///
+    /// - warning: By contract the bytes between (including) `readerIndex` and (excluding) `writerIndex` must be
+    ///            initialised, ie. have been written before. Also the `readerIndex` must always be less than or equal
+    ///            to the `writerIndex`. Failing to meet either of these requirements leads to undefined behaviour.
+    /// - parameters:
+    ///   - offset: The number of bytes to move the reader index forward by.
     public mutating func moveReaderIndex(forwardBy offset: Int) {
         let newIndex = self._readerIndex + _toIndex(offset)
         precondition(newIndex >= 0 && newIndex <= writerIndex, "new readerIndex: \(newIndex), expected: range(0, \(writerIndex))")
@@ -729,6 +742,12 @@ extension ByteBuffer {
     }
 
     /// Set the reader index to `offset`.
+    ///
+    /// - warning: By contract the bytes between (including) `readerIndex` and (excluding) `writerIndex` must be
+    ///            initialised, ie. have been written before. Also the `readerIndex` must always be less than or equal
+    ///            to the `writerIndex`. Failing to meet either of these requirements leads to undefined behaviour.
+    /// - parameters:
+    ///   - offset: The offset in bytes to set the reader index to.
     public mutating func moveReaderIndex(to offset: Int) {
         let newIndex = _toIndex(offset)
         precondition(newIndex >= 0 && newIndex <= writerIndex, "new readerIndex: \(newIndex), expected: range(0, \(writerIndex))")
@@ -736,6 +755,12 @@ extension ByteBuffer {
     }
 
     /// Move the writer index forward by `offset` bytes.
+    ///
+    /// - warning: By contract the bytes between (including) `readerIndex` and (excluding) `writerIndex` must be
+    ///            initialised, ie. have been written before. Also the `readerIndex` must always be less than or equal
+    ///            to the `writerIndex`. Failing to meet either of these requirements leads to undefined behaviour.
+    /// - parameters:
+    ///   - offset: The number of bytes to move the writer index forward by.
     public mutating func moveWriterIndex(forwardBy offset: Int) {
         let newIndex = self._writerIndex + _toIndex(offset)
         precondition(newIndex >= 0 && newIndex <= _toCapacity(self._slice.count),"new writerIndex: \(newIndex), expected: range(0, \(_toCapacity(self._slice.count)))")
@@ -743,6 +768,12 @@ extension ByteBuffer {
     }
 
     /// Set the writer index to `offset`.
+    ///
+    /// - warning: By contract the bytes between (including) `readerIndex` and (excluding) `writerIndex` must be
+    ///            initialised, ie. have been written before. Also the `readerIndex` must always be less than or equal
+    ///            to the `writerIndex`. Failing to meet either of these requirements leads to undefined behaviour.
+    /// - parameters:
+    ///   - offset: The offset in bytes to set the reader index to.
     public mutating func moveWriterIndex(to offset: Int) {
         let newIndex = _toIndex(offset)
         precondition(newIndex >= 0 && newIndex <= _toCapacity(self._slice.count),"new writerIndex: \(newIndex), expected: range(0, \(_toCapacity(self._slice.count)))")

--- a/Sources/NIO/ByteBuffer-int.swift
+++ b/Sources/NIO/ByteBuffer-int.swift
@@ -42,6 +42,13 @@ extension ByteBuffer {
 
     /// Get the integer at `index` from this `ByteBuffer`. Does not move the reader index.
     ///
+    /// - note: Please consider using `readInteger` which is a safer alternative that automatically maintains the
+    ///         `readerIndex` and won't allow you to read uninitialized memory.
+    /// - warning: This method allows the user to read any of the bytes in the `ByteBuffer`'s storage, including
+    ///           _uninitialized_ ones. To use this API in a safe way the user needs to make sure all the requested
+    ///           bytes have been written before and are therefore initialized. Note that bytes between (including)
+    ///           `readerIndex` and (excluding) `writerIndex` are always initialized by contract and therefore must be
+    ///           safe to read.
     /// - parameters:
     ///     - index: The starting index of the bytes for the integer into the `ByteBuffer`.
     ///     - endianness: The endianness of the integer in this `ByteBuffer` (defaults to big endian).

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -60,6 +60,13 @@ extension ByteBuffer {
 
     /// Return `length` bytes starting at `index` and return the result as `Data`. This will not change the reader index.
     ///
+    /// - note: Please consider using `readData` which is a safer alternative that automatically maintains the
+    ///         `readerIndex` and won't allow you to read uninitialized memory.
+    /// - warning: This method allows the user to read any of the bytes in the `ByteBuffer`'s storage, including
+    ///           _uninitialized_ ones. To use this API in a safe way the user needs to make sure all the requested
+    ///           bytes have been written before and are therefore initialized. Note that bytes between (including)
+    ///           `readerIndex` and (excluding) `writerIndex` are always initialized by contract and therefore must be
+    ///           safe to read.
     /// - parameters:
     ///     - index: The starting index of the bytes of interest into the `ByteBuffer`
     ///     - length: The number of bytes of interest
@@ -80,6 +87,13 @@ extension ByteBuffer {
 
     /// Get a `String` decoding `length` bytes starting at `index` with `encoding`. This will not change the reader index.
     ///
+    /// - note: Please consider using `readString` which is a safer alternative that automatically maintains the
+    ///         `readerIndex` and won't allow you to read uninitialized memory.
+    /// - warning: This method allows the user to read any of the bytes in the `ByteBuffer`'s storage, including
+    ///           _uninitialized_ ones. To use this API in a safe way the user needs to make sure all the requested
+    ///           bytes have been written before and are therefore initialized. Note that bytes between (including)
+    ///           `readerIndex` and (excluding) `writerIndex` are always initialized by contract and therefore must be
+    ///           safe to read.
     /// - parameters:
     ///     - index: The starting index of the bytes of interest into the `ByteBuffer`.
     ///     - length: The number of bytes of interest.


### PR DESCRIPTION
CC @ldewailly

Motivation:

`ByteBuffer`'s `get*` methods can be used in an unsafe way and we didn't
warn the user enough.

Modifications:

Warn the user in the documentation of all the `get*` methods.

Result:

Less confusion.