### PR TITLE
Fix some typos in comments

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -296,7 +296,7 @@ class BaseSocket: Selectable {
     /// Create a new instance.
     ///
     /// The ownership of the passed in descriptor is transferred to this class. A user must call `close` to close the underlying
-    /// file descriptor once its not needed / used anymore.
+    /// file descriptor once it's not needed / used anymore.
     ///
     /// - parameters:
     ///     - descriptor: The file descriptor to wrap.

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -187,7 +187,7 @@ public struct EventLoopIterator: Sequence, IteratorProtocol {
 /// }
 /// ```
 ///
-/// Because an `EventLoop` may be shared between multiple `Channel`s its important to _NOT_ block while processing IO / tasks. This also includes long running computations which will have the same
+/// Because an `EventLoop` may be shared between multiple `Channel`s it's important to _NOT_ block while processing IO / tasks. This also includes long running computations which will have the same
 /// effect as blocking in this case.
 public protocol EventLoop: EventLoopGroup {
     /// Returns `true` if the current `Thread` is the same as the `Thread` that is tied to this `EventLoop`. `false` otherwise.
@@ -522,7 +522,7 @@ internal final class SelectableEventLoop: EventLoop {
     public func deregister<C: SelectableChannel>(channel: C) throws {
         assert(inEventLoop)
         guard lifecycleState == .open else {
-            // Its possible the EventLoop was closed before we were able to call deregister, so just return in this case as there is no harm.
+            // It's possible the EventLoop was closed before we were able to call deregister, so just return in this case as there is no harm.
             return
         }
         try selector.deregister(selectable: channel.selectable)

--- a/Sources/NIO/IO.swift
+++ b/Sources/NIO/IO.swift
@@ -54,7 +54,7 @@ public struct IOError: Swift.Error {
 /// - parameters:
 ///       - errorCode: the `errno` that was set for the operation.
 ///       - reason: what failed
-/// -returns: the constructed reason.
+/// - returns: the constructed reason.
 private func reasonForError(errnoCode: Int32, reason: String) -> String {
     if let errorDescC = strerror(errnoCode) {
         let errorDescLen = strlen(errorDescC)

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -257,7 +257,7 @@ public struct NonBlockingFileIO {
     /// Open the file at `path` on a private thread pool which is separate from any `EventLoop` thread.
     ///
     /// This function will return (a future) of the `FileHandle` associated with the file opened and a `FileRegion`
-    /// comprising of the whole file. The caller must close the returned `FileHandle` when its no longer needed.
+    /// comprising of the whole file. The caller must close the returned `FileHandle` when it's no longer needed.
     ///
     /// - note: The reason this returns the `FileHandle` and the `FileRegion` is that both the opening of a file as well as the querying of its size are blocking.
     ///

--- a/Sources/NIO/RecvByteBufferAllocator.swift
+++ b/Sources/NIO/RecvByteBufferAllocator.swift
@@ -124,7 +124,7 @@ public struct AdaptiveRecvByteBufferAllocator: RecvByteBufferAllocator {
                 return high
             }
 
-            // Its import to put (...) around as >> is executed before + in swift while in java its the other way around (doh!)
+            // It's important to put (...) around as >> is executed before + in Swift while in Java it's the other way around (doh!)
             let mid = (low + high) >> 1
 
             let a = sizeTable[mid]

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -718,7 +718,7 @@ public enum IOEvent {
     /// Something is ready to be read.
     case read
 
-    /// Its possible to write some data again.
+    /// It's possible to write some data again.
     case write
 
     /// Combination of `read` and `write`.

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -54,7 +54,7 @@ public typealias IOVector = iovec
     /// Create a new instance.
     ///
     /// The ownership of the passed in descriptor is transferred to this class. A user must call `close` to close the underlying
-    /// file descriptor once its not needed / used anymore.
+    /// file descriptor once it's not needed / used anymore.
     ///
     /// - parameters:
     ///     - descriptor: The file descriptor to wrap.

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -383,7 +383,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
 
         let p: EventLoopPromise<Void> = eventLoop.newPromise()
         p.futureResult.map {
-            // Its important to call the methods before we actually notify the original promise for ordering reasons.
+            // It's important to call the methods before we actually notify the original promise for ordering reasons.
             self.becomeActive0(promise: promise)
         }.whenFailure{ error in
             promise?.fail(error: error)

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 //  This file contains code that ensures errno is captured correctly when doing syscalls and no ARC traffic can happen inbetween that *could* change the errno
 //  value before we were able to read it.
-//  Its important that all static methods are declared with `@inline(never)` so its not possible any ARC traffic happens while we need to read errno.
+//  It's important that all static methods are declared with `@inline(never)` so it's not possible any ARC traffic happens while we need to read errno.
 //
 //  Created by Norman Maurer on 11/10/17.
 //
@@ -373,7 +373,7 @@ internal enum Posix {
         }
     }
 
-    // Its not really posix but exists on Linux and MacOS / BSD so just put it here for now to keep it simple
+    // It's not really posix but exists on Linux and MacOS / BSD so just put it here for now to keep it simple
     @inline(never)
     public static func sendfile(descriptor: CInt, fd: CInt, offset: off_t, count: size_t) throws -> IOResult<Int> {
         var written: off_t = 0

--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -62,7 +62,7 @@ final class Thread {
     /// Get current name of the `Thread` or `nil` if not set.
     var name: String? {
         get {
-            // 64 bytes should be good enough as on linux the limit is usually 16 and its very unlikely a user will ever set something longer anyway.
+            // 64 bytes should be good enough as on Linux the limit is usually 16 and it's very unlikely a user will ever set something longer anyway.
             var chars: [CChar] = Array(repeating: 0, count: 64)
             guard sys_pthread_getname_np(pthread, &chars, chars.count) == 0 else {
                 return nil
@@ -77,7 +77,7 @@ final class Thread {
     ///     - name: The name of the `Thread` or `nil` if no specific name should be set.
     ///     - body: The function to execute within the spawned `Thread`.
     static func spawnAndRun(name: String? = nil, body: @escaping (Thread) -> Void) {
-        // Unfortunately the pthread_create method take a different first argument depending on if its on linux or macOS, so ensure we use the correct one.
+        // Unfortunately the pthread_create method take a different first argument depending on if it's on Linux or macOS, so ensure we use the correct one.
         #if os(Linux)
             var pt: pthread_t = pthread_t()
         #else

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -123,7 +123,7 @@ let bootstrap = ServerBootstrap(group: group)
     .childChannelInitializer { channel in
         // Add handler that will buffer data until a \n is received
         channel.pipeline.add(handler: LineDelimiterCodec()).then { v in
-            // Its important we use the same handler for all accepted channels. The ChatHandler is thread-safe!
+            // It's important we use the same handler for all accepted channels. The ChatHandler is thread-safe!
             channel.pipeline.add(handler: chatHandler)
         }
     }

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -43,7 +43,7 @@ private final class EchoHandler: ChannelInboundHandler {
     public func channelActive(ctx: ChannelHandlerContext) {
         print("Client connected to \(ctx.remoteAddress!)")
 
-        // We are connected its time to send the message to the server to initialize the ping-pong sequence.
+        // We are connected. It's time to send the message to the server to initialize the ping-pong sequence.
         var buffer = ctx.channel.allocator.buffer(capacity: line.utf8.count)
         buffer.write(string: line)
         self.numBytes = buffer.readableBytes

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -525,7 +525,7 @@ public class HTTPDecoder<HTTPMessageT>: ByteToMessageDecoder, AnyHTTPDecoder {
             assert(self.state.slice == nil)
             
             if self.cumulationBuffer!.readableBytes == 0 {
-                // Its safe to just drop the cumulationBuffer as we don't have any extra views into it that are represented as readerIndex / length.
+                // It's safe to just drop the cumulationBuffer as we don't have any extra views into it that are represented as readerIndex / length.
                 self.cumulationBuffer = nil
             }
 
@@ -567,7 +567,7 @@ public class HTTPDecoder<HTTPMessageT>: ByteToMessageDecoder, AnyHTTPDecoder {
         }
     }
 
-    /// Will discard bytes till readerIndex if its needed and then call `fn`.
+    /// Will discard bytes till readerIndex if it's needed and then call `fn`.
     private func mayDiscardDecodedBytes(upTo: Int, _ fn: () -> Void) {
         assert(self.cumulationBuffer!.readerIndex == self.cumulationBuffer!.writerIndex)
         self.cumulationBuffer!.moveReaderIndex(to: upTo)

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -133,7 +133,7 @@ final class NonAcceptingServerSocket: ServerSocket {
     private var errors: [Int32]
 
     init(errors: [Int32]) throws {
-        // Reverse so its cheaper to remove errors.
+        // Reverse so it's cheaper to remove errors.
         self.errors = errors.reversed()
         try super.init(protocolFamily: AF_INET, setNonBlocking: true)
     }


### PR DESCRIPTION
### Motivation:

I came across a few typos and then went through the entire code base
fixing similar errors when I noticed a pattern.

### Modifications:

No changes to the code, just to comments.

### Result:

No changes.