### PR TITLE
remove ugly and unnecessary ignore result (_ = ...)

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -272,6 +272,7 @@ class BaseSocket: Selectable {
                 let ret = try Posix.fcntl(descriptor: sock, command: F_SETFL, value: O_NONBLOCK)
                 assert(ret == 0, "unexpectedly, fcntl(\(sock), F_SETFL, O_NONBLOCK) returned \(ret)")
             } catch {
+                // best effort close
                 _ = try? Posix.close(descriptor: sock)
                 throw error
             }
@@ -280,8 +281,7 @@ class BaseSocket: Selectable {
         if protocolFamily == AF_INET6 {
             var zero: Int32 = 0
             do {
-                _ = try Posix.setsockopt(socket: sock, level: Int32(IPPROTO_IPV6), optionName: IPV6_V6ONLY, optionValue: &zero, optionLen: socklen_t(MemoryLayout.size(ofValue: zero)))
-
+                try Posix.setsockopt(socket: sock, level: Int32(IPPROTO_IPV6), optionName: IPV6_V6ONLY, optionValue: &zero, optionLen: socklen_t(MemoryLayout.size(ofValue: zero)))
             } catch let e as IOError {
                 if e.errnoCode != EAFNOSUPPORT {
                     // Ignore error that may be thrown by close.
@@ -342,7 +342,7 @@ class BaseSocket: Selectable {
         return try withUnsafeFileDescriptor { fd in
             var val = value
 
-            _ = try Posix.setsockopt(
+            try Posix.setsockopt(
                 socket: fd,
                 level: level,
                 optionName: name,
@@ -365,7 +365,7 @@ class BaseSocket: Selectable {
             let storage = UnsafeMutableRawBufferPointer.allocate(byteCount: MemoryLayout<T>.stride,
                                                                  alignment: MemoryLayout<T>.alignment)
             // write zeroes into the memory as Linux's getsockopt doesn't zero them out
-            _ = storage.initializeMemory(as: UInt8.self, repeating: 0)
+            storage.initializeMemory(as: UInt8.self, repeating: 0)
             var val = storage.bindMemory(to: T.self).baseAddress!
             // initialisation will be done by getsockopt
             defer {

--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -238,7 +238,7 @@ extension CircularBuffer: BidirectionalCollection, RandomAccessCollection, Range
         precondition(bounds.upperBound >= self.startIndex && bounds.upperBound <= self.endIndex, "Invalid bounds.")
         switch bounds.count {
         case 1:
-            _ = remove(at: bounds.lowerBound)
+            remove(at: bounds.lowerBound)
         case self.count:
             self = .init(initialRingCapacity: self.buffer.count)
         default:
@@ -266,6 +266,7 @@ extension CircularBuffer: BidirectionalCollection, RandomAccessCollection, Range
     /// *O(1)* if the position is `headIdx` or `tailIdx`.
     /// otherwise
     /// *O(n)* where *n* is the number of elements between `position` and `tailIdx`.
+    @discardableResult
     public mutating func remove(at position: Int) -> E {
         precondition(self.indices.contains(position), "Position out of bounds.")
         var bufferIndex = self.bufferIndex(ofIndex: position)

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -58,6 +58,7 @@ public class EmbeddedEventLoop: EventLoop {
 
     public init() { }
 
+    @discardableResult
     public func scheduleTask<T>(in: TimeAmount, _ task: @escaping () throws -> T) -> Scheduled<T> {
         let promise: EventLoopPromise<T> = newPromise()
         let readyTime = now + UInt64(`in`.nanoseconds)
@@ -80,7 +81,7 @@ public class EmbeddedEventLoop: EventLoop {
     // at which point we run everything that's been submitted. Anything newly submitted
     // either gets on that train if it's still moving or waits until the next call to run().
     public func execute(_ task: @escaping () -> Void) {
-        _ = self.scheduleTask(in: .nanoseconds(0), task)
+        self.scheduleTask(in: .nanoseconds(0), task)
     }
 
     public func run() {
@@ -103,7 +104,7 @@ public class EmbeddedEventLoop: EventLoop {
             var tasks = Array<EmbeddedScheduledTask>()
             while let candidateTask = self.scheduledTasks.peek(), candidateTask.readyTime == nextTask.readyTime {
                 tasks.append(candidateTask)
-                _ = self.scheduledTasks.pop()
+                self.scheduledTasks.pop()
             }
 
             // Set the time correctly before we call into user code, then
@@ -389,7 +390,7 @@ public class EmbeddedChannel: Channel {
         }
 
         // This will never throw...
-        _ = try? register().wait()
+        try! register().wait()
     }
 
     public func setOption<T>(option: T, value: T.OptionType) -> EventLoopFuture<Void> where T: ChannelOption {

--- a/Sources/NIO/Heap.swift
+++ b/Sources/NIO/Heap.swift
@@ -123,32 +123,35 @@ internal struct Heap<T: Comparable> {
         Heap<T>.heapInsert(storage: &self.storage, compare: self.comparator, key: value)
     }
 
+    @discardableResult
     public mutating func removeRoot() -> T? {
         return self.remove(index: 0)
     }
 
+    @discardableResult
     public mutating func remove(value: T) -> Bool {
         if let idx = self.storage.index(of: value) {
-            _ = self.remove(index: idx)
+            self.remove(index: idx)
             return true
         } else {
             return false
         }
     }
 
+    @discardableResult
     private mutating func remove(index: Int) -> T? {
         guard self.storage.count > 0 else {
             return nil
         }
         let element = self.storage[index]
         if self.storage.count == 1 || self.storage[index] == self.storage[self.storage.count - 1] {
-            _ = self.storage.removeLast()
+            self.storage.removeLast()
         } else if !self.comparator(self.storage[index], self.storage[self.storage.count - 1]) {
             Heap<T>.heapRootify(storage: &self.storage, compare: self.comparator, index: index, key: self.storage[self.storage.count - 1])
-            _ = self.storage.removeLast()
+            self.storage.removeLast()
         } else {
             self.storage[index] = self.storage[self.storage.count - 1]
-            _ = self.storage.removeLast()
+            self.storage.removeLast()
             Heap<T>.heapify(storage: &self.storage, compare: self.comparator, index)
         }
         return element

--- a/Sources/NIO/Linux.swift
+++ b/Sources/NIO/Linux.swift
@@ -23,7 +23,7 @@ internal enum TimerFd {
 
     @inline(never)
     public static func timerfd_settime(fd: Int32, flags: Int32, newValue: UnsafePointer<itimerspec>, oldValue: UnsafeMutablePointer<itimerspec>?) throws  {
-        _ = try wrapSyscall {
+        try wrapSyscall {
             CNIOLinux.timerfd_settime(fd, flags, newValue, oldValue)
         }
     }
@@ -97,6 +97,7 @@ internal enum Epoll {
     }
 
     @inline(never)
+    @discardableResult
     public static func epoll_ctl(epfd: Int32, op: Int32, fd: Int32, event: UnsafeMutablePointer<epoll_event>) throws -> Int32 {
         return try wrapSyscall {
             CNIOLinux.epoll_ctl(epfd, op, fd, event)

--- a/Sources/NIO/PriorityQueue.swift
+++ b/Sources/NIO/PriorityQueue.swift
@@ -21,7 +21,7 @@ internal struct PriorityQueue<Element: Comparable> {
 
     public mutating func remove(_ key: Element) {
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
-        _ = self.heap.remove(value: key)
+        self.heap.remove(value: key)
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
     }
 
@@ -41,6 +41,7 @@ internal struct PriorityQueue<Element: Comparable> {
         return self.heap.storage.isEmpty
     }
 
+    @discardableResult
     public mutating func pop() -> Element? {
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
         return self.heap.removeRoot()

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -297,12 +297,12 @@ final class Selector<R: Registration> {
         ev.events = SelectorEventSet.read.epollEventSet
         ev.data.fd = eventfd
 
-        _ = try Epoll.epoll_ctl(epfd: self.fd, op: Epoll.EPOLL_CTL_ADD, fd: eventfd, event: &ev)
+        try Epoll.epoll_ctl(epfd: self.fd, op: Epoll.EPOLL_CTL_ADD, fd: eventfd, event: &ev)
 
         var timerev = Epoll.epoll_event()
         timerev.events = Epoll.EPOLLIN | Epoll.EPOLLERR | Epoll.EPOLLRDHUP | Epoll.EPOLLET
         timerev.data.fd = timerfd
-        _ = try Epoll.epoll_ctl(epfd: self.fd, op: Epoll.EPOLL_CTL_ADD, fd: timerfd, event: &timerev)
+        try Epoll.epoll_ctl(epfd: self.fd, op: Epoll.EPOLL_CTL_ADD, fd: timerfd, event: &timerev)
 #else
         fd = try KQueue.kqueue()
         self.lifecycleState = .open
@@ -360,12 +360,12 @@ final class Selector<R: Registration> {
             return
         }
         do {
-            _ = try KQueue.kevent(kq: self.fd,
-                                  changelist: keventBuffer.baseAddress!,
-                                  nchanges: CInt(keventBuffer.count),
-                                  eventlist: nil,
-                                  nevents: 0,
-                                  timeout: nil)
+            try KQueue.kevent(kq: self.fd,
+                              changelist: keventBuffer.baseAddress!,
+                              nchanges: CInt(keventBuffer.count),
+                              eventlist: nil,
+                              nevents: 0,
+                              timeout: nil)
         } catch let err as IOError {
             if err.errnoCode == EINTR {
                 // See https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
@@ -410,7 +410,7 @@ final class Selector<R: Registration> {
                 ev.events = interested.epollEventSet
                 ev.data.fd = fd
 
-                _ = try Epoll.epoll_ctl(epfd: self.fd, op: Epoll.EPOLL_CTL_ADD, fd: fd, event: &ev)
+                try Epoll.epoll_ctl(epfd: self.fd, op: Epoll.EPOLL_CTL_ADD, fd: fd, event: &ev)
             #else
                 try kqueueUpdateEventNotifications(selectable: selectable, interested: interested, oldInterested: nil)
             #endif

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -417,7 +417,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
                     assert(self.isActive)
                     pipeline.fireChannelRead0(NIOAny(chan))
                 } catch let err {
-                    _ = try? accepted.close()
+                    try? accepted.close()
                     throw err
                 }
             } else {
@@ -511,7 +511,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         do {
             try self.init(socket: socket, eventLoop: eventLoop)
         } catch {
-            _ = try? socket.close()
+            try? socket.close()
             throw error
         }
     }
@@ -521,7 +521,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         do {
             try socket.setNonBlocking()
         } catch let err {
-            _ = try? socket.close()
+            try? socket.close()
             throw err
         }
 

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -132,6 +132,7 @@ internal func wrapSyscallMayBlock<T: FixedWidthInteger>(where function: StaticSt
 
 /* Sorry, we really try hard to not use underscored attributes. In this case however we seem to break the inlining threshold which makes a system call take twice the time, ie. we need this exception. */
 @inline(__always)
+@discardableResult
 internal func wrapSyscall<T: FixedWidthInteger>(where function: StaticString = #function, _ body: () throws -> T) throws -> T {
     while true {
         let res = try body()
@@ -221,7 +222,7 @@ internal enum Posix {
 
     @inline(never)
     public static func shutdown(descriptor: CInt, how: Shutdown) throws {
-        _ = try wrapSyscall {
+        try wrapSyscall {
             sysShutdown(descriptor, how.cValue)
         }
     }
@@ -247,7 +248,7 @@ internal enum Posix {
 
     @inline(never)
     public static func bind(descriptor: CInt, ptr: UnsafePointer<sockaddr>, bytes: Int) throws {
-         _ = try wrapSyscall {
+         try wrapSyscall {
             sysBind(descriptor, ptr, socklen_t(bytes))
         }
     }
@@ -282,7 +283,7 @@ internal enum Posix {
     @inline(never)
     public static func setsockopt(socket: CInt, level: CInt, optionName: CInt,
                                   optionValue: UnsafeRawPointer, optionLen: socklen_t) throws {
-        _ = try wrapSyscall {
+        try wrapSyscall {
             sysSetsockopt(socket, level, optionName, optionValue, optionLen)
         }
     }
@@ -290,14 +291,14 @@ internal enum Posix {
     @inline(never)
     public static func getsockopt(socket: CInt, level: CInt, optionName: CInt,
                                   optionValue: UnsafeMutableRawPointer, optionLen: UnsafeMutablePointer<socklen_t>) throws {
-         _ = try wrapSyscall {
+         try wrapSyscall {
             sysGetsockopt(socket, level, optionName, optionValue, optionLen)
         }
     }
 
     @inline(never)
     public static func listen(descriptor: CInt, backlog: CInt) throws {
-        _ = try wrapSyscall {
+        try wrapSyscall {
             sysListen(descriptor, backlog)
         }
     }
@@ -327,7 +328,7 @@ internal enum Posix {
     @inline(never)
     public static func connect(descriptor: CInt, addr: UnsafePointer<sockaddr>, size: socklen_t) throws -> Bool {
         do {
-            _ = try wrapSyscall {
+            try wrapSyscall {
                 sysConnect(descriptor, addr, size)
             }
             return true
@@ -418,7 +419,7 @@ internal enum Posix {
     public static func sendfile(descriptor: CInt, fd: CInt, offset: off_t, count: size_t) throws -> IOResult<Int> {
         var written: off_t = 0
         do {
-            _ = try wrapSyscall { () -> ssize_t in
+            try wrapSyscall { () -> ssize_t in
                 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
                     var w: off_t = off_t(count)
                     let result: CInt = Darwin.sendfile(fd, descriptor, offset, &w, nil, 0)
@@ -462,21 +463,21 @@ internal enum Posix {
 
     @inline(never)
     public static func getpeername(socket: CInt, address: UnsafeMutablePointer<sockaddr>, addressLength: UnsafeMutablePointer<socklen_t>) throws {
-        _ = try wrapSyscall {
+        try wrapSyscall {
             return sysGetpeername(socket, address, addressLength)
         }
     }
 
     @inline(never)
     public static func getsockname(socket: CInt, address: UnsafeMutablePointer<sockaddr>, addressLength: UnsafeMutablePointer<socklen_t>) throws {
-        _ = try wrapSyscall {
+        try wrapSyscall {
             return sysGetsockname(socket, address, addressLength)
         }
     }
 
     @inline(never)
     public static func getifaddrs(_ addrs: UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>) throws {
-        _ = try wrapSyscall {
+        try wrapSyscall {
             sysGetifaddrs(addrs)
         }
     }
@@ -502,6 +503,7 @@ internal enum KQueue {
     }
 
     @inline(never)
+    @discardableResult
     public static func kevent(kq: CInt, changelist: UnsafePointer<kevent>?, nchanges: CInt, eventlist: UnsafeMutablePointer<kevent>?, nevents: CInt, timeout: UnsafePointer<Darwin.timespec>?) throws -> CInt {
         return try wrapSyscall {
             sysKevent(kq, changelist, nchanges, eventlist, nevents, timeout)

--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -367,7 +367,7 @@ private extension z_stream {
             self.next_out = nil
         }
 
-        _ = from.readWithUnsafeMutableReadableBytes { dataPtr in
+        from.readWithUnsafeMutableReadableBytes { dataPtr in
             let typedPtr = dataPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)
             let typedDataPtr = UnsafeMutableBufferPointer(start: typedPtr,
                                                           count: dataPtr.count)
@@ -388,7 +388,7 @@ private extension z_stream {
     private mutating func deflateToBuffer(buffer: inout ByteBuffer, flag: Int32) -> Int32 {
         var rc = Z_OK
 
-        _ = buffer.writeWithUnsafeMutableBytes { outputPtr in
+        buffer.writeWithUnsafeMutableBytes { outputPtr in
             let typedOutputPtr = UnsafeMutableBufferPointer(start: outputPtr.baseAddress!.assumingMemoryBound(to: UInt8.self),
                                                             count: outputPtr.count)
             self.avail_out = UInt32(typedOutputPtr.count)

--- a/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
@@ -356,7 +356,7 @@ public final class HTTPServerPipelineHandler: ChannelDuplexHandler {
         var deliveredRead = false
 
         while self.state != .responseEndPending, let event = self.eventBuffer.first {
-            _ = self.eventBuffer.removeFirst()
+            self.eventBuffer.removeFirst()
 
             switch event {
             case .channelRead(let read):
@@ -384,7 +384,7 @@ public final class HTTPServerPipelineHandler: ChannelDuplexHandler {
         // This is done after `fireChannelReadComplete` to keep the same observable
         // behaviour as `SocketChannel`, which fires these events in this order.
         if case .some(.halfClose) = self.eventBuffer.first {
-            _ = self.eventBuffer.removeFirst()
+            self.eventBuffer.removeFirst()
             self.readPending = false
             ctx.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
         }

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -177,7 +177,7 @@ private final class HTTPHandler: ChannelInboundHandler {
             ()
         case .end:
             self.state.requestComplete()
-            _ = ctx.eventLoop.scheduleTask(in: delay) { () -> Void in
+            ctx.eventLoop.scheduleTask(in: delay) { () -> Void in
                 var buf = ctx.channel.allocator.buffer(capacity: string.utf8.count)
                 buf.write(string: string)
                 ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buf))), promise: nil)
@@ -203,7 +203,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                 self.continuousCount += 1
                 self.buffer.write(string: "line \(self.continuousCount)\n")
                 ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(self.buffer)))).map {
-                    _ = ctx.eventLoop.scheduleTask(in: .milliseconds(400), doNext)
+                    ctx.eventLoop.scheduleTask(in: .milliseconds(400), doNext)
                 }.whenFailure { (_: Error) in
                     self.completeResponse(ctx, trailers: nil, promise: nil)
                 }
@@ -229,7 +229,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                 self.continuousCount += 1
                 ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(self.buffer)))).whenSuccess {
                     if self.continuousCount < strings.count {
-                        _ = ctx.eventLoop.scheduleTask(in: delay, doNext)
+                        ctx.eventLoop.scheduleTask(in: delay, doNext)
                     } else {
                         self.completeResponse(ctx, trailers: nil, promise: nil)
                     }

--- a/Sources/NIOPriorityQueue/Heap.swift
+++ b/Sources/NIOPriorityQueue/Heap.swift
@@ -129,28 +129,30 @@ internal struct Heap<T: Comparable> {
         return self.remove(index: 0)
     }
 
+    @discardableResult
     public mutating func remove(value: T) -> Bool {
         if let idx = self.storage.index(of: value) {
-            _ = self.remove(index: idx)
+            self.remove(index: idx)
             return true
         } else {
             return false
         }
     }
 
+    @discardableResult
     private mutating func remove(index: Int) -> T? {
         guard self.storage.count > 0 else {
             return nil
         }
         let element = self.storage[index]
         if self.storage.count == 1 || self.storage[index] == self.storage[self.storage.count - 1] {
-            _ = self.storage.removeLast()
+            self.storage.removeLast()
         } else if !self.comparator(self.storage[index], self.storage[self.storage.count - 1]) {
             Heap<T>.heapRootify(storage: &self.storage, compare: self.comparator, index: index, key: self.storage[self.storage.count - 1])
-            _ = self.storage.removeLast()
+            self.storage.removeLast()
         } else {
             self.storage[index] = self.storage[self.storage.count - 1]
-            _ = self.storage.removeLast()
+            self.storage.removeLast()
             Heap<T>.heapify(storage: &self.storage, compare: self.comparator, index)
         }
         return element

--- a/Sources/NIOPriorityQueue/PriorityQueue.swift
+++ b/Sources/NIOPriorityQueue/PriorityQueue.swift
@@ -22,7 +22,7 @@ public struct PriorityQueue<Element: Comparable> {
 
     public mutating func remove(_ key: Element) {
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
-        _ = self.heap.remove(value: key)
+        self.heap.remove(value: key)
         assert(self.heap.checkHeapProperty(), "broken heap: \(self.heap.debugDescription)")
     }
 

--- a/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
@@ -120,7 +120,7 @@ public class ApplicationProtocolNegotiationHandler: ChannelInboundHandler {
         let switchFuture = completionHandler(result)
         switchFuture.whenComplete {
             self.unbuffer(context: context)
-            _ = context.pipeline.remove(handler: self)
+            context.pipeline.remove(handler: self, promise: nil)
         }
     }
 

--- a/Sources/NIOTLS/SNIHandler.swift
+++ b/Sources/NIOTLS/SNIHandler.swift
@@ -427,8 +427,8 @@ public class SniHandler: ByteToMessageDecoder {
     ///    in the pipeline, which is now responsible for the work.
     private func sniComplete(result: SniResult, ctx: ChannelHandlerContext) {
         waitingForUser = true
-        _ = completionHandler(result).then {
-            ctx.pipeline.remove(handler: self)
+        completionHandler(result).whenSuccess {
+            ctx.pipeline.remove(handler: self, promise: nil)
         }
     }
 }


### PR DESCRIPTION
Motivation:

_ = expression() is ugly and in many cases unimportant. In fact we train
ourselves to overread it which makes special cases where you'd actually
expect a result to be used just look normal.

Modifications:

remove _ = from a lot of places. In many cases we already had a better
(and sometimes cheaper way) to not return a value but in some cases
(mostly `remove` functions) I added `@discardableResult`

Result:

NIO source code looks nicer
