### PR TITLE
fix Posix.fcntl return type

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -267,7 +267,8 @@ class BaseSocket: Selectable {
         #if !os(Linux)
         if setNonBlocking {
             do {
-                try Posix.fcntl(descriptor: sock, command: F_SETFL, value: O_NONBLOCK)
+                let ret = try Posix.fcntl(descriptor: sock, command: F_SETFL, value: O_NONBLOCK)
+                assert(ret == 0, "unexpectedly, fcntl(\(sock), F_SETFL, O_NONBLOCK) returned \(ret)")
             } catch {
                 _ = try? Posix.close(descriptor: sock)
                 throw error
@@ -316,7 +317,8 @@ class BaseSocket: Selectable {
     /// throws: An `IOError` if the operation failed.
     final func setNonBlocking() throws {
         return try withUnsafeFileDescriptor { fd in
-            try Posix.fcntl(descriptor: fd, command: F_SETFL, value: O_NONBLOCK)
+            let ret = try Posix.fcntl(descriptor: fd, command: F_SETFL, value: O_NONBLOCK)
+            assert(ret == 0, "unexpectedly, fcntl(\(fd), F_SETFL, O_NONBLOCK) returned \(ret)")
         }
     }
 

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -217,8 +217,8 @@ internal enum Posix {
 
     @inline(never)
     // TODO: Allow varargs
-    public static func fcntl(descriptor: CInt, command: CInt, value: CInt) throws {
-        _ = try wrapSyscall {
+    public static func fcntl(descriptor: CInt, command: CInt, value: CInt) throws -> CInt {
+        return try wrapSyscall {
             sysFcntl(descriptor, command, value)
         }
     }
@@ -233,7 +233,9 @@ internal enum Posix {
                 _ = unsafeBitCast(Glibc.signal(SIGPIPE, SIG_IGN) as sighandler_t?, to: Int.self)
             #else
                 if fd != -1 {
-                    _ = try? Posix.fcntl(descriptor: fd, command: F_SETNOSIGPIPE, value: 1)
+                    let ret = try? Posix.fcntl(descriptor: fd, command: F_SETNOSIGPIPE, value: 1)
+                    assert(ret == .some(0),
+                           "unexpectedly, fcntl(\(fd), F_SETFL, F_SETNOSIGPIPE) returned \(ret.debugDescription)")
                 }
             #endif
             return fd
@@ -270,8 +272,9 @@ internal enum Posix {
 
             #if !os(Linux)
                 if fd != -1 {
-                    // TODO: Handle return code ?
-                    _ = try? Posix.fcntl(descriptor: fd, command: F_SETNOSIGPIPE, value: 1)
+                    let ret = try? Posix.fcntl(descriptor: fd, command: F_SETNOSIGPIPE, value: 1)
+                    assert(ret == .some(0),
+                           "unexpectedly, fcntl(\(fd), F_SETFL, F_SETNOSIGPIPE) returned \(ret.debugDescription)")
                 }
             #endif
             return fd

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -405,7 +405,8 @@ class NonBlockingFileIOTest: XCTestCase {
         try withPipe { readFH, writeFH in
             do {
                 try readFH.withUnsafeFileDescriptor { readFD in
-                    try Posix.fcntl(descriptor: readFD, command: F_SETFL, value: O_NONBLOCK)
+                    let ret = try Posix.fcntl(descriptor: readFD, command: F_SETFL, value: O_NONBLOCK)
+                    assert(ret == 0, "unexpectedly, fcntl(\(readFD), F_SETFL, O_NONBLOCK) returned \(ret)")
                 }
                 try self.fileIO.readChunked(fileHandle: readFH,
                                             byteCount: 10,

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -44,6 +44,7 @@ extension SocketChannelTest {
                 ("testWithConfiguredDatagramSocket", testWithConfiguredDatagramSocket),
                 ("testPendingConnectNotificationOrder", testPendingConnectNotificationOrder),
                 ("testLocalAndRemoteAddressNotNilInChannelInactiveAndHandlerRemoved", testLocalAndRemoteAddressNotNilInChannelInactiveAndHandlerRemoved),
+                ("testSocketFlagNONBLOCKWorks", testSocketFlagNONBLOCKWorks),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously the code said that fcntl doesn't return anything but that's
just not true, it returns `CInt`.

Modifications:

Made `fcntl` return `CInt` and tested that.

Result:

more correct code and more tests
