### PR TITLE
provide ELF.flatMapResult

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -316,8 +316,8 @@ extension EventLoop {
     /// - parameters:
     ///     - error: the `Error` that is used by the `EventLoopFuture`.
     /// - returns: a failed `EventLoopFuture`.
-    public func makeFailedFuture<T>(_ error: Error) -> EventLoopFuture<T> {
-        return EventLoopFuture<T>(eventLoop: self, error: error, file: "n/a", line: 0)
+    public func makeFailedFuture<T>(_ error: Error, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<T> {
+        return EventLoopFuture<T>(eventLoop: self, error: error, file: file, line: line)
     }
 
     /// Creates and returns a new `EventLoopFuture` that is already marked as success. Notifications will be done using this `EventLoop` as execution `Thread`.
@@ -325,8 +325,8 @@ extension EventLoop {
     /// - parameters:
     ///     - result: the value that is used by the `EventLoopFuture`.
     /// - returns: a succeeded `EventLoopFuture`.
-    public func makeSucceededFuture<Success>(_ result: Success) -> EventLoopFuture<Success> {
-        return EventLoopFuture<Success>(eventLoop: self, result: result, file: "n/a", line: 0)
+    public func makeSucceededFuture<Success>(_ value: Success, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Success> {
+        return EventLoopFuture<Success>(eventLoop: self, value: value, file: file, line: line)
     }
 
     public func next() -> EventLoop {

--- a/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
@@ -62,6 +62,8 @@ extension EventLoopFutureTest {
                 ("testLoopHoppingHelperSuccess", testLoopHoppingHelperSuccess),
                 ("testLoopHoppingHelperFailure", testLoopHoppingHelperFailure),
                 ("testLoopHoppingHelperNoHopping", testLoopHoppingHelperNoHopping),
+                ("testFlatMapResultHappyPath", testFlatMapResultHappyPath),
+                ("testFlatMapResultFailurePath", testFlatMapResultFailurePath),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

ELFs and the stdlib's Result should be as compatible as possible so a
flatMapResult function which lifts and combines a result into an
EventLoopFuture sounds like a good idea.

Modifications:

add `flatMapResult` which does what it says.

Result:

more interop between `Result` and `EventLoopFuture`.
