### PR TITLE
output a hint if we get a reset connection w/o error set

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -921,7 +921,12 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
                 } else {
                     // we don't have a socket error, this must be connection reset without an error then
                     // this path should only be executed on Linux (EPOLLHUP, no EPOLLERR)
-                    error = IOError(errnoCode: ECONNRESET, reason: "connection reset (no error set)")
+                    #if os(Linux)
+                    let message: String = "connection reset (no error set)"
+                    #else
+                    let message: String = "BUG IN SwiftNIO (possibly #572), please report! Connection reset (no error set)."
+                    #endif
+                    error = IOError(errnoCode: ECONNRESET, reason: message)
                 }
                 self.close0(error: error, mode: .all, promise: nil)
             } catch {


### PR DESCRIPTION
Motivation:

We have one case in the code where we expect a socket error to be set
when we hit a connection that got the `.reset` event. On Linux that's
expected and therefore we just map this to `ECONNRESET`.
On other platforms however that is unexpected. Now I just found an
[Envoy commit](https://github.com/envoyproxy/envoy/commit/62f8e51bdd2d72cbac739087dabd3f51bdfc5cbd#diff-3315c7b2    91f78a482ebd4cbfc0545362R345)
which suggests this might not work on FreeBSD. This should prompt our
users to let us know if we ever see this error on non-Linux systems.

Modifications:

Add a message that makes it clear this is unexpected and link our
ticket.

Result:

we should learn if this actually happens on macOS.
