### PR TITLE
remove more memory binding assumptions

### DIFF
--- a/Sources/CNIOHTTPParser/include/c_nio_http_parser_swift.h
+++ b/Sources/CNIOHTTPParser/include/c_nio_http_parser_swift.h
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// adaptions for http_parser to make it more straightforward to use from Swift
+
+#ifndef C_NIO_HTTP_PARSER_SWIFT
+#define C_NIO_HTTP_PARSER_SWIFT
+
+#include "c_nio_http_parser.h"
+
+static inline size_t c_nio_http_parser_execute_swift(http_parser *parser,
+                                                     const http_parser_settings *settings,
+                                                     const void *data,
+                                                     size_t len) {
+    return c_nio_http_parser_execute(parser, settings, (const char *)data, len);
+}
+
+#endif

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -279,9 +279,8 @@ private extension ByteBuffer {
         return withVeryUnsafeBytes { buffer in
             // This should never happens as we control when this is called. Adding an assert to ensure this.
             assert(index.start <= self.capacity - index.length)
-            let address = buffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
             for (idx, byte) in view.enumerated() {
-                guard byte.isASCII && address.advanced(by: index.start + idx).pointee & 0xdf == byte & 0xdf else {
+                guard byte.isASCII && buffer[index.start + idx] & 0xdf == byte & 0xdf else {
                     return false
                 }
             }


### PR DESCRIPTION
Motivation:

It's poor style to assume a certain piece of memory is bound to a
certain type across a whole program. That's because any piece of code
run in between might have rebound the memory and also it's hard to prove
that the binding assumption is actually correct. Therefore we should
restrain from using them.

Modifications:

remove more assumptions that memory is bound to a certain type.

Result:

better code