### PR TITLE
[1.12 backport] speed up getBytes

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -37,7 +37,10 @@ extension ByteBuffer {
         }
 
         return self.withVeryUnsafeBytes { ptr in
-            Array<UInt8>(ptr[index..<(index+length)])
+            // this is not technically correct because we shouldn't just bind
+            // the memory to `UInt8` but it's not a real issue either and we
+            // need to work around https://bugs.swift.org/browse/SR-9604
+            Array<UInt8>(UnsafeRawBufferPointer(rebasing: ptr[index..<(index+length)]).bindMemory(to: UInt8.self))
         }
     }
 


### PR DESCRIPTION
Motivation:

Due to https://bugs.swift.org/browse/SR-9604, ByteBuffer.getBytes
seriously regressed (factor 10x) since NIO 1.11 . This works around it
until the issue is fixed.

Modifications:

bind the memory to UInt8s to get an UnsafeBufferPointer<UInt8> rather
than an UnsafeRawBufferPointer.

Result:

- getBytes 10x faster
- make @John-Connolly happy, thanks for reporting!

(cherry picked from commit 264fbe0f315bd50e4a5b81b92ffc5cc93dc558f3)