### PR TITLE
make all removals go through the RemovableChannelHandler API

### DIFF
--- a/Sources/NIO/ChannelHandlers.swift
+++ b/Sources/NIO/ChannelHandlers.swift
@@ -18,7 +18,7 @@
 
 /// A `ChannelHandler` that implements a backoff for a `ServerChannel` when accept produces an `IOError`.
 /// These errors are often recoverable by reducing the rate at which we call accept.
-public final class AcceptBackoffHandler: ChannelDuplexHandler {
+public final class AcceptBackoffHandler: ChannelDuplexHandler, RemovableChannelHandler {
     public typealias InboundIn = Channel
     public typealias OutboundIn = Channel
 
@@ -107,7 +107,7 @@ public final class AcceptBackoffHandler: ChannelDuplexHandler {
  ChannelHandler implementation which enforces back-pressure by stopping to read from the remote peer when it cannot write back fast enough.
  It will start reading again once pending data was written.
 */
-public class BackPressureHandler: ChannelDuplexHandler {
+public class BackPressureHandler: ChannelDuplexHandler, RemovableChannelHandler {
     public typealias OutboundIn = NIOAny
     public typealias InboundIn = ByteBuffer
     public typealias InboundOut = ByteBuffer
@@ -151,7 +151,7 @@ public class BackPressureHandler: ChannelDuplexHandler {
 }
 
 /// Triggers an IdleStateEvent when a Channel has not performed read, write, or both operation for a while.
-public class IdleStateHandler: ChannelDuplexHandler {
+public class IdleStateHandler: ChannelDuplexHandler, RemovableChannelHandler {
     public typealias InboundIn = NIOAny
     public typealias InboundOut = NIOAny
     public typealias OutboundIn = NIOAny

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -165,7 +165,7 @@ public final class HTTPRequestDecoder: HTTPDecoder<HTTPServerRequestPart>, Remov
 /// were for accurate decoding.
 ///
 /// Rather than set this up manually, consider using `ChannelPipeline.addHTTPClientHandlers`.
-public final class HTTPResponseDecoder: HTTPDecoder<HTTPClientResponsePart>, ChannelOutboundHandler {
+public final class HTTPResponseDecoder: HTTPDecoder<HTTPClientResponsePart>, ChannelOutboundHandler, RemovableChannelHandler {
     public typealias OutboundIn = HTTPClientRequestPart
     public typealias OutboundOut = HTTPClientRequestPart
 

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -329,7 +329,7 @@ class HTTPDecoderTest: XCTestCase {
             }
         }
         
-        class Reciever: ChannelInboundHandler, RemovableChannelHandler {
+        class Receiver: ChannelInboundHandler, RemovableChannelHandler {
             typealias InboundIn = HTTPClientResponsePart
             typealias InboundOut = HTTPClientResponsePart
             typealias OutboundOut = HTTPClientRequestPart
@@ -359,7 +359,7 @@ class HTTPDecoderTest: XCTestCase {
         }
         
         XCTAssertNoThrow(try channel.pipeline.add(name: "decoder", handler: HTTPResponseDecoder(leftOverBytesStrategy: .forwardBytes)).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: Reciever()).wait())
+        XCTAssertNoThrow(try channel.pipeline.add(handler: Receiver()).wait())
         
         XCTAssertNoThrow(try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 8888)).wait())
         

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -53,6 +53,8 @@ extension ChannelPipelineTest {
                 ("testRemovingByReferenceWithFutureNotInChannel", testRemovingByReferenceWithFutureNotInChannel),
                 ("testFireChannelReadInInactiveChannelDoesNotCrash", testFireChannelReadInInactiveChannelDoesNotCrash),
                 ("testTeardownDuringFormalRemovalProcess", testTeardownDuringFormalRemovalProcess),
+                ("testVariousChannelRemovalAPIsGoThroughRemovableChannelHandler", testVariousChannelRemovalAPIsGoThroughRemovableChannelHandler),
+                ("testNonRemovableChannelHandlerIsNotRemovable", testNonRemovableChannelHandlerIsNotRemovable),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Some of the ChannelPipeline removal methods did not go through the
RemovableChannelHandler API.

Modifications:

- make all removal APIs go through the RemovableChannelHandler API
- make `IdleStateHandler`, `BackpressureHandler`, and `AcceptBackoffHandler` all `RemovableChannelHandler`s because they don't buffer anything

Result:

fewer bugs
