### PR TITLE
Avoid race condition in Posix.accept() on macOS

### DIFF
--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -45,6 +45,7 @@ extension SocketChannelTest {
                 ("testPendingConnectNotificationOrder", testPendingConnectNotificationOrder),
                 ("testLocalAndRemoteAddressNotNilInChannelInactiveAndHandlerRemoved", testLocalAndRemoteAddressNotNilInChannelInactiveAndHandlerRemoved),
                 ("testSocketFlagNONBLOCKWorks", testSocketFlagNONBLOCKWorks),
+                ("testInstantTCPConnectionResetThrowsError", testInstantTCPConnectionResetThrowsError),
            ]
    }
 }


### PR DESCRIPTION
Fix a race condition when remote closes connection after `accept()` but before `fcntl()` on macOS.

### Motivation:

A race condition occurs when a socket is closed from the remote end after `accept()` returns it, but before `fcntl(F_SETFL, F_SETNOSIGPIPE)` is invoked. This causes the `fcntl()` call to fail with `EINVAL` ("The socket has been shut down."). This currently triggers an assertion failure. As the race depends on the remote and can be easily demonstrated (using `nmap` is a good way to set it off), the assertion is semantically invalid (`EINVAL` is not programmer error). Additionally, errors reported by `fcntl()` in general are being ignored when not asserted.

### Modifications:

The race is avoided by treating `EINVAL` as a normal error while retaining the existing behavior for all other error cases. Both uses of `fcntl()` to disable `SIGPIPE` now properly report errors.

### Result:

`Posix.accept()` and `Posix.socket()` may now potentially throw additional errors. It is no longer possible to crash a debug server by running `nmap` against it.