### PR TITLE
Make withUnsafeMutable{Readable,Writable}Bytes inlinable.

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -494,7 +494,8 @@ public struct ByteBuffer {
         }
     }
 
-    private mutating func copyStorageAndRebaseIfNeeded() {
+    @_versioned
+    mutating func _copyStorageAndRebaseIfNeeded() {
         if !isKnownUniquelyReferenced(&self._storage) {
             self._copyStorageAndRebase()
         }
@@ -507,8 +508,9 @@ public struct ByteBuffer {
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes.
     /// - returns: The value returned by `fn`.
+    @_inlineable
     public mutating func withUnsafeMutableReadableBytes<T>(_ body: (UnsafeMutableRawBufferPointer) throws -> T) rethrows -> T {
-        self.copyStorageAndRebaseIfNeeded()
+        self._copyStorageAndRebaseIfNeeded()
         return try body(UnsafeMutableRawBufferPointer(start: self._storage.bytes.advanced(by: Int(self._slice.lowerBound + self._readerIndex)),
                                                     count: self.readableBytes))
     }
@@ -523,8 +525,9 @@ public struct ByteBuffer {
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and return the number of bytes written.
     /// - returns: The number of bytes written.
+    @_inlineable
     public mutating func withUnsafeMutableWritableBytes<T>(_ body: (UnsafeMutableRawBufferPointer) throws -> T) rethrows -> T {
-        self.copyStorageAndRebaseIfNeeded()
+        self._copyStorageAndRebaseIfNeeded()
         return try body(UnsafeMutableRawBufferPointer(start: self._storage.bytes.advanced(by: Int(self._slice.lowerBound + self._writerIndex)),
                                                     count: self.writableBytes))
     }


### PR DESCRIPTION
Motivation:

I spotted this while flamegraphing: apparently we missed the
declaration for inlineability here.

Modifications:

Made these two functions inlineable.

Result:

Better optimizations.
