### PR TITLE
allow EventLoopIterator to be constructed using [EventLoop]

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -155,7 +155,8 @@ public struct EventLoopIterator: Sequence, IteratorProtocol {
     public typealias Element = EventLoop
     private var eventLoops: IndexingIterator<[EventLoop]>
 
-    internal init(_ eventLoops: [EventLoop]) {
+    /// Create an `EventLoopIterator` from an array of `EventLoop`s.
+    public init(_ eventLoops: [EventLoop]) {
         self.eventLoops = eventLoops.makeIterator()
     }
 


### PR DESCRIPTION
Motivation:

Modules outside of NIO core must be able to create `EventLoopIterator`s
in order to conform to the `EventLoop` protocol, therefore we need an
initialiser that's available.

Modifications:

add public initialiser to construct EventLoopIterator from [EventLoop]

Result:

others can implement EventLoops again
