### PR TITLE
Replace ByteBufferTest use of deprecated "withUnsafeBytes" with new API

### DIFF
--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -763,9 +763,7 @@ class ByteBufferTest: XCTestCase {
         buf.write(string: str)
         var written1: Int = -1
         var written2: Int = -1
-        let hwDataCount = hwData.count
-        hwData.withUnsafeBytes { (ptr: UnsafePointer<Int8>) -> Void in
-            let ptr = UnsafeRawBufferPointer(start: ptr, count: hwDataCount)
+        hwData.withUnsafeBytes { ptr in
             /* ... write a second time and ...*/
             written1 = buf.set(bytes: ptr, at: buf.writerIndex)
             buf.moveWriterIndex(forwardBy: written1)


### PR DESCRIPTION
Motivation:

Remove the only warning in the project.

Modifications:

Use new withUnsafeBytes API.

Result:

The project will have no warnings.