### PR TITLE
override content encoding header value in compressor

### DIFF
--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -119,8 +119,9 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler {
                 ctx.write(wrapOutboundOut(.head(responseHead)), promise: promise)
                 return
             }
-
-            responseHead.headers.add(name: "Content-Encoding", value: algorithm!.rawValue)
+            // Previous handlers in the pipeline might have already set this header even though
+            // they should not as it is compressor responsibility to decide what encoding to use
+            responseHead.headers.replaceOrAdd(name: "Content-Encoding", value: algorithm!.rawValue)
             initializeEncoder(encoding: algorithm!)
             pendingResponse.bufferResponseHead(responseHead)
             chainPromise(promise)

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest+XCTest.swift
@@ -41,6 +41,7 @@ extension HTTPResponseCompressorTest {
                 ("testInfinityQValuePreventsChoice", testInfinityQValuePreventsChoice),
                 ("testNegativeInfinityQValuePreventsChoice", testNegativeInfinityQValuePreventsChoice),
                 ("testOutOfRangeQValuePreventsChoice", testOutOfRangeQValuePreventsChoice),
+                ("testOverridesContentEncodingHeader", testOverridesContentEncodingHeader),
                 ("testRemovingHandlerFailsPendingWrites", testRemovingHandlerFailsPendingWrites),
                 ("testDoesNotBufferWritesNoAlgorithm", testDoesNotBufferWritesNoAlgorithm),
                 ("testStartsWithSameUnicodeScalarsWorksOnEmptyStrings", testStartsWithSameUnicodeScalarsWorksOnEmptyStrings),

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
@@ -505,7 +505,7 @@ class HTTPResponseCompressorTest: XCTestCase {
         }
 
         try sendRequest(acceptEncoding: "deflate;q=2.2, gzip;q=0.3", channel: channel)
-        try assertGzippedResponse(channel: channel, additionalHeaders: HTTPHeaders([("Content-Encoding", "gzip")]))
+        try assertGzippedResponse(channel: channel, additionalHeaders: HTTPHeaders([("Content-Encoding", "deflate")]))
     }
 
     func testRemovingHandlerFailsPendingWrites() throws {


### PR DESCRIPTION
Resolves #718

### Motivation:

Content encoding header may contain invalid value if handlers before compressor have already set it.

### Modifications:

Instead of `headers.add` which appends header value use `headers.replaceOrAdd` which replaces existing value

### Result:

If `Content-Encoding` header was set to some `value`, compressor will reset it to the value of compression algorithm it have picked.
