### PR TITLE
EventLoopFuture: use Result type

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -440,7 +440,7 @@ public final class ClientBootstrap {
                 channel.close(promise: nil)
             }
 
-            connectPromise.futureResult.whenComplete {
+            connectPromise.futureResult.whenComplete { (_: Result<Void, Error>) in
                 cancelTask.cancel()
             }
             return connectPromise.futureResult

--- a/Sources/NIO/ChannelHandlers.swift
+++ b/Sources/NIO/ChannelHandlers.swift
@@ -223,7 +223,7 @@ public class IdleStateHandler: ChannelDuplexHandler {
         }
 
         let writePromise = promise ?? ctx.eventLoop.makePromise()
-        writePromise.futureResult.whenComplete {
+        writePromise.futureResult.whenComplete { (_: Result<Void, Error>) in
             self.lastWriteCompleteTime = DispatchTime.now()
         }
         ctx.write(data, promise: writePromise)

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -116,7 +116,7 @@ public final class RepeatedTask {
         }
 
         scheduled.futureResult.whenSuccess { future in
-            future.whenComplete {
+            future.whenComplete { (_: Result<Void, Error>) in
                 self.reschedule0()
             }
         }
@@ -957,7 +957,7 @@ final public class MultiThreadedEventLoopGroup: EventLoopGroup {
             g.enter()
             loop.closeGently().mapIfError { err in
                 q.sync { error = err }
-            }.whenComplete {
+            }.whenComplete { (_: Result<Void, Error>) in
                 g.leave()
             }
         }

--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -606,7 +606,7 @@ internal class HappyEyeballsConnector {
             self.targets.aResultsAvailable(results)
         }.mapIfError { err in
             self.error.dnsAError = err
-        }.whenComplete {
+        }.whenComplete { (_: Result<Void, Error>) in
             self.dnsResolutions += 1
             self.processInput(.resolverACompleted)
         }
@@ -618,7 +618,7 @@ internal class HappyEyeballsConnector {
             self.targets.aaaaResultsAvailable(results)
         }.mapIfError { err in
             self.error.dnsAAAAError = err
-        }.whenComplete {
+        }.whenComplete { (_: Result<Void, Error>) in
             // It's possible that we were waiting to time out here, so if we were we should
             // cancel that.
             self.resolutionTask?.cancel()

--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -206,7 +206,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
                     if bufferedMessages.count > 0 {
                         ctx.fireChannelReadComplete()
                     }
-                }.whenComplete {
+                }.whenComplete { (_: Result<Void, Error>) in
                     ctx.pipeline.remove(ctx: ctx, promise: nil)
                 }
             }

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -358,7 +358,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                         } else {
                             return ctx.close()
                         }
-                    }.whenComplete {
+                    }.whenComplete { (_: Result<Void, Error>) in
                         _ = try? file.close()
                     }
                 case .sendfile:
@@ -370,7 +370,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                         return p.futureResult
                     }.thenIfError { (_: Error) in
                         ctx.close()
-                    }.whenComplete {
+                    }.whenComplete { (_: Result<Void, Error>) in
                         _ = try? file.close()
                     }
                 }
