### PR TITLE
fix warning in a test

### DIFF
--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -29,7 +29,8 @@ extension EmbeddedChannel {
 
     func finishAcceptingAlreadyClosed() throws {
         do {
-            try self.finish()
+            let res = try self.finish()
+            XCTAssertFalse(res)
         } catch ChannelError.alreadyClosed {
             // ok
         }


### PR DESCRIPTION
Motivation:

nobody likes warnings, even in tests

Modifications:

fixed a test warning

Result:

no more warnings (apart from the deprecation ones)
