### PR TITLE
CI: use Swift 4.2-RELEASE instead of CONVERGENCE

### DIFF
--- a/docker/docker-compose.1404.42.yaml
+++ b/docker/docker-compose.1404.42.yaml
@@ -8,7 +8,6 @@ services:
       args:
         ubuntu_version : "14.04"
         swift_version : "4.2"
-        swift_flavour : "CONVERGENCE"
         install_curl_from_source: "true"
 
   unit-tests:

--- a/docker/docker-compose.1604.42.yaml
+++ b/docker/docker-compose.1604.42.yaml
@@ -8,7 +8,6 @@ services:
       args:
         ubuntu_version : "16.04"
         swift_version : "4.2"
-        swift_flavour : "CONVERGENCE"
 
   unit-tests:
     image: swift-nio:16.04-4.2

--- a/docker/docker-compose.1804.42.yaml
+++ b/docker/docker-compose.1804.42.yaml
@@ -8,7 +8,6 @@ services:
       args:
         ubuntu_version : "18.04"
         swift_version : "4.2"
-        swift_flavour : "CONVERGENCE"
         skip_ruby_from_ppa : "true"
 
   unit-tests:


### PR DESCRIPTION
Motivation:

Now that 4.2 has been released, there's no reason to use the CONVERGENCE
version anymore.

Modifications:

use the RELEASE instead of the CONVERGENCE version of Swift 4.2

Result:

use the latest and greatest