### PR TITLE
malloc-aggregation.d: don't forget posix_memalign

### DIFF
--- a/dev/malloc-aggregation.d
+++ b/dev/malloc-aggregation.d
@@ -28,7 +28,7 @@
     printf("=====\n");
 }
 
-pid$target::malloc:entry, pid$target::posix_memalign:entry, pid$target::realloc:entry, pid$target::reallocf:entry, pid$target::calloc:entry, pid$target::valloc:entry {
+pid$target::malloc:entry, pid$target::posix_memalign:entry, pid$target::realloc:entry, pid$target::reallocf:entry, pid$target::calloc:entry, pid$target::valloc:entry, pid$target::posix_memalign:entry {
     @malloc_calls[ustack()] = count();
 }
 


### PR DESCRIPTION
Motivation:

When counting the number of allocations it's important not to forget an
allocation function that Swift uses.

Modifications:

add posix_memalign to dev/malloc-aggregation.d

Result:

malloc aggregations accurate with recent Swift versions
