### PR TITLE
fix limits on 32-bit systems to values that work

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -105,10 +105,6 @@ public struct ByteBufferAllocator {
                   hookedRealloc: @escaping @convention(c) (UnsafeMutableRawPointer?, size_t) -> UnsafeMutableRawPointer?,
                   hookedFree: @escaping @convention(c) (UnsafeMutableRawPointer?) -> Void,
                   hookedMemcpy: @escaping @convention(c) (UnsafeMutableRawPointer, UnsafeRawPointer, size_t) -> Void) {
-        #if !arch(arm) // only complain on 64-bit, this is unfortunate reality on 32-bit
-            assert(MemoryLayout<ByteBuffer>.size <= 3 * MemoryLayout<Int>.size,
-                   "ByteBuffer has size \(MemoryLayout<ByteBuffer>.size) which is larger than the built-in storage of the existential containers.")
-        #endif
         self.malloc = hookedMalloc
         self.realloc = hookedRealloc
         self.free = hookedFree

--- a/Sources/NIO/ByteBuffer-int.swift
+++ b/Sources/NIO/ByteBuffer-int.swift
@@ -122,10 +122,12 @@ extension UInt32 {
 
         var n = self
 
-        #if arch(arm) // 32-bit, Raspi/AppleWatch/etc
-            let max = UInt32(Int32.max)
+        #if arch(arm) || arch(i386)
+        // on 32-bit platforms we can't make use of a whole UInt32.max (as it doesn't fit in an Int)
+        let max = UInt32(Int.max)
         #else
-            let max = UInt32.max
+        // on 64-bit platforms we're good
+        let max = UInt32.max
         #endif
 
         n -= 1

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -216,10 +216,13 @@ public protocol EventLoop: EventLoopGroup {
 /// - note: `TimeAmount` should not be used to represent a point in time.
 public struct TimeAmount {
   
-    #if arch(arm) // 32-bit, Raspi/AppleWatch/etc
-        public typealias Value = Int64
-    #else // 64-bit, keeping that at Int for SemVer in the 1.x line.
-        public typealias Value = Int
+    #if arch(arm) || arch(i386)
+    // Int64 is the correct type here but we don't want to break SemVer so can't change it for the 64-bit platforms.
+    // To be fixed in NIO 2.0
+    public typealias Value = Int64
+    #else
+    // 64-bit, keeping that at Int for SemVer in the 1.x line.
+    public typealias Value = Int
     #endif
 
     /// The nanoseconds representation of the `TimeAmount`.

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -19,16 +19,7 @@ public typealias IOVector = iovec
 /* final but tests */ class Socket: BaseSocket {
 
     /// The maximum number of bytes to write per `writev` call.
-    static var writevLimitBytes: Int {
-        #if arch(arm) // 32-bit, Raspi/AppleWatch/etc
-            // Note(hh): This is not a _proper_ fix, but necessary because
-            //           other places extend on that. Should be fine in
-            //           practice on 32-bit platforms.
-            return Int(Int32.max / 4)
-        #else
-            return Int(Int32.max)
-        #endif
-    }
+    static var writevLimitBytes = Int(Int32.max)
 
     /// The maximum number of `IOVector`s to write per `writev` call.
     static let writevLimitIOVectors: Int = Posix.UIO_MAXIOV

--- a/Sources/NIOWebSocket/WebSocketFrameEncoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameEncoder.swift
@@ -16,13 +16,12 @@ import NIO
 
 private let maxOneByteSize = 125
 private let maxTwoByteSize = Int(UInt16.max)
-#if arch(arm) // 32-bit, Raspi/AppleWatch/etc
-    // Note(hh): This is not a _proper_ fix, but necessary because
-    //           other places extend on that. Should be fine in
-    //           practice on 32-bit platforms.
-    private let maxNIOFrameSize = Int(Int32.max / 4)
+#if arch(arm) || arch(i386)
+// on 32-bit platforms we can't put a whole UInt32 in an Int
+private let maxNIOFrameSize = Int(UInt32.max / 2)
 #else
-    private let maxNIOFrameSize = Int(UInt32.max)
+// on 64-bit platforms this works just fine
+private let maxNIOFrameSize = Int(UInt32.max)
 #endif
 
 /// An inbound `ChannelHandler` that serializes structured websocket frames into a byte stream

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1073,37 +1073,28 @@ class ByteBufferTest: XCTestCase {
     }
 
     func testAllocationOfReallyBigByteBuffer() throws {
-        #if arch(arm) // 32-bit, Raspi/AppleWatch/etc
-            // FIXME: Fails hard on Raspi 32-bit even with Int16.max in `__memcpy_neon`. Figure out how and why.
-            XCTAssertTrue(false, "testAllocationOfReallyBigByteBuffer fails on 32-bit Raspi")
-        #else
-            let alloc = ByteBufferAllocator(hookedMalloc: { testAllocationOfReallyBigByteBuffer_mallocHook($0) },
-                                            hookedRealloc: { testAllocationOfReallyBigByteBuffer_reallocHook($0, $1) },
-                                            hookedFree: { testAllocationOfReallyBigByteBuffer_freeHook($0) },
-                                            hookedMemcpy: { testAllocationOfReallyBigByteBuffer_memcpyHook($0, $1, $2) })
-
-            #if arch(arm) // 32-bit, Raspi/AppleWatch/etc
-                let reallyBigSize = Int(Int16.max) // well, but Int32 is too big (1GB RAM, no swap)
-            #else
-                let reallyBigSize = Int(Int32.max)
-            #endif
-            XCTAssertEqual(AllocationExpectationState.begin, testAllocationOfReallyBigByteBuffer_state)
-            var buf = alloc.buffer(capacity: reallyBigSize)
-            XCTAssertEqual(AllocationExpectationState.mallocDone, testAllocationOfReallyBigByteBuffer_state)
-            XCTAssertGreaterThanOrEqual(buf.capacity, reallyBigSize)
-
-            buf.set(bytes: [1], at: 0)
-            /* now make it expand (will trigger realloc) */
-            buf.set(bytes: [1], at: buf.capacity)
-
-            XCTAssertEqual(AllocationExpectationState.reallocDone, testAllocationOfReallyBigByteBuffer_state)
-            #if arch(arm) // 32-bit, Raspi/AppleWatch/etc
-                // TODO(hh): no idea, but not UInt32.max :-)
-                XCTAssertGreaterThanOrEqual(buf.capacity, reallyBigSize)
-            #else
-                XCTAssertEqual(buf.capacity, Int(UInt32.max))
-            #endif
+        #if arch(arm) || arch(i386)
+        // this test doesn't work on 32-bit platforms because the address space is only 4GB large and we're trying
+        // to make a 4GB ByteBuffer which just won't fit. Even going down to 2GB won't make it better.
+        return
         #endif
+        let alloc = ByteBufferAllocator(hookedMalloc: { testAllocationOfReallyBigByteBuffer_mallocHook($0) },
+                                        hookedRealloc: { testAllocationOfReallyBigByteBuffer_reallocHook($0, $1) },
+                                        hookedFree: { testAllocationOfReallyBigByteBuffer_freeHook($0) },
+                                        hookedMemcpy: { testAllocationOfReallyBigByteBuffer_memcpyHook($0, $1, $2) })
+
+        let reallyBigSize = Int(Int32.max)
+        XCTAssertEqual(AllocationExpectationState.begin, testAllocationOfReallyBigByteBuffer_state)
+        var buf = alloc.buffer(capacity: reallyBigSize)
+        XCTAssertEqual(AllocationExpectationState.mallocDone, testAllocationOfReallyBigByteBuffer_state)
+        XCTAssertGreaterThanOrEqual(buf.capacity, reallyBigSize)
+
+        buf.set(bytes: [1], at: 0)
+        /* now make it expand (will trigger realloc) */
+        buf.set(bytes: [1], at: buf.capacity)
+
+        XCTAssertEqual(AllocationExpectationState.reallocDone, testAllocationOfReallyBigByteBuffer_state)
+        XCTAssertEqual(buf.capacity, Int(UInt32.max))
     }
 
     func testWritableBytesAccountsForSlicing() throws {

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -159,11 +159,7 @@ public class ChannelTests: XCTestCase {
         }
         
 
-        #if arch(arm) // 32-bit, Raspi/AppleWatch/etc
-            let lotsOfData = Int(Int32.max / 8)
-        #else
-            let lotsOfData = Int(Int32.max)
-        #endif
+        let lotsOfData = Int(Int32.max)
         var written = 0
         while written <= lotsOfData {
             clientChannel.write(NIOAny(buffer), promise: nil)

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -244,11 +244,7 @@ final class DatagramChannelTests: XCTestCase {
             }
             let envelope = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
 
-            #if arch(arm) // 32-bit, Raspi/AppleWatch/etc
-                let lotsOfData = Int(Int32.max / 8)
-            #else
-                let lotsOfData = Int(Int32.max)
-            #endif
+            let lotsOfData = Int(Int32.max)
             var written = 0
             while written <= lotsOfData {
                 self.firstChannel.write(NIOAny(envelope), promise: myPromise)


### PR DESCRIPTION
Motivation:

We should have different constants for 32-bit systems where necessary
for example all the maximums should be Int32.max and not UInt32.max
because UInt32.max doesn't fit into an Int on 32-bit platforms. But
where unnecessary 32-bit and 64-bit should share maximum values.

Modifications:

- removed some constraints that should be unnecessary
- skip tests that can't work on 32-bit systems

Result:

better and more consistent 32-bit runs
