### PR TITLE
Rename `ELF.andAll(_:eventLoop:)` to `andAllSucceed(_:on:)` and add `ELF.andAllComplete`

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -903,8 +903,7 @@ extension ChannelPipeline {
         if first {
             handlers = handlers.reversed()
         }
-
-        return EventLoopFuture<Void>.andAll(handlers.map { add(handler: $0, first: first) }, eventLoop: eventLoop)
+        return .andAllSucceed(handlers.map { add(handler: $0, first: first) }, on: eventLoop)
     }
 
     /// Adds the provided channel handlers to the pipeline in the order given, taking account

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -696,7 +696,7 @@ internal extension Selector where R == NIORegistration {
             return eventLoop.makeSucceededFuture(())
         }
 
-        return EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)
+        return .andAllSucceed(futures, on: eventLoop)
     }
 }
 

--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -249,7 +249,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler {
             return ctx.eventLoop.makeSucceededFuture(())
         }
 
-        return EventLoopFuture<Void>.andAll(self.extraHTTPHandlers.map { ctx.pipeline.remove(handler: $0).map { (_: Bool) in () }},
-                                            eventLoop: ctx.eventLoop)
+        return .andAllSucceed(self.extraHTTPHandlers.map { ctx.pipeline.remove(handler: $0).map { (_: Bool) in () }},
+                              on: ctx.eventLoop)
     }
 }

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -145,6 +145,11 @@ extension EventLoopFuture {
     public func cascadeFailure<NewValue>(promise: EventLoopPromise<NewValue>?) {
         self.cascadeFailure(to: promise)
     }
+
+    @available(*, deprecated, renamed: "andAllSucceed(_:on:)")
+    public func andAll(_ futures: [EventLoopFuture<Void>], eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        return .andAllSucceed(futures, on: eventLoop)
+    }
 }
 
 extension EventLoopPromise {

--- a/Tests/NIOHTTP1Tests/HTTPTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest.swift
@@ -113,7 +113,7 @@ class HTTPTest: XCTestCase {
                 bodyData = nil
             }
             channel.pipeline.flush()
-            XCTAssertNoThrow(try EventLoopFuture<Void>.andAll(writeFutures, eventLoop: channel.eventLoop).wait())
+            XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(writeFutures, on: channel.eventLoop).wait())
             XCTAssertEqual(2 * expecteds.count, step)
 
             if body != nil {
@@ -149,7 +149,7 @@ class HTTPTest: XCTestCase {
                     try chan.writeInbound(buf)
                 })
             }
