### PR TITLE
ignore pthread_setname_np result

### DIFF
--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -97,9 +97,8 @@ final class Thread {
             let pt = pthread_self()
 
             if let threadName = name {
-                let res = sys_pthread_setname_np(pt, threadName)
-                // This should only happen in case of a too-long name.
-                precondition(res == 0, "pthread_setname_np failed for '\(threadName)': \(res)")
+                _ = sys_pthread_setname_np(pt, threadName)
+                // this is non-critical so we ignore the result here, we've seen EPERM in containers.
             }
 
             body(Thread(pthread: pt))


### PR DESCRIPTION
Motivation:

We have seen pthread_setname_np fail with EPERM in containers, it's
non-critical so best to ignore.

Modifications:

ignore pthread_setname_np's return code.

Result:

works in containers.
