### PR TITLE
Provide ChannelPipeline.remove methods with promises.

### DIFF
--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -45,6 +45,12 @@ extension ChannelPipelineTest {
                 ("testFindHandlerByTypeReturnsTheFirstOfItsType", testFindHandlerByTypeReturnsTheFirstOfItsType),
                 ("testContextForHeadOrTail", testContextForHeadOrTail),
                 ("testRemoveHeadOrTail", testRemoveHeadOrTail),
+                ("testRemovingByContextWithPromiseStillInChannel", testRemovingByContextWithPromiseStillInChannel),
+                ("testRemovingByContextWithFutureNotInChannel", testRemovingByContextWithFutureNotInChannel),
+                ("testRemovingByNameWithPromiseStillInChannel", testRemovingByNameWithPromiseStillInChannel),
+                ("testRemovingByNameWithFutureNotInChannel", testRemovingByNameWithFutureNotInChannel),
+                ("testRemovingByReferenceWithPromiseStillInChannel", testRemovingByReferenceWithPromiseStillInChannel),
+                ("testRemovingByReferenceWithFutureNotInChannel", testRemovingByReferenceWithFutureNotInChannel),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

ChannelPipeline.remove0 contains a comment that indicates that users
were expected to be able to use the ChannelHandlerContext when both
handlerRemoved and the promise for channel removal call out.

This works when invoking remove() from outside the event loop, but if
a handler invokes remove on itself then it will only be able to attach
a callback to the future *after* the callout occurs. This means that a
ChannelHandler removing itself from the pipeline cannot rely on there
being a moment when it can still invoke the ChannelHandlerContext, but
when it is no longer a formal part of the pipeline.

This kind of behaviour is useful in some unusual cases, and it would
be nice to support it.

Modifications:

- Added remove() methods that accept promises as input.
- Rewrote the current remove() methods in terms of the new ones.
- Added tests.

Result:

ChannelHandlers can perform cleanup with a valid ChannelHandlerContext
but outside the Channel.
