### PR TITLE
Fix Unmanaged.fromOpaque() usage in class Thread

### DIFF
--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -89,7 +89,7 @@ final class Thread {
         let box = ThreadBox(tuple)
         let res = pthread_create(&pt, nil, { p in
             // Cast to UnsafeMutableRawPointer? and force unwrap to make the same code work on macOS and Linux.
-            let b = Unmanaged<ThreadBox>.fromOpaque((p as UnsafeMutableRawPointer?)!.assumingMemoryBound(to: ThreadBox.self)).takeRetainedValue()
+            let b = Unmanaged<ThreadBox>.fromOpaque((p as UnsafeMutableRawPointer?)!).takeRetainedValue()
 
             let body = b.value.body
             let name = b.value.name


### PR DESCRIPTION
### Motivation:

As discussed with Andrew Trick on the Swift Forums, the additional call
to `assumingMemoryBound(to:)` is redundant here. `Unmanaged.fromOpaque`
takes a raw pointer, and `p` is just that.

See https://forums.swift.org/t/withunsafetypepunnedpointer/14540/9
for the discussion.

### Modifications:

Deleted an unnecessary call to `assumingMemoryBound(to:)`. With this
change, we follow the intended usage of `Unmanaged.fromOpaque` more closely.

### Result:

No material change. We save one redundant `UnsafeRawPointer` ->
`UnsafePointer<ThreadBox>` -> `UnsafeRawPointer` conversion.
