### PR TITLE
fix #657

### DIFF
--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -60,6 +60,7 @@ private let sysOpenWithMode: @convention(c) (UnsafePointer<CChar>, CInt, mode_t)
 private let sysWrite: @convention(c) (CInt, UnsafeRawPointer?, CLong) -> CLong = write
 private let sysRead: @convention(c) (CInt, UnsafeMutableRawPointer?, CLong) -> CLong = read
 private let sysLseek: @convention(c) (CInt, off_t, CInt) -> off_t = lseek
+private let sysPoll: @convention(c) (UnsafeMutablePointer<pollfd>?, nfds_t, Int32) -> CInt = poll
 #if os(Android)
 func sysRecvFrom_wrapper(sockfd: CInt, buf: UnsafeMutableRawPointer, len: CLong, flags: CInt, src_addr: UnsafeMutablePointer<sockaddr>, addrlen: UnsafeMutablePointer<socklen_t>) -> CLong {
     return recvfrom(sockfd, buf, len, flags, src_addr, addrlen) // src_addr is 'UnsafeMutablePointer', but it need to be 'UnsafePointer'
@@ -486,6 +487,13 @@ internal enum Posix {
     public static func if_nametoindex(_ name: UnsafePointer<CChar>?) throws -> CUnsignedInt {
         return try wrapSyscall {
             sysIfNameToIndex(name)
+        }
+    }
+
+    @inline(never)
+    public static func poll(fds: UnsafeMutablePointer<pollfd>, nfds: nfds_t, timeout: CInt) throws -> CInt {
+        return try wrapSyscall {
+            sysPoll(fds, nfds, timeout)
         }
     }
 }


### PR DESCRIPTION
Motivation:

testCloseInReadTriggeredByDrainingTheReceiveBufferBecauseOfWriteError
expected (without knowing it) that networking on localhost is
synchronous enough that a succeeded write means that it has
simultaneously arrived in the reader's read buffer.

On macOS that's not necessarily true, so this test failed very seldom
seemingly more often if you had more physical cores.

Thanks @brentdax for reporting the failure on your machine!

Modifications:

Introduce a nasty blocking `poll` call in the test that waits until we
have bytes in the read buffer.

Result:

- fixes #657