### PR TITLE
Actually remove promise logging info.

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -489,7 +489,7 @@ internal final class SelectableEventLoop: EventLoop {
     internal func promiseCreationStoreRemove<T>(future: EventLoopFuture<T>) -> (file: StaticString, line: UInt) {
         precondition(_isDebugAssertConfiguration())
         return self.promiseCreationStoreLock.withLock {
-            self._promiseCreationStore[ObjectIdentifier(future)]!
+            self._promiseCreationStore.removeValue(forKey: ObjectIdentifier(future))!
         }
     }
 


### PR DESCRIPTION
Motivation:

While it's really a good idea to keep track of where promises get
allocated, once the promise has been fulfilled we probably don't
need to keep track of it any more.

Happily this leak only affects debug mode.

Modifications:

- Actually removed the element from the promise log when we
  said we would.

Result:

Memory usage doesn't get totally out of hand in debug mode.


This patch should also be backported to the 1.12 branch.