### PR TITLE
make factory method names start with make

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -256,7 +256,7 @@ class BaseSocket: Selectable {
     ///     - setNonBlocking: Set non-blocking mode on the socket.
     /// - returns: the file descriptor of the socket that was created.
     /// - throws: An `IOError` if creation of the socket failed.
-    static func newSocket(protocolFamily: Int32, type: CInt, setNonBlocking: Bool = false) throws -> Int32 {
+    static func makeSocket(protocolFamily: Int32, type: CInt, setNonBlocking: Bool = false) throws -> Int32 {
         var sockType = type
         #if os(Linux)
         if setNonBlocking {

--- a/Sources/NIO/BlockingIOThreadPool.swift
+++ b/Sources/NIO/BlockingIOThreadPool.swift
@@ -189,7 +189,7 @@ public extension BlockingIOThreadPool {
     ///     - body: The closure which performs some blocking work to be done on the thread pool.
     /// - returns: The `EventLoopFuture` of `promise` fulfilled with the result (or error) of the passed closure.
     func runIfActive<T>(eventLoop: EventLoop, _ body: @escaping () throws -> T) -> EventLoopFuture<T> {
-        let promise = eventLoop.newPromise(of: T.self)
+        let promise = eventLoop.makePromise(of: T.self)
         self.submit { shouldRun in
             guard case shouldRun = BlockingIOThreadPool.WorkItemState.active else {
                 promise.fail(error: ChannelError.ioOnClosedChannel)

--- a/Sources/NIO/ChannelInvoker.swift
+++ b/Sources/NIO/ChannelInvoker.swift
@@ -138,49 +138,49 @@ public protocol ChannelOutboundInvoker {
 ///     - return `EventLoopPromise.futureResult`
 extension ChannelOutboundInvoker {
     public func register() -> EventLoopFuture<Void> {
-        let promise = newPromise()
+        let promise = makePromise()
         register(promise: promise)
         return promise.futureResult
     }
 
     public func bind(to address: SocketAddress) -> EventLoopFuture<Void> {
-        let promise = newPromise()
+        let promise = makePromise()
         bind(to: address, promise: promise)
         return promise.futureResult
     }
 
     public func connect(to address: SocketAddress) -> EventLoopFuture<Void> {
-        let promise = newPromise()
+        let promise = makePromise()
         connect(to: address, promise: promise)
         return promise.futureResult
     }
 
     public func write(_ data: NIOAny) -> EventLoopFuture<Void> {
-        let promise = newPromise()
+        let promise = makePromise()
         write(data, promise: promise)
         return promise.futureResult
     }
 
     public func writeAndFlush(_ data: NIOAny) -> EventLoopFuture<Void> {
-        let promise = newPromise()
+        let promise = makePromise()
         writeAndFlush(data, promise: promise)
         return promise.futureResult
     }
 
     public func close(mode: CloseMode = .all) -> EventLoopFuture<Void> {
-        let promise = newPromise()
+        let promise = makePromise()
         close(mode: mode, promise: promise)
         return promise.futureResult
     }
 
     public func triggerUserOutboundEvent(_ event: Any) -> EventLoopFuture<Void> {
-        let promise = newPromise()
+        let promise = makePromise()
         triggerUserOutboundEvent(event, promise: promise)
         return promise.futureResult
     }
 
-    private func newPromise(file: StaticString = #file, line: UInt = #line) -> EventLoopPromise<Void> {
-        return eventLoop.newPromise(file: file, line: line)
+    private func makePromise(file: StaticString = #file, line: UInt = #line) -> EventLoopPromise<Void> {
+        return eventLoop.makePromise(file: file, line: line)
     }
 }
 

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -163,7 +163,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - first: `true` to add this handler to the front of the `ChannelPipeline`, `false to add it last
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was added.
     public func add(name: String? = nil, handler: ChannelHandler, first: Bool = false) -> EventLoopFuture<Void> {
-        let promise = self.eventLoop.newPromise(of: Void.self)
+        let promise = self.eventLoop.makePromise(of: Void.self)
 
         func _add() {
             if self.destroyed {
@@ -199,7 +199,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - after: The pre-existing `ChannelHandler` that `handler` should be inserted immediately after.
     /// - returns: An `EventLoopFuture` that will be notified when the `ChannelHandler` is added.
     public func add(name: String? = nil, handler: ChannelHandler, after: ChannelHandler) -> EventLoopFuture<Void> {
-        let promise = self.eventLoop.newPromise(of: Void.self)
+        let promise = self.eventLoop.makePromise(of: Void.self)
 
         if self.eventLoop.inEventLoop {
             self.add0(name: name, handler: handler, relativeHandler: after, operation: self.add0(context:after:), promise: promise)
@@ -222,7 +222,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - after: The pre-existing `ChannelHandler` that `handler` should be inserted immediately before.
     /// - returns: An `EventLoopFuture` that will be notified when the `ChannelHandler` is added.
     public func add(name: String? = nil, handler: ChannelHandler, before: ChannelHandler) -> EventLoopFuture<Void> {
-        let promise = self.eventLoop.newPromise(of: Void.self)
+        let promise = self.eventLoop.makePromise(of: Void.self)
 
         if self.eventLoop.inEventLoop {
             self.add0(name: name, handler: handler, relativeHandler: before, operation: self.add0(context:before:), promise: promise)
@@ -356,7 +356,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - handler: the `ChannelHandler` to remove.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
     public func remove(handler: ChannelHandler) -> EventLoopFuture<Bool> {
-        let promise = self.eventLoop.newPromise(of: Bool.self)
+        let promise = self.eventLoop.makePromise(of: Bool.self)
         self.remove(handler: handler, promise: promise)
         return promise.futureResult
     }
@@ -367,7 +367,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - name: the name that was used to add the `ChannelHandler` to the `ChannelPipeline` before.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
     public func remove(name: String) -> EventLoopFuture<Bool> {
-        let promise = self.eventLoop.newPromise(of: Bool.self)
+        let promise = self.eventLoop.makePromise(of: Bool.self)
         self.remove(name: name, promise: promise)
         return promise.futureResult
     }
@@ -378,7 +378,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - ctx: the `ChannelHandlerContext` that belongs to `ChannelHandler` that should be removed.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
     public func remove(ctx: ChannelHandlerContext) -> EventLoopFuture<Bool> {
-        let promise = self.eventLoop.newPromise(of: Bool.self)
+        let promise = self.eventLoop.makePromise(of: Bool.self)
         self.remove(ctx: ctx, promise: promise)
         return promise.futureResult
     }
@@ -464,7 +464,7 @@ public final class ChannelPipeline: ChannelInvoker {
 
     /// Find a `ChannelHandlerContext` in the `ChannelPipeline`.
     private func context0(_ body: @escaping ((ChannelHandlerContext) -> Bool)) -> EventLoopFuture<ChannelHandlerContext> {
-        let promise = eventLoop.newPromise(of: ChannelHandlerContext.self)
+        let promise = eventLoop.makePromise(of: ChannelHandlerContext.self)
 
         func _context0() {
             if let ctx = self.contextForPredicate0(body) {

--- a/Sources/NIO/DeadChannel.swift
+++ b/Sources/NIO/DeadChannel.swift
@@ -80,7 +80,7 @@ internal final class DeadChannel: Channel {
     let pipeline: ChannelPipeline
 
     public var closeFuture: EventLoopFuture<Void> {
-        return self.eventLoop.newSucceededFuture(result: ())
+        return self.eventLoop.makeSucceededFuture(result: ())
     }
 
     internal init(pipeline: ChannelPipeline) {
@@ -108,7 +108,7 @@ internal final class DeadChannel: Channel {
     }
 
     func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T: ChannelOption {
-        return eventLoop.newFailedFuture(error: ChannelError.ioOnClosedChannel)
+        return eventLoop.makeFailedFuture(error: ChannelError.ioOnClosedChannel)
     }
 
     let isWritable = false

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -60,7 +60,7 @@ public class EmbeddedEventLoop: EventLoop {
 
     @discardableResult
     public func scheduleTask<T>(in: TimeAmount, _ task: @escaping () throws -> T) -> Scheduled<T> {
-        let promise: EventLoopPromise<T> = newPromise()
+        let promise: EventLoopPromise<T> = makePromise()
         let readyTime = now + UInt64(`in`.nanoseconds)
         let task = EmbeddedScheduledTask(readyTime: readyTime) {
             do {
@@ -147,7 +147,7 @@ class EmbeddedChannelCore: ChannelCore {
     private let pipeline: ChannelPipeline
 
     init(pipeline: ChannelPipeline, eventLoop: EventLoop) {
-        closePromise = eventLoop.newPromise()
+        closePromise = eventLoop.makePromise()
         self.pipeline = pipeline
         self.eventLoop = eventLoop
     }
@@ -400,7 +400,7 @@ public class EmbeddedChannel: Channel {
 
     public func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T: ChannelOption {
         if option is AutoReadOption {
-            return self.eventLoop.newSucceededFuture(result: true as! T.OptionType)
+            return self.eventLoop.makeSucceededFuture(result: true as! T.OptionType)
         }
         fatalError("option \(option) not supported")
     }

--- a/Sources/NIO/GetaddrinfoResolver.swift
+++ b/Sources/NIO/GetaddrinfoResolver.swift
@@ -36,8 +36,8 @@ internal class GetaddrinfoResolver: Resolver {
     ///     - aiSocktype: The sock type to use as hint when calling getaddrinfo.
     ///     - aiProtocol: the protocol to use as hint when calling getaddrinfo.
     init(loop: EventLoop, aiSocktype: CInt, aiProtocol: CInt) {
-        self.v4Future = loop.newPromise()
-        self.v6Future = loop.newPromise()
+        self.v4Future = loop.makePromise()
+        self.v6Future = loop.makePromise()
         self.aiSocktype = aiSocktype
         self.aiProtocol = aiProtocol
     }

--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -288,7 +288,7 @@ internal class HappyEyeballsConnector {
         self.channelBuilderCallback = channelBuilderCallback
 
         self.state = .idle
-        self.resolutionPromise = self.loop.newPromise()
+        self.resolutionPromise = self.loop.makePromise()
         self.error = NIOConnectionError(host: host, port: port)
 
         precondition(resolutionDelay.nanoseconds > 0, "Resolution delay must be greater than zero, got \(resolutionDelay).")

--- a/Sources/NIO/MulticastChannel.swift
+++ b/Sources/NIO/MulticastChannel.swift
@@ -62,13 +62,13 @@ public extension MulticastChannel {
     }
 
     func joinGroup(_ group: SocketAddress) -> EventLoopFuture<Void> {
-        let promise = self.eventLoop.newPromise(of: Void.self)
+        let promise = self.eventLoop.makePromise(of: Void.self)
         self.joinGroup(group, promise: promise)
         return promise.futureResult
     }
 
     func joinGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
-        let promise = self.eventLoop.newPromise(of: Void.self)
+        let promise = self.eventLoop.makePromise(of: Void.self)
         self.joinGroup(group, interface: interface, promise: promise)
         return promise.futureResult
     }
@@ -78,13 +78,13 @@ public extension MulticastChannel {
     }
 
     func leaveGroup(_ group: SocketAddress) -> EventLoopFuture<Void> {
-        let promise = self.eventLoop.newPromise(of: Void.self)
+        let promise = self.eventLoop.makePromise(of: Void.self)
         self.leaveGroup(group, promise: promise)
         return promise.futureResult
     }
 
     func leaveGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
-        let promise = self.eventLoop.newPromise(of: Void.self)
+        let promise = self.eventLoop.makePromise(of: Void.self)
         self.leaveGroup(group, interface: interface, promise: promise)
         return promise.futureResult
     }

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -87,7 +87,7 @@ public struct NonBlockingFileIO {
                                     eventLoop: eventLoop,
                                     chunkHandler: chunkHandler)
         } catch {
-            return eventLoop.newFailedFuture(error: error)
+            return eventLoop.makeFailedFuture(error: error)
         }
     }
 
@@ -131,7 +131,7 @@ public struct NonBlockingFileIO {
                     }
                 }
             } else {
-                return eventLoop.newSucceededFuture(result: ())
+                return eventLoop.makeSucceededFuture(result: ())
             }
         }
 
@@ -162,7 +162,7 @@ public struct NonBlockingFileIO {
                              allocator: allocator,
                              eventLoop: eventLoop)
         } catch {
-            return eventLoop.newFailedFuture(error: error)
+            return eventLoop.makeFailedFuture(error: error)
         }
     }
 
@@ -182,7 +182,7 @@ public struct NonBlockingFileIO {
     /// - returns: An `EventLoopFuture` which delivers a `ByteBuffer` if the read was successful or a failure on error.
     public func read(fileHandle: FileHandle, byteCount: Int, allocator: ByteBufferAllocator, eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
         guard byteCount > 0 else {
-            return eventLoop.newSucceededFuture(result: allocator.buffer(capacity: 0))
+            return eventLoop.makeSucceededFuture(result: allocator.buffer(capacity: 0))
         }
 
         var buf = allocator.buffer(capacity: byteCount)
@@ -227,7 +227,7 @@ public struct NonBlockingFileIO {
         var byteCount = buffer.readableBytes
 
         guard byteCount > 0 else {
-            return eventLoop.newSucceededFuture(result: ())
+            return eventLoop.makeSucceededFuture(result: ())
         }
 
         return self.threadPool.runIfActive(eventLoop: eventLoop) {

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -663,7 +663,7 @@ internal extension Selector where R == NIORegistration {
     /// Gently close the `Selector` after all registered `Channel`s are closed.
     func closeGently(eventLoop: EventLoop) -> EventLoopFuture<Void> {
         guard self.lifecycleState == .open else {
-            return eventLoop.newFailedFuture(error: IOError(errnoCode: EBADF, reason: "can't close selector gently as it's \(self.lifecycleState)."))
+            return eventLoop.makeFailedFuture(error: IOError(errnoCode: EBADF, reason: "can't close selector gently as it's \(self.lifecycleState)."))
         }
 
         let futures: [EventLoopFuture<Void>] = self.registrations.map { (_, reg: NIORegistration) -> EventLoopFuture<Void> in
@@ -695,7 +695,7 @@ internal extension Selector where R == NIORegistration {
         }
 
         guard futures.count > 0 else {
-            return eventLoop.newSucceededFuture(result: ())
+            return eventLoop.makeSucceededFuture(result: ())
         }
 
         return EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)

--- a/Sources/NIO/ServerSocket.swift
+++ b/Sources/NIO/ServerSocket.swift
@@ -16,7 +16,7 @@
 /* final but tests */ class ServerSocket: BaseSocket {
     public class func bootstrap(protocolFamily: Int32, host: String, port: Int) throws -> ServerSocket {
         let socket = try ServerSocket(protocolFamily: protocolFamily)
-        try socket.bind(to: SocketAddress.newAddressResolving(host: host, port: port))
+        try socket.bind(to: SocketAddress.makeAddressResolvingHost(host, port: port))
         try socket.listen()
         return socket
     }
@@ -28,7 +28,7 @@
     ///     - setNonBlocking: Set non-blocking mode on the socket.
     /// - throws: An `IOError` if creation of the socket failed.
     init(protocolFamily: Int32, setNonBlocking: Bool = false) throws {
-        let sock = try BaseSocket.newSocket(protocolFamily: protocolFamily, type: Posix.SOCK_STREAM, setNonBlocking: setNonBlocking)
+        let sock = try BaseSocket.makeSocket(protocolFamily: protocolFamily, type: Posix.SOCK_STREAM, setNonBlocking: setNonBlocking)
         super.init(descriptor: sock)
     }
 

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -32,7 +32,7 @@ public typealias IOVector = iovec
     ///     - setNonBlocking: Set non-blocking mode on the socket.
     /// - throws: An `IOError` if creation of the socket failed.
     init(protocolFamily: CInt, type: CInt, setNonBlocking: Bool = false) throws {
-        let sock = try BaseSocket.newSocket(protocolFamily: protocolFamily, type: type, setNonBlocking: setNonBlocking)
+        let sock = try BaseSocket.makeSocket(protocolFamily: protocolFamily, type: type, setNonBlocking: setNonBlocking)
         super.init(descriptor: sock)
     }
 

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -248,7 +248,7 @@ public enum SocketAddress: CustomStringConvertible {
     ///       - port: the port itself
     /// - returns: the `SocketAddress` for the host / port pair.
     /// - throws: a `SocketAddressError.unknown` if we could not resolve the `host`, or `SocketAddressError.unsupported` if the address itself is not supported (yet).
-    public static func newAddressResolving(host: String, port: Int) throws -> SocketAddress {
+    public static func makeAddressResolvingHost(_ host: String, port: Int) throws -> SocketAddress {
         var info: UnsafeMutablePointer<addrinfo>?
 
         /* FIXME: this is blocking! */

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -381,7 +381,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
             return
         }
 
-        let p = eventLoop.newPromise(of: Void.self)
+        let p = eventLoop.makePromise(of: Void.self)
         p.futureResult.map {
             // It's important to call the methods before we actually notify the original promise for ordering reasons.
             self.becomeActive0(promise: promise)

--- a/Sources/NIO/SocketOptionProvider.swift
+++ b/Sources/NIO/SocketOptionProvider.swift
@@ -213,7 +213,7 @@ public extension SocketOptionProvider {
 extension BaseSocketChannel: SocketOptionProvider {
     public func unsafeSetSocketOption<Value>(level: SocketOptionLevel, name: SocketOptionName, value: Value) -> EventLoopFuture<Void> {
         if eventLoop.inEventLoop {
-            let promise = eventLoop.newPromise(of: Void.self)
+            let promise = eventLoop.makePromise(of: Void.self)
             executeAndComplete(promise) {
                 try setSocketOption0(level: level, name: name, value: value)
             }
@@ -227,7 +227,7 @@ extension BaseSocketChannel: SocketOptionProvider {
 
     public func unsafeGetSocketOption<Value>(level: SocketOptionLevel, name: SocketOptionName) -> EventLoopFuture<Value> {
         if eventLoop.inEventLoop {
-            let promise = eventLoop.newPromise(of: Value.self)
+            let promise = eventLoop.makePromise(of: Value.self)
             executeAndComplete(promise) {
                 try getSocketOption0(level: level, name: name)
             }

--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -20,7 +20,7 @@ private func writeChunk(wrapOutboundOut: (IOData) -> NIOAny, ctx: ChannelHandler
     switch (isChunked, promise) {
     case (true, .some(let p)):
         /* chunked encoding and the user's interested: we need three promises and need to cascade into the users promise */
-        let (w1, w2, w3) = (ctx.eventLoop.newPromise() as EventLoopPromise<Void>, ctx.eventLoop.newPromise() as EventLoopPromise<Void>, ctx.eventLoop.newPromise() as EventLoopPromise<Void>)
+        let (w1, w2, w3) = (ctx.eventLoop.makePromise() as EventLoopPromise<Void>, ctx.eventLoop.makePromise() as EventLoopPromise<Void>, ctx.eventLoop.makePromise() as EventLoopPromise<Void>)
         w1.futureResult.and(w2.futureResult).and(w3.futureResult).map { (_: ((((), ()), ()))) in }.cascade(promise: p)
         (mW1, mW2, mW3) = (w1, w2, w3)
     case (false, .some(let p)):

--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -91,7 +91,7 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler {
 
     public func handlerAdded(ctx: ChannelHandlerContext) {
         pendingResponse = PartialHTTPResponse(bodyBuffer: ctx.channel.allocator.buffer(capacity: initialByteBufferCapacity))
-        pendingWritePromise = ctx.eventLoop.newPromise()
+        pendingWritePromise = ctx.eventLoop.makePromise()
     }
 
     public func handlerRemoved(ctx: ChannelHandlerContext) {
@@ -247,7 +247,7 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler {
         }
 
         // Reset the pending promise.
-        pendingWritePromise = ctx.eventLoop.newPromise()
+        pendingWritePromise = ctx.eventLoop.makePromise()
     }
 }
 /// A buffer object that allows us to keep track of how much of a HTTP response we've seen before

--- a/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
@@ -315,7 +315,7 @@ public final class HTTPServerPipelineHandler: ChannelDuplexHandler {
             case .quiescingLastRequestEndReceived:
                 ctx.write(data).then {
                     ctx.close()
-                }.cascade(promise: promise ?? ctx.channel.eventLoop.newPromise())
+                }.cascade(promise: promise ?? ctx.channel.eventLoop.makePromise())
             case .acceptingEvents, .quiescingWaitingForRequestEnd:
                 ctx.write(data, promise: promise)
             }

--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -239,14 +239,14 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
         if let handler = handler {
             return ctx.pipeline.remove(handler: handler)
         } else {
-            return ctx.eventLoop.newSucceededFuture(result: true)
+            return ctx.eventLoop.makeSucceededFuture(result: true)
         }
     }
 
     /// Removes any extra HTTP-related handlers from the channel pipeline.
     private func removeExtraHandlers(ctx: ChannelHandlerContext) -> EventLoopFuture<Void> {
         guard self.extraHTTPHandlers.count > 0 else {
-            return ctx.eventLoop.newSucceededFuture(result: ())
+            return ctx.eventLoop.makeSucceededFuture(result: ())
         }
 
         return EventLoopFuture<Void>.andAll(self.extraHTTPHandlers.map { ctx.pipeline.remove(handler: $0).map { (_: Bool) in () }},

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -342,7 +342,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                                                     }
                                                     return ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buffer))))
                     }.then { () -> EventLoopFuture<Void> in
-                        let p = ctx.eventLoop.newPromise(of: Void.self)
+                        let p = ctx.eventLoop.makePromise(of: Void.self)
                         self.completeResponse(ctx, trailers: nil, promise: p)
                         return p.futureResult
                     }.thenIfError { error in
@@ -364,7 +364,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                     let response = responseHead(request: request, fileRegion: region)
                     ctx.write(self.wrapOutboundOut(.head(response)), promise: nil)
                     ctx.writeAndFlush(self.wrapOutboundOut(.body(.fileRegion(region)))).then {
-                        let p = ctx.eventLoop.newPromise(of: Void.self)
+                        let p = ctx.eventLoop.makePromise(of: Void.self)
                         self.completeResponse(ctx, trailers: nil, promise: p)
                         return p.futureResult
                     }.thenIfError { (_: Error) in
@@ -384,7 +384,7 @@ private final class HTTPHandler: ChannelInboundHandler {
     private func completeResponse(_ ctx: ChannelHandlerContext, trailers: HTTPHeaders?, promise: EventLoopPromise<Void>?) {
         self.state.responseComplete()
 
-        let promise = self.keepAlive ? promise : (promise ?? ctx.eventLoop.newPromise())
+        let promise = self.keepAlive ? promise : (promise ?? ctx.eventLoop.makePromise())
         if !self.keepAlive {
             promise!.futureResult.whenComplete { ctx.close(promise: nil) }
         }

--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -86,7 +86,7 @@ let datagramChannel = try datagramBootstrap
         return channel.joinGroup(chatMulticastGroup, interface: targetInterface).map { channel }
     }.then { channel -> EventLoopFuture<Channel> in
         guard let targetInterface = targetInterface else {
-            return channel.eventLoop.newSucceededFuture(result: channel)
+            return channel.eventLoop.makeSucceededFuture(result: channel)
         }
 
         let provider = channel as! SocketOptionProvider

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -150,7 +150,7 @@ final class RepeatedRequests: ChannelInboundHandler {
     init(numberOfRequests: Int, eventLoop: EventLoop) {
         self.remainingNumberOfRequests = numberOfRequests
         self.numberOfRequests = numberOfRequests
-        self.isDonePromise = eventLoop.newPromise()
+        self.isDonePromise = eventLoop.makePromise()
     }
 
     func wait() throws -> Int {

--- a/Tests/NIOHTTP1Tests/HTTPTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest.swift
@@ -133,7 +133,7 @@ class HTTPTest: XCTestCase {
         let bd1 = try sendAndCheckRequests(expecteds, body: body, trailers: trailers, sendStrategy: { (reqString, chan) in
             var buf = chan.allocator.buffer(capacity: 1024)
             buf.write(string: reqString)
-            return chan.eventLoop.newSucceededFuture(result: ()).thenThrowing {
+            return chan.eventLoop.makeSucceededFuture(result: ()).thenThrowing {
                 try chan.writeInbound(buf)
             }
         })
@@ -145,7 +145,7 @@ class HTTPTest: XCTestCase {
                 var buf = chan.allocator.buffer(capacity: 1024)
 
                 buf.write(string: "\(c)")
-                writeFutures.append(chan.eventLoop.newSucceededFuture(result: ()).thenThrowing {
+                writeFutures.append(chan.eventLoop.makeSucceededFuture(result: ()).thenThrowing {
                     try chan.writeInbound(buf)
                 })
             }

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -77,7 +77,7 @@ private func serverHTTPChannelWithAutoremoval(group: EventLoopGroup,
                                               upgraders: [HTTPProtocolUpgrader],
                                               extraHandlers: [ChannelHandler],
                                               _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) throws -> (Channel, EventLoopFuture<Channel>) {
-    let p = group.next().newPromise(of: Channel.self)
+    let p = group.next().makePromise(of: Channel.self)
     let c = try ServerBootstrap(group: group)
         .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
         .childChannelInitializer { channel in
@@ -182,7 +182,7 @@ private class ExplodingUpgrader: HTTPProtocolUpgrader {
 
     public func upgrade(ctx: ChannelHandlerContext, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<Void> {
         XCTFail("upgrade called")
-        return ctx.eventLoop.newSucceededFuture(result: ())
+        return ctx.eventLoop.makeSucceededFuture(result: ())
     }
 }
 
@@ -204,7 +204,7 @@ private class UpgraderSaysNo: HTTPProtocolUpgrader {
 
     public func upgrade(ctx: ChannelHandlerContext, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<Void> {
         XCTFail("upgrade called")
-        return ctx.eventLoop.newSucceededFuture(result: ())
+        return ctx.eventLoop.makeSucceededFuture(result: ())
     }
 }
 
@@ -227,7 +227,7 @@ private class SuccessfulUpgrader: HTTPProtocolUpgrader {
 
     public func upgrade(ctx: ChannelHandlerContext, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<Void> {
         self.onUpgradeComplete(upgradeRequest)
-        return ctx.eventLoop.newSucceededFuture(result: ())
+        return ctx.eventLoop.makeSucceededFuture(result: ())
     }
 }
 
@@ -249,7 +249,7 @@ private class UpgradeDelayer: HTTPProtocolUpgrader {
     }
 
     public func upgrade(ctx: ChannelHandlerContext, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<Void> {
-        self.upgradePromise = ctx.eventLoop.newPromise()
+        self.upgradePromise = ctx.eventLoop.makePromise()
         self.ctx = ctx
         return self.upgradePromise!.futureResult
     }
@@ -394,7 +394,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise = group.next().newPromise(of: Void.self)
+        let completePromise = group.next().makePromise(of: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -499,7 +499,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise = group.next().newPromise(of: Void.self)
+        let completePromise = group.next().makePromise(of: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -543,7 +543,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise = group.next().newPromise(of: Void.self)
+        let completePromise = group.next().makePromise(of: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -604,7 +604,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise = group.next().newPromise(of: Void.self)
+        let completePromise = group.next().makePromise(of: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -650,7 +650,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise = group.next().newPromise(of: Void.self)
+        let completePromise = group.next().makePromise(of: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -684,7 +684,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise = group.next().newPromise(of: Void.self)
+        let completePromise = group.next().makePromise(of: Void.self)
         let clientHandler = SingleHTTPResponseAccumulator { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -727,7 +727,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let completePromise = group.next().newPromise(of: Void.self)
+        let completePromise = group.next().makePromise(of: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,
@@ -876,9 +876,9 @@ class HTTPUpgradeTestCase: XCTestCase {
         defer {
             XCTAssertNoThrow(try promiseGroup.syncShutdownGracefully())
         }
-        let firstByteDonePromise = promiseGroup.next().newPromise(of: Void.self)
-        let secondByteDonePromise = promiseGroup.next().newPromise(of: Void.self)
-        let allDonePromise = promiseGroup.next().newPromise(of: Void.self)
+        let firstByteDonePromise = promiseGroup.next().makePromise(of: Void.self)
+        let secondByteDonePromise = promiseGroup.next().makePromise(of: Void.self)
+        let allDonePromise = promiseGroup.next().makePromise(of: Void.self)
         let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
                                                                                     extraHandlers: []) { (ctx) in
                                                                                         // This is called before the upgrader gets called.
@@ -893,7 +893,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         
-        let completePromise = group.next().newPromise(of: Void.self)
+        let completePromise = group.next().makePromise(of: Void.self)
         let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
             let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
             assertResponseIs(response: resultString,

--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
@@ -40,7 +40,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             XCTFail("Negotiation fired")
-            return loop.newSucceededFuture(result: ())
+            return loop.makeSucceededFuture(result: ())
         }
 
         try channel.pipeline.add(handler: handler).wait()
@@ -58,7 +58,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
     private func negotiateTest(event: TLSUserEvent, expectedResult: ALPNResult) throws {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise = loop.newPromise(of: Void.self)
+        let continuePromise = loop.makePromise(of: Void.self)
 
         let expectedResult: ALPNResult = .negotiated("h2")
         var called = false
@@ -102,7 +102,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             XCTFail("Should not be called")
-            return loop.newSucceededFuture(result: ())
+            return loop.makeSucceededFuture(result: ())
         }
 
         try channel.pipeline.add(handler: handler).wait()
@@ -117,7 +117,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
     func testBufferingWhileWaitingForFuture() throws {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise = loop.newPromise(of: Void.self)
+        let continuePromise = loop.makePromise(of: Void.self)
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             continuePromise.futureResult
@@ -148,7 +148,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
     func testNothingBufferedDoesNotFireReadCompleted() throws {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise = loop.newPromise(of: Void.self)
+        let continuePromise = loop.makePromise(of: Void.self)
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             continuePromise.futureResult
@@ -175,7 +175,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
     func testUnbufferingFiresReadCompleted() throws {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise = loop.newPromise(of: Void.self)
+        let continuePromise = loop.makePromise(of: Void.self)
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             continuePromise.futureResult

--- a/Tests/NIOTLSTests/SNIHandlerTests.swift
+++ b/Tests/NIOTLSTests/SNIHandlerTests.swift
@@ -262,7 +262,7 @@ class SniHandlerTest: XCTestCase {
         var buffer = bufferForBase64String(string: clientHello)
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise = loop.newPromise(of: Void.self)
+        let continuePromise = loop.makePromise(of: Void.self)
 
         let handler = ByteToMessageHandler(SniHandler { result in
             XCTAssertEqual(expectedResult, result)
@@ -313,7 +313,7 @@ class SniHandlerTest: XCTestCase {
         let buffer = bufferForBase64String(string: clientHello)
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
-        let continuePromise = loop.newPromise(of: Void.self)
+        let continuePromise = loop.makePromise(of: Void.self)
 
         let handler = ByteToMessageHandler(SniHandler { result in
             XCTAssertEqual(expectedResult, result)
@@ -358,7 +358,7 @@ class SniHandlerTest: XCTestCase {
 
         let handler = ByteToMessageHandler(SniHandler { result in
             XCTFail("Handler was called")
-            return loop.newSucceededFuture(result: ())
+            return loop.makeSucceededFuture(result: ())
         })
 
         try channel.pipeline.add(handler: handler).wait()

--- a/Tests/NIOTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOTests/AcceptBackoffHandlerTest.swift
@@ -174,7 +174,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
             return .milliseconds(100)
         }, errors: [ENFILE])
 
-        let inactiveVerificationHandler = InactiveVerificationHandler(promise: serverChannel.eventLoop.newPromise())
+        let inactiveVerificationHandler = InactiveVerificationHandler(promise: serverChannel.eventLoop.makePromise())
         XCTAssertNoThrow(try serverChannel.pipeline.add(handler: inactiveVerificationHandler).wait())
 
         XCTAssertEqual(0, try serverChannel.eventLoop.submit {

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -25,18 +25,18 @@ class BootstrapTest: XCTestCase {
                 XCTAssertNoThrow(try group.syncShutdownGracefully())
             }
 
-            let childChannelDone = group.next().newPromise(of: Void.self)
-            let serverChannelDone = group.next().newPromise(of: Void.self)
+            let childChannelDone = group.next().makePromise(of: Void.self)
+            let serverChannelDone = group.next().makePromise(of: Void.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
                 .childChannelInitializer { channel in
                     XCTAssert(channel.eventLoop.inEventLoop)
                     childChannelDone.succeed(result: ())
-                    return channel.eventLoop.newSucceededFuture(result: ())
+                    return channel.eventLoop.makeSucceededFuture(result: ())
                 }
                 .serverChannelInitializer { channel in
                     XCTAssert(channel.eventLoop.inEventLoop)
                     serverChannelDone.succeed(result: ())
-                    return channel.eventLoop.newSucceededFuture(result: ())
+                    return channel.eventLoop.makeSucceededFuture(result: ())
                 }
                 .bind(host: "localhost", port: 0)
                 .wait())
@@ -47,7 +47,7 @@ class BootstrapTest: XCTestCase {
             let client = try assertNoThrowWithValue(ClientBootstrap(group: group)
                 .channelInitializer { channel in
                     XCTAssert(channel.eventLoop.inEventLoop)
-                    return channel.eventLoop.newSucceededFuture(result: ())
+                    return channel.eventLoop.makeSucceededFuture(result: ())
                 }
                 .connect(to: serverChannel.localAddress!)
                 .wait(), message: "resolver debug info: \(try! resolverDebugInformation(eventLoop: group.next(),host: "localhost", previouslyReceivedResult: serverChannel.localAddress!))")

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -168,7 +168,7 @@ class ChannelNotificationTest: XCTestCase {
         public func register(ctx: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
             XCTAssertNil(self.registerPromise)
 
-            let p = promise ?? ctx.eventLoop.newPromise()
+            let p = promise ?? ctx.eventLoop.makePromise()
             p.futureResult.whenSuccess {
                 XCTAssertFalse(ctx.channel.isActive)
             }
@@ -243,7 +243,7 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNil(self.bindPromise)
             XCTAssertNil(self.closePromise)
 
-            let p = promise ?? ctx.eventLoop.newPromise()
+            let p = promise ?? ctx.eventLoop.makePromise()
             p.futureResult.whenSuccess {
                 XCTAssertFalse(ctx.channel.isActive)
             }
@@ -275,7 +275,7 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNotNil(self.bindPromise)
             XCTAssertNil(self.closePromise)
 
-            let p = promise ?? ctx.eventLoop.newPromise()
+            let p = promise ?? ctx.eventLoop.makePromise()
             p.futureResult.whenSuccess {
                 XCTAssertFalse(ctx.channel.isActive)
             }
@@ -291,7 +291,7 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let acceptedChannelPromise = group.next().newPromise(of: Channel.self)
+        let acceptedChannelPromise = group.next().makePromise(of: Channel.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -374,7 +374,7 @@ class ChannelNotificationTest: XCTestCase {
             }
         }
 
-        let promise = group.next().newPromise(of: Void.self)
+        let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: true)

--- a/Tests/NIOTests/ChannelOptionStorageTest.swift
+++ b/Tests/NIOTests/ChannelOptionStorageTest.swift
@@ -80,7 +80,7 @@ class OptionsCollectingChannel: Channel {
 
     func setOption<T>(option: T, value: T.OptionType) -> EventLoopFuture<Void> where T : ChannelOption {
         self.allOptions.append((option, value))
-        return self.eventLoop.newSucceededFuture(result: ())
+        return self.eventLoop.makeSucceededFuture(result: ())
     }
 
     func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T : ChannelOption {

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -698,7 +698,7 @@ class ChannelPipelineTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 1024)
         buffer.write(staticString: "Hello, world!")
 
-        let removalPromise = channel.eventLoop.newPromise(of: Bool.self)
+        let removalPromise = channel.eventLoop.makePromise(of: Bool.self)
         removalPromise.futureResult.whenSuccess { (_: Bool) in
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
@@ -772,7 +772,7 @@ class ChannelPipelineTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 1024)
         buffer.write(staticString: "Hello, world!")
 
-        let removalPromise = channel.eventLoop.newPromise(of: Bool.self)
+        let removalPromise = channel.eventLoop.makePromise(of: Bool.self)
         removalPromise.futureResult.whenSuccess { (_: Bool) in
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
@@ -847,7 +847,7 @@ class ChannelPipelineTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 1024)
         buffer.write(staticString: "Hello, world!")
 
-        let removalPromise = channel.eventLoop.newPromise(of: Bool.self)
+        let removalPromise = channel.eventLoop.makePromise(of: Bool.self)
         removalPromise.futureResult.whenSuccess { (_: Bool) in
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -76,7 +76,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let serverAcceptedChannelPromise = group.next().newPromise(of: Channel.self)
+        let serverAcceptedChannelPromise = group.next().makePromise(of: Channel.self)
         let serverLifecycleHandler = ChannelLifecycleHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -178,12 +178,12 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let childChannelPromise = group.next().newPromise(of: Channel.self)
+        let childChannelPromise = group.next().makePromise(of: Channel.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
                 childChannelPromise.succeed(result: channel)
-                return channel.eventLoop.newSucceededFuture(result: ())
+                return channel.eventLoop.makeSucceededFuture(result: ())
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -371,7 +371,7 @@ public class ChannelTests: XCTestCase {
 
         try withPendingStreamWritesManager { pwm in
             buffer.clear()
-            let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.makePromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
 
             XCTAssertFalse(pwm.isEmpty)
@@ -427,7 +427,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -463,7 +463,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<4).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<4).map { (_: Int) in el.makePromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[2])
@@ -511,7 +511,7 @@ public class ChannelTests: XCTestCase {
             let numberOfBytes = Int(1 /* first write */ + pwm.writeSpinCount /* the spins */ + 1 /* so one byte remains at the end */)
             buffer.clear()
             buffer.write(bytes: Array<UInt8>(repeating: 0xff, count: numberOfBytes))
-            let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.makePromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             pwm.markFlushCheckpoint()
 
@@ -550,7 +550,7 @@ public class ChannelTests: XCTestCase {
             buffer.clear()
             buffer.write(bytes: [0xff] as [UInt8])
             let ps: [EventLoopPromise<Void>] = (0..<numberOfBytes).map { (_: Int) in
-                let p = el.newPromise(of: Void.self)
+                let p = el.makePromise(of: Void.self)
                 _ = pwm.add(data: .byteBuffer(buffer), promise: p)
                 return p
             }
@@ -610,7 +610,7 @@ public class ChannelTests: XCTestCase {
                 XCTAssertNoThrow(try handle.takeDescriptorOwnership())
             }
             let fileRegion = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 1)
-            let ps: [EventLoopPromise<Void>] = (0..<numberOfWrites).map { _ in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<numberOfWrites).map { _ in el.makePromise() }
             (0..<numberOfWrites).forEach { i in
                 _ = pwm.add(data: i % 2 == 0 ? .byteBuffer(buffer) : .fileRegion(fileRegion), promise: ps[i])
             }
@@ -642,7 +642,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -677,7 +677,7 @@ public class ChannelTests: XCTestCase {
         buffer.moveWriterIndex(to: halfTheWriteVLimit)
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             /* add 1.5x the writev limit */
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
@@ -713,7 +713,7 @@ public class ChannelTests: XCTestCase {
         buffer.moveWriterIndex(to: biggerThanWriteV)
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             /* add 1.5x the writev limit */
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
@@ -746,7 +746,7 @@ public class ChannelTests: XCTestCase {
     func testPendingWritesFileRegion() throws {
         let el = EmbeddedEventLoop()
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.makePromise() }
 
             let fh1 = FileHandle(descriptor: -1)
             let fh2 = FileHandle(descriptor: -2)
@@ -795,7 +795,7 @@ public class ChannelTests: XCTestCase {
     func testPendingWritesEmptyFileRegion() throws {
         let el = EmbeddedEventLoop()
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.makePromise() }
 
             let fh = FileHandle(descriptor: -1)
             let fr = FileRegion(fileHandle: fh, readerIndex: 99, endIndex: 99)
@@ -824,7 +824,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<5).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<5).map { (_: Int) in el.makePromise() }
 
             let fh1 = FileHandle(descriptor: -1)
             let fh2 = FileHandle(descriptor: -1)
@@ -880,7 +880,7 @@ public class ChannelTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
 
             pwm.markFlushCheckpoint()
 
@@ -931,7 +931,7 @@ public class ChannelTests: XCTestCase {
         let emptyBuffer = alloc.buffer(capacity: 12)
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             _ = pwm.add(data: .byteBuffer(emptyBuffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(emptyBuffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -966,7 +966,7 @@ public class ChannelTests: XCTestCase {
         buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -997,7 +997,7 @@ public class ChannelTests: XCTestCase {
         buffer.write(string: "1234")
 
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.makePromise() }
             ps.forEach { p in
                 _ = pwm.add(data: .byteBuffer(buffer), promise: p)
             }
@@ -1026,7 +1026,7 @@ public class ChannelTests: XCTestCase {
     func testPendingWritesIsHappyWhenSendfileReturnsWouldBlockButWroteFully() throws {
         let el = EmbeddedEventLoop()
         try withPendingStreamWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.makePromise() }
 
             let fh = FileHandle(descriptor: -1)
             let fr = FileRegion(fileHandle: fh, readerIndex: 0, endIndex: 8192)
@@ -1059,7 +1059,7 @@ public class ChannelTests: XCTestCase {
             // This must throw as 198.51.100.254 is reserved for documentation only
             _ = try ClientBootstrap(group: group)
                 .channelOption(ChannelOptions.connectTimeout, value: .milliseconds(10))
-                .connect(to: SocketAddress.newAddressResolving(host: "198.51.100.254", port: 65535)).wait()
+                .connect(to: SocketAddress.makeAddressResolvingHost("198.51.100.254", port: 65535)).wait()
             XCTFail()
         } catch let err as ChannelError {
             if case .connectTimeout(_) = err {
@@ -1085,7 +1085,7 @@ public class ChannelTests: XCTestCase {
             // This must throw as 198.51.100.254 is reserved for documentation only
             _ = try ClientBootstrap(group: group)
                 .connectTimeout(.milliseconds(10))
-                .connect(to: SocketAddress.newAddressResolving(host: "198.51.100.254", port: 65535)).wait()
+                .connect(to: SocketAddress.makeAddressResolvingHost("198.51.100.254", port: 65535)).wait()
             XCTFail()
         } catch let err as ChannelError {
             if case .connectTimeout(_) = err {
@@ -1111,11 +1111,11 @@ public class ChannelTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try server.close())
         }
-        try server.bind(to: SocketAddress.newAddressResolving(host: "127.0.0.1", port: 0))
+        try server.bind(to: SocketAddress.makeAddressResolvingHost("127.0.0.1", port: 0))
         try server.listen()
 
-        let byteCountingHandler = ByteCountingHandler(numBytes: 4, promise: group.next().newPromise())
-        let verificationHandler = ShutdownVerificationHandler(shutdownEvent: .output, promise: group.next().newPromise())
+        let byteCountingHandler = ByteCountingHandler(numBytes: 4, promise: group.next().makePromise())
+        let verificationHandler = ShutdownVerificationHandler(shutdownEvent: .output, promise: group.next().makePromise())
         let future = ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.add(handler: verificationHandler).then {
@@ -1167,7 +1167,7 @@ public class ChannelTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try server.close())
         }
-        try server.bind(to: SocketAddress.newAddressResolving(host: "127.0.0.1", port: 0))
+        try server.bind(to: SocketAddress.makeAddressResolvingHost("127.0.0.1", port: 0))
         try server.listen()
 
         class VerifyNoReadHandler : ChannelInboundHandler {
@@ -1178,7 +1178,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let verificationHandler = ShutdownVerificationHandler(shutdownEvent: .input, promise: group.next().newPromise())
+        let verificationHandler = ShutdownVerificationHandler(shutdownEvent: .input, promise: group.next().makePromise())
         let future = ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.add(handler: VerifyNoReadHandler()).then {
@@ -1230,10 +1230,10 @@ public class ChannelTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try server.close())
         }
-        try server.bind(to: SocketAddress.newAddressResolving(host: "127.0.0.1", port: 0))
+        try server.bind(to: SocketAddress.makeAddressResolvingHost("127.0.0.1", port: 0))
         try server.listen()
 
-        let verificationHandler = ShutdownVerificationHandler(shutdownEvent: .input, promise: group.next().newPromise())
+        let verificationHandler = ShutdownVerificationHandler(shutdownEvent: .input, promise: group.next().makePromise())
 
         let future = ClientBootstrap(group: group)
             .channelInitializer { channel in
@@ -1370,16 +1370,16 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let promise = group.next().newPromise(of: ChannelPipeline.self)
+        let promise = group.next().makePromise(of: ChannelPipeline.self)
 
         try {
-            let serverChildChannelPromise = group.next().newPromise(of: Channel.self)
+            let serverChildChannelPromise = group.next().makePromise(of: Channel.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
                 .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
                 .childChannelInitializer { channel in
                     serverChildChannelPromise.succeed(result: channel)
                     channel.close(promise: nil)
-                    return channel.eventLoop.newSucceededFuture(result: ())
+                    return channel.eventLoop.makeSucceededFuture(result: ())
                 }
                 .bind(host: "127.0.0.1", port: 0).wait())
 
@@ -1502,12 +1502,12 @@ public class ChannelTests: XCTestCase {
 
             func handlerAdded(ctx: ChannelHandlerContext) {
                 self.ctx = ctx
-                self.readCountPromise = ctx.eventLoop.newPromise()
+                self.readCountPromise = ctx.eventLoop.makePromise()
             }
 
             public func expectRead(loop: EventLoop) -> EventLoopFuture<Void> {
                 return loop.submit {
-                    self.waitingForReadPromise = loop.newPromise()
+                    self.waitingForReadPromise = loop.makePromise()
                 }.then {
                     self.waitingForReadPromise!.futureResult
                 }
@@ -1700,7 +1700,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let allDone = group.next().newPromise(of: Void.self)
+        let allDone = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: false)
@@ -1751,7 +1751,7 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let promise = group.next().newPromise(of: Void.self)
+        let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: false)
@@ -1944,10 +1944,10 @@ public class ChannelTests: XCTestCase {
             }
         }
 
-        let serverWriteHappenedPromise = serverEL.next().newPromise(of: Void.self)
-        let clientHasRegistered = serverEL.next().newPromise(of: Void.self)
-        let clientHasUnregistered = serverEL.next().newPromise(of: Void.self)
-        let clientHasRead = serverEL.next().newPromise(of: Void.self)
+        let serverWriteHappenedPromise = serverEL.next().makePromise(of: Void.self)
+        let clientHasRegistered = serverEL.next().makePromise(of: Void.self)
+        let clientHasUnregistered = serverEL.next().makePromise(of: Void.self)
+        let clientHasRead = serverEL.next().makePromise(of: Void.self)
 
         let bootstrap = try assertNoThrowWithValue(ServerBootstrap(group: serverEL)
             .childChannelInitializer { channel in
@@ -2124,7 +2124,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        let allDone = clientEL.newPromise(of: Void.self)
+        let allDone = clientEL.makePromise(of: Void.self)
 
         XCTAssertNoThrow(try sc.eventLoop.submit {
             // this is pretty delicate at the moment:
@@ -2173,7 +2173,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        let allDone = group.next().newPromise(of: Void.self)
+        let allDone = group.next().makePromise(of: Void.self)
         let cf = try! sc.eventLoop.submit {
             sc.pipeline.add(handler: VerifyConnectionFailureHandler(allDone: allDone)).then {
                 sc.register().then {
@@ -2219,7 +2219,7 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        let allDone = group.next().newPromise(of: Void.self)
+        let allDone = group.next().makePromise(of: Void.self)
         try! sc.eventLoop.submit {
             let f = sc.pipeline.add(handler: VerifyConnectionFailureHandler(allDone: allDone)).then {
                 sc.register().then {
@@ -2300,7 +2300,7 @@ public class ChannelTests: XCTestCase {
 
         do {
             try sc.eventLoop.submit { () -> EventLoopFuture<Void> in
-                let p = sc.eventLoop.newPromise(of: Void.self)
+                let p = sc.eventLoop.makePromise(of: Void.self)
                 // this callback must be attached before we call the close
                 let f = p.futureResult.map {
                     XCTFail("shouldn't be reached")
@@ -2545,8 +2545,8 @@ public class ChannelTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try singleThreadedELG.syncShutdownGracefully())
         }
-        let serverChannelAvailablePromise = singleThreadedELG.next().newPromise(of: Channel.self)
-        let allDonePromise = singleThreadedELG.next().newPromise(of: Void.self)
+        let serverChannelAvailablePromise = singleThreadedELG.next().makePromise(of: Channel.self)
+        let allDonePromise = singleThreadedELG.next().makePromise(of: Void.self)
         let server = try assertNoThrowWithValue(ServerBootstrap(group: singleThreadedELG)
             .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
             .childChannelInitializer { channel in
@@ -2578,9 +2578,9 @@ public class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try singleThreadedELG.syncShutdownGracefully())
         }
         var numberOfAcceptedChannel = 0
-        var acceptedChannels: [EventLoopPromise<Channel>] = [singleThreadedELG.next().newPromise(),
-                                                             singleThreadedELG.next().newPromise(),
-                                                             singleThreadedELG.next().newPromise()]
+        var acceptedChannels: [EventLoopPromise<Channel>] = [singleThreadedELG.next().makePromise(),
+                                                             singleThreadedELG.next().makePromise(),
+                                                             singleThreadedELG.next().makePromise()]
         let server = try assertNoThrowWithValue(ServerBootstrap(group: singleThreadedELG)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_TIMESTAMP), value: 1)
@@ -2589,7 +2589,7 @@ public class ChannelTests: XCTestCase {
             .childChannelInitializer { channel in
                 acceptedChannels[numberOfAcceptedChannel].succeed(result: channel)
                 numberOfAcceptedChannel += 1
-                return channel.eventLoop.newSucceededFuture(result: ())
+                return channel.eventLoop.makeSucceededFuture(result: ())
             }
             .bind(host: "127.0.0.1", port: 0)
             .wait())

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -42,7 +42,7 @@ private final class ChannelInactivePromiser: ChannelInboundHandler {
     let channelInactivePromise: EventLoopPromise<Void>
 
     init(channel: Channel) {
-        channelInactivePromise = channel.eventLoop.newPromise()
+        channelInactivePromise = channel.eventLoop.makePromise()
     }
 
     func channelInactive(ctx: ChannelHandlerContext) {
@@ -345,7 +345,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
     }
 
     func testLeftOversMakeDecodeLastCalled() {
-        let lastPromise = EmbeddedEventLoop().newPromise(of: ByteBuffer.self)
+        let lastPromise = EmbeddedEventLoop().makePromise(of: ByteBuffer.self)
         let channel = EmbeddedChannel(handler: ByteToMessageHandler(PairOfBytesDecoder(lastPromise: lastPromise)))
 
         var buffer = channel.allocator.buffer(capacity: 16)
@@ -373,7 +373,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
     }
 
     func testRemovingHandlerMakesLeftoversAppearInDecodeLast() {
-        let lastPromise = EmbeddedEventLoop().newPromise(of: ByteBuffer.self)
+        let lastPromise = EmbeddedEventLoop().makePromise(of: ByteBuffer.self)
         let channel = EmbeddedChannel(handler: ByteToMessageHandler(PairOfBytesDecoder(lastPromise: lastPromise)))
         defer {
             XCTAssertNoThrow(XCTAssertFalse(try channel.finish()))

--- a/Tests/NIOTests/CustomChannelTests.swift
+++ b/Tests/NIOTests/CustomChannelTests.swift
@@ -83,7 +83,7 @@ class CustomChannelTests: XCTestCase {
     func testWritingIntToSpecialChannel() throws {
         let loop = EmbeddedEventLoop()
         let intCore = IntChannelCore()
-        let writePromise = loop.newPromise(of: Void.self)
+        let writePromise = loop.makePromise(of: Void.self)
 
         intCore.write0(NIOAny(5), promise: writePromise)
         XCTAssertNoThrow(try writePromise.futureResult.wait())

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -24,7 +24,7 @@ private extension Channel {
             }
 
             XCTFail("Could not wait for reads")
-            return self.eventLoop.newSucceededFuture(result: [] as [AddressedEnvelope<ByteBuffer>])
+            return self.eventLoop.makeSucceededFuture(result: [] as [AddressedEnvelope<ByteBuffer>])
         }.wait()
     }
 }
@@ -73,10 +73,10 @@ private class DatagramReadRecorder<DataType>: ChannelInboundHandler {
 
     func notifyForDatagrams(_ count: Int) -> EventLoopFuture<[AddressedEnvelope<DataType>]> {
         guard reads.count < count else {
-            return loop!.newSucceededFuture(result: .init(reads.prefix(count)))
+            return loop!.makeSucceededFuture(result: .init(reads.prefix(count)))
         }
 
-        readWaiters[count] = loop!.newPromise()
+        readWaiters[count] = loop!.makePromise()
         return readWaiters[count]!.futureResult
     }
 }
@@ -170,7 +170,7 @@ final class DatagramChannelTests: XCTestCase {
             XCTAssertTrue(writable)
         }
 
-        let lastWritePromise = self.firstChannel.eventLoop.newPromise(of: Void.self)
+        let lastWritePromise = self.firstChannel.eventLoop.makePromise(of: Void.self)
         // The last write will push us over the edge.
         var writable: Bool = try self.firstChannel.eventLoop.submit {
             self.firstChannel.write(NIOAny(writeData), promise: lastWritePromise)
@@ -212,9 +212,9 @@ final class DatagramChannelTests: XCTestCase {
         // We're going to try to write loads, and loads, and loads of data. In this case, one more
         // write than the iovecs max.
 
-        var overall: EventLoopFuture<Void> = self.firstChannel.eventLoop.newSucceededFuture(result: ())
+        var overall: EventLoopFuture<Void> = self.firstChannel.eventLoop.makeSucceededFuture(result: ())
         for _ in 0...Socket.writevLimitIOVectors {
-            let myPromise = self.firstChannel.eventLoop.newPromise(of: Void.self)
+            let myPromise = self.firstChannel.eventLoop.makePromise(of: Void.self)
             var buffer = self.firstChannel.allocator.buffer(capacity: 1)
             buffer.write(string: "a")
             let envelope = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
@@ -229,11 +229,11 @@ final class DatagramChannelTests: XCTestCase {
     func testSendmmsgLotsOfData() throws {
         var datagrams = 0
 
-        var overall = self.firstChannel.eventLoop.newSucceededFuture(result: ())
+        var overall = self.firstChannel.eventLoop.makeSucceededFuture(result: ())
         // We defer this work to the background thread because otherwise it incurs an enormous number of context
         // switches.
         try self.firstChannel.eventLoop.submit {
-            let myPromise = self.firstChannel.eventLoop.newPromise(of: Void.self)
+            let myPromise = self.firstChannel.eventLoop.makePromise(of: Void.self)
             // For datagrams this buffer cannot be very large, because if it's larger than the path MTU it
             // will cause EMSGSIZE.
             let bufferSize = 1024 * 5
@@ -403,7 +403,7 @@ final class DatagramChannelTests: XCTestCase {
         }
         let socket = try NonRecvFromSocket(error: error)
         let channel = try DatagramChannel(socket: socket, eventLoop: group.next() as! SelectableEventLoop)
-        let promise = channel.eventLoop.newPromise(of: IOError.self)
+        let promise = channel.eventLoop.makePromise(of: IOError.self)
         XCTAssertNoThrow(try channel.register().wait())
         XCTAssertNoThrow(try channel.pipeline.add(handler: RecvFromHandler(promise)).wait())
         XCTAssertNoThrow(try channel.bind(to: SocketAddress.init(ipAddress: "127.0.0.1", port: 0)).wait())

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -25,7 +25,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let numBytes = 16 * 1024
-        let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().newPromise())
+        let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
 
@@ -72,7 +72,7 @@ class EchoServerClientTest : XCTestCase {
             XCTAssertNoThrow(try serverChannel.close().wait())
         }
 
-        let promise = group.next().newPromise(of: ByteBuffer.self)
+        let promise = group.next().makePromise(of: ByteBuffer.self)
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.add(handler: WriteOnConnectHandler(toWrite: "X")).then { v2 in
@@ -101,7 +101,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let numBytes = 16 * 1024
-        let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().newPromise())
+        let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
 
@@ -146,7 +146,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let numBytes = 16 * 1024
-        let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().newPromise())
+        let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
 
@@ -221,7 +221,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let numBytes = 16 * 1024
-        let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().newPromise())
+        let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { $0.pipeline.add(handler: countingHandler) }
             .connect(to: serverChannel.localAddress!).wait())
@@ -245,7 +245,7 @@ class EchoServerClientTest : XCTestCase {
         private var promise: EventLoopPromise<Void>! = nil
 
         func handlerAdded(ctx: ChannelHandlerContext) {
-            promise = ctx.channel.eventLoop.newPromise()
+            promise = ctx.channel.eventLoop.makePromise()
         }
 
         func channelActive(ctx: ChannelHandlerContext) {
@@ -401,8 +401,8 @@ class EchoServerClientTest : XCTestCase {
                 XCTAssertNoThrow(try group.syncShutdownGracefully())
             }
 
-        let inactivePromise = group.next().newPromise() as EventLoopPromise<Void>
-        let unregistredPromise = group.next().newPromise() as EventLoopPromise<Void>
+        let inactivePromise = group.next().makePromise() as EventLoopPromise<Void>
+        let unregistredPromise = group.next().makePromise() as EventLoopPromise<Void>
         let handler = CloseInInActiveAndUnregisteredChannelHandler(channelUnregisteredPromise: unregistredPromise,
                                                                    channelInactivePromise: inactivePromise)
 
@@ -438,7 +438,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let writingBytes = "hello"
-        let bytesReceivedPromise = group.next().newPromise(of: ByteBuffer.self)
+        let bytesReceivedPromise = group.next().makePromise(of: ByteBuffer.self)
         let byteCountingHandler = ByteCountingHandler(numBytes: writingBytes.utf8.count, promise: bytesReceivedPromise)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -495,7 +495,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let stringToWrite = "hello"
-        let promise = group.next().newPromise(of: ByteBuffer.self)
+        let promise = group.next().makePromise(of: ByteBuffer.self)
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.add(handler: WriteOnConnectHandler(toWrite: stringToWrite)).then {
@@ -528,7 +528,7 @@ class EchoServerClientTest : XCTestCase {
             XCTAssertNoThrow(try serverChannel.close().wait())
         }
 
-        let promise = group.next().newPromise(of: ByteBuffer.self)
+        let promise = group.next().makePromise(of: ByteBuffer.self)
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.add(handler: ByteCountingHandler(numBytes: stringToWrite.utf8.count, promise: promise))
@@ -564,7 +564,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let str = "hi there"
-        let countingHandler = ByteCountingHandler(numBytes: str.utf8.count, promise: group.next().newPromise())
+        let countingHandler = ByteCountingHandler(numBytes: str.utf8.count, promise: group.next().makePromise())
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { $0.pipeline.add(handler: countingHandler) }
             .connect(to: serverChannel.localAddress!).wait())
@@ -589,7 +589,7 @@ class EchoServerClientTest : XCTestCase {
 
         let str = "hi there"
 
-        let countingHandler = ByteCountingHandler(numBytes: str.utf8.count * 4, promise: group.next().newPromise())
+        let countingHandler = ByteCountingHandler(numBytes: str.utf8.count * 4, promise: group.next().makePromise())
 
         class WriteHandler : ChannelInboundHandler {
             typealias InboundIn = ByteBuffer
@@ -703,7 +703,7 @@ class EchoServerClientTest : XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let promise = group.next().newPromise(of: Void.self)
+        let promise = group.next().makePromise(of: Void.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -741,7 +741,7 @@ class EchoServerClientTest : XCTestCase {
                         acceptedRemotePort.store(channel.remoteAddress?.port.map(Int.init) ?? -3)
                         acceptedLocalPort.store(channel.localAddress?.port.map(Int.init) ?? -4)
                         sem.signal()
-                        return channel.eventLoop.newSucceededFuture(result: ())
+                        return channel.eventLoop.makeSucceededFuture(result: ())
                     }.bind(host: host, port: 0).wait()
             } catch let e as SocketAddressError {
                 if case .unknown(host, port: 0) = e {
@@ -782,7 +782,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let numBytes = 16 * 1024
-        let promise = group.next().newPromise(of: ByteBuffer.self)
+        let promise = group.next().makePromise(of: ByteBuffer.self)
         let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: promise)
 
         // we're binding to IPv4 only
@@ -803,7 +803,7 @@ class EchoServerClientTest : XCTestCase {
             .connect(host: "localhost", port: Int(serverChannel.localAddress!.port!))
             .thenIfError {
                 promise.fail(error: $0)
-                return group.next().newFailedFuture(error: $0)
+                return group.next().makeFailedFuture(error: $0)
             }
             .wait())
 

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -159,14 +159,14 @@ class EmbeddedChannelTest: XCTestCase {
     func testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires() throws {
         let channel = EmbeddedChannel()
         XCTAssertFalse(channel.isActive)
-        let connectPromise = channel.eventLoop.newPromise(of: Void.self)
+        let connectPromise = channel.eventLoop.makePromise(of: Void.self)
         connectPromise.futureResult.whenComplete {
             XCTAssertTrue(channel.isActive)
         }
         channel.connect(to: try SocketAddress(ipAddress: "127.0.0.1", port: 0), promise: connectPromise)
         try connectPromise.futureResult.wait()
 
-        let closePromise = channel.eventLoop.newPromise(of: Void.self)
+        let closePromise = channel.eventLoop.makePromise(of: Void.self)
         closePromise.futureResult.whenComplete {
             XCTAssertFalse(channel.isActive)
         }

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -54,12 +54,12 @@ class EventLoopFutureTest : XCTestCase {
 
         var fN = f0.fold(f1s) { (f1Value: [Int], f2Value: Int) -> EventLoopFuture<[Int]> in
             XCTAssert(eventLoop0.inEventLoop)
-            return eventLoop1.newSucceededFuture(result: f1Value + [f2Value])
+            return eventLoop1.makeSucceededFuture(result: f1Value + [f2Value])
         }
 
         fN = fN.fold(f2s) { (f1Value: [Int], f2Value: Int) -> EventLoopFuture<[Int]> in
             XCTAssert(eventLoop0.inEventLoop)
-            return eventLoop2.newSucceededFuture(result: f1Value + [f2Value])
+            return eventLoop2.makeSucceededFuture(result: f1Value + [f2Value])
         }
 
         let allValues = try fN.wait()
@@ -71,13 +71,13 @@ class EventLoopFutureTest : XCTestCase {
     func testFoldWithSuccessAndAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0 = eventLoop.newSucceededFuture(result: [0])
+        let f0 = eventLoop.makeSucceededFuture(result: [0])
 
-        let futures: [EventLoopFuture<Int>] = (1...5).map { (id: Int) in secondEventLoop.newSucceededFuture(result: id) }
+        let futures: [EventLoopFuture<Int>] = (1...5).map { (id: Int) in secondEventLoop.makeSucceededFuture(result: id) }
 
         let fN = f0.fold(futures) { (f1Value: [Int], f2Value: Int) -> EventLoopFuture<[Int]> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.newSucceededFuture(result: f1Value + [f2Value])
+            return secondEventLoop.makeSucceededFuture(result: f1Value + [f2Value])
         }
 
         let allValues = try fN.wait()
@@ -90,16 +90,16 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.newSucceededFuture(result: 0)
+        let f0: EventLoopFuture<Int> = eventLoop.makeSucceededFuture(result: 0)
 
-        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.newPromise() }
+        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makePromise() }
         var futures = promises.map { $0.futureResult }
-        let failedFuture: EventLoopFuture<Int> = secondEventLoop.newFailedFuture(error: E())
+        let failedFuture: EventLoopFuture<Int> = secondEventLoop.makeFailedFuture(error: E())
         futures.insert(failedFuture, at: futures.startIndex)
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.newSucceededFuture(result: f1Value + f2Value)
+            return secondEventLoop.makeSucceededFuture(result: f1Value + f2Value)
         }
 
         _ = promises.map { $0.succeed(result: 0) }
@@ -116,13 +116,13 @@ class EventLoopFutureTest : XCTestCase {
 
     func testFoldWithSuccessAndEmptyFutureList() throws {
         let eventLoop = EmbeddedEventLoop()
-        let f0 = eventLoop.newSucceededFuture(result: 0)
+        let f0 = eventLoop.makeSucceededFuture(result: 0)
 
         let futures: [EventLoopFuture<Int>] = []
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return eventLoop.newSucceededFuture(result: f1Value + f2Value)
+            return eventLoop.makeSucceededFuture(result: f1Value + f2Value)
         }
 
         let summationResult = try fN.wait()
@@ -133,13 +133,13 @@ class EventLoopFutureTest : XCTestCase {
     func testFoldWithFailureAndEmptyFutureList() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.newFailedFuture(error: E())
+        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(error: E())
 
         let futures: [EventLoopFuture<Int>] = []
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return eventLoop.newSucceededFuture(result: f1Value + f2Value)
+            return eventLoop.makeSucceededFuture(result: f1Value + f2Value)
         }
 
         XCTAssert(fN.isFulfilled)
@@ -157,14 +157,14 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.newFailedFuture(error: E())
+        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(error: E())
 
-        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.newPromise() }
+        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.newSucceededFuture(result: f1Value + f2Value)
+            return secondEventLoop.makeSucceededFuture(result: f1Value + f2Value)
         }
 
         _ = promises.map { $0.succeed(result: 1) }
@@ -183,14 +183,14 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.newFailedFuture(error: E())
+        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(error: E())
 
-        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.newPromise() }
+        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.newSucceededFuture(result: f1Value + f2Value)
+            return secondEventLoop.makeSucceededFuture(result: f1Value + f2Value)
         }
 
         XCTAssert(fN.isFulfilled)
@@ -208,13 +208,13 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.newFailedFuture(error: E())
+        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(error: E())
 
-        let futures: [EventLoopFuture<Int>] = (0..<100).map { (_: Int) in secondEventLoop.newFailedFuture(error: E()) }
+        let futures: [EventLoopFuture<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makeFailedFuture(error: E()) }
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.newSucceededFuture(result: f1Value + f2Value)
+            return secondEventLoop.makeSucceededFuture(result: f1Value + f2Value)
         }
 
         XCTAssert(fN.isFulfilled)
@@ -239,7 +239,7 @@ class EventLoopFutureTest : XCTestCase {
 
     func testAndAllWithAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
-        let promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.newPromise() }
+        let promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
         let fN: EventLoopFuture<Void> = EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)
@@ -250,7 +250,7 @@ class EventLoopFutureTest : XCTestCase {
     func testAndAllWithAllFailures() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        let promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.newPromise() }
+        let promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
         let fN: EventLoopFuture<Void> = EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)
@@ -268,9 +268,9 @@ class EventLoopFutureTest : XCTestCase {
     func testAndAllWithOneFailure() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        var promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.newPromise() }
+        var promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
         _ = promises.map { $0.succeed(result: ()) }
-        let failedPromise = eventLoop.newPromise(of: Void.self)
+        let failedPromise = eventLoop.makePromise(of: Void.self)
         failedPromise.fail(error: E())
         promises.append(failedPromise)
 
@@ -289,7 +289,7 @@ class EventLoopFutureTest : XCTestCase {
 
     func testReduceWithAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
-        let promises: [EventLoopPromise<Int>] = (0..<5).map { (_: Int) in eventLoop.newPromise() }
+        let promises: [EventLoopPromise<Int>] = (0..<5).map { (_: Int) in eventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
         let fN: EventLoopFuture<[Int]> = EventLoopFuture<[Int]>.reduce([], futures, eventLoop: eventLoop) {$0 + [$1]}
@@ -315,7 +315,7 @@ class EventLoopFutureTest : XCTestCase {
     func testReduceWithAllFailures() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.newPromise() }
+        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
         let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, eventLoop: eventLoop, +)
@@ -334,9 +334,9 @@ class EventLoopFutureTest : XCTestCase {
     func testReduceWithOneFailure() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        var promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.newPromise() }
+        var promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
         _ = promises.map { $0.succeed(result: (1)) }
-        let failedPromise = eventLoop.newPromise(of: Int.self)
+        let failedPromise = eventLoop.makePromise(of: Int.self)
         failedPromise.fail(error: E())
         promises.append(failedPromise)
 
@@ -357,9 +357,9 @@ class EventLoopFutureTest : XCTestCase {
     func testReduceWhichDoesFailFast() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        var promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.newPromise() }
+        var promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
 
-        let failedPromise = eventLoop.newPromise(of: Int.self)
+        let failedPromise = eventLoop.makePromise(of: Int.self)
         promises.insert(failedPromise, at: promises.startIndex)
 
         let futures = promises.map { $0.futureResult }
@@ -381,7 +381,7 @@ class EventLoopFutureTest : XCTestCase {
 
     func testReduceIntoWithAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
-        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.newSucceededFuture(result: id) }
+        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.makeSucceededFuture(result: id) }
 
         let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(into: [:], futures, eventLoop: eventLoop) { (freqs, elem) in
             if let value = freqs[elem] {
@@ -416,7 +416,7 @@ class EventLoopFutureTest : XCTestCase {
     func testReduceIntoWithAllFailure() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.newFailedFuture(error: E()) }
+        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.makeFailedFuture(error: E()) }
 
         let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(into: [:], futures, eventLoop: eventLoop) { (freqs, elem) in
             if let value = freqs[elem] {
@@ -475,7 +475,7 @@ class EventLoopFutureTest : XCTestCase {
     func testThenThrowingWhichDoesNotThrow() {
         let eventLoop = EmbeddedEventLoop()
         var ran = false
-        let p = eventLoop.newPromise(of: String.self)
+        let p = eventLoop.makePromise(of: String.self)
         p.futureResult.map {
             $0.count
         }.thenThrowing {
@@ -494,7 +494,7 @@ class EventLoopFutureTest : XCTestCase {
         }
         let eventLoop = EmbeddedEventLoop()
         var ran = false
-        let p = eventLoop.newPromise(of: String.self)
+        let p = eventLoop.makePromise(of: String.self)
         p.futureResult.map {
             $0.count
         }.thenThrowing { (x: Int) throws -> Int in
@@ -517,7 +517,7 @@ class EventLoopFutureTest : XCTestCase {
         }
         let eventLoop = EmbeddedEventLoop()
         var ran = false
-        let p = eventLoop.newPromise(of: String.self)
+        let p = eventLoop.makePromise(of: String.self)
         p.futureResult.map {
             $0.count
         }.thenIfErrorThrowing {
@@ -541,7 +541,7 @@ class EventLoopFutureTest : XCTestCase {
         }
         let eventLoop = EmbeddedEventLoop()
         var ran = false
-        let p = eventLoop.newPromise(of: String.self)
+        let p = eventLoop.makePromise(of: String.self)
         p.futureResult.map {
             $0.count
         }.thenIfErrorThrowing { (x: Error) throws -> Int in
@@ -580,9 +580,9 @@ class EventLoopFutureTest : XCTestCase {
     func testEventLoopHoppingInThen() throws {
         let n = 20
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
-        var prev: EventLoopFuture<Int> = elg.next().newSucceededFuture(result: 0)
+        var prev: EventLoopFuture<Int> = elg.next().makeSucceededFuture(result: 0)
         (1..<20).forEach { (i: Int) in
-            let p = elg.next().newPromise(of: Int.self)
+            let p = elg.next().makePromise(of: Int.self)
             prev.then { (i2: Int) -> EventLoopFuture<Int> in
                 XCTAssertEqual(i - 1, i2)
                 p.succeed(result: i)
@@ -602,9 +602,9 @@ class EventLoopFutureTest : XCTestCase {
         }
         let n = 20
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
-        var prev: EventLoopFuture<Int> = elg.next().newSucceededFuture(result: 0)
+        var prev: EventLoopFuture<Int> = elg.next().makeSucceededFuture(result: 0)
         (1..<n).forEach { (i: Int) in
-            let p = elg.next().newPromise(of: Int.self)
+            let p = elg.next().makePromise(of: Int.self)
             prev.then { (i2: Int) -> EventLoopFuture<Int> in
                 XCTAssertEqual(i - 1, i2)
                 if i == n/2 {
@@ -636,7 +636,7 @@ class EventLoopFutureTest : XCTestCase {
         let n = 20
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
         let ps = (0..<n).map { (_: Int) -> EventLoopPromise<Void> in
-            elg.next().newPromise()
+            elg.next().makePromise()
         }
         let allOfEm = EventLoopFuture<Void>.andAll(ps.map { $0.futureResult }, eventLoop: elg.next())
         ps.reversed().forEach { p in
@@ -654,7 +654,7 @@ class EventLoopFutureTest : XCTestCase {
         let fireBackEl = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
         let ps = (0..<n).map { (_: Int) -> EventLoopPromise<Void> in
-            elg.next().newPromise()
+            elg.next().makePromise()
         }
         let allOfEm = EventLoopFuture<Void>.andAll(ps.map { $0.futureResult }, eventLoop: fireBackEl.next())
         ps.reversed().enumerated().forEach { idx, p in
@@ -693,8 +693,8 @@ class EventLoopFutureTest : XCTestCase {
             for eventLoops in [(el1, el1), (el1, el2), (el2, el1), (el2, el2)] {
                 // this determines if the promises fail or succeed
                 for whoSucceeds in [(false, false), (false, true), (true, false), (true, true)] {
-                    let p0 = eventLoops.0.newPromise(of: Int.self)
-                    let p1 = eventLoops.1.newPromise(of: String.self)
+                    let p0 = eventLoops.0.makePromise(of: Int.self)
+                    let p1 = eventLoops.1.makePromise(of: String.self)
                     let fAll = p0.futureResult.and(p1.futureResult)
 
                     // preheat both queues so we have a better chance of racing
@@ -780,7 +780,7 @@ class EventLoopFutureTest : XCTestCase {
         let loop2 = group.next()
         XCTAssertFalse(loop1 === loop2)
 
-        let succeedingPromise = loop1.newPromise(of: Void.self)
+        let succeedingPromise = loop1.makePromise(of: Void.self)
         let succeedingFuture = succeedingPromise.futureResult.map {
             XCTAssertTrue(loop1.inEventLoop)
         }.hopTo(eventLoop: loop2).map {
@@ -800,7 +800,7 @@ class EventLoopFutureTest : XCTestCase {
         let loop2 = group.next()
         XCTAssertFalse(loop1 === loop2)
 
-        let failingPromise = loop2.newPromise(of: Void.self)
+        let failingPromise = loop2.makePromise(of: Void.self)
         let failingFuture = failingPromise.futureResult.thenIfErrorThrowing { error in
             XCTAssertEqual(error as? EventLoopFutureTestError, EventLoopFutureTestError.example)
             XCTAssertTrue(loop2.inEventLoop)
@@ -823,7 +823,7 @@ class EventLoopFutureTest : XCTestCase {
         let loop2 = group.next()
         XCTAssertFalse(loop1 === loop2)
 
-        let noHoppingPromise = loop1.newPromise(of: Void.self)
+        let noHoppingPromise = loop1.makePromise(of: Void.self)
         let noHoppingFuture = noHoppingPromise.futureResult.hopTo(eventLoop: loop1)
         XCTAssertTrue(noHoppingFuture === noHoppingPromise.futureResult)
         noHoppingPromise.succeed(result: ())

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -323,7 +323,7 @@ public class EventLoopTest : XCTestCase {
                     return
                 }
                 XCTAssertTrue(ctx.channel.isActive)
-                self.closePromise = ctx.eventLoop.newPromise()
+                self.closePromise = ctx.eventLoop.makePromise()
                 self.closePromise!.futureResult.whenSuccess {
                     ctx.close(mode: mode, promise: promise)
                 }
@@ -346,7 +346,7 @@ public class EventLoopTest : XCTestCase {
         }
         let loop = group.next() as! SelectableEventLoop
 
-        let serverChannelUp = group.next().newPromise(of: Void.self)
+        let serverChannelUp = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .childChannelInitializer { channel in
                 channel.pipeline.add(handler: WedgeOpenHandler(channelActivePromise: serverChannelUp) { promise in
@@ -357,7 +357,7 @@ public class EventLoopTest : XCTestCase {
         defer {
             XCTAssertNoThrow(try serverChannel.syncCloseAcceptingAlreadyClosed())
         }
-        let connectPromise = loop.newPromise(of: Void.self)
+        let connectPromise = loop.makePromise(of: Void.self)
 
         // We're going to create and register a channel, but not actually attempt to do anything with it.
         let wedgeHandler = WedgeOpenHandler { promise in

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -31,7 +31,7 @@ class FileRegionTest : XCTestCase {
         }
         let bytes = Array(content.utf8)
 
-        let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().newPromise())
+        let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -71,7 +71,7 @@ class FileRegionTest : XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let countingHandler = ByteCountingHandler(numBytes: 0, promise: group.next().newPromise())
+        let countingHandler = ByteCountingHandler(numBytes: 0, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -122,7 +122,7 @@ class FileRegionTest : XCTestCase {
         }
         let bytes = Array(content.utf8)
 
-        let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().newPromise())
+        let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -163,7 +163,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                     XCTAssertEqual(1, buf.readableBytes)
                                     XCTAssertEqual(contentBytes[numCalls], buf.readBytes(length: 1)?.first!)
                                     numCalls += 1
-                                    return self.eventLoop.newSucceededFuture(result: ())
+                                    return self.eventLoop.makeSucceededFuture(result: ())
                 }.wait()
         }
         XCTAssertEqual(content.utf8.count, numCalls)
@@ -186,7 +186,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                         XCTAssertEqual(1, buf.readableBytes)
                                         XCTAssertEqual(contentBytes[numCalls], buf.readBytes(length: 1)?.first!)
                                         numCalls += 1
-                                        return self.eventLoop.newFailedFuture(error: DummyError.dummy)
+                                        return self.eventLoop.makeFailedFuture(error: DummyError.dummy)
                     }.wait()
                 XCTFail("call successful but should've failed")
             } catch let e as DummyError where e == .dummy {
@@ -211,7 +211,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                         allocator: self.allocator,
                                         eventLoop: self.eventLoop) { buf in
                                             XCTFail("shouldn't have been called")
-                                            return self.eventLoop.newSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(result: ())
                 }.wait()
             XCTFail("call successful but should've failed")
         } catch let e as IOError {
@@ -240,7 +240,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             XCTAssertEqual(1, buf.readableBytes)
                                             XCTAssertEqual(expectedByte, buf.readBytes(length: 1)!.first!)
                                             numCalls += 1
-                                            return self.eventLoop.newSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(result: ())
                 }.wait()
         }
         XCTAssertEqual(content.utf8.count, numCalls)
@@ -260,7 +260,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             XCTAssertEqual(2, buf.readableBytes)
                                             XCTAssertEqual(Array("\(numCalls*2)\(numCalls*2 + 1)".utf8), buf.readBytes(length: 2)!)
                                             numCalls += 1
-                                            return self.eventLoop.newSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(result: ())
                 }.wait()
         }
         XCTAssertEqual(content.utf8.count/2, numCalls)
@@ -310,7 +310,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             XCTAssertTrue(self.eventLoop.inEventLoop)
                                             allBytesActual += buf.readString(length: buf.readableBytes) ?? "WRONG"
                                             numCalls += 1
-                                            return self.eventLoop.newSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(result: ())
                 }.wait()
         }
         XCTAssertEqual(allBytesExpected, allBytesActual)
@@ -333,7 +333,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                                     XCTAssertEqual(3, buf.readableBytes)
                                                 }
                                                 allBytes.append(buf.readString(length: buf.readableBytes) ?? "THIS IS WRONG")
-                                                return self.eventLoop.newSucceededFuture(result: ())
+                                                return self.eventLoop.makeSucceededFuture(result: ())
             }
 
             do {
@@ -371,7 +371,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                     XCTAssertEqual(5, buf.readableBytes)
                                     XCTAssertEqual("01234", buf.readString(length: buf.readableBytes) ?? "bad")
                                     numCalls += 1
-                                    return self.eventLoop.newSucceededFuture(result: ())
+                                    return self.eventLoop.makeSucceededFuture(result: ())
                 }.wait()
         }
         XCTAssertEqual(1, numCalls)
@@ -389,7 +389,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             allocator: self.allocator,
                                             eventLoop: self.eventLoop) { buf in
                                                 XCTFail("this shouldn't have been called")
-                                                return self.eventLoop.newSucceededFuture(result: ())
+                                                return self.eventLoop.makeSucceededFuture(result: ())
                     }.wait()
                 XCTFail("succeeded and shouldn't have")
             } catch let e as IOError where e.errnoCode == ESPIPE {
@@ -414,7 +414,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             allocator: self.allocator,
                                             eventLoop: self.eventLoop) { buf in
                                                 XCTFail("this shouldn't have been called")
-                                                return self.eventLoop.newSucceededFuture(result: ())
+                                                return self.eventLoop.makeSucceededFuture(result: ())
                 }.wait()
                 XCTFail("succeeded and shouldn't have")
             } catch let e as NonBlockingFileIO.Error where e == NonBlockingFileIO.Error.descriptorSetToNonBlocking {
@@ -445,7 +445,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                                 XCTAssertEqual(1, buf.readableBytes)
                                                 XCTAssertEqual("9", buf.readString(length: buf.readableBytes) ?? "bad")
                                             }
-                                            return self.eventLoop.newSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(result: ())
                 }.wait()
         }
         XCTAssertEqual(2, numCalls)

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
@@ -231,7 +231,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
 
         try withPendingDatagramWritesManager { pwm in
             buffer.clear()
-            let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.makePromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
 
             XCTAssertFalse(pwm.isEmpty)
@@ -286,7 +286,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: firstAddress, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: secondAddress, data: buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -322,7 +322,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<4).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<4).map { (_: Int) in el.makePromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: firstAddress, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: secondAddress, data: buffer), promise: ps[1])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: firstAddress, data: buffer), promise: ps[2])
@@ -371,7 +371,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         buffer.write(bytes: Array<UInt8>(repeating: 0xff, count: 12))
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0...pwm.writeSpinCount+1).map { (_: UInt) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0...pwm.writeSpinCount+1).map { (_: UInt) in el.makePromise() }
             ps.forEach { _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: $0) }
             let maxVectorWritabilities = ps.map { (_: EventLoopPromise<Void>) in (buffer.readableBytes, address) }
             let actualVectorWritabilities = maxVectorWritabilities.indices.dropLast().map { Array(maxVectorWritabilities[$0...]) }
@@ -410,7 +410,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         _ = buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -445,7 +445,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 65535)
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             /* add 1.5x the writev limit */
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[1])
@@ -481,7 +481,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         buffer.moveWriterIndex(to: biggerThanWriteV)
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             /* add 1.5x the writev limit */
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
             buffer.moveReaderIndex(to: 100)
@@ -524,7 +524,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 80)
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: emptyBuffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: emptyBuffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -558,7 +558,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[0])
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[1])
             pwm.markFlushCheckpoint()
@@ -589,7 +589,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         buffer.write(string: "1234")
 
         try withPendingDatagramWritesManager { pwm in
-            let ps: [EventLoopPromise<Void>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.newPromise() }
+            let ps: [EventLoopPromise<Void>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.makePromise() }
             ps.forEach { p in
                 _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: p)
             }

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -251,7 +251,7 @@ class SelectorTest: XCTestCase {
                 var reconnectedChannelsHaveRead: [EventLoopFuture<Void>] = []
                 for _ in everyOtherIndex {
                     var hasBeenAdded: Bool = false
-                    let p = ctx.channel.eventLoop.newPromise(of: Void.self)
+                    let p = ctx.channel.eventLoop.makePromise(of: Void.self)
                     reconnectedChannelsHaveRead.append(p.futureResult)
                     let newChannel = ClientBootstrap(group: ctx.eventLoop)
                         .channelInitializer { channel in
@@ -343,7 +343,7 @@ class SelectorTest: XCTestCase {
             .bind(to: SocketAddress(unixDomainSocketPath: "\(tempDir)/server-sock.uds"))
             .wait()
 
-        let everythingWasReadPromise = el.newPromise(of: Void.self)
+        let everythingWasReadPromise = el.makePromise(of: Void.self)
         XCTAssertNoThrow(try el.submit { () -> [EventLoopFuture<Channel>] in
             (0..<SelectorTest.testWeDoNotDeliverEventsForPreviouslyClosedChannels_numberOfChannelsToUse).map { (_: Int) in
                 ClientBootstrap(group: el)

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -152,7 +152,7 @@ public class SocketChannelTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerSocketChannel(serverSocket: socket,
                                                                            eventLoop: group.next() as! SelectableEventLoop,
                                                                            group: group))
-        let promise = serverChannel.eventLoop.newPromise(of: IOError.self)
+        let promise = serverChannel.eventLoop.makePromise(of: IOError.self)
 
         XCTAssertNoThrow(try serverChannel.eventLoop.submit {
             serverChannel.pipeline.add(handler: AcceptHandler(promise)).then {
@@ -230,12 +230,12 @@ public class SocketChannelTest : XCTestCase {
         }
 
         let eventLoop = group.next()
-        let connectPromise = eventLoop.newPromise(of: Void.self)
+        let connectPromise = eventLoop.makePromise(of: Void.self)
 
         let channel = try assertNoThrowWithValue(SocketChannel(socket: ConnectSocket(promise: connectPromise),
                                                                parent: nil,
                                                                eventLoop: eventLoop as! SelectableEventLoop))
-        let promise = channel.eventLoop.newPromise(of: Void.self)
+        let promise = channel.eventLoop.makePromise(of: Void.self)
 
         XCTAssertNoThrow(try channel.pipeline.add(handler: ActiveVerificationHandler(promise)).then {
             channel.register()
@@ -424,7 +424,7 @@ public class SocketChannelTest : XCTestCase {
         defer { XCTAssertNoThrow(try serverChannel.close().wait()) }
 
         let eventLoop = group.next()
-        let promise = eventLoop.newPromise(of: Void.self)
+        let promise = eventLoop.makePromise(of: Void.self)
 
         class ConnectPendingSocket: Socket {
             let promise: EventLoopPromise<Void>
@@ -442,8 +442,8 @@ public class SocketChannelTest : XCTestCase {
         }
 
         let channel = try SocketChannel(socket: ConnectPendingSocket(promise: promise), parent: nil, eventLoop: eventLoop as! SelectableEventLoop)
-        let connectPromise = channel.eventLoop.newPromise(of: Void.self)
-        let closePromise = channel.eventLoop.newPromise(of: Void.self)
+        let connectPromise = channel.eventLoop.makePromise(of: Void.self)
+        let closePromise = channel.eventLoop.makePromise(of: Void.self)
 
         closePromise.futureResult.whenComplete {
             XCTAssertTrue(connectPromise.futureResult.isFulfilled)
@@ -522,7 +522,7 @@ public class SocketChannelTest : XCTestCase {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
-        let handler = AddressVerificationHandler(promise: group.next().newPromise())
+        let handler = AddressVerificationHandler(promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .childChannelInitializer { $0.pipeline.add(handler: handler) }
             .bind(host: "127.0.0.1", port: 0)

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -127,7 +127,7 @@ class EndToEndTests: XCTestCase {
 
     func testBasicUpgradeDance() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.newSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -147,7 +147,7 @@ class EndToEndTests: XCTestCase {
 
     func testUpgradeWithProtocolName() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.newSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -169,7 +169,7 @@ class EndToEndTests: XCTestCase {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in nil },
                                               upgradePipelineHandler: { (channel, req) in
                                                   XCTFail("Should not have called")
-                                                  return channel.eventLoop.newSucceededFuture(result: ())
+                                                  return channel.eventLoop.makeSucceededFuture(result: ())
                                               }
         )
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
@@ -199,7 +199,7 @@ class EndToEndTests: XCTestCase {
 
     func testRequiresVersion13() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.newSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -227,7 +227,7 @@ class EndToEndTests: XCTestCase {
 
     func testRequiresVersionHeader() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.newSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -255,7 +255,7 @@ class EndToEndTests: XCTestCase {
 
     func testRequiresKeyHeader() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.newSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -287,7 +287,7 @@ class EndToEndTests: XCTestCase {
                                             hdrs.add(name: "TestHeader", value: "TestValue")
                                             return hdrs
                                          },
-                                         upgradePipelineHandler: { (channel, req) in channel.eventLoop.newSucceededFuture(result: ()) })
+                                         upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
         let (loop, server, client) = createTestFixtures(upgraders: [upgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -313,7 +313,7 @@ class EndToEndTests: XCTestCase {
                                          hdrs.add(name: "Target", value: path)
                                          return hdrs
                                      },
-                                     upgradePipelineHandler: { (channel, req) in channel.eventLoop.newSucceededFuture(result: ()) })
+                                     upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
         }
         let first = buildHandler(path: "first")
         let second = buildHandler(path: "second")
@@ -379,7 +379,7 @@ class EndToEndTests: XCTestCase {
     func testMaxFrameSize() throws {
         let basicUpgrader = WebSocketUpgrader(maxFrameSize: 16, shouldUpgrade: { head in HTTPHeaders() },
                                               upgradePipelineHandler: { (channel, req) in
-            return channel.eventLoop.newSucceededFuture(result: ())
+            return channel.eventLoop.makeSucceededFuture(result: ())
         })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -7,4 +7,6 @@
 - `ByteToMessageDecoder`s now need to be wrapped in `ByteToMessageHandler`
   before they can be added to the pipeline.
   before: `pipeline.add(MyDecoder())`, after: `pipeline.add(ByteToMessageHandler(MyDecoder()))`
-
+- `EventLoop.makePromise`/`makeSucceededFuture`/`makeFailedFuture` instead of `new*`
+- `SocketAddress.makeAddressResolvingHost(:port:)` instead of
+  `SocketAddress.newAddressResolving(host:port:)`


### PR DESCRIPTION
Motivation:

Swift naming guidelines mandate that factory methods start with `make`,
like `makeSomething`. We had a few that were `newSomething`.

Modifications:

make all factories start with make

Result:

more compliant to Swift naming rules
