### PR TITLE
raise Swift 5 HTTP/1 req/res pair alloc limits

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,7 +19,7 @@ services:
   integration-tests:
     image: swift-nio:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=38750
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2150
@@ -28,7 +28,7 @@ services:
   test:
     image: swift-nio:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=38750
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2150


### PR DESCRIPTION
Motivation:

Swift 5 contains a regression where we get 2 extra allocations per
HTTP/1.1 request/response pair _only on Linux_. That happens both on
`master` as well as on `nio-1.12`.

I will track this problem down (filed as #726) but for now it's important to unblock
12 work.

Modifications:

raise the allowed allocations per HTTP/1.1 req/res pair to 38 (from 36)
for Swift 5.

Result:

allocation tests can be re-enabled again.
