### PR TITLE
switch Socket API to Unsafe(Mutable)RawBufferPointers

### DIFF
--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -104,13 +104,12 @@ public typealias IOVector = iovec
     /// Write data to the remote peer.
     ///
     /// - parameters:
-    ///     - pointer: The data to write.
-    ///     - size: The number of bytes to write.
+    ///     - pointer: Pointer (and size) to data to write.
     /// - returns: The `IOResult` which indicates how much data could be written and if the operation returned before all could be written (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
-    func write(pointer: UnsafePointer<UInt8>, size: Int) throws -> IOResult<Int> {
+    func write(pointer: UnsafeRawBufferPointer) throws -> IOResult<Int> {
         return try withUnsafeFileDescriptor { fd in
-            try Posix.write(descriptor: fd, pointer: pointer, size: size)
+            try Posix.write(descriptor: fd, pointer: pointer.baseAddress!, size: pointer.count)
         }
     }
 
@@ -129,43 +128,45 @@ public typealias IOVector = iovec
     /// Send data to a destination.
     ///
     /// - parameters:
-    ///     - pointer: The data to send.
-    ///     - size: The number of bytes to send.
+    ///     - pointer: Pointer (and size) to the data to send.
     ///     - destinationPtr: The destination to which the data should be sent.
     /// - returns: The `IOResult` which indicates how much data could be written and if the operation returned before all could be written (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
-    func sendto(pointer: UnsafePointer<UInt8>, size: Int, destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int> {
+    func sendto(pointer: UnsafeRawBufferPointer, destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int> {
         return try withUnsafeFileDescriptor { fd in
-            try Posix.sendto(descriptor: fd, pointer: UnsafeMutablePointer(mutating: pointer), size: size, destinationPtr: destinationPtr, destinationSize: destinationSize)
+            try Posix.sendto(descriptor: fd, pointer: UnsafeMutableRawPointer(mutating: pointer.baseAddress!),
+                             size: pointer.count, destinationPtr: destinationPtr,
+                             destinationSize: destinationSize)
         }
     }
 
     /// Read data from the socket.
     ///
     /// - parameters:
-    ///     - pointer: The pointer to the storage into which the data should be read.
-    ///     - size: The (max) number of bytes to read.
+    ///     - pointer: The pointer (and size) to the storage into which the data should be read.
     /// - returns: The `IOResult` which indicates how much data could be read and if the operation returned before all could be read (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
-    func read(pointer: UnsafeMutablePointer<UInt8>, size: Int) throws -> IOResult<Int> {
+    func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
         return try withUnsafeFileDescriptor { fd in
-            try Posix.read(descriptor: fd, pointer: pointer, size: size)
+            try Posix.read(descriptor: fd, pointer: pointer.baseAddress!, size: pointer.count)
         }
     }
 
     /// Receive data from the socket.
     ///
     /// - parameters:
-    ///     - pointer: The pointer to the storage into which the data should be read.
-    ///     - size: The (max) number of bytes to read.
+    ///     - pointer: The pointer (and size) to the storage into which the data should be read.
     ///     - storage: The address from which the data was received
     ///     - storageLen: The size of the storage itself.
     /// - returns: The `IOResult` which indicates how much data could be received and if the operation returned before all could be received (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
-    func recvfrom(pointer: UnsafeMutablePointer<UInt8>, size: Int, storage: inout sockaddr_storage, storageLen: inout socklen_t) throws -> IOResult<(Int)> {
+    func recvfrom(pointer: UnsafeMutableRawBufferPointer, storage: inout sockaddr_storage, storageLen: inout socklen_t) throws -> IOResult<(Int)> {
         return try withUnsafeFileDescriptor { fd in
             try storage.withMutableSockAddr { (storagePtr, _) in
-                try Posix.recvfrom(descriptor: fd, pointer: pointer, len: size, addr: storagePtr, addrlen: &storageLen)
+                try Posix.recvfrom(descriptor: fd, pointer: pointer.baseAddress!,
+                                   len: pointer.count,
+                                   addr: storagePtr,
+                                   addrlen: &storageLen)
             }
         }
     }

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -392,7 +392,7 @@ final class DatagramChannelTests: XCTestCase {
                 try super.init(protocolFamily: AF_INET, type: Posix.SOCK_DGRAM)
             }
 
-            override func recvfrom(pointer: UnsafeMutablePointer<UInt8>, size: Int, storage: inout sockaddr_storage, storageLen: inout socklen_t) throws -> IOResult<(Int)> {
+            override func recvfrom(pointer: UnsafeMutableRawBufferPointer, storage: inout sockaddr_storage, storageLen: inout socklen_t) throws -> IOResult<(Int)> {
                 if let err = self.error {
                     self.error = nil
                     throw IOError(errnoCode: err, function: "recvfrom")


### PR DESCRIPTION
Motivation:

The (`internal`) `Socket` API should've always been based on
`Unsafe(Mutable)RawBufferPointer`s but for some reason (probably just
age) it was `Unsafe(Mutable)Pointer<UInt8>` alongside a `size: Int`.

Modifications:

switched the `Socket` APIs from `Unsafe(Mutable)Pointer<UInt8>` and a
size to `Unsafe(Mutable)RawBufferPointer`.

Result:

better Swift code.
