### PR TITLE
EventLoop.assertInEventLoop and preconditionInEventLoop

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -150,7 +150,7 @@ public final class ChannelPipeline: ChannelInvoker {
 
     /// The `Channel` that this `ChannelPipeline` belongs to.
     internal var channel: Channel {
-        assert(self.eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(self._channel != nil || self.destroyed)
         return self._channel ?? DeadChannel(pipeline: self)
     }
@@ -257,7 +257,7 @@ public final class ChannelPipeline: ChannelInvoker {
                       relativeHandler: ChannelHandler,
                       operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void,
                       promise: EventLoopPromise<Void>) {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
         if self.destroyed {
             promise.fail(error: ChannelError.ioOnClosedChannel)
             return
@@ -293,7 +293,7 @@ public final class ChannelPipeline: ChannelInvoker {
                       relativeContext: ChannelHandlerContext,
                       operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void,
                       promise: EventLoopPromise<Void>) {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if destroyed {
             promise.fail(error: ChannelError.ioOnClosedChannel)
@@ -322,7 +322,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - new: The `ChannelHandlerContext` to add to the pipeline.
     ///     - existing: The `ChannelHandlerContext` that `new` will be added after.
     private func add0(context new: ChannelHandlerContext, after existing: ChannelHandlerContext) {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         let next = existing.next
         new.prev = existing
@@ -341,7 +341,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - new: The `ChannelHandlerContext` to add to the pipeline.
     ///     - existing: The `ChannelHandlerContext` that `new` will be added before.
     private func add0(context new: ChannelHandlerContext, before existing: ChannelHandlerContext) {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         let prev = existing.prev
         new.prev = prev
@@ -468,7 +468,7 @@ public final class ChannelPipeline: ChannelInvoker {
 
     /// Remove a `ChannelHandlerContext` from the `ChannelPipeline`. Must only be called from within the `EventLoop`.
     private func remove0(ctx: ChannelHandlerContext, promise: EventLoopPromise<Bool>?) {
-        assert(self.eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         let nextCtx = ctx.next
         let prevCtx = ctx.prev
@@ -493,7 +493,7 @@ public final class ChannelPipeline: ChannelInvoker {
 
     /// Returns the next name to use for a `ChannelHandler`.
     private func nextName() -> String {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         let name = "handler\(idx)"
         idx += 1
@@ -505,7 +505,7 @@ public final class ChannelPipeline: ChannelInvoker {
     /// This method must only be called from within the `EventLoop`. It should only be called from a `ChannelCore`
     /// implementation. Once called, the `ChannelPipeline` is no longer active and cannot be used again.
     func removeHandlers() {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let head = self.head {
             while let ctx = head.next {
@@ -1239,7 +1239,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeChannelRegistered() {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let inboundHandler = self.inboundHandler {
             inboundHandler.channelRegistered(ctx: self)
@@ -1249,7 +1249,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeChannelUnregistered() {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let inboundHandler = self.inboundHandler {
             inboundHandler.channelUnregistered(ctx: self)
@@ -1259,7 +1259,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeChannelActive() {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let inboundHandler = self.inboundHandler {
             inboundHandler.channelActive(ctx: self)
@@ -1269,7 +1269,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeChannelInactive() {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let inboundHandler = self.inboundHandler {
             inboundHandler.channelInactive(ctx: self)
@@ -1279,7 +1279,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeChannelRead(_ data: NIOAny) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let inboundHandler = self.inboundHandler {
             inboundHandler.channelRead(ctx: self, data: data)
@@ -1289,7 +1289,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeChannelReadComplete() {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let inboundHandler = self.inboundHandler {
             inboundHandler.channelReadComplete(ctx: self)
@@ -1299,7 +1299,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeChannelWritabilityChanged() {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let inboundHandler = self.inboundHandler {
             inboundHandler.channelWritabilityChanged(ctx: self)
@@ -1309,7 +1309,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeErrorCaught(_ error: Error) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let inboundHandler = self.inboundHandler {
             inboundHandler.errorCaught(ctx: self, error: error)
@@ -1319,7 +1319,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeUserInboundEventTriggered(_ event: Any) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let inboundHandler = self.inboundHandler {
             inboundHandler.userInboundEventTriggered(ctx: self, event: event)
@@ -1329,7 +1329,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeRegister(promise: EventLoopPromise<Void>?) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
@@ -1340,7 +1340,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
    fileprivate func invokeBind(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
@@ -1351,7 +1351,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeConnect(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
@@ -1362,7 +1362,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeWrite(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
@@ -1373,7 +1373,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeFlush() {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let outboundHandler = self.outboundHandler {
             outboundHandler.flush(ctx: self)
@@ -1383,7 +1383,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeWriteAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
@@ -1395,7 +1395,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeRead() {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         if let outboundHandler = self.outboundHandler {
             outboundHandler.read(ctx: self)
@@ -1405,7 +1405,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeClose(mode: CloseMode, promise: EventLoopPromise<Void>?) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
@@ -1416,7 +1416,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeTriggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
@@ -1427,19 +1427,15 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     fileprivate func invokeHandlerAdded() throws {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         handler.handlerAdded(ctx: self)
     }
 
     fileprivate func invokeHandlerRemoved() throws {
-        assert(inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         handler.handlerRemoved(ctx: self)
-    }
-
-    private var inEventLoop: Bool {
-        return eventLoop.inEventLoop
     }
 }
 

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -126,7 +126,7 @@ public struct NonBlockingFileIO {
                 assert(readSize > 0)
                 return self.read(fileHandle: fileHandle, byteCount: readSize, allocator: allocator, eventLoop: eventLoop).then { buffer in
                     chunkHandler(buffer).then { () -> EventLoopFuture<Void> in
-                        assert(eventLoop.inEventLoop)
+                        eventLoop.assertInEventLoop()
                         return _read(remainingReads: remainingReads - 1)
                     }
                 }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -48,7 +48,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
     }
 
     override var isOpen: Bool {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(super.isOpen == self.pendingWrites.isOpen)
         return super.isOpen
     }
@@ -71,7 +71,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
     }
 
     override func setOption0<T: ChannelOption>(option: T, value: T.OptionType) throws {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
             throw ChannelError.ioOnClosedChannel
@@ -92,7 +92,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
     }
 
     override func getOption0<T: ChannelOption>(option: T) throws -> T.OptionType {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
             throw ChannelError.ioOnClosedChannel
@@ -122,7 +122,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
     }
 
     override func readFromSocket() throws -> ReadResult {
-        assert(self.eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
         // Just allocate one time for the while read loop. This is fine as ByteBuffer is a struct and uses COW.
         var buffer = recvAllocator.buffer(allocator: allocator)
         var result = ReadResult.none
@@ -339,7 +339,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     }
 
     override func setOption0<T: ChannelOption>(option: T, value: T.OptionType) throws {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
             throw ChannelError.ioOnClosedChannel
@@ -354,7 +354,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     }
 
     override func getOption0<T: ChannelOption>(option: T) throws -> T.OptionType {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
             throw ChannelError.ioOnClosedChannel
@@ -369,7 +369,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     }
 
     override public func bind0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
             promise?.fail(error: ChannelError.ioOnClosedChannel)
@@ -450,7 +450,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     }
 
     override public func channelRead0(_ data: NIOAny) {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         let ch = data.forceAsOther() as SocketChannel
         ch.eventLoop.execute {
@@ -500,7 +500,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     }
 
     override var isOpen: Bool {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
         assert(super.isOpen == self.pendingWrites.isOpen)
         return super.isOpen
     }
@@ -545,7 +545,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     // MARK: Datagram Channel overrides required by BaseSocketChannel
 
     override func setOption0<T: ChannelOption>(option: T, value: T.OptionType) throws {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
             throw ChannelError.ioOnClosedChannel
@@ -562,7 +562,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     }
 
     override func getOption0<T: ChannelOption>(option: T) throws -> T.OptionType {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
             throw ChannelError.ioOnClosedChannel
@@ -696,7 +696,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     // MARK: Datagram Channel overrides not required by BaseSocketChannel
 
     override func bind0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
-        assert(self.eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
         guard self.isRegistered else {
             promise?.fail(error: ChannelLifecycleError.inappropriateOperationForState)
             return
@@ -790,7 +790,7 @@ extension DatagramChannel: MulticastChannel {
                                         interface: NIONetworkInterface?,
                                         promise: EventLoopPromise<Void>?,
                                         operation: GroupOperation) {
-        assert(self.eventLoop.inEventLoop)
+        self.eventLoop.assertInEventLoop()
 
         guard self.isActive else {
             promise?.fail(error: ChannelLifecycleError.inappropriateOperationForState)

--- a/Sources/NIO/Utilities.swift
+++ b/Sources/NIO/Utilities.swift
@@ -19,6 +19,7 @@
 /// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
 import CNIOLinux
 
+@_inlineable @_versioned
 internal func debugOnly(_ body: () -> Void) {
     assert({ body(); return true }())
 }


### PR DESCRIPTION
Motivation:

Dispatch can only precondition that code is run from a certain queue, it
can't return if code is running on a certain queue.
To support that this introduces new EventLoop.assertInEventLoop and
EventLoop.preconditionInEventLoop methods instead of
assert(eventLoop.inEventLoop).

Modifications:

add EventLoop.assertInEventLoop and EventLoop.preconditionInEventLoop

Result:

better support for Network.framework in NIOTS