### PR TITLE
more debugging for flaky tests

### DIFF
--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+@testable import NIO
 import XCTest
 
 class BootstrapTest: XCTestCase {
@@ -50,7 +50,7 @@ class BootstrapTest: XCTestCase {
                     return channel.eventLoop.newSucceededFuture(result: ())
                 }
                 .connect(to: serverChannel.localAddress!)
-                .wait())
+                .wait(), message: "resolver debug info: \(try! resolverDebugInformation(eventLoop: group.next(),host: "localhost", previouslyReceivedResult: serverChannel.localAddress!))")
             defer {
                 XCTAssertNoThrow(try client.syncCloseAcceptingAlreadyClosed())
             }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2402,7 +2402,7 @@ public class ChannelTests: XCTestCase {
         }
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .connect(to: serverChannel.localAddress!)
-            .wait())
+            .wait(), message: "resolver debug info: \(try! resolverDebugInformation(eventLoop: group.next(),host: "localhost", previouslyReceivedResult: serverChannel.localAddress!))")
         XCTAssertNoThrow(try clientChannel.closeFuture.wait() as Void)
     }
 


### PR DESCRIPTION
Motivation:

We suspect a DNS resolver issue in one of our test harnesses to cause
most of the flaky tests. This patch adds more debug information about
the resolver to flaky tests.

Modifications:

print the resolver output when flaky tests fail

Result:

one step closer to no flaky tests
