### PR TITLE
define NIO_CI_BUILD in the CI builds

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -14,7 +14,7 @@ services:
 
   unit-tests:
     image: swift-nio:18.04-5.0
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors"
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors -Xswiftc -DNIO_CI_BUILD"
 
   integration-tests:
     image: swift-nio:18.04-5.0
@@ -27,7 +27,7 @@ services:
 
   test:
     image: swift-nio:18.04-5.0
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors && ./scripts/integration_tests.sh"
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors -Xswiftc -DNIO_CI_BUILD && ./scripts/integration_tests.sh"
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=38750
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
 
   unit-tests:
     <<: *common
-    command: /bin/bash -cl "swift test"
+    command: /bin/bash -cl "swift test -Xswiftc -DNIO_CI_BUILD"
 
   integration-tests:
     <<: *common
@@ -33,7 +33,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -cl "swift test && ./scripts/integration_tests.sh"
+    command: /bin/bash -cl "swift test -Xswiftc -DNIO_CI_BUILD && ./scripts/integration_tests.sh"
 
   echo:
     <<: *common


### PR DESCRIPTION
Motivation:

Certain warnings we want to ignore in CI builds but we want to keep
`-warnings-to-errors` on.

Modifications:

define `NIO_CI_BUILD` in the CI builds

Result:

can ignore select warnings in CI
