### PR TITLE
Include ipaddress in SocketAddress.description.

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -24,7 +24,7 @@ protocol SockAddrProtocol {
 }
 
 /// Returns a description for the given address.
-private func descriptionForAddress(family: CInt, bytes: UnsafeRawPointer, length byteCount: Int) -> String {
+internal func descriptionForAddress(family: CInt, bytes: UnsafeRawPointer, length byteCount: Int) -> String {
     var addressBytes: [Int8] = Array(repeating: 0, count: byteCount)
     return addressBytes.withUnsafeMutableBufferPointer { (addressBytesPtr: inout UnsafeMutableBufferPointer<Int8>) -> String in
         try! Posix.inet_ntop(addressFamily: family,

--- a/Tests/NIOTests/SocketAddressTest+XCTest.swift
+++ b/Tests/NIOTests/SocketAddressTest+XCTest.swift
@@ -27,6 +27,8 @@ extension SocketAddressTest {
    static var allTests : [(String, (SocketAddressTest) -> () throws -> Void)] {
       return [
                 ("testDescriptionWorks", testDescriptionWorks),
+                ("testDescriptionWorksWithoutIP", testDescriptionWorksWithoutIP),
+                ("testDescriptionWorksWithIPOnly", testDescriptionWorksWithIPOnly),
                 ("testIn6AddrDescriptionWorks", testIn6AddrDescriptionWorks),
                 ("testCanCreateIPv4AddressFromString", testCanCreateIPv4AddressFromString),
                 ("testCanCreateIPv6AddressFromString", testCanCreateIPv6AddressFromString),

--- a/Tests/NIOTests/SocketAddressTest.swift
+++ b/Tests/NIOTests/SocketAddressTest.swift
@@ -19,11 +19,28 @@ class SocketAddressTest: XCTestCase {
 
     func testDescriptionWorks() throws {
         var ipv4SocketAddress = sockaddr_in()
+        let res = "10.0.0.1".withCString { p in
+            inet_pton(AF_INET, p, &ipv4SocketAddress.sin_addr)
+        }
+        XCTAssertEqual(res, 1)
+        //ipv4SocketAddress.sin_addr =
         ipv4SocketAddress.sin_port = (12345 as UInt16).bigEndian
         let sa = SocketAddress(ipv4SocketAddress, host: "foobar.com")
-        XCTAssertEqual("[IPv4]foobar.com:12345", sa.description)
+        XCTAssertEqual("[IPv4]foobar.com/10.0.0.1:12345", sa.description)
     }
 
+    func testDescriptionWorksWithoutIP() throws {
+        var ipv4SocketAddress = sockaddr_in()
+        ipv4SocketAddress.sin_port = (12345 as UInt16).bigEndian
+        let sa = SocketAddress(ipv4SocketAddress, host: "foobar.com")
+        XCTAssertEqual("[IPv4]foobar.com/0.0.0.0:12345", sa.description)
+    }
+    
+    func testDescriptionWorksWithIPOnly() throws {
+        let sa = try! SocketAddress(ipAddress: "10.0.0.2", port: 12345)
+        XCTAssertEqual("[IPv4]10.0.0.2:12345", sa.description)
+    }
+    
     func testIn6AddrDescriptionWorks() throws {
         let sampleString = "::1"
         let sampleIn6Addr: [UInt8] = [ // ::1


### PR DESCRIPTION
Motivation:

WE should include the ipaddress in the description of SocketAddress if any way used as there may be no host at all.

Modifications:

- Always include ipaddress if possible.
- Add unit tests.

Result:

More useful description of the SocketAddress