### PR TITLE
ByteBuffer: rename set(<type>:, ...) to set<Type>(...)

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -37,7 +37,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
     private func responseBody(allocator: ByteBufferAllocator) -> ByteBuffer {
         var buffer = allocator.buffer(capacity: self.bodyLength)
         for i in 0..<self.bodyLength {
-            buffer.write(integer: UInt8(i % Int(UInt8.max)))
+            buffer.writeInteger(UInt8(i % Int(UInt8.max)))
         }
         return buffer
     }
@@ -77,7 +77,7 @@ private final class PingHandler: ChannelInboundHandler {
 
     public func channelActive(ctx: ChannelHandlerContext) {
         self.pingBuffer = ctx.channel.allocator.buffer(capacity: 1)
-        self.pingBuffer.write(integer: PingHandler.pingCode)
+        self.pingBuffer.writeInteger(PingHandler.pingCode)
 
         ctx.writeAndFlush(self.wrapOutboundOut(self.pingBuffer), promise: nil)
     }
@@ -112,7 +112,7 @@ private final class PongHandler: ChannelInboundHandler {
 
     public func channelActive(ctx: ChannelHandlerContext) {
         self.pongBuffer = ctx.channel.allocator.buffer(capacity: 1)
-        self.pongBuffer.write(integer: PongHandler.pongCode)
+        self.pongBuffer.writeInteger(PongHandler.pongCode)
     }
 
     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
@@ -310,15 +310,15 @@ public func swiftMain() -> Int {
         @inline(never)
         func doWrites(buffer: inout ByteBuffer) {
             /* these ones are zero allocations */
-            // buffer.write(bytes: foundationData) // see SR-7542
-            buffer.write(bytes: [0x41])
-            buffer.write(bytes: "A".utf8)
-            buffer.write(string: "A")
-            buffer.write(staticString: "A")
-            buffer.write(integer: 0x41, as: UInt8.self)
+            // buffer.writeBytes(foundationData) // see SR-7542
+            buffer.writeBytes([0x41])
+            buffer.writeBytes("A".utf8)
+            buffer.writeString("A")
+            buffer.writeStaticString("A")
+            buffer.writeInteger(0x41, as: UInt8.self)
 
             /* those down here should be one allocation each (on Linux) */
-            buffer.write(bytes: dispatchData) // see https://bugs.swift.org/browse/SR-9597
+            buffer.writeBytes(dispatchData) // see https://bugs.swift.org/browse/SR-9597
         }
         @inline(never)
         func doReads(buffer: inout ByteBuffer) {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import PackageDescription
 
 var targets: [PackageDescription.Target] = [
     .target(name: "_NIO1APIShims",
-            dependencies: ["NIO", "NIOHTTP1", "NIOTLS"]),
+            dependencies: ["NIO", "NIOHTTP1", "NIOTLS", "NIOFoundationCompat"]),
     .target(name: "NIO",
             dependencies: ["CNIOLinux",
                            "CNIODarwin",

--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -71,8 +71,8 @@ extension ByteBuffer {
     ///     - string: The string to write.
     /// - returns: The number of bytes written.
     @discardableResult
-    public mutating func write(staticString string: StaticString) -> Int {
-        let written = self.set(staticString: string, at: self.writerIndex)
+    public mutating func writeStaticString(_ string: StaticString) -> Int {
+        let written = self.setStaticString(string, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
         return written
     }
@@ -83,10 +83,10 @@ extension ByteBuffer {
     ///     - string: The string to write.
     ///     - index: The index for the first serialized byte.
     /// - returns: The number of bytes written.
-    public mutating func set(staticString string: StaticString, at index: Int) -> Int {
+    public mutating func setStaticString(_ string: StaticString, at index: Int) -> Int {
         // please do not replace the code below with code that uses `string.withUTF8Buffer { ... }` (see SR-7541)
-        return self.set(bytes: UnsafeRawBufferPointer(start: string.utf8Start,
-                                                      count: string.utf8CodeUnitCount), at: index)
+        return self.setBytes(UnsafeRawBufferPointer(start: string.utf8Start,
+                                                    count: string.utf8CodeUnitCount), at: index)
     }
 
     // MARK: String APIs
@@ -96,8 +96,8 @@ extension ByteBuffer {
     ///     - string: The string to write.
     /// - returns: The number of bytes written.
     @discardableResult
-    public mutating func write(string: String) -> Int {
-        let written = self.set(string: string, at: self.writerIndex)
+    public mutating func writeString(_ string: String) -> Int {
+        let written = self.setString(string, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
         return written
     }
@@ -107,11 +107,11 @@ extension ByteBuffer {
     mutating func _setStringSlowpath(_ string: String, at index: Int) -> Int {
         // slow path, let's try to force the string to be native
         if let written = (string + "").utf8.withContiguousStorageIfAvailable({ utf8Bytes in
-            self.set(bytes: utf8Bytes, at: index)
+            self.setBytes(utf8Bytes, at: index)
         }) {
             return written
         } else {
-            return self.set(bytes: string.utf8, at: index)
+            return self.setBytes(string.utf8, at: index)
         }
     }
 
@@ -123,9 +123,9 @@ extension ByteBuffer {
     /// - returns: The number of bytes written.
     @discardableResult
     @inlinable
-    public mutating func set(string: String, at index: Int) -> Int {
+    public mutating func setString(_ string: String, at index: Int) -> Int {
         if let written = string.utf8.withContiguousStorageIfAvailable({ utf8Bytes in
-            self.set(bytes: utf8Bytes, at: index)
+            self.setBytes(utf8Bytes, at: index)
         }) {
             // fast path, directly available
             return written
@@ -181,8 +181,8 @@ extension ByteBuffer {
     ///     - dispatchData: The `DispatchData` instance to write to the `ByteBuffer`.
     /// - returns: The number of bytes written.
     @discardableResult
-    public mutating func write(dispatchData: DispatchData) -> Int {
-        let written = self.set(dispatchData: dispatchData, at: self.writerIndex)
+    public mutating func writeDispatchData(_ dispatchData: DispatchData) -> Int {
+        let written = self.setDispatchData(dispatchData, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
         return written
     }
@@ -194,7 +194,7 @@ extension ByteBuffer {
     ///     - index: The index for the first serialized byte.
     /// - returns: The number of bytes written.
     @discardableResult
-    public mutating func set(dispatchData: DispatchData, at index: Int) -> Int {
+    public mutating func setDispatchData(_ dispatchData: DispatchData, at index: Int) -> Int {
         let allBytesCount = dispatchData.count
         self.reserveCapacity(index + allBytesCount)
         self.withVeryUnsafeMutableBytes { destCompleteStorage in
@@ -319,7 +319,7 @@ extension ByteBuffer {
     @discardableResult
     public mutating func set(buffer: ByteBuffer, at index: Int) -> Int {
         return buffer.withUnsafeReadableBytes{ p in
-            self.set(bytes: p, at: index)
+            self.setBytes(p, at: index)
         }
     }
 
@@ -330,7 +330,7 @@ extension ByteBuffer {
     ///     - buffer: The `ByteBuffer` to write.
     /// - returns: The number of bytes written to this `ByteBuffer` which is equal to the number of bytes read from `buffer`.
     @discardableResult
-    public mutating func write(buffer: inout ByteBuffer) -> Int {
+    public mutating func writeBuffer(_ buffer: inout ByteBuffer) -> Int {
         let written = set(buffer: buffer, at: writerIndex)
         self._moveWriterIndex(forwardBy: written)
         buffer._moveReaderIndex(forwardBy: written)
@@ -344,8 +344,8 @@ extension ByteBuffer {
     /// - returns: The number of bytes written or `bytes.count`.
     @discardableResult
     @inlinable
-    public mutating func write<Bytes: Sequence>(bytes: Bytes) -> Int where Bytes.Element == UInt8 {
-        let written = self.set(bytes: bytes, at: self.writerIndex)
+    public mutating func writeBytes<Bytes: Sequence>(_ bytes: Bytes) -> Int where Bytes.Element == UInt8 {
+        let written = self.setBytes(bytes, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
         return written
     }
@@ -357,8 +357,8 @@ extension ByteBuffer {
     /// - returns: The number of bytes written or `bytes.count`.
     @discardableResult
     @inlinable
-    public mutating func write(bytes: UnsafeRawBufferPointer) -> Int {
-        let written = self.set(bytes: bytes, at: self.writerIndex)
+    public mutating func writeBytes(_ bytes: UnsafeRawBufferPointer) -> Int {
+        let written = self.setBytes(bytes, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
         return written
     }

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -123,10 +123,10 @@ public struct ByteBufferAllocator {
 /// Example:
 ///
 ///     var buf = ...
-///     buf.set(string: "Hello World", at: 0)
+///     buf.setString("Hello World", at: 0)
 ///     let helloWorld = buf.getString(at: 0, length: 11)
 ///
-///     buf.set(integer: 17 as Int, at: 11)
+///     buf.setInteger(17 as Int, at: 11)
 ///     let seventeen: Int = buf.getInteger(at: 11)
 ///
 /// If needed, `ByteBuffer` will automatically resize its storage to accommodate your `set` request.
@@ -138,14 +138,14 @@ public struct ByteBufferAllocator {
 ///
 /// For every supported type `ByteBuffer` usually contains two methods for sequential access:
 ///
-///  1. `read<type>(length: Int)` to read `length` bytes from the current `readerIndex` (and then advance the reader index by `length` bytes)
-///  2. `write(<type>: Type)` to write, advancing the `writerIndex` by the appropriate amount
+///  1. `read<Type>(length: Int)` to read `length` bytes from the current `readerIndex` (and then advance the reader index by `length` bytes)
+///  2. `write<Type>(Type)` to write, advancing the `writerIndex` by the appropriate amount
 ///
 /// Example:
 ///
 ///      var buf = ...
-///      buf.write(string: "Hello World")
-///      buf.write(integer: 17 as Int)
+///      buf.writeString("Hello World")
+///      buf.writeInteger(17 as Int)
 ///      let helloWorld = buf.readString(length: 11)
 ///      let seventeen: Int = buf.readInteger()
 ///
@@ -170,8 +170,8 @@ public struct ByteBufferAllocator {
 ///     var buf = ...
 ///     let dataBytes: [UInt8] = [0xca, 0xfe, 0xba, 0xbe]
 ///     let dataBytesLength = UInt32(dataBytes.count)
-///     buf.write(integer: dataBytesLength) /* the header */
-///     buf.write(bytes: dataBytes) /* the data */
+///     buf.writeInteger(dataBytesLength) /* the header */
+///     buf.writeBytes(dataBytes) /* the data */
 ///     let bufDataBytesOnly = buf.getSlice(at: 4, length: dataBytes.count)
 ///     /* `bufDataByteOnly` and `buf` will share their storage */
 ///
@@ -342,7 +342,7 @@ public struct ByteBuffer {
     }
 
     @inlinable
-    mutating func _set(bytes: UnsafeRawBufferPointer, at index: _Index) -> _Capacity {
+    mutating func _setBytes(_ bytes: UnsafeRawBufferPointer, at index: _Index) -> _Capacity {
         let bytesCount = bytes.count
         let newEndIndex: _Index = index + _toIndex(bytesCount)
         if !isKnownUniquelyReferenced(&self._storage) {
@@ -383,9 +383,9 @@ public struct ByteBuffer {
     }
 
     @inlinable
-    mutating func _set<Bytes: Sequence>(bytes: Bytes, at index: _Index) -> _Capacity where Bytes.Element == UInt8 {
+    mutating func _setBytes<Bytes: Sequence>(_ bytes: Bytes, at index: _Index) -> _Capacity where Bytes.Element == UInt8 {
         if let written = bytes.withContiguousStorageIfAvailable({ bytes in
-            self._set(bytes: UnsafeRawBufferPointer(bytes), at: index)
+            self._setBytes(UnsafeRawBufferPointer(bytes), at: index)
         }) {
             // fast path, we've got access to the contiguous bytes
             return written
@@ -686,15 +686,15 @@ extension ByteBuffer {
     /// Copy the collection of `bytes` into the `ByteBuffer` at `index`.
     @discardableResult
     @inlinable
-    public mutating func set<Bytes: Sequence>(bytes: Bytes, at index: Int) -> Int where Bytes.Element == UInt8 {
-        return Int(self._set(bytes: bytes, at: _toIndex(index)))
+    public mutating func setBytes<Bytes: Sequence>(_ bytes: Bytes, at index: Int) -> Int where Bytes.Element == UInt8 {
+        return Int(self._setBytes(bytes, at: _toIndex(index)))
     }
 
     /// Copy `bytes` into the `ByteBuffer` at `index`.
     @discardableResult
     @inlinable
-    public mutating func set(bytes: UnsafeRawBufferPointer, at index: Int) -> Int {
-        return Int(self._set(bytes: bytes, at: _toIndex(index)))
+    public mutating func setBytes(_ bytes: UnsafeRawBufferPointer, at index: Int) -> Int {
+        return Int(self._setBytes(bytes, at: _toIndex(index)))
     }
 
     /// Move the reader index forward by `offset` bytes.

--- a/Sources/NIO/ByteBuffer-int.swift
+++ b/Sources/NIO/ByteBuffer-int.swift
@@ -78,8 +78,10 @@ extension ByteBuffer {
     /// - returns: The number of bytes written.
     @discardableResult
     @inlinable
-    public mutating func write<T: FixedWidthInteger>(integer: T, endianness: Endianness = .big, as: T.Type = T.self) -> Int {
-        let bytesWritten = self.set(integer: integer, at: self.writerIndex, endianness: endianness)
+    public mutating func writeInteger<T: FixedWidthInteger>(_ integer: T,
+                                                            endianness: Endianness = .big,
+                                                            as: T.Type = T.self) -> Int {
+        let bytesWritten = self.setInteger(integer, at: self.writerIndex, endianness: endianness)
         self._moveWriterIndex(forwardBy: bytesWritten)
         return Int(bytesWritten)
     }
@@ -93,10 +95,10 @@ extension ByteBuffer {
     /// - returns: The number of bytes written.
     @discardableResult
     @inlinable
-    public mutating func set<T: FixedWidthInteger>(integer: T, at index: Int, endianness: Endianness = .big, as: T.Type = T.self) -> Int {
+    public mutating func setInteger<T: FixedWidthInteger>(_ integer: T, at index: Int, endianness: Endianness = .big, as: T.Type = T.self) -> Int {
         var value = _toEndianness(value: integer, endianness: endianness)
         return Swift.withUnsafeBytes(of: &value) { ptr in
-            self.set(bytes: ptr, at: index)
+            self.setBytes(ptr, at: index)
         }
     }
 }

--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -216,7 +216,7 @@ private extension ByteBuffer {
         }
         self.reserveCapacity(requiredCapacity)
         for var buffer in buffers {
-            self.write(buffer: &buffer)
+            self.writeBuffer(&buffer)
         }
     }
 }
@@ -232,7 +232,7 @@ private extension B2MDBuffer {
             let firstIndex = self.buffers.startIndex
             var firstBuffer = self.buffers[firstIndex]
             for var buffer in self.buffers[self.buffers.index(after: firstIndex)...] {
-                firstBuffer.write(buffer: &buffer)
+                firstBuffer.writeBuffer(&buffer)
             }
             return firstBuffer
         }

--- a/Sources/NIOChatClient/main.swift
+++ b/Sources/NIOChatClient/main.swift
@@ -93,7 +93,7 @@ print("ChatClient connected to ChatServer: \(channel.remoteAddress!), happy chat
 
 while let line = readLine(strippingNewline: false) {
     var buffer = channel.allocator.buffer(capacity: line.utf8.count)
-    buffer.write(string: line)
+    buffer.writeString(line)
     try! channel.writeAndFlush(buffer).wait()
 }
 

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -57,8 +57,8 @@ final class ChatHandler: ChannelInboundHandler {
 
         // 64 should be good enough for the ipaddress
         var buffer = ctx.channel.allocator.buffer(capacity: read.readableBytes + 64)
-        buffer.write(string: "(\(ctx.remoteAddress!)) - ")
-        buffer.write(buffer: &read)
+        buffer.writeString("(\(ctx.remoteAddress!)) - ")
+        buffer.writeBuffer(&read)
         self.channelsSyncQueue.async {
             // broadcast the message to all the connected clients except the one that wrote it.
             self.writeToAll(channels: self.channels.filter { id != $0.key }, buffer: buffer)
@@ -84,7 +84,7 @@ final class ChatHandler: ChannelInboundHandler {
         }
 
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(string: "(ChatServer) - Welcome to: \(ctx.localAddress!)\n")
+        buffer.writeString("(ChatServer) - Welcome to: \(ctx.localAddress!)\n")
         ctx.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
     }
 
@@ -100,7 +100,7 @@ final class ChatHandler: ChannelInboundHandler {
 
     private func writeToAll(channels: [ObjectIdentifier: Channel], allocator: ByteBufferAllocator, message: String) {
         var buffer =  allocator.buffer(capacity: message.utf8.count)
-        buffer.write(string: message)
+        buffer.writeString(message)
         self.writeToAll(channels: channels, buffer: buffer)
     }
 

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -50,7 +50,7 @@ private final class EchoHandler: ChannelInboundHandler {
 
         // We are connected. It's time to send the message to the server to initialize the ping-pong sequence.
         var buffer = ctx.channel.allocator.buffer(capacity: line.utf8.count)
-        buffer.write(string: line)
+        buffer.writeString(line)
         self.numBytes = buffer.readableBytes
         ctx.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
     }

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -132,8 +132,8 @@ extension ByteBuffer {
     ///     - encoding: The encoding to use to encode the string.
     /// - returns: The number of bytes written.
     @discardableResult
-    public mutating func write(string: String, encoding: String.Encoding) throws -> Int {
-        let written = try self.set(string: string, encoding: encoding, at: self.writerIndex)
+    public mutating func writeString(_ string: String, encoding: String.Encoding) throws -> Int {
+        let written = try self.setString(string, encoding: encoding, at: self.writerIndex)
         self.moveWriterIndex(forwardBy: written)
         return written
     }
@@ -146,10 +146,10 @@ extension ByteBuffer {
     ///     - index: The index for the first serialized byte.
     /// - returns: The number of bytes written.
     @discardableResult
-    public mutating func set(string: String, encoding: String.Encoding, at index: Int) throws -> Int {
+    public mutating func setString(_ string: String, encoding: String.Encoding, at index: Int) throws -> Int {
         guard let data = string.data(using: encoding) else {
             throw ByteBufferFoundationError.failedToEncodeString
         }
-        return self.set(bytes: data, at: index)
+        return self.setBytes(data, at: index)
     }
 }

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -606,7 +606,7 @@ public class HTTPDecoder<HTTPMessageT>: ChannelInboundHandler, AnyHTTPDecoder {
         if self.cumulationBuffer == nil {
             self.cumulationBuffer = buffer
         } else {
-            self.cumulationBuffer!.write(buffer: &buffer)
+            self.cumulationBuffer!.writeBuffer(&buffer)
         }
 
         do {

--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -37,8 +37,8 @@ private func writeChunk(wrapOutboundOut: (IOData) -> NIOAny, ctx: ChannelHandler
     if isChunked {
         var buffer = ctx.channel.allocator.buffer(capacity: 32)
         let len = String(readableBytes, radix: 16)
-        buffer.write(string: len)
-        buffer.write(staticString: "\r\n")
+        buffer.writeString(len)
+        buffer.writeStaticString("\r\n")
         ctx.write(wrapOutboundOut(.byteBuffer(buffer)), promise: mW1)
 
         ctx.write(wrapOutboundOut(chunk), promise: mW2)
@@ -57,11 +57,11 @@ private func writeTrailers(wrapOutboundOut: (IOData) -> NIOAny, ctx: ChannelHand
         var buffer: ByteBuffer
         if let trailers = trailers {
             buffer = ctx.channel.allocator.buffer(capacity: 256)
-            buffer.write(staticString: "0\r\n")
+            buffer.writeStaticString("0\r\n")
             buffer.write(headers: trailers) // Includes trailing CRLF.
         } else {
             buffer = ctx.channel.allocator.buffer(capacity: 8)
-            buffer.write(staticString: "0\r\n\r\n")
+            buffer.writeStaticString("0\r\n\r\n")
         }
         ctx.write(wrapOutboundOut(.byteBuffer(buffer)), promise: p)
     case (false, .some(let p)):
@@ -188,367 +188,367 @@ public final class HTTPResponseEncoder: ChannelOutboundHandler, RemovableChannel
 
 private extension ByteBuffer {
     private mutating func write(status: HTTPResponseStatus) {
-        self.write(string: String(status.code))
+        self.writeString(String(status.code))
         self.writeWhitespace()
-        self.write(string: status.reasonPhrase)
+        self.writeString(status.reasonPhrase)
     }
 
     mutating func write(response: HTTPResponseHead) {
         switch (response.version.major, response.version.minor, response.status) {
         // Optimization for HTTP/1.0
         case (1, 0, .custom(_, _)):
-            self.write(staticString: "HTTP/1.0 ")
+            self.writeStaticString("HTTP/1.0 ")
             self.write(status: response.status)
-            self.write(staticString: "\r\n")
+            self.writeStaticString("\r\n")
         case (1, 0, .continue):
-            self.write(staticString: "HTTP/1.0 100 Continue\r\n")
+            self.writeStaticString("HTTP/1.0 100 Continue\r\n")
         case (1, 0, .switchingProtocols):
-            self.write(staticString: "HTTP/1.0 101 Switching Protocols\r\n")
+            self.writeStaticString("HTTP/1.0 101 Switching Protocols\r\n")
         case (1, 0, .processing):
-            self.write(staticString: "HTTP/1.0 102 Processing\r\n")
+            self.writeStaticString("HTTP/1.0 102 Processing\r\n")
         case (1, 0, .ok):
-            self.write(staticString: "HTTP/1.0 200 OK\r\n")
+            self.writeStaticString("HTTP/1.0 200 OK\r\n")
         case (1, 0, .created):
-            self.write(staticString: "HTTP/1.0 201 Created\r\n")
+            self.writeStaticString("HTTP/1.0 201 Created\r\n")
         case (1, 0, .accepted):
-            self.write(staticString: "HTTP/1.0 202 Accepted\r\n")
+            self.writeStaticString("HTTP/1.0 202 Accepted\r\n")
         case (1, 0, .nonAuthoritativeInformation):
-            self.write(staticString: "HTTP/1.0 203 Non-Authoritative Information\r\n")
+            self.writeStaticString("HTTP/1.0 203 Non-Authoritative Information\r\n")
         case (1, 0, .noContent):
-            self.write(staticString: "HTTP/1.0 204 No Content\r\n")
+            self.writeStaticString("HTTP/1.0 204 No Content\r\n")
         case (1, 0, .resetContent):
-            self.write(staticString: "HTTP/1.0 205 Reset Content\r\n")
+            self.writeStaticString("HTTP/1.0 205 Reset Content\r\n")
         case (1, 0, .partialContent):
-            self.write(staticString: "HTTP/1.0 206 Partial Content\r\n")
+            self.writeStaticString("HTTP/1.0 206 Partial Content\r\n")
         case (1, 0, .multiStatus):
-            self.write(staticString: "HTTP/1.0 207 Multi-Status\r\n")
+            self.writeStaticString("HTTP/1.0 207 Multi-Status\r\n")
         case (1, 0, .alreadyReported):
-            self.write(staticString: "HTTP/1.0 208 Already Reported\r\n")
+            self.writeStaticString("HTTP/1.0 208 Already Reported\r\n")
         case (1, 0, .imUsed):
-            self.write(staticString: "HTTP/1.0 226 IM Used\r\n")
+            self.writeStaticString("HTTP/1.0 226 IM Used\r\n")
         case (1, 0, .multipleChoices):
-            self.write(staticString: "HTTP/1.0 300 Multiple Choices\r\n")
+            self.writeStaticString("HTTP/1.0 300 Multiple Choices\r\n")
         case (1, 0, .movedPermanently):
-            self.write(staticString: "HTTP/1.0 301 Moved Permanently\r\n")
+            self.writeStaticString("HTTP/1.0 301 Moved Permanently\r\n")
         case (1, 0, .found):
-            self.write(staticString: "HTTP/1.0 302 Found\r\n")
+            self.writeStaticString("HTTP/1.0 302 Found\r\n")
         case (1, 0, .seeOther):
-            self.write(staticString: "HTTP/1.0 303 See Other\r\n")
+            self.writeStaticString("HTTP/1.0 303 See Other\r\n")
         case (1, 0, .notModified):
-            self.write(staticString: "HTTP/1.0 304 Not Modified\r\n")
+            self.writeStaticString("HTTP/1.0 304 Not Modified\r\n")
         case (1, 0, .useProxy):
-            self.write(staticString: "HTTP/1.0 305 Use Proxy\r\n")
+            self.writeStaticString("HTTP/1.0 305 Use Proxy\r\n")
         case (1, 0, .temporaryRedirect):
-            self.write(staticString: "HTTP/1.0 307 Tempory Redirect\r\n")
+            self.writeStaticString("HTTP/1.0 307 Tempory Redirect\r\n")
         case (1, 0, .permanentRedirect):
-            self.write(staticString: "HTTP/1.0 308 Permanent Redirect\r\n")
+            self.writeStaticString("HTTP/1.0 308 Permanent Redirect\r\n")
         case (1, 0, .badRequest):
-            self.write(staticString: "HTTP/1.0 400 Bad Request\r\n")
+            self.writeStaticString("HTTP/1.0 400 Bad Request\r\n")
         case (1, 0, .unauthorized):
-            self.write(staticString: "HTTP/1.0 401 Unauthorized\r\n")
+            self.writeStaticString("HTTP/1.0 401 Unauthorized\r\n")
         case (1, 0, .paymentRequired):
-            self.write(staticString: "HTTP/1.0 402 Payment Required\r\n")
+            self.writeStaticString("HTTP/1.0 402 Payment Required\r\n")
         case (1, 0, .forbidden):
-            self.write(staticString: "HTTP/1.0 403 Forbidden\r\n")
+            self.writeStaticString("HTTP/1.0 403 Forbidden\r\n")
         case (1, 0, .notFound):
-            self.write(staticString: "HTTP/1.0 404 Not Found\r\n")
+            self.writeStaticString("HTTP/1.0 404 Not Found\r\n")
         case (1, 0, .methodNotAllowed):
-            self.write(staticString: "HTTP/1.0 405 Method Not Allowed\r\n")
+            self.writeStaticString("HTTP/1.0 405 Method Not Allowed\r\n")
         case (1, 0, .notAcceptable):
-            self.write(staticString: "HTTP/1.0 406 Not Acceptable\r\n")
+            self.writeStaticString("HTTP/1.0 406 Not Acceptable\r\n")
         case (1, 0, .proxyAuthenticationRequired):
-            self.write(staticString: "HTTP/1.0 407 Proxy Authentication Required\r\n")
+            self.writeStaticString("HTTP/1.0 407 Proxy Authentication Required\r\n")
         case (1, 0, .requestTimeout):
-            self.write(staticString: "HTTP/1.0 408 Request Timeout\r\n")
+            self.writeStaticString("HTTP/1.0 408 Request Timeout\r\n")
         case (1, 0, .conflict):
-            self.write(staticString: "HTTP/1.0 409 Conflict\r\n")
+            self.writeStaticString("HTTP/1.0 409 Conflict\r\n")
         case (1, 0, .gone):
-            self.write(staticString: "HTTP/1.0 410 Gone\r\n")
+            self.writeStaticString("HTTP/1.0 410 Gone\r\n")
         case (1, 0, .lengthRequired):
-            self.write(staticString: "HTTP/1.0 411 Length Required\r\n")
+            self.writeStaticString("HTTP/1.0 411 Length Required\r\n")
         case (1, 0, .preconditionFailed):
-            self.write(staticString: "HTTP/1.0 412 Precondition Failed\r\n")
+            self.writeStaticString("HTTP/1.0 412 Precondition Failed\r\n")
         case (1, 0, .payloadTooLarge):
-            self.write(staticString: "HTTP/1.0 413 Payload Too Large\r\n")
+            self.writeStaticString("HTTP/1.0 413 Payload Too Large\r\n")
         case (1, 0, .uriTooLong):
-            self.write(staticString: "HTTP/1.0 414 URI Too Long\r\n")
+            self.writeStaticString("HTTP/1.0 414 URI Too Long\r\n")
         case (1, 0, .unsupportedMediaType):
-            self.write(staticString: "HTTP/1.0 415 Unsupported Media Type\r\n")
+            self.writeStaticString("HTTP/1.0 415 Unsupported Media Type\r\n")
         case (1, 0, .rangeNotSatisfiable):
-            self.write(staticString: "HTTP/1.0 416 Range Not Satisfiable\r\n")
+            self.writeStaticString("HTTP/1.0 416 Range Not Satisfiable\r\n")
         case (1, 0, .expectationFailed):
-            self.write(staticString: "HTTP/1.0 417 Expectation Failed\r\n")
+            self.writeStaticString("HTTP/1.0 417 Expectation Failed\r\n")
         case (1, 0, .misdirectedRequest):
-            self.write(staticString: "HTTP/1.0 421 Misdirected Request\r\n")
+            self.writeStaticString("HTTP/1.0 421 Misdirected Request\r\n")
         case (1, 0, .unprocessableEntity):
-            self.write(staticString: "HTTP/1.0 422 Unprocessable Entity\r\n")
+            self.writeStaticString("HTTP/1.0 422 Unprocessable Entity\r\n")
         case (1, 0, .locked):
-            self.write(staticString: "HTTP/1.0 423 Locked\r\n")
+            self.writeStaticString("HTTP/1.0 423 Locked\r\n")
         case (1, 0, .failedDependency):
-            self.write(staticString: "HTTP/1.0 424 Failed Dependency\r\n")
+            self.writeStaticString("HTTP/1.0 424 Failed Dependency\r\n")
         case (1, 0, .upgradeRequired):
-            self.write(staticString: "HTTP/1.0 426 Upgrade Required\r\n")
+            self.writeStaticString("HTTP/1.0 426 Upgrade Required\r\n")
         case (1, 0, .preconditionRequired):
-            self.write(staticString: "HTTP/1.0 428 Precondition Required\r\n")
+            self.writeStaticString("HTTP/1.0 428 Precondition Required\r\n")
         case (1, 0, .tooManyRequests):
-            self.write(staticString: "HTTP/1.0 429 Too Many Requests\r\n")
+            self.writeStaticString("HTTP/1.0 429 Too Many Requests\r\n")
         case (1, 0, .requestHeaderFieldsTooLarge):
-            self.write(staticString: "HTTP/1.0 431 Request Header Fields Too Large\r\n")
+            self.writeStaticString("HTTP/1.0 431 Request Header Fields Too Large\r\n")
         case (1, 0, .unavailableForLegalReasons):
-            self.write(staticString: "HTTP/1.0 451 Unavailable For Legal Reasons\r\n")
+            self.writeStaticString("HTTP/1.0 451 Unavailable For Legal Reasons\r\n")
         case (1, 0, .internalServerError):
-            self.write(staticString: "HTTP/1.0 500 Internal Server Error\r\n")
+            self.writeStaticString("HTTP/1.0 500 Internal Server Error\r\n")
         case (1, 0, .notImplemented):
-            self.write(staticString: "HTTP/1.0 501 Not Implemented\r\n")
+            self.writeStaticString("HTTP/1.0 501 Not Implemented\r\n")
         case (1, 0, .badGateway):
-            self.write(staticString: "HTTP/1.0 502 Bad Gateway\r\n")
+            self.writeStaticString("HTTP/1.0 502 Bad Gateway\r\n")
         case (1, 0, .serviceUnavailable):
-            self.write(staticString: "HTTP/1.0 503 Service Unavailable\r\n")
+            self.writeStaticString("HTTP/1.0 503 Service Unavailable\r\n")
         case (1, 0, .gatewayTimeout):
-            self.write(staticString: "HTTP/1.0 504 Gateway Timeout\r\n")
+            self.writeStaticString("HTTP/1.0 504 Gateway Timeout\r\n")
         case (1, 0, .httpVersionNotSupported):
-            self.write(staticString: "HTTP/1.0 505 HTTP Version Not Supported\r\n")
+            self.writeStaticString("HTTP/1.0 505 HTTP Version Not Supported\r\n")
         case (1, 0, .variantAlsoNegotiates):
-            self.write(staticString: "HTTP/1.0 506 Variant Also Negotiates\r\n")
+            self.writeStaticString("HTTP/1.0 506 Variant Also Negotiates\r\n")
         case (1, 0, .insufficientStorage):
-            self.write(staticString: "HTTP/1.0 507 Insufficient Storage\r\n")
+            self.writeStaticString("HTTP/1.0 507 Insufficient Storage\r\n")
         case (1, 0, .loopDetected):
-            self.write(staticString: "HTTP/1.0 508 Loop Detected\r\n")
+            self.writeStaticString("HTTP/1.0 508 Loop Detected\r\n")
         case (1, 0, .notExtended):
-            self.write(staticString: "HTTP/1.0 510 Not Extended\r\n")
+            self.writeStaticString("HTTP/1.0 510 Not Extended\r\n")
         case (1, 0, .networkAuthenticationRequired):
-            self.write(staticString: "HTTP/1.1 511 Network Authentication Required\r\n")
+            self.writeStaticString("HTTP/1.1 511 Network Authentication Required\r\n")
 
         // Optimization for HTTP/1.1
         case (1, 1, .custom(_, _)):
-            self.write(staticString: "HTTP/1.1 ")
+            self.writeStaticString("HTTP/1.1 ")
             self.write(status: response.status)
-            self.write(staticString: "\r\n")
+            self.writeStaticString("\r\n")
         case (1, 1, .continue):
-            self.write(staticString: "HTTP/1.1 100 Continue\r\n")
+            self.writeStaticString("HTTP/1.1 100 Continue\r\n")
         case (1, 1, .switchingProtocols):
-            self.write(staticString: "HTTP/1.1 101 Switching Protocols\r\n")
+            self.writeStaticString("HTTP/1.1 101 Switching Protocols\r\n")
         case (1, 1, .processing):
-            self.write(staticString: "HTTP/1.1 102 Processing\r\n")
+            self.writeStaticString("HTTP/1.1 102 Processing\r\n")
         case (1, 1, .ok):
-            self.write(staticString: "HTTP/1.1 200 OK\r\n")
+            self.writeStaticString("HTTP/1.1 200 OK\r\n")
         case (1, 1, .created):
-            self.write(staticString: "HTTP/1.1 201 Created\r\n")
+            self.writeStaticString("HTTP/1.1 201 Created\r\n")
         case (1, 1, .accepted):
-            self.write(staticString: "HTTP/1.1 202 Accepted\r\n")
+            self.writeStaticString("HTTP/1.1 202 Accepted\r\n")
         case (1, 1, .nonAuthoritativeInformation):
-            self.write(staticString: "HTTP/1.1 203 Non-Authoritative Information\r\n")
+            self.writeStaticString("HTTP/1.1 203 Non-Authoritative Information\r\n")
         case (1, 1, .noContent):
-            self.write(staticString: "HTTP/1.1 204 No Content\r\n")
+            self.writeStaticString("HTTP/1.1 204 No Content\r\n")
         case (1, 1, .resetContent):
-            self.write(staticString: "HTTP/1.1 205 Reset Content\r\n")
+            self.writeStaticString("HTTP/1.1 205 Reset Content\r\n")
         case (1, 1, .partialContent):
-            self.write(staticString: "HTTP/1.1 206 Partial Content\r\n")
+            self.writeStaticString("HTTP/1.1 206 Partial Content\r\n")
         case (1, 1, .multiStatus):
-            self.write(staticString: "HTTP/1.1 207 Multi-Status\r\n")
+            self.writeStaticString("HTTP/1.1 207 Multi-Status\r\n")
         case (1, 1, .alreadyReported):
-            self.write(staticString: "HTTP/1.1 208 Already Reported\r\n")
+            self.writeStaticString("HTTP/1.1 208 Already Reported\r\n")
         case (1, 1, .imUsed):
-            self.write(staticString: "HTTP/1.1 226 IM Used\r\n")
+            self.writeStaticString("HTTP/1.1 226 IM Used\r\n")
         case (1, 1, .multipleChoices):
-            self.write(staticString: "HTTP/1.1 300 Multiple Choices\r\n")
+            self.writeStaticString("HTTP/1.1 300 Multiple Choices\r\n")
         case (1, 1, .movedPermanently):
-            self.write(staticString: "HTTP/1.1 301 Moved Permanently\r\n")
+            self.writeStaticString("HTTP/1.1 301 Moved Permanently\r\n")
         case (1, 1, .found):
-            self.write(staticString: "HTTP/1.1 302 Found\r\n")
+            self.writeStaticString("HTTP/1.1 302 Found\r\n")
         case (1, 1, .seeOther):
-            self.write(staticString: "HTTP/1.1 303 See Other\r\n")
+            self.writeStaticString("HTTP/1.1 303 See Other\r\n")
         case (1, 1, .notModified):
-            self.write(staticString: "HTTP/1.1 304 Not Modified\r\n")
+            self.writeStaticString("HTTP/1.1 304 Not Modified\r\n")
         case (1, 1, .useProxy):
-            self.write(staticString: "HTTP/1.1 305 Use Proxy\r\n")
+            self.writeStaticString("HTTP/1.1 305 Use Proxy\r\n")
         case (1, 1, .temporaryRedirect):
-            self.write(staticString: "HTTP/1.1 307 Tempory Redirect\r\n")
+            self.writeStaticString("HTTP/1.1 307 Tempory Redirect\r\n")
         case (1, 1, .permanentRedirect):
-            self.write(staticString: "HTTP/1.1 308 Permanent Redirect\r\n")
+            self.writeStaticString("HTTP/1.1 308 Permanent Redirect\r\n")
         case (1, 1, .badRequest):
-            self.write(staticString: "HTTP/1.1 400 Bad Request\r\n")
+            self.writeStaticString("HTTP/1.1 400 Bad Request\r\n")
         case (1, 1, .unauthorized):
-            self.write(staticString: "HTTP/1.1 401 Unauthorized\r\n")
+            self.writeStaticString("HTTP/1.1 401 Unauthorized\r\n")
         case (1, 1, .paymentRequired):
-            self.write(staticString: "HTTP/1.1 402 Payment Required\r\n")
+            self.writeStaticString("HTTP/1.1 402 Payment Required\r\n")
         case (1, 1, .forbidden):
-            self.write(staticString: "HTTP/1.1 403 Forbidden\r\n")
+            self.writeStaticString("HTTP/1.1 403 Forbidden\r\n")
         case (1, 1, .notFound):
-            self.write(staticString: "HTTP/1.1 404 Not Found\r\n")
+            self.writeStaticString("HTTP/1.1 404 Not Found\r\n")
         case (1, 1, .methodNotAllowed):
-            self.write(staticString: "HTTP/1.1 405 Method Not Allowed\r\n")
+            self.writeStaticString("HTTP/1.1 405 Method Not Allowed\r\n")
         case (1, 1, .notAcceptable):
-            self.write(staticString: "HTTP/1.1 406 Not Acceptable\r\n")
+            self.writeStaticString("HTTP/1.1 406 Not Acceptable\r\n")
         case (1, 1, .proxyAuthenticationRequired):
-            self.write(staticString: "HTTP/1.1 407 Proxy Authentication Required\r\n")
+            self.writeStaticString("HTTP/1.1 407 Proxy Authentication Required\r\n")
         case (1, 1, .requestTimeout):
-            self.write(staticString: "HTTP/1.1 408 Request Timeout\r\n")
+            self.writeStaticString("HTTP/1.1 408 Request Timeout\r\n")
         case (1, 1, .conflict):
-            self.write(staticString: "HTTP/1.1 409 Conflict\r\n")
+            self.writeStaticString("HTTP/1.1 409 Conflict\r\n")
         case (1, 1, .gone):
-            self.write(staticString: "HTTP/1.1 410 Gone\r\n")
+            self.writeStaticString("HTTP/1.1 410 Gone\r\n")
         case (1, 1, .lengthRequired):
-            self.write(staticString: "HTTP/1.1 411 Length Required\r\n")
+            self.writeStaticString("HTTP/1.1 411 Length Required\r\n")
         case (1, 1, .preconditionFailed):
-            self.write(staticString: "HTTP/1.1 412 Precondition Failed\r\n")
+            self.writeStaticString("HTTP/1.1 412 Precondition Failed\r\n")
         case (1, 1, .payloadTooLarge):
-            self.write(staticString: "HTTP/1.1 413 Payload Too Large\r\n")
+            self.writeStaticString("HTTP/1.1 413 Payload Too Large\r\n")
         case (1, 1, .uriTooLong):
-            self.write(staticString: "HTTP/1.1 414 URI Too Long\r\n")
+            self.writeStaticString("HTTP/1.1 414 URI Too Long\r\n")
         case (1, 1, .unsupportedMediaType):
-            self.write(staticString: "HTTP/1.1 415 Unsupported Media Type\r\n")
+            self.writeStaticString("HTTP/1.1 415 Unsupported Media Type\r\n")
         case (1, 1, .rangeNotSatisfiable):
-            self.write(staticString: "HTTP/1.1 416 Request Range Not Satisified\r\n")
+            self.writeStaticString("HTTP/1.1 416 Request Range Not Satisified\r\n")
         case (1, 1, .expectationFailed):
-            self.write(staticString: "HTTP/1.1 417 Expectation Failed\r\n")
+            self.writeStaticString("HTTP/1.1 417 Expectation Failed\r\n")
         case (1, 1, .misdirectedRequest):
-            self.write(staticString: "HTTP/1.1 421 Misdirected Request\r\n")
+            self.writeStaticString("HTTP/1.1 421 Misdirected Request\r\n")
         case (1, 1, .unprocessableEntity):
-            self.write(staticString: "HTTP/1.1 422 Unprocessable Entity\r\n")
+            self.writeStaticString("HTTP/1.1 422 Unprocessable Entity\r\n")
         case (1, 1, .locked):
-            self.write(staticString: "HTTP/1.1 423 Locked\r\n")
+            self.writeStaticString("HTTP/1.1 423 Locked\r\n")
         case (1, 1, .failedDependency):
-            self.write(staticString: "HTTP/1.1 424 Failed Dependency\r\n")
+            self.writeStaticString("HTTP/1.1 424 Failed Dependency\r\n")
         case (1, 1, .upgradeRequired):
-            self.write(staticString: "HTTP/1.1 426 Upgrade Required\r\n")
+            self.writeStaticString("HTTP/1.1 426 Upgrade Required\r\n")
         case (1, 1, .preconditionRequired):
-            self.write(staticString: "HTTP/1.1 428 Precondition Required\r\n")
+            self.writeStaticString("HTTP/1.1 428 Precondition Required\r\n")
         case (1, 1, .tooManyRequests):
-            self.write(staticString: "HTTP/1.1 429 Too Many Requests\r\n")
+            self.writeStaticString("HTTP/1.1 429 Too Many Requests\r\n")
         case (1, 1, .requestHeaderFieldsTooLarge):
-            self.write(staticString: "HTTP/1.1 431 Range Not Satisfiable\r\n")
+            self.writeStaticString("HTTP/1.1 431 Range Not Satisfiable\r\n")
         case (1, 1, .unavailableForLegalReasons):
-            self.write(staticString: "HTTP/1.1 451 Unavailable For Legal Reasons\r\n")
+            self.writeStaticString("HTTP/1.1 451 Unavailable For Legal Reasons\r\n")
         case (1, 1, .internalServerError):
-            self.write(staticString: "HTTP/1.1 500 Internal Server Error\r\n")
+            self.writeStaticString("HTTP/1.1 500 Internal Server Error\r\n")
         case (1, 1, .notImplemented):
-            self.write(staticString: "HTTP/1.1 501 Not Implemented\r\n")
+            self.writeStaticString("HTTP/1.1 501 Not Implemented\r\n")
         case (1, 1, .badGateway):
-            self.write(staticString: "HTTP/1.1 502 Bad Gateway\r\n")
+            self.writeStaticString("HTTP/1.1 502 Bad Gateway\r\n")
         case (1, 1, .serviceUnavailable):
-            self.write(staticString: "HTTP/1.1 503 Service Unavailable\r\n")
+            self.writeStaticString("HTTP/1.1 503 Service Unavailable\r\n")
         case (1, 1, .gatewayTimeout):
-            self.write(staticString: "HTTP/1.1 504 Gateway Timeout\r\n")
+            self.writeStaticString("HTTP/1.1 504 Gateway Timeout\r\n")
         case (1, 1, .httpVersionNotSupported):
-            self.write(staticString: "HTTP/1.1 505 HTTP Version Not Supported\r\n")
+            self.writeStaticString("HTTP/1.1 505 HTTP Version Not Supported\r\n")
         case (1, 1, .variantAlsoNegotiates):
-            self.write(staticString: "HTTP/1.1 506 Variant Also Negotiates\r\n")
+            self.writeStaticString("HTTP/1.1 506 Variant Also Negotiates\r\n")
         case (1, 1, .insufficientStorage):
-            self.write(staticString: "HTTP/1.1 507 Insufficient Storage\r\n")
+            self.writeStaticString("HTTP/1.1 507 Insufficient Storage\r\n")
         case (1, 1, .loopDetected):
-            self.write(staticString: "HTTP/1.1 508 Loop Detected\r\n")
+            self.writeStaticString("HTTP/1.1 508 Loop Detected\r\n")
         case (1, 1, .notExtended):
-            self.write(staticString: "HTTP/1.1 510 Not Extended\r\n")
+            self.writeStaticString("HTTP/1.1 510 Not Extended\r\n")
         case (1, 1, .networkAuthenticationRequired):
-            self.write(staticString: "HTTP/1.1 511 Network Authentication Required\r\n")
+            self.writeStaticString("HTTP/1.1 511 Network Authentication Required\r\n")
 
         // Fallback for non-known HTTP version
         default:
             self.write(version: response.version)
             self.writeWhitespace()
             self.write(status: response.status)
-            self.write(staticString: "\r\n")
+            self.writeStaticString("\r\n")
         }
     }
 
     private mutating func write(version: HTTPVersion) {
         switch (version.minor, version.major) {
         case (1, 0):
-            self.write(staticString: "HTTP/1.0")
+            self.writeStaticString("HTTP/1.0")
         case (1, 1):
-            self.write(staticString: "HTTP/1.1")
+            self.writeStaticString("HTTP/1.1")
         default:
-            self.write(staticString: "HTTP/")
-            self.write(string: String(version.major))
-            self.write(staticString: ".")
-            self.write(string: String(version.minor))
+            self.writeStaticString("HTTP/")
+            self.writeString(String(version.major))
+            self.writeStaticString(".")
+            self.writeString(String(version.minor))
         }
     }
 
     mutating func write(request: HTTPRequestHead) {
         self.write(method: request.method)
         self.writeWhitespace()
-        self.write(string: request.uri)
+        self.writeString(request.uri)
         self.writeWhitespace()
         self.write(version: request.version)
-        self.write(staticString: "\r\n")
+        self.writeStaticString("\r\n")
     }
 
     mutating func writeWhitespace() {
-        self.write(integer: 32, as: UInt8.self)
+        self.writeInteger(32, as: UInt8.self)
     }
 
     private mutating func write(method: HTTPMethod) {
         switch method {
         case .GET:
-            self.write(staticString: "GET")
+            self.writeStaticString("GET")
         case .PUT:
-            self.write(staticString: "PUT")
+            self.writeStaticString("PUT")
         case .ACL:
-            self.write(staticString: "ACL")
+            self.writeStaticString("ACL")
         case .HEAD:
-            self.write(staticString: "HEAD")
+            self.writeStaticString("HEAD")
         case .POST:
-            self.write(staticString: "POST")
+            self.writeStaticString("POST")
         case .COPY:
-            self.write(staticString: "COPY")
+            self.writeStaticString("COPY")
         case .LOCK:
-            self.write(staticString: "LOCK")
+            self.writeStaticString("LOCK")
         case .MOVE:
-            self.write(staticString: "MOVE")
+            self.writeStaticString("MOVE")
         case .BIND:
-            self.write(staticString: "BIND")
+            self.writeStaticString("BIND")
         case .LINK:
-            self.write(staticString: "LINK")
+            self.writeStaticString("LINK")
         case .PATCH:
-            self.write(staticString: "PATCH")
+            self.writeStaticString("PATCH")
         case .TRACE:
-            self.write(staticString: "TRACE")
+            self.writeStaticString("TRACE")
         case .MKCOL:
-            self.write(staticString: "MKCOL")
+            self.writeStaticString("MKCOL")
         case .MERGE:
-            self.write(staticString: "MERGE")
+            self.writeStaticString("MERGE")
         case .PURGE:
-            self.write(staticString: "PURGE")
+            self.writeStaticString("PURGE")
         case .NOTIFY:
-            self.write(staticString: "NOTIFY")
+            self.writeStaticString("NOTIFY")
         case .SEARCH:
-            self.write(staticString: "SEARCH")
+            self.writeStaticString("SEARCH")
         case .UNLOCK:
-            self.write(staticString: "UNLOCK")
+            self.writeStaticString("UNLOCK")
         case .REBIND:
-            self.write(staticString: "REBIND")
+            self.writeStaticString("REBIND")
         case .UNBIND:
-            self.write(staticString: "UNBIND")
+            self.writeStaticString("UNBIND")
         case .REPORT:
-            self.write(staticString: "REPORT")
+            self.writeStaticString("REPORT")
         case .DELETE:
-            self.write(staticString: "DELETE")
+            self.writeStaticString("DELETE")
         case .UNLINK:
-            self.write(staticString: "UNLINK")
+            self.writeStaticString("UNLINK")
         case .CONNECT:
-            self.write(staticString: "CONNECT")
+            self.writeStaticString("CONNECT")
         case .MSEARCH:
-            self.write(staticString: "MSEARCH")
+            self.writeStaticString("MSEARCH")
         case .OPTIONS:
-            self.write(staticString: "OPTIONS")
+            self.writeStaticString("OPTIONS")
         case .PROPFIND:
-            self.write(staticString: "PROPFIND")
+            self.writeStaticString("PROPFIND")
         case .CHECKOUT:
-            self.write(staticString: "CHECKOUT")
+            self.writeStaticString("CHECKOUT")
         case .PROPPATCH:
-            self.write(staticString: "PROPPATCH")
+            self.writeStaticString("PROPPATCH")
         case .SUBSCRIBE:
-            self.write(staticString: "SUBSCRIBE")
+            self.writeStaticString("SUBSCRIBE")
         case .MKCALENDAR:
-            self.write(staticString: "MKCALENDAR")
+            self.writeStaticString("MKCALENDAR")
         case .MKACTIVITY:
-            self.write(staticString: "MKACTIVITY")
+            self.writeStaticString("MKACTIVITY")
         case .UNSUBSCRIBE:
-            self.write(staticString: "UNSUBSCRIBE")
+            self.writeStaticString("UNSUBSCRIBE")
         case .RAW(let value):
-            self.write(string: value)
+            self.writeString(value)
         }
     }
 }

--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -280,7 +280,7 @@ private struct PartialHTTPResponse {
     mutating func bufferBodyPart(_ bodyPart: IOData) {
         switch bodyPart {
         case .byteBuffer(var buffer):
-            body.write(buffer: &buffer)
+            body.writeBuffer(&buffer)
         case .fileRegion:
             fatalError("Cannot currently compress file regions")
         }

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -576,14 +576,14 @@ public struct HTTPHeaders: CustomStringConvertible {
             self._storage = self._storage.copy()
         }
         let nameStart = self.buffer.writerIndex
-        let nameLength = self._storage.buffer.write(string: name)
-        self._storage.buffer.write(staticString: headerSeparator)
+        let nameLength = self._storage.buffer.writeString(name)
+        self._storage.buffer.writeStaticString(headerSeparator)
         let valueStart = self.buffer.writerIndex
-        let valueLength = self._storage.buffer.write(string: value)
+        let valueLength = self._storage.buffer.writeString(value)
         
         let nameIdx = HTTPHeaderIndex(start: nameStart, length: nameLength)
         self._storage.headers.append(HTTPHeader(name: nameIdx, value: HTTPHeaderIndex(start: valueStart, length: valueLength)))
-        self._storage.buffer.write(staticString: crlf)
+        self._storage.buffer.writeStaticString(crlf)
         
         if self.isConnectionHeader(nameIdx) {
             self._storage.keepAliveState = .unknown
@@ -724,18 +724,18 @@ internal extension ByteBuffer {
         if headers.continuous {
             // Declare an extra variable so we not affect the readerIndex of the buffer itself.
             var buf = headers.buffer
-            self.write(buffer: &buf)
+            self.writeBuffer(&buf)
         } else {
             // slow-path....
             // TODO: This can still be improved to write as many continuous data as possible and just skip over stuff that was removed.
             for header in headers.self.headers {
                 let fieldLength = (header.value.start + header.value.length) - header.name.start
                 var header = headers.buffer.getSlice(at: header.name.start, length: fieldLength)!
-                self.write(buffer: &header)
-                self.write(staticString: crlf)
+                self.writeBuffer(&header)
+                self.writeStaticString(crlf)
             }
         }
-        self.write(staticString: crlf)
+        self.writeStaticString(crlf)
     }
 }
 extension HTTPHeaders: Sequence {

--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -40,7 +40,7 @@ private final class ChatMessageEncoder: ChannelOutboundHandler {
     func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let message = self.unwrapOutboundIn(data)
         var buffer = ctx.channel.allocator.buffer(capacity: message.data.utf8.count)
-        buffer.write(string: message.data)
+        buffer.writeString(message.data)
         ctx.write(self.wrapOutboundOut(AddressedEnvelope(remoteAddress: message.remoteAddress, data: buffer)), promise: promise)
     }
 }

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -95,7 +95,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
             switch req.uri {
             case "/perf-test-1":
                 var buffer = ctx.channel.allocator.buffer(capacity: self.cachedBody.count)
-                buffer.write(bytes: self.cachedBody)
+                buffer.writeBytes(self.cachedBody)
                 ctx.write(self.wrapOutboundOut(.head(self.cachedHead)), promise: nil)
                 ctx.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
                 ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
@@ -211,7 +211,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_short_string_literals") {
     for _ in 0 ..< 5 {
         buffer.clear()
         for _ in 0 ..< (bufferSize / 4) {
-            buffer.write(string: "abcd")
+            buffer.writeString("abcd")
         }
     }
 
@@ -228,7 +228,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_short_calculated_strings") {
     for _ in 0 ..< 5 {
         buffer.clear()
         for _ in  0 ..< (bufferSize / 4) {
-            buffer.write(string: s)
+            buffer.writeString(s)
         }
     }
 
@@ -244,7 +244,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_medium_string_literals") {
     for _ in 0 ..< 10 {
         buffer.clear()
         for _ in  0 ..< (bufferSize / 24) {
-            buffer.write(string: "012345678901234567890123")
+            buffer.writeString("012345678901234567890123")
         }
     }
 
@@ -261,7 +261,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_medium_calculated_strings") {
     for _ in 0 ..< 10 {
         buffer.clear()
         for _ in 0 ..< (bufferSize / 24) {
-            buffer.write(string: s)
+            buffer.writeString(s)
         }
     }
 
@@ -278,7 +278,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_large_calculated_strings") {
     for _ in 0 ..< 10 {
         buffer.clear()
         for _ in 0 ..< 12 {
-            buffer.write(string: s)
+            buffer.writeString(s)
         }
     }
 
@@ -297,13 +297,13 @@ measureAndPrint(desc: "bytebuffer_lots_of_rw") {
     func doWrites(buffer: inout ByteBuffer) {
         /* all of those should be 0 allocations */
 
-        // buffer.write(bytes: foundationData) // see SR-7542
-        buffer.write(bytes: [0x41])
-        buffer.write(bytes: dispatchData)
-        buffer.write(bytes: "A".utf8)
-        buffer.write(string: "A")
-        buffer.write(staticString: "A")
-        buffer.write(integer: 0x41, as: UInt8.self)
+        // buffer.writeBytes(foundationData) // see SR-7542
+        buffer.writeBytes([0x41])
+        buffer.writeBytes(dispatchData)
+        buffer.writeBytes("A".utf8)
+        buffer.writeString("A")
+        buffer.writeStaticString("A")
+        buffer.writeInteger(0x41, as: UInt8.self)
     }
     @inline(never)
     func doReads(buffer: inout ByteBuffer) {
@@ -331,132 +331,132 @@ measureAndPrint(desc: "bytebuffer_lots_of_rw") {
 }
 
 func writeExampleHTTPResponseAsString(buffer: inout ByteBuffer) {
-    buffer.write(string: "HTTP/1.1 200 OK")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Connection")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "close")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Proxy-Connection")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "close")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Via")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "HTTP/1.1 localhost (IBM-PROXY-WTE)")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Date")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "Tue, 08 May 2018 13:42:56 GMT")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Server")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "Apache/2.2.15 (Red Hat)")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Strict-Transport-Security")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "max-age=15768000; includeSubDomains")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Last-Modified")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "Tue, 08 May 2018 13:39:13 GMT")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "ETag")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "357031-1809-56bb1e96a6240")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Accept-Ranges")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "bytes")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Content-Length")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "6153")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "Content-Type")
-    buffer.write(string: ":")
-    buffer.write(string: " ")
-    buffer.write(string: "text/html; charset=UTF-8")
-    buffer.write(string: "\r\n")
-    buffer.write(string: "\r\n")
+    buffer.writeString("HTTP/1.1 200 OK")
+    buffer.writeString("\r\n")
+    buffer.writeString("Connection")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("close")
+    buffer.writeString("\r\n")
+    buffer.writeString("Proxy-Connection")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("close")
+    buffer.writeString("\r\n")
+    buffer.writeString("Via")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("HTTP/1.1 localhost (IBM-PROXY-WTE)")
+    buffer.writeString("\r\n")
+    buffer.writeString("Date")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("Tue, 08 May 2018 13:42:56 GMT")
+    buffer.writeString("\r\n")
+    buffer.writeString("Server")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("Apache/2.2.15 (Red Hat)")
+    buffer.writeString("\r\n")
+    buffer.writeString("Strict-Transport-Security")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("max-age=15768000; includeSubDomains")
+    buffer.writeString("\r\n")
+    buffer.writeString("Last-Modified")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("Tue, 08 May 2018 13:39:13 GMT")
+    buffer.writeString("\r\n")
+    buffer.writeString("ETag")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("357031-1809-56bb1e96a6240")
+    buffer.writeString("\r\n")
+    buffer.writeString("Accept-Ranges")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("bytes")
+    buffer.writeString("\r\n")
+    buffer.writeString("Content-Length")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("6153")
+    buffer.writeString("\r\n")
+    buffer.writeString("Content-Type")
+    buffer.writeString(":")
+    buffer.writeString(" ")
+    buffer.writeString("text/html; charset=UTF-8")
+    buffer.writeString("\r\n")
+    buffer.writeString("\r\n")
 }
 
 func writeExampleHTTPResponseAsStaticString(buffer: inout ByteBuffer) {
-    buffer.write(staticString: "HTTP/1.1 200 OK")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Connection")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "close")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Proxy-Connection")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "close")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Via")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "HTTP/1.1 localhost (IBM-PROXY-WTE)")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Date")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "Tue, 08 May 2018 13:42:56 GMT")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Server")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "Apache/2.2.15 (Red Hat)")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Strict-Transport-Security")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "max-age=15768000; includeSubDomains")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Last-Modified")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "Tue, 08 May 2018 13:39:13 GMT")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "ETag")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "357031-1809-56bb1e96a6240")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Accept-Ranges")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "bytes")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Content-Length")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "6153")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "Content-Type")
-    buffer.write(staticString: ":")
-    buffer.write(staticString: " ")
-    buffer.write(staticString: "text/html; charset=UTF-8")
-    buffer.write(staticString: "\r\n")
-    buffer.write(staticString: "\r\n")
+    buffer.writeStaticString("HTTP/1.1 200 OK")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Connection")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("close")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Proxy-Connection")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("close")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Via")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("HTTP/1.1 localhost (IBM-PROXY-WTE)")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Date")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("Tue, 08 May 2018 13:42:56 GMT")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Server")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("Apache/2.2.15 (Red Hat)")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Strict-Transport-Security")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("max-age=15768000; includeSubDomains")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Last-Modified")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("Tue, 08 May 2018 13:39:13 GMT")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("ETag")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("357031-1809-56bb1e96a6240")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Accept-Ranges")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("bytes")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Content-Length")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("6153")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("Content-Type")
+    buffer.writeStaticString(":")
+    buffer.writeStaticString(" ")
+    buffer.writeStaticString("text/html; charset=UTF-8")
+    buffer.writeStaticString("\r\n")
+    buffer.writeStaticString("\r\n")
 }
 
 measureAndPrint(desc: "bytebuffer_write_http_response_ascii_only_as_string") {
     var buffer = ByteBufferAllocator().buffer(capacity: 16 * 1024)
     for _ in 0..<20_000 {
         writeExampleHTTPResponseAsString(buffer: &buffer)
-        buffer.write(string: htmlASCIIOnly)
+        buffer.writeString(htmlASCIIOnly)
         buffer.clear()
     }
     return buffer.readableBytes
@@ -466,7 +466,7 @@ measureAndPrint(desc: "bytebuffer_write_http_response_ascii_only_as_staticstring
     var buffer = ByteBufferAllocator().buffer(capacity: 16 * 1024)
     for _ in 0..<20_000 {
         writeExampleHTTPResponseAsStaticString(buffer: &buffer)
-        buffer.write(staticString: htmlASCIIOnlyStaticString)
+        buffer.writeStaticString(htmlASCIIOnlyStaticString)
         buffer.clear()
     }
     return buffer.readableBytes
@@ -476,7 +476,7 @@ measureAndPrint(desc: "bytebuffer_write_http_response_some_nonascii_as_string") 
     var buffer = ByteBufferAllocator().buffer(capacity: 16 * 1024)
     for _ in 0..<20_000 {
         writeExampleHTTPResponseAsString(buffer: &buffer)
-        buffer.write(string: htmlMostlyASCII)
+        buffer.writeString(htmlMostlyASCII)
         buffer.clear()
     }
     return buffer.readableBytes
@@ -486,7 +486,7 @@ measureAndPrint(desc: "bytebuffer_write_http_response_some_nonascii_as_staticstr
     var buffer = ByteBufferAllocator().buffer(capacity: 16 * 1024)
     for _ in 0..<20_000 {
         writeExampleHTTPResponseAsStaticString(buffer: &buffer)
-        buffer.write(staticString: htmlMostlyASCIIStaticString)
+        buffer.writeStaticString(htmlMostlyASCIIStaticString)
         buffer.clear()
     }
     return buffer.readableBytes
@@ -513,7 +513,7 @@ try measureAndPrint(desc: "no-net_http1_10k_reqs_1_conn") {
 
         func handlerAdded(ctx: ChannelHandlerContext) {
             self.requestBuffer = ctx.channel.allocator.buffer(capacity: 512)
-            self.requestBuffer.write(string: """
+            self.requestBuffer.writeString("""
                                              GET /perf-test-2 HTTP/1.1\r
                                              Host: example.com\r
                                              X-Some-Header-1: foo\r

--- a/Sources/NIOWebSocket/WebSocketErrorCodes.swift
+++ b/Sources/NIOWebSocket/WebSocketErrorCodes.swift
@@ -152,7 +152,7 @@ public extension ByteBuffer {
     /// - parameters:
     ///     - code: The code to write into the buffer.
     mutating func write(webSocketErrorCode code: WebSocketErrorCode) {
-        self.write(integer: UInt16(webSocketErrorCode: code))
+        self.writeInteger(UInt16(webSocketErrorCode: code))
     }
 }
 

--- a/Sources/NIOWebSocket/WebSocketFrameEncoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameEncoder.swift
@@ -64,24 +64,24 @@ public final class WebSocketFrameEncoder: ChannelOutboundHandler {
         switch data.length {
         case 0...maxOneByteSize:
             buffer = ctx.channel.allocator.buffer(capacity: baseLength)
-            buffer.write(integer: data.firstByte)
-            buffer.write(integer: UInt8(data.length) | maskBitMask)
+            buffer.writeInteger(data.firstByte)
+            buffer.writeInteger(UInt8(data.length) | maskBitMask)
         case (maxOneByteSize + 1)...maxTwoByteSize:
             buffer = ctx.channel.allocator.buffer(capacity: baseLength + 2)
-            buffer.write(integer: data.firstByte)
-            buffer.write(integer: UInt8(126) | maskBitMask)
-            buffer.write(integer: UInt16(data.length))
+            buffer.writeInteger(data.firstByte)
+            buffer.writeInteger(UInt8(126) | maskBitMask)
+            buffer.writeInteger(UInt16(data.length))
         case (maxTwoByteSize + 1)...maxNIOFrameSize:
             buffer = ctx.channel.allocator.buffer(capacity: baseLength + 8)
-            buffer.write(integer: data.firstByte)
-            buffer.write(integer: UInt8(127) | maskBitMask)
-            buffer.write(integer: UInt64(data.length))
+            buffer.writeInteger(data.firstByte)
+            buffer.writeInteger(UInt8(127) | maskBitMask)
+            buffer.writeInteger(UInt64(data.length))
         default:
             fatalError("NIO cannot serialize frames longer than \(maxNIOFrameSize)")
         }
 
         if let maskKey = data.maskKey {
-            buffer.write(bytes: maskKey)
+            buffer.writeBytes(maskKey)
         }
 
         // Ok, frame header away!

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -48,7 +48,7 @@ private final class HTTPHandler: ChannelInboundHandler, RemovableChannelHandler 
 
     func channelRegistered(ctx: ChannelHandlerContext) {
         var buffer = ctx.channel.allocator.buffer(capacity: websocketResponse.utf8.count)
-        buffer.write(string: websocketResponse)
+        buffer.writeString(websocketResponse)
         self.responseBody = buffer
     }
 
@@ -146,7 +146,7 @@ private final class WebSocketTimeHandler: ChannelInboundHandler {
         // example so let's not worry about it.
         let theTime = NIODeadline.now().uptimeNanoseconds
         var buffer = ctx.channel.allocator.buffer(capacity: 12)
-        buffer.write(string: "\(theTime)")
+        buffer.writeString("\(theTime)")
 
         let frame = WebSocketFrame(fin: true, opcode: .text, data: buffer)
         ctx.writeAndFlush(self.wrapOutboundOut(frame)).map {

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -12,7 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
+import Foundation
 import NIO
+import NIOFoundationCompat
 import NIOHTTP1
 import NIOTLS
 
@@ -268,6 +271,83 @@ extension MarkedCircularBuffer {
     @available(*, deprecated, renamed: "init(initialCapacity:)")
     public init(initialRingCapacity: Int) {
         self = .init(initialCapacity: initialRingCapacity)
+    }
+}
+
+extension ByteBuffer {
+    @available(*, deprecated, renamed: "writeStaticString(_:)")
+    public mutating func write(staticString: StaticString) -> Int {
+        return self.writeStaticString(staticString)
+    }
+
+    @available(*, deprecated, renamed: "setStaticString(_:at:)")
+    public mutating func set(staticString: StaticString, at index: Int) -> Int {
+        return self.setStaticString(staticString, at: index)
+    }
+
+    @available(*, deprecated, renamed: "writeString(_:)")
+    public mutating func write(string: String) -> Int {
+        return self.writeString(string)
+    }
+
+    @available(*, deprecated, renamed: "setString(at:)")
+    public mutating func set(string: String, at index: Int) -> Int {
+        return self.setString(string, at: index)
+    }
+
+    @available(*, deprecated, renamed: "writeDispatchData(_:)")
+    public mutating func write(dispatchData: DispatchData) -> Int {
+        return self.writeDispatchData(dispatchData)
+    }
+
+    @available(*, deprecated, renamed: "setDispatchData(_:)")
+    public mutating func set(dispatchData: DispatchData, at index: Int) -> Int {
+        return self.setDispatchData(dispatchData, at: index)
+    }
+
+    @available(*, deprecated, renamed: "writeBuffer(_:)")
+    public mutating func write(buffer: inout ByteBuffer) -> Int {
+        return self.writeBuffer(&buffer)
+    }
+
+    @available(*, deprecated, renamed: "writeBytes(_:)")
+    public mutating func write<Bytes: Sequence>(bytes: Bytes) -> Int where Bytes.Element == UInt8 {
+        return self.writeBytes(bytes)
+    }
+
+    @available(*, deprecated, renamed: "writeBytes(_:)")
+    public mutating func write(bytes: UnsafeRawBufferPointer) -> Int {
+        return self.writeBytes(bytes)
+    }
+
+    @available(*, deprecated, renamed: "setBytes(at:)")
+    public mutating func set<Bytes: Sequence>(bytes: Bytes, at index: Int) -> Int where Bytes.Element == UInt8 {
+        return self.setBytes(bytes, at: index)
+    }
+
+    @available(*, deprecated, renamed: "setBytes(at:)")
+    public mutating func set(bytes: UnsafeRawBufferPointer, at index: Int) -> Int {
+        return self.setBytes(bytes, at: index)
+    }
+
+    @available(*, deprecated, renamed: "writeInteger(_:endianness:as:)")
+    public mutating func write<T: FixedWidthInteger>(integer: T, endianness: Endianness = .big, as type: T.Type = T.self) -> Int {
+        return self.writeInteger(integer, endianness: endianness, as: type)
+    }
+
+    @available(*, deprecated, renamed: "setInteger(_:at:endianness:as:)")
+    public mutating func set<T: FixedWidthInteger>(integer: T, at index: Int, endianness: Endianness = .big, as type: T.Type = T.self) -> Int {
+        return self.setInteger(integer, at: index, endianness: endianness, as: type)
+    }
+
+    @available(*, deprecated, renamed: "writeString(_:encoding:)")
+    public mutating func write(string: String, encoding: String.Encoding) throws -> Int {
+        return try self.writeString(string, encoding: encoding)
+    }
+
+    @available(*, deprecated, renamed: "setString(at:encoding:at:)")
+    public mutating func set(string: String, encoding: String.Encoding, at index: Int) throws -> Int {
+        return try self.setString(string, encoding: encoding, at: index)
     }
 }
 

--- a/Tests/NIOHTTP1Tests/ByteBufferUtilsTest.swift
+++ b/Tests/NIOHTTP1Tests/ByteBufferUtilsTest.swift
@@ -24,7 +24,7 @@ class ByteBufferUtilsTest: XCTestCase {
     
     func testComparators() {
         var someByteBuffer: ByteBuffer = ByteBufferAllocator().buffer(capacity: 16)
-        someByteBuffer.write(string: "fiRSt")
+        someByteBuffer.writeString("fiRSt")
         XCTAssert(
             someByteBuffer.readableBytesView.compareCaseInsensitiveASCIIBytes(
                 to: "first".utf8))
@@ -57,7 +57,7 @@ class ByteBufferUtilsTest: XCTestCase {
     private func byteBufferView(string: String) -> ByteBufferView {
         let byteBufferAllocator = ByteBufferAllocator()
         var buffer = byteBufferAllocator.buffer(capacity: string.lengthOfBytes(using: .utf8))
-        buffer.write(string: string)
+        buffer.writeString(string)
         return buffer.readableBytesView
     }
 

--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -19,7 +19,7 @@ import NIOHTTP1
 extension ByteBuffer {
     init(string: String) {
         self = ByteBufferAllocator().buffer(capacity: string.utf8.count)
-        self.write(string: string)
+        self.writeString(string)
     }
 }
 
@@ -203,17 +203,17 @@ class HTTPDecoderLengthTest: XCTestCase {
         // We now want to send a HTTP/1.1 response. This response may contain some length framing fields that RFC 7230 says MUST
         // be ignored.
         var response = channel.allocator.buffer(capacity: 256)
-        response.write(string: "HTTP/1.1 \(responseStatus.code) \(responseStatus.reasonPhrase)\r\nServer: example\r\n")
+        response.writeString("HTTP/1.1 \(responseStatus.code) \(responseStatus.reasonPhrase)\r\nServer: example\r\n")
 
         switch responseFramingField {
         case .contentLength:
-            response.write(staticString: "Content-Length: 16\r\n")
+            response.writeStaticString("Content-Length: 16\r\n")
         case .transferEncoding:
-            response.write(staticString: "Transfer-Encoding: chunked\r\n")
+            response.writeStaticString("Transfer-Encoding: chunked\r\n")
         case .neither:
             break
         }
-        response.write(staticString: "\r\n")
+        response.writeStaticString("\r\n")
 
         XCTAssertNoThrow(try channel.writeInbound(IOData.byteBuffer(response)))
 

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -37,7 +37,7 @@ class HTTPDecoderTest: XCTestCase {
         // trigger https://github.com/nodejs/http-parser/issues/386 or http_parser won't
         // actually parse this at all.
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "GET /a-file\r\n\r\n")
+        buffer.writeStaticString("GET /a-file\r\n\r\n")
 
         do {
             try channel.writeInbound(buffer)
@@ -56,7 +56,7 @@ class HTTPDecoderTest: XCTestCase {
 
         // This is a HTTP/1.1-formatted request that claims to be HTTP/0.9.
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "GET / HTTP/0.9\r\nHost: whatever\r\n\r\n")
+        buffer.writeStaticString("GET / HTTP/0.9\r\nHost: whatever\r\n\r\n")
 
         do {
             try channel.writeInbound(buffer)
@@ -76,7 +76,7 @@ class HTTPDecoderTest: XCTestCase {
         // This is a hypothetical HTTP/2.0 protocol request, assuming it is
         // byte for byte identical (which such a protocol would never be).
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "GET / HTTP/2.0\r\nHost: whatever\r\n\r\n")
+        buffer.writeStaticString("GET / HTTP/2.0\r\nHost: whatever\r\n\r\n")
 
         do {
             try channel.writeInbound(buffer)
@@ -96,7 +96,7 @@ class HTTPDecoderTest: XCTestCase {
         // We tolerate higher versions of HTTP/1 than we know about because RFC 7230
         // says that these should be treated like HTTP/1.1 by our users.
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "GET / HTTP/1.3\r\nHost: whatever\r\n\r\n")
+        buffer.writeStaticString("GET / HTTP/1.3\r\nHost: whatever\r\n\r\n")
 
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.finish())
@@ -112,7 +112,7 @@ class HTTPDecoderTest: XCTestCase {
         // The HTTP parser has no special logic for HTTP/0.9 simple responses, but we'll send
         // one anyway just to prove it explodes.
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "This is file data\n")
+        buffer.writeStaticString("This is file data\n")
 
         do {
             try channel.writeInbound(buffer)
@@ -135,7 +135,7 @@ class HTTPDecoderTest: XCTestCase {
 
         // The HTTP parser rejects HTTP/1.1-formatted responses claiming 0.9 as a version.
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "HTTP/0.9 200 OK\r\nServer: whatever\r\n\r\n")
+        buffer.writeStaticString("HTTP/0.9 200 OK\r\nServer: whatever\r\n\r\n")
 
         do {
             try channel.writeInbound(buffer)
@@ -159,7 +159,7 @@ class HTTPDecoderTest: XCTestCase {
         // This is a hypothetical HTTP/2.0 protocol response, assuming it is
         // byte for byte identical (which such a protocol would never be).
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "HTTP/2.0 200 OK\r\nServer: whatever\r\n\r\n")
+        buffer.writeStaticString("HTTP/2.0 200 OK\r\nServer: whatever\r\n\r\n")
 
         do {
             try channel.writeInbound(buffer)
@@ -183,7 +183,7 @@ class HTTPDecoderTest: XCTestCase {
         // We tolerate higher versions of HTTP/1 than we know about because RFC 7230
         // says that these should be treated like HTTP/1.1 by our users.
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "HTTP/1.3 200 OK\r\nServer: whatever\r\n\r\n")
+        buffer.writeStaticString("HTTP/1.3 200 OK\r\nServer: whatever\r\n\r\n")
 
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.finish())
@@ -214,19 +214,19 @@ class HTTPDecoderTest: XCTestCase {
         // This is a hypothetical HTTP/2.0 protocol response, assuming it is
         // byte for byte identical (which such a protocol would never be).
         var buffer = channel.allocator.buffer(capacity: 16)
-        buffer.write(staticString: "GET /SomeURL HTTP/1.1\r\n")
+        buffer.writeStaticString("GET /SomeURL HTTP/1.1\r\n")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         var written = 0
         repeat {
             var buffer2 = channel.allocator.buffer(capacity: 16)
 
-            written += buffer2.write(staticString: "X-Header: value\r\n")
+            written += buffer2.writeStaticString("X-Header: value\r\n")
             try channel.writeInbound(buffer2)
         } while written < 8192 // Use a value that w
 
         var buffer3 = channel.allocator.buffer(capacity: 2)
-        buffer3.write(staticString: "\r\n")
+        buffer3.writeStaticString("\r\n")
 
         XCTAssertNoThrow(try channel.writeInbound(buffer3))
         XCTAssertNoThrow(try channel.finish())
@@ -251,7 +251,7 @@ class HTTPDecoderTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.add(handler: Receiver()).wait())
 
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\nXXXX")
+        buffer.writeStaticString("OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\nXXXX")
 
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.pipeline.assertDoesNotContain(handlerType: HTTPRequestDecoder.self))
@@ -302,7 +302,7 @@ class HTTPDecoderTest: XCTestCase {
         XCTAssertNoThrow(try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 8888)).wait())
 
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\nXXXX")
+        buffer.writeStaticString("OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\nXXXX")
 
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.pipeline.assertDoesNotContain(handlerType: HTTPRequestDecoder.self))
@@ -364,7 +364,7 @@ class HTTPDecoderTest: XCTestCase {
         XCTAssertNoThrow(try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 8888)).wait())
         
         var buffer = channel.allocator.buffer(capacity: 32)
-        buffer.write(staticString: "HTTP/1.1 101 Switching Protocols\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\nXXXX")
+        buffer.writeStaticString("HTTP/1.1 101 Switching Protocols\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\nXXXX")
         
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.pipeline.assertDoesNotContain(handlerType: HTTPResponseDecoder.self))
@@ -377,7 +377,7 @@ class HTTPDecoderTest: XCTestCase {
         // This is a simple HTTP/1.1 request with a few too many CRLFs before it, to trigger
         // https://github.com/nodejs/http-parser/pull/432.
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "\r\nGET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        buffer.writeStaticString("\r\nGET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
         try channel.writeInbound(buffer)
 
         let message: HTTPServerRequestPart? = self.channel.readInbound()
@@ -406,7 +406,7 @@ class HTTPDecoderTest: XCTestCase {
         // This is a simple HTTP/1.1 request with the SOURCE verb which is newly added to
         // http_parser.
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "SOURCE / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        buffer.writeStaticString("SOURCE / HTTP/1.1\r\nHost: example.com\r\n\r\n")
         try channel.writeInbound(buffer)
 
         let message: HTTPServerRequestPart? = self.channel.readInbound()
@@ -435,9 +435,9 @@ class HTTPDecoderTest: XCTestCase {
         // This is a simple HTTP/1.1 request with an extra \r between first and second message, designed to hit the code
         // changed in https://github.com/nodejs/http-parser/pull/432 .
         var buffer = channel.allocator.buffer(capacity: 64)
-        buffer.write(staticString: "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
-        buffer.write(staticString: "\r") // this is extra
-        buffer.write(staticString: "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        buffer.writeStaticString("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        buffer.writeStaticString("\r") // this is extra
+        buffer.writeStaticString("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
         try channel.writeInbound(buffer)
 
         let message: HTTPServerRequestPart? = self.channel.readInbound()

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -146,7 +146,7 @@ class HTTPHeadersTest : XCTestCase {
     
     func testKeepAliveStateStartsWithClose() {
         var buffer = ByteBufferAllocator().buffer(capacity: 32)
-        buffer.write(string: "Connection: close\r\n")
+        buffer.writeString("Connection: close\r\n")
         var headers = HTTPHeaders(buffer: buffer, headers: [HTTPHeader(name: HTTPHeaderIndex(start: 0, length: 10), value: HTTPHeaderIndex(start: 12, length: 5))], keepAliveState: .close)
         
         XCTAssertEqual("close", headers["connection"].first)
@@ -164,7 +164,7 @@ class HTTPHeadersTest : XCTestCase {
     
     func testKeepAliveStateStartsWithKeepAlive() {
         var buffer = ByteBufferAllocator().buffer(capacity: 32)
-        buffer.write(string: "Connection: keep-alive\r\n")
+        buffer.writeString("Connection: keep-alive\r\n")
         var headers = HTTPHeaders(buffer: buffer, headers: [HTTPHeader(name: HTTPHeaderIndex(start: 0, length: 10), value: HTTPHeaderIndex(start: 12, length: 10))], keepAliveState: .keepAlive)
         
         XCTAssertEqual("keep-alive", headers["connection"].first)
@@ -273,14 +273,14 @@ class HTTPHeadersTest : XCTestCase {
         var locations: [HTTPHeader] = []
         for (name, value) in originalHeaders {
             let nstart = buf.writerIndex
-            buf.write(string: name)
+            buf.writeString(name)
             let nameLoc = HTTPHeaderIndex(start: nstart, length: buf.writerIndex - nstart)
-            buf.write(string: ": ")
+            buf.writeString(": ")
             
             let vstart = buf.writerIndex
-            buf.write(string: value)
+            buf.writeString(value)
             let valueLoc = HTTPHeaderIndex(start: vstart, length: buf.writerIndex - vstart)
-            buf.write(string: "\r\n")
+            buf.writeString("\r\n")
             
             locations.append(HTTPHeader(name: nameLoc, value: valueLoc))
         }

--- a/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
@@ -99,7 +99,7 @@ class HTTPRequestEncoderTests: XCTestCase {
         request.headers.add(name: "content-length", value: "4")
 
         var buf = channel.allocator.buffer(capacity: 4)
-        buf.write(staticString: "test")
+        buf.writeStaticString("test")
 
         XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(request)))
         XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.body(.byteBuffer(buf))))

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
@@ -74,7 +74,7 @@ private extension ByteBuffer {
 
     mutating func merge<S: Sequence>(_ others: S) -> ByteBuffer where S.Element == ByteBuffer {
         for var buffer in others {
-            self.write(buffer: &buffer)
+            self.writeBuffer(&buffer)
         }
         return self
     }
@@ -237,7 +237,7 @@ class HTTPResponseCompressorTest: XCTestCase {
                                         status: .ok)
         let body = [UInt8](repeating: 60, count: bodySize)
         var bodyBuffer = channel.allocator.buffer(capacity: bodySize)
-        bodyBuffer.write(bytes: body)
+        bodyBuffer.writeBytes(body)
 
         var bodyChunks = [ByteBuffer]()
         for index in stride(from: 0, to: bodyBuffer.readableBytes, by: 2) {
@@ -275,7 +275,7 @@ class HTTPResponseCompressorTest: XCTestCase {
         response.headers = additionalHeaders
         let body = [UInt8](repeating: 60, count: bodySize)
         var bodyBuffer = channel.allocator.buffer(capacity: bodySize)
-        bodyBuffer.write(bytes: body)
+        bodyBuffer.writeBytes(body)
 
         var bodyChunks = [ByteBuffer]()
         for index in stride(from: 0, to: bodyBuffer.readableBytes, by: 2) {
@@ -312,7 +312,7 @@ class HTTPResponseCompressorTest: XCTestCase {
                                         status: .ok)
         let body = [UInt8](repeating: 60, count: bodySize)
         var bodyBuffer = channel.allocator.buffer(capacity: bodySize)
-        bodyBuffer.write(bytes: body)
+        bodyBuffer.writeBytes(body)
 
         var bodyChunks = [ByteBuffer]()
         for index in stride(from: 0, to: bodyBuffer.readableBytes, by: 2) {

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -121,7 +121,7 @@ class HTTPServerClientTest : XCTestCase {
                     let r = HTTPServerResponsePart.head(head)
                     ctx.write(self.wrapOutboundOut(r), promise: nil)
                     var b = ctx.channel.allocator.buffer(capacity: replyString.count)
-                    b.write(string: replyString)
+                    b.writeString(replyString)
 
                     let outbound = self.outboundBody(b)
                     ctx.write(self.wrapOutboundOut(outbound.body)).whenComplete { (_: Result<Void, Error>) in
@@ -143,7 +143,7 @@ class HTTPServerClientTest : XCTestCase {
                     var b = ctx.channel.allocator.buffer(capacity: 1024)
                     for i in 1...10 {
                         b.clear()
-                        b.write(string: "\(i)")
+                        b.writeString("\(i)")
 
                         let outbound = self.outboundBody(b)
                         ctx.write(self.wrapOutboundOut(outbound.body)).recover { error in
@@ -169,7 +169,7 @@ class HTTPServerClientTest : XCTestCase {
                     var b = ctx.channel.allocator.buffer(capacity: 1024)
                     for i in 1...10 {
                         b.clear()
-                        b.write(string: "\(i)")
+                        b.writeString("\(i)")
 
                         let outbound = self.outboundBody(b)
                         ctx.write(self.wrapOutboundOut(outbound.body)).recover { error in
@@ -198,7 +198,7 @@ class HTTPServerClientTest : XCTestCase {
                             return srcPtr.count
                         }
                     }
-                    buf.write(bytes: HTTPServerClientTest.massiveResponseBytes)
+                    buf.writeBytes(HTTPServerClientTest.massiveResponseBytes)
                     var head = HTTPResponseHead(version: req.version, status: .ok)
                     head.headers.add(name: "Connection", value: "close")
                     head.headers.add(name: "Content-Length", value: "\(HTTPServerClientTest.massiveResponseLength)")
@@ -529,7 +529,7 @@ class HTTPServerClientTest : XCTestCase {
         }
 
         var buffer = clientChannel.allocator.buffer(capacity: numBytes)
-        buffer.write(staticString: "GET /massive-response HTTP/1.1\r\nHost: nio.net\r\n\r\n")
+        buffer.writeStaticString("GET /massive-response HTTP/1.1\r\nHost: nio.net\r\n\r\n")
 
         try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
         accumulation.syncWaitForCompletion()

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -22,7 +22,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).wait())
 
         var buffer = channel.allocator.buffer(capacity: 1024)
-        buffer.write(staticString: "GET / HTTP/1.1\r\nContent-Length: -4\r\n\r\n")
+        buffer.writeStaticString("GET / HTTP/1.1\r\nContent-Length: -4\r\n\r\n")
         do {
             try channel.writeInbound(buffer)
         } catch HTTPParserError.invalidContentLength {
@@ -118,7 +118,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         }.wait())
 
         var buffer = channel.allocator.buffer(capacity: 1024)
-        buffer.write(staticString: "GET / HTTP/1.1\r\n\r\nGET / HTTP/1.1\r\n\r\nGET / HT")
+        buffer.writeStaticString("GET / HTTP/1.1\r\n\r\nGET / HTTP/1.1\r\n\r\nGET / HT")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.close().wait())
         (channel.eventLoop as! EmbeddedEventLoop).run()

--- a/Tests/NIOHTTP1Tests/HTTPTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest.swift
@@ -132,7 +132,7 @@ class HTTPTest: XCTestCase {
         /* send all bytes in one go */
         let bd1 = try sendAndCheckRequests(expecteds, body: body, trailers: trailers, sendStrategy: { (reqString, chan) in
             var buf = chan.allocator.buffer(capacity: 1024)
-            buf.write(string: reqString)
+            buf.writeString(reqString)
             return chan.eventLoop.makeSucceededFuture(()).flatMapThrowing {
                 try chan.writeInbound(buf)
             }
@@ -144,7 +144,7 @@ class HTTPTest: XCTestCase {
             for c in reqString {
                 var buf = chan.allocator.buffer(capacity: 1024)
 
-                buf.write(string: "\(c)")
+                buf.writeString("\(c)")
                 writeFutures.append(chan.eventLoop.makeSucceededFuture(()).flatMapThrowing {
                     try chan.writeInbound(buf)
                 })

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -65,7 +65,7 @@ extension EmbeddedChannel {
     func readAllOutboundBuffers() -> ByteBuffer {
         var buffer = self.allocator.buffer(capacity: 100)
         while var writtenData = self.readOutbound(as: ByteBuffer.self) {
-            buffer.write(buffer: &writtenData)
+            buffer.writeBuffer(&writtenData)
         }
 
         return buffer
@@ -298,7 +298,7 @@ private class DataRecorder<T>: ChannelInboundHandler {
 private extension ByteBuffer {
     static func forString(_ string: String) -> ByteBuffer {
         var buf = ByteBufferAllocator().buffer(capacity: string.utf8.count)
-        buf.write(string: string)
+        buf.writeString(string)
         return buf
     }
 }

--- a/Tests/NIOTLSTests/SNIHandlerTests.swift
+++ b/Tests/NIOTLSTests/SNIHandlerTests.swift
@@ -250,7 +250,7 @@ class SNIHandlerTest: XCTestCase {
         let data = Data(base64Encoded: string, options: .ignoreUnknownCharacters)!
         let allocator = ByteBufferAllocator()
         var buffer = allocator.buffer(capacity: data.count)
-        buffer.write(bytes: data)
+        buffer.writeBytes(data)
         return buffer
     }
 

--- a/Tests/NIOTests/BaseObjectsTest.swift
+++ b/Tests/NIOTests/BaseObjectsTest.swift
@@ -108,7 +108,7 @@ class BaseObjectTest: XCTestCase {
         let handle = FileHandle(descriptor: -1)
         var bb1 = ByteBufferAllocator().buffer(capacity: 1024)
         let bb2 = ByteBufferAllocator().buffer(capacity: 1024)
-        bb1.write(string: "hello")
+        bb1.writeString("hello")
         let fr = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
         defer {
             // fake descriptor, so shouldn't be closed.

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -24,14 +24,14 @@ class ByteBufferTest: XCTestCase {
     private func setGetInt<T: FixedWidthInteger>(index: Int, v: T) throws {
         var buffer = allocator.buffer(capacity: 32)
 
-        XCTAssertEqual(MemoryLayout<T>.size, buffer.set(integer: v, at: index))
+        XCTAssertEqual(MemoryLayout<T>.size, buffer.setInteger(v, at: index))
         XCTAssertEqual(v, buffer.getInteger(at: index))
     }
 
     private func writeReadInt<T: FixedWidthInteger>(v: T) throws {
         var buffer = allocator.buffer(capacity: 32)
         XCTAssertEqual(0, buffer.writerIndex)
-        XCTAssertEqual(MemoryLayout<T>.size, buffer.write(integer: v))
+        XCTAssertEqual(MemoryLayout<T>.size, buffer.writeInteger(v))
         XCTAssertEqual(MemoryLayout<T>.size, buffer.writerIndex)
 
         XCTAssertEqual(v, buffer.readInteger())
@@ -59,13 +59,13 @@ class ByteBufferTest: XCTestCase {
 
     func testEqualsComparesReadBuffersOnly() throws {
         // Only cares about the read buffer
-        buf.write(integer: Int8.max)
-        buf.write(string: "oh hi")
+        buf.writeInteger(Int8.max)
+        buf.writeString("oh hi")
         let actual: Int8 = buf.readInteger()! // Just getting rid of it from the read buffer
         XCTAssertEqual(Int8.max, actual)
 
         var otherBuffer = allocator.buffer(capacity: 32)
-        otherBuffer.write(string: "oh hi")
+        otherBuffer.writeString("oh hi")
         XCTAssertEqual(otherBuffer, buf)
     }
 
@@ -74,22 +74,22 @@ class ByteBufferTest: XCTestCase {
             XCTAssertEqual(ptr.count, 0)
         }
 
-        buf.write(string: "Hello world!")
+        buf.writeString("Hello world!")
         buf.withUnsafeReadableBytes { ptr in
             XCTAssertEqual(12, ptr.count)
         }
     }
 
     func testSimpleWrites() {
-        var written = buf.write(string: "")
+        var written = buf.writeString("")
         XCTAssertEqual(0, written)
         XCTAssertEqual(0, buf.readableBytes)
 
-        written = buf.write(string: "X")
+        written = buf.writeString("X")
         XCTAssertEqual(1, written)
         XCTAssertEqual(1, buf.readableBytes)
 
-        written = buf.write(string: "XXXXX")
+        written = buf.writeString("XXXXX")
         XCTAssertEqual(5, written)
         XCTAssertEqual(6, buf.readableBytes)
     }
@@ -97,7 +97,7 @@ class ByteBufferTest: XCTestCase {
     func makeSliceToBufferWhichIsDeallocated() -> ByteBuffer {
         var buf = self.allocator.buffer(capacity: 16)
         let oldCapacity = buf.capacity
-        buf.write(bytes: 0..<16)
+        buf.writeBytes(0..<16)
         XCTAssertEqual(oldCapacity, buf.capacity)
         return buf.getSlice(at: 15, length: 1)!
     }
@@ -108,7 +108,7 @@ class ByteBufferTest: XCTestCase {
         let oldStorageBegin = slice.withUnsafeReadableBytes { ptr in
             return UInt(bitPattern: ptr.baseAddress!)
         }
-        slice.set(integer: 1, at: 0, as: UInt8.self)
+        slice.setInteger(1, at: 0, as: UInt8.self)
         let newStorageBegin = slice.withUnsafeReadableBytes { ptr in
             return UInt(bitPattern: ptr.baseAddress!)
         }
@@ -120,17 +120,17 @@ class ByteBufferTest: XCTestCase {
         XCTAssertEqual(1, slice.capacity)
         // this will cause a re-allocation, the whole buffer should be 32 bytes then, the slice having 17 of that.
         // this fills 16 bytes so will still fit
-        slice.write(bytes: Array(16..<32))
+        slice.writeBytes(Array(16..<32))
         XCTAssertEqual(Array(15..<32), slice.readBytes(length: slice.readableBytes)!)
 
         // and this will need another re-allocation
-        slice.write(bytes: Array(32..<47))
+        slice.writeBytes(Array(32..<47))
     }
 
 
     func testReadWrite() {
-        buf.write(string: "X")
-        buf.write(string: "Y")
+        buf.writeString("X")
+        buf.writeString("Y")
         let d = buf.readData(length: 1)
         XCTAssertNotNil(d)
         if let d = d {
@@ -148,7 +148,7 @@ class ByteBufferTest: XCTestCase {
             XCTAssertEqual(0, buf.readableBytes)
             XCTAssertEqual(allBytes, buf.readerIndex)
 
-            let bytes = buf.write(staticString: testString)
+            let bytes = buf.writeStaticString(testString)
             XCTAssertEqual(testString.utf8CodeUnitCount, Int(bytes))
             allBytes += bytes
             XCTAssertEqual(allBytes - bytes, buf.readerIndex)
@@ -169,13 +169,13 @@ class ByteBufferTest: XCTestCase {
     }
 
     func testString() {
-        let written = buf.write(string: "Hello")
+        let written = buf.writeString("Hello")
         let string = buf.getString(at: 0, length: written)
         XCTAssertEqual("Hello", string)
     }
 
     func testSliceEasy() {
-        buf.write(string: "0123456789abcdefg")
+        buf.writeString("0123456789abcdefg")
         for i in 0..<16 {
             let slice = buf.getSlice(at: i, length: 1)
             XCTAssertEqual(1, slice?.capacity)
@@ -185,7 +185,7 @@ class ByteBufferTest: XCTestCase {
 
     func testWriteStringMovesWriterIndex() throws {
         var buf = allocator.buffer(capacity: 1024)
-        buf.write(string: "hello")
+        buf.writeString("hello")
         XCTAssertEqual(5, buf.writerIndex)
         buf.withUnsafeReadableBytes { (ptr: UnsafeRawBufferPointer) -> Void in
             let s = String(decoding: ptr, as: Unicode.UTF8.self)
@@ -195,15 +195,15 @@ class ByteBufferTest: XCTestCase {
 
     func testSetExpandsBufferOnUpperBoundsCheckFailure() {
         let initialCapacity = buf.capacity
-        XCTAssertEqual(5, buf.set(string: "oh hi", at: buf.capacity))
+        XCTAssertEqual(5, buf.setString("oh hi", at: buf.capacity))
         XCTAssert(initialCapacity < buf.capacity)
     }
 
     func testCoWWorks() {
-        buf.write(string: "Hello")
+        buf.writeString("Hello")
         var a = buf!
         let b = buf!
-        a.write(string: " World")
+        a.writeString(" World")
         XCTAssertEqual(buf, b)
         XCTAssertNotEqual(buf, a)
     }
@@ -212,7 +212,7 @@ class ByteBufferTest: XCTestCase {
         XCTAssertEqual(0, buf.readerIndex)
         // We use mutable read pointers when we're consuming the data
         // so first we need some data there!
-        buf.write(string: "hello again")
+        buf.writeString("hello again")
 
         let bytesConsumed = buf.readWithUnsafeReadableBytes { dst in
             // Pretend we did some operation which made use of entire 11 byte string
@@ -296,7 +296,7 @@ class ByteBufferTest: XCTestCase {
 
     func testSlice() throws {
         var buffer = allocator.buffer(capacity: 32)
-        XCTAssertEqual(MemoryLayout<UInt64>.size, buffer.write(integer: UInt64.max))
+        XCTAssertEqual(MemoryLayout<UInt64>.size, buffer.writeInteger(UInt64.max))
         var slice = buffer.slice()
         XCTAssertEqual(MemoryLayout<UInt64>.size, slice.readableBytes)
         XCTAssertEqual(UInt64.max, slice.readInteger())
@@ -306,7 +306,7 @@ class ByteBufferTest: XCTestCase {
 
     func testSliceWithParams() throws {
         var buffer = allocator.buffer(capacity: 32)
-        XCTAssertEqual(MemoryLayout<UInt64>.size, buffer.write(integer: UInt64.max))
+        XCTAssertEqual(MemoryLayout<UInt64>.size, buffer.writeInteger(UInt64.max))
         var slice = buffer.getSlice(at: 0, length: MemoryLayout<UInt64>.size)!
         XCTAssertEqual(MemoryLayout<UInt64>.size, slice.readableBytes)
         XCTAssertEqual(UInt64.max, slice.readInteger())
@@ -316,7 +316,7 @@ class ByteBufferTest: XCTestCase {
 
     func testReadSlice() throws {
         var buffer = allocator.buffer(capacity: 32)
-        XCTAssertEqual(MemoryLayout<UInt64>.size, buffer.write(integer: UInt64.max))
+        XCTAssertEqual(MemoryLayout<UInt64>.size, buffer.writeInteger(UInt64.max))
         var slice = buffer.readSlice(length: buffer.readableBytes)!
         XCTAssertEqual(MemoryLayout<UInt64>.size, slice.readableBytes)
         XCTAssertEqual(UInt64.max, slice.readInteger())
@@ -327,7 +327,7 @@ class ByteBufferTest: XCTestCase {
 
     func testSliceNoCopy() throws {
         var buffer = allocator.buffer(capacity: 32)
-        XCTAssertEqual(MemoryLayout<UInt64>.size, buffer.write(integer: UInt64.max))
+        XCTAssertEqual(MemoryLayout<UInt64>.size, buffer.writeInteger(UInt64.max))
         let slice = buffer.readSlice(length: buffer.readableBytes)!
 
         buffer.withVeryUnsafeBytes { ptr1 in
@@ -341,7 +341,7 @@ class ByteBufferTest: XCTestCase {
         var buffer = allocator.buffer(capacity: 32)
         let data = Data([1, 2, 3])
 
-        XCTAssertEqual(3, buffer.set(bytes: data, at: 0))
+        XCTAssertEqual(3, buffer.setBytes(data, at: 0))
         XCTAssertEqual(0, buffer.readableBytes)
         XCTAssertEqual(data, buffer.getData(at: 0, length: 3))
     }
@@ -350,17 +350,17 @@ class ByteBufferTest: XCTestCase {
         var buffer = allocator.buffer(capacity: 32)
         let data = Data([1, 2, 3])
 
-        XCTAssertEqual(3, buffer.write(bytes: data))
+        XCTAssertEqual(3, buffer.writeBytes(data))
         XCTAssertEqual(3, buffer.readableBytes)
         XCTAssertEqual(data, buffer.readData(length: 3))
     }
 
     func testDiscardReadBytes() throws {
         var buffer = allocator.buffer(capacity: 32)
-        buffer.write(integer: 1, as: UInt8.self)
-        buffer.write(integer: UInt8(2))
-        buffer.write(integer: 3 as UInt8)
-        buffer.write(integer: 4, as: UInt8.self)
+        buffer.writeInteger(1, as: UInt8.self)
+        buffer.writeInteger(UInt8(2))
+        buffer.writeInteger(3 as UInt8)
+        buffer.writeInteger(4, as: UInt8.self)
         XCTAssertEqual(4, buffer.readableBytes)
         buffer.moveReaderIndex(forwardBy: 2)
         XCTAssertEqual(2, buffer.readableBytes)
@@ -379,7 +379,7 @@ class ByteBufferTest: XCTestCase {
 
     func testDiscardReadBytesCoW() throws {
         var buffer = allocator.buffer(capacity: 32)
-        let bytesWritten = buffer.write(bytes: "0123456789abcdef0123456789ABCDEF".data(using: .utf8)!)
+        let bytesWritten = buffer.writeBytes("0123456789abcdef0123456789ABCDEF".data(using: .utf8)!)
         XCTAssertEqual(32, bytesWritten)
 
         func testAssumptionOriginalBuffer(_ buf: inout ByteBuffer) {
@@ -420,10 +420,10 @@ class ByteBufferTest: XCTestCase {
 
     func testDiscardReadBytesSlice() throws {
         var buffer = allocator.buffer(capacity: 32)
-        buffer.write(integer: UInt8(1))
-        buffer.write(integer: UInt8(2))
-        buffer.write(integer: UInt8(3))
-        buffer.write(integer: UInt8(4))
+        buffer.writeInteger(UInt8(1))
+        buffer.writeInteger(UInt8(2))
+        buffer.writeInteger(UInt8(3))
+        buffer.writeInteger(UInt8(4))
         XCTAssertEqual(4, buffer.readableBytes)
         var slice = buffer.getSlice(at: 1, length: 3)!
         XCTAssertEqual(3, slice.readableBytes)
@@ -450,8 +450,8 @@ class ByteBufferTest: XCTestCase {
         let testString = "\(testStringPrefix)\(testStringSuffix)"
 
         var buffer = allocator.buffer(capacity: testString.utf8.count)
-        buffer.write(string: testStringPrefix)
-        buffer.write(string: testStringSuffix)
+        buffer.writeString(testStringPrefix)
+        buffer.writeString(testStringSuffix)
         XCTAssertEqual(testString.utf8.count, buffer.capacity)
 
         func runTestForRemaining(string: String, buffer: ByteBuffer) {
@@ -487,12 +487,12 @@ class ByteBufferTest: XCTestCase {
 
     func testEndianness() throws {
         let value: UInt32 = 0x12345678
-        buf.write(integer: value)
+        buf.writeInteger(value)
         let actualRead: UInt32 = buf.readInteger()!
         XCTAssertEqual(value, actualRead)
-        buf.write(integer: value, endianness: .big)
-        buf.write(integer: value, endianness: .little)
-        buf.write(integer: value)
+        buf.writeInteger(value, endianness: .big)
+        buf.writeInteger(value, endianness: .little)
+        buf.writeInteger(value)
         let actual = buf.getData(at: 4, length: 12)!
         let expected = Data([0x12, 0x34, 0x56, 0x78, 0x78, 0x56, 0x34, 0x12, 0x12, 0x34, 0x56, 0x78])
         XCTAssertEqual(expected, actual)
@@ -507,11 +507,11 @@ class ByteBufferTest: XCTestCase {
     func testExpansion() throws {
         var buf = allocator.buffer(capacity: 16)
         XCTAssertEqual(16, buf.capacity)
-        buf.write(bytes: "0123456789abcdef".data(using: .utf8)!)
+        buf.writeBytes("0123456789abcdef".data(using: .utf8)!)
         XCTAssertEqual(16, buf.capacity)
         XCTAssertEqual(16, buf.writerIndex)
         XCTAssertEqual(0, buf.readerIndex)
-        buf.write(bytes: "X".data(using: .utf8)!)
+        buf.writeBytes("X".data(using: .utf8)!)
         XCTAssertGreaterThan(buf.capacity, 16)
         XCTAssertEqual(17, buf.writerIndex)
         XCTAssertEqual(0, buf.readerIndex)
@@ -525,7 +525,7 @@ class ByteBufferTest: XCTestCase {
     func testExpansion2() throws {
         var buf = allocator.buffer(capacity: 2)
         XCTAssertEqual(2, buf.capacity)
-        buf.write(bytes: "0123456789abcdef".data(using: .utf8)!)
+        buf.writeBytes("0123456789abcdef".data(using: .utf8)!)
         XCTAssertEqual(16, buf.capacity)
         XCTAssertEqual(16, buf.writerIndex)
         buf.withUnsafeReadableBytes { ptr in
@@ -538,7 +538,7 @@ class ByteBufferTest: XCTestCase {
     func testNotEnoughBytesToReadForIntegers() throws {
         let byteCount = 15
         func initBuffer() {
-            let written = buf.write(bytes: Data(Array(repeating: 0, count: byteCount)))
+            let written = buf.writeBytes(Data(Array(repeating: 0, count: byteCount)))
             XCTAssertEqual(byteCount, written)
         }
 
@@ -568,7 +568,7 @@ class ByteBufferTest: XCTestCase {
     func testNotEnoughBytesToReadForData() throws {
         let cap = buf.capacity
         let expected = Data(Array(repeating: 0, count: cap))
-        let written = buf.write(bytes: expected)
+        let written = buf.writeBytes(expected)
         XCTAssertEqual(cap, written)
         XCTAssertEqual(cap, buf.capacity)
 
@@ -660,8 +660,8 @@ class ByteBufferTest: XCTestCase {
 
         var otherBuf = buf
 
-        otherBuf.set(bytes: Data(), at: 0)
-        buf.set(bytes: Data(), at: 0)
+        otherBuf.setBytes(Data(), at: 0)
+        buf.setBytes(Data(), at: 0)
 
         XCTAssertEqual(0, buf.capacity)
         XCTAssertEqual(0, otherBuf.capacity)
@@ -680,10 +680,10 @@ class ByteBufferTest: XCTestCase {
 
     func testReadDataNotEnoughAvailable() throws {
         /* write some bytes */
-        buf.write(bytes: Data([0, 1, 2, 3]))
+        buf.writeBytes(Data([0, 1, 2, 3]))
 
         /* make more available in the buffer that should not be readable */
-        buf.set(bytes: Data([4, 5, 6, 7]), at: 4)
+        buf.setBytes(Data([4, 5, 6, 7]), at: 4)
 
         let actualNil = buf.readData(length: 5)
         XCTAssertNil(actualNil)
@@ -697,10 +697,10 @@ class ByteBufferTest: XCTestCase {
 
     func testReadSliceNotEnoughAvailable() throws {
         /* write some bytes */
-        buf.write(bytes: Data([0, 1, 2, 3]))
+        buf.writeBytes(Data([0, 1, 2, 3]))
 
         /* make more available in the buffer that should not be readable */
-        buf.set(bytes: Data([4, 5, 6, 7]), at: 4)
+        buf.setBytes(Data([4, 5, 6, 7]), at: 4)
 
         let actualNil = buf.readSlice(length: 5)
         XCTAssertNil(actualNil)
@@ -715,7 +715,7 @@ class ByteBufferTest: XCTestCase {
 
     func testSetBuffer() throws {
         var src = allocator.buffer(capacity: 4)
-        src.write(bytes: Data([0, 1, 2, 3]))
+        src.writeBytes(Data([0, 1, 2, 3]))
 
         buf.set(buffer: src, at: 1)
 
@@ -728,9 +728,9 @@ class ByteBufferTest: XCTestCase {
 
     func testWriteBuffer() throws {
         var src = allocator.buffer(capacity: 4)
-        src.write(bytes: Data([0, 1, 2, 3]))
+        src.writeBytes(Data([0, 1, 2, 3]))
 
-        buf.write(buffer: &src)
+        buf.writeBuffer(&src)
 
         /* Should increase the writerIndex of the src buffer */
         XCTAssertEqual(0, src.readableBytes)
@@ -741,8 +741,8 @@ class ByteBufferTest: XCTestCase {
     func testMisalignedIntegerRead() throws {
         let value = UInt64(7)
 
-        buf.write(bytes: Data([1]))
-        buf.write(integer: value)
+        buf.writeBytes(Data([1]))
+        buf.writeInteger(value)
         let actual = buf.readData(length: 1)
         XCTAssertEqual(Data([1]), actual)
 
@@ -760,15 +760,15 @@ class ByteBufferTest: XCTestCase {
         let str = "hello world!"
         let hwData = str.data(using: .utf8)!
         /* write once, ... */
-        buf.write(string: str)
+        buf.writeString(str)
         var written1: Int = -1
         var written2: Int = -1
         hwData.withUnsafeBytes { ptr in
             /* ... write a second time and ...*/
-            written1 = buf.set(bytes: ptr, at: buf.writerIndex)
+            written1 = buf.setBytes(ptr, at: buf.writerIndex)
             buf.moveWriterIndex(forwardBy: written1)
             /* ... a lucky third time! */
-            written2 = buf.write(bytes: ptr)
+            written2 = buf.writeBytes(ptr)
         }
         XCTAssertEqual(written1, written2)
         XCTAssertEqual(str.utf8.count, written1)
@@ -780,28 +780,28 @@ class ByteBufferTest: XCTestCase {
 
     func testWriteABunchOfCollections() throws {
         let overallData = "0123456789abcdef".data(using: .utf8)!
-        buf.write(bytes: "0123".utf8)
+        buf.writeBytes("0123".utf8)
         "4567".withCString { ptr in
             ptr.withMemoryRebound(to: UInt8.self, capacity: 4) { ptr in
-                _ = buf.write(bytes: UnsafeBufferPointer<UInt8>(start: ptr, count: 4))
+                _ = buf.writeBytes(UnsafeBufferPointer<UInt8>(start: ptr, count: 4))
             }
         }
-        buf.write(bytes: Array("89ab".utf8))
-        buf.write(bytes: "cdef".data(using: .utf8)!)
+        buf.writeBytes(Array("89ab".utf8))
+        buf.writeBytes("cdef".data(using: .utf8)!)
         let actual = buf.getData(at: 0, length: buf.readableBytes)
         XCTAssertEqual(overallData, actual)
     }
 
     func testSetABunchOfCollections() throws {
         let overallData = "0123456789abcdef".data(using: .utf8)!
-        _ = buf.set(bytes: "0123".utf8, at: 0)
+        _ = buf.setBytes("0123".utf8, at: 0)
         "4567".withCString { ptr in
             ptr.withMemoryRebound(to: UInt8.self, capacity: 4) { ptr in
-                _ = buf.set(bytes: UnsafeBufferPointer<UInt8>(start: ptr, count: 4), at: 4)
+                _ = buf.setBytes(UnsafeBufferPointer<UInt8>(start: ptr, count: 4), at: 4)
             }
         }
-        _ = buf.set(bytes: Array("89ab".utf8), at: 8)
-        _ = buf.set(bytes: "cdef".data(using: .utf8)!, at: 12)
+        _ = buf.setBytes(Array("89ab".utf8), at: 8)
+        _ = buf.setBytes("cdef".data(using: .utf8)!, at: 12)
         let actual = buf.getData(at: 0, length: 16)
         XCTAssertEqual(overallData, actual)
     }
@@ -809,19 +809,19 @@ class ByteBufferTest: XCTestCase {
     func testTryStringTooLong() throws {
         let capacity = buf.capacity
         for i in 0..<buf.capacity {
-            buf.set(string: "x", at: i)
+            buf.setString("x", at: i)
         }
         XCTAssertEqual(capacity, buf.capacity, "buffer capacity needlessly changed from \(capacity) to \(buf.capacity)")
         XCTAssertNil(buf.getString(at: 0, length: capacity+1))
     }
 
     func testSetGetBytesAllFine() throws {
-        buf.set(bytes: [1, 2, 3, 4], at: 0)
+        buf.setBytes([1, 2, 3, 4], at: 0)
         XCTAssertEqual([1, 2, 3, 4], buf.getBytes(at: 0, length: 4) ?? [])
 
         let capacity = buf.capacity
         for i in 0..<buf.capacity {
-            buf.set(bytes: [0xFF], at: i)
+            buf.setBytes([0xFF], at: i)
         }
         XCTAssertEqual(capacity, buf.capacity, "buffer capacity needlessly changed from \(capacity) to \(buf.capacity)")
         XCTAssertEqual(Array(repeating: 0xFF, count: capacity), buf.getBytes(at: 0, length: capacity)!)
@@ -839,7 +839,7 @@ class ByteBufferTest: XCTestCase {
         let capacity = buf.capacity
         for i in 0..<capacity {
             let expected = Array(repeating: UInt8(i % 255), count: i)
-            buf.write(bytes: expected)
+            buf.writeBytes(expected)
             let actual = buf.readBytes(length: i)!
             XCTAssertEqual(expected, actual)
             XCTAssertEqual(capacity, buf.capacity, "buffer capacity needlessly changed from \(capacity) to \(buf.capacity)")
@@ -886,7 +886,7 @@ class ByteBufferTest: XCTestCase {
     func testReadWithUnsafeReadableBytesVariantsSomethingToRead() throws {
         var buf = ByteBufferAllocator().buffer(capacity: 1)
         buf.clear()
-        buf.write(bytes: [1, 2, 3, 4, 5, 6, 7, 8])
+        buf.writeBytes([1, 2, 3, 4, 5, 6, 7, 8])
         XCTAssertEqual(0, buf.readerIndex)
         XCTAssertEqual(8, buf.writerIndex)
 
@@ -920,7 +920,7 @@ class ByteBufferTest: XCTestCase {
 
     func testSomePotentialIntegerUnderOrOverflows() throws {
         buf.reserveCapacity(1024)
-        buf.write(staticString: "hello world, just some trap bytes here")
+        buf.writeStaticString("hello world, just some trap bytes here")
 
         func testIndexAndLengthFunc<T>(_ body: (Int, Int) -> T?, file: StaticString = #file, line: UInt = #line) {
             XCTAssertNil(body(Int.max, 1), file: file, line: line)
@@ -949,52 +949,52 @@ class ByteBufferTest: XCTestCase {
 
     func testWriteForContiguousCollections() throws {
         buf.clear()
-        var written = buf.write(bytes: [1, 2, 3, 4])
+        var written = buf.writeBytes([1, 2, 3, 4])
         XCTAssertEqual(4, written)
         // UnsafeRawBufferPointer
         written += [5 as UInt8, 6, 7, 8].withUnsafeBytes { ptr in
-            buf.write(bytes: ptr)
+            buf.writeBytes(ptr)
         }
         XCTAssertEqual(8, written)
         // UnsafeBufferPointer<UInt8>
         written += [9 as UInt8, 10, 11, 12].withUnsafeBufferPointer { ptr in
-            buf.write(bytes: ptr)
+            buf.writeBytes(ptr)
         }
         XCTAssertEqual(12, written)
         // ContiguousArray
-        written += buf.write(bytes: ContiguousArray<UInt8>([13, 14, 15, 16]))
+        written += buf.writeBytes(ContiguousArray<UInt8>([13, 14, 15, 16]))
         XCTAssertEqual(16, written)
 
         // Data
-        written += buf.write(bytes: "EFGH".data(using: .utf8)!)
+        written += buf.writeBytes("EFGH".data(using: .utf8)!)
         XCTAssertEqual(20, written)
         var more = Array("IJKL".utf8)
 
         // UnsafeMutableRawBufferPointer
         written += more.withUnsafeMutableBytes { ptr in
-            buf.write(bytes: ptr)
+            buf.writeBytes(ptr)
         }
         more = Array("MNOP".utf8)
         // UnsafeMutableBufferPointer<UInt8>
         written += more.withUnsafeMutableBufferPointer { ptr in
-            buf.write(bytes: ptr)
+            buf.writeBytes(ptr)
         }
         more = Array("mnopQRSTuvwx".utf8)
 
         // ArraySlice
-        written += buf.write(bytes: more.dropFirst(4).dropLast(4))
+        written += buf.writeBytes(more.dropFirst(4).dropLast(4))
 
         let moreCA = ContiguousArray("qrstUVWXyz01".utf8)
         // ContiguousArray's slice (== ArraySlice)
-        written += buf.write(bytes: moreCA.dropFirst(4).dropLast(4))
+        written += buf.writeBytes(moreCA.dropFirst(4).dropLast(4))
 
         // Slice<UnsafeRawBufferPointer>
         written += Array("uvwxYZ01abcd".utf8).withUnsafeBytes { ptr in
-            buf.write(bytes: ptr.dropFirst(4).dropLast(4) as UnsafeRawBufferPointer.SubSequence)
+            buf.writeBytes(ptr.dropFirst(4).dropLast(4) as UnsafeRawBufferPointer.SubSequence)
         }
         more = Array("2345".utf8)
         written += more.withUnsafeMutableBytes { ptr in
-            buf.write(bytes: ptr.dropFirst(0)) + buf.write(bytes: ptr.dropFirst(4 /* drop all of them */))
+            buf.writeBytes(ptr.dropFirst(0)) + buf.writeBytes(ptr.dropFirst(4 /* drop all of them */))
         }
 
         let expected = Array(1...16) + Array("EFGHIJKLMNOPQRSTUVWXYZ012345".utf8)
@@ -1004,7 +1004,7 @@ class ByteBufferTest: XCTestCase {
 
     func testWriteForNonContiguousCollections() throws {
         buf.clear()
-        let written = buf.write(bytes: "ABCD".utf8)
+        let written = buf.writeBytes("ABCD".utf8)
         XCTAssertEqual(4, written)
 
         let expected = ["A".utf8.first!, "B".utf8.first!, "C".utf8.first!, "D".utf8.first!]
@@ -1015,7 +1015,7 @@ class ByteBufferTest: XCTestCase {
     func testReadStringOkay() throws {
         buf.clear()
         let expected = "hello"
-        buf.write(string: expected)
+        buf.writeString(expected)
         let actual = buf.readString(length: expected.utf8.count)
         XCTAssertEqual(expected, actual)
         XCTAssertEqual("", buf.readString(length: 0))
@@ -1026,7 +1026,7 @@ class ByteBufferTest: XCTestCase {
         buf.clear()
         XCTAssertNil(buf.readString(length: 1))
 
-        buf.write(string: "a")
+        buf.writeString("a")
         XCTAssertNil(buf.readString(length: 2))
 
         XCTAssertEqual("a", buf.readString(length: 1))
@@ -1036,7 +1036,7 @@ class ByteBufferTest: XCTestCase {
         var buf = ByteBufferAllocator().buffer(capacity: 32)
         XCTAssertLessThan(buf.capacity, 200)
 
-        buf.set(integer: 17, at: 201)
+        buf.setInteger(17, at: 201)
         let i: Int = buf.getInteger(at: 201)!
         XCTAssertEqual(17, i)
         XCTAssertGreaterThanOrEqual(buf.capacity, 200 + MemoryLayout.size(ofValue: i))
@@ -1054,7 +1054,7 @@ class ByteBufferTest: XCTestCase {
         var buf = ByteBufferAllocator().buffer(capacity: 32)
         XCTAssertLessThan(buf.capacity, 200)
 
-        buf.set(string: "HW", at: 201)
+        buf.setString("HW", at: 201)
         let s = buf.getString(at: 201, length: 2)!
         XCTAssertEqual("HW", s)
         XCTAssertGreaterThanOrEqual(buf.capacity, 202)
@@ -1085,9 +1085,9 @@ class ByteBufferTest: XCTestCase {
         XCTAssertEqual(AllocationExpectationState.mallocDone, testAllocationOfReallyBigByteBuffer_state)
         XCTAssertGreaterThanOrEqual(buf.capacity, reallyBigSize)
 
-        buf.set(bytes: [1], at: 0)
+        buf.setBytes([1], at: 0)
         /* now make it expand (will trigger realloc) */
-        buf.set(bytes: [1], at: buf.capacity)
+        buf.setBytes([1], at: buf.capacity)
 
         XCTAssertEqual(AllocationExpectationState.reallocDone, testAllocationOfReallyBigByteBuffer_state)
         XCTAssertEqual(buf.capacity, Int(UInt32.max))
@@ -1186,12 +1186,12 @@ class ByteBufferTest: XCTestCase {
             }
         }
         buf.clear()
-        buf.write(bytes: WrongCollection())
+        buf.writeBytes(WrongCollection())
         XCTAssertEqual(3, buf.readableBytes)
         XCTAssertEqual(1, buf.readInteger()! as UInt8)
         XCTAssertEqual(2, buf.readInteger()! as UInt8)
         XCTAssertEqual(3, buf.readInteger()! as UInt8)
-        buf.set(bytes: WrongCollection(), at: 0)
+        buf.setBytes(WrongCollection(), at: 0)
         XCTAssertEqual(0, buf.readableBytes)
         XCTAssertEqual(1, buf.getInteger(at: 0)! as UInt8)
         XCTAssertEqual(2, buf.getInteger(at: 1)! as UInt8)
@@ -1221,14 +1221,14 @@ class ByteBufferTest: XCTestCase {
         }
         buf = self.allocator.buffer(capacity: 4)
         buf.clear()
-        buf.write(bytes: UnderestimatingSequence())
+        buf.writeBytes(UnderestimatingSequence())
         XCTAssertEqual(256, buf.readableBytes)
         for i in 0..<256 {
             let actual = Int(buf.readInteger()! as UInt8)
             XCTAssertEqual(i, actual)
         }
         buf = self.allocator.buffer(capacity: 4)
-        buf.set(bytes: UnderestimatingSequence(), at: 0)
+        buf.setBytes(UnderestimatingSequence(), at: 0)
         XCTAssertEqual(0, buf.readableBytes)
         for i in 0..<256 {
             let actual = Int(buf.getInteger(at: i)! as UInt8)
@@ -1238,15 +1238,15 @@ class ByteBufferTest: XCTestCase {
 
     func testZeroSizeByteBufferResizes() {
         var buf = ByteBufferAllocator().buffer(capacity: 0)
-        buf.write(staticString: "x")
+        buf.writeStaticString("x")
         XCTAssertEqual(buf.writerIndex, 1)
     }
 
     func testSpecifyTypesAndEndiannessForIntegerMethods() {
         self.buf.clear()
-        self.buf.write(integer: -1, endianness: .big, as: Int64.self)
+        self.buf.writeInteger(-1, endianness: .big, as: Int64.self)
         XCTAssertEqual(-1, self.buf.readInteger(endianness: .big, as: Int64.self))
-        self.buf.set(integer: 0xdeadbeef, at: 0, endianness: .little, as: UInt64.self)
+        self.buf.setInteger(0xdeadbeef, at: 0, endianness: .little, as: UInt64.self)
         XCTAssertEqual(0xdeadbeef, self.buf.getInteger(at: 0, endianness: .little, as: UInt64.self))
     }
 
@@ -1285,22 +1285,22 @@ class ByteBufferTest: XCTestCase {
 
     func testLargeSliceBegin16MBIsOkayAndDoesNotCopy() throws {
         var fourMBBuf = self.allocator.buffer(capacity: 4 * 1024 * 1024)
-        fourMBBuf.write(bytes: repeatElement(0xff, count: fourMBBuf.capacity))
+        fourMBBuf.writeBytes(repeatElement(0xff, count: fourMBBuf.capacity))
         let totalBufferSize = 5 * fourMBBuf.readableBytes
         XCTAssertEqual(4 * 1024 * 1024, fourMBBuf.readableBytes)
         var buf = self.allocator.buffer(capacity: totalBufferSize)
         for _ in 0..<5 {
             var fresh = fourMBBuf
-            buf.write(buffer: &fresh)
+            buf.writeBuffer(&fresh)
         }
 
         let offset = Int(_UInt24.max)
 
         // mark some special bytes
-        buf.set(integer: 0xaa, at: 0, as: UInt8.self)
-        buf.set(integer: 0xbb, at: offset - 1, as: UInt8.self)
-        buf.set(integer: 0xcc, at: offset, as: UInt8.self)
-        buf.set(integer: 0xdd, at: buf.writerIndex - 1, as: UInt8.self)
+        buf.setInteger(0xaa, at: 0, as: UInt8.self)
+        buf.setInteger(0xbb, at: offset - 1, as: UInt8.self)
+        buf.setInteger(0xcc, at: offset, as: UInt8.self)
+        buf.setInteger(0xdd, at: buf.writerIndex - 1, as: UInt8.self)
 
         XCTAssertEqual(totalBufferSize, buf.readableBytes)
 
@@ -1322,22 +1322,22 @@ class ByteBufferTest: XCTestCase {
 
     func testLargeSliceBeginMoreThan16MBIsOkay() throws {
         var fourMBBuf = self.allocator.buffer(capacity: 4 * 1024 * 1024)
-        fourMBBuf.write(bytes: repeatElement(0xff, count: fourMBBuf.capacity))
+        fourMBBuf.writeBytes(repeatElement(0xff, count: fourMBBuf.capacity))
         let totalBufferSize = 5 * fourMBBuf.readableBytes + 1
         XCTAssertEqual(4 * 1024 * 1024, fourMBBuf.readableBytes)
         var buf = self.allocator.buffer(capacity: totalBufferSize)
         for _ in 0..<5 {
             var fresh = fourMBBuf
-            buf.write(buffer: &fresh)
+            buf.writeBuffer(&fresh)
         }
 
         let offset = Int(_UInt24.max) + 1
 
         // mark some special bytes
-        buf.set(integer: 0xaa, at: 0, as: UInt8.self)
-        buf.set(integer: 0xbb, at: offset - 1, as: UInt8.self)
-        buf.set(integer: 0xcc, at: offset, as: UInt8.self)
-        buf.write(integer: 0xdd, as: UInt8.self) // write extra byte so the slice is the same length as above
+        buf.setInteger(0xaa, at: 0, as: UInt8.self)
+        buf.setInteger(0xbb, at: offset - 1, as: UInt8.self)
+        buf.setInteger(0xcc, at: offset, as: UInt8.self)
+        buf.writeInteger(0xdd, as: UInt8.self) // write extra byte so the slice is the same length as above
         XCTAssertEqual(totalBufferSize, buf.readableBytes)
 
         let expectedReadableBytes = totalBufferSize - offset
@@ -1353,7 +1353,7 @@ class ByteBufferTest: XCTestCase {
 
     func testDiscardReadBytesOnConsumedBuffer() {
         var buffer = self.allocator.buffer(capacity: 8)
-        buffer.write(integer: 0xaa, as: UInt8.self)
+        buffer.writeInteger(0xaa, as: UInt8.self)
         XCTAssertEqual(1, buffer.readableBytes)
         XCTAssertEqual(0xaa, buffer.readInteger(as: UInt8.self))
         XCTAssertEqual(0, buffer.readableBytes)
@@ -1371,7 +1371,7 @@ class ByteBufferTest: XCTestCase {
     func testDumpBytesFormat() throws {
         self.buf.clear()
         for f in UInt8.min...UInt8.max {
-            self.buf.write(integer: f)
+            self.buf.writeInteger(f)
         }
         let actual = self.buf._storage.dumpBytes(slice: self.buf._slice, offset: 0, length: self.buf.readableBytes)
         let expected = """
@@ -1390,7 +1390,7 @@ class ByteBufferTest: XCTestCase {
 
     func testReadableBytesView() throws {
         self.buf.clear()
-        self.buf.write(string: "hello world 012345678")
+        self.buf.writeString("hello world 012345678")
         XCTAssertEqual("hello ", self.buf.readString(length: 6))
         self.buf.moveWriterIndex(to: self.buf.writerIndex - 10)
         XCTAssertEqual("world", String(decoding: self.buf.readableBytesView, as: Unicode.UTF8.self))
@@ -1405,7 +1405,7 @@ class ByteBufferTest: XCTestCase {
 
     func testBytesView() throws {
         self.buf.clear()
-        self.buf.write(string: "hello world 012345678")
+        self.buf.writeString("hello world 012345678")
 
         XCTAssertEqual(String(decoding: self.buf.viewBytes(at: self.buf.readerIndex,
                                                            length: self.buf.writerIndex - self.buf.readerIndex),
@@ -1417,7 +1417,7 @@ class ByteBufferTest: XCTestCase {
     }
 
     func testViewsStartIndexIsStable() throws {
-        self.buf.write(string: "hello")
+        self.buf.writeString("hello")
         let view = self.buf.viewBytes(at: 1, length: 3)
         XCTAssertEqual(1, view.startIndex)
         XCTAssertEqual(3, view.count)
@@ -1426,7 +1426,7 @@ class ByteBufferTest: XCTestCase {
     }
 
     func testSlicesOfByteBufferViewsAreByteBufferViews() throws {
-        self.buf.write(string: "hello")
+        self.buf.writeString("hello")
         let view: ByteBufferView = self.buf.viewBytes(at: 1, length: 3)
         XCTAssertEqual("ell", String(decoding: view, as: Unicode.UTF8.self))
         let viewSlice: ByteBufferView = view[view.startIndex + 1 ..< view.endIndex]
@@ -1528,7 +1528,7 @@ class ByteBufferTest: XCTestCase {
 
     func testReadWithFunctionsThatReturnNumberOfReadBytesAreDiscardable() {
         var buf = self.buf!
-        buf.write(string: "ABCD")
+        buf.writeString("ABCD")
 
         /* deliberately not ignoring the result */ buf.readWithUnsafeReadableBytes { buffer in
             XCTAssertEqual(4, buffer.count)
@@ -1547,12 +1547,12 @@ class ByteBufferTest: XCTestCase {
         var buf = self.buf!
         buf.clear()
 
-        var writtenBytes = try assertNoThrowWithValue(buf.write(string: "ÆBCD", encoding: .utf16LittleEndian))
+        var writtenBytes = try assertNoThrowWithValue(buf.writeString("ÆBCD", encoding: .utf16LittleEndian))
         XCTAssertEqual(writtenBytes, 8)
         XCTAssertEqual(buf.readableBytes, 8)
         XCTAssertEqual(buf.getString(at: buf.readerIndex + 2, length: 6, encoding: .utf16LittleEndian), "BCD")
 
-        writtenBytes = try assertNoThrowWithValue(buf.set(string: "EFGH", encoding: .utf32BigEndian, at: buf.readerIndex))
+        writtenBytes = try assertNoThrowWithValue(buf.setString("EFGH", encoding: .utf32BigEndian, at: buf.readerIndex))
         XCTAssertEqual(writtenBytes, 16)
         XCTAssertEqual(buf.readableBytes, 8)
         XCTAssertEqual(buf.readString(length: 8, encoding: .utf32BigEndian), "EF")
@@ -1561,10 +1561,10 @@ class ByteBufferTest: XCTestCase {
         buf.clear()
 
         // Confirm that we do throw.
-        XCTAssertThrowsError(try buf.set(string: "🤷‍♀️", encoding: .ascii, at: buf.readerIndex)) {
+        XCTAssertThrowsError(try buf.setString("🤷‍♀️", encoding: .ascii, at: buf.readerIndex)) {
             XCTAssertEqual($0 as? ByteBufferFoundationError, .failedToEncodeString)
         }
-        XCTAssertThrowsError(try buf.write(string: "🤷‍♀️", encoding: .ascii)) {
+        XCTAssertThrowsError(try buf.writeString("🤷‍♀️", encoding: .ascii)) {
             XCTAssertEqual($0 as? ByteBufferFoundationError, .failedToEncodeString)
         }
     }
@@ -1575,7 +1575,7 @@ class ByteBufferTest: XCTestCase {
         let slowString = String(data: utf16Bytes, encoding: .utf16)!
 
         self.buf.clear()
-        let written = self.buf.write(string: slowString as String)
+        let written = self.buf.writeString(slowString as String)
         XCTAssertEqual(10, written)
         XCTAssertEqual("abcäää\n", String(decoding: self.buf.readableBytesView, as: Unicode.UTF8.self))
     }
@@ -1592,7 +1592,7 @@ class ByteBufferTest: XCTestCase {
         var buf = self.allocator.buffer(capacity: 16)
         let capacity = buf.capacity
         XCTAssertGreaterThanOrEqual(capacity, 16)
-        buf.write(string: "1234")
+        buf.writeString("1234")
         XCTAssertEqual(capacity, buf.capacity)
         buf.withVeryUnsafeMutableBytes { ptr in
             XCTAssertEqual(capacity, ptr.count)
@@ -1604,7 +1604,7 @@ class ByteBufferTest: XCTestCase {
         var buf = self.allocator.buffer(capacity: 16)
         let capacity = buf.capacity
         XCTAssertGreaterThanOrEqual(capacity, 16)
-        buf.write(string: "1234")
+        buf.writeString("1234")
         XCTAssertEqual(capacity, buf.capacity)
         buf.withVeryUnsafeMutableBytes { ptr in
             XCTAssertEqual(capacity, ptr.count)
@@ -1629,7 +1629,7 @@ class ByteBufferTest: XCTestCase {
         var buf = self.allocator.buffer(capacity: 16)
         let capacity = buf.capacity
         XCTAssertGreaterThanOrEqual(capacity, 16)
-        buf.write(string: "1234")
+        buf.writeString("1234")
         let bufCopy = buf
         XCTAssertEqual(capacity, buf.capacity)
         buf.withVeryUnsafeMutableBytes { ptr in
@@ -1646,7 +1646,7 @@ class ByteBufferTest: XCTestCase {
         var buf = self.allocator.buffer(capacity: 16)
         let capacity = buf.capacity
         XCTAssertGreaterThanOrEqual(capacity, 16)
-        buf.write(string: "1234567890")
+        buf.writeString("1234567890")
         var buf2 = buf.getSlice(at: 4, length: 4)!
         XCTAssertEqual(capacity, buf.capacity)
         let capacity2 = buf2.capacity
@@ -1661,7 +1661,7 @@ class ByteBufferTest: XCTestCase {
 
     func testGetDispatchDataWorks() {
         self.buf.clear()
-        self.buf.write(string: "abcdefgh")
+        self.buf.writeString("abcdefgh")
 
         XCTAssertEqual(0, self.buf.getDispatchData(at: 7, length: 0)!.count)
         XCTAssertNil(self.buf.getDispatchData(at: self.buf.capacity, length: 1))
@@ -1676,9 +1676,9 @@ class ByteBufferTest: XCTestCase {
             buffer.deallocate()
         }
         self.buf.clear()
-        self.buf.write(string: "abcdefgh")
-        self.buf.write(dispatchData: DispatchData.empty)
-        self.buf.write(dispatchData: DispatchData(bytes: UnsafeRawBufferPointer(buffer)))
+        self.buf.writeString("abcdefgh")
+        self.buf.writeDispatchData( DispatchData.empty)
+        self.buf.writeDispatchData( DispatchData(bytes: UnsafeRawBufferPointer(buffer)))
         XCTAssertEqual(12, self.buf.readableBytes)
         XCTAssertEqual("abcdefgh1234", String(decoding: self.buf.readDispatchData(length: 12)!, as: Unicode.UTF8.self))
         XCTAssertNil(self.buf.readDispatchData(length: 1))

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -314,7 +314,7 @@ class ChannelNotificationTest: XCTestCase {
 
         let channel = try acceptedChannelPromise.futureResult.wait()
         var buffer = channel.allocator.buffer(capacity: 8)
-        buffer.write(string: "test")
+        buffer.writeString("test")
 
 
         while (try? channel.writeAndFlush(buffer).wait()) != nil {
@@ -387,7 +387,7 @@ class ChannelNotificationTest: XCTestCase {
             .connect(to: serverChannel.localAddress!).wait())
 
         var buffer = clientChannel.allocator.buffer(capacity: 2)
-        buffer.write(string: "X")
+        buffer.writeString("X")
         XCTAssertNoThrow(try clientChannel.writeAndFlush(buffer).flatMap {
             clientChannel.close()
         }.wait())

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -30,13 +30,13 @@ private final class IndexWritingHandler: ChannelDuplexHandler {
 
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         var buf = self.unwrapInboundIn(data)
-        buf.write(integer: UInt8(self.index))
+        buf.writeInteger(UInt8(self.index))
         ctx.fireChannelRead(self.wrapInboundOut(buf))
     }
 
     func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         var buf = self.unwrapOutboundIn(data)
-        buf.write(integer: UInt8(self.index))
+        buf.writeInteger(UInt8(self.index))
         ctx.write(self.wrapOutboundOut(buf), promise: promise)
     }
 }
@@ -99,7 +99,7 @@ class ChannelPipelineTest: XCTestCase {
         let channel = EmbeddedChannel()
 
         var buf = channel.allocator.buffer(capacity: 1024)
-        buf.write(string: "hello")
+        buf.writeString("hello")
 
         _ = try channel.pipeline.add(handler: TestChannelOutboundHandler<Int, ByteBuffer> { data in
             XCTAssertEqual(1, data)
@@ -278,7 +278,7 @@ class ChannelPipelineTest: XCTestCase {
             func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
                 let data = self.unwrapOutboundIn(data)
                 var buf = ctx.channel.allocator.buffer(capacity: 123)
-                buf.write(string: String(describing: data))
+                buf.writeString(String(describing: data))
                 ctx.write(self.wrapOutboundOut(buf), promise: promise)
             }
         }
@@ -433,7 +433,7 @@ class ChannelPipelineTest: XCTestCase {
 
         let countHandler = ReceiveIntHandler()
         var buffer = channel.allocator.buffer(capacity: 12)
-        buffer.write(staticString: "hello, world")
+        buffer.writeStaticString("hello, world")
 
         XCTAssertNoThrow(try channel.pipeline.add(handler: countHandler).wait())
         XCTAssertFalse(try channel.writeInbound(buffer))
@@ -696,7 +696,7 @@ class ChannelPipelineTest: XCTestCase {
         let context = try assertNoThrowWithValue(channel.pipeline.context(handlerType: NoOpHandler.self).wait())
 
         var buffer = channel.allocator.buffer(capacity: 1024)
-        buffer.write(staticString: "Hello, world!")
+        buffer.writeStaticString("Hello, world!")
 
         let removalPromise = channel.eventLoop.makePromise(of: Void.self)
         removalPromise.futureResult.whenSuccess {
@@ -742,7 +742,7 @@ class ChannelPipelineTest: XCTestCase {
         let context = try assertNoThrowWithValue(channel.pipeline.context(handlerType: NoOpHandler.self).wait())
 
         var buffer = channel.allocator.buffer(capacity: 1024)
-        buffer.write(staticString: "Hello, world!")
+        buffer.writeStaticString("Hello, world!")
 
         XCTAssertNil(channel.readOutbound())
         XCTAssertNoThrow(try channel.throwIfErrorCaught())
@@ -771,7 +771,7 @@ class ChannelPipelineTest: XCTestCase {
         let context = try assertNoThrowWithValue(channel.pipeline.context(handlerType: NoOpHandler.self).wait())
 
         var buffer = channel.allocator.buffer(capacity: 1024)
-        buffer.write(staticString: "Hello, world!")
+        buffer.writeStaticString("Hello, world!")
 
         let removalPromise = channel.eventLoop.makePromise(of: Void.self)
         removalPromise.futureResult.whenSuccess {
@@ -812,7 +812,7 @@ class ChannelPipelineTest: XCTestCase {
         let context = try assertNoThrowWithValue(channel.pipeline.context(handlerType: NoOpHandler.self).wait())
 
         var buffer = channel.allocator.buffer(capacity: 1024)
-        buffer.write(staticString: "Hello, world!")
+        buffer.writeStaticString("Hello, world!")
 
         XCTAssertNil(channel.readOutbound())
         XCTAssertNoThrow(try channel.throwIfErrorCaught())
@@ -842,7 +842,7 @@ class ChannelPipelineTest: XCTestCase {
         let context = try assertNoThrowWithValue(channel.pipeline.context(handlerType: NoOpHandler.self).wait())
 
         var buffer = channel.allocator.buffer(capacity: 1024)
-        buffer.write(staticString: "Hello, world!")
+        buffer.writeStaticString("Hello, world!")
 
         let removalPromise = channel.eventLoop.makePromise(of: Void.self)
         removalPromise.futureResult.whenSuccess {
@@ -884,7 +884,7 @@ class ChannelPipelineTest: XCTestCase {
         let context = try assertNoThrowWithValue(channel.pipeline.context(handlerType: NoOpHandler.self).wait())
 
         var buffer = channel.allocator.buffer(capacity: 1024)
-        buffer.write(staticString: "Hello, world!")
+        buffer.writeStaticString("Hello, world!")
 
         XCTAssertNil(channel.readOutbound())
         XCTAssertNoThrow(try channel.throwIfErrorCaught())

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -91,7 +91,7 @@ public class ChannelTests: XCTestCase {
             .connect(to: serverChannel.localAddress!).wait())
 
         var buffer = clientChannel.allocator.buffer(capacity: 1)
-        buffer.write(string: "a")
+        buffer.writeString("a")
         try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
 
         let serverAcceptedChannel = try serverAcceptedChannelPromise.futureResult.wait()
@@ -128,11 +128,11 @@ public class ChannelTests: XCTestCase {
         var buffer = clientChannel.allocator.buffer(capacity: 1)
         for _ in 0..<Socket.writevLimitIOVectors {
             buffer.clear()
-            buffer.write(string: "a")
+            buffer.writeString("a")
             clientChannel.write(NIOAny(buffer), promise: nil)
         }
         buffer.clear()
-        buffer.write(string: "a")
+        buffer.writeString("a")
         try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
 
         // Start shutting stuff down.
@@ -155,7 +155,7 @@ public class ChannelTests: XCTestCase {
         let bufferSize = 1024 * 1024 * 2
         var buffer = clientChannel.allocator.buffer(capacity: bufferSize)
         for _ in 0..<bufferSize {
-            buffer.write(staticString: "a")
+            buffer.writeStaticString("a")
         }
 
 
@@ -424,7 +424,7 @@ public class ChannelTests: XCTestCase {
         let alloc = ByteBufferAllocator()
         var buffer = alloc.buffer(capacity: 12)
         let emptyBuffer = buffer
-        _ = buffer.write(string: "1234")
+        _ = buffer.writeString("1234")
 
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
@@ -460,7 +460,7 @@ public class ChannelTests: XCTestCase {
         let el = EmbeddedEventLoop()
         let alloc = ByteBufferAllocator()
         var buffer = alloc.buffer(capacity: 12)
-        _ = buffer.write(string: "1234")
+        _ = buffer.writeString("1234")
 
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<4).map { (_: Int) in el.makePromise() }
@@ -510,7 +510,7 @@ public class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let numberOfBytes = Int(1 /* first write */ + pwm.writeSpinCount /* the spins */ + 1 /* so one byte remains at the end */)
             buffer.clear()
-            buffer.write(bytes: Array<UInt8>(repeating: 0xff, count: numberOfBytes))
+            buffer.writeBytes(Array<UInt8>(repeating: 0xff, count: numberOfBytes))
             let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.makePromise() }
             _ = pwm.add(data: .byteBuffer(buffer), promise: ps[0])
             pwm.markFlushCheckpoint()
@@ -548,7 +548,7 @@ public class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let numberOfBytes = Int(1 /* first write */ + pwm.writeSpinCount /* the spins */ + 1 /* so one byte remains at the end */)
             buffer.clear()
-            buffer.write(bytes: [0xff] as [UInt8])
+            buffer.writeBytes([0xff] as [UInt8])
             let ps: [EventLoopPromise<Void>] = (0..<numberOfBytes).map { (_: Int) in
                 let p = el.makePromise(of: Void.self)
                 _ = pwm.add(data: .byteBuffer(buffer), promise: p)
@@ -603,7 +603,7 @@ public class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let numberOfWrites = Int(1 /* first write */ + pwm.writeSpinCount /* the spins */ + 1 /* so one byte remains at the end */)
             buffer.clear()
-            buffer.write(bytes: Array<UInt8>(repeating: 0xff, count: 1))
+            buffer.writeBytes(Array<UInt8>(repeating: 0xff, count: 1))
             let handle = FileHandle(descriptor: -1)
             defer {
                 /* fake file handle, so don't actually close */
@@ -639,7 +639,7 @@ public class ChannelTests: XCTestCase {
         let alloc = ByteBufferAllocator()
         var buffer = alloc.buffer(capacity: 12)
         let emptyBuffer = buffer
-        _ = buffer.write(string: "1234")
+        _ = buffer.writeString("1234")
 
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
@@ -821,7 +821,7 @@ public class ChannelTests: XCTestCase {
         let el = EmbeddedEventLoop()
         let alloc = ByteBufferAllocator()
         var buffer = alloc.buffer(capacity: 12)
-        _ = buffer.write(string: "1234")
+        _ = buffer.writeString("1234")
 
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<5).map { (_: Int) in el.makePromise() }
@@ -877,7 +877,7 @@ public class ChannelTests: XCTestCase {
         let alloc = ByteBufferAllocator()
         var buffer = alloc.buffer(capacity: 12)
         let emptyBuffer = buffer
-        _ = buffer.write(string: "1234")
+        _ = buffer.writeString("1234")
 
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
@@ -963,7 +963,7 @@ public class ChannelTests: XCTestCase {
         let el = EmbeddedEventLoop()
         let alloc = ByteBufferAllocator()
         var buffer = alloc.buffer(capacity: 12)
-        buffer.write(string: "1234")
+        buffer.writeString("1234")
 
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
@@ -994,7 +994,7 @@ public class ChannelTests: XCTestCase {
         let el = EmbeddedEventLoop()
         let alloc = ByteBufferAllocator()
         var buffer = alloc.buffer(capacity: 12)
-        buffer.write(string: "1234")
+        buffer.writeString("1234")
 
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.makePromise() }
@@ -1134,7 +1134,7 @@ public class ChannelTests: XCTestCase {
         }
 
         var buffer = channel.allocator.buffer(capacity: 12)
-        buffer.write(string: "1234")
+        buffer.writeString("1234")
 
         try channel.writeAndFlush(NIOAny(buffer)).wait()
         try channel.close(mode: .output).wait()
@@ -1202,7 +1202,7 @@ public class ChannelTests: XCTestCase {
         verificationHandler.waitForEvent()
 
         var buffer = channel.allocator.buffer(capacity: 12)
-        buffer.write(string: "1234")
+        buffer.writeString("1234")
 
         let written = try buffer.withUnsafeReadableBytes { p in
             try accepted.write(pointer: UnsafeRawBufferPointer(rebasing: p.prefix(4)))
@@ -1256,7 +1256,7 @@ public class ChannelTests: XCTestCase {
         verificationHandler.waitForEvent()
 
         var buffer = channel.allocator.buffer(capacity: 12)
-        buffer.write(string: "1234")
+        buffer.writeString("1234")
 
         try channel.writeAndFlush(NIOAny(buffer)).wait()
     }
@@ -1551,7 +1551,7 @@ public class ChannelTests: XCTestCase {
         // We send a first write and expect it to arrive.
         var buffer = clientChannel.allocator.buffer(capacity: 12)
         let firstReadPromise = readDelayer.expectRead(loop: serverChannel.eventLoop)
-        buffer.write(staticString: "hello, world")
+        buffer.writeStaticString("hello, world")
         XCTAssertNoThrow(try clientChannel.writeAndFlush(buffer).wait())
         XCTAssertNoThrow(try firstReadPromise.wait())
 
@@ -1605,7 +1605,7 @@ public class ChannelTests: XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .connect(to: serverChannel.localAddress!).wait())
         var buffer = clientChannel.allocator.buffer(capacity: 8)
-        buffer.write(string: "test")
+        buffer.writeString("test")
         try clientChannel.writeAndFlush(buffer).wait()
 
         // Wait for 100 ms. No data should be delivered.
@@ -1663,7 +1663,7 @@ public class ChannelTests: XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .connect(to: serverChannel.localAddress!).wait())
         var buffer = clientChannel.allocator.buffer(capacity: 8)
-        buffer.write(string: "01234567")
+        buffer.writeString("01234567")
         for _ in 0..<20 {
             XCTAssertNoThrow(try clientChannel.writeAndFlush(buffer).wait())
         }
@@ -1717,7 +1717,7 @@ public class ChannelTests: XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .connect(to: serverChannel.localAddress!).wait())
         var buf = clientChannel.allocator.buffer(capacity: 16)
-        buf.write(staticString: "012345678")
+        buf.writeStaticString("012345678")
         XCTAssertNoThrow(try clientChannel.writeAndFlush(buf).wait())
         XCTAssertNoThrow(try clientChannel.writeAndFlush(buf).wait())
         XCTAssertNoThrow(try clientChannel.close().wait())
@@ -1763,7 +1763,7 @@ public class ChannelTests: XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .connect(to: serverChannel.localAddress!).wait())
         var buffer = clientChannel.allocator.buffer(capacity: 8)
-        buffer.write(string: "test")
+        buffer.writeString("test")
         try clientChannel.writeAndFlush(buffer).wait()
         try clientChannel.close().wait()
         try promise.futureResult.wait()
@@ -1939,7 +1939,7 @@ public class ChannelTests: XCTestCase {
 
             func channelActive(ctx: ChannelHandlerContext) {
                 var buffer = ctx.channel.allocator.buffer(capacity: 4)
-                buffer.write(string: "foo")
+                buffer.writeString("foo")
                 ctx.writeAndFlush(NIOAny(buffer), promise: self.writeDonePromise)
             }
         }
@@ -2115,7 +2115,7 @@ public class ChannelTests: XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: serverEL)
             .childChannelInitializer { channel in
                 var buffer = channel.allocator.buffer(capacity: 4)
-                buffer.write(string: "foo")
+                buffer.writeString("foo")
                 return channel.write(NIOAny(buffer))
             }
             .bind(host: "127.0.0.1", port: 0)
@@ -2474,7 +2474,7 @@ public class ChannelTests: XCTestCase {
 
             func channelActive(ctx: ChannelHandlerContext) {
                 var buffer = ctx.channel.allocator.buffer(capacity: 1)
-                buffer.write(staticString: "X")
+                buffer.writeStaticString("X")
                 ctx.channel.writeAndFlush(self.wrapOutboundOut(buffer)).map { ctx.channel }.cascade(to: self.channelAvailablePromise)
             }
         }
@@ -2534,7 +2534,7 @@ public class ChannelTests: XCTestCase {
                     ctx.channel.setOption(option: ChannelOptions.autoRead, value: true).flatMap {
                         // let's trigger the write error
                         var buffer = ctx.channel.allocator.buffer(capacity: 16)
-                        buffer.write(staticString: "THIS WILL FAIL ANYWAY")
+                        buffer.writeStaticString("THIS WILL FAIL ANYWAY")
 
                         // this needs to be in a function as otherwise the Swift compiler believes this is throwing
                         func workaroundSR487() {

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -109,7 +109,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         _ = try channel.pipeline.add(handler: ByteToMessageHandler(ByteToInt32Decoder())).wait()
 
         var buffer = channel.allocator.buffer(capacity: 32)
-        buffer.write(integer: Int32(1))
+        buffer.writeInteger(Int32(1))
         let writerIndex = buffer.writerIndex
         buffer.moveWriterIndex(to: writerIndex - 1)
 
@@ -119,8 +119,8 @@ public class ByteToMessageDecoderTest: XCTestCase {
         channel.pipeline.fireChannelRead(NIOAny(buffer.getSlice(at: writerIndex - 1, length: 1)!))
 
         var buffer2 = channel.allocator.buffer(capacity: 32)
-        buffer2.write(integer: Int32(2))
-        buffer2.write(integer: Int32(3))
+        buffer2.writeInteger(Int32(2))
+        buffer2.writeInteger(Int32(3))
         channel.pipeline.fireChannelRead(NIOAny(buffer2))
 
         XCTAssertNoThrow(try channel.finish())
@@ -141,7 +141,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         _ = try channel.pipeline.add(handler: inactivePromiser).wait()
 
         var buffer = channel.allocator.buffer(capacity: 32)
-        buffer.write(integer: Int32(1))
+        buffer.writeInteger(Int32(1))
         channel.pipeline.fireChannelRead(NIOAny(buffer))
         XCTAssertEqual(Int32(1), channel.readInbound())
 
@@ -167,7 +167,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
                                                  hookedMemcpy: testDecoderIsNotQuadratic_memcpyHook)
         channel.allocator = dummyAllocator
         var inputBuffer = dummyAllocator.buffer(capacity: 8)
-        inputBuffer.write(staticString: "whatwhat")
+        inputBuffer.writeStaticString("whatwhat")
 
         for _ in 0..<10 {
             channel.pipeline.fireChannelRead(NIOAny(inputBuffer))
@@ -191,7 +191,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         // We're going to send in 513 bytes. This will cause a chunk to be passed on, and will leave
         // a 512-byte empty region in a 513 byte buffer. This will not cause a shrink.
         var buffer = channel.allocator.buffer(capacity: 513)
-        buffer.write(bytes: Array(repeating: 0x04, count: 513))
+        buffer.writeBytes(Array(repeating: 0x04, count: 513))
         XCTAssertTrue(try channel.writeInbound(buffer))
 
         XCTAssertEqual(decoder.cumulationBuffer!.readableBytes, 1)
@@ -216,7 +216,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
 
         // We're going to send in 5119 bytes. This will be held.
         var buffer = channel.allocator.buffer(capacity: 5119)
-        buffer.write(bytes: Array(repeating: 0x04, count: 5119))
+        buffer.writeBytes(Array(repeating: 0x04, count: 5119))
         XCTAssertFalse(try channel.writeInbound(buffer))
 
         XCTAssertEqual(decoder.cumulationBuffer!.readableBytes, 5119)
@@ -251,13 +251,13 @@ public class ByteToMessageDecoderTest: XCTestCase {
                     // this is the first time, let's fireChannelRead
                     self.hasReentranced = true
                     reentrantWriteBuffer.clear()
-                    reentrantWriteBuffer.write(staticString: "3")
+                    reentrantWriteBuffer.writeStaticString("3")
                     ctx.channel.pipeline.fireChannelRead(self.wrapInboundOut(reentrantWriteBuffer))
                 }
                 ctx.fireChannelRead(self.wrapInboundOut(buffer.readSlice(length: 1)!))
                 if self.numberOfDecodeCalls == 2 {
                     reentrantWriteBuffer.clear()
-                    reentrantWriteBuffer.write(staticString: "4")
+                    reentrantWriteBuffer.writeStaticString("4")
                     ctx.channel.pipeline.fireChannelRead(self.wrapInboundOut(reentrantWriteBuffer))
                 }
                 return .continue
@@ -270,17 +270,17 @@ public class ByteToMessageDecoderTest: XCTestCase {
 
         var inputBuffer = channel.allocator.buffer(capacity: 4)
         /* 1 */
-        inputBuffer.write(staticString: "1")
+        inputBuffer.writeStaticString("1")
         XCTAssertTrue(try channel.writeInbound(inputBuffer))
         inputBuffer.clear()
 
         /* 2 */
-        inputBuffer.write(staticString: "2")
+        inputBuffer.writeStaticString("2")
         XCTAssertTrue(try channel.writeInbound(inputBuffer))
         inputBuffer.clear()
 
         /* 3 */
-        inputBuffer.write(staticString: "5")
+        inputBuffer.writeStaticString("5")
         XCTAssertTrue(try channel.writeInbound(inputBuffer))
         inputBuffer.clear()
 
@@ -328,13 +328,13 @@ public class ByteToMessageDecoderTest: XCTestCase {
 
         var buffer = channel.allocator.buffer(capacity: 16)
         buffer.clear()
-        buffer.write(staticString: "1")
+        buffer.writeStaticString("1")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         buffer.clear()
-        buffer.write(staticString: "23")
+        buffer.writeStaticString("23")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         buffer.clear()
-        buffer.write(staticString: "4567890")
+        buffer.writeStaticString("4567890")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertFalse(channel.isActive)
 
@@ -350,13 +350,13 @@ public class ByteToMessageDecoderTest: XCTestCase {
 
         var buffer = channel.allocator.buffer(capacity: 16)
         buffer.clear()
-        buffer.write(staticString: "1")
+        buffer.writeStaticString("1")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         buffer.clear()
-        buffer.write(staticString: "23")
+        buffer.writeStaticString("23")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         buffer.clear()
-        buffer.write(staticString: "4567890x")
+        buffer.writeStaticString("4567890x")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.close().wait())
         XCTAssertFalse(channel.isActive)
@@ -382,13 +382,13 @@ public class ByteToMessageDecoderTest: XCTestCase {
 
         var buffer = channel.allocator.buffer(capacity: 16)
         buffer.clear()
-        buffer.write(staticString: "1")
+        buffer.writeStaticString("1")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         buffer.clear()
-        buffer.write(staticString: "23")
+        buffer.writeStaticString("23")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         buffer.clear()
-        buffer.write(staticString: "4567890x")
+        buffer.writeStaticString("4567890x")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         channel.pipeline.context(handlerType: ByteToMessageHandler<PairOfBytesDecoder>.self).flatMap { ctx in
@@ -437,13 +437,13 @@ public class ByteToMessageDecoderTest: XCTestCase {
 
         var buffer = channel.allocator.buffer(capacity: 16)
         buffer.clear()
-        buffer.write(staticString: "1")
+        buffer.writeStaticString("1")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         buffer.clear()
-        buffer.write(staticString: "23")
+        buffer.writeStaticString("23")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         buffer.clear()
-        buffer.write(staticString: "4567890qwer")
+        buffer.writeStaticString("4567890qwer")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         XCTAssertEqual(1, channel.readInbound())
@@ -480,7 +480,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         }
         let channel = EmbeddedChannel(handler: ByteToMessageHandler(ProcessAndReentrantylyProcessExponentiallyLessStuffDecoder()))
         var buffer = channel.allocator.buffer(capacity: 16)
-        buffer.write(staticString: "0123456789abcdef")
+        buffer.writeStaticString("0123456789abcdef")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         XCTAssertEqual("0123456789abcdef", channel.readInbound())
@@ -514,7 +514,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         }
         let channel = EmbeddedChannel(handler: ByteToMessageHandler(Take16BytesThenCloseAndPassOnDecoder()))
         var buffer = channel.allocator.buffer(capacity: 16)
-        buffer.write(staticString: "0123456789abcdefQWER")
+        buffer.writeStaticString("0123456789abcdefQWER")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         XCTAssertEqual("0123456789abcdef", channel.readInbound(as: ByteBuffer.self).map { String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)})
@@ -545,7 +545,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         }
         let channel = EmbeddedChannel(handler: ByteToMessageHandler(Take16BytesThenCloseAndPassOnDecoder()))
         var buffer = channel.allocator.buffer(capacity: 16)
-        buffer.write(staticString: "0123456789abcdefQWER")
+        buffer.writeStaticString("0123456789abcdefQWER")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         XCTAssertEqual("0123456789abcdef", (channel.readInbound() as ByteBuffer?).map { String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)})
@@ -584,7 +584,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         let channel = EmbeddedChannel(handler: ByteToMessageHandler(Take16BytesThenCloseAndPassOnDecoder()))
         XCTAssertNoThrow(try channel.pipeline.add(handler: DoNotForwardChannelInactiveHandler(), first: true).wait())
         var buffer = channel.allocator.buffer(capacity: 16)
-        buffer.write(staticString: "0123456789abcdefQWER")
+        buffer.writeStaticString("0123456789abcdefQWER")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         XCTAssertEqual("0123456789abcdef", (channel.readInbound() as ByteBuffer?).map { String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)})
@@ -630,7 +630,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         }
 
         var buffer = channel.allocator.buffer(capacity: 9)
-        buffer.write(staticString: "012345678")
+        buffer.writeStaticString("012345678")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         (channel.eventLoop as! EmbeddedEventLoop).run()
         XCTAssertEqual(1, handler.decoder?.callsToDecode)
@@ -649,7 +649,7 @@ public class MessageToByteEncoderTest: XCTestCase {
 
         public func encode(ctx: ChannelHandlerContext, data value: Int32, out: inout ByteBuffer) throws {
             XCTAssertEqual(MemoryLayout<Int32>.size, out.writableBytes)
-            out.write(integer: value)
+            out.writeInteger(value)
         }
 
         public func allocateOutBuffer(ctx: ChannelHandlerContext, data: Int32) throws -> ByteBuffer {
@@ -663,7 +663,7 @@ public class MessageToByteEncoderTest: XCTestCase {
 
         public func encode(ctx: ChannelHandlerContext, data value: Int32, out: inout ByteBuffer) throws {
             XCTAssertEqual(MemoryLayout<Int32>.size, 256)
-            out.write(integer: value)
+            out.writeInteger(value)
         }
     }
 

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -110,7 +110,7 @@ final class DatagramChannelTests: XCTestCase {
 
     func testBasicChannelCommunication() throws {
         var buffer = self.firstChannel.allocator.buffer(capacity: 256)
-        buffer.write(staticString: "hello, world!")
+        buffer.writeStaticString("hello, world!")
         let writeData = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
         XCTAssertNoThrow(try self.firstChannel.writeAndFlush(NIOAny(writeData)).wait())
 
@@ -123,7 +123,7 @@ final class DatagramChannelTests: XCTestCase {
 
     func testManyWrites() throws {
         var buffer = firstChannel.allocator.buffer(capacity: 256)
-        buffer.write(staticString: "hello, world!")
+        buffer.writeStaticString("hello, world!")
         let writeData = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
         var writeFutures: [EventLoopFuture<Void>] = []
         for _ in 0..<5 {
@@ -157,7 +157,7 @@ final class DatagramChannelTests: XCTestCase {
         _ = try self.firstChannel.setOption(option: ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 1, high: 1024)).wait()
 
         var buffer = self.firstChannel.allocator.buffer(capacity: 256)
-        buffer.write(bytes: [UInt8](repeating: 5, count: 256))
+        buffer.writeBytes([UInt8](repeating: 5, count: 256))
         let writeData = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
         XCTAssertTrue(self.firstChannel.isWritable)
         for _ in 0..<4 {
@@ -186,7 +186,7 @@ final class DatagramChannelTests: XCTestCase {
 
     func testWriteFuturesFailWhenChannelClosed() throws {
         var buffer = self.firstChannel.allocator.buffer(capacity: 256)
-        buffer.write(staticString: "hello, world!")
+        buffer.writeStaticString("hello, world!")
         let writeData = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
         let promises = (0..<5).map { _ in self.firstChannel.write(NIOAny(writeData)) }
 
@@ -216,7 +216,7 @@ final class DatagramChannelTests: XCTestCase {
         for _ in 0...Socket.writevLimitIOVectors {
             let myPromise = self.firstChannel.eventLoop.makePromise(of: Void.self)
             var buffer = self.firstChannel.allocator.buffer(capacity: 1)
-            buffer.write(string: "a")
+            buffer.writeString("a")
             let envelope = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
             self.firstChannel.write(NIOAny(envelope), promise: myPromise)
             overall = EventLoopFuture.andAllSucceed([overall, myPromise.futureResult], on: self.firstChannel.eventLoop)
@@ -426,7 +426,7 @@ final class DatagramChannelTests: XCTestCase {
 
     func testWritesAreAccountedCorrectly() throws {
         var buffer = firstChannel.allocator.buffer(capacity: 256)
-        buffer.write(staticString: "hello, world!")
+        buffer.writeStaticString("hello, world!")
         let firstWrite = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer.getSlice(at: buffer.readerIndex, length: 5)!)
         let secondWrite = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
         self.firstChannel.write(NIOAny(firstWrite), promise: nil)

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -48,7 +48,7 @@ class EchoServerClientTest : XCTestCase {
         var buffer = clientChannel.allocator.buffer(capacity: numBytes)
 
         for i in 0..<numBytes {
-            buffer.write(integer: UInt8(i % 256))
+            buffer.writeInteger(UInt8(i % 256))
         }
 
         try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
@@ -126,7 +126,7 @@ class EchoServerClientTest : XCTestCase {
         var buffer = clientChannel.allocator.buffer(capacity: numBytes)
 
         for i in 0..<numBytes {
-            buffer.write(integer: UInt8(i % 256))
+            buffer.writeInteger(UInt8(i % 256))
         }
 
         XCTAssertNoThrow(try clientChannel.writeAndFlush(NIOAny(buffer)).wait())
@@ -170,7 +170,7 @@ class EchoServerClientTest : XCTestCase {
         var buffer = clientChannel.allocator.buffer(capacity: numBytes)
 
         for i in 0..<numBytes {
-            buffer.write(integer: UInt8(i % 256))
+            buffer.writeInteger(UInt8(i % 256))
         }
 
         try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
@@ -232,7 +232,7 @@ class EchoServerClientTest : XCTestCase {
 
         var buffer = clientChannel.allocator.buffer(capacity: numBytes)
         for i in 0..<numBytes {
-            buffer.write(integer: UInt8(i % 256))
+            buffer.writeInteger(UInt8(i % 256))
         }
         XCTAssertNoThrow(try clientChannel.writeAndFlush(NIOAny(buffer)).wait())
 
@@ -389,7 +389,7 @@ class EchoServerClientTest : XCTestCase {
 
         func channelActive(ctx: ChannelHandlerContext) {
             var dataToWrite = ctx.channel.allocator.buffer(capacity: toWrite.utf8.count)
-            dataToWrite.write(string: toWrite)
+            dataToWrite.writeString(toWrite)
             ctx.writeAndFlush(NIOAny(dataToWrite), promise: nil)
             ctx.fireChannelActive()
         }
@@ -464,7 +464,7 @@ class EchoServerClientTest : XCTestCase {
 
         // First we confirm that the channel really is up by sending in the appropriate number of bytes.
         var bytesToWrite = clientChannel.allocator.buffer(capacity: writingBytes.utf8.count)
-        bytesToWrite.write(string: writingBytes)
+        bytesToWrite.writeString(writingBytes)
         let lastWriteFuture = clientChannel.writeAndFlush(NIOAny(bytesToWrite))
 
         // When we've received all the bytes we know the connection is up.
@@ -570,7 +570,7 @@ class EchoServerClientTest : XCTestCase {
             .connect(to: serverChannel.localAddress!).wait())
 
         var buffer = clientChannel.allocator.buffer(capacity: str.utf8.count)
-        buffer.write(string: str)
+        buffer.writeString(str)
         try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
 
         try countingHandler.assertReceived(buffer: buffer)
@@ -598,7 +598,7 @@ class EchoServerClientTest : XCTestCase {
 
             func channelActive(ctx: ChannelHandlerContext) {
                 var buffer = ctx.channel.allocator.buffer(capacity: 4)
-                buffer.write(string: "test")
+                buffer.writeString("test")
                 writeUntilFailed(ctx, buffer)
             }
 
@@ -624,7 +624,7 @@ class EchoServerClientTest : XCTestCase {
             func channelActive(ctx: ChannelHandlerContext) {
                 ctx.fireChannelActive()
                 var buffer = ctx.channel.allocator.buffer(capacity: str.utf8.count)
-                buffer.write(string: str)
+                buffer.writeString(str)
 
                 // write it four times and then close the connect.
                 ctx.writeAndFlush(NIOAny(buffer)).flatMap {
@@ -666,10 +666,10 @@ class EchoServerClientTest : XCTestCase {
         dpGroup.wait()
 
         var completeBuffer = clientChannel.allocator.buffer(capacity: str.utf8.count * 4)
-        completeBuffer.write(string: str)
-        completeBuffer.write(string: str)
-        completeBuffer.write(string: str)
-        completeBuffer.write(string: str)
+        completeBuffer.writeString(str)
+        completeBuffer.writeString(str)
+        completeBuffer.writeString(str)
+        completeBuffer.writeString(str)
 
         try countingHandler.assertReceived(buffer: completeBuffer)
 
@@ -814,7 +814,7 @@ class EchoServerClientTest : XCTestCase {
         var buffer = clientChannel.allocator.buffer(capacity: numBytes)
 
         for i in 0..<numBytes {
-            buffer.write(integer: UInt8(i % 256))
+            buffer.writeInteger(UInt8(i % 256))
         }
 
         try clientChannel.writeAndFlush(NIOAny(buffer)).wait()

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -19,7 +19,7 @@ class EmbeddedChannelTest: XCTestCase {
     func testWriteOutboundByteBuffer() throws {
         let channel = EmbeddedChannel()
         var buf = channel.allocator.buffer(capacity: 1024)
-        buf.write(string: "hello")
+        buf.writeString("hello")
         
         XCTAssertTrue(try channel.writeOutbound(buf))
         XCTAssertTrue(try channel.finish())
@@ -31,7 +31,7 @@ class EmbeddedChannelTest: XCTestCase {
     func testWriteInboundByteBuffer() throws {
         let channel = EmbeddedChannel()
         var buf = channel.allocator.buffer(capacity: 1024)
-        buf.write(string: "hello")
+        buf.writeString("hello")
 
         XCTAssertTrue(try channel.writeInbound(buf))
         XCTAssertTrue(try channel.finish())
@@ -182,7 +182,7 @@ class EmbeddedChannelTest: XCTestCase {
         let channel = EmbeddedChannel()
 
         var buf = ByteBufferAllocator().buffer(capacity: 1)
-        buf.write(bytes: [1])
+        buf.writeBytes([1])
         let writeFuture = channel.write(buf)
         XCTAssertNil(channel.readOutbound())
         XCTAssertFalse(writeFuture.isFulfilled)

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -282,7 +282,7 @@ public class EventLoopTest : XCTestCase {
 
             var buffer = clientChannel.allocator.buffer(capacity: numBytes)
             for i in 0..<numBytes {
-                buffer.write(integer: UInt8(i % 256))
+                buffer.writeInteger(UInt8(i % 256))
             }
 
             try clientChannel.writeAndFlush(NIOAny(buffer)).wait()

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -60,7 +60,7 @@ class FileRegionTest : XCTestCase {
             try content.write(toFile: filePath, atomically: false, encoding: .ascii)
             try clientChannel.writeAndFlush(NIOAny(fr)).wait()
             var buffer = clientChannel.allocator.buffer(capacity: bytes.count)
-            buffer.write(bytes: bytes)
+            buffer.writeBytes(bytes)
             try countingHandler.assertReceived(buffer: buffer)
         }
     }
@@ -156,7 +156,7 @@ class FileRegionTest : XCTestCase {
                 () = try clientChannel.writeAndFlush(NIOAny(fr1)).flatMap {
                     let frFuture = clientChannel.write(NIOAny(fr2))
                     var buffer = clientChannel.allocator.buffer(capacity: bytes.count)
-                    buffer.write(bytes: bytes)
+                    buffer.writeBytes(bytes)
                     let bbFuture = clientChannel.write(NIOAny(buffer))
                     clientChannel.close(promise: nil)
                     clientChannel.flush()
@@ -170,7 +170,7 @@ class FileRegionTest : XCTestCase {
             }
 
             var buffer = clientChannel.allocator.buffer(capacity: bytes.count)
-            buffer.write(bytes: bytes)
+            buffer.writeBytes(bytes)
             try countingHandler.assertReceived(buffer: buffer)
         }
     }

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -68,7 +68,7 @@ class IdleStateHandlerTest : XCTestCase {
             public func channelActive(ctx: ChannelHandlerContext) {
                 if writeToChannel {
                     var buffer = ctx.channel.allocator.buffer(capacity: 4)
-                    buffer.write(staticString: "test")
+                    buffer.writeStaticString("test")
                     ctx.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
                 }
             }
@@ -91,7 +91,7 @@ class IdleStateHandlerTest : XCTestCase {
             .wait())
         if !writeToChannel {
             var buffer = clientChannel.allocator.buffer(capacity: 4)
-            buffer.write(staticString: "test")
+            buffer.writeStaticString("test")
             XCTAssertNoThrow(try clientChannel.writeAndFlush(NIOAny(buffer)).wait())
         }
         XCTAssertNoThrow(try clientChannel.closeFuture.wait())

--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -123,7 +123,7 @@ final class MulticastTest: XCTestCase {
         XCTAssertNoThrow(try multicastChannel.pipeline.add(handler: PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
 
         var messageBuffer = sender.allocator.buffer(capacity: 24)
-        messageBuffer.write(staticString: "hello, world!")
+        messageBuffer.writeStaticString("hello, world!")
 
         XCTAssertNoThrow(
             try sender.writeAndFlush(AddressedEnvelope(remoteAddress: multicastAddress, data: messageBuffer)).wait(),
@@ -151,7 +151,7 @@ final class MulticastTest: XCTestCase {
         }.cascadeFailure(to: timeoutPromise)
 
         var messageBuffer = sender.allocator.buffer(capacity: 24)
-        messageBuffer.write(staticString: "hello, world!")
+        messageBuffer.writeStaticString("hello, world!")
 
         XCTAssertNoThrow(
             try sender.writeAndFlush(AddressedEnvelope(remoteAddress: multicastAddress, data: messageBuffer)).wait(),

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -453,7 +453,7 @@ class NonBlockingFileIOTest: XCTestCase {
 
     func testWriting() throws {
         var buffer = allocator.buffer(capacity: 3)
-        buffer.write(staticString: "123")
+        buffer.writeStaticString("123")
 
         try withTemporaryFile(content: "") { (fileHandle, path) in
             try self.fileIO.write(fileHandle: fileHandle,

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
@@ -278,7 +278,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let secondAddress = try SocketAddress(ipAddress: "127.0.0.2", port: 65535)
         var buffer = alloc.buffer(capacity: 12)
         let emptyBuffer = buffer
-        _ = buffer.write(string: "1234")
+        _ = buffer.writeString("1234")
 
         try withPendingDatagramWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
@@ -314,7 +314,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let firstAddress = try SocketAddress(ipAddress: "fe80::1", port: 65535)
         let secondAddress = try SocketAddress(ipAddress: "fe80::2", port: 65535)
         var buffer = alloc.buffer(capacity: 12)
-        _ = buffer.write(string: "1234")
+        buffer.writeString("1234")
 
         try withPendingDatagramWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<4).map { (_: Int) in el.makePromise() }
@@ -363,7 +363,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let alloc = ByteBufferAllocator()
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 65535)
         var buffer = alloc.buffer(capacity: 12)
-        buffer.write(bytes: Array<UInt8>(repeating: 0xff, count: 12))
+        buffer.writeBytes(Array<UInt8>(repeating: 0xff, count: 12))
 
         try withPendingDatagramWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0...pwm.writeSpinCount+1).map { (_: UInt) in el.makePromise() }
@@ -402,7 +402,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let alloc = ByteBufferAllocator()
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 65535)
         var buffer = alloc.buffer(capacity: 12)
-        _ = buffer.write(string: "1234")
+        buffer.writeString("1234")
 
         try withPendingDatagramWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
@@ -550,7 +550,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let alloc = ByteBufferAllocator()
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 80)
         var buffer = alloc.buffer(capacity: 12)
-        buffer.write(string: "1234")
+        buffer.writeString("1234")
 
         try withPendingDatagramWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<3).map { (_: Int) in el.makePromise() }
@@ -581,7 +581,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         let alloc = ByteBufferAllocator()
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 80)
         var buffer = alloc.buffer(capacity: 12)
-        buffer.write(string: "1234")
+        buffer.writeString("1234")
 
         try withPendingDatagramWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0...Socket.writevLimitIOVectors).map { (_: Int) in el.makePromise() }

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -317,7 +317,7 @@ class SelectorTest: XCTestCase {
 
             func channelActive(ctx: ChannelHandlerContext) {
                 var buf = ctx.channel.allocator.buffer(capacity: 1)
-                buf.write(string: "H")
+                buf.writeString("H")
                 ctx.channel.writeAndFlush(buf, promise: nil)
                 self.number += 1
                 self.allServerChannels.value.append(ctx.channel)

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -316,7 +316,7 @@ public class SocketChannelTest : XCTestCase {
         // close the channel. This should trigger an error callback that will
         // re-close the channel, which should fail with `alreadyClosed`.
         var buffer = clientChannel.allocator.buffer(capacity: 12)
-        buffer.write(staticString: "hello")
+        buffer.writeStaticString("hello")
         let writeFut = clientChannel.write(buffer).map {
             XCTFail("Must not succeed")
         }.flatMapError { error in

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -131,7 +131,7 @@ final class ByteCountingHandler : ChannelInboundHandler, RemovableChannelHandler
 
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         var currentBuffer = self.unwrapInboundIn(data)
-        buffer.write(buffer: &currentBuffer)
+        buffer.writeBuffer(&currentBuffer)
 
         if buffer.readableBytes == numBytes {
             promise.succeed(buffer)

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -21,7 +21,7 @@ extension EmbeddedChannel {
     func readAllInboundBuffers() -> ByteBuffer {
         var buffer = self.allocator.buffer(capacity: 100)
         while var writtenData: ByteBuffer = self.readInbound() {
-            buffer.write(buffer: &writtenData)
+            buffer.writeBuffer(&writtenData)
         }
 
         return buffer
@@ -46,7 +46,7 @@ extension ByteBuffer {
 extension EmbeddedChannel {
     func writeString(_ string: String) -> EventLoopFuture<Void> {
         var buffer = self.allocator.buffer(capacity: string.utf8.count)
-        buffer.write(string: string)
+        buffer.writeString(string)
         return self.writeAndFlush(buffer)
     }
 }
@@ -181,7 +181,7 @@ class EndToEndTests: XCTestCase {
 
         let upgradeRequest = self.upgradeRequest(extraHeaders: ["Sec-WebSocket-Version": "13", "Sec-WebSocket-Key": "AQIDBAUGBwgJCgsMDQ4PEC=="])
         var buffer = server.allocator.buffer(capacity: upgradeRequest.utf8.count)
-        buffer.write(string: upgradeRequest)
+        buffer.writeString(upgradeRequest)
 
         // Write this directly to the server.
         do {
@@ -209,7 +209,7 @@ class EndToEndTests: XCTestCase {
 
         let upgradeRequest = self.upgradeRequest(extraHeaders: ["Sec-WebSocket-Version": "12", "Sec-WebSocket-Key": "AQIDBAUGBwgJCgsMDQ4PEC=="])
         var buffer = server.allocator.buffer(capacity: upgradeRequest.utf8.count)
-        buffer.write(string: upgradeRequest)
+        buffer.writeString(upgradeRequest)
 
         // Write this directly to the server.
         do {
@@ -237,7 +237,7 @@ class EndToEndTests: XCTestCase {
 
         let upgradeRequest = self.upgradeRequest(extraHeaders: ["Sec-WebSocket-Key": "AQIDBAUGBwgJCgsMDQ4PEC=="])
         var buffer = server.allocator.buffer(capacity: upgradeRequest.utf8.count)
-        buffer.write(string: upgradeRequest)
+        buffer.writeString(upgradeRequest)
 
         // Write this directly to the server.
         do {
@@ -265,7 +265,7 @@ class EndToEndTests: XCTestCase {
 
         let upgradeRequest = self.upgradeRequest(extraHeaders: ["Sec-WebSocket-Version": "13"])
         var buffer = server.allocator.buffer(capacity: upgradeRequest.utf8.count)
-        buffer.write(string: upgradeRequest)
+        buffer.writeString(upgradeRequest)
 
         // Write this directly to the server.
         do {
@@ -363,7 +363,7 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try client.pipeline.add(handler: WebSocketFrameEncoder()).wait())
 
         var data = client.allocator.buffer(capacity: 12)
-        data.write(string: "hello, world")
+        data.writeString("hello, world")
 
         // Let's send a frame or two, to confirm that this works.
         let dataFrame = WebSocketFrame(fin: true, opcode: .binary, data: data)
@@ -426,7 +426,7 @@ class EndToEndTests: XCTestCase {
 
         // Send a fake frame header that claims this is a ping frame with 126 bytes of data.
         var data = client.allocator.buffer(capacity: 12)
-        data.write(bytes: [0x89, 0x7E, 0x00, 0x7E])
+        data.writeBytes([0x89, 0x7E, 0x00, 0x7E])
         XCTAssertNoThrow(try client.writeAndFlush(data).wait())
 
         do {
@@ -472,7 +472,7 @@ class EndToEndTests: XCTestCase {
 
         // Send a fake frame header that claims this is a ping frame with 126 bytes of data.
         var data = client.allocator.buffer(capacity: 12)
-        data.write(bytes: [0x89, 0x7E, 0x00, 0x7E])
+        data.writeBytes([0x89, 0x7E, 0x00, 0x7E])
         XCTAssertNoThrow(try client.writeAndFlush(data).wait())
 
         do {

--- a/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
@@ -123,7 +123,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
 
     public func testFramesWithExtensionDataDontRoundTrip() throws {
         // We don't know what the extensions are, so all data goes in...well...data.
-        self.buffer.write(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        self.buffer.writeBytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         let frame = WebSocketFrame(fin: false,
                                    opcode: .binary,
                                    data: self.buffer.getSlice(at: self.buffer.readerIndex, length: 5)!,
@@ -132,7 +132,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
     }
 
     public func testFramesWithExtensionDataCanBeRecovered() throws {
-        self.buffer.write(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        self.buffer.writeBytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         let frame = WebSocketFrame(fin: false,
                                    opcode: .binary,
                                    data: self.buffer.getSlice(at: self.buffer.readerIndex, length: 5)!,
@@ -144,7 +144,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
     }
 
     public func testFramesWithReservedBitsSetRoundTrip() throws {
-        self.buffer.write(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        self.buffer.writeBytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         let frame = WebSocketFrame(fin: false,
                                    rsv1: true,
                                    rsv2: true,
@@ -155,7 +155,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
     }
 
     public func testFramesWith16BitLengthsRoundTrip() throws {
-        self.buffer.write(bytes: Array(repeating: UInt8(4), count: 300))
+        self.buffer.writeBytes(Array(repeating: UInt8(4), count: 300))
         let frame = WebSocketFrame(fin: true,
                                    opcode: .binary,
                                    data: self.buffer)
@@ -168,7 +168,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         self.decoderChannel = EmbeddedChannel()
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: ByteToMessageHandler(WebSocketFrameDecoder(maxFrameSize: 80000))).wait())
 
-        self.buffer.write(bytes: Array(repeating: UInt8(4), count: 66000))
+        self.buffer.writeBytes(Array(repeating: UInt8(4), count: 66000))
         let frame = WebSocketFrame(fin: true,
                                    opcode: .binary,
                                    data: self.buffer)
@@ -176,7 +176,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
     }
 
     public func testMaskedFramesRoundTripWithMaskingIntact() throws {
-        self.buffer.write(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        self.buffer.writeBytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         let frame = WebSocketFrame(fin: false,
                                    opcode: .binary,
                                    maskKey: [0x80, 0x77, 0x11, 0x33],
@@ -199,7 +199,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
     }
 
     public func testMaskedFramesRoundTripWithMaskingIntactEvenWithExtensions() throws {
-        self.buffer.write(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        self.buffer.writeBytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         let frame = WebSocketFrame(fin: false,
                                    opcode: .binary,
                                    maskKey: [0x80, 0x77, 0x11, 0x33],
@@ -232,7 +232,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
 
         // A fake frame header that claims that the length of the frame is 16385 bytes,
         // larger than the frame max.
-        self.buffer.write(bytes: [0x81, 0xFE, 0x40, 0x01])
+        self.buffer.writeBytes([0x81, 0xFE, 0x40, 0x01])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -252,7 +252,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: WebSocketFrameEncoder(), first: true).wait())
 
         // A fake frame header that claims this is a fragmented ping frame.
-        self.buffer.write(bytes: [0x09, 0x00])
+        self.buffer.writeBytes([0x09, 0x00])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -272,7 +272,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: WebSocketFrameEncoder(), first: true).wait())
 
         // A fake frame header that claims this is a ping frame with 126 bytes of data.
-        self.buffer.write(bytes: [0x89, 0x7E, 0x00, 0x7E])
+        self.buffer.writeBytes([0x89, 0x7E, 0x00, 0x7E])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -294,7 +294,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: swallower, first: true).wait())
 
         // A fake frame header that claims this is a fragmented ping frame.
-        self.buffer.write(bytes: [0x09, 0x00])
+        self.buffer.writeBytes([0x09, 0x00])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -312,7 +312,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         // Now write another broken frame, this time an overlong frame.
         // No error should occur here.
         self.buffer.clear()
-        self.buffer.write(bytes: [0x81, 0xFE, 0x40, 0x01])
+        self.buffer.writeBytes([0x81, 0xFE, 0x40, 0x01])
         XCTAssertNoThrow(try self.decoderChannel.writeInbound(self.buffer))
 
         // No extra data should have been sent.
@@ -338,7 +338,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         self.encoderChannel.write(frame, promise: nil)
         var frameBuffer = self.decoderChannel.allocator.buffer(capacity: 10)
         while var d = self.encoderChannel.readOutbound(as: ByteBuffer.self) {
-            frameBuffer.write(buffer: &d)
+            frameBuffer.writeBuffer(&d)
         }
         XCTAssertNoThrow(try self.decoderChannel.writeInbound(frameBuffer))
 
@@ -355,7 +355,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
 
         // A fake frame header that claims that the length of the frame is 16385 bytes,
         // larger than the frame max.
-        self.buffer.write(bytes: [0x81, 0xFE, 0x40, 0x01])
+        self.buffer.writeBytes([0x81, 0xFE, 0x40, 0x01])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -378,7 +378,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: WebSocketFrameEncoder(), first: true).wait())
 
         // A fake frame header that claims this is a fragmented ping frame.
-        self.buffer.write(bytes: [0x09, 0x00])
+        self.buffer.writeBytes([0x09, 0x00])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -401,7 +401,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: WebSocketFrameEncoder(), first: true).wait())
 
         // A fake frame header that claims this is a ping frame with 126 bytes of data.
-        self.buffer.write(bytes: [0x89, 0x7E, 0x00, 0x7E])
+        self.buffer.writeBytes([0x89, 0x7E, 0x00, 0x7E])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -424,7 +424,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: WebSocketFrameEncoder(), first: true).wait())
 
         // A fake frame header that claims this is a fragmented ping frame.
-        self.buffer.write(bytes: [0x09, 0x00])
+        self.buffer.writeBytes([0x09, 0x00])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -442,7 +442,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         // Now write another broken frame, this time an overlong frame.
         // No error should occur here.
         self.buffer.clear()
-        self.buffer.write(bytes: [0x81, 0xFE, 0x40, 0x01])
+        self.buffer.writeBytes([0x81, 0xFE, 0x40, 0x01])
         XCTAssertNoThrow(try self.decoderChannel.writeInbound(self.buffer))
 
         // No extra data should have been sent.
@@ -458,7 +458,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
 
         // A fake frame header that claims that the length of the frame is 16385 bytes,
         // larger than the frame max.
-        self.buffer.write(bytes: [0x81, 0xFE, 0x40, 0x01])
+        self.buffer.writeBytes([0x81, 0xFE, 0x40, 0x01])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -482,7 +482,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: WebSocketProtocolErrorHandler()).wait())
 
         // A fake frame header that claims this is a fragmented ping frame.
-        self.buffer.write(bytes: [0x09, 0x00])
+        self.buffer.writeBytes([0x09, 0x00])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -506,7 +506,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: WebSocketProtocolErrorHandler()).wait())
 
         // A fake frame header that claims this is a ping frame with 126 bytes of data.
-        self.buffer.write(bytes: [0x89, 0x7E, 0x00, 0x7E])
+        self.buffer.writeBytes([0x89, 0x7E, 0x00, 0x7E])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -532,7 +532,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         XCTAssertNoThrow(try self.decoderChannel.pipeline.add(handler: swallower, first: true).wait())
 
         // A fake frame header that claims this is a fragmented ping frame.
-        self.buffer.write(bytes: [0x09, 0x00])
+        self.buffer.writeBytes([0x09, 0x00])
 
         do {
             try self.decoderChannel.writeInbound(self.buffer)
@@ -550,7 +550,7 @@ public class WebSocketFrameDecoderTest: XCTestCase {
         // Now write another broken frame, this time an overlong frame.
         // No error should occur here.
         self.buffer.clear()
-        self.buffer.write(bytes: [0x81, 0xFE, 0x40, 0x01])
+        self.buffer.writeBytes([0x81, 0xFE, 0x40, 0x01])
         XCTAssertNoThrow(try self.decoderChannel.writeInbound(self.buffer))
 
         // No extra data should have been sent.

--- a/Tests/NIOWebSocketTests/WebSocketFrameEncoderTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameEncoderTest.swift
@@ -20,7 +20,7 @@ extension EmbeddedChannel {
     func readAllOutboundBuffers() -> ByteBuffer {
         var buffer = self.allocator.buffer(capacity: 100)
         while var writtenData = self.readOutbound(as: ByteBuffer.self) {
-            buffer.write(buffer: &writtenData)
+            buffer.writeBuffer(&writtenData)
         }
 
         return buffer
@@ -56,7 +56,7 @@ public class WebSocketFrameEncoderTest: XCTestCase {
 
     func testBasicFrameEncoding() throws {
         let dataString = "hello, world!"
-        self.buffer.write(string: "hello, world!")
+        self.buffer.writeString("hello, world!")
         let frame = WebSocketFrame(fin: true, opcode: .binary, data: self.buffer)
         let expectedBytes = [0x82, UInt8(dataString.count)] + Array(dataString.utf8)
         assertFrameEncodes(frame: frame, expectedBytes: expectedBytes)
@@ -64,7 +64,7 @@ public class WebSocketFrameEncoderTest: XCTestCase {
 
     func test16BitFrameLength() throws {
         let dataBytes = Array(repeating: UInt8(4), count: 1000)
-        self.buffer.write(bytes: dataBytes)
+        self.buffer.writeBytes(dataBytes)
         let frame = WebSocketFrame(fin: true, opcode: .text, data: self.buffer)
         let expectedBytes = [0x81, UInt8(126), UInt8(0x03), UInt8(0xE8)] + dataBytes
         assertFrameEncodes(frame: frame, expectedBytes: expectedBytes)
@@ -72,7 +72,7 @@ public class WebSocketFrameEncoderTest: XCTestCase {
 
     func test64BitFrameLength() throws {
         let dataBytes = Array(repeating: UInt8(4), count: 65536)
-        self.buffer.write(bytes: dataBytes)
+        self.buffer.writeBytes(dataBytes)
 
         let frame = WebSocketFrame(fin: true, opcode: .binary, data: self.buffer)
         self.channel.writeAndFlush(frame, promise: nil)
@@ -94,7 +94,7 @@ public class WebSocketFrameEncoderTest: XCTestCase {
 
     func testEncodesExtensionDataCorrectly() throws {
         let dataBytes: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        self.buffer.write(bytes: dataBytes)
+        self.buffer.writeBytes(dataBytes)
 
         let frame = WebSocketFrame(fin: false,
                                    opcode: .text,
@@ -107,7 +107,7 @@ public class WebSocketFrameEncoderTest: XCTestCase {
     func testMasksDataCorrectly() throws {
         let dataBytes: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         let maskKey: WebSocketMaskingKey = [0x80, 0x08, 0x10, 0x01]
-        self.buffer.write(bytes: dataBytes)
+        self.buffer.writeBytes(dataBytes)
 
         let frame = WebSocketFrame(fin: true,
                                    opcode: .binary,

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -25,7 +25,7 @@
 - `markedElementIndex()`, `markedElement()` and `hasMark()` are now computed variables instead of functions.
 - `ByteBuffer.set(string:at:)` no longer returns an `Int?`, instead it
   returns `Int` and has had its return value made discardable.
-- `ByteBuffer.write(string:)` no longer returns an `Int?`, instead it
+- `ByteBuffer.write(string:)` (now named `ByteBuffer.writeString(_:)`) no longer returns an `Int?`, instead it
   returns `Int` and has had its return value made discardable.
 - removed ContiguousCollection
 - CircularBuffer(initialRingCapacity:) is now CircularBuffer(initialCapacity:)
@@ -43,4 +43,6 @@
 - `EventLoopFuture.cascade(promise: EventLoopPromise)` had its label changed to `EventLoopFuture.cascade(to: EventLoopPromise)`
 - `EventLoopFuture.cascadeFailure(promise: EventLoopPromise)` had its label changed to `EventLoopFuture.cascade(to: EventLoopPromise)`
 - renamed `EventLoopFuture.andAll(_:eventLoop:)` to `EventLoopFuture.andAllSucceed(_:on:)`
-- all ChannelPipeline.remove(...) now return `EventLoopFuture<Void>` instead of `EventLoopFuture<Bool>`
+- all `ChannelPipeline.remove(...)` now return `EventLoopFuture<Void>` instead of `EventLoopFuture<Bool>`
+- `ByteBuffer.set(<type>, ...)` is now `ByteBuffer.set<Type>`
+- `ByteBuffer.write(<type>, ...)` is now `ByteBuffer.write<Type>`


### PR DESCRIPTION
Motivation:

ByteBuffer methods like `set(string:)` never felt very Swift-like and
also didn't look the same as their counterparts like `getString(...)`.

Modifications:

- rename all `ByteBuffer.set/write(<type>:,...)` methods to
  `ByteBuffer.set/write<Type>(...)`
- polyfill the old spellings in `_NIO1APIShims`

Result:

code more Swift-like