@@ -387,7 +387,7 @@ private final class HTTPHandler: ChannelInboundHandler {
 
         let promise = self.keepAlive ? promise : (promise ?? ctx.eventLoop.makePromise())
         if !self.keepAlive {
-            promise!.futureResult.whenComplete { ctx.close(promise: nil) }
+            promise!.futureResult.whenComplete { (_: Result<Void, Error>) in ctx.close(promise: nil) }
         }
         self.handler = nil
 

--- a/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
@@ -118,7 +118,7 @@ public class ApplicationProtocolNegotiationHandler: ChannelInboundHandler {
         }
 
         let switchFuture = completionHandler(result)
-        switchFuture.whenComplete {
+        switchFuture.whenComplete { (_: Result<Void, Error>) in
             self.unbuffer(context: context)
             context.pipeline.remove(handler: self, promise: nil)
         }

--- a/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
@@ -309,7 +309,7 @@ public final class WebSocketFrameDecoder: ByteToMessageDecoder {
             let frame = WebSocketFrame(fin: true,
                                        opcode: .connectionClose,
                                        data: data)
-            ctx.writeAndFlush(self.wrapInboundOut(frame)).whenComplete {
+            ctx.writeAndFlush(self.wrapInboundOut(frame)).whenComplete { (_: Result<Void, Error>) in
                 ctx.close(promise: nil)
             }
         }

--- a/Sources/NIOWebSocket/WebSocketProtocolErrorHandler.swift
+++ b/Sources/NIOWebSocket/WebSocketProtocolErrorHandler.swift
@@ -32,7 +32,7 @@ public final class WebSocketProtocolErrorHandler: ChannelInboundHandler {
             let frame = WebSocketFrame(fin: true,
                                        opcode: .connectionClose,
                                        data: data)
-            ctx.writeAndFlush(self.wrapOutboundOut(frame)).whenComplete {
+            ctx.writeAndFlush(self.wrapOutboundOut(frame)).whenComplete { (_: Result<Void, Error>) in
                 ctx.close(promise: nil)
             }
         }

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -81,7 +81,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                                     headers: headers)
         ctx.write(self.wrapOutboundOut(.head(responseHead)), promise: nil)
         ctx.write(self.wrapOutboundOut(.body(.byteBuffer(self.responseBody))), promise: nil)
-        ctx.write(self.wrapOutboundOut(.end(nil))).whenComplete {
+        ctx.write(self.wrapOutboundOut(.end(nil))).whenComplete { (_: Result<Void, Error>) in
             ctx.close(promise: nil)
         }
         ctx.flush()
@@ -95,7 +95,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                                     status: .methodNotAllowed,
                                     headers: headers)
         ctx.write(self.wrapOutboundOut(.head(head)), promise: nil)
-        ctx.write(self.wrapOutboundOut(.end(nil))).whenComplete {
+        ctx.write(self.wrapOutboundOut(.end(nil))).whenComplete { (_: Result<Void, Error>) in
             ctx.close(promise: nil)
         }
         ctx.flush()
@@ -194,7 +194,7 @@ private final class WebSocketTimeHandler: ChannelInboundHandler {
         var data = ctx.channel.allocator.buffer(capacity: 2)
         data.write(webSocketErrorCode: .protocolError)
         let frame = WebSocketFrame(fin: true, opcode: .connectionClose, data: data)
-        ctx.write(self.wrapOutboundOut(frame)).whenComplete {
+        ctx.write(self.wrapOutboundOut(frame)).whenComplete { (_: Result<Void, Error>) in
             ctx.close(mode: .output, promise: nil)
         }
         awaitingClose = true

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
@@ -36,7 +36,7 @@ private class PromiseOrderer {
         let thisPromiseIndex = promiseArray.count
         promiseArray.append(promise)
 
-        promise.futureResult.whenComplete {
+        promise.futureResult.whenComplete { (_: Result<Void, Error>) in
             let priorFutures = self.promiseArray[0..<thisPromiseIndex]
             let subsequentFutures = self.promiseArray[(thisPromiseIndex + 1)...]
             let allPriorFuturesFired = priorFutures.map { $0.futureResult.isFulfilled }.allSatisfy { $0 }

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -124,12 +124,12 @@ class HTTPServerClientTest : XCTestCase {
                     b.write(string: replyString)
 
                     let outbound = self.outboundBody(b)
-                    ctx.write(self.wrapOutboundOut(outbound.body)).whenComplete {
+                    ctx.write(self.wrapOutboundOut(outbound.body)).whenComplete { (_: Result<Void, Error>) in
                         outbound.destructor()
                     }
                     ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
                         XCTFail("unexpected error \(error)")
-                    }.whenComplete {
+                    }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
                         self.maybeClose(ctx: ctx)
                     }
@@ -148,13 +148,13 @@ class HTTPServerClientTest : XCTestCase {
                         let outbound = self.outboundBody(b)
                         ctx.write(self.wrapOutboundOut(outbound.body)).mapIfError { error in
                             XCTFail("unexpected error \(error)")
-                        }.whenComplete {
+                        }.whenComplete { (_: Result<Void, Error>) in
                             outbound.destructor()
                         }
                     }
                     ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
                         XCTFail("unexpected error \(error)")
-                    }.whenComplete {
+                    }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
                         self.maybeClose(ctx: ctx)
                     }
@@ -174,7 +174,7 @@ class HTTPServerClientTest : XCTestCase {
                         let outbound = self.outboundBody(b)
                         ctx.write(self.wrapOutboundOut(outbound.body)).mapIfError { error in
                             XCTFail("unexpected error \(error)")
-                        }.whenComplete {
+                        }.whenComplete { (_: Result<Void, Error>) in
                             outbound.destructor()
                         }
                     }
@@ -184,7 +184,7 @@ class HTTPServerClientTest : XCTestCase {
                     trailers.add(name: "X-Should-Trail", value: "sure")
                     ctx.write(self.wrapOutboundOut(.end(trailers))).mapIfError { error in
                         XCTFail("unexpected error \(error)")
-                    }.whenComplete {
+                    }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
                         self.maybeClose(ctx: ctx)
                     }
@@ -209,12 +209,12 @@ class HTTPServerClientTest : XCTestCase {
                     let outbound = self.outboundBody(buf)
                     ctx.writeAndFlush(self.wrapOutboundOut(outbound.body)).mapIfError { error in
                         XCTFail("unexpected error \(error)")
-                    }.whenComplete {
+                    }.whenComplete { (_: Result<Void, Error>) in
                         outbound.destructor()
                     }
                     ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
                         XCTFail("unexpected error \(error)")
-                    }.whenComplete {
+                    }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
                         self.maybeClose(ctx: ctx)
                     }
@@ -227,7 +227,7 @@ class HTTPServerClientTest : XCTestCase {
                     }
                     ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
                         XCTFail("unexpected error \(error)")
-                    }.whenComplete {
+                    }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
                         self.maybeClose(ctx: ctx)
                     }
@@ -239,7 +239,7 @@ class HTTPServerClientTest : XCTestCase {
                     }
                     ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
                         XCTFail("unexpected error \(error)")
-                    }.whenComplete {
+                    }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
                         self.maybeClose(ctx: ctx)
                     }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -972,7 +972,7 @@ public class ChannelTests: XCTestCase {
             pwm.markFlushCheckpoint()
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[2])
 
-            ps[0].futureResult.whenComplete {
+            ps[0].futureResult.whenComplete { (_: Result<Void, Error>) in
                 pwm.failAll(error: ChannelError.inputClosed, close: true)
             }
 

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -350,7 +350,7 @@ class EchoServerClientTest : XCTestCase {
                     default:
                         XCTFail("unexpected error: \(err)")
                     }
-                }.whenComplete {
+                }.whenComplete { (_: Result<Void, Error>) in
                     self.channelInactivePromise.succeed(result: ())
                 }
             }
@@ -370,7 +370,7 @@ class EchoServerClientTest : XCTestCase {
                     default:
                         XCTFail("unexpected error: \(err)")
                     }
-                }.whenComplete {
+                }.whenComplete { (_: Result<Void, Error>) in
                     self.channelUnregisteredPromise.succeed(result: ())
                 }
             }
