### PR TITLE
Remove useless comment

### DIFF
--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -25,9 +25,6 @@ private final class EchoHandler: ChannelInboundHandler {
 
     // Flush it out. This can make use of gathering writes if multiple buffers are pending
     public func channelReadComplete(ctx: ChannelHandlerContext) {
-
-        // As we are not really interested getting notified on success or failure we just pass nil as promise to
-        // reduce allocations.
         ctx.flush()
     }
 


### PR DESCRIPTION
Now that flush() doesn't take a promise anymore, this comment isn't
needed.