### PR TITLE
ByteBuffer test: remove bogus test assertion

### DIFF
--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1594,7 +1594,6 @@ class ByteBufferTest: XCTestCase {
         }
 
         XCTAssertNotEqual(buf.capacity, oldCapacity)
-        XCTAssertNotEqual(oldPtrVal, newPtrVal)
     }
 
     func testReserveCapacityLargerMultipleReferenceCallsMalloc() throws {


### PR DESCRIPTION
Motivation:

One ByteBuffer test was (for whatever reason) asserting that realloc
never succeeds in realloc'ing from 16 to 32 bytes. That just failed on
macOS, presumably an allocator change.

Modifications:

remove bogus assertion about reallocs ability to grow allocations.

Result:

tests more stable
