### PR TITLE
CONNECT method should not have request body

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -957,9 +957,9 @@ public enum HTTPMethod: Equatable {
     /// Whether requests with this verb may have a request body.
     public var hasRequestBody: HasBody {
         switch self {
-        case .HEAD, .DELETE, .TRACE:
+        case .HEAD, .DELETE, .CONNECT, .TRACE:
             return .no
-        case .POST, .PUT, .CONNECT, .PATCH:
+        case .POST, .PUT, .PATCH:
             return .yes
         case .GET, .OPTIONS:
             fallthrough

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -957,11 +957,11 @@ public enum HTTPMethod: Equatable {
     /// Whether requests with this verb may have a request body.
     public var hasRequestBody: HasBody {
         switch self {
-        case .HEAD, .DELETE, .CONNECT, .TRACE:
+        case .HEAD, .DELETE, .TRACE:
             return .no
         case .POST, .PUT, .PATCH:
             return .yes
-        case .GET, .OPTIONS:
+        case .GET, .CONNECT, .OPTIONS:
             fallthrough
         default:
             return .unlikely

--- a/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest+XCTest.swift
@@ -33,6 +33,7 @@ extension HTTPRequestEncoderTests {
                 ("testNoTransferEncodingHeadersForHEAD", testNoTransferEncodingHeadersForHEAD),
                 ("testNoChunkedEncodingForHTTP10", testNoChunkedEncodingForHTTP10),
                 ("testBody", testBody),
+                ("testCONNECT", testCONNECT),
            ]
    }
 }


### PR DESCRIPTION
`CONNECT` method should not have request body.

### Motivation:

[rfc7231](https://tools.ietf.org/html/rfc7231#section-4.3.6) said:
> A payload within a `CONNECT` request message has no defined semantics;
   sending a payload body on a `CONNECT` request might cause some existing
   implementations to reject the request.

### Modifications:

Change `HTTPMethod.CONNECT.hasRequestBody` to returns `.no`.

### Result:

`HTTPRequestEncoder` does not generate chunked body for `CONNECT` method.