### PR TITLE
Update list_topsorted_dependencies script.

### DIFF
--- a/scripts/list_topsorted_dependencies.sh
+++ b/scripts/list_topsorted_dependencies.sh
@@ -60,7 +60,7 @@ fi
 
 if [[ ! -z "$package_dependency" ]]; then
   swift package dump-package | jq -r ".targets |
-                                      map(select(.name == \"$package_dependency\" and .type == \"regular\") | .dependencies | map(.name)) | .[] | .[]"
+                                      map(select(.name == \"$package_dependency\" and .type == \"regular\") | .dependencies | map(.byName | first)) | .[] | .[]"
   exit 0
 fi
 
@@ -68,14 +68,14 @@ fi
 cd "$here/.."
 if $only_libs; then
     swift package dump-package | jq '.products |
-                                     map(select(.product_type != "library")) |
+                                     map(select(.type | has("library") | not)) |
                                      map(.name) | .[]' | tr -d '"' \
                                      >> "$tmpfile"
 fi
 swift package dump-package | jq '.targets |
                                  map(.name as $name |
                                  select(.name == $name and .type == "regular") |
-                                 { "\($name)": .dependencies | map(.name) } ) |
+                                 { "\($name)": .dependencies | map(.byName | first) } ) |
                                  map(to_entries[]) |
                                  map("\(.key) \(.value | .[])") |
                                  .[]' | \


### PR DESCRIPTION
Motivation:

Newer versions of SwiftPM for the Swift 5 release have changed the output
format of swift package dump-package. This has broken our
list_topsorted_dependencies script. This script is highly useful, so we'd
like to keep it working.

The discussion on SR-9191 suggests that SwiftPM considers this format
changeable at any time, so we may need to make a change like this in future.
We may want to consider writing tests for this script to ensure its continued good functioning.

Modifications:

- Amended the jq scripts to parse the new JSON format.

Result:

list_topsorted_dependencies will work with Swift 5 development copies of
SwiftPM. Note that this will break this script with earlier copies of SwiftPM,
but as we only support Swift 5 on the master branch this change is safe to
make.
