### PR TITLE
don't crash when Channel goes inactive in read triggered by write error

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -931,10 +931,11 @@ extension ChannelPipeline {
 }
 
 private extension CloseMode {
+    /// Returns the error to fail outstanding operations writes with.
     var error: ChannelError {
         switch self {
         case .all:
-            return .alreadyClosed
+            return .ioOnClosedChannel
         case .output:
             return .outputClosed
         case .input:

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -75,6 +75,7 @@ extension ChannelTests {
                 ("testFailedRegistrationOfAcceptedSocket", testFailedRegistrationOfAcceptedSocket),
                 ("testFailedRegistrationOfServerSocket", testFailedRegistrationOfServerSocket),
                 ("testTryingToBindOnPortThatIsAlreadyBoundFailsButDoesNotCrash", testTryingToBindOnPortThatIsAlreadyBoundFailsButDoesNotCrash),
+                ("testCloseInReadTriggeredByDrainingTheReceiveBufferBecauseOfWriteError", testCloseInReadTriggeredByDrainingTheReceiveBufferBecauseOfWriteError),
            ]
    }
 }

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -200,7 +200,7 @@ final class DatagramChannelTests: XCTestCase {
             do {
                 try $0.wait()
                 XCTFail("Did not error")
-            } catch ChannelError.alreadyClosed {
+            } catch ChannelError.ioOnClosedChannel {
                 // All good
             } catch {
                 XCTFail("Unexpected error: \(error)")

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -164,7 +164,7 @@ class FileRegionTest : XCTestCase {
                 }.wait()
                 XCTFail("no error happened even though we closed before flush")
             } catch let e as ChannelError {
-                XCTAssertEqual(ChannelError.alreadyClosed, e)
+                XCTAssertEqual(ChannelError.ioOnClosedChannel, e)
             } catch let e {
                 XCTFail("unexpected error \(e)")
             }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -321,7 +321,7 @@ public class SocketChannelTest : XCTestCase {
         let writeFut = clientChannel.write(buffer).map {
             XCTFail("Must not succeed")
         }.thenIfError { error in
-            XCTAssertEqual(error as? ChannelError, ChannelError.alreadyClosed)
+            XCTAssertEqual(error as? ChannelError, ChannelError.ioOnClosedChannel)
             return clientChannel.close()
         }
         XCTAssertNoThrow(try clientChannel.close().wait())
@@ -470,7 +470,7 @@ public class SocketChannelTest : XCTestCase {
         do {
             try connectPromise.futureResult.wait()
             XCTFail("Did not throw")
-        } catch let err as ChannelError where err == .alreadyClosed {
+        } catch let err as ChannelError where err == .ioOnClosedChannel {
             // expected
         }
         XCTAssertNoThrow(try closePromise.futureResult.wait())


### PR DESCRIPTION
Motivation:

Previously we asserted that a Channel cannot go inactive after calling
out for a read that was triggered by (draining the receive buffer after)
a write error.

This assertion was put in place to guard against `readComplete` events
sent on inactive channels. It did that job just fine but crashes aren't
great so we now conditionally fire the `readComplete` event if the
Channel stays active.

Modifications:

make the readComplete event firing conditional

Result:

fewer crashes, more happy faces
