### PR TITLE
better ChannelHandler removal API

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -341,6 +341,9 @@ public enum ChannelError: Error {
 
     /// An operation that was inappropriate given the current `Channel` state was attempted.
     case inappropriateOperationForState
+
+    /// An attempt was made to remove a ChannelHandler that is not removable.
+    case unremovableHandler
 }
 
 extension ChannelError: Equatable { }

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -143,7 +143,7 @@ private protocol AnyHTTPDecoder: class {
 /// `ChannelPipeline` than the `HTTPResponseEncoder`.
 ///
 /// Rather than set this up manually, consider using `ChannelPipeline.addHTTPServerHandlers`.
-public final class HTTPRequestDecoder: HTTPDecoder<HTTPServerRequestPart> {
+public final class HTTPRequestDecoder: HTTPDecoder<HTTPServerRequestPart>, RemovableChannelHandler {
     public convenience init() {
         self.init(leftOverBytesStrategy: .dropBytes)
     }

--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -161,7 +161,7 @@ public final class HTTPRequestEncoder: ChannelOutboundHandler {
 ///
 /// This channel handler is used to translate messages from a series of
 /// `HTTPServerResponsePart` into the HTTP/1.1 wire format.
-public final class HTTPResponseEncoder: ChannelOutboundHandler {
+public final class HTTPResponseEncoder: ChannelOutboundHandler, RemovableChannelHandler {
     public typealias OutboundIn = HTTPServerResponsePart
     public typealias OutboundOut = IOData
 

--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -64,7 +64,7 @@ public extension ChannelPipeline {
         let responseEncoder = HTTPResponseEncoder()
         let requestDecoder = HTTPRequestDecoder(leftOverBytesStrategy: upgrade == nil ? .dropBytes : .forwardBytes)
 
-        var handlers: [ChannelHandler] = [responseEncoder, requestDecoder]
+        var handlers: [RemovableChannelHandler] = [responseEncoder, requestDecoder]
 
         if pipelining {
             handlers.append(HTTPServerPipelineHandler())

--- a/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
@@ -57,7 +57,7 @@ internal func debugOnly(_ body: () -> Void) {
 /// or during a request body upload, it will be delivered immediately. If a half-close is
 /// received immediately after `HTTPServerRequestPart.end`, it will also be passed along
 /// immediately, allowing this signal to be seen by the HTTP server as early as possible.
-public final class HTTPServerPipelineHandler: ChannelDuplexHandler {
+public final class HTTPServerPipelineHandler: ChannelDuplexHandler, RemovableChannelHandler {
     public typealias InboundIn = HTTPServerRequestPart
     public typealias InboundOut = HTTPServerRequestPart
     public typealias OutboundIn = HTTPServerResponsePart

--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -21,7 +21,7 @@ import NIO
 /// servers want. This handler does not suppress the parser errors: it allows them to
 /// continue to pass through the pipeline so that other handlers (e.g. logging ones) can
 /// deal with the error.
-public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler {
+public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler, RemovableChannelHandler {
     public typealias InboundIn = HTTPServerRequestPart
     public typealias InboundOut = HTTPServerRequestPart
     public typealias OutboundIn = HTTPServerResponsePart

--- a/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
@@ -56,7 +56,7 @@ public enum ALPNResult: Equatable {
 /// down the channel. Then, finally, this channel handler will automatically remove
 /// itself from the channel pipeline, leaving the pipeline in its final
 /// configuration.
-public class ApplicationProtocolNegotiationHandler: ChannelInboundHandler {
+public class ApplicationProtocolNegotiationHandler: ChannelInboundHandler, RemovableChannelHandler {
     public typealias InboundIn = Any
     public typealias InboundOut = Any
 

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -40,7 +40,7 @@ let websocketResponse = """
 </html>
 """
 
-private final class HTTPHandler: ChannelInboundHandler {
+private final class HTTPHandler: ChannelInboundHandler, RemovableChannelHandler {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
 
@@ -216,8 +216,8 @@ let bootstrap = ServerBootstrap(group: group)
     .childChannelInitializer { channel in
         let httpHandler = HTTPHandler()
         let config: HTTPUpgradeConfiguration = (
-                        upgraders: [ upgrader ], 
-                        completionHandler: { _ in 
+                        upgraders: [ upgrader ],
+                        completionHandler: { _ in
                             channel.pipeline.remove(handler: httpHandler, promise: nil)
                         }
                     )

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -278,7 +278,7 @@ class HTTPDecoderTest: XCTestCase {
             }
         }
 
-        class Receiver: ChannelInboundHandler {
+        class Receiver: ChannelInboundHandler, RemovableChannelHandler {
             typealias InboundIn = HTTPServerRequestPart
             let collector = ByteCollector()
 
@@ -329,7 +329,7 @@ class HTTPDecoderTest: XCTestCase {
             }
         }
         
-        class Reciever: ChannelInboundHandler {
+        class Reciever: ChannelInboundHandler, RemovableChannelHandler {
             typealias InboundIn = HTTPClientResponsePart
             typealias InboundOut = HTTPClientResponsePart
             typealias OutboundOut = HTTPClientRequestPart

--- a/Tests/NIOTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOTests/AcceptBackoffHandlerTest.swift
@@ -95,7 +95,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
             return readCountHandler.readCount
         }.wait())
 
-        XCTAssertTrue(try serverChannel.pipeline.remove(name: acceptHandlerName).wait())
+        XCTAssertNoThrow(try serverChannel.pipeline.remove(name: acceptHandlerName).wait())
 
         if read {
             // Removal should have triggered a read.

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -52,6 +52,7 @@ extension ChannelPipelineTest {
                 ("testRemovingByReferenceWithPromiseStillInChannel", testRemovingByReferenceWithPromiseStillInChannel),
                 ("testRemovingByReferenceWithFutureNotInChannel", testRemovingByReferenceWithFutureNotInChannel),
                 ("testFireChannelReadInInactiveChannelDoesNotCrash", testFireChannelReadInInactiveChannelDoesNotCrash),
+                ("testTeardownDuringFormalRemovalProcess", testTeardownDuringFormalRemovalProcess),
            ]
    }
 }

--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -38,6 +38,9 @@ extension ByteToMessageDecoderTest {
                 ("testStructsWorkAsByteToMessageDecoders", testStructsWorkAsByteToMessageDecoders),
                 ("testReentrantChannelReadWhileWholeBufferIsBeingProcessed", testReentrantChannelReadWhileWholeBufferIsBeingProcessed),
                 ("testReentrantChannelCloseInChannelRead", testReentrantChannelCloseInChannelRead),
+                ("testHandlerRemoveInChannelRead", testHandlerRemoveInChannelRead),
+                ("testChannelCloseInChannelRead", testChannelCloseInChannelRead),
+                ("testDecodeLoopGetsInterruptedWhenRemovalIsTriggered", testDecodeLoopGetsInterruptedWhenRemovalIsTriggered),
            ]
    }
 }

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -110,7 +110,7 @@ internal extension Channel {
     }
 }
 
-final class ByteCountingHandler : ChannelInboundHandler {
+final class ByteCountingHandler : ChannelInboundHandler, RemovableChannelHandler {
     typealias InboundIn = ByteBuffer
 
     private let numBytes: Int

--- a/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
@@ -16,7 +16,7 @@ import XCTest
 import NIO
 import NIOWebSocket
 
-private class CloseSwallower: ChannelOutboundHandler {
+private class CloseSwallower: ChannelOutboundHandler, RemovableChannelHandler {
     typealias OutboundIn = Any
     typealias OutboundOut = Any
 
@@ -103,9 +103,15 @@ public class WebSocketFrameDecoderTest: XCTestCase {
     private func swapDecoder(for handler: ChannelHandler) {
         // We need to insert a decoder that doesn't do error handling. We still insert
         // an encoder because we want to fail gracefully if a frame is written.
-        XCTAssertNoThrow(try self.decoderChannel.pipeline.context(handlerType: ByteToMessageHandler<WebSocketFrameDecoder>.self).flatMap {
-            self.decoderChannel.pipeline.remove(handler: $0.handler)
-        }.flatMap { (_: Bool) in
+        XCTAssertNoThrow(try self.decoderChannel.pipeline.context(handlerType: ByteToMessageHandler<WebSocketFrameDecoder>.self).flatMapThrowing {
+            if let handler = $0.handler as? RemovableChannelHandler {
+                return handler
+            } else {
+                throw ChannelError.unremovableHandler
+            }
+        }.flatMap {
+            self.decoderChannel.pipeline.remove(handler: $0)
+        }.flatMap {
             self.decoderChannel.pipeline.add(handler: handler)
         }.wait())
     }

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -20,7 +20,7 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=691050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=692050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
@@ -30,7 +30,7 @@ services:
     command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors -Xswiftc -DNIO_CI_BUILD && ./scripts/integration_tests.sh"
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=691050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=692050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -43,3 +43,4 @@
 - `EventLoopFuture.cascade(promise: EventLoopPromise)` had its label changed to `EventLoopFuture.cascade(to: EventLoopPromise)`
 - `EventLoopFuture.cascadeFailure(promise: EventLoopPromise)` had its label changed to `EventLoopFuture.cascade(to: EventLoopPromise)`
 - renamed `EventLoopFuture.andAll(_:eventLoop:)` to `EventLoopFuture.andAllSucceed(_:on:)`
+- all ChannelPipeline.remove(...) now return `EventLoopFuture<Void>` instead of `EventLoopFuture<Bool>`


### PR DESCRIPTION
Motivation:

If ChannelHandler removal worked correctly, it was often either by
accident or by intricate knowledge about the implementation of the
ChannelHandler that is to be removed. Especially when it comes to
re-entrancy it mostly didn't work correctly.

Modifications:

- introduce a `RemovableChannelHandler` API
- raise allocation limit per HTTP connection by 1
  (https://bugs.swift.org/browse/SR-9905)

Result:

Make things work by contruction rather than accident