### PR TITLE
NIO1 API Shims: Forgotten deprecation warning

### DIFF
--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -119,6 +119,7 @@ extension EventLoopFuture {
         return self.flatMapError(file: file, line: line, callback)
     }
 
+    @available(*, deprecated, renamed: "flatMapErrorThrowing")
     public func thenIfErrorThrowing(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) throws -> Value) -> EventLoopFuture<Value> {
         return self.flatMapErrorThrowing(file: file, line: line, callback)
     }


### PR DESCRIPTION
Motivation:

It's important that in NIO1 API Shims everything that's defined is also
deprecated. Unfortunately I forgot one.

Modifications:

- deprecate thenIfErrorThrowing

Result:

- Xcode will correctly suggest changing thenIfErrorThrowing to flatMapErrorThrowing