-            return EventLoopFuture<Void>.andAll(writeFutures, eventLoop: chan.eventLoop)
+            return EventLoopFuture.andAllSucceed(writeFutures, on: chan.eventLoop)
         })
 
         XCTAssertEqual(bd1, bd2)

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -85,7 +85,7 @@ private func serverHTTPChannelWithAutoremoval(group: EventLoopGroup,
             let upgradeConfig = (upgraders: upgraders, completionHandler: upgradeCompletionHandler)
             return channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: pipelining, withServerUpgrade: upgradeConfig).flatMap {
                 let futureResults = extraHandlers.map { channel.pipeline.add(handler: $0) }
-                return EventLoopFuture<Void>.andAll(futureResults, eventLoop: channel.eventLoop)
+                return EventLoopFuture.andAllSucceed(futureResults, on: channel.eventLoop)
             }
         }.bind(host: "127.0.0.1", port: 0).wait()
     return (c, p.futureResult)

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -100,9 +100,9 @@ public class ChannelTests: XCTestCase {
         XCTAssertNoThrow(try clientChannel.close().wait())
 
         // Wait for the close promises. These fire last.
-        XCTAssertNoThrow(try EventLoopFuture<Void>.andAll([clientChannel.closeFuture,
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed([clientChannel.closeFuture,
                                                            serverAcceptedChannel.closeFuture],
-                                                          eventLoop: group.next()).map {
+                                                           on: group.next()).map {
             XCTAssertEqual(clientLifecycleHandler.currentState, .unregistered)
             XCTAssertEqual(serverLifecycleHandler.currentState, .unregistered)
             XCTAssertEqual(clientLifecycleHandler.stateHistory, [.unregistered, .registered, .active, .inactive, .unregistered])

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -130,7 +130,7 @@ final class DatagramChannelTests: XCTestCase {
             writeFutures.append(self.firstChannel.write(NIOAny(writeData)))
         }
         self.firstChannel.flush()
-        XCTAssertNoThrow(try EventLoopFuture<Void>.andAll(writeFutures, eventLoop: self.firstChannel.eventLoop).wait())
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(writeFutures, on: self.firstChannel.eventLoop).wait())
 
         let reads = try self.secondChannel.waitForDatagrams(count: 5)
 
@@ -219,7 +219,7 @@ final class DatagramChannelTests: XCTestCase {
             buffer.write(string: "a")
             let envelope = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
             self.firstChannel.write(NIOAny(envelope), promise: myPromise)
-            overall = EventLoopFuture<Void>.andAll([overall, myPromise.futureResult], eventLoop: self.firstChannel.eventLoop)
+            overall = EventLoopFuture.andAllSucceed([overall, myPromise.futureResult], on: self.firstChannel.eventLoop)
         }
         self.firstChannel.flush()
         XCTAssertNoThrow(try overall.wait())
@@ -248,7 +248,7 @@ final class DatagramChannelTests: XCTestCase {
             var written: Int64 = 0
             while written <= lotsOfData {
                 self.firstChannel.write(NIOAny(envelope), promise: myPromise)
-                overall = EventLoopFuture<Void>.andAll([overall, myPromise.futureResult], eventLoop: self.firstChannel.eventLoop)
+                overall = EventLoopFuture.andAllSucceed([overall, myPromise.futureResult], on: self.firstChannel.eventLoop)
                 written += Int64(bufferSize)
                 datagrams += 1
             }

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -232,7 +232,7 @@ class EventLoopFutureTest : XCTestCase {
         let eventLoop = EmbeddedEventLoop()
         let futures: [EventLoopFuture<Void>] = []
 
-        let fN: EventLoopFuture<Void> = EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)
+        let fN = EventLoopFuture.andAllSucceed(futures, on: eventLoop)
 
         XCTAssert(fN.isFulfilled)
     }
@@ -242,7 +242,7 @@ class EventLoopFutureTest : XCTestCase {
         let promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
-        let fN: EventLoopFuture<Void> = EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)
+        let fN = EventLoopFuture.andAllSucceed(futures, on: eventLoop)
         _ = promises.map { $0.succeed(()) }
         () = try fN.wait()
     }
@@ -253,7 +253,7 @@ class EventLoopFutureTest : XCTestCase {
         let promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
-        let fN: EventLoopFuture<Void> = EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)
+        let fN = EventLoopFuture.andAllSucceed(futures, on: eventLoop)
         _ = promises.map { $0.fail(E()) }
         do {
             () = try fN.wait()
@@ -276,7 +276,7 @@ class EventLoopFutureTest : XCTestCase {
 
         let futures = promises.map { $0.futureResult }
 
-        let fN: EventLoopFuture<Void> = EventLoopFuture<Void>.andAll(futures, eventLoop: eventLoop)
+        let fN = EventLoopFuture.andAllSucceed(futures, on: eventLoop)
         do {
             () = try fN.wait()
             XCTFail("should've thrown an error")
@@ -638,7 +638,7 @@ class EventLoopFutureTest : XCTestCase {
         let ps = (0..<n).map { (_: Int) -> EventLoopPromise<Void> in
             elg.next().makePromise()
         }
-        let allOfEm = EventLoopFuture<Void>.andAll(ps.map { $0.futureResult }, eventLoop: elg.next())
+        let allOfEm = EventLoopFuture.andAllSucceed(ps.map { $0.futureResult }, on: elg.next())
         ps.reversed().forEach { p in
             DispatchQueue.global().async {
                 p.succeed(())
@@ -656,7 +656,7 @@ class EventLoopFutureTest : XCTestCase {
         let ps = (0..<n).map { (_: Int) -> EventLoopPromise<Void> in
             elg.next().makePromise()
         }
-        let allOfEm = EventLoopFuture<Void>.andAll(ps.map { $0.futureResult }, eventLoop: fireBackEl.next())
+        let allOfEm = EventLoopFuture.andAllSucceed(ps.map { $0.futureResult }, on: fireBackEl.next())
         ps.reversed().enumerated().forEach { idx, p in
             DispatchQueue.global().async {
                 if idx == n / 2 {

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -285,8 +285,8 @@ class SelectorTest: XCTestCase {
                 }
 
                 // if all the new re-connected channels have read, then we're happy here.
-                EventLoopFuture<Void>.andAll(reconnectedChannelsHaveRead,
-                                             eventLoop: ctx.eventLoop).cascade(to: self.everythingWasReadPromise)
+                EventLoopFuture.andAllSucceed(reconnectedChannelsHaveRead, on: ctx.eventLoop)
+                    .cascade(to: self.everythingWasReadPromise)
                 // let's also remove all the channels so this code will not be triggered again.
                 self.allChannels.value.removeAll()
             }

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -42,3 +42,4 @@
 - renamed `HTTPProtocolUpgrader` to `HTTPServerProtocolUpgrader`
 - `EventLoopFuture.cascade(promise: EventLoopPromise)` had its label changed to `EventLoopFuture.cascade(to: EventLoopPromise)`
 - `EventLoopFuture.cascadeFailure(promise: EventLoopPromise)` had its label changed to `EventLoopFuture.cascade(to: EventLoopPromise)`
+- renamed `EventLoopFuture.andAll(_:eventLoop:)` to `EventLoopFuture.andAllSucceed(_:on:)`


### PR DESCRIPTION
Motiviation:

After adding `ELF.whenAllComplete` the concept of "fail fast" and "fail slow" for reducing an array of future results together was introduced.

This commit adds that concepts with the `andAll* methods that act as simple completion notifications.

Modifications:

Rename `EventLoopFuture.andAll(_:eventLoop:)` to `andAllSucceed(_:on:)` to denote its "fail fast" nature, and to match Swift API guidelines.

Add new `EventLoopFuture.andAllComplete(_:on:)` for a "fail slow" companion.

Shift implementation of `whenAllComplete(_:on:)` to be usable without unnecessary allocations in `andAllComplete`

Result:

EventLoopFuture now has two methods for "flattening" arrays of EventLoopFuture into a single notification ELF