### PR TITLE
EventLoopPromise didn't point out it has reference semantics

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -147,6 +147,7 @@ private struct CallbackList: ExpressibleByArrayLiteral {
 ///     some other API, create an already-resolved object with `eventLoop.newSucceededFuture(result)`
 ///     or `eventLoop.newFailedFuture(error:)`.
 ///
+/// - note: `EventLoopPromise` has reference semantics.
 public struct EventLoopPromise<T> {
     /// The `EventLoopFuture` which is used by the `EventLoopPromise`. You can use it to add callbacks which are notified once the
     /// `EventLoopPromise` is completed.


### PR DESCRIPTION
Motivation:

Sometimes people assume that all `struct`s have value semantics but
that's not true. We should still point that out.

Modifications:

point out that EventLoopPromise has reference semantics

Result:

clearer docs
