### PR TITLE
remove ELP.succeed/fail's labels

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -94,7 +94,7 @@ private final class PingHandler: ChannelInboundHandler {
             }
         } else {
             ctx.close(promise: nil)
-            self.allDone.fail(error: PingPongFailure(problem: "wrong buffer received: \(buf.debugDescription)"))
+            self.allDone.fail(PingPongFailure(problem: "wrong buffer received: \(buf.debugDescription)"))
         }
     }
 
@@ -165,7 +165,7 @@ public func swiftMain() -> Int {
 
         func errorCaught(ctx: ChannelHandlerContext, error: Error) {
             ctx.channel.close(promise: nil)
-            self.isDonePromise.fail(error: error)
+            self.isDonePromise.fail(error)
         }
 
         func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
@@ -352,7 +352,7 @@ public func swiftMain() -> Int {
             let f = p.futureResult.flatMap { (r: Int) -> EventLoopFuture<Int> in
                 // This call allocates a new Future, and
                 // so does flatMap(), so this is two Futures.
-                return loop.makeSucceededFuture(result: r + 1)
+                return loop.makeSucceededFuture(r + 1)
             }.flatMapThrowing { (r: Int) -> Int in
                 // flatMapThrowing allocates a new Future, and calls `flatMap`
                 // which also allocates, so this is two.
@@ -368,7 +368,7 @@ public func swiftMain() -> Int {
             }.flatMapError { (err: Error) -> EventLoopFuture<Int> in
                 // This call allocates a new Future, and so does flatMapError,
                 // so this is two Futures.
-                return loop.makeFailedFuture(error: err)
+                return loop.makeFailedFuture(err)
             }.flatMapErrorThrowing { (err: Error) -> Int in
                 // flatMapError allocates a new Future, and calls flatMapError,
                 // so this is two Futures
@@ -378,7 +378,7 @@ public func swiftMain() -> Int {
                 // this is two Futures.
                 return 1
             }
-            p.succeed(result: 0)
+            p.succeed(0)
             
             // Wait also allocates a lock.
             try! f.wait()
@@ -395,12 +395,12 @@ public func swiftMain() -> Int {
             let f = p1.futureResult
                         .and(p2.futureResult)
                         .and(p3.futureResult)
-                        .and(result: 1)
-                        .and(result: 1)
+                        .and(value: 1)
+                        .and(value: 1)
 
-            p1.succeed(result: 1)
-            p2.succeed(result: 1)
-            p3.succeed(result: 1)
+            p1.succeed(1)
+            p2.succeed(1)
+            p3.succeed(1)
             let r = try! f.wait()
         }
         let el = EmbeddedEventLoop()

--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -97,28 +97,28 @@ private struct SocketChannelLifecycleManager {
         case (.fresh, .beginRegistration):
             self.currentState = .preRegistered
             return { promise, pipeline in
-                promise?.succeed(result: ())
+                promise?.succeed(())
                 pipeline.fireChannelRegistered0()
             }
 
         case (.fresh, .close):
             self.currentState = .closed
             return { (promise, _: ChannelPipeline) in
-                promise?.succeed(result: ())
+                promise?.succeed(())
             }
 
         // origin: .preRegistered
         case (.preRegistered, .finishRegistration):
             self.currentState = .fullyRegistered
             return { (promise, _: ChannelPipeline) in
-                promise?.succeed(result: ())
+                promise?.succeed(())
             }
 
         // origin: .fullyRegistered
         case (.fullyRegistered, .activate):
             self.currentState = .activated
             return { promise, pipeline in
-                promise?.succeed(result: ())
+                promise?.succeed(())
                 pipeline.fireChannelActive0()
             }
 
@@ -126,7 +126,7 @@ private struct SocketChannelLifecycleManager {
         case (.preRegistered, .close), (.fullyRegistered, .close):
             self.currentState = .closed
             return { promise, pipeline in
-                promise?.succeed(result: ())
+                promise?.succeed(())
                 pipeline.fireChannelUnregistered0()
             }
 
@@ -134,7 +134,7 @@ private struct SocketChannelLifecycleManager {
         case (.activated, .close):
             self.currentState = .closed
             return { promise, pipeline in
-                promise?.succeed(result: ())
+                promise?.succeed(())
                 pipeline.fireChannelInactive0()
                 pipeline.fireChannelUnregistered0()
             }
@@ -515,9 +515,9 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
     public func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T: ChannelOption {
         if eventLoop.inEventLoop {
             do {
-                return eventLoop.makeSucceededFuture(result: try getOption0(option: option))
+                return eventLoop.makeSucceededFuture(try getOption0(option: option))
             } catch {
-                return eventLoop.makeFailedFuture(error: error)
+                return eventLoop.makeFailedFuture(error)
             }
         } else {
             return eventLoop.submit { try self.getOption0(option: option) }
@@ -568,11 +568,11 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
             return
         }
         guard self.lifecycleManager.isPreRegistered else {
-            promise?.fail(error: ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError.inappropriateOperationForState)
             return
         }
 
@@ -587,12 +587,12 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
 
         guard self.isOpen else {
             // Channel was already closed, fail the promise and not even queue it.
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
             return
         }
 
         guard self.lifecycleManager.isActive else {
-            promise?.fail(error: ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError.inappropriateOperationForState)
             return
         }
 
@@ -698,12 +698,12 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(error: ChannelError.alreadyClosed)
+            promise?.fail(ChannelError.alreadyClosed)
             return
         }
 
         guard mode == .all else {
-            promise?.fail(error: ChannelError.operationUnsupported)
+            promise?.fail(ChannelError.operationUnsupported)
             return
         }
 
@@ -727,7 +727,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
             p = promise
         } catch {
             errorCallouts.append { (_: ChannelPipeline) in
-                promise?.fail(error: error)
+                promise?.fail(error)
                 // Set p to nil as we want to ensure we pass nil to becomeInactive0(...) so we not try to notify the promise again.
             }
             p = nil
@@ -749,7 +749,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
 
         if let connectPromise = self.pendingConnect {
             self.pendingConnect = nil
-            connectPromise.fail(error: error)
+            connectPromise.fail(error)
         }
 
         callouts(p, self.pipeline)
@@ -758,7 +758,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
             // ensure this is executed in a delayed fashion as the users code may still traverse the pipeline
             self.pipeline.removeHandlers()
 
-            self.closePromise.succeed(result: ())
+            self.closePromise.succeed(())
 
             // Now reset the addresses as we notified all handlers / futures.
             self.unsetCachedAddressesFromSocket()
@@ -770,12 +770,12 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
             return
         }
 
         guard !self.lifecycleManager.isPreRegistered else {
-            promise?.fail(error: ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError.inappropriateOperationForState)
             return
         }
 
@@ -785,7 +785,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
             // `close0`'s error is about the result of the `close` operation, ...
             self.close0(error: error, mode: .all, promise: nil)
             // ... therefore we need to fail the registration `promise` separately.
-            promise?.fail(error: error)
+            promise?.fail(error)
             return
         }
 
@@ -816,7 +816,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
     }
 
     public final func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
-        promise?.succeed(result: ())
+        promise?.succeed(())
     }
 
     // Methods invoked from the EventLoop itself
@@ -1033,17 +1033,17 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
             return
         }
 
         guard pendingConnect == nil else {
-            promise?.fail(error: ChannelError.connectPending)
+            promise?.fail(ChannelError.connectPending)
             return
         }
 
         guard self.lifecycleManager.isPreRegistered else {
-            promise?.fail(error: ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError.inappropriateOperationForState)
             return
         }
 

--- a/Sources/NIO/BlockingIOThreadPool.swift
+++ b/Sources/NIO/BlockingIOThreadPool.swift
@@ -193,13 +193,13 @@ public extension BlockingIOThreadPool {
         let promise = eventLoop.makePromise(of: T.self)
         self.submit { shouldRun in
             guard case shouldRun = BlockingIOThreadPool.WorkItemState.active else {
-                promise.fail(error: ChannelError.ioOnClosedChannel)
+                promise.fail(ChannelError.ioOnClosedChannel)
                 return
             }
             do {
-                try promise.succeed(result: body())
+                try promise.succeed(body())
             } catch {
-                promise.fail(error: error)
+                promise.fail(error)
             }
         }
         return promise.futureResult

--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -211,7 +211,7 @@ extension Channel {
     }
 
     public func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.operationUnsupported)
+        promise?.fail(ChannelError.operationUnsupported)
     }
 
     public func triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -167,7 +167,7 @@ public final class ChannelPipeline: ChannelInvoker {
 
         func _add() {
             if self.destroyed {
-                promise.fail(error: ChannelError.ioOnClosedChannel)
+                promise.fail(ChannelError.ioOnClosedChannel)
                 return
             }
 
@@ -259,12 +259,12 @@ public final class ChannelPipeline: ChannelInvoker {
                       promise: EventLoopPromise<Void>) {
         self.eventLoop.assertInEventLoop()
         if self.destroyed {
-            promise.fail(error: ChannelError.ioOnClosedChannel)
+            promise.fail(ChannelError.ioOnClosedChannel)
             return
         }
 
         guard let ctx = self.contextForPredicate0({ $0.handler === relativeHandler }) else {
-            promise.fail(error: ChannelPipelineError.notFound)
+            promise.fail(ChannelPipelineError.notFound)
             return
         }
 
@@ -296,7 +296,7 @@ public final class ChannelPipeline: ChannelInvoker {
         self.eventLoop.assertInEventLoop()
 
         if destroyed {
-            promise.fail(error: ChannelError.ioOnClosedChannel)
+            promise.fail(ChannelError.ioOnClosedChannel)
             return
         }
 
@@ -305,10 +305,10 @@ public final class ChannelPipeline: ChannelInvoker {
 
         do {
             try ctx.invokeHandlerAdded()
-            promise.succeed(result: ())
+            promise.succeed(())
         } catch let err {
             remove0(ctx: ctx, promise: nil)
-            promise.fail(error: err)
+            promise.fail(err)
         }
     }
 
@@ -464,9 +464,9 @@ public final class ChannelPipeline: ChannelInvoker {
 
         func _context0() {
             if let ctx = self.contextForPredicate0(body) {
-                promise.succeed(result: ctx)
+                promise.succeed(ctx)
             } else {
-                promise.fail(error: ChannelPipelineError.notFound)
+                promise.fail(ChannelPipelineError.notFound)
             }
         }
 
@@ -514,9 +514,9 @@ public final class ChannelPipeline: ChannelInvoker {
 
         do {
             try ctx.invokeHandlerRemoved()
-            promise?.succeed(result: true)
+            promise?.succeed(true)
         } catch let err {
-            promise?.fail(error: err)
+            promise?.fail(err)
         }
 
         // We need to keep the current node alive until after the callout in case the user uses the context.
@@ -748,7 +748,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeClose(mode: mode, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.alreadyClosed)
+            promise?.fail(ChannelError.alreadyClosed)
         }
     }
 
@@ -768,7 +768,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWrite(data, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -776,7 +776,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWriteAndFlush(data, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -784,7 +784,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeBind(to: address, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -792,7 +792,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeConnect(to: address, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -800,7 +800,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeRegister(promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -808,7 +808,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeTriggerUserOutboundEvent(event, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -1160,7 +1160,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeRegister(promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -1174,7 +1174,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeBind(to: address, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -1188,7 +1188,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeConnect(to: address, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -1203,7 +1203,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeWrite(data, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -1230,7 +1230,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeWriteAndFlush(data, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 
@@ -1254,7 +1254,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeClose(mode: mode, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.alreadyClosed)
+            promise?.fail(ChannelError.alreadyClosed)
         }
     }
 
@@ -1267,7 +1267,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeTriggerUserOutboundEvent(event, promise: promise)
         } else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
         }
     }
 

--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -420,7 +420,7 @@ extension MessageToByteEncoder {
             try encode(ctx: ctx, data: data, out: &buffer)
             ctx.write(self.wrapOutboundOut(buffer), promise: promise)
         } catch let err {
-            promise?.fail(error: err)
+            promise?.fail(err)
         }
     }
 

--- a/Sources/NIO/DeadChannel.swift
+++ b/Sources/NIO/DeadChannel.swift
@@ -25,23 +25,23 @@ private final class DeadChannelCore: ChannelCore {
     }
 
     func register0(promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError.ioOnClosedChannel)
     }
 
     func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError.ioOnClosedChannel)
     }
 
     func bind0(to: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError.ioOnClosedChannel)
     }
 
     func connect0(to: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError.ioOnClosedChannel)
     }
 
     func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError.ioOnClosedChannel)
     }
 
     func flush0() {
@@ -51,11 +51,11 @@ private final class DeadChannelCore: ChannelCore {
     }
 
     func close0(error: Error, mode: CloseMode, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.alreadyClosed)
+        promise?.fail(ChannelError.alreadyClosed)
     }
 
     func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError.ioOnClosedChannel)
     }
 
     func channelRead0(_ data: NIOAny) {
@@ -80,7 +80,7 @@ internal final class DeadChannel: Channel {
     let pipeline: ChannelPipeline
 
     public var closeFuture: EventLoopFuture<Void> {
-        return self.eventLoop.makeSucceededFuture(result: ())
+        return self.eventLoop.makeSucceededFuture(())
     }
 
     internal init(pipeline: ChannelPipeline) {
@@ -108,7 +108,7 @@ internal final class DeadChannel: Channel {
     }
 
     func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T: ChannelOption {
-        return eventLoop.makeFailedFuture(error: ChannelError.ioOnClosedChannel)
+        return eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
     }
 
     let isWritable = false

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -64,9 +64,9 @@ public class EmbeddedEventLoop: EventLoop {
         let readyTime = now + UInt64(`in`.nanoseconds)
         let task = EmbeddedScheduledTask(readyTime: readyTime) {
             do {
-                promise.succeed(result: try task())
+                promise.succeed(try task())
             } catch let err {
-                promise.fail(error: err)
+                promise.fail(err)
             }
         }
 
@@ -155,7 +155,7 @@ class EmbeddedChannelCore: ChannelCore {
     deinit {
         assert(self.pipeline.destroyed, "leaked an open EmbeddedChannel, maybe forgot to call channel.finish()?")
         isOpen = false
-        closePromise.succeed(result: ())
+        closePromise.succeed(())
     }
 
     /// Contains the flushed items that went into the `Channel` (and on a regular channel would have hit the network).
@@ -178,12 +178,12 @@ class EmbeddedChannelCore: ChannelCore {
 
     func close0(error: Error, mode: CloseMode, promise: EventLoopPromise<Void>?) {
         guard self.isOpen else {
-            promise?.fail(error: ChannelError.alreadyClosed)
+            promise?.fail(ChannelError.alreadyClosed)
             return
         }
         isOpen = false
         isActive = false
-        promise?.succeed(result: ())
+        promise?.succeed(())
 
         // As we called register() in the constructor of EmbeddedChannel we also need to ensure we call unregistered here.
         pipeline.fireChannelInactive0()
@@ -192,22 +192,22 @@ class EmbeddedChannelCore: ChannelCore {
         eventLoop.execute {
             // ensure this is executed in a delayed fashion as the users code may still traverse the pipeline
             self.pipeline.removeHandlers()
-            self.closePromise.succeed(result: ())
+            self.closePromise.succeed(())
         }
     }
 
     func bind0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.succeed(result: ())
+        promise?.succeed(())
     }
 
     func connect0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         isActive = true
-        promise?.succeed(result: ())
+        promise?.succeed(())
         pipeline.fireChannelActive0()
     }
 
     func register0(promise: EventLoopPromise<Void>?) {
-        promise?.succeed(result: ())
+        promise?.succeed(())
         pipeline.fireChannelRegistered0()
     }
 
@@ -219,7 +219,7 @@ class EmbeddedChannelCore: ChannelCore {
 
     func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         guard let data = data.tryAsIOData() else {
-            promise?.fail(error: ChannelError.writeDataUnsupported)
+            promise?.fail(ChannelError.writeDataUnsupported)
             return
         }
 
@@ -231,7 +231,7 @@ class EmbeddedChannelCore: ChannelCore {
         self.pendingOutboundBuffer.removeAll()
         for dataAndPromise in pendings {
             self.addToBuffer(buffer: &self.outboundBuffer, data: dataAndPromise.0)
-            dataAndPromise.1?.succeed(result: ())
+            dataAndPromise.1?.succeed(())
         }
     }
 
@@ -240,7 +240,7 @@ class EmbeddedChannelCore: ChannelCore {
     }
 
     public final func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
-        promise?.succeed(result: ())
+        promise?.succeed(())
     }
 
     func channelRead0(_ data: NIOAny) {
@@ -400,7 +400,7 @@ public class EmbeddedChannel: Channel {
 
     public func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T: ChannelOption {
         if option is AutoReadOption {
-            return self.eventLoop.makeSucceededFuture(result: true as! T.OptionType)
+            return self.eventLoop.makeSucceededFuture(true as! T.OptionType)
         }
         fatalError("option \(option) not supported")
     }

--- a/Sources/NIO/GetaddrinfoResolver.swift
+++ b/Sources/NIO/GetaddrinfoResolver.swift
@@ -91,7 +91,7 @@ internal class GetaddrinfoResolver: Resolver {
         hint.ai_socktype = self.aiSocktype
         hint.ai_protocol = self.aiProtocol
         guard getaddrinfo(host, String(port), &hint, &info) == 0 else {
-            self.fail(error: SocketAddressError.unknown(host: host, port: port))
+            self.fail(SocketAddressError.unknown(host: host, port: port))
             return
         }
 
@@ -100,7 +100,7 @@ internal class GetaddrinfoResolver: Resolver {
             freeaddrinfo(info)
         } else {
             /* this is odd, getaddrinfo returned NULL */
-            self.fail(error: SocketAddressError.unsupported)
+            self.fail(SocketAddressError.unsupported)
         }
     }
 
@@ -125,7 +125,7 @@ internal class GetaddrinfoResolver: Resolver {
                     v6Results.append(.init(ptr.pointee, host: host))
                 }
             default:
-                self.fail(error: SocketAddressError.unsupported)
+                self.fail(SocketAddressError.unsupported)
                 return
             }
 
@@ -136,16 +136,16 @@ internal class GetaddrinfoResolver: Resolver {
             info = nextInfo
         }
 
-        v6Future.succeed(result: v6Results)
-        v4Future.succeed(result: v4Results)
+        v6Future.succeed(v6Results)
+        v4Future.succeed(v4Results)
     }
 
     /// Record an error and fail the lookup process.
     ///
     /// - parameters:
     ///     - error: The error encountered during lookup.
-    private func fail(error: Error) {
-        self.v6Future.fail(error: error)
-        self.v4Future.fail(error: error)
+    private func fail(_ error: Error) {
+        self.v6Future.fail(error)
+        self.v4Future.fail(error)
     }
 }

--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -507,7 +507,7 @@ internal class HappyEyeballsConnector {
     /// Cleans up internal state and fails the connection promise.
     private func timedOut() {
         cleanUp()
-        self.resolutionPromise.fail(error: ChannelError.connectTimeout(self.connectTimeout))
+        self.resolutionPromise.fail(ChannelError.connectTimeout(self.connectTimeout))
     }
 
     /// Called when we've attempted to connect to all our resolved targets,
@@ -518,7 +518,7 @@ internal class HappyEyeballsConnector {
     private func failed() {
         precondition(pendingConnections.count == 0, "failed with pending connections")
         cleanUp()
-        self.resolutionPromise.fail(error: self.error)
+        self.resolutionPromise.fail(self.error)
     }
 
     /// Called to connect to a given target.
@@ -547,7 +547,7 @@ internal class HappyEyeballsConnector {
                         channel.close(promise: nil)
                     } else {
                         self.processInput(.connectSuccess)
-                        self.resolutionPromise.succeed(result: channel)
+                        self.resolutionPromise.succeed(channel)
                     }
                 }.whenFailure { err in
                     // The connection attempt failed. If we're in the complete state then there's nothing

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -87,7 +87,7 @@ public struct NonBlockingFileIO {
                                     eventLoop: eventLoop,
                                     chunkHandler: chunkHandler)
         } catch {
-            return eventLoop.makeFailedFuture(error: error)
+            return eventLoop.makeFailedFuture(error)
         }
     }
 
@@ -131,7 +131,7 @@ public struct NonBlockingFileIO {
                     }
                 }
             } else {
-                return eventLoop.makeSucceededFuture(result: ())
+                return eventLoop.makeSucceededFuture(())
             }
         }
 
@@ -162,7 +162,7 @@ public struct NonBlockingFileIO {
                              allocator: allocator,
                              eventLoop: eventLoop)
         } catch {
-            return eventLoop.makeFailedFuture(error: error)
+            return eventLoop.makeFailedFuture(error)
         }
     }
 
@@ -182,7 +182,7 @@ public struct NonBlockingFileIO {
     /// - returns: An `EventLoopFuture` which delivers a `ByteBuffer` if the read was successful or a failure on error.
     public func read(fileHandle: FileHandle, byteCount: Int, allocator: ByteBufferAllocator, eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
         guard byteCount > 0 else {
-            return eventLoop.makeSucceededFuture(result: allocator.buffer(capacity: 0))
+            return eventLoop.makeSucceededFuture(allocator.buffer(capacity: 0))
         }
 
         var buf = allocator.buffer(capacity: byteCount)
@@ -227,7 +227,7 @@ public struct NonBlockingFileIO {
         var byteCount = buffer.readableBytes
 
         guard byteCount > 0 else {
-            return eventLoop.makeSucceededFuture(result: ())
+            return eventLoop.makeSucceededFuture(())
         }
 
         return self.threadPool.runIfActive(eventLoop: eventLoop) {

--- a/Sources/NIO/PendingDatagramWritesManager.swift
+++ b/Sources/NIO/PendingDatagramWritesManager.swift
@@ -289,7 +289,7 @@ private struct PendingDatagramWritesState {
             w.promise.map { promises.append($0) }
         }
 
-        promises.forEach { $0.fail(error: error) }
+        promises.forEach { $0.fail(error) }
     }
 
     /// Returns the best mechanism to write pending data at the current point in time.
@@ -528,9 +528,9 @@ final class PendingDatagramWritesManager: PendingWritesManager {
 
     private func fulfillPromise(_ promise: PendingDatagramWritesState.DatagramWritePromiseFiller?) {
         if let promise = promise, let error = promise.1 {
-            promise.0.fail(error: error)
+            promise.0.fail(error)
         } else if let promise = promise {
-            promise.0.succeed(result: ())
+            promise.0.succeed(())
         }
     }
 

--- a/Sources/NIO/PendingWritesManager.swift
+++ b/Sources/NIO/PendingWritesManager.swift
@@ -355,7 +355,7 @@ final class PendingStreamWritesManager: PendingWritesManager {
             channelWritabilityFlag.store(true)
         }
 
-        promise?.succeed(result: ())
+        promise?.succeed(())
         return result
     }
 
@@ -416,7 +416,7 @@ final class PendingStreamWritesManager: PendingWritesManager {
             self.isOpen = false
         }
 
-        self.state.removeAll()?.fail(error: error)
+        self.state.removeAll()?.fail(error)
 
         assert(self.state.isEmpty)
     }

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -663,7 +663,7 @@ internal extension Selector where R == NIORegistration {
     /// Gently close the `Selector` after all registered `Channel`s are closed.
     func closeGently(eventLoop: EventLoop) -> EventLoopFuture<Void> {
         guard self.lifecycleState == .open else {
-            return eventLoop.makeFailedFuture(error: IOError(errnoCode: EBADF, reason: "can't close selector gently as it's \(self.lifecycleState)."))
+            return eventLoop.makeFailedFuture(IOError(errnoCode: EBADF, reason: "can't close selector gently as it's \(self.lifecycleState)."))
         }
 
         let futures: [EventLoopFuture<Void>] = self.registrations.map { (_, reg: NIORegistration) -> EventLoopFuture<Void> in
@@ -695,7 +695,7 @@ internal extension Selector where R == NIORegistration {
         }
 
         guard futures.count > 0 else {
-            return eventLoop.makeSucceededFuture(result: ())
+            return eventLoop.makeSucceededFuture(())
         }
 
         return EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -224,7 +224,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
             switch mode {
             case .output:
                 if outputShutdown {
-                    promise?.fail(error: ChannelError.outputClosed)
+                    promise?.fail(ChannelError.outputClosed)
                     return
                 }
                 try socket.shutdown(how: .WR)
@@ -232,13 +232,13 @@ final class SocketChannel: BaseSocketChannel<Socket> {
                 // Fail all pending writes and so ensure all pending promises are notified
                 pendingWrites.failAll(error: error, close: false)
                 unregisterForWritable()
-                promise?.succeed(result: ())
+                promise?.succeed(())
 
                 pipeline.fireUserInboundEventTriggered(ChannelEvent.outputClosed)
 
             case .input:
                 if inputShutdown {
-                    promise?.fail(error: ChannelError.inputClosed)
+                    promise?.fail(ChannelError.inputClosed)
                     return
                 }
                 switch error {
@@ -251,7 +251,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
                 }
                 inputShutdown = true
                 unregisterForReadable()
-                promise?.succeed(result: ())
+                promise?.succeed(())
 
                 pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
             case .all:
@@ -262,7 +262,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
                 super.close0(error: error, mode: mode, promise: promise)
             }
         } catch let err {
-            promise?.fail(error: err)
+            promise?.fail(err)
         }
     }
 
@@ -292,12 +292,12 @@ final class SocketChannel: BaseSocketChannel<Socket> {
 
     override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
         if outputShutdown {
-            promise?.fail(error: ChannelError.outputClosed)
+            promise?.fail(ChannelError.outputClosed)
             return
         }
 
         guard let data = data.tryAsIOData() else {
-            promise?.fail(error: ChannelError.writeDataUnsupported)
+            promise?.fail(ChannelError.writeDataUnsupported)
             return
         }
 
@@ -372,12 +372,12 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(error: ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError.ioOnClosedChannel)
             return
         }
 
         guard self.isRegistered else {
-            promise?.fail(error: ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError.inappropriateOperationForState)
             return
         }
 
@@ -386,7 +386,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
             // It's important to call the methods before we actually notify the original promise for ordering reasons.
             self.becomeActive0(promise: promise)
         }.whenFailure{ error in
-            promise?.fail(error: error)
+            promise?.fail(error)
         }
         executeAndComplete(p) {
             try socket.bind(to: address)
@@ -466,7 +466,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     }
 
     override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: ChannelError.operationUnsupported)
+        promise?.fail(ChannelError.operationUnsupported)
     }
 
     override func markFlushPoint() {
@@ -648,7 +648,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     /// Buffer a write in preparation for a flush.
     override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
         guard let data = data.tryAsByteEnvelope() else {
-            promise?.fail(error: ChannelError.writeDataUnsupported)
+            promise?.fail(ChannelError.writeDataUnsupported)
             return
         }
 
@@ -698,7 +698,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     override func bind0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         self.eventLoop.assertInEventLoop()
         guard self.isRegistered else {
-            promise?.fail(error: ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError.inappropriateOperationForState)
             return
         }
         do {
@@ -706,7 +706,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             self.updateCachedAddressesFromSocket(updateRemote: false)
             becomeActive0(promise: promise)
         } catch let err {
-            promise?.fail(error: err)
+            promise?.fail(err)
         }
     }
 }
@@ -793,25 +793,25 @@ extension DatagramChannel: MulticastChannel {
         self.eventLoop.assertInEventLoop()
 
         guard self.isActive else {
-            promise?.fail(error: ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError.inappropriateOperationForState)
             return
         }
 
         // We need to check that we have the appropriate address types in all cases. They all need to overlap with
         // the address type of this channel, or this cannot work.
         guard let localAddress = self.localAddress else {
-            promise?.fail(error: ChannelError.unknownLocalAddress)
+            promise?.fail(ChannelError.unknownLocalAddress)
             return
         }
 
         guard localAddress.protocolFamily == group.protocolFamily else {
-            promise?.fail(error: ChannelError.badMulticastGroupAddressFamily)
+            promise?.fail(ChannelError.badMulticastGroupAddressFamily)
             return
         }
 
         // Ok, now we need to check that the group we've been asked to join is actually a multicast group.
         guard group.isMulticast else {
-            promise?.fail(error: ChannelError.illegalMulticastAddress(group))
+            promise?.fail(ChannelError.illegalMulticastAddress(group))
             return
         }
 
@@ -841,9 +841,9 @@ extension DatagramChannel: MulticastChannel {
                 throw ChannelError.badInterfaceAddressFamily
             }
 
-            promise?.succeed(result: ())
+            promise?.succeed(())
         } catch {
-            promise?.fail(error: error)
+            promise?.fail(error)
             return
         }
     }

