### PR TITLE
Work around SE-0213

### DIFF
--- a/Tests/NIOTests/IntegerTypesTest.swift
+++ b/Tests/NIOTests/IntegerTypesTest.swift
@@ -85,9 +85,10 @@ public class IntegerTypesTest: XCTestCase {
     func testDescriptionUInt24() {
         XCTAssertEqual("0", _UInt24.min.description)
         XCTAssertEqual("16777215", _UInt24.max.description)
-        XCTAssertEqual("12345678", _UInt24(12345678).description)
+        XCTAssertEqual("12345678", _UInt24(12345678 as UInt32).description)
         XCTAssertEqual("1", _UInt24(1).description)
         XCTAssertEqual("8388608", _UInt24(1 << 23).description)
+        XCTAssertEqual("66", _UInt24(66).description)
     }
 
     func testDescriptionUInt56() {
@@ -96,5 +97,6 @@ public class IntegerTypesTest: XCTestCase {
         XCTAssertEqual("12345678901234567", _UInt56(12345678901234567 as UInt64).description)
         XCTAssertEqual("1", _UInt56(1).description)
         XCTAssertEqual("36028797018963968", _UInt56(1 << 55).description)
+        XCTAssertEqual("66", _UInt56(66).description)
     }
 }


### PR DESCRIPTION
Motivation:

In Swift 5, types that conform to ExpressibleByIntegerLiteral will now
have their init(integerLiteral:) initializer invoked whenever the
compiler sees code of the form `Type(integerLiteral)`, rather than
before where the integer literal would be created as `Int` and then
an alternative initializer would be called. This broke our tests, so
we should fix it now that we're aware of it.

See also [SR-8816](https://bugs.swift.org/browse/SR-8816).

Modifications:

Force the type of the argument for the one broken test line, add new
test lines that execute this code path.

Result:

Better testing, fewer compile errors.