### PR TITLE
prefer non-deprecated API for Data/Range

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -324,13 +324,7 @@ public struct ByteBuffer {
     private mutating func _copyStorageAndRebase(capacity: _Capacity, resetIndices: Bool = false) {
         let indexRebaseAmount = resetIndices ? self._readerIndex : 0
         let storageRebaseAmount = self._slice.lowerBound + indexRebaseAmount
-        let _newSlice = storageRebaseAmount ..< min(storageRebaseAmount + _toCapacity(self._slice.count), self._slice.upperBound, storageRebaseAmount + capacity)
-        #if swift(>=4.2)
-        // no need for the conversion anymore
-        let newSlice = _newSlice
-        #else
-        let newSlice = Range(_newSlice)
-        #endif
+        let newSlice = storageRebaseAmount ..< min(storageRebaseAmount + _toCapacity(self._slice.count), self._slice.upperBound, storageRebaseAmount + capacity)
         self._storage = self._storage.reallocSlice(newSlice, capacity: capacity)
         self._moveReaderIndex(to: self._readerIndex - indexRebaseAmount)
         self._moveWriterIndex(to: self._writerIndex - indexRebaseAmount)

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -339,7 +339,7 @@ class ByteBufferTest: XCTestCase {
 
     func testSetGetData() throws {
         var buffer = allocator.buffer(capacity: 32)
-        let data = Data(bytes: [1, 2, 3])
+        let data = Data([1, 2, 3])
 
         XCTAssertEqual(3, buffer.set(bytes: data, at: 0))
         XCTAssertEqual(0, buffer.readableBytes)
@@ -348,7 +348,7 @@ class ByteBufferTest: XCTestCase {
 
     func testWriteReadData() throws {
         var buffer = allocator.buffer(capacity: 32)
-        let data = Data(bytes: [1, 2, 3])
+        let data = Data([1, 2, 3])
 
         XCTAssertEqual(3, buffer.write(bytes: data))
         XCTAssertEqual(3, buffer.readableBytes)
@@ -494,7 +494,7 @@ class ByteBufferTest: XCTestCase {
         buf.write(integer: value, endianness: .little)
         buf.write(integer: value)
         let actual = buf.getData(at: 4, length: 12)!
-        let expected = Data(bytes: [0x12, 0x34, 0x56, 0x78, 0x78, 0x56, 0x34, 0x12, 0x12, 0x34, 0x56, 0x78])
+        let expected = Data([0x12, 0x34, 0x56, 0x78, 0x78, 0x56, 0x34, 0x12, 0x12, 0x34, 0x56, 0x78])
         XCTAssertEqual(expected, actual)
         let actualA: UInt32 = buf.readInteger(endianness: .big)!
         let actualB: UInt32 = buf.readInteger(endianness: .little)!


### PR DESCRIPTION
Motivation:

Deprecated API sucks.

Modifications:

Use non-deprecated API for Data/Range stuff

Result:

better code