@@ -603,7 +603,7 @@ class EchoServerClientTest : XCTestCase {
             }
 
             private func writeUntilFailed(_ ctx: ChannelHandlerContext, _ buffer: ByteBuffer) {
-                ctx.writeAndFlush(NIOAny(buffer)).whenComplete {
+                ctx.writeAndFlush(NIOAny(buffer)).whenComplete { (_: Result<Void, Error>) in
                     ctx.eventLoop.execute {
                         self.writeUntilFailed(ctx, buffer)
                     }
@@ -635,7 +635,7 @@ class EchoServerClientTest : XCTestCase {
                     ctx.writeAndFlush(NIOAny(buffer))
                 }.then {
                     ctx.close()
-                }.whenComplete {
+                }.whenComplete { (_: Result<Void, Error>) in
                     self.dpGroup.leave()
                 }
             }

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -160,14 +160,14 @@ class EmbeddedChannelTest: XCTestCase {
         let channel = EmbeddedChannel()
         XCTAssertFalse(channel.isActive)
         let connectPromise = channel.eventLoop.makePromise(of: Void.self)
-        connectPromise.futureResult.whenComplete {
+        connectPromise.futureResult.whenComplete { (_: Result<Void, Error>) in
             XCTAssertTrue(channel.isActive)
         }
         channel.connect(to: try SocketAddress(ipAddress: "127.0.0.1", port: 0), promise: connectPromise)
         try connectPromise.futureResult.wait()
 
         let closePromise = channel.eventLoop.makePromise(of: Void.self)
-        closePromise.futureResult.whenComplete {
+        closePromise.futureResult.whenComplete { (_: Result<Void, Error>) in
             XCTAssertFalse(channel.isActive)
         }
 

--- a/Tests/NIOTests/EmbeddedEventLoopTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest.swift
@@ -215,7 +215,7 @@ public class EmbeddedEventLoopTest: XCTestCase {
             XCTFail("Scheduled future completed")
         }.mapIfError { caughtErr in
             XCTAssertTrue(err === caughtErr as? EmbeddedTestError)
-        }.whenComplete {
+        }.whenComplete { (_: Result<Void, Error>) in
             fired = true
         }
 

--- a/Tests/NIOTests/HappyEyeballsTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest.swift
@@ -72,7 +72,7 @@ private class ConnectRecorder: ChannelOutboundHandler {
 
     public func close(ctx: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
         let connectPromise = promise ?? ctx.eventLoop.makePromise()
-        connectPromise.futureResult.whenComplete {
+        connectPromise.futureResult.whenComplete { (_: Result<Void, Error>) in
             self.state = .closed
         }
         ctx.close(promise: connectPromise)

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
@@ -50,11 +50,6 @@ private extension SocketAddress {
 }
 
 class PendingDatagramWritesManagerTests: XCTestCase {
-    private enum FakeWriteResult {
-        case ok(IOResult<Int>)
-        case error(Error)
-    }
-
     private func withPendingDatagramWritesManager(_ body: (PendingDatagramWritesManager) throws -> Void) rethrows {
         try withExtendedLifetime(NSObject()) { o in
             var iovecs: [IOVector] = Array(repeating: iovec(), count: Socket.writevLimitIOVectors + 1)
@@ -107,7 +102,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                            promises: [EventLoopPromise<Void>],
                                            expectedSingleWritabilities: [(Int, SocketAddress)]?,
                                            expectedVectorWritabilities: [[(Int, SocketAddress)]]?,
-                                           returns: [FakeWriteResult],
+                                           returns: [Result<IOResult<Int>, Error>],
                                            promiseStates: [[Bool]],
                                            file: StaticString = #file,
                                            line: UInt = #line) throws -> OverallWriteResult {
@@ -131,9 +126,9 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                         XCTAssertEqual(expected[singleState].1.expectedSize, len, "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].1.expectedSize) socklen expected but \(len) received", file: file, line: line)
 
                         switch returns[everythingState] {
-                        case .ok(let r):
+                        case .success(let r):
                             return r
-                        case .error(let e):
+                        case .failure(let e):
                             throw e
                         }
                     } else {
@@ -165,9 +160,9 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                             file:file, line: line)
 
                         switch returns[everythingState] {
-                        case .ok(let r):
+                        case .success(let r):
                             return r
-                        case .error(let e):
+                        case .failure(let e):
                             throw e
                         }
                     } else {
@@ -248,7 +243,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        promises: ps,
                                                        expectedSingleWritabilities: [(0, address)],
                                                        expectedVectorWritabilities: nil,
-                                                       returns: [.ok(.processed(0))],
+                                                       returns: [.success(.processed(0))],
                                                        promiseStates: [[true, false]])
 
             XCTAssertFalse(pwm.isEmpty)
@@ -269,7 +264,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    promises: ps,
                                                    expectedSingleWritabilities: [(0, address)],
                                                    expectedVectorWritabilities: nil,
-                                                   returns: [.ok(.processed(0))],
+                                                   returns: [.success(.processed(0))],
                                                    promiseStates: [[true, true]])
             XCTAssertEqual(.writtenCompletely, result)
         }
@@ -296,7 +291,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        promises: ps,
                                                        expectedSingleWritabilities: nil,
                                                        expectedVectorWritabilities: [[(4, firstAddress), (4, secondAddress)]],
-                                                       returns: [.ok(.processed(2))],
+                                                       returns: [.success(.processed(2))],
                                                        promiseStates: [[true, true, false]])
             XCTAssertEqual(.writtenCompletely, result)
 
@@ -306,7 +301,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    promises: ps,
                                                    expectedSingleWritabilities: [(0, firstAddress)],
                                                    expectedVectorWritabilities: nil,
-                                                   returns: [.ok(.processed(0))],
+                                                   returns: [.success(.processed(0))],
                                                    promiseStates: [[true, true, true]])
             XCTAssertEqual(.writtenCompletely, result)
         }
@@ -336,7 +331,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                             [(4, firstAddress), (4, secondAddress), (4, firstAddress), (4, secondAddress)],
                                                             [(4, secondAddress), (4, firstAddress), (4, secondAddress)]
                                                        ],
-                                                       returns: [.ok(.processed(1)), .ok(.wouldBlock(0))],
+                                                       returns: [.success(.processed(1)), .success(.wouldBlock(0))],
                                                        promiseStates: [[true, false, false, false], [true, false, false, false]])
 
             XCTAssertEqual(.couldNotWriteEverything, result)
@@ -346,7 +341,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    expectedVectorWritabilities: [
                                                         [(4, secondAddress), (4, firstAddress), (4, secondAddress)],
                                                    ],
-                                                   returns: [.ok(.processed(2)), .ok(.wouldBlock(0))],
+                                                   returns: [.success(.processed(2)), .success(.wouldBlock(0))],
                                                    promiseStates: [[true, true, true, false], [true, true, true, false]]
 
             )
@@ -356,7 +351,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    promises: ps,
                                                    expectedSingleWritabilities: [(4, secondAddress)],
                                                    expectedVectorWritabilities: nil,
-                                                   returns: [.ok(.processed(4))],
+                                                   returns: [.success(.processed(4))],
                                                    promiseStates: [[true, true, true, true]])
             XCTAssertEqual(.writtenCompletely, result)
         }
