### PR TITLE
Fix documenation markup

### DIFF
--- a/Sources/NIO/ChannelInvoker.swift
+++ b/Sources/NIO/ChannelInvoker.swift
@@ -18,22 +18,22 @@ public protocol ChannelOutboundInvoker {
     /// Register on an `EventLoop` and so have all its IO handled.
     ///
     /// - parameters:
-    ///       - promise: the `EventLoopPromise` that will be notified once the operation completes,
-    ///                  or `nil` if not interested in the outcome of the operation.
+    ///     - promise: the `EventLoopPromise` that will be notified once the operation completes,
+    ///                or `nil` if not interested in the outcome of the operation.
     func register(promise: EventLoopPromise<Void>?)
 
     /// Bind to a `SocketAddress`.
     /// - parameters:
-    ///       - to: the `SocketAddress` to which we should bind the `Channel`.
-    ///       - promise: the `EventLoopPromise` that will be notified once the operation completes,
-    ///                  or `nil` if not interested in the outcome of the operation.
+    ///     - to: the `SocketAddress` to which we should bind the `Channel`.
+    ///     - promise: the `EventLoopPromise` that will be notified once the operation completes,
+    ///                or `nil` if not interested in the outcome of the operation.
     func bind(to: SocketAddress, promise: EventLoopPromise<Void>?)
 
     /// Connect to a `SocketAddress`.
     /// - parameters:
-    ///       - to: the `SocketAddress` to which we should connect the `Channel`.
-    ///       - promise: the `EventLoopPromise` that will be notified once the operation completes,
-    ///                  or `nil` if not interested in the outcome of the operation.
+    ///     - to: the `SocketAddress` to which we should connect the `Channel`.
+    ///     - promise: the `EventLoopPromise` that will be notified once the operation completes,
+    ///                or `nil` if not interested in the outcome of the operation.
     func connect(to: SocketAddress, promise: EventLoopPromise<Void>?)
 
     /// Write data to the remote peer.
@@ -42,9 +42,9 @@ public protocol ChannelOutboundInvoker {
     /// Calling `write` multiple times and then `flush` may allow the `Channel` to `write` multiple data objects to the remote peer with one syscall.
     ///
     /// - parameters:
-    ///       - data: the data to write
-    ///       - promise: the `EventLoopPromise` that will be notified once the operation completes,
-    ///                  or `nil` if not interested in the outcome of the operation.
+    ///     - data: the data to write
+    ///     - promise: the `EventLoopPromise` that will be notified once the operation completes,
+    ///                or `nil` if not interested in the outcome of the operation.
     func write(_ data: NIOAny, promise: EventLoopPromise<Void>?)
 
     /// Flush data that was previously written via `write` to the remote peer.
@@ -53,9 +53,9 @@ public protocol ChannelOutboundInvoker {
     /// Shortcut for calling `write` and `flush`.
     ///
     /// - parameters:
-    ///       - data: the data to write
-    ///       - promise: the `EventLoopPromise` that will be notified once the `write` operation completes,
-    ///                  or `nil` if not interested in the outcome of the operation.
+    ///     - data: the data to write
+    ///     - promise: the `EventLoopPromise` that will be notified once the `write` operation completes,
+    ///                or `nil` if not interested in the outcome of the operation.
     func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?)
 
     /// Signal that we want to read from the `Channel` once there is data ready.
@@ -68,16 +68,16 @@ public protocol ChannelOutboundInvoker {
     /// Close the `Channel` and so the connection if one exists.
     ///
     /// - parameters:
-    ///       - mode: the `CloseMode` that is used
-    ///       - promise: the `EventLoopPromise` that will be notified once the operation completes,
-    ///                  or `nil` if not interested in the outcome of the operation.
+    ///     - mode: the `CloseMode` that is used
+    ///     - promise: the `EventLoopPromise` that will be notified once the operation completes,
+    ///                or `nil` if not interested in the outcome of the operation.
     func close(mode: CloseMode, promise: EventLoopPromise<Void>?)
 
     /// Trigger a custom user outbound event which will flow through the `ChannelPipeline`.
     ///
     /// - parameters:
-    ///       - promise: the `EventLoopPromise` that will be notified once the operation completes,
-    ///                  or `nil` if not interested in the outcome of the operation.
+    ///     - promise: the `EventLoopPromise` that will be notified once the operation completes,
+    ///                or `nil` if not interested in the outcome of the operation.
     func triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?)
 
     /// The `EventLoop` which is used by this `ChannelOutboundInvoker` for execution.
@@ -101,7 +101,7 @@ extension ChannelOutboundInvoker {
 
     /// Bind to a `SocketAddress`.
     /// - parameters:
-    ///       - to: the `SocketAddress` to which we should bind the `Channel`.
+    ///     - to: the `SocketAddress` to which we should bind the `Channel`.
     /// - returns: the future which will be notified once the operation completes.
     public func bind(to address: SocketAddress, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Void> {
         let promise = makePromise(file: file, line: line)
@@ -111,7 +111,7 @@ extension ChannelOutboundInvoker {
 
     /// Connect to a `SocketAddress`.
     /// - parameters:
-    ///       - to: the `SocketAddress` to which we should connect the `Channel`.
+    ///     - to: the `SocketAddress` to which we should connect the `Channel`.
     /// - returns: the future which will be notified once the operation completes.
     public func connect(to address: SocketAddress, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Void> {
         let promise = makePromise(file: file, line: line)
@@ -125,7 +125,7 @@ extension ChannelOutboundInvoker {
     /// Calling `write` multiple times and then `flush` may allow the `Channel` to `write` multiple data objects to the remote peer with one syscall.
     ///
     /// - parameters:
-    ///       - data: the data to write
+    ///     - data: the data to write
     /// - returns: the future which will be notified once the operation completes.
     public func write(_ data: NIOAny, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Void> {
         let promise = makePromise(file: file, line: line)
@@ -136,7 +136,7 @@ extension ChannelOutboundInvoker {
     /// Shortcut for calling `write` and `flush`.
     ///
     /// - parameters:
-    ///       - data: the data to write
+    ///     - data: the data to write
     /// - returns: the future which will be notified once the `write` operation completes.
     public func writeAndFlush(_ data: NIOAny, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Void> {
         let promise = makePromise(file: file, line: line)
@@ -147,7 +147,7 @@ extension ChannelOutboundInvoker {
     /// Close the `Channel` and so the connection if one exists.
     ///
     /// - parameters:
-    ///       - mode: the `CloseMode` that is used
+    ///     - mode: the `CloseMode` that is used
     /// - returns: the future which will be notified once the operation completes.
     public func close(mode: CloseMode = .all, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Void> {
         let promise = makePromise(file: file, line: line)
@@ -158,7 +158,7 @@ extension ChannelOutboundInvoker {
     /// Trigger a custom user outbound event which will flow through the `ChannelPipeline`.
     ///
     /// - parameters:
-    ///       - event: the event itself.
+    ///     - event: the event itself.
     /// - returns: the future which will be notified once the operation completes.
     public func triggerUserOutboundEvent(_ event: Any, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Void> {
         let promise = makePromise(file: file, line: line)
@@ -195,7 +195,7 @@ public protocol ChannelInboundInvoker {
     /// Called once there is some data read for a `Channel` that needs processing.
     ///
     /// - parameters:
-    ///       - data: the data that was read and is ready to be processed.
+    ///     - data: the data that was read and is ready to be processed.
     func fireChannelRead(_ data: NIOAny)
 
     /// Called once there is no more data to read immediately on a `Channel`. Any new data received will be handled later.
@@ -217,13 +217,13 @@ public protocol ChannelInboundInvoker {
     /// the `EventLoopFuture` or `EventLoopPromise` will be notified.
     ///
     /// - parameters:
-    ///       - error: the error we encountered.
+    ///     - error: the error we encountered.
     func fireErrorCaught(_ error: Error)
 
     /// Trigger a custom user inbound event which will flow through the `ChannelPipeline`.
     ///
     /// - parameters:
-    ///       - event: the event itself.
+    ///     - event: the event itself.
     func fireUserInboundEventTriggered(_ event: Any)
 }
 

--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -58,8 +58,8 @@ public enum SocketOption: ChannelOption {
     /// Create a new `SocketOption`.
     ///
     /// - parameters:
-    ///       - level: The level for the option as defined in `man setsockopt`, e.g. SO_SOCKET.
-    ///       - name: The name of the option as defined in `man setsockopt`, e.g. `SO_REUSEADDR`.
+    ///     - level: The level for the option as defined in `man setsockopt`, e.g. SO_SOCKET.
+    ///     - name: The name of the option as defined in `man setsockopt`, e.g. `SO_REUSEADDR`.
     public init(level: SocketOptionLevel, name: SocketOptionName) {
         self = .const((level, name))
     }

--- a/Sources/NIO/IO.swift
+++ b/Sources/NIO/IO.swift
@@ -29,8 +29,8 @@ public struct IOError: Swift.Error {
     /// - note: At the moment, this constructor is more expensive than `IOError(errnoCode:function:)` as the `String` will incur reference counting
     ///
     /// - parameters:
-    ///       - errorCode: the `errno` that was set for the operation.
-    ///       - reason: the actual reason (in an human-readable form).
+    ///     - errorCode: the `errno` that was set for the operation.
+    ///     - reason: the actual reason (in an human-readable form).
     public init(errnoCode: Int32, reason: String) {
         self.errnoCode = errnoCode
         self.reason = .reason(reason)
@@ -41,8 +41,8 @@ public struct IOError: Swift.Error {
     /// - note: This constructor is the cheapest way to create an `IOError`.
     ///
     /// - parameters:
-    ///       - errorCode: the `errno` that was set for the operation.
-    ///       - function: The function the error happened in, the human readable description will be generated automatically when needed.
+    ///     - errorCode: the `errno` that was set for the operation.
+    ///     - function: The function the error happened in, the human readable description will be generated automatically when needed.
     public init(errnoCode: Int32, function: StaticString) {
         self.errnoCode = errnoCode
         self.reason = .function(function)
@@ -52,8 +52,8 @@ public struct IOError: Swift.Error {
 /// Returns a reason to use when constructing a `IOError`.
 ///
 /// - parameters:
-///       - errorCode: the `errno` that was set for the operation.
-///       - reason: what failed
+///     - errorCode: the `errno` that was set for the operation.
+///     - reason: what failed
 /// - returns: the constructed reason.
 private func reasonForError(errnoCode: Int32, reason: String) -> String {
     if let errorDescC = strerror(errnoCode) {

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -158,8 +158,8 @@ public enum SocketAddress: CustomStringConvertible {
     /// Creates a new IPv4 `SocketAddress`.
     ///
     /// - parameters:
-    ///       - addr: the `sockaddr_in` that holds the ipaddress and port.
-    ///       - host: the hostname that resolved to the ipaddress.
+    ///     - addr: the `sockaddr_in` that holds the ipaddress and port.
+    ///     - host: the hostname that resolved to the ipaddress.
     public init(_ addr: sockaddr_in, host: String) {
         self = .v4(.init(address: addr, host: host))
     }
@@ -167,8 +167,8 @@ public enum SocketAddress: CustomStringConvertible {
     /// Creates a new IPv6 `SocketAddress`.
     ///
     /// - parameters:
-    ///       - addr: the `sockaddr_in` that holds the ipaddress and port.
-    ///       - host: the hostname that resolved to the ipaddress.
+    ///     - addr: the `sockaddr_in` that holds the ipaddress and port.
+    ///     - host: the hostname that resolved to the ipaddress.
     public init(_ addr: sockaddr_in6, host: String) {
         self = .v6(.init(address: addr, host: host))
     }
@@ -176,7 +176,7 @@ public enum SocketAddress: CustomStringConvertible {
     /// Creates a new Unix Domain Socket `SocketAddress`.
     ///
     /// - parameters:
-    ///       - addr: the `sockaddr_un` that holds the socket path.
+    ///     - addr: the `sockaddr_un` that holds the socket path.
     public init(_ addr: sockaddr_un) {
         self = .unixDomainSocket(.init(address: addr))
     }
@@ -246,8 +246,8 @@ public enum SocketAddress: CustomStringConvertible {
     /// Creates a new `SocketAddress` for the given host (which will be resolved) and port.
     ///
     /// - parameters:
-    ///       - host: the hostname which should be resolved.
-    ///       - port: the port itself
+    ///     - host: the hostname which should be resolved.
+    ///     - port: the port itself
     /// - returns: the `SocketAddress` for the host / port pair.
     /// - throws: a `SocketAddressError.unknown` if we could not resolve the `host`, or `SocketAddressError.unsupported` if the address itself is not supported (yet).
     public static func makeAddressResolvingHost(_ host: String, port: Int) throws -> SocketAddress {


### PR DESCRIPTION
### Motivation:

Quick Documentation was not rendering some parameter documentation
correctly as it was over-indented. 

### Modifications:

Reduced indentation for over-indented parameters.

### Result:

Quick Documentation renders correctly.