### PR TITLE
Added public init for HTTPServerProtocolErrorHandler

### DIFF
--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -29,6 +29,8 @@ public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler {
 
     private var hasUnterminatedResponse: Bool = false
 
+	public init() {}
+	
     public func errorCaught(ctx: ChannelHandlerContext, error: Error) {
         guard error is HTTPParserError else {
             ctx.fireErrorCaught(error)


### PR DESCRIPTION
Added an empty public init to HTTPServerProtocolErrorHandler.

### Motivation:

HTTPServerProtocolErrorHandler is a class declared as public, yet it had no initializers, therefore it could not be instantiated by end-user code.

### Modifications:

An empty init function was added `public init() {}`

### Result:

The functionality of the object is unchanged, but end user code can now instantiate HTTPServerProtocolErrorHandler and add it to pipelines.