### PR TITLE
use DEVELOPMENT-SNAPSHOT-2019-01-28-a

### DIFF
--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -763,9 +763,7 @@ class ByteBufferTest: XCTestCase {
         buf.write(string: str)
         var written1: Int = -1
         var written2: Int = -1
-        let hwDataCount = hwData.count
-        hwData.withUnsafeBytes { (ptr: UnsafePointer<Int8>) -> Void in
-            let ptr = UnsafeRawBufferPointer(start: ptr, count: hwDataCount)
+        hwData.withUnsafeBytes { ptr in
             /* ... write a second time and ...*/
             written1 = buf.set(bytes: ptr, at: buf.writerIndex)
             buf.moveWriterIndex(forwardBy: written1)

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,7 +8,7 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-01-23-a"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-01-28-a"
         swift_builds_suffix: "branch"
         skip_ruby_from_ppa: "true"
 


### PR DESCRIPTION
Motivation:

New Swift versions are great.

Modifications:

Upgrade to 5.0-DEVELOPMENT-SNAPSHOT-2019-01-28-a.

Result:

Should unblock #769.