### PR TITLE
make ELF.cascade accept an optional promise

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -802,9 +802,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         registerPromise.futureResult.whenFailure { (_: Error) in
             self.close(promise: nil)
         }
-        if let promise = promise {
-            registerPromise.futureResult.cascadeFailure(promise: promise)
-        }
+        registerPromise.futureResult.cascadeFailure(promise: promise)
 
         if self.lifecycleManager.isPreRegistered {
             // we expect kqueue/epoll registration to always succeed which is basically true, except for errors that

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -395,9 +395,7 @@ public final class ChannelPipeline: ChannelInvoker {
             self.remove0(ctx: ctx, promise: promise)
         }
 
-        if let promise = promise {
-            contextFuture.cascadeFailure(promise: promise)
-        }
+        contextFuture.cascadeFailure(promise: promise)
     }
 
     /// Remove a `ChannelHandler` from the `ChannelPipeline`.
@@ -412,9 +410,7 @@ public final class ChannelPipeline: ChannelInvoker {
             self.remove0(ctx: ctx, promise: promise)
         }
 
-        if let promise = promise {
-            contextFuture.cascadeFailure(promise: promise)
-        }
+        contextFuture.cascadeFailure(promise: promise)
     }
 
     /// Remove a `ChannelHandler` from the `ChannelPipeline`.

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -770,7 +770,8 @@ extension EventLoopFuture {
     ///
     /// - parameters:
     ///     - promise: The `EventLoopPromise` to fulfill with the results of this future.
-    public func cascadeFailure<U>(promise: EventLoopPromise<U>) {
+    public func cascadeFailure<U>(promise: EventLoopPromise<U>?) {
+        guard let promise = promise else { return }
         self.whenFailure { err in
             promise.fail(error: err)
         }

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -749,7 +749,8 @@ extension EventLoopFuture {
     ///
     /// - parameters:
     ///     - promise: The `EventLoopPromise` to fulfill with the results of this future.
-    public func cascade(promise: EventLoopPromise<T>) {
+    public func cascade(promise: EventLoopPromise<T>?) {
+        guard let promise = promise else { return }
         _whenCompleteWithValue { v in
             switch v {
             case .failure(let err):

--- a/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
@@ -315,7 +315,7 @@ public final class HTTPServerPipelineHandler: ChannelDuplexHandler {
             case .quiescingLastRequestEndReceived:
                 ctx.write(data).then {
                     ctx.close()
-                }.cascade(promise: promise ?? ctx.channel.eventLoop.makePromise())
+                }.cascade(promise: promise)
             case .acceptingEvents, .quiescingWaitingForRequestEnd:
                 ctx.write(data, promise: promise)
             }


### PR DESCRIPTION
Make EventLoopFuture.cascade and EventLoopFuture.cascadeFailure accept an optional promise

### Motivation:

Addressing #756

Code like this

```Swift
    let f = ctx.connect(to: address).then {
        ctx.channel.setOption(option: NIOTSChannelOptions.waitForActivity, value: false)
    }
    if let promise = promise {
        f.cascade(promise: promise)
        // or f.cascadeFailure(promise)
    }
```

can be replaced with this

```Swift
    let f = ctx.connect(to: address).then {
        ctx.channel.setOption(option: NIOTSChannelOptions.waitForActivity, value: false)
    }.cascade(promise)
    // or }.cascadeFailure(promise)
```

### Modifications:

Change EventLoopFuture.cascade to `func cascade(promise: EventLoopPromise<T>?)`
Change EventLoopFuture.cascadeFailure to `func cascadeFailure<U>(promise: EventLoopPromise<U>?)`

### Result:

`cascade` and `cascadeFailure` can be called without needing to check if the promise is nil