### PR TITLE
allow 2017-2019 copyright headers

### DIFF
--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the SwiftNIO open source project
 ##
-## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Copyright (c) 2017-2019 Apple Inc. and the SwiftNIO project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -15,6 +15,11 @@
 
 set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function replace_acceptable_years() {
+    # this needs to replace all acceptable forms with 'YEARS'
+    sed 's/2017-201[89]/YEARS/g'
+}
 
 printf "=> Checking linux tests... "
 FIRST_OUT="$(git status --porcelain)"
@@ -45,7 +50,7 @@ for language in swift-or-c bash dtrace; do
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) YEARS Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -64,7 +69,7 @@ EOF
 ##
 ## This source file is part of the SwiftNIO open source project
 ##
-## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Copyright (c) YEARS Apple Inc. and the SwiftNIO project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -83,7 +88,7 @@ EOF
  *
  *  This source file is part of the SwiftNIO open source project
  *
- *  Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+ *  Copyright (c) YEARS Apple Inc. and the SwiftNIO project authors
  *  Licensed under Apache License v2.0
  *
  *  See LICENSE.txt for license information
@@ -108,9 +113,9 @@ EOF
       \( \! -path './.build/*' -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do
-      if [[ "$(cat "$line" | head -n $expected_lines | shasum)" != "$expected_sha" ]]; then
+      if [[ "$(cat "$line" | replace_acceptable_years | head -n $expected_lines | shasum)" != "$expected_sha" ]]; then
         printf "\033[0;31mmissing headers in file '$line'!\033[0m\n"
-        diff -u <(cat "$line" | head -n $expected_lines) "$tmp"
+        diff -u <(cat "$line" | replace_acceptable_years | head -n $expected_lines) "$tmp"
         exit 1
       fi
     done


### PR DESCRIPTION
Motivation:

Previously we required all copyright headers to be 2017-2018 but now
that's not the only allowed string anymore.

Modifications:

allow 2017-2019 besides 2017-2018

Result:

Happy New Year