@@ -386,7 +381,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        promises: ps,
                                                        expectedSingleWritabilities: nil,
                                                        expectedVectorWritabilities: Array(actualVectorWritabilities),
-                                                       returns: Array(repeating: .ok(.processed(1)), count: ps.count - 1),
+                                                       returns: Array(repeating: .success(.processed(1)), count: ps.count - 1),
                                                        promiseStates: actualPromiseStates)
             XCTAssertEqual(.couldNotWriteEverything, result)
 
@@ -395,7 +390,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    promises: ps,
                                                    expectedSingleWritabilities: [(12, address)],
                                                    expectedVectorWritabilities: nil,
-                                                   returns: [.ok(.processed(12))],
+                                                   returns: [.success(.processed(12))],
                                                    promiseStates: [Array(repeating: true, count: ps.count - 1) + [true]])
             XCTAssertEqual(.writtenCompletely, result)
         }
@@ -420,7 +415,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        promises: ps,
                                                        expectedSingleWritabilities: nil,
                                                        expectedVectorWritabilities: [[(4, address), (4, address)]],
-                                                       returns: [.ok(.wouldBlock(0))],
+                                                       returns: [.success(.wouldBlock(0))],
                                                        promiseStates: [[false, false, false], [false, false, false]])
             XCTAssertEqual(.couldNotWriteEverything, result)
 
