### PR TITLE
add forgotten selfs

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -793,7 +793,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         assert(self.isOpen)
         assert(!self.lifecycleManager.isActive)
         let registerPromise: EventLoopPromise<Void> = self.eventLoop.newPromise()
-        register0(promise: registerPromise)
+        self.register0(promise: registerPromise)
         registerPromise.futureResult.whenFailure { (_: Error) in
             self.close(promise: nil)
         }
@@ -804,7 +804,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         if self.lifecycleManager.isPreRegistered {
             try! becomeFullyRegistered0()
             if self.lifecycleManager.isRegisteredFully {
-                becomeActive0(promise: promise)
+                self.becomeActive0(promise: promise)
             }
         }
     }
@@ -818,10 +818,10 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         assert(self.eventLoop.inEventLoop)
         assert(self.isOpen)
 
-        finishConnect()  // If we were connecting, that has finished.
-        if flushNow() == .unregister {
+        self.finishConnect()  // If we were connecting, that has finished.
+        if self.flushNow() == .unregister {
             // Everything was written or connect was complete
-            finishWritable()
+            self.finishWritable()
         }
     }
 
@@ -829,11 +829,11 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         assert(eventLoop.inEventLoop)
         assert(self.lifecycleManager.isPreRegistered)
 
-        if let connectPromise = pendingConnect {
+        if let connectPromise = self.pendingConnect {
             assert(!self.lifecycleManager.isActive)
 
             do {
-                try finishConnectSocket()
+                try self.finishConnectSocket()
             } catch {
                 assert(!self.lifecycleManager.isActive)
                 // close0 fails the connectPromise itself so no need to do it here
@@ -844,7 +844,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
             self.pendingConnect = nil
             // We already know what the local address is.
             self.updateCachedAddressesFromSocket(updateLocal: false, updateRemote: true)
-            becomeActive0(promise: connectPromise)
+            self.becomeActive0(promise: connectPromise)
         } else {
             assert(self.lifecycleManager.isActive)
         }
@@ -855,7 +855,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
 
         if self.isOpen {
             assert(self.lifecycleManager.isPreRegistered)
-            unregisterForWritable()
+            self.unregisterForWritable()
         }
     }
 
@@ -962,11 +962,11 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
                     // If we want to allow half closure we will just mark the input side of the Channel
                     // as closed.
                     assert(self.lifecycleManager.isActive)
-                    pipeline.fireChannelReadComplete0()
-                    if shouldCloseOnReadError(err) {
-                        close0(error: err, mode: .input, promise: nil)
+                    self.pipeline.fireChannelReadComplete0()
+                    if self.shouldCloseOnReadError(err) {
+                        self.close0(error: err, mode: .input, promise: nil)
                     }
-                    readPending = false
+                    self.readPending = false
                     return .eof
                 }
             } else {
@@ -976,19 +976,19 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
 
             // Call before triggering the close of the Channel.
             if self.lifecycleManager.isActive {
-                pipeline.fireChannelReadComplete0()
+                self.pipeline.fireChannelReadComplete0()
             }
 
-            if shouldCloseOnReadError(err) {
+            if self.shouldCloseOnReadError(err) {
                 self.close0(error: err, mode: .all, promise: nil)
             }
 
             return readStreamState
         }
         if self.lifecycleManager.isActive {
-            pipeline.fireChannelReadComplete0()
+            self.pipeline.fireChannelReadComplete0()
         }
-        readIfNeeded0()
+        self.readIfNeeded0()
         return .normal(readResult)
     }
 
@@ -1034,19 +1034,19 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         }
 
         do {
-            if try !connectSocket(to: address) {
+            if try !self.connectSocket(to: address) {
                 // We aren't connected, we'll get the remote address later.
                 self.updateCachedAddressesFromSocket(updateLocal: true, updateRemote: false)
                 if promise != nil {
-                    pendingConnect = promise
+                    self.pendingConnect = promise
                 } else {
-                    pendingConnect = eventLoop.newPromise()
+                    self.pendingConnect = eventLoop.newPromise()
                 }
-                try becomeFullyRegistered0()
-                registerForWritable()
+                try self.becomeFullyRegistered0()
+                self.registerForWritable()
             } else {
                 self.updateCachedAddressesFromSocket()
-                becomeActive0(promise: promise)
+                self.becomeActive0(promise: promise)
             }
         } catch let error {
             assert(self.lifecycleManager.isPreRegistered)

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -71,11 +71,11 @@ public typealias IOVector = iovec
     func connect(to address: SocketAddress) throws -> Bool {
         switch address {
         case .v4(let addr):
-            return try connectSocket(addr: addr.address)
+            return try self.connectSocket(addr: addr.address)
         case .v6(let addr):
-            return try connectSocket(addr: addr.address)
+            return try self.connectSocket(addr: addr.address)
         case .unixDomainSocket(let addr):
-            return try connectSocket(addr: addr.address)
+            return try self.connectSocket(addr: addr.address)
         }
     }
 

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -211,9 +211,9 @@ final class SocketChannel: BaseSocketChannel<Socket> {
     }
 
     override func finishConnectSocket() throws {
-        if let scheduled = connectTimeoutScheduled {
+        if let scheduled = self.connectTimeoutScheduled {
             // Connection established so cancel the previous scheduled timeout.
-            connectTimeoutScheduled = nil
+            self.connectTimeoutScheduled = nil
             scheduled.cancel()
         }
         try self.socket.finishConnect()


### PR DESCRIPTION
Motivation:

Swift code that doesn't use explicit `self.` is hard to read, even
harder to search for and quite bug prone. During my analysis I found
quite a number of them, this fixes the ones I came across.

Modifications:

Add a bunch of missing explicit `self.`s

Result:

code easier to read and less bug prone
