### PR TITLE
[NIO 1.12] remove bogus 'is active' assertion in channelRead0

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -1076,8 +1076,8 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
     }
 
     public func channelRead0(_ data: NIOAny) {
-        assert(self.lifecycleManager.isActive)
         // Do nothing by default
+        // note: we can't assert that we're active here as TailChannelHandler will call this on channelRead
     }
 
     public func errorCaught0(error: Error) {

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -51,6 +51,7 @@ extension ChannelPipelineTest {
                 ("testRemovingByNameWithFutureNotInChannel", testRemovingByNameWithFutureNotInChannel),
                 ("testRemovingByReferenceWithPromiseStillInChannel", testRemovingByReferenceWithPromiseStillInChannel),
                 ("testRemovingByReferenceWithFutureNotInChannel", testRemovingByReferenceWithFutureNotInChannel),
+                ("testFireChannelReadInInactiveChannelDoesNotCrash", testFireChannelReadInInactiveChannelDoesNotCrash),
            ]
    }
 }


### PR DESCRIPTION
(cherry picked from commit 722ceb869dbd8d4cdcfa9e916de063a3e6f05254)

Motivation:

BaseSocketChannel used to assert that `channelRead0` is only called when
the channel is active. That's bogus and it's trivial to hit this issue
when calling `fireChannelRead` in the last `ChannelHandler` when the
channel has gone inactive.

Modifications:

remove assertion, add comment

Result:

fewer crashes
