### PR TITLE
Correct propagate channelActive events to the next handler when using…

### DIFF
--- a/Sources/NIO/ChannelHandlers.swift
+++ b/Sources/NIO/ChannelHandlers.swift
@@ -198,6 +198,7 @@ public class IdleStateHandler: ChannelDuplexHandler {
 
     public func channelActive(ctx: ChannelHandlerContext) {
         initIdleTasks(ctx)
+        ctx.fireChannelActive()
     }
 
     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {

--- a/Tests/NIOTests/IdleStateHandlerTest+XCTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest+XCTest.swift
@@ -30,6 +30,7 @@ extension IdleStateHandlerTest {
                 ("testIdleWrite", testIdleWrite),
                 ("testIdleAllWrite", testIdleAllWrite),
                 ("testIdleAllRead", testIdleAllRead),
+                ("testPropagateInboundEvents", testPropagateInboundEvents),
            ]
    }
 }

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -98,7 +98,7 @@ class IdleStateHandlerTest : XCTestCase {
     }
     
     func testPropagateInboundEvents() {
-        class EventHandler : ChannelInboundHandler {
+        class EventHandler: ChannelInboundHandler {
             typealias InboundIn = Any
             
             var active = false
@@ -172,8 +172,8 @@ class IdleStateHandlerTest : XCTestCase {
         channel.pipeline.fireUserInboundEventTriggered("")
 
         channel.pipeline.fireChannelWritabilityChanged()
-        channel.pipeline.fireChannelUnregistered()
         channel.pipeline.fireChannelInactive()
+        channel.pipeline.fireChannelUnregistered()
         
         XCTAssertFalse(try channel.finish())
         eventHandler.assertAllEventsReceived()

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -96,4 +96,86 @@ class IdleStateHandlerTest : XCTestCase {
         }
         XCTAssertNoThrow(try clientChannel.closeFuture.wait())
     }
+    
+    func testPropagateInboundEvents() {
+        class EventHandler : ChannelInboundHandler {
+            typealias InboundIn = Any
+            
+            var active = false
+            var inactive = false
+            var read = false
+            var readComplete = false
+            var writabilityChanged = false
+            var eventTriggered = false
+            var errorCaught = false
+            var registered = false
+            var unregistered = false
+
+            func channelActive(ctx: ChannelHandlerContext) {
+                self.active = true
+            }
+            
+            func channelInactive(ctx: ChannelHandlerContext) {
+                self.inactive = true
+            }
+            
+            func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+                self.read = true
+            }
+            
+            func channelReadComplete(ctx: ChannelHandlerContext) {
+                self.readComplete = true
+            }
+            
+            func channelWritabilityChanged(ctx: ChannelHandlerContext) {
+                self.writabilityChanged = true
+            }
+  
+            func userInboundEventTriggered(ctx: ChannelHandlerContext, event: Any) {
+                self.eventTriggered = true
+            }
+            
+            func errorCaught(ctx: ChannelHandlerContext, error: Error) {
+                self.errorCaught = true
+            }
+            
+            func channelRegistered(ctx: ChannelHandlerContext) {
+                self.registered = true
+            }
+            
+            func channelUnregistered(ctx: ChannelHandlerContext) {
+                self.unregistered = true
+            }
+            
+            func assertAllEventsReceived() {
+                XCTAssertTrue(self.active)
+                XCTAssertTrue(self.inactive)
+                XCTAssertTrue(self.read)
+                XCTAssertTrue(self.readComplete)
+                XCTAssertTrue(self.writabilityChanged)
+                XCTAssertTrue(self.eventTriggered)
+                XCTAssertTrue(self.errorCaught)
+                XCTAssertTrue(self.registered)
+                XCTAssertTrue(self.unregistered)
+            }
+        }
+        let eventHandler = EventHandler()
+        let channel = EmbeddedChannel()
+        XCTAssertNoThrow(try channel.pipeline.add(handler: IdleStateHandler()).wait())
+        XCTAssertNoThrow(try channel.pipeline.add(handler: eventHandler).wait())
+        
+        channel.pipeline.fireChannelRegistered()
+        channel.pipeline.fireChannelActive()
+        channel.pipeline.fireChannelRead(NIOAny(""))
+        channel.pipeline.fireChannelReadComplete()
+        channel.pipeline.fireErrorCaught(ChannelError.alreadyClosed)
+        channel.pipeline.fireUserInboundEventTriggered("")
+
+        channel.pipeline.fireChannelWritabilityChanged()
+        channel.pipeline.fireChannelUnregistered()
+        channel.pipeline.fireChannelInactive()
+        
+        XCTAssertFalse(try channel.finish())
+        eventHandler.assertAllEventsReceived()
+    }
 }


### PR DESCRIPTION
… IdleStateHandler.

Motivation:

We missed to propagate the channelActive event to the next handler in IdleStateHandler, which means handlers placed after it in the pipeline will never receive such an event.

Modifications:

- Correctly call ctx.fireChannelActive()
- Add unit test to assert we forward all inbound events.

Result:

Fixes https://github.com/apple/swift-nio/issues/614.