### PR TITLE
[probably close in favour of #709] prefix ContiguousCollection with NIO

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -260,7 +260,7 @@ extension ByteBuffer {
     /// - returns: The number of bytes written or `bytes.count`.
     @discardableResult
     @inlinable
-    public mutating func write<Bytes: ContiguousCollection>(bytes: Bytes) -> Int where Bytes.Element == UInt8 {
+    public mutating func write<Bytes: NIOContiguousCollection>(bytes: Bytes) -> Int where Bytes.Element == UInt8 {
         let written = set(bytes: bytes, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
         return written

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -395,7 +395,7 @@ public struct ByteBuffer {
     }
 
     @inlinable
-    mutating func _set<Bytes: ContiguousCollection>(bytes: Bytes, at index: _Index) -> _Capacity where Bytes.Element == UInt8 {
+    mutating func _set<Bytes: NIOContiguousCollection>(bytes: Bytes, at index: _Index) -> _Capacity where Bytes.Element == UInt8 {
         let bytesCount = bytes.count
         let newEndIndex: _Index = index + _toIndex(Int(bytesCount))
         if !isKnownUniquelyReferenced(&self._storage) {
@@ -405,9 +405,9 @@ public struct ByteBuffer {
 
         self._ensureAvailableCapacity(_Capacity(bytesCount), at: index)
         let targetPtr = UnsafeMutableRawBufferPointer(rebasing: self._slicedStorageBuffer.dropFirst(Int(index)))
-        bytes.withUnsafeBytes { srcPtr in
+        bytes.withUnsafeBytesNIO { srcPtr in
             precondition(srcPtr.count >= bytesCount,
-                         "collection \(bytes) claims count \(bytesCount) but withUnsafeBytes only offers \(srcPtr.count) bytes")
+                         "collection \(bytes) claims count \(bytesCount) but withUnsafeBytesNIO only offers \(srcPtr.count) bytes")
             targetPtr.copyMemory(from: UnsafeRawBufferPointer(rebasing: srcPtr.prefix(Int(bytesCount))))
         }
         return _toCapacity(Int(bytesCount))
@@ -730,7 +730,7 @@ extension ByteBuffer {
     /// Copy the collection of `bytes` into the `ByteBuffer` at `index`.
     @discardableResult
     @inlinable
-    public mutating func set<Bytes: ContiguousCollection>(bytes: Bytes, at index: Int) -> Int where Bytes.Element == UInt8 {
+    public mutating func set<Bytes: NIOContiguousCollection>(bytes: Bytes, at index: Int) -> Int where Bytes.Element == UInt8 {
         return Int(self._set(bytes: bytes, at: _toIndex(index)))
     }
 

--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -16,7 +16,7 @@
 ///
 /// A `ByteBufferView` is useful whenever a `Collection where Element == UInt8` representing a portion of a
 /// `ByteBuffer` is needed.
-public struct ByteBufferView: ContiguousCollection, RandomAccessCollection {
+public struct ByteBufferView: NIOContiguousCollection, RandomAccessCollection {
     public typealias Element = UInt8
     public typealias Index = Int
     public typealias SubSequence = ByteBufferView
@@ -30,7 +30,7 @@ public struct ByteBufferView: ContiguousCollection, RandomAccessCollection {
         self.range = range
     }
 
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withUnsafeBytesNIO<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.buffer.withVeryUnsafeBytes { ptr in
             try body(UnsafeRawBufferPointer.init(start: ptr.baseAddress!.advanced(by: self.range.lowerBound),
                                                  count: self.range.count))

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -37,9 +37,9 @@ public enum ByteBufferFoundationError: Error {
  *   the platforms OpenSSL in which might cause problems.
  */
 
-extension Data: ContiguousCollection {
+extension Data: NIOContiguousCollection {
     @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withUnsafeBytesNIO<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> R in
             try body(UnsafeRawBufferPointer(start: ptr, count: self.count))
         }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1154,7 +1154,7 @@ class ByteBufferTest: XCTestCase {
     }
 
     func testWeUseFastWriteForContiguousCollections() throws {
-        struct WrongCollection: ContiguousCollection {
+        struct WrongCollection: NIOContiguousCollection {
             let storage: [UInt8] = [1, 2, 3]
             typealias Element = UInt8
             typealias Index = Array<UInt8>.Index
@@ -1185,7 +1185,7 @@ class ByteBufferTest: XCTestCase {
                 return self.storage.index(after: i)
             }
 
-            func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+            func withUnsafeBytesNIO<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
                 return try self.storage.withUnsafeBytes(body)
             }
         }
@@ -1453,7 +1453,7 @@ class ByteBufferTest: XCTestCase {
 
     func testWeDontWriteTooMuchForUnderreportingContiguousCollection() throws {
         // this is an illegal contiguous collection but we should still be able to deal with this
-        struct UnderreportingContiguousCollection: ContiguousCollection {
+        struct UnderreportingContiguousCollection: NIOContiguousCollection {
             let storage: [UInt8] = Array(repeating: 0xff, count: 4096)
             typealias Element = UInt8
             typealias Index = Array<UInt8>.Index
@@ -1491,7 +1491,7 @@ class ByteBufferTest: XCTestCase {
                 return self.storage.index(after: i)
             }
 
-            func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+            func withUnsafeBytesNIO<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
                 // we're giving access to 4096 elements despite the fact we claim to only have 3 available
                 return try self.storage.withUnsafeBytes(body)
             }


### PR DESCRIPTION
Motivation:

The standard library will likely get a ContiguousCollection protocol
(https://forums.swift.org/t/contiguous-collection-protocols/17875) so we
should prefix ours.
Also we made a public Data extension which isn't necessary.

Modifications:

- rename ContiguousCollection to NIOContiguousCollection (to be removed
  when the stdlib gets its ContiguousCollection)
- remove the public extension on Data

Result:

- more compatibility
- https://bugs.swift.org/browse/SR-9505
