### PR TITLE
use String.UTF8View.withContiguousStorageIfAvailable

### DIFF
--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -128,6 +128,7 @@ extension ByteBufferTest {
                 ("testReserveCapacityLargerMultipleReferenceCallsMalloc", testReserveCapacityLargerMultipleReferenceCallsMalloc),
                 ("testReadWithFunctionsThatReturnNumberOfReadBytesAreDiscardable", testReadWithFunctionsThatReturnNumberOfReadBytesAreDiscardable),
                 ("testWriteAndSetAndGetAndReadEncoding", testWriteAndSetAndGetAndReadEncoding),
+                ("testPossiblyLazilyBridgedString", testPossiblyLazilyBridgedString),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1627,6 +1627,17 @@ class ByteBufferTest: XCTestCase {
             XCTAssertEqual($0 as? ByteBufferFoundationError, .failedToEncodeString)
         }
     }
+
+    func testPossiblyLazilyBridgedString() {
+        // won't hit the String writing fast path
+        let utf16Bytes = Data([0xfe, 0xff, 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0xe4, 0x00, 0xe4, 0x00, 0xe4, 0x00, 0x0a])
+        let slowString = String(data: utf16Bytes, encoding: .utf16)!
+
+        self.buf.clear()
+        let written = self.buf.write(string: slowString as String)
+        XCTAssertEqual(10, written)
+        XCTAssertEqual("abcäää\n", String(decoding: self.buf.readableBytesView, as: Unicode.UTF8.self))
+    }
 }
 
 private enum AllocationExpectationState: Int {


### PR DESCRIPTION
Motivation:

The new shiny Swift 5 gives us fast access to the UTF8 bytes (if
available, which mostly means not bridged from Cocoa), we should use
that.

Modifications:

use UTF8View.withContiguousStorageIfAvailable

Result:

faster String access