### PR TITLE
changed port/HTTP version parts to Ints

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -249,7 +249,7 @@ extension ByteBuffer {
     /// - returns: The number of bytes written or `bytes.count`.
     @discardableResult
     @inlinable
-    public mutating func write<S: Sequence>(bytes: S) -> Int where S.Element == UInt8 {
+    public mutating func write<Bytes: Sequence>(bytes: Bytes) -> Int where Bytes.Element == UInt8 {
         let written = set(bytes: bytes, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
         return written
@@ -263,7 +263,7 @@ extension ByteBuffer {
     /// - returns: The number of bytes written or `bytes.count`.
     @discardableResult
     @inlinable
-    public mutating func write<S: ContiguousCollection>(bytes: S) -> Int where S.Element == UInt8 {
+    public mutating func write<Bytes: ContiguousCollection>(bytes: Bytes) -> Int where Bytes.Element == UInt8 {
         let written = set(bytes: bytes, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
         return written

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -395,7 +395,7 @@ public struct ByteBuffer {
     }
 
     @inlinable
-    mutating func _set<S: ContiguousCollection>(bytes: S, at index: _Index) -> _Capacity where S.Element == UInt8 {
+    mutating func _set<Bytes: ContiguousCollection>(bytes: Bytes, at index: _Index) -> _Capacity where Bytes.Element == UInt8 {
         let bytesCount = bytes.count
         let newEndIndex: _Index = index + _toIndex(Int(bytesCount))
         if !isKnownUniquelyReferenced(&self._storage) {
@@ -414,12 +414,12 @@ public struct ByteBuffer {
     }
 
     @inlinable
-    mutating func _set<S: Sequence>(bytes: S, at index: _Index) -> _Capacity where S.Element == UInt8 {
-        assert(!([Array<S.Element>.self, StaticString.self, ContiguousArray<S.Element>.self,
+    mutating func _set<Bytes: Sequence>(bytes: Bytes, at index: _Index) -> _Capacity where Bytes.Element == UInt8 {
+        assert(!([Array<Bytes.Element>.self, StaticString.self, ContiguousArray<Bytes.Element>.self,
                   UnsafeRawBufferPointer.self, UnsafeBufferPointer<UInt8>.self, UnsafeMutableRawBufferPointer.self,
                   UnsafeMutableBufferPointer<UInt8>.self,
                   ArraySlice<UInt8>.self].contains(where: { (t: Any.Type) -> Bool in t == type(of: bytes) })),
-               "called the slower set<S: Sequence> function even though \(S.self) is a ContiguousCollection")
+               "called the slower set<Bytes: Sequence> function even though \(Bytes.self) is a ContiguousCollection")
         func ensureCapacityAndReturnStorageBase(capacity: Int) -> UnsafeMutablePointer<UInt8> {
             self._ensureAvailableCapacity(_Capacity(capacity), at: index)
             let newBytesPtr = UnsafeMutableRawBufferPointer(rebasing: self._slicedStorageBuffer[Int(index) ..< Int(index) + Int(capacity)])
@@ -723,14 +723,14 @@ extension ByteBuffer {
     /// Copy the collection of `bytes` into the `ByteBuffer` at `index`.
     @discardableResult
     @inlinable
-    public mutating func set<S: Sequence>(bytes: S, at index: Int) -> Int where S.Element == UInt8 {
+    public mutating func set<Bytes: Sequence>(bytes: Bytes, at index: Int) -> Int where Bytes.Element == UInt8 {
         return Int(self._set(bytes: bytes, at: _toIndex(index)))
     }
 
     /// Copy the collection of `bytes` into the `ByteBuffer` at `index`.
     @discardableResult
     @inlinable
-    public mutating func set<S: ContiguousCollection>(bytes: S, at index: Int) -> Int where S.Element == UInt8 {
+    public mutating func set<Bytes: ContiguousCollection>(bytes: Bytes, at index: Int) -> Int where Bytes.Element == UInt8 {
         return Int(self._set(bytes: bytes, at: _toIndex(index)))
     }
 

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -241,7 +241,7 @@ public class HTTPDecoder<HTTPMessageT>: ChannelInboundHandler, AnyHTTPDecoder {
 
     private func newRequestHead(_ parser: UnsafeMutablePointer<http_parser>!) -> HTTPRequestHead {
         let method = HTTPMethod.from(httpParserMethod: http_method(rawValue: parser.pointee.method))
-        let version = HTTPVersion(major: parser.pointee.http_major, minor: parser.pointee.http_minor)
+        let version = HTTPVersion(major: Int(parser.pointee.http_major), minor: Int(parser.pointee.http_minor))
         let request = HTTPRequestHead(version: version, method: method, rawURI: state.currentURI!, headers: HTTPHeaders(buffer: cumulationBuffer!, headers: state.currentHeaders, keepAliveState: parser.keepAliveState))
         self.state.currentHeaders.removeAll(keepingCapacity: true)
         return request
@@ -249,7 +249,7 @@ public class HTTPDecoder<HTTPMessageT>: ChannelInboundHandler, AnyHTTPDecoder {
 
     private func newResponseHead(_ parser: UnsafeMutablePointer<http_parser>!) -> HTTPResponseHead {
         let status = HTTPResponseStatus(statusCode: Int(parser.pointee.status_code), reasonPhrase: state.currentStatus!)
-        let version = HTTPVersion(major: parser.pointee.http_major, minor: parser.pointee.http_minor)
+        let version = HTTPVersion(major: Int(parser.pointee.http_major), minor: Int(parser.pointee.http_minor))
         let response = HTTPResponseHead(version: version, status: status, headers: HTTPHeaders(buffer: cumulationBuffer!, headers: state.currentHeaders, keepAliveState: parser.keepAliveState))
         self.state.currentHeaders.removeAll(keepingCapacity: true)
         return response

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -963,16 +963,34 @@ public struct HTTPVersion: Equatable {
     ///
     /// - Parameter major: The major version number.
     /// - Parameter minor: The minor version number.
-    public init(major: UInt16, minor: UInt16) {
-        self.major = major
-        self.minor = minor
+    public init(major: Int, minor: Int) {
+        self._major = UInt16(major)
+        self._minor = UInt16(minor)
     }
 
+    private var _minor: UInt16
+    private var _major: UInt16
+
     /// The major version number.
-    public let major: UInt16
+    public var major: Int {
+        get {
+            return Int(self._major)
+        }
+        set {
+            self._major = UInt16(newValue)
+        }
+    }
 
     /// The minor version number.
-    public let minor: UInt16
+    public var minor: Int {
+        get {
+            return Int(self._minor)
+        }
+        set {
+            self._minor = UInt16(newValue)
+        }
+    }
+
 }
 
 extension HTTPParserError: CustomDebugStringConvertible {

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -125,7 +125,7 @@ class ChannelPipelineTest: XCTestCase {
     func testConnectingDoesntCallBind() throws {
         let channel = EmbeddedChannel()
         var ipv4SocketAddress = sockaddr_in()
-        ipv4SocketAddress.sin_port = (12345 as UInt16).bigEndian
+        ipv4SocketAddress.sin_port = (12345 as in_port_t).bigEndian
         let sa = SocketAddress(ipv4SocketAddress, host: "foobar.com")
 
         _ = try channel.pipeline.add(handler: NoBindAllowed()).wait()

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -738,8 +738,8 @@ class EchoServerClientTest : XCTestCase {
                 serverChannel = try ServerBootstrap(group: group)
                     .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
                     .childChannelInitializer { channel in
-                        acceptedRemotePort.store(channel.remoteAddress?.port.map(Int.init) ?? -3)
-                        acceptedLocalPort.store(channel.localAddress?.port.map(Int.init) ?? -4)
+                        acceptedRemotePort.store(channel.remoteAddress?.port ?? -3)
+                        acceptedLocalPort.store(channel.localAddress?.port ?? -4)
                         sem.signal()
                         return channel.eventLoop.makeSucceededFuture(result: ())
                     }.bind(host: host, port: 0).wait()
@@ -769,8 +769,8 @@ class EchoServerClientTest : XCTestCase {
             }
             sem.wait()
             XCTAssertEqual(serverChannel.localAddress?.port, clientChannel.remoteAddress?.port)
-            XCTAssertEqual(acceptedLocalPort.load(), clientChannel.remoteAddress?.port.map(Int.init) ?? -5)
-            XCTAssertEqual(acceptedRemotePort.load(), clientChannel.localAddress?.port.map(Int.init) ?? -6)
+            XCTAssertEqual(acceptedLocalPort.load(), clientChannel.remoteAddress?.port ?? -5)
+            XCTAssertEqual(acceptedRemotePort.load(), clientChannel.localAddress?.port ?? -6)
         }
         XCTAssertTrue(atLeastOneSucceeded)
     }

--- a/Tests/NIOTests/SocketAddressTest.swift
+++ b/Tests/NIOTests/SocketAddressTest.swift
@@ -23,14 +23,14 @@ class SocketAddressTest: XCTestCase {
             inet_pton(AF_INET, p, &ipv4SocketAddress.sin_addr)
         }
         XCTAssertEqual(res, 1)
-        ipv4SocketAddress.sin_port = (12345 as UInt16).bigEndian
+        ipv4SocketAddress.sin_port = (12345 as in_port_t).bigEndian
         let sa = SocketAddress(ipv4SocketAddress, host: "foobar.com")
         XCTAssertEqual("[IPv4]foobar.com/10.0.0.1:12345", sa.description)
     }
 
     func testDescriptionWorksWithoutIP() throws {
         var ipv4SocketAddress = sockaddr_in()
-        ipv4SocketAddress.sin_port = (12345 as UInt16).bigEndian
+        ipv4SocketAddress.sin_port = (12345 as in_port_t).bigEndian
         let sa = SocketAddress(ipv4SocketAddress, host: "foobar.com")
         XCTAssertEqual("[IPv4]foobar.com/0.0.0.0:12345", sa.description)
     }

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -10,3 +10,7 @@
 - `EventLoop.makePromise`/`makeSucceededFuture`/`makeFailedFuture` instead of `new*`
 - `SocketAddress.makeAddressResolvingHost(:port:)` instead of
   `SocketAddress.newAddressResolving(host:port:)`
+- changed all ports to `Int` (from `UInt16`)
+- changed `HTTPVersion`'s `major` and `minor` properties to `Int` (from `UInt16`)
+- renamed the generic parameter name to `Bytes` where we're talking about a
+  generic collection of bytes


### PR DESCRIPTION
Motivation:

- `Int` is the currency type for integral things and we already sort of
  changed the the type for ports but not everywhere.
- generic parameters that aren't just 'any type' shouldn't be just `T`
  or `S` or something

Modifications:

- make more use of `Int`
- rename generic parameters to something more descriptive like `Bytes`

Result:

easier to read/write NIO code
