### PR TITLE
NIOWebSocket: A tweak to improve the frame data unmasking time

### DIFF
--- a/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
@@ -59,8 +59,10 @@ public extension ByteBuffer {
     ///         start each time.
     mutating func webSocketMask(_ maskingKey: WebSocketMaskingKey, indexOffset: Int = 0) {
         self.withUnsafeMutableReadableBytes {
-            for (index, byte) in $0.enumerated() {
+            var index = 0
+            for byte in $0 {
                 $0[index] = byte ^ maskingKey[(index + indexOffset) % 4]
+                index += 1
             }
         }
     }


### PR DESCRIPTION
A minor tweak to improve the time taken for unmasking of frame data

### Motivation:

This is in the context of [Autobahn](https://github.com/crossbario/autobahn-testsuite) testing against the Kitura-Websocket[ implementation using NIOWebSocket](https://github.com/IBM-Swift/Kitura-WebSocket/tree/websocket-nio). The autobahn test suite contains some performance use cases (numbered 9.*.*). On studying a flamegraph profile of these performance tests, we found `Sequence.enumerated()` running almost 75% of the time.  The function used for unmasking frame data aka `ByteBuffer.websocketMask(_:indexOffset:)` uses `UnsafeRawBufferPointer`'s implementation of `Sequence.enumerated()`, which seems to be sub-optimal. 

While I'm not sure if the performance penalties of using `UnsafeRawBufferPointer.enumerated()` are justified, not using this method seems to be a good alternative for now. Here are the numbers for the different tests using the enumerator vs. using a simple `for-in` loop with a manually tracked index:

**Text message(increasing size)**

Test number | enumerator(time in ms) | for-in loop(time in ms) | % drop
-- | -- | -- | --
9.1.1 | 17 | 6 | 64.7058824
9.1.2 | 65 | 18 | 72.3076923
9.1.3 | 259 | 68 | 73.7451737
9.1.4 | 1018 | 269 | 73.5756385
9.1.5 | 2019 | 553 | 72.6102031
9.1.6 | 4047 | 1121 | 72.3004695

**Binary message(increasing size)**

Test number | enumerator(time in ms) | for-in loop(time in ms) | % drop
-- | -- | -- | --
9.2.1 | 17 | 7 | 58.8235294
9.2.2 | 62 | 15 | 75.8064516
9.2.3 | 242 | 57 | 76.446281
9.2.4 | 976 | 230 | 76.4344262
9.2.5 | 1941 | 486 | 74.9613601
9.2.6 | 3956 | 983 | 75.1516684

**Fragmented Text Message (fixed size, increasing fragment size)**

Test number | enumerator(time in ms) | for-in loop(time in ms) | % drop
-- | -- | -- | --
9.3.1 | 2620 | 2077 | 20.7251908
9.3.2 | 1415 | 734 | 48.1272085
9.3.3 | 1098 | 370 | 66.3023679
9.3.4 | 1003 | 241 | 75.9720837
9.3.5 | 983 | 243 | 75.2797558
9.3.6 | 987 | 240 | 75.6838906
9.3.7 | 985 | 240 | 75.6345178
9.3.8 | 1008 | 233 | 76.8849206
9.3.9 | 966 | 243 | 74.8447205

**Fragmented Binary Message (fixed size, increasing fragment size)**

Test number | enumerator(time in ms) | for-in loop(time in ms) | % drop
-- | -- | -- | --
9.4.1 | 2546 | 2036 | 20.0314218
9.4.2 | 1373 | 678 | 50.6190823
9.4.3 | 1050 | 310 | 70.4761905
9.4.4 | 961 | 215 | 77.6274714
9.4.5 | 943 | 194 | 79.4273595
9.4.6 | 959 | 164 | 82.898853
9.4.7 | 936 | 177 | 81.0897436
9.4.8 | 927 | 174 | 81.2297735
9.4.9 | 920 | 173 | 81.1956522

**Text Message (fixed size, increasing chop size)**

Test number | enumerator(time in ms) | for-in loop(time in ms) | % drop
-- | -- | -- | --
9.5.1 | 1176 | 1008 | 14.2857143
9.5.2 | 667 | 498 | 25.3373313
9.5.3 | 461 | 276 | 40.1301518
9.5.4 | 358 | 174 | 51.396648
9.5.5 | 312 | 120 | 61.5384615
9.5.6 | 280 | 92 | 67.1428571

**Binary Text Message (fixed size, increasing chop size)**

Test number | enumerator(time in ms) | for-in loop(time in ms) | % drop
-- | -- | -- | --
9.6.1 | 1157 | 903 | 21.9533276
9.6.2 | 727 | 481 | 33.8376891
9.6.3 | 503 | 265 | 47.3161034
9.6.4 | 384 | 162 | 57.8125
9.6.5 | 297 | 115 | 61.2794613
9.6.6 | 269 | 85 | 68.401487


**Text Message Roundtrip Time (fixed number, increasing size)**

Test number | enumerator(time in ms) | for-in loop(time in ms) | % drop
-- | -- | -- | --
9.7.1 | 303 | 316 | -4.290429
9.7.2 | 313 | 328 | -4.7923323
9.7.3 | 334 | 339 | -1.497006
9.7.4 | 436 | 361 | 17.2018349
9.7.5 | 738 | 475 | 35.6368564
9.7.6 | 1642 | 966 | 41.1693057

**Binary Message Roundtrip Time (fixed number, increasing size)**

Test number | enumerator(time in ms) | for-in loop(time in ms) | % drop
-- | -- | -- | --
9.8.1 | 257 | 274 | -6.614786
9.8.2 | 267 | 296 | -10.861423
9.8.3 | 280 | 289 | -3.2142857
9.8.4 | 350 | 314 | 10.2857143
9.8.5 | 663 | 386 | 41.7797888
9.8.6 | 1556 | 836 | 46.2724936



### Modifications:

Use a simple for-in loop instead of `Sequence.enumerated()` with UnsafeRawBufferPointer

### Result:

No changes in behaviour. Performance expected to improve.