### PR TITLE
rename ELF.mapIfError to ELF.recover

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -373,15 +373,15 @@ public func swiftMain() -> Int {
                 // flatMapError allocates a new Future, and calls flatMapError,
                 // so this is two Futures
                 throw err
-            }.mapIfError { (err: Error) -> Int in
-                // mapIfError allocates a future, and calls flatMapError, so
+            }.recover { (err: Error) -> Int in
+                // recover allocates a future, and calls flatMapError, so
                 // this is two Futures.
                 return 1
             }
             p.succeed(result: 0)
             
             // Wait also allocates a lock.
-            try! f.wait()
+            _ = try! f.wait()
         }
         @inline(never)
         func doAnd(loop: EventLoop) {
@@ -401,7 +401,7 @@ public func swiftMain() -> Int {
             p1.succeed(result: 1)
             p2.succeed(result: 1)
             p3.succeed(result: 1)
-            let r = try! f.wait()
+            _ = try! f.wait()
         }
         let el = EmbeddedEventLoop()
         for _ in 0..<1000  {

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -951,7 +951,7 @@ final public class MultiThreadedEventLoopGroup: EventLoopGroup {
 
         for loop in self.eventLoops {
             g.enter()
-            loop.closeGently().mapIfError { err in
+            loop.closeGently().recover { err in
                 q.sync { error = err }
             }.whenComplete { (_: Result<Void, Error>) in
                 g.leave()

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -566,15 +566,15 @@ extension EventLoopFuture {
     /// can recover from the error and return a new value of type `Value`. The provided callback may not `throw`,
     /// so this function should be used when the error is always recoverable.
     ///
-    /// Operations performed in `mapIfError` should not block, or they will block the entire
-    /// event loop. `mapIfError` is intended for use when you have the ability to synchronously
+    /// Operations performed in `recover` should not block, or they will block the entire
+    /// event loop. `recover` is intended for use when you have the ability to synchronously
     /// recover from errors.
     ///
     /// - parameters:
     ///     - callback: Function that will receive the error value of this `EventLoopFuture` and return
     ///         a new value lifted into a new `EventLoopFuture`.
     /// - returns: A future that will receive the recovered value.
-    public func mapIfError(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) -> Value) -> EventLoopFuture<Value> {
+    public func recover(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) -> Value) -> EventLoopFuture<Value> {
         return flatMapError(file: file, line: line) {
             return EventLoopFuture<Value>(eventLoop: self.eventLoop, result: callback($0), file: file, line: line)
         }
@@ -632,7 +632,7 @@ extension EventLoopFuture {
     /// `EventLoopFuture` has a failure result.
     ///
     /// An observer callback cannot return a value, meaning that this function cannot be chained
-    /// from. If you are attempting to create a computation pipeline, consider `mapIfError` or `flatMapError`.
+    /// from. If you are attempting to create a computation pipeline, consider `recover` or `flatMapError`.
     /// If you find yourself passing the results from this `EventLoopFuture` to a new `EventLoopPromise`
     /// in the body of this function, consider using `cascade` instead.
     ///

--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -604,7 +604,7 @@ internal class HappyEyeballsConnector {
     private func whenALookupComplete(future: EventLoopFuture<[SocketAddress]>) {
         future.map { results in
             self.targets.aResultsAvailable(results)
-        }.mapIfError { err in
+        }.recover { err in
             self.error.dnsAError = err
         }.whenComplete { (_: Result<Void, Error>) in
             self.dnsResolutions += 1
@@ -616,7 +616,7 @@ internal class HappyEyeballsConnector {
     private func whenAAAALookupComplete(future: EventLoopFuture<[SocketAddress]>) {
         future.map { results in
             self.targets.aaaaResultsAvailable(results)
-        }.mapIfError { err in
+        }.recover { err in
             self.error.dnsAAAAError = err
         }.whenComplete { (_: Result<Void, Error>) in
             // It's possible that we were waiting to time out here, so if we were we should

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -123,6 +123,11 @@ extension EventLoopFuture {
     public func thenIfErrorThrowing(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) throws -> Value) -> EventLoopFuture<Value> {
         return self.flatMapErrorThrowing(file: file, line: line, callback)
     }
+
+    @available(*, deprecated, renamed: "recover")
+    public func mapIfError(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) -> Value) -> EventLoopFuture<Value> {
+        return self.recover(file: file, line: line, callback)
+    }
 }
 
 extension EventLoopGroup {

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -127,7 +127,7 @@ class HTTPServerClientTest : XCTestCase {
                     ctx.write(self.wrapOutboundOut(outbound.body)).whenComplete { (_: Result<Void, Error>) in
                         outbound.destructor()
                     }
-                    ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
+                    ctx.write(self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
@@ -146,13 +146,13 @@ class HTTPServerClientTest : XCTestCase {
                         b.write(string: "\(i)")
 
                         let outbound = self.outboundBody(b)
-                        ctx.write(self.wrapOutboundOut(outbound.body)).mapIfError { error in
+                        ctx.write(self.wrapOutboundOut(outbound.body)).recover { error in
                             XCTFail("unexpected error \(error)")
                         }.whenComplete { (_: Result<Void, Error>) in
                             outbound.destructor()
                         }
                     }
-                    ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
+                    ctx.write(self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
@@ -172,7 +172,7 @@ class HTTPServerClientTest : XCTestCase {
                         b.write(string: "\(i)")
 
                         let outbound = self.outboundBody(b)
-                        ctx.write(self.wrapOutboundOut(outbound.body)).mapIfError { error in
+                        ctx.write(self.wrapOutboundOut(outbound.body)).recover { error in
                             XCTFail("unexpected error \(error)")
                         }.whenComplete { (_: Result<Void, Error>) in
                             outbound.destructor()
@@ -182,7 +182,7 @@ class HTTPServerClientTest : XCTestCase {
                     var trailers = HTTPHeaders()
                     trailers.add(name: "X-URL-Path", value: "/trailers")
                     trailers.add(name: "X-Should-Trail", value: "sure")
-                    ctx.write(self.wrapOutboundOut(.end(trailers))).mapIfError { error in
+                    ctx.write(self.wrapOutboundOut(.end(trailers))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
@@ -207,12 +207,12 @@ class HTTPServerClientTest : XCTestCase {
                         XCTFail("unexpected error \(error)")
                     }
                     let outbound = self.outboundBody(buf)
-                    ctx.writeAndFlush(self.wrapOutboundOut(outbound.body)).mapIfError { error in
+                    ctx.writeAndFlush(self.wrapOutboundOut(outbound.body)).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
                         outbound.destructor()
                     }
-                    ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
+                    ctx.write(self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
@@ -225,7 +225,7 @@ class HTTPServerClientTest : XCTestCase {
                     ctx.write(self.wrapOutboundOut(.head(head))).whenFailure { error in
                         XCTFail("unexpected error \(error)")
                     }
-                    ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
+                    ctx.write(self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true
@@ -237,7 +237,7 @@ class HTTPServerClientTest : XCTestCase {
                     ctx.write(self.wrapOutboundOut(.head(head))).whenFailure { error in
                         XCTFail("unexpected error \(error)")
                     }
-                    ctx.write(self.wrapOutboundOut(.end(nil))).mapIfError { error in
+                    ctx.write(self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
                         self.sentEnd = true

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -294,7 +294,7 @@ class EchoServerClientTest : XCTestCase {
             _ = ctx.eventLoop.scheduleTask(in: self.timeAmount) {
                 ctx.writeAndFlush(data, promise: nil)
                 self.group.leave()
-            }.futureResult.mapIfError { e in
+            }.futureResult.recover { e in
                 XCTFail("we failed to schedule the task: \(e)")
                 self.group.leave()
             }
@@ -342,7 +342,7 @@ class EchoServerClientTest : XCTestCase {
                                "channelInactive should fire before channelUnregistered")
                 ctx.close().map {
                     XCTFail("unexpected success")
-                }.mapIfError { err in
+                }.recover { err in
                     switch err {
                     case ChannelError.alreadyClosed:
                         // OK
@@ -362,7 +362,7 @@ class EchoServerClientTest : XCTestCase {
                               "when channelUnregister fires, channelInactive should already have fired")
                 ctx.close().map {
                     XCTFail("unexpected success")
-                }.mapIfError { err in
+                }.recover { err in
                     switch err {
                     case ChannelError.alreadyClosed:
                         // OK

--- a/Tests/NIOTests/EmbeddedEventLoopTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest.swift
@@ -213,7 +213,7 @@ public class EmbeddedEventLoopTest: XCTestCase {
         }
         task.futureResult.map {
             XCTFail("Scheduled future completed")
-        }.mapIfError { caughtErr in
+        }.recover { caughtErr in
             XCTAssertTrue(err === caughtErr as? EmbeddedTestError)
         }.whenComplete { (_: Result<Void, Error>) in
             fired = true

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -805,7 +805,7 @@ class EventLoopFutureTest : XCTestCase {
             XCTAssertEqual(error as? EventLoopFutureTestError, EventLoopFutureTestError.example)
             XCTAssertTrue(loop2.inEventLoop)
             throw error
-        }.hopTo(eventLoop: loop1).mapIfError { error in
+        }.hopTo(eventLoop: loop1).recover { error in
             XCTAssertEqual(error as? EventLoopFutureTestError, EventLoopFutureTestError.example)
             XCTAssertTrue(loop1.inEventLoop)
         }

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -31,5 +31,6 @@
 - EventLoopFuture.whenComplete now provides Result<T, Error>
 - renamed `EventLoopFuture.then` to `EventLoopFuture.flatMap`
 - renamed `EventLoopFuture.thenIfError` to `EventLoopFuture.flatMapError`
+- renamed `EventLoopFuture.mapIfError` to `EventLoopFuture.recover`
 - renamed `EventLoopFuture.thenThrowing` to `EventLoopFuture.flatMapThrowing`
 - renamed `EventLoopFuture`'s generic parameter from `T` to `Value`


### PR DESCRIPTION
Motivation:

The name `mapIfError` implied that you can transform the error value but
really that's never what it did. Instead, it allowed you to recover
from a failure.

Modifications:

- rename `mapIfError` to `recover`

Result:

cleaner method names
