### PR TITLE
 Simplify C string to String conversion in IOError.reasonForError

### DIFF
--- a/Sources/NIO/IO.swift
+++ b/Sources/NIO/IO.swift
@@ -57,11 +57,7 @@ public struct IOError: Swift.Error {
 /// -returns: the constructed reason.
 private func reasonForError(errnoCode: Int32, reason: String) -> String {
     if let errorDescC = strerror(errnoCode) {
-        let errorDescLen = strlen(errorDescC)
-        return errorDescC.withMemoryRebound(to: UInt8.self, capacity: errorDescLen) { ptr in
-            let errorDescPtr = UnsafeBufferPointer<UInt8>(start: ptr, count: errorDescLen)
-            return "\(reason): \(String(decoding: errorDescPtr, as: UTF8.self)) (errno: \(errnoCode))"
-        }
+        return "\(reason): \(String(cString: errorDescC)) (errno: \(errnoCode))"
     } else {
         return "\(reason): Broken strerror, unknown error: \(errnoCode)"
     }

--- a/Sources/NIO/IO.swift
+++ b/Sources/NIO/IO.swift
@@ -60,7 +60,7 @@ private func reasonForError(errnoCode: Int32, reason: String) -> String {
         let errorDescLen = strlen(errorDescC)
         return errorDescC.withMemoryRebound(to: UInt8.self, capacity: errorDescLen) { ptr in
             let errorDescPtr = UnsafeBufferPointer<UInt8>(start: ptr, count: errorDescLen)
-            return "\(reason): \(String(decoding: errorDescPtr, as: UTF8.self)) (errno: \(errnoCode)) "
+            return "\(reason): \(String(decoding: errorDescPtr, as: UTF8.self)) (errno: \(errnoCode))"
         }
     } else {
         return "\(reason): Broken strerror, unknown error: \(errnoCode)"


### PR DESCRIPTION
### Motivation:

The standard library already has a String initializer that takes a
null-terminated UTF-8 C string. There's no need to construct an
`UnsafeBufferPointer` to use the `Collection`-based `init(decoding:as:)`.

### Modifications:

- Replaced a manual pointer conversion with the appropriate stdlib API.

- I also removed a stray space from the end of the string interpolation literal
that's used to construct the error message. The stray space looked like an oversight.

### Result:

The string API change doesn't change the result of the method. Both versions return the same `String`. The new version is is arguably more correct because it saves the memory-rebinding step. I haven't added new tests because the modified code is covered by `SystemTest.testErrorsWorkCorrectly`.

Removing the space at the end of the error message string changes the exact value (but not the meaning) of the error message string. Clients that match against the exact error message might break, but that's arguably bad practice.