### PR TITLE
Add `ThreadOwnershipModel` enum

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -15,6 +15,15 @@
 import NIOConcurrencyHelpers
 import Dispatch
 
+/// A model representing how ownership of threading objects should be handled.
+///
+/// - `internal` defines that whatever object operating under this model is wholely responsible for its own threading resources.
+/// - `external` defines that the object is borrowing the provided `EventLoopGroup` for its necessary tasks, but is not responsible for releasing it.
+public enum ThreadOwnershipModel {
+    case `internal`(threadCount: Int)
+    case external(EventLoopGroup)
+}
+
 /// Returned once a task was scheduled on the `EventLoop` for later execution.
 ///
 /// A `Scheduled` allows the user to either `cancel()` the execution of the scheduled task (if possible) or obtain a reference to the `EventLoopFuture` that


### PR DESCRIPTION
Motiviation:

As discussed in the pitch for NIORedis and NIOPostgres (https://forums.swift.org/t/swiftnio-redis-client/19325 and https://forums.swift.org/t/pitch-swiftnio-based-postgresql-client/18020),
an idea has been floated of providing a `ThreadOwnership` model to provide capabilities of these libraries to be used "out of the box" without having to think about setting up and maintaining
EventLoopGroups by end users.

It might be useful to have this type be defined in NIO itself, so as framework and library authors can share this type and reference it in whatever features they may want to build.

An example of use can be found in NIORedis at https://github.com/Mordil/nio-redis/blob/e168b6c65eb471e186fd43623af93a4902564756/Sources/NIORedis/RedisDriver.swift

Modifications:

Added a `ThreadOwnershipModel` public enum with two cases: `internal` and `external`

Results:

A new enum type that implementers can use to define how their types can be used to manage NIO threading resources.