### PR TITLE
if an EventLoopFuture.wait() blows up, tell users where

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -795,7 +795,7 @@ extension EventLoopFuture {
     ///
     /// - returns: The value of the `EventLoopFuture` when it completes.
     /// - throws: The error value of the `EventLoopFuture` if it errors.
-    public func wait() throws -> T {
+    public func wait(file: StaticString = #file, line: UInt = #line) throws -> T {
         if !(self.eventLoop is EmbeddedEventLoop) {
             let explainer: () -> String = { """
 BUG DETECTED: wait() must not be called when on an EventLoop.
@@ -808,8 +808,8 @@ Further information:
 - event loop associated to future: \(self.eventLoop)
 """
             }
-            precondition(!eventLoop.inEventLoop, explainer())
-            precondition(MultiThreadedEventLoopGroup.currentEventLoop == nil, explainer())
+            precondition(!eventLoop.inEventLoop, explainer(), file: file, line: line)
+            precondition(MultiThreadedEventLoopGroup.currentEventLoop == nil, explainer(), file: file, line: line)
         }
 
         var v: EventLoopFutureValue <T>? = nil


### PR DESCRIPTION
Motivation:

If the deadlock detection in EventLoopFuture.wait() blows up we should
tell users the file/line where they called it from not where our
preconditon is.

Modifications:

- add a file/line parameter with default value obvs

Result:

better diagnostics
