### PR TITLE
enable HTTP1 error handling by default

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -219,7 +219,8 @@ public func swiftMain() -> Int {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true).flatMap {
+                channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true,
+                                                             withErrorHandling: false).flatMap {
                     channel.pipeline.add(handler: SimpleHTTPServer())
                 }
             }.bind(host: "127.0.0.1", port: 0).wait()

--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -55,13 +55,12 @@ public extension ChannelPipeline {
     ///         completion handler. See the documentation on `HTTPServerUpgradeHandler` for more
     ///         details.
     ///     - errorHandling: Whether to provide assistance handling protocol errors (e.g.
-    ///         failure to parse the HTTP request) by sending 400 errors. Defaults to `false` for
-    ///         backward-compatibility reasons.
+    ///         failure to parse the HTTP request) by sending 400 errors. Defaults to `true`.
     /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
     func configureHTTPServerPipeline(first: Bool = false,
                                      withPipeliningAssistance pipelining: Bool = true,
                                      withServerUpgrade upgrade: HTTPUpgradeConfiguration? = nil,
-                                     withErrorHandling errorHandling: Bool = false) -> EventLoopFuture<Void> {
+                                     withErrorHandling errorHandling: Bool = true) -> EventLoopFuture<Void> {
         let responseEncoder = HTTPResponseEncoder()
         let requestDecoder = HTTPRequestDecoder(leftOverBytesStrategy: upgrade == nil ? .dropBytes : .forwardBytes)
 


### PR DESCRIPTION
Motivation:

For compatibility reasons, we used to disable HTTP1 error handling by
default to not break SemVer.

Modifications:

enable HTTP1 error handling by default

Result:

HTTP1 protocol errors now handled automatically by default
