### PR TITLE
connect timeout tests: work around ECONNREFUSED

### DIFF
--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -1067,8 +1067,9 @@ public class ChannelTests: XCTestCase {
             } else {
                 XCTFail()
             }
-        } catch let err as IOError where err.errnoCode == ENETDOWN || err.errnoCode == ENETUNREACH {
+        } catch let err as IOError where err.errnoCode == ENETDOWN || err.errnoCode == ENETUNREACH || err.errnoCode == ECONNREFUSED {
             // we need to accept those too unfortunately
+            print("WARNING: \(#function) did not meaningfully test anything, received \(err)")
         } catch {
             XCTFail("unexpected error \(error)")
         }
@@ -1092,8 +1093,9 @@ public class ChannelTests: XCTestCase {
             } else {
                 XCTFail()
             }
-        } catch let err as IOError where err.errnoCode == ENETDOWN || err.errnoCode == ENETUNREACH {
+        } catch let err as IOError where err.errnoCode == ENETDOWN || err.errnoCode == ENETUNREACH || err.errnoCode == ECONNREFUSED {
             // we need to accept those too unfortunately
+            print("WARNING: \(#function) did not meaningfully test anything, received \(err)")
         } catch {
             XCTFail("unexpected error \(error)")
         }


### PR DESCRIPTION
Motivation:

Some network configurations might disallow connecting to unknown IP
addresses. The effect of that is that we might see `ECONNREFUSED` when
trying to connect to 198.51.100.254 which nominally is reserved for
documentation only (ie. we shouldn't get any RSTs).

Modifications:

ignore `ECONNREFUSED` in the timeout tests too

Result:

tests stable in less permissive network environments
