### PR TITLE
add missing @discardableResults in readWith* methods

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -161,6 +161,7 @@ extension ByteBuffer {
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and returns the number of bytes it processed.
     /// - returns: The number of bytes read.
+    @discardableResult
     @_inlineable
     public mutating func readWithUnsafeReadableBytes(_ body: (UnsafeRawBufferPointer) throws -> Int) rethrows -> Int {
         let bytesRead = try self.withUnsafeReadableBytes(body)
@@ -191,6 +192,7 @@ extension ByteBuffer {
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and returns the number of bytes it processed.
     /// - returns: The number of bytes read.
+    @discardableResult
     @_inlineable
     public mutating func readWithUnsafeMutableReadableBytes(_ body: (UnsafeMutableRawBufferPointer) throws -> Int) rethrows -> Int {
         let bytesRead = try self.withUnsafeMutableReadableBytes(body)

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -129,6 +129,7 @@ extension ByteBufferTest {
                 ("testReserveCapacitySameCapacity", testReserveCapacitySameCapacity),
                 ("testReserveCapacityLargerUniquelyReferencedCallsRealloc", testReserveCapacityLargerUniquelyReferencedCallsRealloc),
                 ("testReserveCapacityLargerMultipleReferenceCallsMalloc", testReserveCapacityLargerMultipleReferenceCallsMalloc),
+                ("testReadWithFunctionsThatReturnNumberOfReadBytesAreDiscardable", testReadWithFunctionsThatReturnNumberOfReadBytesAreDiscardable),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1586,6 +1586,23 @@ class ByteBufferTest: XCTestCase {
             XCTAssertNotEqual(oldPtrVal, newPtrVal)
         }
     }
+
+    func testReadWithFunctionsThatReturnNumberOfReadBytesAreDiscardable() {
+        var buf = self.buf!
+        buf.write(string: "ABCD")
+
+        /* deliberately not ignoring the result */ buf.readWithUnsafeReadableBytes { buffer in
+            XCTAssertEqual(4, buffer.count)
+            return 2
+        }
+
+        /* deliberately not ignoring the result */ buf.readWithUnsafeMutableReadableBytes { buffer in
+            XCTAssertEqual(2, buffer.count)
+            return 2
+        }
+
+        XCTAssertEqual(0, buf.readableBytes)
+    }
 }
 
 private enum AllocationExpectationState: Int {


### PR DESCRIPTION
Motivation:

ByteBuffer has a number of readWith* methods, some of them return the
`T` which was returned from the closure. This shouldn't be discardable.
Others however just return thr number of bytes read which should be
discardable.

Modifications:

made the readWith* functions that return the number of bytes read
@discardableResults

Result:

nicer user code
