### PR TITLE
Deprecate and replace changeCapacity.

### DIFF
--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -303,7 +303,7 @@ private struct PartialHTTPResponse {
         head = nil
         end = nil
         body.clear()
-        body.changeCapacity(to: initialBufferSize)
+        body.reserveCapacity(initialBufferSize)
     }
 
     mutating private func compressBody(compressor: inout z_stream, allocator: ByteBufferAllocator, flag: Int32) -> ByteBuffer? {

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -125,6 +125,10 @@ extension ByteBufferTest {
                 ("testSlicesOfByteBufferViewsAreByteBufferViews", testSlicesOfByteBufferViewsAreByteBufferViews),
                 ("testReadableBufferViewRangeEqualCapacity", testReadableBufferViewRangeEqualCapacity),
                 ("testWeDontWriteTooMuchForUnderreportingContiguousCollection", testWeDontWriteTooMuchForUnderreportingContiguousCollection),
+                ("testReserveCapacityWhenOversize", testReserveCapacityWhenOversize),
+                ("testReserveCapacitySameCapacity", testReserveCapacitySameCapacity),
+                ("testReserveCapacityLargerUniquelyReferencedCallsRealloc", testReserveCapacityLargerUniquelyReferencedCallsRealloc),
+                ("testReserveCapacityLargerMultipleReferenceCallsMalloc", testReserveCapacityLargerMultipleReferenceCallsMalloc),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

As described in #537, ByteBuffer.changeCapacity is not a very good
function. We want to replace it with a better one, more similar to
reserveCapacity on the standard library data structures, and ideally
substantially faster.

Modifications:

- Deprecated ByteBuffer.changeCapacity.
- Added ByteBuffer.reserveCapacity.
- Changed the implementation of changeCapacity to call reserveCapacity
  when we're increasing the capacity.

Result:

Better APIs, better performance in the legacy ones, everything is
better.

Resolves #537.