### PR TITLE
Avoid implicit conversion.

### DIFF
--- a/Sources/CNIODarwin/shim.c
+++ b/Sources/CNIODarwin/shim.c
@@ -39,7 +39,7 @@ int CNIODarwin_sendmmsg(int sockfd, CNIODarwin_mmsghdr *msgvec, unsigned int vle
         }
 
         // Send succeeded, save off the bytes written.
-        msgvec[i].msg_len = sendAmount;
+        msgvec[i].msg_len = (unsigned int)sendAmount;
     }
 
     // If we dropped out, we sent everything.


### PR DESCRIPTION
Motivation:

We were inadvertently doing an implicit integer conversion from
ssize_t to unsigned int in our sendmmsg shim. This can sometimes
generate warnings. The conversion itself is safe.

Modifications:

Make the conversion explicit.

Result:

No warnings.