--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -95,7 +95,7 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler {
     }
 
     public func handlerRemoved(ctx: ChannelHandlerContext) {
-        pendingWritePromise?.fail(error: CompressionError.uncompressedWritesPending)
+        pendingWritePromise?.fail(CompressionError.uncompressedWritesPending)
         if algorithm != nil {
             deinitializeEncoder()
             algorithm = nil
@@ -238,7 +238,7 @@ public final class HTTPResponseCompressor: ChannelDuplexHandler {
         // If we still have the pending promise, we never emitted a write. Fail the promise,
         // as anything that is listening for its data somehow lost it.
         if let stillPendingPromise = pendingPromise {
-            stillPendingPromise.fail(error: CompressionError.noDataToWrite)
+            stillPendingPromise.fail(CompressionError.noDataToWrite)
         }
 
         // Reset the pending promise.

--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -239,14 +239,14 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
         if let handler = handler {
             return ctx.pipeline.remove(handler: handler)
         } else {
-            return ctx.eventLoop.makeSucceededFuture(result: true)
+            return ctx.eventLoop.makeSucceededFuture(true)
         }
     }
 
     /// Removes any extra HTTP-related handlers from the channel pipeline.
     private func removeExtraHandlers(ctx: ChannelHandlerContext) -> EventLoopFuture<Void> {
         guard self.extraHTTPHandlers.count > 0 else {
-            return ctx.eventLoop.makeSucceededFuture(result: ())
+            return ctx.eventLoop.makeSucceededFuture(())
         }
 
         return EventLoopFuture<Void>.andAll(self.extraHTTPHandlers.map { ctx.pipeline.remove(handler: $0).map { (_: Bool) in () }},

--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -86,7 +86,7 @@ let datagramChannel = try datagramBootstrap
         return channel.joinGroup(chatMulticastGroup, interface: targetInterface).map { channel }
     }.flatMap { channel -> EventLoopFuture<Channel> in
         guard let targetInterface = targetInterface else {
-            return channel.eventLoop.makeSucceededFuture(result: channel)
+            return channel.eventLoop.makeSucceededFuture(channel)
         }
 
         let provider = channel as! SocketOptionProvider

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -161,7 +161,7 @@ final class RepeatedRequests: ChannelInboundHandler {
 
     func errorCaught(ctx: ChannelHandlerContext, error: Error) {
         ctx.channel.close(promise: nil)
-        self.isDonePromise.fail(error: error)
+        self.isDonePromise.fail(error)
     }
 
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -82,14 +82,14 @@ extension EventLoop {
         return self.makePromise(of: type, file: file, line: line)
     }
 
-    @available(*, deprecated, renamed: "makeSucceededFuture")
+    @available(*, deprecated, renamed: "makeSucceededFuture(_:)")
     public func newSucceededFuture<T>(result: T) -> EventLoopFuture<T> {
-        return self.makeSucceededFuture(result: result)
+        return self.makeSucceededFuture(result)
     }
 
-    @available(*, deprecated, renamed: "makeFailedFuture")
+    @available(*, deprecated, renamed: "makeFailedFuture(_:)")
     public func newFailedFuture<T>(error: Error) -> EventLoopFuture<T> {
-        return self.makeFailedFuture(error: error)
+        return self.makeFailedFuture(error)
     }
 }
 
@@ -122,6 +122,25 @@ extension EventLoopFuture {
     @available(*, deprecated, renamed: "flatMapErrorThrowing")
     public func thenIfErrorThrowing(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) throws -> Value) -> EventLoopFuture<Value> {
         return self.flatMapErrorThrowing(file: file, line: line, callback)
+    }
+
+    @available(*, deprecated, renamed: "and(value:file:line:)")
+    public func and<OtherValue>(result: OtherValue,
+                                file: StaticString = #file,
+                                line: UInt = #line) -> EventLoopFuture<(Value, OtherValue)> {
+        return self.and(value: result, file: file, line: line)
+    }
+}
+
+extension EventLoopPromise {
+    @available(*, deprecated, renamed: "succeed(_:)")
+    public func succeed(result: Value) {
+        self.succeed(result)
+    }
+
+    @available(*, deprecated, renamed: "fail(_:)")
+    public func fail(error: Error) {
+        self.fail(error)
     }
 }
 

--- a/Tests/NIOHTTP1Tests/HTTPTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest.swift
@@ -133,7 +133,7 @@ class HTTPTest: XCTestCase {
         let bd1 = try sendAndCheckRequests(expecteds, body: body, trailers: trailers, sendStrategy: { (reqString, chan) in
             var buf = chan.allocator.buffer(capacity: 1024)
             buf.write(string: reqString)
-            return chan.eventLoop.makeSucceededFuture(result: ()).flatMapThrowing {
+            return chan.eventLoop.makeSucceededFuture(()).flatMapThrowing {
                 try chan.writeInbound(buf)
             }
         })
@@ -145,7 +145,7 @@ class HTTPTest: XCTestCase {
                 var buf = chan.allocator.buffer(capacity: 1024)
 
                 buf.write(string: "\(c)")
-                writeFutures.append(chan.eventLoop.makeSucceededFuture(result: ()).flatMapThrowing {
+                writeFutures.append(chan.eventLoop.makeSucceededFuture(()).flatMapThrowing {
                     try chan.writeInbound(buf)
                 })
             }

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -81,7 +81,7 @@ private func serverHTTPChannelWithAutoremoval(group: EventLoopGroup,
     let c = try ServerBootstrap(group: group)
         .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
         .childChannelInitializer { channel in
-            p.succeed(result: channel)
+            p.succeed(channel)
             let upgradeConfig = (upgraders: upgraders, completionHandler: upgradeCompletionHandler)
             return channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: pipelining, withServerUpgrade: upgradeConfig).flatMap {
                 let futureResults = extraHandlers.map { channel.pipeline.add(handler: $0) }
@@ -182,7 +182,7 @@ private class ExplodingUpgrader: HTTPProtocolUpgrader {
 
     public func upgrade(ctx: ChannelHandlerContext, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<Void> {
         XCTFail("upgrade called")
-        return ctx.eventLoop.makeSucceededFuture(result: ())
+        return ctx.eventLoop.makeSucceededFuture(())
     }
 }
 
@@ -204,7 +204,7 @@ private class UpgraderSaysNo: HTTPProtocolUpgrader {
 
     public func upgrade(ctx: ChannelHandlerContext, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<Void> {
         XCTFail("upgrade called")
-        return ctx.eventLoop.makeSucceededFuture(result: ())
+        return ctx.eventLoop.makeSucceededFuture(())
     }
 }
 
@@ -227,7 +227,7 @@ private class SuccessfulUpgrader: HTTPProtocolUpgrader {
 
     public func upgrade(ctx: ChannelHandlerContext, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<Void> {
         self.onUpgradeComplete(upgradeRequest)
-        return ctx.eventLoop.makeSucceededFuture(result: ())
+        return ctx.eventLoop.makeSucceededFuture(())
     }
 }
 
@@ -255,7 +255,7 @@ private class UpgradeDelayer: HTTPProtocolUpgrader {
     }
 
     public func unblockUpgrade() {
-        self.upgradePromise!.succeed(result: ())
+        self.upgradePromise!.succeed(())
     }
 }
 
@@ -400,7 +400,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
-            completePromise.succeed(result: ())
+            completePromise.succeed(())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
 
@@ -505,7 +505,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
-            completePromise.succeed(result: ())
+            completePromise.succeed(())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
 
@@ -549,7 +549,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
-            completePromise.succeed(result: ())
+            completePromise.succeed(())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
 
@@ -610,7 +610,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
-            completePromise.succeed(result: ())
+            completePromise.succeed(())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
 
@@ -656,7 +656,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
-            completePromise.succeed(result: ())
+            completePromise.succeed(())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
 
@@ -690,7 +690,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
-            completePromise.succeed(result: ())
+            completePromise.succeed(())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
 
@@ -733,7 +733,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
-            completePromise.succeed(result: ())
+            completePromise.succeed(())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
 
@@ -839,18 +839,18 @@ class HTTPUpgradeTestCase: XCTestCase {
                     XCTAssertEqual("A", stringRead)
                     self.state = .inlineDataRead
                     if stringRead == .some("A") {
-                        self.firstByteDonePromise.succeed(result: ())
+                        self.firstByteDonePromise.succeed(())
                     } else {
-                        self.firstByteDonePromise.fail(error: ReceivedTheWrongThingError.error)
+                        self.firstByteDonePromise.fail(ReceivedTheWrongThingError.error)
                     }
                 case .inlineDataRead:
                     XCTAssertEqual("B", stringRead)
                     self.state = .extraDataRead
                     ctx.channel.close(promise: nil)
                     if stringRead == .some("B") {
-                        self.secondByteDonePromise.succeed(result: ())
+                        self.secondByteDonePromise.succeed(())
                     } else {
-                        self.secondByteDonePromise.fail(error: ReceivedTheWrongThingError.error)
+                        self.secondByteDonePromise.fail(ReceivedTheWrongThingError.error)
                     }
                 default:
                     XCTFail("channel read in wrong state \(self.state)")
@@ -862,7 +862,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                 self.state = .closed
                 ctx.close(mode: mode, promise: promise)
                 
-                self.allDonePromise.succeed(result: ())
+                self.allDonePromise.succeed(())
             }
         }
         
@@ -899,7 +899,7 @@ class HTTPUpgradeTestCase: XCTestCase {
             assertResponseIs(response: resultString,
                              expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
-            completePromise.succeed(result: ())
+            completePromise.succeed(())
         }
         XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
         

--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
@@ -40,7 +40,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             XCTFail("Negotiation fired")
-            return loop.makeSucceededFuture(result: ())
+            return loop.makeSucceededFuture(())
         }
 
         try channel.pipeline.add(handler: handler).wait()
@@ -80,7 +80,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         try channel.pipeline.assertContains(handler: handler)
 
         // Now we fire the future.
-        continuePromise.succeed(result: ())
+        continuePromise.succeed(())
 
         // Now the handler should have removed itself from the pipeline.
         try channel.pipeline.assertDoesNotContain(handler: handler)
@@ -102,7 +102,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
 
         let handler = ApplicationProtocolNegotiationHandler { result in
             XCTFail("Should not be called")
-            return loop.makeSucceededFuture(result: ())
+            return loop.makeSucceededFuture(())
         }
 
         try channel.pipeline.add(handler: handler).wait()
@@ -135,7 +135,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         XCTAssertNil(channel.readInbound())
 
         // Complete the pipeline swap.
-        continuePromise.succeed(result: ())
+        continuePromise.succeed(())
 
         // Now everything should have been unbuffered.
         XCTAssertEqual(channel.readInbound()!, "writes")
@@ -166,7 +166,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
 
         // Now satisfy the future, which forces data unbuffering. As we haven't buffered any data,
         // readComplete should not be fired.
-        continuePromise.succeed(result: ())
+        continuePromise.succeed(())
         XCTAssertEqual(readCompleteHandler.readCompleteCount, 0)
 
         XCTAssertFalse(try channel.finish())
@@ -195,7 +195,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         XCTAssertEqual(readCompleteHandler.readCompleteCount, 1)
 
         // Now satisfy the future, which forces data unbuffering. This should fire readComplete.
-        continuePromise.succeed(result: ())
+        continuePromise.succeed(())
         XCTAssertEqual(channel.readInbound()!, "a write")
 
         XCTAssertEqual(readCompleteHandler.readCompleteCount, 2)

--- a/Tests/NIOTLSTests/SNIHandlerTests.swift
+++ b/Tests/NIOTLSTests/SNIHandlerTests.swift
@@ -293,7 +293,7 @@ class SNIHandlerTest: XCTestCase {
 
         // Now we're going to complete the promise and run the loop. This should cause the complete
         // ClientHello to be sent on, and the SNIHandler to be removed from the pipeline.
-        continuePromise.succeed(result: ())
+        continuePromise.succeed(())
         loop.run()
 
         let writtenBuffer: ByteBuffer = channel.readInbound() ?? channel.allocator.buffer(capacity: 0)
@@ -335,7 +335,7 @@ class SNIHandlerTest: XCTestCase {
 
         // Now we're going to complete the promise and run the loop. This should cause the complete
         // ClientHello to be sent on, and the SNIHandler to be removed from the pipeline.
-        continuePromise.succeed(result: ())
+        continuePromise.succeed(())
         loop.run()
 
         let writtenBuffer: ByteBuffer? = channel.readInbound()
@@ -358,7 +358,7 @@ class SNIHandlerTest: XCTestCase {
 
         let handler = ByteToMessageHandler(SNIHandler { result in
             XCTFail("Handler was called")
-            return loop.makeSucceededFuture(result: ())
+            return loop.makeSucceededFuture(())
         })
 
         try channel.pipeline.add(handler: handler).wait()

--- a/Tests/NIOTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOTests/AcceptBackoffHandlerTest.swift
@@ -161,7 +161,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
             }
 
             public func channelInactive(ctx: ChannelHandlerContext) {
-                promise.succeed(result: ())
+                promise.succeed(())
             }
 
             func waitForInactive() throws {

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -30,13 +30,13 @@ class BootstrapTest: XCTestCase {
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
                 .childChannelInitializer { channel in
                     XCTAssert(channel.eventLoop.inEventLoop)
-                    childChannelDone.succeed(result: ())
-                    return channel.eventLoop.makeSucceededFuture(result: ())
+                    childChannelDone.succeed(())
+                    return channel.eventLoop.makeSucceededFuture(())
                 }
                 .serverChannelInitializer { channel in
                     XCTAssert(channel.eventLoop.inEventLoop)
-                    serverChannelDone.succeed(result: ())
-                    return channel.eventLoop.makeSucceededFuture(result: ())
+                    serverChannelDone.succeed(())
+                    return channel.eventLoop.makeSucceededFuture(())
                 }
                 .bind(host: "localhost", port: 0)
                 .wait())
@@ -47,7 +47,7 @@ class BootstrapTest: XCTestCase {
             let client = try assertNoThrowWithValue(ClientBootstrap(group: group)
                 .channelInitializer { channel in
                     XCTAssert(channel.eventLoop.inEventLoop)
-                    return channel.eventLoop.makeSucceededFuture(result: ())
+                    return channel.eventLoop.makeSucceededFuture(())
                 }
                 .connect(to: serverChannel.localAddress!)
                 .wait(), message: "resolver debug info: \(try! resolverDebugInformation(eventLoop: group.next(),host: "localhost", previouslyReceivedResult: serverChannel.localAddress!))")

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -138,7 +138,7 @@ class ChannelNotificationTest: XCTestCase {
 
             XCTAssertFalse(ctx.channel.closeFuture.isFulfilled)
             XCTAssertFalse(self.activeChannelPromise.futureResult.isFulfilled)
-            self.activeChannelPromise.succeed(result: ctx.channel)
+            self.activeChannelPromise.succeed(ctx.channel)
         }
 
         public func channelInactive(ctx: ChannelHandlerContext) {
@@ -370,7 +370,7 @@ class ChannelNotificationTest: XCTestCase {
                 XCTAssertEqual(.readComplete, state)
                 state = .inactive
 
-                promise.succeed(result: ())
+                promise.succeed(())
             }
         }
 

--- a/Tests/NIOTests/ChannelOptionStorageTest.swift
+++ b/Tests/NIOTests/ChannelOptionStorageTest.swift
@@ -80,7 +80,7 @@ class OptionsCollectingChannel: Channel {
 
     func setOption<T>(option: T, value: T.OptionType) -> EventLoopFuture<Void> where T : ChannelOption {
         self.allOptions.append((option, value))
-        return self.eventLoop.makeSucceededFuture(result: ())
+        return self.eventLoop.makeSucceededFuture(())
     }
 
     func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T : ChannelOption {

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -153,7 +153,7 @@ class ChannelPipelineTest: XCTestCase {
             do {
                 ctx.write(self.wrapOutboundOut(try body(self.unwrapOutboundIn(data))), promise: promise)
             } catch let err {
-                promise!.fail(error: err)
+                promise!.fail(err)
             }
         }
     }
@@ -167,7 +167,7 @@ class ChannelPipelineTest: XCTestCase {
         }
 
         public func bind(ctx: ChannelHandlerContext, to address: SocketAddress, promise: EventLoopPromise<Void>?) {
-            promise!.fail(error: TestFailureError.CalledBind)
+            promise!.fail(TestFailureError.CalledBind)
         }
     }
 

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -81,7 +81,7 @@ public class ChannelTests: XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                serverAcceptedChannelPromise.succeed(result: channel)
+                serverAcceptedChannelPromise.succeed(channel)
                 return channel.pipeline.add(handler: serverLifecycleHandler)
             }.bind(host: "127.0.0.1", port: 0).wait())
 
@@ -182,8 +182,8 @@ public class ChannelTests: XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                childChannelPromise.succeed(result: channel)
-                return channel.eventLoop.makeSucceededFuture(result: ())
+                childChannelPromise.succeed(channel)
+                return channel.eventLoop.makeSucceededFuture(())
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -1288,14 +1288,14 @@ public class ChannelTests: XCTestCase {
                     inputShutdownEventReceived = true
 
                     if shutdownEvent == .input {
-                        promise.succeed(result: ())
+                        promise.succeed(())
                     }
                 case .outputClosed:
                     XCTAssertFalse(outputShutdownEventReceived)
                     outputShutdownEventReceived = true
 
                     if shutdownEvent == .output {
-                        promise.succeed(result: ())
+                        promise.succeed(())
                     }
                 }
 
@@ -1320,7 +1320,7 @@ public class ChannelTests: XCTestCase {
                 XCTAssertTrue(outputShutdownEventReceived)
             }
 
-            promise.succeed(result: ())
+            promise.succeed(())
         }
     }
 
@@ -1358,7 +1358,7 @@ public class ChannelTests: XCTestCase {
             }
 
             func channelRegistered(ctx: ChannelHandlerContext) {
-                self.promise.succeed(result: ctx.channel.pipeline)
+                self.promise.succeed(ctx.channel.pipeline)
             }
         }
         weak var weakClientChannel: Channel? = nil
@@ -1377,9 +1377,9 @@ public class ChannelTests: XCTestCase {
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
                 .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
                 .childChannelInitializer { channel in
-                    serverChildChannelPromise.succeed(result: channel)
+                    serverChildChannelPromise.succeed(channel)
                     channel.close(promise: nil)
-                    return channel.eventLoop.makeSucceededFuture(result: ())
+                    return channel.eventLoop.makeSucceededFuture(())
                 }
                 .bind(host: "127.0.0.1", port: 0).wait())
 
@@ -1514,7 +1514,7 @@ public class ChannelTests: XCTestCase {
             }
 
             func channelReadComplete(ctx: ChannelHandlerContext) {
-                self.waitingForReadPromise?.succeed(result: ())
+                self.waitingForReadPromise?.succeed(())
                 self.waitingForReadPromise = nil
             }
 
@@ -1747,7 +1747,7 @@ public class ChannelTests: XCTestCase {
             }
 
             public func channelInactive(ctx: ChannelHandlerContext) {
-                promise.succeed(result: ())
+                promise.succeed(())
             }
         }
 
@@ -1902,7 +1902,7 @@ public class ChannelTests: XCTestCase {
             func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
                 XCTAssertEqual(.active, self.state)
                 self.state = .read
-                self.hasReadPromise.succeed(result: ())
+                self.hasReadPromise.succeed(())
             }
             func channelActive(ctx: ChannelHandlerContext) {
                 XCTAssertEqual(.registered, self.state)
@@ -1911,10 +1911,10 @@ public class ChannelTests: XCTestCase {
             func channelRegistered(ctx: ChannelHandlerContext) {
                 XCTAssertEqual(.start, self.state)
                 self.state = .registered
-                self.hasRegisteredPromise.succeed(result: ())
+                self.hasRegisteredPromise.succeed(())
             }
             func channelUnregistered(ctx: ChannelHandlerContext) {
-                self.hasUnregisteredPromise.succeed(result: ())
+                self.hasUnregisteredPromise.succeed(())
             }
         }
 
@@ -2100,7 +2100,7 @@ public class ChannelTests: XCTestCase {
             func channelInactive(ctx: ChannelHandlerContext) {
                 XCTAssertEqual(.error, self.state)
                 self.state = .inactive
-                self.allDone.succeed(result: ())
+                self.allDone.succeed(())
             }
         }
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
@@ -2529,7 +2529,7 @@ public class ChannelTests: XCTestCase {
                     }.whenFailure { error in
                         XCTAssertEqual(ChannelError.ioOnClosedChannel, error as? ChannelError)
                         XCTAssertTrue(inSameStackFrame)
-                        self.allDonePromise.succeed(result: ())
+                        self.allDonePromise.succeed(())
                     }
                 }
             }
@@ -2587,9 +2587,9 @@ public class ChannelTests: XCTestCase {
             .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_KEEPALIVE), value: 1)
             .childChannelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
             .childChannelInitializer { channel in
-                acceptedChannels[numberOfAcceptedChannel].succeed(result: channel)
+                acceptedChannels[numberOfAcceptedChannel].succeed(channel)
                 numberOfAcceptedChannel += 1
-                return channel.eventLoop.makeSucceededFuture(result: ())
+                return channel.eventLoop.makeSucceededFuture(())
             }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
@@ -2656,7 +2656,7 @@ fileprivate final class FailRegistrationAndDelayCloseHandler: ChannelOutboundHan
     typealias OutboundIn = Never
 
     func register(ctx: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
-        promise!.fail(error: RegistrationFailedError.error)
+        promise!.fail(RegistrationFailedError.error)
     }
 
     func close(ctx: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
@@ -2699,7 +2699,7 @@ fileprivate class VerifyConnectionFailureHandler: ChannelInboundHandler {
     func channelUnregistered(ctx: ChannelHandlerContext) {
         XCTAssertEqual(.registered, self.state)
         self.state = .unregistered
-        self.allDone.succeed(result: ())
+        self.allDone.succeed(())
         ctx.fireChannelUnregistered()
     }
 }

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -46,7 +46,7 @@ private final class ChannelInactivePromiser: ChannelInboundHandler {
     }
 
     func channelInactive(ctx: ChannelHandlerContext) {
-        channelInactivePromise.succeed(result: ())
+        channelInactivePromise.succeed(())
     }
 }
 
@@ -598,7 +598,7 @@ private class PairOfBytesDecoder: ByteToMessageDecoder {
     func decodeLast(ctx: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
         self.decodeLastCalls += 1
         XCTAssertEqual(1, self.decodeLastCalls)
-        self.lastPromise.succeed(result: buffer)
+        self.lastPromise.succeed(buffer)
         return .needMoreData
     }
 }

--- a/Tests/NIOTests/CustomChannelTests.swift
+++ b/Tests/NIOTests/CustomChannelTests.swift
@@ -34,24 +34,24 @@ private class IntChannelCore: ChannelCore {
     }
 
     func register0(promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: NotImplementedError())
+        promise?.fail(NotImplementedError())
     }
 
     func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: NotImplementedError())
+        promise?.fail(NotImplementedError())
     }
 
     func bind0(to: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: NotImplementedError())
+        promise?.fail(NotImplementedError())
     }
 
     func connect0(to: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: NotImplementedError())
+        promise?.fail(NotImplementedError())
     }
 
     func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         _ = self.unwrapData(data, as: Int.self)
-        promise?.succeed(result: ())
+        promise?.succeed(())
     }
 
     func flush0() {
@@ -63,11 +63,11 @@ private class IntChannelCore: ChannelCore {
     }
 
     func close0(error: Error, mode: CloseMode, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: NotImplementedError())
+        promise?.fail(NotImplementedError())
     }
 
     func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
