### PR TITLE
fix some test warnings

### DIFF
--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1579,20 +1579,12 @@ class ByteBufferTest: XCTestCase {
 
 
         let oldCapacity = buf.capacity
-        let oldPtrVal = buf.withVeryUnsafeBytes {
-            UInt(bitPattern: $0.baseAddress!)
-        }
 
         XCTAssertEqual(testReserveCapacityLarger_mallocCount, 1)
         XCTAssertEqual(testReserveCapacityLarger_reallocCount, 0)
         buf.reserveCapacity(32)
         XCTAssertEqual(testReserveCapacityLarger_mallocCount, 1)
         XCTAssertEqual(testReserveCapacityLarger_reallocCount, 1)
-
-        let newPtrVal = buf.withVeryUnsafeBytes {
-            UInt(bitPattern: $0.baseAddress!)
-        }
-
         XCTAssertNotEqual(buf.capacity, oldCapacity)
     }
 


### PR DESCRIPTION
Motivation:

I recently removed a bogus assertion but forgot to remove some now
useless variables.

Modifications:

Remove those useless variables.

Result:

Only deprecation warnings left.
