### PR TITLE
CI: update to Swift snapshot 13th Dec 2018

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,7 +8,7 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2018-12-04-a"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2018-12-13-a"
         swift_builds_suffix: "branch"
         skip_ruby_from_ppa: "true"
 


### PR DESCRIPTION
Motivation:

SwiftPM was very outdated on the old Swift snapshots, we should update
the CI.

Modifications:

use swift-5.0-DEVELOPMENT-SNAPSHOT-2018-12-13-a-ubuntu18.04.tar.gz

Result:

can use swift-tools-version: 5.0 and all the goodies from that
