### PR TITLE
better DispatchData support

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -308,15 +308,16 @@ public func swiftMain() -> Int {
         let foundationData = "A".data(using: .utf8)!
         @inline(never)
         func doWrites(buffer: inout ByteBuffer) {
-            /* all of those should be 0 allocations */
-
+            /* these ones are zero allocations */
             // buffer.write(bytes: foundationData) // see SR-7542
             buffer.write(bytes: [0x41])
-            buffer.write(bytes: dispatchData)
             buffer.write(bytes: "A".utf8)
             buffer.write(string: "A")
             buffer.write(staticString: "A")
             buffer.write(integer: 0x41, as: UInt8.self)
+
+            /* those down here should be one allocation each (on Linux) */
+            buffer.write(bytes: dispatchData) // see https://bugs.swift.org/browse/SR-9597
         }
         @inline(never)
         func doReads(buffer: inout ByteBuffer) {

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -548,6 +548,16 @@ public struct ByteBuffer {
         return try body(.init(self._slicedStorageBuffer))
     }
 
+    /// This vends a pointer to the storage of the `ByteBuffer`. It's marked as _very unsafe_ because it might contain
+    /// uninitialised memory and it's undefined behaviour to read it. In most cases you should use `withUnsafeMutableWritableBytes`.
+    ///
+    /// - warning: Do not escape the pointer from the closure for later use.
+    @inlinable
+    public mutating func withVeryUnsafeMutableBytes<T>(_ body: (UnsafeMutableRawBufferPointer) throws -> T) rethrows -> T {
+        self._copyStorageAndRebaseIfNeeded() // this will trigger a CoW if necessary
+        return try body(.init(self._slicedStorageBuffer))
+    }
+
     /// Yields a buffer pointer containing this `ByteBuffer`'s readable bytes.
     ///
     /// - warning: Do not escape the pointer from the closure for later use.

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -127,6 +127,13 @@ extension ByteBufferTest {
                 ("testReadWithFunctionsThatReturnNumberOfReadBytesAreDiscardable", testReadWithFunctionsThatReturnNumberOfReadBytesAreDiscardable),
                 ("testWriteAndSetAndGetAndReadEncoding", testWriteAndSetAndGetAndReadEncoding),
                 ("testPossiblyLazilyBridgedString", testPossiblyLazilyBridgedString),
+                ("testWithVeryUnsafeMutableBytesWorksOnEmptyByteBuffer", testWithVeryUnsafeMutableBytesWorksOnEmptyByteBuffer),
+                ("testWithVeryUnsafeMutableBytesYieldsPointerToWholeStorage", testWithVeryUnsafeMutableBytesYieldsPointerToWholeStorage),
+                ("testWithVeryUnsafeMutableBytesYieldsPointerToWholeStorageAndCanBeWritenTo", testWithVeryUnsafeMutableBytesYieldsPointerToWholeStorageAndCanBeWritenTo),
+                ("testWithVeryUnsafeMutableBytesDoesCoW", testWithVeryUnsafeMutableBytesDoesCoW),
+                ("testWithVeryUnsafeMutableBytesDoesCoWonSlices", testWithVeryUnsafeMutableBytesDoesCoWonSlices),
+                ("testGetDispatchDataWorks", testGetDispatchDataWorks),
+                ("testGetDispatchDataReadWrite", testGetDispatchDataReadWrite),
            ]
    }
 }


### PR DESCRIPTION
better DispatchData support
Motivation:

DispatchData's APIs are less than optimal and the current one we used
did allocate at least on Linux to copy bytes out.

Modifications:

introduce ByteBuffer.write/read/set/getDispatchData

Result:

when Dispatch gets fixed, lower allocations