### PR TITLE
Remove unnecessary import in c-atomics.h

### DIFF
--- a/Sources/CNIOAtomics/include/c-atomics.h
+++ b/Sources/CNIOAtomics/include/c-atomics.h
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <stdbool.h>
-#include <inttypes.h>
 #include <stdint.h>
 
 #if __clang_major__ == 3 && __clang_minor__ <= 6


### PR DESCRIPTION
We don't need this import, so let's not bring it along.