### PR TITLE
make the allocation limits for Swift 4.2 the main ones

### DIFF
--- a/docker/docker-compose.1404.41.yaml
+++ b/docker/docker-compose.1404.41.yaml
@@ -16,6 +16,13 @@ services:
   integration-tests:
     image: swift-nio:14.04-4.1
     environment:
+        # We mostly care about the allocation limits for the latest Swift
+        # version which at this point is Swift 4.2. It's too much overhead to
+        # maintain numbers about older Swift versions and it's also not that
+        # useful to have them around. But because it doesn't hurt
+        # to leave the old ones in as long as they don't change let's leave
+        # them. If there's any change needed here, just delete those limits and
+        # make sure the Swift 4.2 ones are up to date.
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=718100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
@@ -25,6 +32,13 @@ services:
   test:
     image: swift-nio:14.04-4.1
     environment:
+        # We mostly care about the allocation limits for the latest Swift
+        # version which at this point is Swift 4.2. It's too much overhead to
+        # maintain numbers about older Swift versions and it's also not that
+        # useful to have them around. But because it doesn't hurt
+        # to leave the old ones in as long as they don't change let's leave
+        # them. If there's any change needed here, just delete those limits and
+        # make sure the Swift 4.2 ones are up to date.
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=718100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600

--- a/docker/docker-compose.1604.41.yaml
+++ b/docker/docker-compose.1604.41.yaml
@@ -15,6 +15,13 @@ services:
   integration-tests:
     image: swift-nio:16.04-4.1
     environment:
+        # We mostly care about the allocation limits for the latest Swift
+        # version which at this point is Swift 4.2. It's too much overhead to
+        # maintain numbers about older Swift versions and it's also not that
+        # useful to have them around. But because it doesn't hurt
+        # to leave the old ones in as long as they don't change let's leave
+        # them. If there's any change needed here, just delete those limits and
+        # make sure the Swift 4.2 ones are up to date.
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=719100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
@@ -24,6 +31,13 @@ services:
   test:
     image: swift-nio:16.04-4.1
     environment:
+        # We mostly care about the allocation limits for the latest Swift
+        # version which at this point is Swift 4.2. It's too much overhead to
+        # maintain numbers about older Swift versions and it's also not that
+        # useful to have them around. But because it doesn't hurt
+        # to leave the old ones in as long as they don't change let's leave
+        # them. If there's any change needed here, just delete those limits and
+        # make sure the Swift 4.2 ones are up to date.
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=47000
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=719100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600

--- a/docker/docker-compose.1804.42.yaml
+++ b/docker/docker-compose.1804.42.yaml
@@ -15,9 +15,21 @@ services:
 
   integration-tests:
     image: swift-nio:18.04-4.2
+    environment:
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2150
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   test:
     image: swift-nio:18.04-4.2
+    environment:
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2150
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   echo:
     image: swift-nio:18.04-4.2


### PR DESCRIPTION
Motivation:

We always care most about the latest released Swift version. Therefore I
added allocation limits for Swift 4.2 and indicated that the old ones
can be removed as soon as they change.

Modifications:

- added allocation limits for Swift 4.2
- added a comment to the old ones that they don't need to be changed
  anymore now

Result:

- best support for best version
- document that Swift 4.2 is awesome, lots fewer allocations!
