### PR TITLE
Update ELF parameter labels to be more Swifty

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -285,7 +285,7 @@ public final class ServerBootstrap {
             } else {
                 fireThroughPipeline(childEventLoop.submit {
                     return setupChildChannel()
-                }.flatMap { $0 }.hopTo(eventLoop: ctxEventLoop))
+                }.flatMap { $0 }.hop(to: ctxEventLoop))
             }
         }
 

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -153,6 +153,27 @@ extension EventLoopFuture {
     public func andAll(_ futures: [EventLoopFuture<Void>], eventLoop: EventLoop) -> EventLoopFuture<Void> {
         return .andAllSucceed(futures, on: eventLoop)
     }
+
+    @available(*, deprecated, renamed: "hop(to:)")
+    public func hopTo(eventLoop: EventLoop) -> EventLoopFuture<Value> {
+        return self.hop(to: eventLoop)
+    }
+
+    @available(*, deprecated, renamed: "reduce(_:_:on:_:)")
+    public static func reduce<InputValue>(_ initialResult: Value,
+                                          _ futures: [EventLoopFuture<InputValue>],
+                                          eventLoop: EventLoop,
+                                          _ nextPartialResult: @escaping (Value, InputValue) -> Value) -> EventLoopFuture<Value> {
+        return .reduce(initialResult, futures, on: eventLoop, nextPartialResult)
+    }
+
+    @available(*, deprecated, renamed: "reduce(into:_:on:_:)")
+    public static func reduce<InputValue>(into initialResult: Value,
+                                          _ futures: [EventLoopFuture<InputValue>],
+                                          eventLoop: EventLoop,
+                                          _ updateAccumulatingResult: @escaping (inout Value, InputValue) -> Void) -> EventLoopFuture<Value> {
+        return .reduce(into: initialResult, futures, on: eventLoop, updateAccumulatingResult)
+    }
 }
 
 extension EventLoopPromise {

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -46,3 +46,6 @@
 - all `ChannelPipeline.remove(...)` now return `EventLoopFuture<Void>` instead of `EventLoopFuture<Bool>`
 - `ByteBuffer.set(<type>, ...)` is now `ByteBuffer.set<Type>`
 - `ByteBuffer.write(<type>, ...)` is now `ByteBuffer.write<Type>`
+- renamed `EventLoopFuture.hopTo(eventLoop:)` to `EventLoopFuture.hop(to:)`
+- `EventLoopFuture.reduce(into:_:eventLoop:_:)` had its label signature changed to `EventLoopFuture.reduce(into:_:on:_:)`
+- `EventLoopFuture.reduce(_:_:eventLoop:_:` had its label signature changed to `EventLoopFuture.reduce(_:_:on:_:)`


### PR DESCRIPTION
Motivation:

As part of NIO2 - much work has been done to round out the API of EventLoopFuture. This finishes existing public API parameters to be more in line with Swift API guidelines.

Modifications:

Methods in EventLoopFuture that had `eventLoop` as a parameter label have been changed to `on`

Results:

EventLoopFuture public API is more "Swifty" with calls such as `future.hop(to: eventLoop)` rather than `future.hopTo(eventLoop: eventLoop)`