### PR TITLE
Fix NIOHTTP1Server handleJustWrite always using response status "ok"

### DIFF
--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -173,7 +173,7 @@ private final class HTTPHandler: ChannelInboundHandler {
         case .head(let request):
             self.keepAlive = request.isKeepAlive
             self.state.requestReceived()
-            ctx.writeAndFlush(self.wrapOutboundOut(.head(httpResponseHead(request: request, status: .ok))), promise: nil)
+            ctx.writeAndFlush(self.wrapOutboundOut(.head(httpResponseHead(request: request, status: statusCode))), promise: nil)
         case .body(buffer: _):
             ()
         case .end:


### PR DESCRIPTION
Motivation:

Addressing the https://github.com/apple/swift-nio/issues/713

Modifications:

Forward the statusCode from NIOHTTP1Server main handleJustWrite to ctx.writeAndFlush instead of always using "ok"

Result:

ChannelHandlerContext will write the correct status code even when it's not "ok"