### PR TITLE
Add `whenAllComplete` EventLoopFuture method

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -1030,10 +1030,10 @@ extension EventLoopFuture {
                     guard remainingCount == 0 else { return }
 
                     // verify that all operations have been completed
-                    assert(results.contains(where: {
+                    assert(!results.contains(where: {
                         guard case let .failure(error) = $0 else { return false }
                         return error is OperationPlaceholderError
-                    }) == false)
+                    }))
 
                     promise.succeed(result: results)
                 }

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -1035,7 +1035,7 @@ extension EventLoopFuture {
                         return error is OperationPlaceholderError
                     }))
 
-                    promise.succeed(result: results)
+                    promise.succeed(results)
                 }
         }
     }

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -996,9 +996,9 @@ extension EventLoopFuture {
     /// use one of the `reduce` methods instead.
     /// - Parameter futures: An array of homogenous `EventLoopFuture`s to gather results from.
     /// - Returns: A new `EventLoopFuture` with all the results of the provided futures.
-    public static func whenAllComplete<InputValue>(_ futures: [EventLoopFuture<InputValue>],
-                                                   eventLoop: EventLoop) -> EventLoopFuture<[Result<InputValue, Error>]> {
-        let promise = eventLoop.makePromise(of: [Result<InputValue, Error>].self)
+    public static func whenAllComplete(_ futures: [EventLoopFuture<Value>],
+                                       eventLoop: EventLoop) -> EventLoopFuture<[Result<Value, Error>]> {
+        let promise = eventLoop.makePromise(of: [Result<Value, Error>].self)
 
         if eventLoop.inEventLoop {
             _whenAllComplete0(promise, futures, eventLoop: eventLoop)

--- a/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
@@ -64,6 +64,9 @@ extension EventLoopFutureTest {
                 ("testLoopHoppingHelperNoHopping", testLoopHoppingHelperNoHopping),
                 ("testFlatMapResultHappyPath", testFlatMapResultHappyPath),
                 ("testFlatMapResultFailurePath", testFlatMapResultFailurePath),
+                ("testWhenAllCompleteResultsWithFailuresStillSucceed", testWhenAllCompleteResultsWithFailuresStillSucceed),
+                ("testWhenAllCompleteResults", testWhenAllCompleteResults),
+                ("testWhenAllCompleteResolvesAfterFutures", testWhenAllCompleteResolvesAfterFutures),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -918,7 +918,7 @@ class EventLoopFutureTest : XCTestCase {
 
         // complete the first four promises
         for (index, promise) in promises.dropLast().enumerated() {
-            promise.succeed(result: index)
+            promise.succeed(index)
         }
 
         // Should still be false, as one promise hasn't completed yet
@@ -926,7 +926,7 @@ class EventLoopFutureTest : XCTestCase {
 
         // Complete the last promise
         completedPromises = true
-        promises.last!.succeed(result: 4)
+        promises.last!.succeed(4)
 
         let results = try assertNoThrowWithValue(mainFuture.wait().map { try $0.get() })
         XCTAssertEqual(results, [0, 1, 2, 3, 4])

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -867,8 +867,8 @@ class EventLoopFutureTest : XCTestCase {
         }
 
         let future = EventLoopFuture.whenAllComplete([
-            group.next().makeFailedFuture(error: EventLoopFutureTestError.example),
-            group.next().makeSucceededFuture(result: true)
+            group.next().makeFailedFuture(EventLoopFutureTestError.example),
+            group.next().makeSucceededFuture(true)
         ], eventLoop: group.next())
         XCTAssertNoThrow(try future.wait())
     }
@@ -880,11 +880,11 @@ class EventLoopFutureTest : XCTestCase {
         }
 
         let results = try EventLoopFuture.whenAllComplete([
-            group.next().makeSucceededFuture(result: 3),
-            group.next().makeFailedFuture(error: EventLoopFutureTestError.example),
-            group.next().makeSucceededFuture(result: 10),
-            group.next().makeFailedFuture(error: EventLoopFutureTestError.example),
-            group.next().makeSucceededFuture(result: 5)
+            group.next().makeSucceededFuture(3),
+            group.next().makeFailedFuture(EventLoopFutureTestError.example),
+            group.next().makeSucceededFuture(10),
+            group.next().makeFailedFuture(EventLoopFutureTestError.example),
+            group.next().makeSucceededFuture(5)
         ], eventLoop: group.next()).wait()
 
         XCTAssertEqual(try results[0].get(), 3)

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -866,7 +866,7 @@ class EventLoopFutureTest : XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let future: EventLoopFuture<[Result<Bool, Error>]> = .whenAllComplete([
+        let future = EventLoopFuture.whenAllComplete([
             group.next().makeFailedFuture(error: EventLoopFutureTestError.example),
             group.next().makeSucceededFuture(result: true)
         ], eventLoop: group.next())
@@ -879,7 +879,7 @@ class EventLoopFutureTest : XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let results = try EventLoopFuture<[Result<Int, Error>]>.whenAllComplete([
+        let results = try EventLoopFuture.whenAllComplete([
             group.next().makeSucceededFuture(result: 3),
             group.next().makeFailedFuture(error: EventLoopFutureTestError.example),
             group.next().makeSucceededFuture(result: 10),
@@ -913,7 +913,7 @@ class EventLoopFutureTest : XCTestCase {
             )
         }
 
-        let mainFuture = EventLoopFuture<[Result<Int, Error>]>.whenAllComplete(futures, eventLoop: group.next())
+        let mainFuture = EventLoopFuture.whenAllComplete(futures, eventLoop: group.next())
         mainFuture.whenSuccess { _ in tally *= -1 }
 
         let _ = try mainFuture.wait()


### PR DESCRIPTION
Add `whenAllComplete` method to group a homogenous array of future results into a single ELF that returns a `[Result<Value, Error>]`

### Motivation:
Methods like `reduce`, `and`, or `fold` all "fail fast" by failing the top-level ELF if any of the sub-ELFs hit a failure.

However, it is common to have a group of sub-tasks that may have results to work with at the end, but each task's success or failure status is mutually exclusive from each other.

An example might be a bulk update of records in a database - where I just want to know when all of them completed. If one failed, I still want all the others to continue.

For example:

```swift
let taskResults: EventLoopFuture<[Result<Int, Error>]> = .whenAllComplete([
    obj1.updateDatabase(),
    obj2.updateDatabase(),
    // ...
], eventLoop: eventLoop)
```

This will allow me to handle each individual failure, or ignoring the results altogether.