### PR TITLE
Typo in comments of EchoServer example

### DIFF
--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -47,7 +47,7 @@ let bootstrap = ServerBootstrap(group: group)
 
     // Set the handlers that are appled to the accepted Channels
     .childChannelInitializer { channel in
-        // Ensure we don't read faster then we can write by adding the BackPressureHandler into the pipeline.
+        // Ensure we don't read faster than we can write by adding the BackPressureHandler into the pipeline.
         channel.pipeline.add(handler: BackPressureHandler()).then { v in
             channel.pipeline.add(handler: EchoHandler())
         }


### PR DESCRIPTION
Fix typo in comments of the **EchoServer** example