### PR TITLE
More `swift-nio-http2` compatibility.

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -372,8 +372,8 @@ public struct HTTPResponseHead: Equatable {
 /// - note: This is public to aid in the creation of supplemental HTTP libraries, e.g.
 ///         NIOHTTP2 and NIOHPACK. It is not intended for general use.
 public struct HTTPHeaderIndex {
-    let start: Int
-    let length: Int
+    public let start: Int
+    public let length: Int
 }
 
 /// Struct which holds name, value pairs.
@@ -381,8 +381,8 @@ public struct HTTPHeaderIndex {
 /// - note: This is public to aid in the creation of supplemental HTTP libraries, e.g.
 ///         NIOHTTP2 and NIOHPACK. It is not intended for general use.
 public struct HTTPHeader {
-    let name: HTTPHeaderIndex
-    let value: HTTPHeaderIndex
+    public let name: HTTPHeaderIndex
+    public let value: HTTPHeaderIndex
 }
 
 private extension ByteBuffer {


### PR DESCRIPTION
Make the member variables of `HTTPHeader` and `HTTPHeaderIndex` visible to swift-nio-http2.

### Motivation:

When gleefully attempting to use the methods I added to `HTTPHeaders` to get a direct copy/map of the header buffers into the H2 `HPACKHeaders` structure, I discovered I had neglected to make the actual member variables available, and thus could do approximately nothing with the new API I'd created. Sigh.

### Modifications:

Attached a `public` keyword to the members of the `HTTPHeader` and `HTTPHeaderIndex` types. The note on the type itself still applies here: this is intended to help interoperability with other SwiftNIO projects, it's not really something for end users to use.

### Result:

I'll feel marginally less foolish for missing it in the first place, and I'll actually be able to do what I intended when converting from `HTTPHeaders` to `HPACKHeaders` and back again.