### PR TITLE
fix remaining warnings & -warnings-as-errors

### DIFF
--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -24,7 +24,7 @@ final class LineDelimiterCodec: ByteToMessageDecoder {
     public var cumulationBuffer: ByteBuffer?
 
     public func decode(ctx: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
-        let readable = buffer.withUnsafeReadableBytes { $0.index(of: newLine) }
+        let readable = buffer.withUnsafeReadableBytes { $0.firstIndex(of: newLine) }
         if let r = readable {
             ctx.fireChannelRead(self.wrapInboundOut(buffer.readSlice(length: r + 1)!))
             return .continue

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -14,6 +14,7 @@ services:
 
   unit-tests:
     image: swift-nio:18.04-5.0
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors"
 
   integration-tests:
     image: swift-nio:18.04-5.0


### PR DESCRIPTION
Motivation:

Warnings are bad.

Modifications:

- fixed remaining warnings
- enabled -warnings-as-errors

Result:

happier devs