@@ -456,7 +451,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        promises: ps,
                                                        expectedSingleWritabilities: [(halfTheWriteVLimit, address)],
                                                        expectedVectorWritabilities: [[(halfTheWriteVLimit, address), (halfTheWriteVLimit, address)]],
-                                                       returns: [.ok(.processed(2)), .ok(.processed(1))],
+                                                       returns: [.success(.processed(2)), .success(.processed(1))],
                                                        promiseStates: [[true, true, false], [true, true, true]])
             XCTAssertEqual(.writtenCompletely, result)
         }
@@ -496,9 +491,9 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                                                      (Socket.writevLimitBytes - 77, address)],
                                                        expectedVectorWritabilities: [[(Socket.writevLimitBytes - 77, address)]],
                                                        returns: [
-                                                            .error(IOError(errnoCode: EMSGSIZE, reason: "")),
-                                                            .ok(.processed(1)),
-                                                            .ok(.processed(1))],
+                                                            .failure(IOError(errnoCode: EMSGSIZE, reason: "")),
+                                                            .success(.processed(1)),
+                                                            .success(.processed(1))],
                                                        promiseStates: [[true, false, false], [true, true, false], [true, true, true]])
 
             XCTAssertEqual(.writtenCompletely, result)
@@ -534,7 +529,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        promises: ps,
                                                        expectedSingleWritabilities: nil,
                                                        expectedVectorWritabilities: [[(0, address), (0, address)]],
