### PR TITLE
actually enable warnings as errors

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -27,6 +27,7 @@ services:
 
   test:
     image: swift-nio:18.04-5.0
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors && ./scripts/integration_tests.sh"
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=38750
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050


### PR DESCRIPTION
Motivation:

Forgot to introduce the -warnings-as-errors parameter in the `test:`
directive in the docker compose file.

Modifications:

added warnings-to-errors to the docker-compose.yml for 5.0

Result:

warnings to errors
