### PR TITLE
CI: use DEVELOPMENT-SNAPSHOT-2019-01-23-a

### DIFF
--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -74,6 +74,9 @@ private func writeTrailers(wrapOutboundOut: (IOData) -> NIOAny, ctx: ChannelHand
     }
 }
 
+// starting about swift-5.0-DEVELOPMENT-SNAPSHOT-2019-01-20-a, this doesn't get automatically inlined, which costs
+// 2 extra allocations so we need to help the optimiser out.
+@inline(__always)
 private func writeHead(wrapOutboundOut: (IOData) -> NIOAny, writeStartLine: (inout ByteBuffer) -> Void, ctx: ChannelHandlerContext, headers: HTTPHeaders, promise: EventLoopPromise<Void>?) {
 
     var buffer = ctx.channel.allocator.buffer(capacity: 256)

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,7 +8,7 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2018-12-28-a"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-01-23-a"
         swift_builds_suffix: "branch"
         skip_ruby_from_ppa: "true"
 
@@ -19,20 +19,20 @@ services:
   integration-tests:
     image: swift-nio:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=38750
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=691050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3150
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   test:
     image: swift-nio:18.04-5.0
     command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors -Xswiftc -DNIO_CI_BUILD && ./scripts/integration_tests.sh"
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=38750
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=691050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3150
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   echo:


### PR DESCRIPTION
Motivation:

Newer Swift versions are good and we should test them, this one threw a few curveballs at us:
- started using `posix_memalign` which needed fixing in our alloc tests (fixed in #782)
- the optimiser decided not to inline a function that needs to be inlined

Modifications
- `@inline(__always)` to help the optimiser
- update Swift version

Result:
- fixes #727
- fixes #726