-        promise?.fail(error: NotImplementedError())
+        promise?.fail(NotImplementedError())
     }
 
     func channelRead0(_ data: NIOAny) {

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -24,7 +24,7 @@ private extension Channel {
             }
 
             XCTFail("Could not wait for reads")
-            return self.eventLoop.makeSucceededFuture(result: [] as [AddressedEnvelope<ByteBuffer>])
+            return self.eventLoop.makeSucceededFuture([] as [AddressedEnvelope<ByteBuffer>])
         }.wait()
     }
 }
@@ -65,7 +65,7 @@ private class DatagramReadRecorder<DataType>: ChannelInboundHandler {
         reads.append(data)
 
         if let promise = readWaiters.removeValue(forKey: reads.count) {
-            promise.succeed(result: reads)
+            promise.succeed(reads)
         }
 
         ctx.fireChannelRead(self.wrapInboundOut(data))
@@ -73,7 +73,7 @@ private class DatagramReadRecorder<DataType>: ChannelInboundHandler {
 
     func notifyForDatagrams(_ count: Int) -> EventLoopFuture<[AddressedEnvelope<DataType>]> {
         guard reads.count < count else {
-            return loop!.makeSucceededFuture(result: .init(reads.prefix(count)))
+            return loop!.makeSucceededFuture(.init(reads.prefix(count)))
         }
 
         readWaiters[count] = loop!.makePromise()
@@ -212,7 +212,7 @@ final class DatagramChannelTests: XCTestCase {
         // We're going to try to write loads, and loads, and loads of data. In this case, one more
         // write than the iovecs max.
 
-        var overall: EventLoopFuture<Void> = self.firstChannel.eventLoop.makeSucceededFuture(result: ())
+        var overall: EventLoopFuture<Void> = self.firstChannel.eventLoop.makeSucceededFuture(())
         for _ in 0...Socket.writevLimitIOVectors {
             let myPromise = self.firstChannel.eventLoop.makePromise(of: Void.self)
             var buffer = self.firstChannel.allocator.buffer(capacity: 1)
@@ -229,7 +229,7 @@ final class DatagramChannelTests: XCTestCase {
     func testSendmmsgLotsOfData() throws {
         var datagrams = 0
 
-        var overall = self.firstChannel.eventLoop.makeSucceededFuture(result: ())
+        var overall = self.firstChannel.eventLoop.makeSucceededFuture(())
         // We defer this work to the background thread because otherwise it incurs an enormous number of context
         // switches.
         try self.firstChannel.eventLoop.submit {
@@ -376,7 +376,7 @@ final class DatagramChannelTests: XCTestCase {
 
             func errorCaught(ctx: ChannelHandlerContext, error: Error) {
                 if let ioError = error as? IOError {
-                    self.promise.succeed(result: ioError)
+                    self.promise.succeed(ioError)
                 }
             }
         }

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -249,7 +249,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         func channelActive(ctx: ChannelHandlerContext) {
-            promise.succeed(result: ())
+            promise.succeed(())
             ctx.fireChannelActive()
         }
 
@@ -351,7 +351,7 @@ class EchoServerClientTest : XCTestCase {
                         XCTFail("unexpected error: \(err)")
                     }
                 }.whenComplete { (_: Result<Void, Error>) in
-                    self.channelInactivePromise.succeed(result: ())
+                    self.channelInactivePromise.succeed(())
                 }
             }
         }
@@ -371,7 +371,7 @@ class EchoServerClientTest : XCTestCase {
                         XCTFail("unexpected error: \(err)")
                     }
                 }.whenComplete { (_: Result<Void, Error>) in
-                    self.channelUnregisteredPromise.succeed(result: ())
+                    self.channelUnregisteredPromise.succeed(())
                 }
             }
         }
@@ -694,7 +694,7 @@ class EchoServerClientTest : XCTestCase {
             }
 
             public func channelInactive(ctx: ChannelHandlerContext) {
-                self.promise.succeed(result: ())
+                self.promise.succeed(())
             }
         }
 
@@ -741,7 +741,7 @@ class EchoServerClientTest : XCTestCase {
                         acceptedRemotePort.store(channel.remoteAddress?.port ?? -3)
                         acceptedLocalPort.store(channel.localAddress?.port ?? -4)
                         sem.signal()
-                        return channel.eventLoop.makeSucceededFuture(result: ())
+                        return channel.eventLoop.makeSucceededFuture(())
                     }.bind(host: host, port: 0).wait()
             } catch let e as SocketAddressError {
                 if case .unknown(host, port: 0) = e {
@@ -802,8 +802,8 @@ class EchoServerClientTest : XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .connect(host: "localhost", port: Int(serverChannel.localAddress!.port!))
             .flatMapError {
-                promise.fail(error: $0)
-                return group.next().makeFailedFuture(error: $0)
+                promise.fail($0)
+                return group.next().makeFailedFuture($0)
             }
             .wait())
 

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -119,7 +119,7 @@ class EmbeddedChannelTest: XCTestCase {
         typealias OutboundOut = Never
 
         public func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-            promise!.fail(error: ChannelError.operationUnsupported)
+            promise!.fail(ChannelError.operationUnsupported)
         }
     }
 

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -54,12 +54,12 @@ class EventLoopFutureTest : XCTestCase {
 
         var fN = f0.fold(f1s) { (f1Value: [Int], f2Value: Int) -> EventLoopFuture<[Int]> in
             XCTAssert(eventLoop0.inEventLoop)
-            return eventLoop1.makeSucceededFuture(result: f1Value + [f2Value])
+            return eventLoop1.makeSucceededFuture(f1Value + [f2Value])
         }
 
         fN = fN.fold(f2s) { (f1Value: [Int], f2Value: Int) -> EventLoopFuture<[Int]> in
             XCTAssert(eventLoop0.inEventLoop)
-            return eventLoop2.makeSucceededFuture(result: f1Value + [f2Value])
+            return eventLoop2.makeSucceededFuture(f1Value + [f2Value])
         }
 
         let allValues = try fN.wait()
@@ -71,13 +71,13 @@ class EventLoopFutureTest : XCTestCase {
     func testFoldWithSuccessAndAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0 = eventLoop.makeSucceededFuture(result: [0])
+        let f0 = eventLoop.makeSucceededFuture([0])
 
-        let futures: [EventLoopFuture<Int>] = (1...5).map { (id: Int) in secondEventLoop.makeSucceededFuture(result: id) }
+        let futures: [EventLoopFuture<Int>] = (1...5).map { (id: Int) in secondEventLoop.makeSucceededFuture(id) }
 
         let fN = f0.fold(futures) { (f1Value: [Int], f2Value: Int) -> EventLoopFuture<[Int]> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.makeSucceededFuture(result: f1Value + [f2Value])
+            return secondEventLoop.makeSucceededFuture(f1Value + [f2Value])
         }
 
         let allValues = try fN.wait()
@@ -90,19 +90,19 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.makeSucceededFuture(result: 0)
+        let f0: EventLoopFuture<Int> = eventLoop.makeSucceededFuture(0)
 
         let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makePromise() }
         var futures = promises.map { $0.futureResult }
-        let failedFuture: EventLoopFuture<Int> = secondEventLoop.makeFailedFuture(error: E())
+        let failedFuture: EventLoopFuture<Int> = secondEventLoop.makeFailedFuture(E())
         futures.insert(failedFuture, at: futures.startIndex)
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.makeSucceededFuture(result: f1Value + f2Value)
+            return secondEventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
-        _ = promises.map { $0.succeed(result: 0) }
+        _ = promises.map { $0.succeed(0) }
         XCTAssert(fN.isFulfilled)
         do {
             _ = try fN.wait()
@@ -116,13 +116,13 @@ class EventLoopFutureTest : XCTestCase {
 
     func testFoldWithSuccessAndEmptyFutureList() throws {
         let eventLoop = EmbeddedEventLoop()
-        let f0 = eventLoop.makeSucceededFuture(result: 0)
+        let f0 = eventLoop.makeSucceededFuture(0)
 
         let futures: [EventLoopFuture<Int>] = []
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return eventLoop.makeSucceededFuture(result: f1Value + f2Value)
+            return eventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
         let summationResult = try fN.wait()
@@ -133,13 +133,13 @@ class EventLoopFutureTest : XCTestCase {
     func testFoldWithFailureAndEmptyFutureList() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(error: E())
+        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(E())
 
         let futures: [EventLoopFuture<Int>] = []
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return eventLoop.makeSucceededFuture(result: f1Value + f2Value)
+            return eventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
         XCTAssert(fN.isFulfilled)
@@ -157,17 +157,17 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(error: E())
+        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(E())
 
         let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.makeSucceededFuture(result: f1Value + f2Value)
+            return secondEventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
-        _ = promises.map { $0.succeed(result: 1) }
+        _ = promises.map { $0.succeed(1) }
         XCTAssert(fN.isFulfilled)
         do {
             _ = try fN.wait()
@@ -183,14 +183,14 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(error: E())
+        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(E())
 
         let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.makeSucceededFuture(result: f1Value + f2Value)
+            return secondEventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
         XCTAssert(fN.isFulfilled)
@@ -208,13 +208,13 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
-        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(error: E())
+        let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(E())
 
-        let futures: [EventLoopFuture<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makeFailedFuture(error: E()) }
+        let futures: [EventLoopFuture<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makeFailedFuture(E()) }
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
             XCTAssert(eventLoop.inEventLoop)
-            return secondEventLoop.makeSucceededFuture(result: f1Value + f2Value)
+            return secondEventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
         XCTAssert(fN.isFulfilled)
@@ -243,7 +243,7 @@ class EventLoopFutureTest : XCTestCase {
         let futures = promises.map { $0.futureResult }
 
         let fN: EventLoopFuture<Void> = EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)
-        _ = promises.map { $0.succeed(result: ()) }
+        _ = promises.map { $0.succeed(()) }
         () = try fN.wait()
     }
 
@@ -254,7 +254,7 @@ class EventLoopFutureTest : XCTestCase {
         let futures = promises.map { $0.futureResult }
 
         let fN: EventLoopFuture<Void> = EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)
-        _ = promises.map { $0.fail(error: E()) }
+        _ = promises.map { $0.fail(E()) }
         do {
             () = try fN.wait()
             XCTFail("should've thrown an error")
@@ -269,9 +269,9 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         var promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
-        _ = promises.map { $0.succeed(result: ()) }
+        _ = promises.map { $0.succeed(()) }
         let failedPromise = eventLoop.makePromise(of: Void.self)
-        failedPromise.fail(error: E())
+        failedPromise.fail(E())
         promises.append(failedPromise)
 
         let futures = promises.map { $0.futureResult }
@@ -294,7 +294,7 @@ class EventLoopFutureTest : XCTestCase {
 
         let fN: EventLoopFuture<[Int]> = EventLoopFuture<[Int]>.reduce([], futures, eventLoop: eventLoop) {$0 + [$1]}
         for i in 1...5 {
-            promises[i - 1].succeed(result: (i))
+            promises[i - 1].succeed((i))
         }
         let results = try fN.wait()
         XCTAssertEqual(results, [1, 2, 3, 4, 5])
@@ -319,7 +319,7 @@ class EventLoopFutureTest : XCTestCase {
         let futures = promises.map { $0.futureResult }
 
         let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, eventLoop: eventLoop, +)
-        _ = promises.map { $0.fail(error: E()) }
+        _ = promises.map { $0.fail(E()) }
         XCTAssert(fN.eventLoop === eventLoop)
         do {
             _ = try fN.wait()
@@ -335,9 +335,9 @@ class EventLoopFutureTest : XCTestCase {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         var promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
-        _ = promises.map { $0.succeed(result: (1)) }
+        _ = promises.map { $0.succeed((1)) }
         let failedPromise = eventLoop.makePromise(of: Int.self)
-        failedPromise.fail(error: E())
+        failedPromise.fail(E())
         promises.append(failedPromise)
 
         let futures = promises.map { $0.futureResult }
@@ -365,7 +365,7 @@ class EventLoopFutureTest : XCTestCase {
         let futures = promises.map { $0.futureResult }
         let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, eventLoop: eventLoop, +)
 
-        failedPromise.fail(error: E())
+        failedPromise.fail(E())
 
         XCTAssertTrue(fN.isFulfilled)
         XCTAssert(fN.eventLoop === eventLoop)
@@ -381,7 +381,7 @@ class EventLoopFutureTest : XCTestCase {
 
     func testReduceIntoWithAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
-        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.makeSucceededFuture(result: id) }
+        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.makeSucceededFuture(id) }
 
         let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(into: [:], futures, eventLoop: eventLoop) { (freqs, elem) in
             if let value = freqs[elem] {
@@ -416,7 +416,7 @@ class EventLoopFutureTest : XCTestCase {
     func testReduceIntoWithAllFailure() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.makeFailedFuture(error: E()) }
+        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.makeFailedFuture(E()) }
 
         let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(into: [:], futures, eventLoop: eventLoop) { (freqs, elem) in
             if let value = freqs[elem] {
@@ -484,7 +484,7 @@ class EventLoopFutureTest : XCTestCase {
             ran = true
             XCTAssertEqual($0, 6)
         }
-        p.succeed(result: "hello")
+        p.succeed("hello")
         XCTAssertTrue(ran)
     }
 
@@ -507,7 +507,7 @@ class EventLoopFutureTest : XCTestCase {
             ran = true
             XCTAssertEqual(.some(DummyError.dummyError), $0 as? DummyError)
         }
-        p.succeed(result: "hello")
+        p.succeed("hello")
         XCTAssertTrue(ran)
     }
 
@@ -530,7 +530,7 @@ class EventLoopFutureTest : XCTestCase {
             ran = true
             XCTAssertEqual($0, 5)
         }
-        p.fail(error: DummyError.dummyError)
+        p.fail(DummyError.dummyError)
         XCTAssertTrue(ran)
     }
 
@@ -554,7 +554,7 @@ class EventLoopFutureTest : XCTestCase {
             ran = true
             XCTAssertEqual(.some(DummyError.dummyError2), $0 as? DummyError)
         }
-        p.fail(error: DummyError.dummyError1)
+        p.fail(DummyError.dummyError1)
         XCTAssertTrue(ran)
     }
 
@@ -572,7 +572,7 @@ class EventLoopFutureTest : XCTestCase {
             XCTAssertEqual(state, 2)
             state += 1
         }
-        p.succeed(result: ())
+        p.succeed(())
         XCTAssertTrue(p.futureResult.isFulfilled)
         XCTAssertEqual(state, 3)
     }
@@ -580,12 +580,12 @@ class EventLoopFutureTest : XCTestCase {
     func testEventLoopHoppingInThen() throws {
         let n = 20
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
-        var prev: EventLoopFuture<Int> = elg.next().makeSucceededFuture(result: 0)
+        var prev: EventLoopFuture<Int> = elg.next().makeSucceededFuture(0)
         (1..<20).forEach { (i: Int) in
             let p = elg.next().makePromise(of: Int.self)
             prev.flatMap { (i2: Int) -> EventLoopFuture<Int> in
                 XCTAssertEqual(i - 1, i2)
-                p.succeed(result: i)
+                p.succeed(i)
                 return p.futureResult
             }.whenSuccess { i2 in
                 XCTAssertEqual(i, i2)
@@ -602,19 +602,19 @@ class EventLoopFutureTest : XCTestCase {
         }
         let n = 20
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
-        var prev: EventLoopFuture<Int> = elg.next().makeSucceededFuture(result: 0)
+        var prev: EventLoopFuture<Int> = elg.next().makeSucceededFuture(0)
         (1..<n).forEach { (i: Int) in
             let p = elg.next().makePromise(of: Int.self)
             prev.flatMap { (i2: Int) -> EventLoopFuture<Int> in
                 XCTAssertEqual(i - 1, i2)
                 if i == n/2 {
-                    p.fail(error: DummyError.dummy)
+                    p.fail(DummyError.dummy)
                 } else {
-                    p.succeed(result: i)
+                    p.succeed(i)
                 }
                 return p.futureResult
             }.flatMapError { error in
-                p.fail(error: error)
+                p.fail(error)
                 return p.futureResult
             }.whenSuccess { i2 in
                 XCTAssertEqual(i, i2)
@@ -641,7 +641,7 @@ class EventLoopFutureTest : XCTestCase {
         let allOfEm = EventLoopFuture<Void>.andAll(ps.map { $0.futureResult }, eventLoop: elg.next())
         ps.reversed().forEach { p in
             DispatchQueue.global().async {
-                p.succeed(result: ())
+                p.succeed(())
             }
         }
         try allOfEm.wait()
@@ -660,9 +660,9 @@ class EventLoopFutureTest : XCTestCase {
         ps.reversed().enumerated().forEach { idx, p in
             DispatchQueue.global().async {
                 if idx == n / 2 {
-                    p.fail(error: DummyError.dummy)
+                    p.fail(DummyError.dummy)
                 } else {
-                    p.succeed(result: ())
+                    p.succeed(())
                 }
             }
         }
@@ -714,16 +714,16 @@ class EventLoopFutureTest : XCTestCase {
                     if whoGoesFirst.0 {
                         q1.async {
                             if whoSucceeds.0 {
-                                p0.succeed(result: 7)
+                                p0.succeed(7)
                             } else {
-                                p0.fail(error: DummyError.dummy0)
+                                p0.fail(DummyError.dummy0)
                             }
                             if !whoGoesFirst.1 {
                                 q2.asyncAfter(deadline: .now() + 0.1) {
                                     if whoSucceeds.1 {
-                                        p1.succeed(result: "hello")
+                                        p1.succeed("hello")
                                     } else {
-                                        p1.fail(error: DummyError.dummy1)
+                                        p1.fail(DummyError.dummy1)
                                     }
                                 }
                             }
@@ -732,16 +732,16 @@ class EventLoopFutureTest : XCTestCase {
                     if whoGoesFirst.1 {
                         q2.async {
                             if whoSucceeds.1 {
-                                p1.succeed(result: "hello")
+                                p1.succeed("hello")
                             } else {
-                                p1.fail(error: DummyError.dummy1)
+                                p1.fail(DummyError.dummy1)
                             }
                             if !whoGoesFirst.0 {
                                 q1.asyncAfter(deadline: .now() + 0.1) {
                                     if whoSucceeds.0 {
-                                        p0.succeed(result: 7)
+                                        p0.succeed(7)
                                     } else {
-                                        p0.fail(error: DummyError.dummy0)
+                                        p0.fail(DummyError.dummy0)
                                     }
                                 }
                             }
@@ -786,7 +786,7 @@ class EventLoopFutureTest : XCTestCase {
         }.hopTo(eventLoop: loop2).map {
             XCTAssertTrue(loop2.inEventLoop)
         }
-        succeedingPromise.succeed(result: ())
+        succeedingPromise.succeed(())
         XCTAssertNoThrow(try succeedingFuture.wait())
     }
 
@@ -810,7 +810,7 @@ class EventLoopFutureTest : XCTestCase {
             XCTAssertTrue(loop1.inEventLoop)
         }
 
-        failingPromise.fail(error: EventLoopFutureTestError.example)
+        failingPromise.fail(EventLoopFutureTestError.example)
         XCTAssertNoThrow(try failingFuture.wait())
     }
 
@@ -826,6 +826,6 @@ class EventLoopFutureTest : XCTestCase {
         let noHoppingPromise = loop1.makePromise(of: Void.self)
         let noHoppingFuture = noHoppingPromise.futureResult.hopTo(eventLoop: loop1)
         XCTAssertTrue(noHoppingFuture === noHoppingPromise.futureResult)
-        noHoppingPromise.succeed(result: ())
+        noHoppingPromise.succeed(())
     }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -314,7 +314,7 @@ public class EventLoopTest : XCTestCase {
             }
 
             func channelActive(ctx: ChannelHandlerContext) {
-                self.channelActivePromise?.succeed(result: ())
+                self.channelActivePromise?.succeed(())
             }
 
             func close(ctx: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
@@ -398,7 +398,7 @@ public class EventLoopTest : XCTestCase {
 
         // Now let it close.
         promiseQueue.sync {
-            promises.forEach { $0.succeed(result: ()) }
+            promises.forEach { $0.succeed(()) }
         }
         XCTAssertNoThrow(try loopCloseFut.wait())
     }

--- a/Tests/NIOTests/HappyEyeballsTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest.swift
@@ -99,13 +99,13 @@ private extension Channel {
 
     func succeedConnection() {
         return try! self.pipeline.context(name: CONNECT_DELAYER).map {
-            ($0.handler as! ConnectionDelayer).connectPromise!.succeed(result: ())
+            ($0.handler as! ConnectionDelayer).connectPromise!.succeed(())
         }.wait()
     }
 
     func failConnection(error: Error) {
         return try! self.pipeline.context(name: CONNECT_DELAYER).map {
-            ($0.handler as! ConnectionDelayer).connectPromise!.fail(error: error)
+            ($0.handler as! ConnectionDelayer).connectPromise!.fail(error)
         }.wait()
     }
 
@@ -215,7 +215,7 @@ extension DummyResolver.Event: Equatable {
 private func defaultChannelBuilder(loop: EventLoop, family: Int32) -> EventLoopFuture<Channel> {
     let channel = EmbeddedChannel(loop: loop as! EmbeddedEventLoop)
     XCTAssertNoThrow(try channel.pipeline.add(name: CONNECT_RECORDER, handler: ConnectRecorder()).wait())
-    return loop.makeSucceededFuture(result: channel)
+    return loop.makeSucceededFuture(channel)
 }
 
 private func buildEyeballer(host: String,
@@ -242,8 +242,8 @@ public class HappyEyeballsTest : XCTestCase {
             return target
         }
         loop.run()
-        resolver.v6Promise.fail(error: DummyError())
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v6Promise.fail(DummyError())
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.run()
 
         // No time should have needed to pass: we return only one target and it connects immediately.
@@ -266,8 +266,8 @@ public class HappyEyeballsTest : XCTestCase {
             return target
         }
         loop.run()
-        resolver.v4Promise.fail(error: DummyError())
-        resolver.v6Promise.succeed(result: SINGLE_IPv6_RESULT)
+        resolver.v4Promise.fail(DummyError())
+        resolver.v6Promise.succeed(SINGLE_IPv6_RESULT)
         loop.run()
 
         // No time should have needed to pass: we return only one target and it connects immediately.
@@ -308,8 +308,8 @@ public class HappyEyeballsTest : XCTestCase {
 
         // We now want to confirm that nothing awful happens if those DNS results
         // return late.
-        resolver.v6Promise.succeed(result: SINGLE_IPv6_RESULT)
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v6Promise.succeed(SINGLE_IPv6_RESULT)
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.run()
         XCTAssertEqual(resolver.events, expectedQueries + [.cancel])
     }
@@ -329,7 +329,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertEqual(resolver.events, expectedQueries)
         XCTAssertFalse(targetFuture.isFulfilled)
 
-        resolver.v6Promise.succeed(result: SINGLE_IPv6_RESULT)
+        resolver.v6Promise.succeed(SINGLE_IPv6_RESULT)
         loop.run()
 
         // No time should have needed to pass: we return only one target and it connects immediately.
@@ -341,7 +341,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertEqual(resolver.events, expectedQueries + [.cancel])
 
         // Now return a result for the IPv4 query. Nothing bad should happen.
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.run()
         XCTAssertEqual(resolver.events, expectedQueries + [.cancel])
     }
@@ -361,7 +361,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertEqual(resolver.events, expectedQueries)
         XCTAssertFalse(targetFuture.isFulfilled)
 
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.run()
 
         // There should have been no connection attempt yet.
@@ -383,7 +383,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertEqual(resolver.events, expectedQueries + [.cancel])
 
         // Now return a result for the IPv6 query. Nothing bad should happen.
-        resolver.v6Promise.succeed(result: SINGLE_IPv6_RESULT)
+        resolver.v6Promise.succeed(SINGLE_IPv6_RESULT)
         loop.run()
         XCTAssertEqual(resolver.events, expectedQueries + [.cancel])
     }
@@ -403,7 +403,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertEqual(resolver.events, expectedQueries)
         XCTAssertFalse(targetFuture.isFulfilled)
 
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.run()
 
         // There should have been no connection attempt yet.
@@ -411,7 +411,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(targetFuture.isFulfilled)
 
         // Now the AAAA returns.
-        resolver.v6Promise.succeed(result: SINGLE_IPv6_RESULT)
+        resolver.v6Promise.succeed(SINGLE_IPv6_RESULT)
         loop.run()
 
         // The connection attempt should have been made with the IPv6 result.
@@ -437,7 +437,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertEqual(resolver.events, expectedQueries)
         XCTAssertFalse(targetFuture.isFulfilled)
 
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.run()
 
         // There should have been no connection attempt yet.
@@ -445,7 +445,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(targetFuture.isFulfilled)
 
         // Now the AAAA fails.
-        resolver.v6Promise.fail(error: DummyError())
+        resolver.v6Promise.fail(DummyError())
         loop.run()
 
         // The connection attempt should have been made with the IPv4 result.
@@ -471,7 +471,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertEqual(resolver.events, expectedQueries)
         XCTAssertFalse(targetFuture.isFulfilled)
 
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.run()
 
         // There should have been no connection attempt yet.
@@ -479,7 +479,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(targetFuture.isFulfilled)
 
         // Now the AAAA returns empty.
-        resolver.v6Promise.succeed(result: [])
+        resolver.v6Promise.succeed([])
         loop.run()
 
         // The connection attempt should have been made with the IPv4 result.
@@ -501,8 +501,8 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertEqual(resolver.events, expectedQueries)
         XCTAssertFalse(channelFuture.isFulfilled)
 
-        resolver.v4Promise.succeed(result: [])
-        resolver.v6Promise.succeed(result: [])
+        resolver.v4Promise.succeed([])
+        resolver.v6Promise.succeed([])
         loop.run()
 
 
@@ -534,8 +534,8 @@ public class HappyEyeballsTest : XCTestCase {
 
         let v4Error = DummyError()
         let v6Error = DummyError()
-        resolver.v4Promise.fail(error: v4Error)
-        resolver.v6Promise.fail(error: v6Error)
+        resolver.v4Promise.fail(v4Error)
+        resolver.v6Promise.fail(v6Error)
         loop.run()
 
         // We should have had queries for AAAA and A, with no cancel.
@@ -578,8 +578,8 @@ public class HappyEyeballsTest : XCTestCase {
 
         // We're providing the IPv4 and IPv6 results. This will lead to 20 total hosts
         // for us to try to connect to.
-        resolver.v4Promise.succeed(result: MANY_IPv4_RESULTS)
-        resolver.v6Promise.succeed(result: MANY_IPv6_RESULTS)
+        resolver.v4Promise.succeed(MANY_IPv4_RESULTS)
+        resolver.v6Promise.succeed(MANY_IPv6_RESULTS)
 
         for connectionCount in 1...20 {
             XCTAssertEqual(channels.count, connectionCount)
@@ -647,8 +647,8 @@ public class HappyEyeballsTest : XCTestCase {
 
         // We're providing the IPv4 and IPv6 results. This will lead to 20 total hosts
         // for us to try to connect to.
-        resolver.v4Promise.succeed(result: MANY_IPv4_RESULTS)
-        resolver.v6Promise.succeed(result: MANY_IPv6_RESULTS)
+        resolver.v4Promise.succeed(MANY_IPv4_RESULTS)
+        resolver.v6Promise.succeed(MANY_IPv6_RESULTS)
 
         // Let all the connections fire.
         for _ in 1...20 {
@@ -716,7 +716,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(channelFuture.isFulfilled)
 
         // Provide the IPv4 results and let five connection attempts play out.
-        resolver.v4Promise.succeed(result: MANY_IPv4_RESULTS)
+        resolver.v4Promise.succeed(MANY_IPv4_RESULTS)
         loop.advanceTime(by: .milliseconds(50))
 
         for connectionCount in 1...4 {
@@ -726,7 +726,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertEqual(channels.last!.connectTarget()!, "10.0.0.5")
 
         // Now the IPv6 results come in.
-        resolver.v6Promise.succeed(result: MANY_IPv6_RESULTS)
+        resolver.v6Promise.succeed(MANY_IPv6_RESULTS)
 
         // The next 10 connection attempts will interleave the IPv6 and IPv4 results,
         // starting with IPv6.
@@ -757,7 +757,7 @@ public class HappyEyeballsTest : XCTestCase {
 
         // Here the A result returns, but the timeout is sufficiently low that the connect attempt
         // times out before the AAAA can return.
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.advanceTime(by: .milliseconds(48))
         XCTAssertFalse(channelFuture.isFulfilled)
 
@@ -800,7 +800,7 @@ public class HappyEyeballsTest : XCTestCase {
 
         // Here the A result returns, but the timeout is sufficiently low that the connect attempt
         // times out before the AAAA can return and before the connection succeeds.
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.advanceTime(by: .milliseconds(99))
         XCTAssertFalse(channelFuture.isFulfilled)
         XCTAssertEqual(channels.count, 1)
@@ -845,7 +845,7 @@ public class HappyEyeballsTest : XCTestCase {
 
         // Here the A result returns and a connection attempt is made. This fails, and we test that
         // we wait for the AAAA query to come in before acting. That connection attempt then times out.
-        resolver.v4Promise.succeed(result: SINGLE_IPv4_RESULT)
+        resolver.v4Promise.succeed(SINGLE_IPv4_RESULT)
         loop.advanceTime(by: .milliseconds(50))
         XCTAssertFalse(channelFuture.isFulfilled)
         XCTAssertEqual(channels.count, 1)
@@ -856,7 +856,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(channelFuture.isFulfilled)
 
         // Now the AAAA returns.
-        resolver.v6Promise.succeed(result: SINGLE_IPv6_RESULT)
+        resolver.v6Promise.succeed(SINGLE_IPv6_RESULT)
         XCTAssertFalse(channelFuture.isFulfilled)
         XCTAssertEqual(channels.count, 2)
         XCTAssertEqual(channels.last!.state(), .idle)
@@ -899,7 +899,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(channelFuture.isFulfilled)
 
         // Provide the IPv6 results and let all 10 connection attempts play out.
-        resolver.v6Promise.succeed(result: MANY_IPv6_RESULTS)
+        resolver.v6Promise.succeed(MANY_IPv6_RESULTS)
 
         for connectionCount in 1...10 {
             XCTAssertEqual(channels.last!.connectTarget()!, "fe80::\(connectionCount)")
@@ -913,7 +913,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(channelFuture.isFulfilled)
 
         // Now the IPv4 results come in. Let all 10 connection attempts play out.
-        resolver.v4Promise.succeed(result: MANY_IPv4_RESULTS)
+        resolver.v4Promise.succeed(MANY_IPv4_RESULTS)
         for connectionCount in 1...10 {
             XCTAssertEqual(channels.last!.connectTarget()!, "10.0.0.\(connectionCount)")
             loop.advanceTime(by: .milliseconds(250))
@@ -946,7 +946,7 @@ public class HappyEyeballsTest : XCTestCase {
 
         // Here the AAAA result returns, but the timeout is sufficiently low that the connect attempt
         // times out before the A returns.
-        resolver.v6Promise.succeed(result: SINGLE_IPv6_RESULT)
+        resolver.v6Promise.succeed(SINGLE_IPv6_RESULT)
         loop.advanceTime(by: .milliseconds(99))
         XCTAssertFalse(channelFuture.isFulfilled)
         XCTAssertEqual(channels.count, 1)
@@ -991,7 +991,7 @@ public class HappyEyeballsTest : XCTestCase {
 
         // Here the AAAA and A results return. We are going to fail the connections
         // instantly, which should cause all 20 to appear.
-        resolver.v6Promise.succeed(result: MANY_IPv6_RESULTS)
+        resolver.v6Promise.succeed(MANY_IPv6_RESULTS)
         for channelCount in 1...10 {
             XCTAssertFalse(channelFuture.isFulfilled)
             XCTAssertEqual(channels.count, channelCount)
@@ -999,7 +999,7 @@ public class HappyEyeballsTest : XCTestCase {
             channels.last?.failConnection(error: DummyError())
         }
 
-        resolver.v4Promise.succeed(result: MANY_IPv4_RESULTS)
+        resolver.v4Promise.succeed(MANY_IPv4_RESULTS)
         for channelCount in 11...20 {
             XCTAssertFalse(channelFuture.isFulfilled)
             XCTAssertEqual(channels.count, channelCount)
@@ -1040,7 +1040,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(channelFuture.isFulfilled)
 
         // Here the AAAA results return. Let all the connection attempts go out.
-        resolver.v6Promise.succeed(result: MANY_IPv6_RESULTS)
+        resolver.v6Promise.succeed(MANY_IPv6_RESULTS)
         for channelCount in 1...10 {
             XCTAssertEqual(channels.count, channelCount)
             loop.advanceTime(by: .milliseconds(250))
@@ -1077,7 +1077,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(channelFuture.isFulfilled)
 
         // Return the IPv6 results and observe the channel creation attempts.
-        resolver.v6Promise.succeed(result: MANY_IPv6_RESULTS)
+        resolver.v6Promise.succeed(MANY_IPv6_RESULTS)
         for channelCount in 1...10 {
             XCTAssertEqual(ourChannelFutures.count, channelCount)
             loop.advanceTime(by: .milliseconds(250))
@@ -1087,19 +1087,19 @@ public class HappyEyeballsTest : XCTestCase {
         // Succeed the first channel future, which will connect because the default
         // channel builder always does.
         defaultChannelBuilder(loop: loop, family: AF_INET6).whenSuccess {
-            ourChannelFutures.first!.succeed(result: $0)
+            ourChannelFutures.first!.succeed($0)
             XCTAssertEqual($0.state(), .connected)
         }
         XCTAssertTrue(channelFuture.isFulfilled)
 
         // Ok, now succeed the second channel future. This should cause the channel to immediately be closed.
         defaultChannelBuilder(loop: loop, family: AF_INET6).whenSuccess {
-            ourChannelFutures[1].succeed(result: $0)
+            ourChannelFutures[1].succeed($0)
             XCTAssertEqual($0.state(), .closed)
         }
 
         // Ok, now fail the third channel future. Nothing bad should happen here.
-        ourChannelFutures[2].fail(error: DummyError())
+        ourChannelFutures[2].fail(DummyError())
 
         // Verify that the first channel is the one listed as connected.
         XCTAssertTrue((try ourChannelFutures.first!.futureResult.wait()) === (try channelFuture.wait()))
@@ -1109,7 +1109,7 @@ public class HappyEyeballsTest : XCTestCase {
         var errors: [DummyError] = []
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80) { loop, _ in
             errors.append(DummyError())
-            return loop.makeFailedFuture(error: errors.last!)
+            return loop.makeFailedFuture(errors.last!)
         }
         let channelFuture = eyeballer.resolveAndConnect()
         let expectedQueries: [DummyResolver.Event] = [
@@ -1122,10 +1122,10 @@ public class HappyEyeballsTest : XCTestCase {
 
         // Here the AAAA and A results return. We are going to fail the channel creation
         // instantly, which should cause all 20 to appear.
-        resolver.v6Promise.succeed(result: MANY_IPv6_RESULTS)
+        resolver.v6Promise.succeed(MANY_IPv6_RESULTS)
         XCTAssertEqual(errors.count, 10)
         XCTAssertFalse(channelFuture.isFulfilled)
-        resolver.v4Promise.succeed(result: MANY_IPv4_RESULTS)
+        resolver.v4Promise.succeed(MANY_IPv4_RESULTS)
         XCTAssertEqual(errors.count, 20)
 
         XCTAssertTrue(channelFuture.isFulfilled)
@@ -1160,7 +1160,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(channelFuture.isFulfilled)
 
         // Here the AAAA results return. Let the first connection attempt go out.
-        resolver.v6Promise.succeed(result: MANY_IPv6_RESULTS)
+        resolver.v6Promise.succeed(MANY_IPv6_RESULTS)
         XCTAssertEqual(channels.count, 1)
 
         // Advance time by 250 ms.
@@ -1209,7 +1209,7 @@ public class HappyEyeballsTest : XCTestCase {
         XCTAssertFalse(channelFuture.isFulfilled)
 
         // Here the A results return. Let the first connection attempt go out.
-        resolver.v4Promise.succeed(result: MANY_IPv4_RESULTS)
+        resolver.v4Promise.succeed(MANY_IPv4_RESULTS)
         XCTAssertEqual(channels.count, 0)
 
         // Advance time by 50 ms.

--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -26,7 +26,7 @@ final class PromiseOnReadHandler: ChannelInboundHandler {
     }
 
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
-        self.promise.succeed(result: self.unwrapInboundIn(data))
+        self.promise.succeed(self.unwrapInboundIn(data))
         _ = ctx.pipeline.remove(ctx: ctx)
     }
 }
@@ -77,7 +77,7 @@ final class MulticastTest: XCTestCase {
                     let multicastAddress = try SocketAddress(ipAddress: multicastAddress, port: channel.localAddress!.port!)
                     return channel.joinGroup(multicastAddress, interface: interface).map { channel }
                 } catch {
-                    return channel.eventLoop.makeFailedFuture(error: error)
+                    return channel.eventLoop.makeFailedFuture(error)
                 }
             }.flatMap { (channel: MulticastChannel) -> EventLoopFuture<MulticastChannel> in
                 let provider = channel as! SocketOptionProvider
@@ -103,7 +103,7 @@ final class MulticastTest: XCTestCase {
             return provider.setIPv6MulticastIF(CUnsignedInt(multicastInterface.interfaceIndex))
         default:
             XCTFail("Cannot join channel bound to \(sender.localAddress!) to interface at \(multicastInterface.address)")
-            return sender.eventLoop.makeFailedFuture(error: MulticastInterfaceMismatchError())
+            return sender.eventLoop.makeFailedFuture(MulticastInterfaceMismatchError())
         }
     }
 
@@ -114,7 +114,7 @@ final class MulticastTest: XCTestCase {
             let multicastAddress = try SocketAddress(ipAddress: multicastAddress, port: channel.localAddress!.port!)
             return channel.leaveGroup(multicastAddress, interface: interface)
         } catch {
-            return channel.eventLoop.makeFailedFuture(error: error)
+            return channel.eventLoop.makeFailedFuture(error)
         }
     }
 
@@ -147,7 +147,7 @@ final class MulticastTest: XCTestCase {
 
         // If we receive a datagram, or the reader promise fails, we must fail the timeoutPromise.
         receivedMulticastDatagram.futureResult.map { (_: AddressedEnvelope<ByteBuffer>) in
-            timeoutPromise.fail(error: ReceivedDatagramError())
+            timeoutPromise.fail(ReceivedDatagramError())
         }.cascadeFailure(promise: timeoutPromise)
 
         var messageBuffer = sender.allocator.buffer(capacity: 24)
@@ -159,7 +159,7 @@ final class MulticastTest: XCTestCase {
             line: line
         )
 
-        _ = multicastChannel.eventLoop.scheduleTask(in: timeout) { timeoutPromise.succeed(result: ()) }
+        _ = multicastChannel.eventLoop.scheduleTask(in: timeout) { timeoutPromise.succeed(()) }
         XCTAssertNoThrow(try timeoutPromise.futureResult.wait(), file: file, line: line)
     }
 

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -163,7 +163,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                     XCTAssertEqual(1, buf.readableBytes)
                                     XCTAssertEqual(contentBytes[numCalls], buf.readBytes(length: 1)?.first!)
                                     numCalls += 1
-                                    return self.eventLoop.makeSucceededFuture(result: ())
+                                    return self.eventLoop.makeSucceededFuture(())
                 }.wait()
         }
         XCTAssertEqual(content.utf8.count, numCalls)
@@ -186,7 +186,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                         XCTAssertEqual(1, buf.readableBytes)
                                         XCTAssertEqual(contentBytes[numCalls], buf.readBytes(length: 1)?.first!)
                                         numCalls += 1
-                                        return self.eventLoop.makeFailedFuture(error: DummyError.dummy)
+                                        return self.eventLoop.makeFailedFuture(DummyError.dummy)
                     }.wait()
                 XCTFail("call successful but should've failed")
             } catch let e as DummyError where e == .dummy {
@@ -211,7 +211,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                         allocator: self.allocator,
                                         eventLoop: self.eventLoop) { buf in
                                             XCTFail("shouldn't have been called")
-                                            return self.eventLoop.makeSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(())
                 }.wait()
             XCTFail("call successful but should've failed")
         } catch let e as IOError {
@@ -240,7 +240,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             XCTAssertEqual(1, buf.readableBytes)
                                             XCTAssertEqual(expectedByte, buf.readBytes(length: 1)!.first!)
                                             numCalls += 1
-                                            return self.eventLoop.makeSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(())
                 }.wait()
         }
         XCTAssertEqual(content.utf8.count, numCalls)
@@ -260,7 +260,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             XCTAssertEqual(2, buf.readableBytes)
                                             XCTAssertEqual(Array("\(numCalls*2)\(numCalls*2 + 1)".utf8), buf.readBytes(length: 2)!)
                                             numCalls += 1
-                                            return self.eventLoop.makeSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(())
                 }.wait()
         }
         XCTAssertEqual(content.utf8.count/2, numCalls)
@@ -310,7 +310,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             XCTAssertTrue(self.eventLoop.inEventLoop)
                                             allBytesActual += buf.readString(length: buf.readableBytes) ?? "WRONG"
                                             numCalls += 1
-                                            return self.eventLoop.makeSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(())
                 }.wait()
         }
         XCTAssertEqual(allBytesExpected, allBytesActual)
@@ -333,7 +333,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                                     XCTAssertEqual(3, buf.readableBytes)
                                                 }
                                                 allBytes.append(buf.readString(length: buf.readableBytes) ?? "THIS IS WRONG")
-                                                return self.eventLoop.makeSucceededFuture(result: ())
+                                                return self.eventLoop.makeSucceededFuture(())
             }
 
             do {
@@ -371,7 +371,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                     XCTAssertEqual(5, buf.readableBytes)
                                     XCTAssertEqual("01234", buf.readString(length: buf.readableBytes) ?? "bad")
                                     numCalls += 1
-                                    return self.eventLoop.makeSucceededFuture(result: ())
+                                    return self.eventLoop.makeSucceededFuture(())
                 }.wait()
         }
         XCTAssertEqual(1, numCalls)
@@ -389,7 +389,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             allocator: self.allocator,
                                             eventLoop: self.eventLoop) { buf in
                                                 XCTFail("this shouldn't have been called")
-                                                return self.eventLoop.makeSucceededFuture(result: ())
+                                                return self.eventLoop.makeSucceededFuture(())
                     }.wait()
                 XCTFail("succeeded and shouldn't have")
             } catch let e as IOError where e.errnoCode == ESPIPE {
@@ -414,7 +414,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                             allocator: self.allocator,
                                             eventLoop: self.eventLoop) { buf in
                                                 XCTFail("this shouldn't have been called")
-                                                return self.eventLoop.makeSucceededFuture(result: ())
+                                                return self.eventLoop.makeSucceededFuture(())
                 }.wait()
                 XCTFail("succeeded and shouldn't have")
             } catch let e as NonBlockingFileIO.Error where e == NonBlockingFileIO.Error.descriptorSetToNonBlocking {
@@ -445,7 +445,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                                 XCTAssertEqual(1, buf.readableBytes)
                                                 XCTAssertEqual("9", buf.readString(length: buf.readableBytes) ?? "bad")
                                             }
-                                            return self.eventLoop.makeSucceededFuture(result: ())
+                                            return self.eventLoop.makeSucceededFuture(())
                 }.wait()
         }
         XCTAssertEqual(2, numCalls)

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -156,7 +156,7 @@ class SelectorTest: XCTestCase {
                 XCTAssertTrue(self.hasReConnectEventLoopTickFinished.value)
                 XCTAssertTrue(self.didRead)
                 if !self.didRead {
-                    self.didReadPromise.fail(error: DidNotReadError.didNotReadGotInactive)
+                    self.didReadPromise.fail(DidNotReadError.didNotReadGotInactive)
                     ctx.close(promise: nil)
                 }
             }
@@ -171,7 +171,7 @@ class SelectorTest: XCTestCase {
                 XCTAssertEqual(1, buf.readableBytes)
                 XCTAssertEqual("H", buf.readString(length: 1)!)
                 self.didRead = true
-                self.didReadPromise.succeed(result: ())
+                self.didReadPromise.succeed(())
             }
 
             func channelReadComplete(ctx: ChannelHandlerContext) {
@@ -180,7 +180,7 @@ class SelectorTest: XCTestCase {
                 XCTAssertTrue(self.hasReConnectEventLoopTickFinished.value)
                 XCTAssertTrue(self.didRead)
                 if !self.didRead {
-                    self.didReadPromise.fail(error: DidNotReadError.didNotReadGotReadComplete)
+                    self.didReadPromise.fail(DidNotReadError.didNotReadGotReadComplete)
                     ctx.close(promise: nil)
                 }
             }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -139,7 +139,7 @@ public class SocketChannelTest : XCTestCase {
 
             func errorCaught(ctx: ChannelHandlerContext, error: Error) {
                 if let ioError = error as? IOError {
-                    self.promise.succeed(result: ioError)
+                    self.promise.succeed(ioError)
                 }
             }
         }
@@ -207,7 +207,7 @@ public class SocketChannelTest : XCTestCase {
             }
 
             func channelActive(ctx: ChannelHandlerContext) {
-                promise.succeed(result: ())
+                promise.succeed(())
             }
         }
 
@@ -224,7 +224,7 @@ public class SocketChannelTest : XCTestCase {
             }
 
             override func connect(to address: SocketAddress) throws -> Bool {
-                self.promise.succeed(result: ())
+                self.promise.succeed(())
                 return true
             }
         }
@@ -436,7 +436,7 @@ public class SocketChannelTest : XCTestCase {
             override func connect(to address: SocketAddress) throws -> Bool {
                 // We want to return false here to have a pending connect.
                 _ = try super.connect(to: address)
-                self.promise.succeed(result: ())
+                self.promise.succeed(())
                 return false
             }
         }
@@ -514,7 +514,7 @@ public class SocketChannelTest : XCTestCase {
                     XCTAssertNil(ctx.localAddress)
                     XCTAssertNil(ctx.remoteAddress)
 
-                    self.promise.succeed(result: ())
+                    self.promise.succeed(())
                 }
             }
         }

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -127,7 +127,7 @@ final class ByteCountingHandler : ChannelInboundHandler {
     func handlerAdded(ctx: ChannelHandlerContext) {
         buffer = ctx.channel.allocator.buffer(capacity: numBytes)
         if self.numBytes == 0 {
-            self.promise.succeed(result: buffer)
+            self.promise.succeed(buffer)
         }
     }
 
@@ -136,7 +136,7 @@ final class ByteCountingHandler : ChannelInboundHandler {
         buffer.write(buffer: &currentBuffer)
 
         if buffer.readableBytes == numBytes {
-            promise.succeed(result: buffer)
+            promise.succeed(buffer)
         }
     }
 

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -127,7 +127,7 @@ class EndToEndTests: XCTestCase {
 
     func testBasicUpgradeDance() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -147,7 +147,7 @@ class EndToEndTests: XCTestCase {
 
     func testUpgradeWithProtocolName() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -169,7 +169,7 @@ class EndToEndTests: XCTestCase {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in nil },
                                               upgradePipelineHandler: { (channel, req) in
                                                   XCTFail("Should not have called")
-                                                  return channel.eventLoop.makeSucceededFuture(result: ())
+                                                  return channel.eventLoop.makeSucceededFuture(())
                                               }
         )
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
@@ -199,7 +199,7 @@ class EndToEndTests: XCTestCase {
 
     func testRequiresVersion13() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -227,7 +227,7 @@ class EndToEndTests: XCTestCase {
 
     func testRequiresVersionHeader() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -255,7 +255,7 @@ class EndToEndTests: XCTestCase {
 
     func testRequiresKeyHeader() throws {
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
-                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
+                                              upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(()) })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -287,7 +287,7 @@ class EndToEndTests: XCTestCase {
                                             hdrs.add(name: "TestHeader", value: "TestValue")
                                             return hdrs
                                          },
-                                         upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
+                                         upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(()) })
         let (loop, server, client) = createTestFixtures(upgraders: [upgrader])
         defer {
             XCTAssertNoThrow(try client.finish())
@@ -313,7 +313,7 @@ class EndToEndTests: XCTestCase {
                                          hdrs.add(name: "Target", value: path)
                                          return hdrs
                                      },
-                                     upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(result: ()) })
+                                     upgradePipelineHandler: { (channel, req) in channel.eventLoop.makeSucceededFuture(()) })
         }
         let first = buildHandler(path: "first")
         let second = buildHandler(path: "second")
@@ -379,7 +379,7 @@ class EndToEndTests: XCTestCase {
     func testMaxFrameSize() throws {
         let basicUpgrader = WebSocketUpgrader(maxFrameSize: 16, shouldUpgrade: { head in HTTPHeaders() },
                                               upgradePipelineHandler: { (channel, req) in
-            return channel.eventLoop.makeSucceededFuture(result: ())
+            return channel.eventLoop.makeSucceededFuture(())
         })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
         defer {

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -9,7 +9,7 @@
 - `ByteToMessageDecoder`s now need to be wrapped in `ByteToMessageHandler`
   before they can be added to the pipeline.
   before: `pipeline.add(MyDecoder())`, after: `pipeline.add(ByteToMessageHandler(MyDecoder()))`
-- `EventLoop.makePromise`/`makeSucceededFuture`/`makeFailedFuture` instead of `new*`
+- `EventLoop.makePromise`/`makeSucceededFuture`/`makeFailedFuture` instead of `new*`, also `result:`/`error:` labels dropped
 - `SocketAddress.makeAddressResolvingHost(:port:)` instead of
   `SocketAddress.newAddressResolving(host:port:)`
 - changed all ports to `Int` (from `UInt16`)
@@ -33,3 +33,6 @@
 - renamed `EventLoopFuture.thenIfError` to `EventLoopFuture.flatMapError`
 - renamed `EventLoopFuture.thenThrowing` to `EventLoopFuture.flatMapThrowing`
 - renamed `EventLoopFuture`'s generic parameter from `T` to `Value`
+- renamed `EventLoopFuture.and(result:)` to `EventLoopFuture.and(value:)`
+- `EventLoopPromise.succeed(result: Value)` lost its label so is now `EventLoopPromise.succeed(Value)`
+- `EventLoopPromise.fail(error: Error)` lost its label so is now `EventLoopPromise.fail(Error)`


### PR DESCRIPTION
Motivation:

EventLoopPromise.succeed/fail has extraneous labels that don't add
anything but noise.

Modifications:

remove extraneous labels

Result:

less noise in the code