-                                                       returns: [.ok(.processed(2))],
+                                                       returns: [.success(.processed(2))],
                                                        promiseStates: [[true, true, false]])
             XCTAssertEqual(.writtenCompletely, result)
 
@@ -544,7 +539,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    promises: ps,
                                                    expectedSingleWritabilities: [(0, address)],
                                                    expectedVectorWritabilities: nil,
-                                                   returns: [.ok(.processed(0))],
+                                                   returns: [.success(.processed(0))],
                                                    promiseStates: [[true, true, true]])
             XCTAssertEqual(.writtenCompletely, result)
         }
@@ -564,7 +559,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
             pwm.markFlushCheckpoint()
             _ = pwm.add(envelope: AddressedEnvelope(remoteAddress: address, data: buffer), promise: ps[2])
 
-            ps[0].futureResult.whenComplete {
+            ps[0].futureResult.whenComplete { (_: Result<Void, Error>) in
                 pwm.failAll(error: ChannelError.inputClosed, close: true)
             }
 
@@ -572,7 +567,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        promises: ps,
                                                        expectedSingleWritabilities: nil,
                                                        expectedVectorWritabilities: [[(4, address), (4, address)]],
-                                                       returns: [.ok(.processed(1))],
+                                                       returns: [.success(.processed(1))],
                                                        promiseStates: [[true, true, true]])
             XCTAssertEqual(.writtenCompletely, result)
             XCTAssertNoThrow(try ps[0].futureResult.wait())
@@ -599,7 +594,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        promises: ps,
                                                        expectedSingleWritabilities: [(4, address)],
                                                        expectedVectorWritabilities: [Array(repeating: (4, address), count: Socket.writevLimitIOVectors)],
-                                                       returns: [.ok(.processed(Socket.writevLimitIOVectors)), .ok(.wouldBlock(0))],
+                                                       returns: [.success(.processed(Socket.writevLimitIOVectors)), .success(.wouldBlock(0))],
                                                        promiseStates: [Array(repeating: true, count: Socket.writevLimitIOVectors) + [false],
                                                                        Array(repeating: true, count: Socket.writevLimitIOVectors) + [false]])
             XCTAssertEqual(.couldNotWriteEverything, result)
@@ -607,7 +602,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    promises: ps,
                                                    expectedSingleWritabilities: [(4, address)],
                                                    expectedVectorWritabilities: nil,
-                                                   returns: [.ok(.processed(4))],
+                                                   returns: [.success(.processed(4))],
                                                    promiseStates: [Array(repeating: true, count: Socket.writevLimitIOVectors + 1)])
             XCTAssertEqual(.writtenCompletely, result)
         }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -445,10 +445,10 @@ public class SocketChannelTest : XCTestCase {
         let connectPromise = channel.eventLoop.makePromise(of: Void.self)
         let closePromise = channel.eventLoop.makePromise(of: Void.self)
 
-        closePromise.futureResult.whenComplete {
+        closePromise.futureResult.whenComplete { (_: Result<Void, Error>) in
             XCTAssertTrue(connectPromise.futureResult.isFulfilled)
         }
-        connectPromise.futureResult.whenComplete {
+        connectPromise.futureResult.whenComplete { (_: Result<Void, Error>) in
             XCTAssertFalse(closePromise.futureResult.isFulfilled)
         }
 
@@ -510,7 +510,7 @@ public class SocketChannelTest : XCTestCase {
                 XCTAssertEqual(.inactive, state)
                 state = .removed
 
-                ctx.channel.closeFuture.whenComplete {
+                ctx.channel.closeFuture.whenComplete { (_: Result<Void, Error>) in
                     XCTAssertNil(ctx.localAddress)
                     XCTAssertNil(ctx.remoteAddress)
 

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -28,3 +28,4 @@
 - `ByteBuffer.write(string:)` no longer returns an `Int?`, instead it
   returns `Int` and has had its return value made discardable.
 - removed ContiguousCollection
+- EventLoopFuture.whenComplete now provides Result<T, Error>


### PR DESCRIPTION
Motivation:

Now that the stdlib has introduced the Result type, we can use it in the
implementation (and the whenComplete) function of EventLoopFuture

Modifications:

- replace EventLoopValue with Result
- make whenComplete provide the Result

Result:

use the new shiny stuff