### PR TITLE
use the Swift 5.0 snapshot from 2018-12-28

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,7 +8,7 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2018-12-13-a"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2018-12-28-a"
         swift_builds_suffix: "branch"
         skip_ruby_from_ppa: "true"
 


### PR DESCRIPTION
Motivation:

that snapshot fixes https://bugs.swift.org/browse/SR-9518 which blocks
the allocation tests and therefore #710 .

Modifications:

made our docker use the 2012-12-28 snapshot.

Result:

allocation tests hopefully work again because Swift doesn't accidentally
forget to decrease some reference count anymore.
