### PR TITLE
String decoding: go through URBP directly instead of Slice

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -131,7 +131,7 @@ extension ByteBuffer {
             guard index <= pointer.count - length else {
                 return nil
             }
-            return String(decoding: pointer[index..<(index+length)], as: UTF8.self)
+            return String(decoding: UnsafeRawBufferPointer(rebasing: pointer[index..<(index+length)]), as: UTF8.self)
         }
     }
 


### PR DESCRIPTION
Motivation:

String decoding can work faster when going through URBP directly instead
of a Slice of a URBP. The reason is that if the String has the utf8
represenation stored directly it'll just be a memcpy (+ validation).

Modifications:

go through URBP when decoding a String using String(decoding:as:)

Result:

faster if the String utf8 representation happens to be available