### PR TITLE
use automatic Equatable conformances

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -58,12 +58,7 @@ let sysFree: @convention(c) (UnsafeMutableRawPointer?) -> Void = free
     }
 #endif
 
-extension _ByteBufferSlice: Equatable {
-    @usableFromInline
-    static func ==(_ lhs: _ByteBufferSlice, _ rhs: _ByteBufferSlice) -> Bool {
-        return lhs._begin == rhs._begin && lhs.upperBound == rhs.upperBound
-    }
-}
+extension _ByteBufferSlice: Equatable {}
 
 /// The slice of a `ByteBuffer`, it's different from `Range<UInt32>` because the lower bound is actually only
 /// 24 bits (the upper bound is still 32). Before constructing, you need to make sure the lower bound actually

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -220,7 +220,7 @@ public protocol EventLoop: EventLoopGroup {
 /// Represents a time _interval_.
 ///
 /// - note: `TimeAmount` should not be used to represent a point in time.
-public struct TimeAmount {
+public struct TimeAmount: Equatable {
     public typealias Value = Int64
 
     /// The nanoseconds representation of the `TimeAmount`.
@@ -288,10 +288,6 @@ public struct TimeAmount {
 extension TimeAmount: Comparable {
     public static func < (lhs: TimeAmount, rhs: TimeAmount) -> Bool {
         return lhs.nanoseconds < rhs.nanoseconds
-    }
-
-    public static func == (lhs: TimeAmount, rhs: TimeAmount) -> Bool {
-        return lhs.nanoseconds == rhs.nanoseconds
     }
 }
 

--- a/Sources/NIO/IO.swift
+++ b/Sources/NIO/IO.swift
@@ -79,7 +79,7 @@ extension IOError: CustomStringConvertible {
 }
 
 /// An result for an IO operation that was done on a non-blocking resource.
-enum IOResult<T: Equatable> {
+enum IOResult<T: Equatable>: Equatable {
 
     /// Signals that the IO operation could not be completed as otherwise we would need to block.
     case wouldBlock(T)
@@ -87,17 +87,3 @@ enum IOResult<T: Equatable> {
     /// Signals that the IO operation was completed.
     case processed(T)
 }
-
-extension IOResult: Equatable {
-    public static func ==(lhs: IOResult<T>, rhs: IOResult<T>) -> Bool {
-        switch (lhs, rhs) {
-        case (.wouldBlock(let lhs), .wouldBlock(let rhs)):
-            return lhs == rhs
-        case (.processed(let lhs), .processed(let rhs)):
-            return lhs == rhs
-        case (.wouldBlock, _), (.processed, _):
-            return false
-        }
-    }
-}
-

--- a/Sources/NIO/IOData.swift
+++ b/Sources/NIO/IOData.swift
@@ -22,18 +22,7 @@ public enum IOData {
 }
 
 /// `IOData` objects are comparable just like the values they wrap.
-extension IOData: Equatable {
-    public static func ==(lhs: IOData, rhs: IOData) -> Bool {
-        switch (lhs, rhs) {
-        case (.byteBuffer(let lhs), .byteBuffer(let rhs)):
-            return lhs == rhs
-        case (.fileRegion(let lhs), .fileRegion(let rhs)):
-            return lhs == rhs
-        case (.byteBuffer, _), (.fileRegion, _):
-            return false
-        }
-    }
-}
+extension IOData: Equatable {}
 
 /// `IOData` provide a number of readable bytes.
 extension IOData {

--- a/Sources/NIO/IntegerTypes.swift
+++ b/Sources/NIO/IntegerTypes.swift
@@ -68,12 +68,7 @@ extension _UInt24 {
     }
 }
 
-extension _UInt24: Equatable {
-    @usableFromInline
-    static func ==(_ lhs: _UInt24, _ rhs: _UInt24) -> Bool {
-        return lhs.b12 == rhs.b12 && lhs.b3 == rhs.b3
-    }
-}
+extension _UInt24: Equatable {}
 
 extension _UInt24: CustomStringConvertible {
     @usableFromInline
@@ -140,11 +135,7 @@ extension Int {
     }
 }
 
-extension _UInt56: Equatable {
-    static func ==(_ lhs: _UInt56, _ rhs: _UInt56) -> Bool {
-        return lhs.b1234 == rhs.b1234 && lhs.b56 == rhs.b56 && lhs.b7 == rhs.b7
-    }
-}
+extension _UInt56: Equatable {}
 
 extension _UInt56: CustomStringConvertible {
     var description: String {

--- a/Sources/NIO/LinuxCPUSet.swift
+++ b/Sources/NIO/LinuxCPUSet.swift
@@ -42,11 +42,7 @@ import CNIOLinux
         }
     }
 
-    extension LinuxCPUSet: Equatable {
-        public static func ==(lhs: LinuxCPUSet, rhs: LinuxCPUSet) -> Bool {
-            return lhs.cpuIds == rhs.cpuIds
-        }
-    }
+    extension LinuxCPUSet: Equatable {}
 
     /// Linux specific extension to `Thread`.
     internal extension Thread {

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -263,20 +263,7 @@ public enum HTTPPart<HeadT: Equatable, BodyT: Equatable> {
     case end(HTTPHeaders?)
 }
 
-extension HTTPPart: Equatable {
-    public static func ==(lhs: HTTPPart, rhs: HTTPPart) -> Bool {
-        switch (lhs, rhs) {
-        case (.head(let h1), .head(let h2)):
-            return h1 == h2
-        case (.body(let b1), .body(let b2)):
-            return b1 == b2
-        case (.end(let h1), .end(let h2)):
-            return h1 == h2
-        case (.head, _), (.body, _), (.end, _):
-            return false
-        }
-    }
-}
+extension HTTPPart: Equatable {}
 
 /// The components of a HTTP request from the view of a HTTP client.
 public typealias HTTPClientRequestPart = HTTPPart<HTTPRequestHead, IOData>
@@ -828,81 +815,6 @@ public enum HTTPMethod: Equatable {
         case unlikely
     }
 
-    public static func ==(lhs: HTTPMethod, rhs: HTTPMethod) -> Bool {
-        switch (lhs, rhs){
-        case (.GET, .GET):
-            return true
-        case (.PUT, .PUT):
-            return true
-        case (.ACL, .ACL):
-            return true
-        case (.HEAD, .HEAD):
-            return true
-        case (.POST, .POST):
-            return true
-        case (.COPY, .COPY):
-            return true
-        case (.LOCK, .LOCK):
-            return true
-        case (.MOVE, .MOVE):
-            return true
-        case (.BIND, .BIND):
-            return true
-        case (.LINK, .LINK):
-            return true
-        case (.PATCH, .PATCH):
-            return true
-        case (.TRACE, .TRACE):
-            return true
-        case (.MKCOL, .MKCOL):
-            return true
-        case (.MERGE, .MERGE):
-            return true
-        case (.PURGE, .PURGE):
-            return true
-        case (.NOTIFY, .NOTIFY):
-            return true
-        case (.SEARCH, .SEARCH):
-            return true
-        case (.UNLOCK, .UNLOCK):
-            return true
-        case (.REBIND, .REBIND):
-            return true
-        case (.UNBIND, .UNBIND):
-            return true
-        case (.REPORT, .REPORT):
-            return true
-        case (.DELETE, .DELETE):
-            return true
-        case (.UNLINK, .UNLINK):
-            return true
-        case (.CONNECT, .CONNECT):
-            return true
-        case (.MSEARCH, .MSEARCH):
-            return true
-        case (.OPTIONS, .OPTIONS):
-            return true
-        case (.PROPFIND, .PROPFIND):
-            return true
-        case (.CHECKOUT, .CHECKOUT):
-            return true
-        case (.PROPPATCH, .PROPPATCH):
-            return true
-        case (.SUBSCRIBE, .SUBSCRIBE):
-            return true
-        case (.MKCALENDAR, .MKCALENDAR):
-            return true
-        case (.MKACTIVITY, .MKACTIVITY):
-            return true
-        case (.UNSUBSCRIBE, .UNSUBSCRIBE):
-            return true
-        case (.RAW(let l), .RAW(let r)):
-            return l == r
-        default:
-            return false
-        }
-    }
-
     case GET
     case PUT
     case ACL
@@ -955,10 +867,6 @@ public enum HTTPMethod: Equatable {
 
 /// A structure representing a HTTP version.
 public struct HTTPVersion: Equatable {
-    public static func ==(lhs: HTTPVersion, rhs: HTTPVersion) -> Bool {
-        return lhs.major == rhs.major && lhs.minor == rhs.minor
-    }
-
     /// Create a HTTP version.
     ///
     /// - Parameter major: The major version number.

--- a/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
@@ -34,17 +34,6 @@ public enum ALPNResult: Equatable {
     /// ALPN negotiation either failed, or never took place. The application
     /// should fall back to a default protocol choice or close the connection.
     case fallback
-
-    public static func ==(lhs: ALPNResult, rhs: ALPNResult) -> Bool {
-        switch (lhs, rhs) {
-        case (.negotiated(let p1), .negotiated(let p2)):
-            return p1 == p2
-        case (.fallback, .fallback):
-            return true
-        case (.fallback, _), (.negotiated, _):
-            return false
-        }
-    }
 }
 
 /// A helper `ChannelInboundHandler` that makes it easy to swap channel pipelines

--- a/Sources/NIOTLS/SNIHandler.swift
+++ b/Sources/NIOTLS/SNIHandler.swift
@@ -36,17 +36,6 @@ private let sniHostNameType: UInt8 = 0
 public enum SNIResult: Equatable {
     case fallback
     case hostname(String)
-
-    public static func ==(lhs: SNIResult, rhs: SNIResult) -> Bool {
-        switch (lhs, rhs) {
-        case (.fallback, .fallback):
-            return true
-        case (.hostname(let s1), .hostname(let s2)):
-            return s1 == s2
-        case (.fallback, _), (.hostname, _):
-            return false
-        }
-    }
 }
 
 private enum InternalSNIErrors: Error {

--- a/Sources/NIOTLS/TLSEvents.swift
+++ b/Sources/NIOTLS/TLSEvents.swift
@@ -21,15 +21,4 @@ public enum TLSUserEvent: Equatable {
     /// The TLS connection has been successfully and cleanly shut down.
     /// No further application data can be sent or received at this time.
     case shutdownCompleted
-
-    public static func ==(lhs: TLSUserEvent, rhs: TLSUserEvent) -> Bool {
-        switch (lhs, rhs) {
-        case (.handshakeCompleted(let p1), .handshakeCompleted(let p2)):
-            return p1 == p2
-        case (.shutdownCompleted, .shutdownCompleted):
-            return true
-        case (.handshakeCompleted, _), (.shutdownCompleted, _):
-            return false
-        }
-    }
 }

--- a/Sources/NIOWebSocket/WebSocketErrorCodes.swift
+++ b/Sources/NIOWebSocket/WebSocketErrorCodes.swift
@@ -123,26 +123,7 @@ public enum WebSocketErrorCode {
     }
 }
 
-extension WebSocketErrorCode: Equatable {
-    public static func ==(lhs: WebSocketErrorCode, rhs: WebSocketErrorCode) -> Bool {
-        switch (lhs, rhs) {
-        case (.normalClosure, .normalClosure),
-             (.goingAway, .goingAway),
-             (.protocolError, .protocolError),
-             (.unacceptableData, .unacceptableData),
-             (.dataInconsistentWithMessage, .dataInconsistentWithMessage),
-             (.policyViolation, .policyViolation),
-             (.messageTooLarge, .messageTooLarge),
-             (.missingExtension, .missingExtension),
-             (.unexpectedServerError, .unexpectedServerError):
-            return true
-        case (.unknown(let l), .unknown(let r)):
-            return l == r
-        default:
-            return false
-        }
-    }
-}
+extension WebSocketErrorCode: Equatable {}
 
 public extension ByteBuffer {
     /// Read a websocket error code from a byte buffer.

--- a/Sources/NIOWebSocket/WebSocketFrame.swift
+++ b/Sources/NIOWebSocket/WebSocketFrame.swift
@@ -269,11 +269,4 @@ public struct WebSocketFrame {
     }
 }
 
-extension WebSocketFrame: Equatable {
-    public static func ==(lhs: WebSocketFrame, rhs: WebSocketFrame) -> Bool {
-        return lhs.firstByte == rhs.firstByte &&
-               lhs.maskKey == rhs.maskKey &&
-               lhs.data == rhs.data &&
-               lhs.extensionData == rhs.extensionData
-    }
-}
+extension WebSocketFrame: Equatable {}

--- a/Tests/NIOTests/HappyEyeballsTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest.swift
@@ -210,18 +210,6 @@ private class DummyResolver: Resolver {
 }
 
 extension DummyResolver.Event: Equatable {
-    fileprivate static func ==(lhs: DummyResolver.Event, rhs: DummyResolver.Event) -> Bool {
-        switch (lhs, rhs) {
-        case (.a(let host1, let port1), .a(let host2, let port2)):
-            return host1 == host2 && port1 == port2
-        case (.aaaa(let host1, let port1), .aaaa(let host2, let port2)):
-            return host1 == host2 && port1 == port2
-        case(.cancel, .cancel):
-            return true
-        case (.a, _), (.aaaa, _), (.cancel, _):
-            return false
-        }
-    }
 }
 
 private func defaultChannelBuilder(loop: EventLoop, family: Int32) -> EventLoopFuture<Channel> {


### PR DESCRIPTION
Motivation:

No code is the best code, let's have the compiler generate more
Equatable instances for us.

Modifications:

remove some hand-written Equatable conformances

Result:

less code, possibly fewer bugs