### PR TITLE
[FORWARD_PORT] Fix: BlockingIOThreadPool not releasing the latest WorkItem (#716)

### DIFF
--- a/Sources/NIO/BlockingIOThreadPool.swift
+++ b/Sources/NIO/BlockingIOThreadPool.swift
@@ -126,6 +126,7 @@ public final class BlockingIOThreadPool {
         var item: WorkItem? = nil
         repeat {
             /* wait until work has become available */
+            item = nil	// ensure previous work item is not retained for duration of semaphore wait
             self.semaphore.wait()
 
             item = self.lock.withLock { () -> (WorkItem)? in

--- a/Tests/NIOTests/BlockingIOThreadPoolTest+XCTest.swift
+++ b/Tests/NIOTests/BlockingIOThreadPoolTest+XCTest.swift
@@ -32,6 +32,8 @@ extension BlockingIOThreadPoolTest {
                 ("testLoseLastReferenceAndShutdownWhileTaskStillRunning", testLoseLastReferenceAndShutdownWhileTaskStillRunning),
                 ("testDeadLockIfCalledOutWithLockHeld", testDeadLockIfCalledOutWithLockHeld),
                 ("testPoolDoesGetReleasedWhenStoppedAndReferencedDropped", testPoolDoesGetReleasedWhenStoppedAndReferencedDropped),
+                ("testClosureReferenceDroppedAfterSingleWorkItemExecution", testClosureReferenceDroppedAfterSingleWorkItemExecution),
+                ("testClosureReferencesDroppedAfterTwoConsecutiveWorkItemsExecution", testClosureReferencesDroppedAfterTwoConsecutiveWorkItemsExecution),
            ]
    }
 }

--- a/Tests/NIOTests/BlockingIOThreadPoolTest.swift
+++ b/Tests/NIOTests/BlockingIOThreadPoolTest.swift
@@ -125,4 +125,65 @@ class BlockingIOThreadPoolTest: XCTestCase {
         shutdownDoneSem.wait()
         assert(weakThreadPool == nil, within: .seconds(1))
     }
+
+    class SomeClass {
+        init() {}
+        func dummy() {}
+    }
+
+    func testClosureReferenceDroppedAfterSingleWorkItemExecution() throws {
+        let taskRunningSem = DispatchSemaphore(value: 0)
+        let doneSem = DispatchSemaphore(value: 0)
+        let threadPool = BlockingIOThreadPool(numberOfThreads: 1)
+        threadPool.start()
+        weak var referencedObject: SomeClass? = nil
+        ({
+            let object = SomeClass()
+            referencedObject = object
+            threadPool.submit { state in
+                XCTAssertEqual(.active, state)
+                taskRunningSem.signal()
+                object.dummy()
+                doneSem.wait()
+            }
+        })()
+        taskRunningSem.wait()
+        doneSem.signal()
+        assert(referencedObject == nil, within: .seconds(1))
+        try threadPool.syncShutdownGracefully()
+    }
+
+    func testClosureReferencesDroppedAfterTwoConsecutiveWorkItemsExecution() throws {
+        let taskRunningSem = DispatchSemaphore(value: 0)
+        let doneSem = DispatchSemaphore(value: 0)
+        let threadPool = BlockingIOThreadPool(numberOfThreads: 1)
+        threadPool.start()
+        weak var referencedObject1: SomeClass? = nil
+        weak var referencedObject2: SomeClass? = nil
+        ({
+            let object1 = SomeClass()
+            let object2 = SomeClass()
+            referencedObject1 = object1
+            referencedObject2 = object2
+            threadPool.submit { state in
+                XCTAssertEqual(.active, state)
+                taskRunningSem.signal()
+                object1.dummy()
+                doneSem.wait()
+            }
+            threadPool.submit { state in
+                XCTAssertEqual(.active, state)
+                taskRunningSem.signal()
+                object2.dummy()
+                doneSem.wait()
+            }
+        })()
+        taskRunningSem.wait()
+        doneSem.signal()
+        taskRunningSem.wait()
+        doneSem.signal()
+        assert(referencedObject1 == nil, within: .seconds(1))
+        assert(referencedObject2 == nil, within: .seconds(1))
+        try threadPool.syncShutdownGracefully()
+    }
 }


### PR DESCRIPTION
This is a forward port of #716 to master. The rest of the message comes from #716.

BUGFIX: BlockingIOThreadPool not releasing the latest WorkItem

Fix is to clear the latest work item just before waiting for
the next one to be submitted.

Added two tests to validate the fix: submitting only one work item
to an IO thread pool, and submitting two consecutive work items.

Thanks to Gwynne Raskind for help troubleshooting & fix

(cherry picked from commit 8df414b716587fe236cdb12ea8f5e57ff139b497)