### PR TITLE
update tools-version to 5.0 & fix latest warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -238,10 +238,10 @@ public struct ByteBuffer {
     public typealias _Index = UInt32
     public typealias _Capacity = UInt32
 
-    @usableFromInline private(set) var _storage: _Storage
-    @usableFromInline private(set) var _readerIndex: _Index = 0
-    @usableFromInline private(set) var _writerIndex: _Index = 0
-    @usableFromInline private(set) var _slice: Slice
+    @usableFromInline var _storage: _Storage
+    @usableFromInline var _readerIndex: _Index = 0
+    @usableFromInline var _writerIndex: _Index = 0
+    @usableFromInline var _slice: Slice
 
     // MARK: Internal _Storage for CoW
     @usableFromInline final class _Storage {

--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -27,7 +27,7 @@
 
 private extension Array where Element == EventLoopFuture<Channel> {
     mutating func remove(element: Element) {
-        guard let channelIndex = index(where: { $0 === element }) else {
+        guard let channelIndex = self.firstIndex(where: { $0 === element }) else {
             return
         }
 
@@ -553,7 +553,7 @@ internal class HappyEyeballsConnector {
                     // The connection attempt failed. If we're in the complete state then there's nothing
                     // to do. Otherwise, notify the state machine of the failure.
                     if case .complete = self.state {
-                        assert(self.pendingConnections.index { $0 === channelFuture } == nil, "failed but was still in pending connections")
+                        assert(self.pendingConnections.firstIndex { $0 === channelFuture } == nil, "failed but was still in pending connections")
                     } else {
                         self.error.connectionErrors.append(SingleConnectionFailure(target: target, error: err))
                         self.pendingConnections.remove(element: channelFuture)

--- a/Sources/NIO/Heap.swift
+++ b/Sources/NIO/Heap.swift
@@ -130,7 +130,7 @@ internal struct Heap<T: Comparable> {
 
     @discardableResult
     public mutating func remove(value: T) -> Bool {
-        if let idx = self.storage.index(of: value) {
+        if let idx = self.storage.firstIndex(of: value) {
             self.remove(index: idx)
             return true
         } else {

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -151,7 +151,7 @@ internal func assertResponseIs(response: String, expectedResponseLine: String, e
 
     // For each header, find it in the actual response headers and remove it.
     for expectedHeader in expectedResponseHeaders {
-        guard let index = lines.index(of: expectedHeader) else {
+        guard let index = lines.firstIndex(of: expectedHeader) else {
             XCTFail("Could not find header \"\(expectedHeader)\"")
             return
         }

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -124,19 +124,19 @@ class ChannelPipelineTest: XCTestCase {
 
     func testConnectingDoesntCallBind() throws {
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertFalse(try channel.finish())
+        }
         var ipv4SocketAddress = sockaddr_in()
         ipv4SocketAddress.sin_port = (12345 as in_port_t).bigEndian
         let sa = SocketAddress(ipv4SocketAddress, host: "foobar.com")
 
-        _ = try channel.pipeline.add(handler: NoBindAllowed()).wait()
-        _ = try channel.pipeline.add(handler: TestChannelOutboundHandler<ByteBuffer, ByteBuffer> { data in
+        XCTAssertNoThrow(try channel.pipeline.add(handler: NoBindAllowed()).wait())
+        XCTAssertNoThrow(try channel.pipeline.add(handler: TestChannelOutboundHandler<ByteBuffer, ByteBuffer> { data in
             data
-        }).wait()
+        }).wait())
 
-        _ = try channel.connect(to: sa).wait()
-        defer {
-            XCTAssertFalse(try channel.finish())
-        }
+        XCTAssertNoThrow(try channel.connect(to: sa).wait())
     }
 
     private final class TestChannelOutboundHandler<In, Out>: ChannelOutboundHandler {

--- a/Tests/NIOTests/HappyEyeballsTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest.swift
@@ -1114,7 +1114,7 @@ public class HappyEyeballsTest : XCTestCase {
         ourChannelFutures[2].fail(error: DummyError())
 
         // Verify that the first channel is the one listed as connected.
-        XCTAssertTrue((try? ourChannelFutures.first!.futureResult.wait()) === (try? channelFuture.wait()))
+        XCTAssertTrue((try ourChannelFutures.first!.futureResult.wait()) === (try channelFuture.wait()))
     }
 
     func testChannelCreationFails() throws {

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -81,7 +81,7 @@ private func assertResponseIs(response: String, expectedResponseLine: String, ex
 
     // For each header, find it in the actual response headers and remove it.
     for expectedHeader in expectedResponseHeaders {
-        guard let index = lines.index(of: expectedHeader) else {
+        guard let index = lines.firstIndex(of: expectedHeader) else {
             XCTFail("Could not find header \"\(expectedHeader)\"")
             return
         }


### PR DESCRIPTION
Motivation:

The latest Swift 5.0s bring us new goodies (hence tools version) and
also more warnings, hence the fixes for them.

Modifications:

- set tools-version to 5.0
- fix warnings

Result:

happier developers
