### PR TITLE
use cross-testTarget dependencies for TestUtils

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,16 +53,18 @@ var targets: [PackageDescription.Target] = [
             dependencies: ["NIO", "NIOHTTP1", "NIOWebSocket"]),
     .target(name: "NIOPerformanceTester",
             dependencies: ["NIO", "NIOHTTP1", "NIOFoundationCompat"]),
+    .testTarget(name: "NIOTestUtils",
+                dependencies: ["NIO"]),
     .testTarget(name: "NIOTests",
-                dependencies: ["NIO", "NIOFoundationCompat"]),
+                dependencies: ["NIO", "NIOFoundationCompat", "NIOTestUtils"]),
     .testTarget(name: "NIOConcurrencyHelpersTests",
-                dependencies: ["NIOConcurrencyHelpers"]),
+                dependencies: ["NIOConcurrencyHelpers", "NIOTestUtils"]),
     .testTarget(name: "NIOHTTP1Tests",
-                dependencies: ["NIOHTTP1", "NIOFoundationCompat"]),
+                dependencies: ["NIOHTTP1", "NIOFoundationCompat", "NIOTestUtils"]),
     .testTarget(name: "NIOTLSTests",
-                dependencies: ["NIO", "NIOTLS", "NIOFoundationCompat"]),
+                dependencies: ["NIO", "NIOTLS", "NIOFoundationCompat", "NIOTestUtils"]),
     .testTarget(name: "NIOWebSocketTests",
-                dependencies: ["NIO", "NIOWebSocket"]),
+                dependencies: ["NIO", "NIOWebSocket", "NIOTestUtils"]),
 ]
 
 let package = Package(

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -12,11 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
 import XCTest
+
 import NIO
 import NIOConcurrencyHelpers
 import NIOFoundationCompat
-import Dispatch
+import NIOTestUtils
+
 @testable import NIOHTTP1
 
 extension Array where Array.Element == ByteBuffer {

--- a/Tests/NIOHTTP1Tests/TestUtils.swift
+++ b/Tests/NIOHTTP1Tests/TestUtils.swift
@@ -1,1 +1,0 @@
-../NIOTests/TestUtils.swift

--- a/Tests/NIOTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOTests/AcceptBackoffHandlerTest.swift
@@ -12,10 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-@testable import NIO
 import Dispatch
+import XCTest
+
 import NIOConcurrencyHelpers
+import NIOTestUtils
+
+@testable import NIO
 
 
 public class AcceptBackoffHandlerTest: XCTestCase {

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -12,8 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import NIO
 import XCTest
+
+import NIOTestUtils
+
+@testable import NIO
 
 class BootstrapTest: XCTestCase {
     func testBootstrapsCallInitializersOnCorrectEventLoop() throws {

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -12,8 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import NIO
 import XCTest
+
+import NIOTestUtils
+
+@testable import NIO
 
 class ChannelNotificationTest: XCTestCase {
 

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -13,7 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+
 import NIOConcurrencyHelpers
+import NIOTestUtils
+
 @testable import NIO
 
 private final class IndexWritingHandler: ChannelDuplexHandler {

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -12,10 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-@testable import NIO
-import NIOConcurrencyHelpers
 import Dispatch
+import XCTest
+
+import NIOConcurrencyHelpers
+import NIOTestUtils
+
+@testable import NIO
 
 func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testInterval: TimeAmount? = nil, _ message: String, file: StaticString = #file, line: UInt = #line) {
     let testInterval = testInterval ?? TimeAmount.nanoseconds(time.nanoseconds / 5)

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -12,9 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOConcurrencyHelpers
-@testable import NIO
 import XCTest
+
+import NIOConcurrencyHelpers
+import NIOTestUtils
+
+@testable import NIO
 
 private extension Channel {
     func waitForDatagrams(count: Int) throws -> [AddressedEnvelope<ByteBuffer>] {

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -12,9 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import NIOConcurrencyHelpers
 import Dispatch
+import XCTest
+
+import NIOConcurrencyHelpers
+import NIOTestUtils
+
 @testable import NIO
 
 class EchoServerClientTest : XCTestCase {

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -11,10 +11,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import XCTest
-@testable import NIO
+
 import Dispatch
+import XCTest
+
 import NIOConcurrencyHelpers
+import NIOTestUtils
+
+@testable import NIO
 
 public class EventLoopTest : XCTestCase {
 

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -13,6 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+
+import NIOTestUtils
+
 @testable import NIO
 
 class FileRegionTest : XCTestCase {

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -13,6 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+
+import NIOTestUtils
+
 @testable import NIO
 
 class IdleStateHandlerTest : XCTestCase {

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -13,6 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+
+import NIOTestUtils
+
 @testable import NIO
 
 class NonBlockingFileIOTest: XCTestCase {

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -12,9 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import NIO
-import NIOConcurrencyHelpers
 import XCTest
+
+import NIOConcurrencyHelpers
+import NIOTestUtils
+
+@testable import NIO
 
 class SelectorTest: XCTestCase {
 

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -11,10 +11,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
 import XCTest
-@testable import NIO
 import Dispatch
+
 import NIOConcurrencyHelpers
+import NIOTestUtils
+
+@testable import NIO
 
 private extension Array {
     /// A helper function that asserts that a predicate is true for all elements.

--- a/Tests/NIOTests/SystemTest.swift
+++ b/Tests/NIOTests/SystemTest.swift
@@ -13,6 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+
+import NIOTestUtils
+
 @testable import NIO
 
 class SystemTest: XCTestCase {


### PR DESCRIPTION
Motivation:

SwiftPM seems to support cross-testTarget dependencies when running
`swift test`.

Modifications:

use cross-testTarget dependencies instead of symlink

Result:

better
