### PR TITLE
fix races in RepeatedTasks and its tests

### DIFF
--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -30,6 +30,8 @@ extension EventLoopTest {
                 ("testScheduleWithDelay", testScheduleWithDelay),
                 ("testScheduleCancelled", testScheduleCancelled),
                 ("testScheduleRepeatedTask", testScheduleRepeatedTask),
+                ("testScheduledTaskThatIsImmediatelyCancelledNeverFires", testScheduledTaskThatIsImmediatelyCancelledNeverFires),
+                ("testRepeatedTaskThatIsImmediatelyCancelledNeverFires", testRepeatedTaskThatIsImmediatelyCancelledNeverFires),
                 ("testScheduleRepeatedTaskCancelFromDifferentThread", testScheduleRepeatedTaskCancelFromDifferentThread),
                 ("testScheduleRepeatedTaskToNotRetainRepeatedTask", testScheduleRepeatedTaskToNotRetainRepeatedTask),
                 ("testScheduleRepeatedTaskToNotRetainEventLoop", testScheduleRepeatedTaskToNotRetainEventLoop),


### PR DESCRIPTION
CC @FranzBusch 

Motivation:

There were a number of race conditions in both the RepeatedTasks
implementation and its tests:

- #554: the RepeatedTask could fire more than once before the
  cancellation was actually processed leading to a crash in tests
- #548: a test was testing that the RepeatedTask ran a certain
  number of times but the counting was racing with the checking
- TOCTOU issue: When a RepeatedTask was cancelled it was possible that
  it fires one extra time because a TOCTOU issue

Modifications:

- fixed the test races
- fixed the TOCTOU issue by checking if it was cancelled when it's
  executed rather than only when it's scheduled to be executed

Result:

- tests should be more stable (fixes #548 & fixes #554)
- RepeatedTask cancellation improved
