### PR TITLE
add support for swift 5.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,8 +51,10 @@ RUN gem install jazzy --no-ri --no-rdoc
 # swift
 ARG swift_version=4.0.3
 ARG swift_flavour=RELEASE
+ARG swift_builds_suffix=release
+
 RUN mkdir $HOME/.swift
-RUN wget -q https://swift.org/builds/swift-${swift_version}-$(echo $swift_flavour | tr A-Z a-z)/ubuntu$(echo $ubuntu_version | sed 's/\.//g')/swift-${swift_version}-${swift_flavour}/swift-${swift_version}-${swift_flavour}-ubuntu${ubuntu_version}.tar.gz -O $HOME/swift.tar.gz
+RUN wget -q "https://swift.org/builds/swift-${swift_version}-${swift_builds_suffix}/ubuntu$(echo $ubuntu_version | sed 's/\.//g')/swift-${swift_version}-${swift_flavour}/swift-${swift_version}-${swift_flavour}-ubuntu${ubuntu_version}.tar.gz" -O $HOME/swift.tar.gz
 RUN tar xzf $HOME/swift.tar.gz --directory $HOME/.swift --strip-components=1
 RUN echo 'export PATH="$HOME/.swift/usr/bin:$PATH"' >> $HOME/.profile
 RUN echo 'export LINUX_SOURCEKIT_LIB_PATH="$HOME/.swift/usr/lib"' >> $HOME/.profile

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -1,0 +1,40 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio:18.04-5.0
+    build:
+      args:
+        ubuntu_version: "18.04"
+        swift_version: "5.0"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2018-12-04-a"
+        swift_builds_suffix: "branch"
+        skip_ruby_from_ppa: "true"
+
+  unit-tests:
+    image: swift-nio:18.04-5.0
+
+  integration-tests:
+    image: swift-nio:18.04-5.0
+    environment:
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2150
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
+
+  test:
+    image: swift-nio:18.04-5.0
+    environment:
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2150
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
+
+  echo:
+    image: swift-nio:18.04-5.0
+
+  http:
+    image: swift-nio:18.04-5.0


### PR DESCRIPTION
Motivation: enable tests against swift 5.0

Modifications:
* add a docker-compose file for ubuntu 18.04 and swift 5.0-DEVELOPMENT-SNAPSHOT-2018-12-04-a
* update Dockerfile to correctly handle development builds

Result:
* you can now test against swift 5.0 with `docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.1804.50.yaml run test`
