### PR TITLE
Enhanced the output of the NIOEchoClient Example

### DIFF
--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -23,19 +23,14 @@ private final class EchoHandler: ChannelInboundHandler {
 
 
     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
-
-        var byteBuffer = self.unwrapInboundIn(data) as ByteBuffer
+        var byteBuffer = self.unwrapInboundIn(data)
         numBytes -= byteBuffer.readableBytes
 
         assert(numBytes >= 0)
 
         if numBytes == 0 {
-            if let charArray = byteBuffer.readBytes(length: byteBuffer.readableBytes) {
-                var str = ""
-                for byte in charArray {
-                    str += String(UnicodeScalar(byte))
-                }
-                print("Received: '\(str)' back from the server, closing channel.")
+            if let string = byteBuffer.readString(length: byteBuffer.readableBytes) {
+                print("Received: '\(string)' back from the server, closing channel.")
             }
             ctx.close(promise: nil)
         }

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 import NIO
-import Foundation
 
 print("Please enter line to send to the server")
 let line = readLine(strippingNewline: true)!
@@ -25,23 +24,18 @@ private final class EchoHandler: ChannelInboundHandler {
 
     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
 
-        var charArray: [UInt8] = []
         var byteBuffer = self.unwrapInboundIn(data) as ByteBuffer
         numBytes -= byteBuffer.readableBytes
-
-
-        while let byte: UInt8 = byteBuffer.readInteger() {
-            charArray.append(byte)
-        }
 
         assert(numBytes >= 0)
 
         if numBytes == 0 {
-            if charArray.count > 0,
-                let charString = String(bytes: charArray, encoding: .utf8) {
-                print("Received: '\(charString)' back from the server, closing channel.")
-            } else {
-                print("Received line back from the server, closing channel.")
+            if let charArray = byteBuffer.readBytes(length: byteBuffer.readableBytes) {
+                var str = ""
+                for byte in charArray {
+                    str += String(UnicodeScalar(byte))
+                }
+                print("Received: '\(str)' back from the server, closing channel.")
             }
             ctx.close(promise: nil)
         }

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -21,7 +21,6 @@ private final class EchoHandler: ChannelInboundHandler {
     public typealias OutboundOut = ByteBuffer
     private var numBytes = 0
 
-
     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         var byteBuffer = self.unwrapInboundIn(data)
         numBytes -= byteBuffer.readableBytes
@@ -31,6 +30,8 @@ private final class EchoHandler: ChannelInboundHandler {
         if numBytes == 0 {
             if let string = byteBuffer.readString(length: byteBuffer.readableBytes) {
                 print("Received: '\(string)' back from the server, closing channel.")
+            } else {
+                print("Received the line back from the server, closing channel")
             }
             ctx.close(promise: nil)
         }


### PR DESCRIPTION
Motivation:

I was testing the NIOEchoClient example on Linux and noticed that I received no character output.
I thought this would be handy and added this code to do so.

Modifications:

Small modification to the channelRead method in NIOEchoClient to read the bytes and transform to a string.

Result:

The display of the characters on your echo client before the channel closes.

