### PR TITLE
Make use of dropFirst(_:) in example code

### DIFF
--- a/Sources/NIOChatClient/main.swift
+++ b/Sources/NIOChatClient/main.swift
@@ -55,7 +55,7 @@ defer {
 // First argument is the program path
 let arguments = CommandLine.arguments
 let arg1 = arguments.dropFirst().first
-let arg2 = arguments.dropFirst().dropFirst().first
+let arg2 = arguments.dropFirst(2).first
 
 let defaultHost = "::1"
 let defaultPort = 9999

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -70,7 +70,7 @@ defer {
 // First argument is the program path
 let arguments = CommandLine.arguments
 let arg1 = arguments.dropFirst().first
-let arg2 = arguments.dropFirst().dropFirst().first
+let arg2 = arguments.dropFirst(2).first
 
 let defaultHost = "::1"
 let defaultPort: Int = 9999

--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -65,7 +65,7 @@ defer {
 // First argument is the program path
 let arguments = CommandLine.arguments
 let arg1 = arguments.dropFirst().first
-let arg2 = arguments.dropFirst().dropFirst().first
+let arg2 = arguments.dropFirst(2).first
 
 let defaultHost = "::1"
 let defaultPort = 9999

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -471,8 +471,8 @@ if arguments.dropFirst().first == .some("--disable-half-closure") {
     arguments = arguments.dropFirst()
 }
 let arg1 = arguments.dropFirst().first
-let arg2 = arguments.dropFirst().dropFirst().first
-let arg3 = arguments.dropFirst().dropFirst().dropFirst().first
+let arg2 = arguments.dropFirst(2).first
+let arg3 = arguments.dropFirst(3).first
 
 let defaultHost = "::1"
 let defaultPort = 8888


### PR DESCRIPTION
Motivation:

While getting into NIO through the examples I stumbled
across some chained `dropFirst()` calls, which can be
simplified by using `dropFirst(_:)` instead.

Modifications:

I did a quick project-wide search of chained `dropFirst()`
usage and modified every line to use `dropFirst(_:)` instead.

Result:

This will only affect the readability of the code,
not it's functionality.
