### PR TITLE
optional type parameter for newPromise()

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -347,7 +347,7 @@ public func swiftMain() -> Int {
         struct MyError: Error { }
         @inline(never)
         func doThenAndFriends(loop: EventLoop) {
-            let p: EventLoopPromise<Int> = loop.newPromise()
+            let p = loop.newPromise(for: Int.self)
             let f = p.futureResult.then { (r: Int) -> EventLoopFuture<Int> in 
                 // This call allocates a new Future, and
                 // so does then(), so this is two Futures.
@@ -384,9 +384,9 @@ public func swiftMain() -> Int {
         }
         @inline(never)
         func doAnd(loop: EventLoop) {
-            let p1: EventLoopPromise<Int> = loop.newPromise()
-            let p2: EventLoopPromise<Int> = loop.newPromise()
-            let p3: EventLoopPromise<Int> = loop.newPromise()
+            let p1 = loop.newPromise(for: Int.self)
+            let p2 = loop.newPromise(for: Int.self)
+            let p3 = loop.newPromise(for: Int.self)
 
             // Each call to and() allocates a Future. The calls to
             // and(result:) allocate two.

--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -468,7 +468,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
 
     public final func setOption<T: ChannelOption>(option: T, value: T.OptionType) -> EventLoopFuture<Void> {
         if eventLoop.inEventLoop {
-            let promise: EventLoopPromise<Void> = eventLoop.newPromise()
+            let promise = eventLoop.newPromise(for: Void.self)
             executeAndComplete(promise) { try setOption0(option: option, value: value) }
             return promise.futureResult
         } else {
@@ -797,7 +797,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         self.eventLoop.assertInEventLoop()
         assert(self.isOpen)
         assert(!self.lifecycleManager.isActive)
-        let registerPromise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+        let registerPromise = self.eventLoop.newPromise(for: Void.self)
         self.register0(promise: registerPromise)
         registerPromise.futureResult.whenFailure { (_: Error) in
             self.close(promise: nil)

--- a/Sources/NIO/BlockingIOThreadPool.swift
+++ b/Sources/NIO/BlockingIOThreadPool.swift
@@ -189,7 +189,7 @@ public extension BlockingIOThreadPool {
     ///     - body: The closure which performs some blocking work to be done on the thread pool.
     /// - returns: The `EventLoopFuture` of `promise` fulfilled with the result (or error) of the passed closure.
     func runIfActive<T>(eventLoop: EventLoop, _ body: @escaping () throws -> T) -> EventLoopFuture<T> {
-        let promise: EventLoopPromise<T> = eventLoop.newPromise()
+        let promise = eventLoop.newPromise(for: T.self)
         self.submit { shouldRun in
             guard case shouldRun = BlockingIOThreadPool.WorkItemState.active else {
                 promise.fail(error: ChannelError.ioOnClosedChannel)

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -172,7 +172,7 @@ public final class ServerBootstrap {
             return try ServerSocketChannel(descriptor: descriptor, eventLoop: eventLoop, group: childEventLoopGroup)
         }
         return bind0(makeServerChannel: makeChannel) { (eventLoop, serverChannel) in
-            let promise: EventLoopPromise<Void> = eventLoop.newPromise()
+            let promise = eventLoop.newPromise(for: Void.self)
             serverChannel.registerAlreadyConfigured0(promise: promise)
             return promise.futureResult
         }
@@ -433,7 +433,7 @@ public final class ClientBootstrap {
     /// - returns: An `EventLoopFuture<Channel>` to deliver the `Channel` when connected.
     public func connect(to address: SocketAddress) -> EventLoopFuture<Channel> {
         return execute(eventLoop: group.next(), protocolFamily: address.protocolFamily) { channel in
-            let connectPromise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
+            let connectPromise = channel.eventLoop.newPromise(for: Void.self)
             channel.connect(to: address, promise: connectPromise)
             let cancelTask = channel.eventLoop.scheduleTask(in: self.connectTimeout) {
                 connectPromise.fail(error: ChannelError.connectTimeout(self.connectTimeout))
@@ -479,7 +479,7 @@ public final class ClientBootstrap {
         return channelInitializer(channel).then {
             self.channelOptions.applyAll(channel: channel)
         }.then {
-            let promise: EventLoopPromise<Void> = eventLoop.newPromise()
+            let promise = eventLoop.newPromise(for: Void.self)
             channel.registerAlreadyConfigured0(promise: promise)
             return promise.futureResult
         }.map {
@@ -496,7 +496,7 @@ public final class ClientBootstrap {
         let channelInitializer = self.channelInitializer ?? { _ in eventLoop.newSucceededFuture(result: ()) }
         let channelOptions = self.channelOptions
 
-        let promise: EventLoopPromise<Channel> = eventLoop.newPromise()
+        let promise = eventLoop.newPromise(for: Channel.self)
         let channel: SocketChannel
         do {
             channel = try SocketChannel(eventLoop: eventLoop as! SelectableEventLoop, protocolFamily: protocolFamily)
@@ -595,7 +595,7 @@ public final class DatagramBootstrap {
             return try DatagramChannel(eventLoop: eventLoop, descriptor: descriptor)
         }
         return bind0(makeChannel: makeChannel) { (eventLoop, channel) in
-            let promise: EventLoopPromise<Void> = eventLoop.newPromise()
+            let promise = eventLoop.newPromise(for: Void.self)
             channel.registerAlreadyConfigured0(promise: promise)
             return promise.futureResult
         }
@@ -717,7 +717,7 @@ public final class DatagramBootstrap {
     }
 
     func applyAll(channel: Channel) -> EventLoopFuture<Void> {
-        let applyPromise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
+        let applyPromise = channel.eventLoop.newPromise(for: Void.self)
         var it = self.storage.makeIterator()
 
         func applyNext() {

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -163,7 +163,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - first: `true` to add this handler to the front of the `ChannelPipeline`, `false to add it last
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was added.
     public func add(name: String? = nil, handler: ChannelHandler, first: Bool = false) -> EventLoopFuture<Void> {
-        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Void.self)
 
         func _add() {
             if self.destroyed {
@@ -199,7 +199,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - after: The pre-existing `ChannelHandler` that `handler` should be inserted immediately after.
     /// - returns: An `EventLoopFuture` that will be notified when the `ChannelHandler` is added.
     public func add(name: String? = nil, handler: ChannelHandler, after: ChannelHandler) -> EventLoopFuture<Void> {
-        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Void.self)
 
         if self.eventLoop.inEventLoop {
             self.add0(name: name, handler: handler, relativeHandler: after, operation: self.add0(context:after:), promise: promise)
@@ -222,7 +222,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - after: The pre-existing `ChannelHandler` that `handler` should be inserted immediately before.
     /// - returns: An `EventLoopFuture` that will be notified when the `ChannelHandler` is added.
     public func add(name: String? = nil, handler: ChannelHandler, before: ChannelHandler) -> EventLoopFuture<Void> {
-        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Void.self)
 
         if self.eventLoop.inEventLoop {
             self.add0(name: name, handler: handler, relativeHandler: before, operation: self.add0(context:before:), promise: promise)
@@ -356,7 +356,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - handler: the `ChannelHandler` to remove.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
     public func remove(handler: ChannelHandler) -> EventLoopFuture<Bool> {
-        let promise: EventLoopPromise<Bool> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Bool.self)
         self.remove(handler: handler, promise: promise)
         return promise.futureResult
     }
@@ -367,7 +367,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - name: the name that was used to add the `ChannelHandler` to the `ChannelPipeline` before.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
     public func remove(name: String) -> EventLoopFuture<Bool> {
-        let promise: EventLoopPromise<Bool> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Bool.self)
         self.remove(name: name, promise: promise)
         return promise.futureResult
     }
@@ -378,7 +378,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - ctx: the `ChannelHandlerContext` that belongs to `ChannelHandler` that should be removed.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
     public func remove(ctx: ChannelHandlerContext) -> EventLoopFuture<Bool> {
-        let promise: EventLoopPromise<Bool> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Bool.self)
         self.remove(ctx: ctx, promise: promise)
         return promise.futureResult
     }
@@ -464,7 +464,7 @@ public final class ChannelPipeline: ChannelInvoker {
 
     /// Find a `ChannelHandlerContext` in the `ChannelPipeline`.
     private func context0(_ body: @escaping ((ChannelHandlerContext) -> Bool)) -> EventLoopFuture<ChannelHandlerContext> {
-        let promise: EventLoopPromise<ChannelHandlerContext> = eventLoop.newPromise()
+        let promise = eventLoop.newPromise(for: ChannelHandlerContext.self)
 
         func _context0() {
             if let ctx = self.contextForPredicate0(body) {

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -318,7 +318,7 @@ extension EventLoop {
     }
 
     /// Creates and returns a new `EventLoopPromise` that will be notified using this `EventLoop` as execution `Thread`.
-    public func newPromise<T>(file: StaticString = #file, line: UInt = #line) -> EventLoopPromise<T> {
+    public func newPromise<T>(for type: T.Type = T.self, file: StaticString = #file, line: UInt = #line) -> EventLoopPromise<T> {
         return EventLoopPromise<T>(eventLoop: self, file: file, line: line)
     }
 
@@ -757,7 +757,7 @@ internal final class SelectableEventLoop: EventLoop {
         if self.inEventLoop {
             return closeGently0()
         } else {
-            let p: EventLoopPromise<Void> = self.newPromise()
+            let p = self.newPromise(for: Void.self)
             self.execute {
                 closeGently0().cascade(promise: p)
             }

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -123,7 +123,7 @@ private struct CallbackList: ExpressibleByArrayLiteral {
 ///
 /// ```
 /// func someAsyncOperation(args) -> EventLoopFuture<ResultType> {
-///     let promise: EventLoopPromise<ResultType> = eventLoop.newPromise()
+///     let promise = eventLoop.newPromise(for: ResultType.self)
 ///     someAsyncOperationWithACallback(args) { result -> Void in
 ///         // when finished...
 ///         promise.succeed(result: result)
@@ -218,7 +218,7 @@ public struct EventLoopPromise<T> {
 ///
 /// ```
 /// func getNetworkData(args) -> EventLoopFuture<NetworkResponse> {
-///     let promise: EventLoopPromise<NetworkResponse> = eventLoop.newPromise()
+///     let promise = eventLoop.newPromise(for: NetworkResponse.self)
 ///     queue.async {
 ///         . . . do some work . . .
 ///         promise.succeed(response)
@@ -928,7 +928,7 @@ extension EventLoopFuture {
     ///     - updateAccumulatingResult: The bifunction used to combine partialResults with new elements.
     /// - returns: A new `EventLoopFuture` with the combined value.
     public static func reduce<U>(into initialResult: T, _ futures: [EventLoopFuture<U>], eventLoop: EventLoop, _ updateAccumulatingResult: @escaping (inout T, U) -> Void) -> EventLoopFuture<T> {
-        let p0: EventLoopPromise<T> = eventLoop.newPromise()
+        let p0 = eventLoop.newPromise(for: T.self)
         var result: T = initialResult
 
         let f0 = eventLoop.newSucceededFuture(result: ())
@@ -967,7 +967,7 @@ public extension EventLoopFuture {
             // We're already on that event loop, nothing to do here. Save an allocation.
             return self
         }
-        let hoppingPromise: EventLoopPromise<T> = target.newPromise()
+        let hoppingPromise = target.newPromise(for: T.self)
         self.cascade(promise: hoppingPromise)
         return hoppingPromise.futureResult
     }

--- a/Sources/NIO/MulticastChannel.swift
+++ b/Sources/NIO/MulticastChannel.swift
@@ -62,13 +62,13 @@ public extension MulticastChannel {
     }
 
     func joinGroup(_ group: SocketAddress) -> EventLoopFuture<Void> {
-        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Void.self)
         self.joinGroup(group, promise: promise)
         return promise.futureResult
     }
 
     func joinGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
-        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Void.self)
         self.joinGroup(group, interface: interface, promise: promise)
         return promise.futureResult
     }
@@ -78,13 +78,13 @@ public extension MulticastChannel {
     }
 
     func leaveGroup(_ group: SocketAddress) -> EventLoopFuture<Void> {
-        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Void.self)
         self.leaveGroup(group, promise: promise)
         return promise.futureResult
     }
 
     func leaveGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
-        let promise: EventLoopPromise<Void> = self.eventLoop.newPromise()
+        let promise = self.eventLoop.newPromise(for: Void.self)
         self.leaveGroup(group, interface: interface, promise: promise)
         return promise.futureResult
     }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -381,7 +381,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
             return
         }
 
-        let p: EventLoopPromise<Void> = eventLoop.newPromise()
+        let p = eventLoop.newPromise(for: Void.self)
         p.futureResult.map {
             // It's important to call the methods before we actually notify the original promise for ordering reasons.
             self.becomeActive0(promise: promise)

--- a/Sources/NIO/SocketOptionProvider.swift
+++ b/Sources/NIO/SocketOptionProvider.swift
@@ -213,7 +213,7 @@ public extension SocketOptionProvider {
 extension BaseSocketChannel: SocketOptionProvider {
     public func unsafeSetSocketOption<Value>(level: SocketOptionLevel, name: SocketOptionName, value: Value) -> EventLoopFuture<Void> {
         if eventLoop.inEventLoop {
-            let promise: EventLoopPromise<Void> = eventLoop.newPromise()
+            let promise = eventLoop.newPromise(for: Void.self)
             executeAndComplete(promise) {
                 try setSocketOption0(level: level, name: name, value: value)
             }
@@ -227,7 +227,7 @@ extension BaseSocketChannel: SocketOptionProvider {
 
     public func unsafeGetSocketOption<Value>(level: SocketOptionLevel, name: SocketOptionName) -> EventLoopFuture<Value> {
         if eventLoop.inEventLoop {
-            let promise: EventLoopPromise<Value> = eventLoop.newPromise()
+            let promise = eventLoop.newPromise(for: Value.self)
             executeAndComplete(promise) {
                 try getSocketOption0(level: level, name: name)
             }

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -342,7 +342,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                                                     }
                                                     return ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buffer))))
                     }.then { () -> EventLoopFuture<Void> in
-                        let p: EventLoopPromise<Void> = ctx.eventLoop.newPromise()
+                        let p = ctx.eventLoop.newPromise(for: Void.self)
                         self.completeResponse(ctx, trailers: nil, promise: p)
                         return p.futureResult
                     }.thenIfError { error in
@@ -364,7 +364,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                     let response = responseHead(request: request, fileRegion: region)
                     ctx.write(self.wrapOutboundOut(.head(response)), promise: nil)
                     ctx.writeAndFlush(self.wrapOutboundOut(.body(.fileRegion(region)))).then {
-                        let p: EventLoopPromise<Void> = ctx.eventLoop.newPromise()
+                        let p = ctx.eventLoop.newPromise(for: Void.self)
                         self.completeResponse(ctx, trailers: nil, promise: p)
                         return p.futureResult
                     }.thenIfError { (_: Error) in

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
@@ -27,7 +27,7 @@ private class PromiseOrderer {
     }
 
     func newPromise() -> EventLoopPromise<Void> {
-        let promise: EventLoopPromise<Void> = eventLoop.newPromise()
+        let promise = eventLoop.newPromise(for: Void.self)
         appendPromise(promise)
         return promise
     }
@@ -501,7 +501,7 @@ class HTTPResponseCompressorTest: XCTestCase {
         let channel = try compressionChannel()
         try sendRequest(acceptEncoding: "gzip", channel: channel)
         let head = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok)
-        let writePromise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
+        let writePromise = channel.eventLoop.newPromise(for: Void.self)
         channel.write(NIOAny(HTTPServerResponsePart.head(head)), promise: writePromise)
         writePromise.futureResult.map {
             XCTFail("Write succeeded")
@@ -528,7 +528,7 @@ class HTTPResponseCompressorTest: XCTestCase {
         let channel = try compressionChannel()
         try sendRequest(acceptEncoding: nil, channel: channel)
         let head = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok)
-        let writePromise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
+        let writePromise = channel.eventLoop.newPromise(for: Void.self)
         channel.writeAndFlush(NIOAny(HTTPServerResponsePart.head(head)), promise: writePromise)
         channel.pipeline.removeHandlers()
         try writePromise.futureResult.wait()

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -77,7 +77,7 @@ private func serverHTTPChannelWithAutoremoval(group: EventLoopGroup,
                                               upgraders: [HTTPProtocolUpgrader],
                                               extraHandlers: [ChannelHandler],
                                               _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) throws -> (Channel, EventLoopFuture<Channel>) {
-    let p: EventLoopPromise<Channel> = group.next().newPromise()
+    let p = group.next().newPromise(for: Channel.self)
     let c = try ServerBootstrap(group: group)
         .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
         .childChannelInitializer { channel in
@@ -394,7 +394,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise: EventLoopPromise<Void> = group.next().newPromise()
+        let completePromise = group.next().newPromise(for: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -499,7 +499,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise: EventLoopPromise<Void> = group.next().newPromise()
+        let completePromise = group.next().newPromise(for: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -543,7 +543,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise: EventLoopPromise<Void> = group.next().newPromise()
+        let completePromise = group.next().newPromise(for: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -604,7 +604,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise: EventLoopPromise<Void> = group.next().newPromise()
+        let completePromise = group.next().newPromise(for: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -650,7 +650,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise: EventLoopPromise<Void> = group.next().newPromise()
+        let completePromise = group.next().newPromise(for: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -684,7 +684,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise: EventLoopPromise<Void> = group.next().newPromise()
+        let completePromise = group.next().newPromise(for: Void.self)
         let clientHandler = SingleHTTPResponseAccumulator { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -727,7 +727,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise: EventLoopPromise<Void> = group.next().newPromise()
+        let completePromise = group.next().newPromise(for: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -898,9 +898,9 @@ class HTTPUpgradeTestCase: XCTestCase {
         defer {
             XCTAssertNoThrow(try promiseGroup.syncShutdownGracefully())
         }
-        let firstByteDonePromise: EventLoopPromise<Void> = promiseGroup.next().newPromise()
-        let secondByteDonePromise: EventLoopPromise<Void> = promiseGroup.next().newPromise()
-        let allDonePromise: EventLoopPromise<Void> = promiseGroup.next().newPromise()
+        let firstByteDonePromise = promiseGroup.next().newPromise(for: Void.self)
+        let secondByteDonePromise = promiseGroup.next().newPromise(for: Void.self)
+        let allDonePromise = promiseGroup.next().newPromise(for: Void.self)
         let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
                                                                                     extraHandlers: []) { (ctx) in
                                                                                         // This is called before the upgrader gets called.
@@ -915,7 +915,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         
-        let completePromise: EventLoopPromise<Void> = group.next().newPromise()
+        let completePromise = group.next().newPromise(for: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,

--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
@@ -58,7 +58,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
     private func negotiateTest(event: TLSUserEvent, expectedResult: ALPNResult) throws {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise: EventLoopPromise<Void> = loop.newPromise()
+        let continuePromise = loop.newPromise(for: Void.self)
 
         let expectedResult: ALPNResult = .negotiated("h2")
         var called = false
@@ -117,7 +117,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
     func testBufferingWhileWaitingForFuture() throws {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise: EventLoopPromise<Void> = loop.newPromise()
+        let continuePromise = loop.newPromise(for: Void.self)
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             continuePromise.futureResult
@@ -148,7 +148,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
     func testNothingBufferedDoesNotFireReadCompleted() throws {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise: EventLoopPromise<Void> = loop.newPromise()
+        let continuePromise = loop.newPromise(for: Void.self)
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             continuePromise.futureResult
@@ -175,7 +175,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
     func testUnbufferingFiresReadCompleted() throws {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise: EventLoopPromise<Void> = loop.newPromise()
+        let continuePromise = loop.newPromise(for: Void.self)
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             continuePromise.futureResult

--- a/Tests/NIOTLSTests/SNIHandlerTests.swift
+++ b/Tests/NIOTLSTests/SNIHandlerTests.swift
@@ -262,7 +262,7 @@ class SniHandlerTest: XCTestCase {
         var buffer = bufferForBase64String(string: clientHello)
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise: EventLoopPromise<Void> = loop.newPromise()
+        let continuePromise = loop.newPromise(for: Void.self)
 
         let handler = SniHandler { result in
             XCTAssertEqual(expectedResult, result)
@@ -313,7 +313,7 @@ class SniHandlerTest: XCTestCase {
         let buffer = bufferForBase64String(string: clientHello)
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise: EventLoopPromise<Void> = loop.newPromise()
+        let continuePromise = loop.newPromise(for: Void.self)
 
         let handler = SniHandler { result in
             XCTAssertEqual(expectedResult, result)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -25,8 +25,8 @@ class BootstrapTest: XCTestCase {
                 XCTAssertNoThrow(try group.syncShutdownGracefully())
             }
 
-            let childChannelDone: EventLoopPromise<Void> = group.next().newPromise()
-            let serverChannelDone: EventLoopPromise<Void> = group.next().newPromise()
+            let childChannelDone = group.next().newPromise(for: Void.self)
+            let serverChannelDone = group.next().newPromise(for: Void.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
                 .childChannelInitializer { channel in
                     XCTAssert(channel.eventLoop.inEventLoop)

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -291,7 +291,7 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let acceptedChannelPromise: EventLoopPromise<Channel> = group.next().newPromise()
+        let acceptedChannelPromise = group.next().newPromise(for: Channel.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -374,7 +374,7 @@ class ChannelNotificationTest: XCTestCase {
             }
         }
 
-        let promise: EventLoopPromise<Void> = group.next().newPromise()
+        let promise = group.next().newPromise(for: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: true)

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -698,7 +698,7 @@ class ChannelPipelineTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 1024)
         buffer.write(staticString: "Hello, world!")
 
-        let removalPromise: EventLoopPromise<Bool> = channel.eventLoop.newPromise()
+        let removalPromise = channel.eventLoop.newPromise(for: Bool.self)
         removalPromise.futureResult.whenSuccess { (_: Bool) in
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
@@ -772,7 +772,7 @@ class ChannelPipelineTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 1024)
         buffer.write(staticString: "Hello, world!")
 
-        let removalPromise: EventLoopPromise<Bool> = channel.eventLoop.newPromise()
+        let removalPromise = channel.eventLoop.newPromise(for: Bool.self)
         removalPromise.futureResult.whenSuccess { (_: Bool) in
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
@@ -847,7 +847,7 @@ class ChannelPipelineTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 1024)
         buffer.write(staticString: "Hello, world!")
 
-        let removalPromise: EventLoopPromise<Bool> = channel.eventLoop.newPromise()
+        let removalPromise = channel.eventLoop.newPromise(for: Bool.self)
         removalPromise.futureResult.whenSuccess { (_: Bool) in
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -76,7 +76,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let serverAcceptedChannelPromise: EventLoopPromise<Channel> = group.next().newPromise()
+        let serverAcceptedChannelPromise = group.next().newPromise(for: Channel.self)
         let serverLifecycleHandler = ChannelLifecycleHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -178,7 +178,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let childChannelPromise: EventLoopPromise<Channel> = group.next().newPromise()
+        let childChannelPromise = group.next().newPromise(for: Channel.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
@@ -550,7 +550,7 @@ public class ChannelTests: XCTestCase {
             buffer.clear()
             buffer.write(bytes: [0xff] as [UInt8])
             let ps: [EventLoopPromise<Void>] = (0..<numberOfBytes).map { (_: Int) in
-                let p: EventLoopPromise<Void> = el.newPromise()
+                let p = el.newPromise(for: Void.self)
                 _ = pwm.add(data: .byteBuffer(buffer), promise: p)
                 return p
             }
@@ -1370,10 +1370,10 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let promise: EventLoopPromise<ChannelPipeline> = group.next().newPromise()
+        let promise = group.next().newPromise(for: ChannelPipeline.self)
 
         try {
-            let serverChildChannelPromise: EventLoopPromise<Channel> = group.next().newPromise()
+            let serverChildChannelPromise = group.next().newPromise(for: Channel.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
                 .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
                 .childChannelInitializer { channel in
@@ -1700,7 +1700,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let allDone: EventLoopPromise<Void> = group.next().newPromise()
+        let allDone = group.next().newPromise(for: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: false)
@@ -1751,7 +1751,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let promise: EventLoopPromise<Void> = group.next().newPromise()
+        let promise = group.next().newPromise(for: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: false)
@@ -1944,10 +1944,10 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let serverWriteHappenedPromise: EventLoopPromise<Void> = serverEL.next().newPromise()
-        let clientHasRegistered: EventLoopPromise<Void> = serverEL.next().newPromise()
-        let clientHasUnregistered: EventLoopPromise<Void> = serverEL.next().newPromise()
-        let clientHasRead: EventLoopPromise<Void> = serverEL.next().newPromise()
+        let serverWriteHappenedPromise = serverEL.next().newPromise(for: Void.self)
+        let clientHasRegistered = serverEL.next().newPromise(for: Void.self)
+        let clientHasUnregistered = serverEL.next().newPromise(for: Void.self)
+        let clientHasRead = serverEL.next().newPromise(for: Void.self)
 
         let bootstrap = try assertNoThrowWithValue(ServerBootstrap(group: serverEL)
             .childChannelInitializer { channel in
@@ -2124,7 +2124,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        let allDone: EventLoopPromise<Void> = clientEL.newPromise()
+        let allDone = clientEL.newPromise(for: Void.self)
 
         XCTAssertNoThrow(try sc.eventLoop.submit {
             // this is pretty delicate at the moment:
@@ -2173,7 +2173,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        let allDone: EventLoopPromise<Void> = group.next().newPromise()
+        let allDone = group.next().newPromise(for: Void.self)
         let cf = try! sc.eventLoop.submit {
             sc.pipeline.add(handler: VerifyConnectionFailureHandler(allDone: allDone)).then {
                 sc.register().then {
@@ -2219,7 +2219,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        let allDone: EventLoopPromise<Void> = group.next().newPromise()
+        let allDone = group.next().newPromise(for: Void.self)
         try! sc.eventLoop.submit {
             let f = sc.pipeline.add(handler: VerifyConnectionFailureHandler(allDone: allDone)).then {
                 sc.register().then {
@@ -2300,7 +2300,7 @@ public class ChannelTests: XCTestCase {
 
         do {
             try sc.eventLoop.submit { () -> EventLoopFuture<Void> in
-                let p: EventLoopPromise<Void> = sc.eventLoop.newPromise()
+                let p = sc.eventLoop.newPromise(for: Void.self)
                 // this callback must be attached before we call the close
                 let f = p.futureResult.map {
                     XCTFail("shouldn't be reached")
@@ -2545,8 +2545,8 @@ public class ChannelTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try singleThreadedELG.syncShutdownGracefully())
         }
-        let serverChannelAvailablePromise: EventLoopPromise<Channel> = singleThreadedELG.next().newPromise()
-        let allDonePromise: EventLoopPromise<Void> = singleThreadedELG.next().newPromise()
+        let serverChannelAvailablePromise = singleThreadedELG.next().newPromise(for: Channel.self)
+        let allDonePromise = singleThreadedELG.next().newPromise(for: Void.self)
         let server = try assertNoThrowWithValue(ServerBootstrap(group: singleThreadedELG)
             .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
             .childChannelInitializer { channel in

--- a/Tests/NIOTests/CustomChannelTests.swift
+++ b/Tests/NIOTests/CustomChannelTests.swift
@@ -83,7 +83,7 @@ class CustomChannelTests: XCTestCase {
     func testWritingIntToSpecialChannel() throws {
         let loop = EmbeddedEventLoop()
         let intCore = IntChannelCore()
-        let writePromise: EventLoopPromise<Void> = loop.newPromise()
+        let writePromise = loop.newPromise(for: Void.self)
 
         intCore.write0(NIOAny(5), promise: writePromise)
         XCTAssertNoThrow(try writePromise.futureResult.wait())

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -170,7 +170,7 @@ final class DatagramChannelTests: XCTestCase {
             XCTAssertTrue(writable)
         }
 
-        let lastWritePromise: EventLoopPromise<Void> = self.firstChannel.eventLoop.newPromise()
+        let lastWritePromise = self.firstChannel.eventLoop.newPromise(for: Void.self)
         // The last write will push us over the edge.
         var writable: Bool = try self.firstChannel.eventLoop.submit {
             self.firstChannel.write(NIOAny(writeData), promise: lastWritePromise)
@@ -214,7 +214,7 @@ final class DatagramChannelTests: XCTestCase {
 
         var overall: EventLoopFuture<Void> = self.firstChannel.eventLoop.newSucceededFuture(result: ())
         for _ in 0...Socket.writevLimitIOVectors {
-            let myPromise: EventLoopPromise<Void> = self.firstChannel.eventLoop.newPromise()
+            let myPromise = self.firstChannel.eventLoop.newPromise(for: Void.self)
             var buffer = self.firstChannel.allocator.buffer(capacity: 1)
             buffer.write(string: "a")
             let envelope = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
@@ -233,7 +233,7 @@ final class DatagramChannelTests: XCTestCase {
         // We defer this work to the background thread because otherwise it incurs an enormous number of context
         // switches.
         try self.firstChannel.eventLoop.submit {
-            let myPromise: EventLoopPromise<Void> = self.firstChannel.eventLoop.newPromise()
+            let myPromise = self.firstChannel.eventLoop.newPromise(for: Void.self)
             // For datagrams this buffer cannot be very large, because if it's larger than the path MTU it
             // will cause EMSGSIZE.
             let bufferSize = 1024 * 5
@@ -403,7 +403,7 @@ final class DatagramChannelTests: XCTestCase {
         }
         let socket = try NonRecvFromSocket(error: error)
         let channel = try DatagramChannel(socket: socket, eventLoop: group.next() as! SelectableEventLoop)
-        let promise: EventLoopPromise<IOError> = channel.eventLoop.newPromise()
+        let promise = channel.eventLoop.newPromise(for: IOError.self)
         XCTAssertNoThrow(try channel.register().wait())
         XCTAssertNoThrow(try channel.pipeline.add(handler: RecvFromHandler(promise)).wait())
         XCTAssertNoThrow(try channel.bind(to: SocketAddress.init(ipAddress: "127.0.0.1", port: 0)).wait())

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -72,7 +72,7 @@ class EchoServerClientTest : XCTestCase {
             XCTAssertNoThrow(try serverChannel.close().wait())
         }
 
-        let promise: EventLoopPromise<ByteBuffer> = group.next().newPromise()
+        let promise = group.next().newPromise(for: ByteBuffer.self)
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.add(handler: WriteOnConnectHandler(toWrite: "X")).then { v2 in
@@ -438,7 +438,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let writingBytes = "hello"
-        let bytesReceivedPromise: EventLoopPromise<ByteBuffer> = group.next().newPromise()
+        let bytesReceivedPromise = group.next().newPromise(for: ByteBuffer.self)
         let byteCountingHandler = ByteCountingHandler(numBytes: writingBytes.utf8.count, promise: bytesReceivedPromise)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -495,7 +495,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let stringToWrite = "hello"
-        let promise: EventLoopPromise<ByteBuffer> = group.next().newPromise()
+        let promise = group.next().newPromise(for: ByteBuffer.self)
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.add(handler: WriteOnConnectHandler(toWrite: stringToWrite)).then {
@@ -528,7 +528,7 @@ class EchoServerClientTest : XCTestCase {
             XCTAssertNoThrow(try serverChannel.close().wait())
         }
 
-        let promise: EventLoopPromise<ByteBuffer> = group.next().newPromise()
+        let promise = group.next().newPromise(for: ByteBuffer.self)
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.add(handler: ByteCountingHandler(numBytes: stringToWrite.utf8.count, promise: promise))
@@ -703,7 +703,7 @@ class EchoServerClientTest : XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let promise: EventLoopPromise<Void> = group.next().newPromise()
+        let promise = group.next().newPromise(for: Void.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -782,7 +782,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let numBytes = 16 * 1024
-        let promise: EventLoopPromise<ByteBuffer> = group.next().newPromise()
+        let promise = group.next().newPromise(for: ByteBuffer.self)
         let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: promise)
 
         // we're binding to IPv4 only

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -159,14 +159,14 @@ class EmbeddedChannelTest: XCTestCase {
     func testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires() throws {
         let channel = EmbeddedChannel()
         XCTAssertFalse(channel.isActive)
-        let connectPromise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
+        let connectPromise = channel.eventLoop.newPromise(for: Void.self)
         connectPromise.futureResult.whenComplete {
             XCTAssertTrue(channel.isActive)
         }
         channel.connect(to: try SocketAddress(ipAddress: "127.0.0.1", port: 0), promise: connectPromise)
         try connectPromise.futureResult.wait()
 
-        let closePromise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
+        let closePromise = channel.eventLoop.newPromise(for: Void.self)
         closePromise.futureResult.whenComplete {
             XCTAssertFalse(channel.isActive)
         }

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -270,7 +270,7 @@ class EventLoopFutureTest : XCTestCase {
         let eventLoop = EmbeddedEventLoop()
         var promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.newPromise() }
         _ = promises.map { $0.succeed(result: ()) }
-        let failedPromise: EventLoopPromise<Void> = eventLoop.newPromise()
+        let failedPromise = eventLoop.newPromise(for: Void.self)
         failedPromise.fail(error: E())
         promises.append(failedPromise)
 
@@ -336,7 +336,7 @@ class EventLoopFutureTest : XCTestCase {
         let eventLoop = EmbeddedEventLoop()
         var promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.newPromise() }
         _ = promises.map { $0.succeed(result: (1)) }
-        let failedPromise: EventLoopPromise<Int> = eventLoop.newPromise()
+        let failedPromise = eventLoop.newPromise(for: Int.self)
         failedPromise.fail(error: E())
         promises.append(failedPromise)
 
@@ -359,7 +359,7 @@ class EventLoopFutureTest : XCTestCase {
         let eventLoop = EmbeddedEventLoop()
         var promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.newPromise() }
 
-        let failedPromise: EventLoopPromise<Int> = eventLoop.newPromise()
+        let failedPromise = eventLoop.newPromise(for: Int.self)
         promises.insert(failedPromise, at: promises.startIndex)
 
         let futures = promises.map { $0.futureResult }
@@ -475,7 +475,7 @@ class EventLoopFutureTest : XCTestCase {
     func testThenThrowingWhichDoesNotThrow() {
         let eventLoop = EmbeddedEventLoop()
         var ran = false
-        let p: EventLoopPromise<String> = eventLoop.newPromise()
+        let p = eventLoop.newPromise(for: String.self)
         p.futureResult.map {
             $0.count
         }.thenThrowing {
@@ -494,7 +494,7 @@ class EventLoopFutureTest : XCTestCase {
         }
         let eventLoop = EmbeddedEventLoop()
         var ran = false
-        let p: EventLoopPromise<String> = eventLoop.newPromise()
+        let p = eventLoop.newPromise(for: String.self)
         p.futureResult.map {
             $0.count
         }.thenThrowing { (x: Int) throws -> Int in
@@ -517,7 +517,7 @@ class EventLoopFutureTest : XCTestCase {
         }
         let eventLoop = EmbeddedEventLoop()
         var ran = false
-        let p: EventLoopPromise<String> = eventLoop.newPromise()
+        let p = eventLoop.newPromise(for: String.self)
         p.futureResult.map {
             $0.count
         }.thenIfErrorThrowing {
@@ -541,7 +541,7 @@ class EventLoopFutureTest : XCTestCase {
         }
         let eventLoop = EmbeddedEventLoop()
         var ran = false
-        let p: EventLoopPromise<String> = eventLoop.newPromise()
+        let p = eventLoop.newPromise(for: String.self)
         p.futureResult.map {
             $0.count
         }.thenIfErrorThrowing { (x: Error) throws -> Int in
@@ -582,7 +582,7 @@ class EventLoopFutureTest : XCTestCase {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
         var prev: EventLoopFuture<Int> = elg.next().newSucceededFuture(result: 0)
         (1..<20).forEach { (i: Int) in
-            let p: EventLoopPromise<Int> = elg.next().newPromise()
+            let p = elg.next().newPromise(for: Int.self)
             prev.then { (i2: Int) -> EventLoopFuture<Int> in
                 XCTAssertEqual(i - 1, i2)
                 p.succeed(result: i)
@@ -604,7 +604,7 @@ class EventLoopFutureTest : XCTestCase {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
         var prev: EventLoopFuture<Int> = elg.next().newSucceededFuture(result: 0)
         (1..<n).forEach { (i: Int) in
-            let p: EventLoopPromise<Int> = elg.next().newPromise()
+            let p = elg.next().newPromise(for: Int.self)
             prev.then { (i2: Int) -> EventLoopFuture<Int> in
                 XCTAssertEqual(i - 1, i2)
                 if i == n/2 {
@@ -693,8 +693,8 @@ class EventLoopFutureTest : XCTestCase {
             for eventLoops in [(el1, el1), (el1, el2), (el2, el1), (el2, el2)] {
                 // this determines if the promises fail or succeed
                 for whoSucceeds in [(false, false), (false, true), (true, false), (true, true)] {
-                    let p0: EventLoopPromise<Int> = eventLoops.0.newPromise()
-                    let p1: EventLoopPromise<String> = eventLoops.1.newPromise()
+                    let p0 = eventLoops.0.newPromise(for: Int.self)
+                    let p1 = eventLoops.1.newPromise(for: String.self)
                     let fAll = p0.futureResult.and(p1.futureResult)
 
                     // preheat both queues so we have a better chance of racing
@@ -780,7 +780,7 @@ class EventLoopFutureTest : XCTestCase {
         let loop2 = group.next()
         XCTAssertFalse(loop1 === loop2)
 
-        let succeedingPromise: EventLoopPromise<Void> = loop1.newPromise()
+        let succeedingPromise = loop1.newPromise(for: Void.self)
         let succeedingFuture = succeedingPromise.futureResult.map {
             XCTAssertTrue(loop1.inEventLoop)
         }.hopTo(eventLoop: loop2).map {
@@ -800,7 +800,7 @@ class EventLoopFutureTest : XCTestCase {
         let loop2 = group.next()
         XCTAssertFalse(loop1 === loop2)
 
-        let failingPromise: EventLoopPromise<Void> = loop2.newPromise()
+        let failingPromise = loop2.newPromise(for: Void.self)
         let failingFuture = failingPromise.futureResult.thenIfErrorThrowing { error in
             XCTAssertEqual(error as? EventLoopFutureTestError, EventLoopFutureTestError.example)
             XCTAssertTrue(loop2.inEventLoop)
@@ -823,7 +823,7 @@ class EventLoopFutureTest : XCTestCase {
         let loop2 = group.next()
         XCTAssertFalse(loop1 === loop2)
 
-        let noHoppingPromise: EventLoopPromise<Void> = loop1.newPromise()
+        let noHoppingPromise = loop1.newPromise(for: Void.self)
         let noHoppingFuture = noHoppingPromise.futureResult.hopTo(eventLoop: loop1)
         XCTAssertTrue(noHoppingFuture === noHoppingPromise.futureResult)
         noHoppingPromise.succeed(result: ())

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -359,7 +359,7 @@ public class EventLoopTest : XCTestCase {
         }
         let loop = group.next() as! SelectableEventLoop
 
-        let serverChannelUp: EventLoopPromise<Void> = group.next().newPromise()
+        let serverChannelUp = group.next().newPromise(for: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .childChannelInitializer { channel in
                 channel.pipeline.add(handler: WedgeOpenHandler(channelActivePromise: serverChannelUp) { promise in
@@ -370,7 +370,7 @@ public class EventLoopTest : XCTestCase {
         defer {
             XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
-        let connectPromise: EventLoopPromise<Void> = loop.newPromise()
+        let connectPromise = loop.newPromise(for: Void.self)
 
         // We're going to create and register a channel, but not actually attempt to do anything with it.
         let wedgeHandler = WedgeOpenHandler { promise in

--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -119,7 +119,7 @@ final class MulticastTest: XCTestCase {
     }
 
     private func assertDatagramReaches(multicastChannel: Channel, sender: Channel, multicastAddress: SocketAddress, file: StaticString = #file, line: UInt = #line) throws {
-        let receivedMulticastDatagram: EventLoopPromise<AddressedEnvelope<ByteBuffer>> = multicastChannel.eventLoop.newPromise()
+        let receivedMulticastDatagram = multicastChannel.eventLoop.newPromise(for: AddressedEnvelope<ByteBuffer>.self)
         XCTAssertNoThrow(try multicastChannel.pipeline.add(handler: PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
 
         var messageBuffer = sender.allocator.buffer(capacity: 24)
@@ -141,8 +141,8 @@ final class MulticastTest: XCTestCase {
                                             sender: Channel,
                                             multicastAddress: SocketAddress,
                                             file: StaticString = #file, line: UInt = #line) throws {
-        let timeoutPromise: EventLoopPromise<Void> = multicastChannel.eventLoop.newPromise()
-        let receivedMulticastDatagram: EventLoopPromise<AddressedEnvelope<ByteBuffer>> = multicastChannel.eventLoop.newPromise()
+        let timeoutPromise = multicastChannel.eventLoop.newPromise(for: Void.self)
+        let receivedMulticastDatagram = multicastChannel.eventLoop.newPromise(for: AddressedEnvelope<ByteBuffer>.self)
         XCTAssertNoThrow(try multicastChannel.pipeline.add(handler: PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
 
         // If we receive a datagram, or the reader promise fails, we must fail the timeoutPromise.

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -251,7 +251,7 @@ class SelectorTest: XCTestCase {
                 var reconnectedChannelsHaveRead: [EventLoopFuture<Void>] = []
                 for _ in everyOtherIndex {
                     var hasBeenAdded: Bool = false
-                    let p: EventLoopPromise<Void> = ctx.channel.eventLoop.newPromise()
+                    let p = ctx.channel.eventLoop.newPromise(for: Void.self)
                     reconnectedChannelsHaveRead.append(p.futureResult)
                     let newChannel = ClientBootstrap(group: ctx.eventLoop)
                         .channelInitializer { channel in
@@ -343,7 +343,7 @@ class SelectorTest: XCTestCase {
             .bind(to: SocketAddress(unixDomainSocketPath: "\(tempDir)/server-sock.uds"))
             .wait()
 
-        let everythingWasReadPromise: EventLoopPromise<Void> = el.newPromise()
+        let everythingWasReadPromise = el.newPromise(for: Void.self)
         XCTAssertNoThrow(try el.submit { () -> [EventLoopFuture<Channel>] in
             (0..<SelectorTest.testWeDoNotDeliverEventsForPreviouslyClosedChannels_numberOfChannelsToUse).map { (_: Int) in
                 ClientBootstrap(group: el)

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -152,7 +152,7 @@ public class SocketChannelTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerSocketChannel(serverSocket: socket,
                                                                            eventLoop: group.next() as! SelectableEventLoop,
                                                                            group: group))
-        let promise: EventLoopPromise<IOError> = serverChannel.eventLoop.newPromise()
+        let promise = serverChannel.eventLoop.newPromise(for: IOError.self)
 
         XCTAssertNoThrow(try serverChannel.eventLoop.submit {
             serverChannel.pipeline.add(handler: AcceptHandler(promise)).then {
@@ -230,12 +230,12 @@ public class SocketChannelTest : XCTestCase {
         }
 
         let eventLoop = group.next()
-        let connectPromise: EventLoopPromise<Void> = eventLoop.newPromise()
+        let connectPromise = eventLoop.newPromise(for: Void.self)
 
         let channel = try assertNoThrowWithValue(SocketChannel(socket: ConnectSocket(promise: connectPromise),
                                                                parent: nil,
                                                                eventLoop: eventLoop as! SelectableEventLoop))
-        let promise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
+        let promise = channel.eventLoop.newPromise(for: Void.self)
 
         XCTAssertNoThrow(try channel.pipeline.add(handler: ActiveVerificationHandler(promise)).then {
             channel.register()
@@ -424,7 +424,7 @@ public class SocketChannelTest : XCTestCase {
         defer { XCTAssertNoThrow(try serverChannel.close().wait()) }
 
         let eventLoop = group.next()
-        let promise: EventLoopPromise<Void> = eventLoop.newPromise()
+        let promise = eventLoop.newPromise(for: Void.self)
 
         class ConnectPendingSocket: Socket {
             let promise: EventLoopPromise<Void>
@@ -442,8 +442,8 @@ public class SocketChannelTest : XCTestCase {
         }
 
         let channel = try SocketChannel(socket: ConnectPendingSocket(promise: promise), parent: nil, eventLoop: eventLoop as! SelectableEventLoop)
-        let connectPromise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
-        let closePromise: EventLoopPromise<Void> = channel.eventLoop.newPromise()
+        let connectPromise = channel.eventLoop.newPromise(for: Void.self)
+        let closePromise = channel.eventLoop.newPromise(for: Void.self)
 
         closePromise.futureResult.whenComplete {
             XCTAssertTrue(connectPromise.futureResult.isFulfilled)


### PR DESCRIPTION
Motivation:

When creating new promises I always find it very frustrating to type the
`: EventLoopPromise<Type>` type annotation but it's necessary for the
compiler to know type the promise will be fulfilled with.

Modifications:

allow an optional `for: SomeType.self` parameter for `newPromise` as

    let p = eventLoop.newPromise(for: Int.self)

is much easier to type than

    let p: EventLoopPromise<Int> = eventLoop.newPromise()

Result:

easier to write code
