### PR TITLE
ChannelPipeline: addHandler and removeHandler instead of add/remove

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -221,7 +221,7 @@ public func swiftMain() -> Int {
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true,
                                                              withErrorHandling: false).flatMap {
-                    channel.pipeline.add(handler: SimpleHTTPServer())
+                    channel.pipeline.addHandler(SimpleHTTPServer())
                 }
             }.bind(host: "127.0.0.1", port: 0).wait()
 
@@ -235,7 +235,7 @@ public func swiftMain() -> Int {
         let clientChannel = try ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers().flatMap {
-                    channel.pipeline.add(handler: repeatedRequestsHandler)
+                    channel.pipeline.addHandler(repeatedRequestsHandler)
                 }
             }
             .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
@@ -253,7 +253,7 @@ public func swiftMain() -> Int {
             .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .childChannelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: PongHandler())
+                channel.pipeline.addHandler(PongHandler())
             }.bind(host: "127.0.0.1", port: 0).wait()
 
         defer {
@@ -263,7 +263,7 @@ public func swiftMain() -> Int {
         let pingHandler = PingHandler(numberOfRequests: numberOfRequests, eventLoop: group.next())
         _ = try ClientBootstrap(group: group)
             .channelInitializer { channel in
-                channel.pipeline.add(handler: pingHandler)
+                channel.pipeline.addHandler(pingHandler)
             }
             .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .channelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -29,10 +29,10 @@
 ///         // Set the handlers that are applied to the accepted child `Channel`s.
 ///         .childChannelInitializer { channel in
 ///             // Ensure we don't read faster then we can write by adding the BackPressureHandler into the pipeline.
-///             channel.pipeline.add(handler: BackPressureHandler()).flatMap { () in
+///             channel.pipeline.addHandler(BackPressureHandler()).flatMap { () in
 ///                 // make sure to instantiate your `ChannelHandlers` inside of
 ///                 // the closure as it will be invoked once per connection.
-///                 channel.pipeline.add(handler: MyChannelHandler())
+///                 channel.pipeline.addHandler(MyChannelHandler())
 ///             }
 ///         }
 ///
@@ -219,7 +219,7 @@ public final class ServerBootstrap {
 
         return eventLoop.submit {
             return serverChannelInit(serverChannel).flatMap {
-                serverChannel.pipeline.add(handler: AcceptHandler(childChannelInitializer: childChannelInit,
+                serverChannel.pipeline.addHandler(AcceptHandler(childChannelInitializer: childChannelInit,
                                                                   childChannelOptions: childChannelOptions))
             }.flatMap {
                 serverChannelOptions.applyAll(channel: serverChannel)
@@ -339,7 +339,7 @@ private extension Channel {
 ///             // always instantiate the handler _within_ the closure as
 ///             // it may be called multiple times (for example if the hostname
 ///             // resolves to both IPv4 and IPv6 addresses, cf. Happy Eyeballs).
-///             channel.pipeline.add(handler: MyChannelHandler())
+///             channel.pipeline.addHandler(MyChannelHandler())
 ///         }
 ///     try! bootstrap.connect(host: "example.org", port: 12345).wait()
 ///     /* the Channel is now connected */
@@ -549,7 +549,7 @@ public final class ClientBootstrap {
 ///         // Enable SO_REUSEADDR.
 ///         .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
 ///         .channelInitializer { channel in
-///             channel.pipeline.add(handler: MyChannelHandler())
+///             channel.pipeline.addHandler(MyChannelHandler())
 ///         }
 ///     let channel = try! bootstrap.bind(host: "127.0.0.1", port: 53).wait()
 ///     /* the Channel is now ready to send/receive datagrams */

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -378,7 +378,7 @@ public class EmbeddedChannel: Channel {
 
         if let handler = handler {
             // This will be propagated via fireErrorCaught
-            _ = try? _pipeline.add(handler: handler).wait()
+            _ = try? _pipeline.addHandler(handler).wait()
         }
 
         // This will never throw...

--- a/Sources/NIOChatClient/main.swift
+++ b/Sources/NIOChatClient/main.swift
@@ -46,7 +46,7 @@ let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
     .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
     .channelInitializer { channel in
-        channel.pipeline.add(handler: ChatHandler())
+        channel.pipeline.addHandler(ChatHandler())
     }
 defer {
     try! group.syncShutdownGracefully()

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -122,9 +122,9 @@ let bootstrap = ServerBootstrap(group: group)
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
         // Add handler that will buffer data until a \n is received
-        channel.pipeline.add(handler: ByteToMessageHandler(LineDelimiterCodec())).flatMap { v in
+        channel.pipeline.addHandler(ByteToMessageHandler(LineDelimiterCodec())).flatMap { v in
             // It's important we use the same handler for all accepted channels. The ChatHandler is thread-safe!
-            channel.pipeline.add(handler: chatHandler)
+            channel.pipeline.addHandler(chatHandler)
         }
     }
 

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -61,7 +61,7 @@ let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
     .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
     .channelInitializer { channel in
-        channel.pipeline.add(handler: EchoHandler())
+        channel.pipeline.addHandler(EchoHandler())
     }
 defer {
     try! group.syncShutdownGracefully()

--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -45,8 +45,8 @@ let bootstrap = ServerBootstrap(group: group)
     // Set the handlers that are appled to the accepted Channels
     .childChannelInitializer { channel in
         // Ensure we don't read faster than we can write by adding the BackPressureHandler into the pipeline.
-        channel.pipeline.add(handler: BackPressureHandler()).flatMap { v in
-            channel.pipeline.add(handler: EchoHandler())
+        channel.pipeline.addHandler(BackPressureHandler()).flatMap { v in
+            channel.pipeline.addHandler(EchoHandler())
         }
     }
 

--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -24,12 +24,12 @@ extension ChannelPipeline {
     /// Configure a `ChannelPipeline` for use as a HTTP client.
     ///
     /// - parameters:
-    ///     - first: Whether to add the HTTP client at the head of the channel pipeline,
-    ///              or at the tail.
+    ///     - position: The position in the `ChannelPipeline` where to add the HTTP client handlers. Defaults to `.last`.
     /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
-    public func addHTTPClientHandlers(first: Bool = false,
+    public func addHTTPClientHandlers(position: ChannelPipeline.Position = .last,
                                       leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes) -> EventLoopFuture<Void> {
-        return addHandlers(HTTPRequestEncoder(), HTTPResponseDecoder(leftOverBytesStrategy: leftOverBytesStrategy), first: first)
+        return addHandlers(HTTPRequestEncoder(), HTTPResponseDecoder(leftOverBytesStrategy: leftOverBytesStrategy),
+                           position: position)
     }
 
     /// Configure a `ChannelPipeline` for use as a HTTP server.
@@ -45,8 +45,7 @@ extension ChannelPipeline {
     /// features.
     ///
     /// - parameters:
-    ///     - first: Whether to add the HTTP server at the head of the channel pipeline,
-    ///         or at the tail.
+    ///     - position: Where in the pipeline to add the HTTP server handlers, defaults to `.last`.
     ///     - pipelining: Whether to provide assistance handling HTTP clients that pipeline
     ///         their requests. Defaults to `true`. If `false`, users will need to handle
     ///         clients that pipeline themselves.
@@ -58,7 +57,7 @@ extension ChannelPipeline {
     ///     - errorHandling: Whether to provide assistance handling protocol errors (e.g.
     ///         failure to parse the HTTP request) by sending 400 errors. Defaults to `true`.
     /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
-    public func configureHTTPServerPipeline(first: Bool = false,
+    public func configureHTTPServerPipeline(position: ChannelPipeline.Position = .last,
                                             withPipeliningAssistance pipelining: Bool = true,
                                             withServerUpgrade upgrade: HTTPUpgradeConfiguration? = nil,
                                             withErrorHandling errorHandling: Bool = true) -> EventLoopFuture<Void> {
@@ -83,7 +82,7 @@ extension ChannelPipeline {
             handlers.append(upgrader)
         }
 
-        return self.addHandlers(handlers, first: first)
+        return self.addHandlers(handlers, position: position)
     }
 }
 

--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -207,7 +207,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableChannelHa
                         ctx.fireChannelReadComplete()
                     }
                 }.whenComplete { (_: Result<Void, Error>) in
-                    ctx.pipeline.remove(ctx: ctx, promise: nil)
+                    ctx.pipeline.removeHandler(ctx: ctx, promise: nil)
                 }
             }
         }
@@ -226,7 +226,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableChannelHa
     private func notUpgrading(ctx: ChannelHandlerContext, data: NIOAny) {
         assert(self.receivedMessages.count == 0)
         ctx.fireChannelRead(data)
-        ctx.pipeline.remove(ctx: ctx, promise: nil)
+        ctx.pipeline.removeHandler(ctx: ctx, promise: nil)
     }
 
     /// Builds the initial mandatory HTTP headers for HTTP ugprade responses.
@@ -237,7 +237,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableChannelHa
     /// Removes the given channel handler from the channel pipeline.
     private func removeHandler(ctx: ChannelHandlerContext, handler: RemovableChannelHandler?) -> EventLoopFuture<Void> {
         if let handler = handler {
-            return ctx.pipeline.remove(handler: handler)
+            return ctx.pipeline.removeHandler(handler)
         } else {
             return ctx.eventLoop.makeSucceededFuture(())
         }
@@ -249,7 +249,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableChannelHa
             return ctx.eventLoop.makeSucceededFuture(())
         }
 
-        return .andAllSucceed(self.extraHTTPHandlers.map { ctx.pipeline.remove(handler: $0) },
+        return .andAllSucceed(self.extraHTTPHandlers.map { ctx.pipeline.removeHandler($0) },
                               on: ctx.eventLoop)
     }
 }

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -517,7 +517,7 @@ let bootstrap = ServerBootstrap(group: group)
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
         channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
-            channel.pipeline.add(handler: HTTPHandler(fileIO: fileIO, htdocsPath: htdocs))
+            channel.pipeline.addHandler(HTTPHandler(fileIO: fileIO, htdocsPath: htdocs))
         }
     }
 

--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -73,8 +73,8 @@ var datagramBootstrap = DatagramBootstrap(group: group)
     .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
     .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEPORT), value: 1)
     .channelInitializer { channel in
-        return channel.pipeline.add(handler: ChatMessageEncoder()).flatMap {
-            channel.pipeline.add(handler: ChatMessageDecoder())
+        return channel.pipeline.addHandler(ChatMessageEncoder()).flatMap {
+            channel.pipeline.addHandler(ChatMessageDecoder())
         }
     }
 

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -127,7 +127,7 @@ let serverChannel = try ServerBootstrap(group: group)
     .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     .childChannelInitializer { channel in
         channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true).flatMap {
-            channel.pipeline.add(handler: SimpleHTTPServer())
+            channel.pipeline.addHandler(SimpleHTTPServer())
         }
     }.bind(host: "127.0.0.1", port: 0).wait()
 
@@ -559,9 +559,9 @@ try measureAndPrint(desc: "no-net_http1_10k_reqs_1_conn") {
     }
     try channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true,
                                                      withErrorHandling: true).flatMap {
-        channel.pipeline.add(handler: SimpleHTTPServer())
+        channel.pipeline.addHandler(SimpleHTTPServer())
     }.flatMap {
-        channel.pipeline.add(handler: measuringHandler, first: true)
+        channel.pipeline.addHandler(measuringHandler, position: .first)
     }.wait()
 
     measuringHandler.kickOff(channel: channel)
@@ -581,7 +581,7 @@ measureAndPrint(desc: "http1_10k_reqs_1_conn") {
         .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
         .channelInitializer { channel in
             channel.pipeline.addHTTPClientHandlers().flatMap {
-                channel.pipeline.add(handler: repeatedRequestsHandler)
+                channel.pipeline.addHandler(repeatedRequestsHandler)
             }
         }
         .connect(to: serverChannel.localAddress!)
@@ -602,7 +602,7 @@ measureAndPrint(desc: "http1_10k_reqs_100_conns") {
         let clientChannel = try! ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers().flatMap {
-                    channel.pipeline.add(handler: repeatedRequestsHandler)
+                    channel.pipeline.addHandler(repeatedRequestsHandler)
                 }
             }
             .connect(to: serverChannel.localAddress!)

--- a/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
@@ -109,7 +109,7 @@ public class ApplicationProtocolNegotiationHandler: ChannelInboundHandler, Remov
         let switchFuture = completionHandler(result)
         switchFuture.whenComplete { (_: Result<Void, Error>) in
             self.unbuffer(context: context)
-            context.pipeline.remove(handler: self, promise: nil)
+            context.pipeline.removeHandler(self, promise: nil)
         }
     }
 

--- a/Sources/NIOTLS/SNIHandler.swift
+++ b/Sources/NIOTLS/SNIHandler.swift
@@ -421,7 +421,7 @@ public class SNIHandler: ByteToMessageDecoder {
     private func sniComplete(result: SNIResult, ctx: ChannelHandlerContext) {
         waitingForUser = true
         completionHandler(result).whenSuccess {
-            ctx.pipeline.remove(ctx: ctx, promise: nil)
+            ctx.pipeline.removeHandler(ctx: ctx, promise: nil)
         }
     }
 }

--- a/Sources/NIOWebSocket/WebSocketUpgrader.swift
+++ b/Sources/NIOWebSocket/WebSocketUpgrader.swift
@@ -147,12 +147,12 @@ public final class WebSocketUpgrader: HTTPServerProtocolUpgrader {
     public func upgrade(ctx: ChannelHandlerContext, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<Void> {
         /// We never use the automatic error handling feature of the WebSocketFrameDecoder: we always use the separate channel
         /// handler.
-        var upgradeFuture = ctx.pipeline.add(handler: WebSocketFrameEncoder()).flatMap {
-            ctx.pipeline.add(handler: ByteToMessageHandler(WebSocketFrameDecoder(maxFrameSize: self.maxFrameSize, automaticErrorHandling: false)))
+        var upgradeFuture = ctx.pipeline.addHandler(WebSocketFrameEncoder()).flatMap {
+            ctx.pipeline.addHandler(ByteToMessageHandler(WebSocketFrameDecoder(maxFrameSize: self.maxFrameSize, automaticErrorHandling: false)))
         }
 
         if self.automaticErrorHandling {
-            upgradeFuture = upgradeFuture.flatMap { ctx.pipeline.add(handler: WebSocketProtocolErrorHandler())}
+            upgradeFuture = upgradeFuture.flatMap { ctx.pipeline.addHandler(WebSocketProtocolErrorHandler())}
         }
 
         return upgradeFuture.flatMap {

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -204,7 +204,7 @@ let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
 let upgrader = WebSocketUpgrader(shouldUpgrade: { (head: HTTPRequestHead) in HTTPHeaders() },
                                  upgradePipelineHandler: { (channel: Channel, _: HTTPRequestHead) in
-                                    channel.pipeline.add(handler: WebSocketTimeHandler())
+                                    channel.pipeline.addHandler(WebSocketTimeHandler())
                                  })
 
 let bootstrap = ServerBootstrap(group: group)
@@ -218,11 +218,11 @@ let bootstrap = ServerBootstrap(group: group)
         let config: HTTPUpgradeConfiguration = (
                         upgraders: [ upgrader ],
                         completionHandler: { _ in
-                            channel.pipeline.remove(handler: httpHandler, promise: nil)
+                            channel.pipeline.removeHandler(httpHandler, promise: nil)
                         }
                     )
         return channel.pipeline.configureHTTPServerPipeline(withServerUpgrade: config).flatMap {
-            channel.pipeline.add(handler: httpHandler)
+            channel.pipeline.addHandler(httpHandler)
         }
     }
 

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -78,7 +78,57 @@ extension StaticString: Collection {
 extension ChannelPipeline {
     @available(*, deprecated, message: "please use ByteToMessageHandler(myByteToMessageDecoder)")
     public func add<Decoder: ByteToMessageDecoder>(handler decoder: Decoder) -> EventLoopFuture<Void> {
-        return self.add(handler: ByteToMessageHandler(decoder))
+        return self.addHandler(ByteToMessageHandler(decoder))
+    }
+
+    @available(*, deprecated, renamed: "addHandler(_:position:)")
+    public func add(handler: ChannelHandler, first: Bool = false) -> EventLoopFuture<Void> {
+        return self.addHandler(handler, position: first ? .first : .last)
+    }
+
+    @available(*, deprecated, renamed: "addHandler(_:name:position:)")
+    public func add(name: String, handler: ChannelHandler, first: Bool = false) -> EventLoopFuture<Void> {
+        return self.addHandler(handler, name: name, position: first ? .first : .last)
+    }
+
+    @available(*, deprecated, renamed: "addHandler(_:name:position:)")
+    public func add(name: String? = nil, handler: ChannelHandler, after: ChannelHandler) -> EventLoopFuture<Void> {
+        return self.addHandler(handler, name: name, position: .after(after))
+    }
+
+    @available(*, deprecated, renamed: "addHandler(_:name:position:)")
+    public func add(name: String? = nil, handler: ChannelHandler, before: ChannelHandler) -> EventLoopFuture<Void> {
+        return self.addHandler(handler, name: name, position: .before(before))
+    }
+
+    @available(*, deprecated, renamed: "removeHandler(_:)")
+    public func remove(handler: RemovableChannelHandler) -> EventLoopFuture<Void> {
+        return self.removeHandler(handler)
+    }
+
+    @available(*, deprecated, renamed: "removeHandler(name:)")
+    public func remove(name: String) -> EventLoopFuture<Void> {
+        return self.removeHandler(name: name)
+    }
+
+    @available(*, deprecated, renamed: "removeHandler(ctx:)")
+    public func remove(ctx: ChannelHandlerContext) -> EventLoopFuture<Void> {
+        return self.removeHandler(ctx: ctx)
+    }
+
+    @available(*, deprecated, renamed: "removeHandler(_:promise:)")
+    public func remove(handler: RemovableChannelHandler, promise: EventLoopPromise<Void>?) {
+        return self.removeHandler(handler, promise: promise)
+    }
+
+    @available(*, deprecated, renamed: "removeHandler(name:promise:)")
+    public func remove(name: String, promise: EventLoopPromise<Void>?) {
+        return self.removeHandler(name: name, promise: promise)
+    }
+
+    @available(*, deprecated, renamed: "removeHandler(ctx:promise:)")
+    public func remove(ctx: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
+        return self.removeHandler(ctx: ctx, promise: promise)
     }
 }
 

--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -125,11 +125,11 @@ class HTTPDecoderLengthTest: XCTestCase {
             }
         }
 
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseDecoder()).wait())
 
         let handler = ChannelInactiveHandler(eofMechanism)
-        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         // Prime the decoder with a GET and consume it.
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: version, method: .GET, uri: "/"))))
@@ -188,11 +188,11 @@ class HTTPDecoderLengthTest: XCTestCase {
     private func assertIgnoresLengthFields(requestMethod: HTTPMethod,
                                            responseStatus: HTTPResponseStatus,
                                            responseFramingField: FramingField) throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseDecoder()).wait())
 
         let handler = MessageEndHandler<HTTPResponseHead, ByteBuffer>()
-        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         // Prime the decoder with a request and consume it.
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
@@ -292,10 +292,10 @@ class HTTPDecoderLengthTest: XCTestCase {
     }
 
     private func assertRequestTransferEncodingHasNoBody(transferEncodingHeader: String) throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         let handler = MessageEndHandler<HTTPRequestHead, ByteBuffer>()
-        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         // Send a GET with the appropriate Transfer Encoding header.
         XCTAssertNoThrow(try channel.writeInbound(ByteBuffer(string: "POST / HTTP/1.1\r\nTransfer-Encoding: \(transferEncodingHeader)\r\n\r\n")))
@@ -327,11 +327,11 @@ class HTTPDecoderLengthTest: XCTestCase {
     }
 
     private func assertResponseTransferEncodingHasBodyTerminatedByEOF(transferEncodingHeader: String, eofMechanism: EOFMechanism) throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseDecoder()).wait())
 
         let handler = MessageEndHandler<HTTPResponseHead, ByteBuffer>()
-        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         // Prime the decoder with a request and consume it.
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
@@ -398,7 +398,7 @@ class HTTPDecoderLengthTest: XCTestCase {
     }
 
     func testRequestWithTEAndContentLengthErrors() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // Send a GET with the invalid headers.
         do {
@@ -416,8 +416,8 @@ class HTTPDecoderLengthTest: XCTestCase {
     }
 
     func testResponseWithTEAndContentLengthErrors() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseDecoder()).wait())
 
         // Prime the decoder with a request.
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
@@ -440,7 +440,7 @@ class HTTPDecoderLengthTest: XCTestCase {
     }
 
     private func assertRequestWithInvalidCLErrors(contentLengthField: String) throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // Send a GET with the invalid headers.
         do {
@@ -474,7 +474,7 @@ class HTTPDecoderLengthTest: XCTestCase {
     func testRequestWithIdenticalContentLengthRepeatedErrors() throws {
         // This is another case where http_parser is, if not wrong, then aggressively interpreting
         // the spec. Regardless, we match it.
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // Send two POSTs with repeated content length, one with one field and one with two.
         // Both should error.
@@ -495,7 +495,7 @@ class HTTPDecoderLengthTest: XCTestCase {
     func testRequestWithMultipleIdenticalContentLengthFieldsErrors() throws {
         // This is another case where http_parser is, if not wrong, then aggressively interpreting
         // the spec. Regardless, we match it.
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         do {
             try channel.writeInbound(ByteBuffer(string: "POST / HTTP/1.1\r\nContent-Length: 4\r\nContent-Length: 4\r\n\r\n"))
@@ -512,10 +512,10 @@ class HTTPDecoderLengthTest: XCTestCase {
     }
 
     func testRequestWithoutExplicitLengthIsZeroLength() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         let handler = MessageEndHandler<HTTPRequestHead, ByteBuffer>()
-        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         // Send a POST without a length field of any kind. This should be a zero-length request,
         // so .end should come immediately.

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -31,7 +31,7 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testDoesNotDecodeRealHTTP09Request() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // This is an invalid HTTP/0.9 simple request (too many CRLFs), but we need to
         // trigger https://github.com/nodejs/http-parser/issues/386 or http_parser won't
@@ -52,7 +52,7 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testDoesNotDecodeFakeHTTP09Request() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // This is a HTTP/1.1-formatted request that claims to be HTTP/0.9.
         var buffer = channel.allocator.buffer(capacity: 64)
@@ -71,7 +71,7 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testDoesNotDecodeHTTP2XRequest() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // This is a hypothetical HTTP/2.0 protocol request, assuming it is
         // byte for byte identical (which such a protocol would never be).
@@ -91,7 +91,7 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testToleratesHTTP13Request() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // We tolerate higher versions of HTTP/1 than we know about because RFC 7230
         // says that these should be treated like HTTP/1.1 by our users.
@@ -103,8 +103,8 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testDoesNotDecodeRealHTTP09Response() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseDecoder()).wait())
 
         // We need to prime the decoder by seeing a GET request.
         try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 0, minor: 9), method: .GET, uri: "/")))
@@ -127,8 +127,8 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testDoesNotDecodeFakeHTTP09Response() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseDecoder()).wait())
 
         // We need to prime the decoder by seeing a GET request.
         try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 0, minor: 9), method: .GET, uri: "/")))
@@ -150,8 +150,8 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testDoesNotDecodeHTTP2XResponse() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseDecoder()).wait())
 
         // We need to prime the decoder by seeing a GET request.
         try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 2, minor: 0), method: .GET, uri: "/")))
@@ -174,8 +174,8 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testToleratesHTTP13Response() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseDecoder()).wait())
 
         // We need to prime the decoder by seeing a GET request.
         try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 2, minor: 0), method: .GET, uri: "/")))
@@ -208,8 +208,8 @@ class HTTPDecoderTest: XCTestCase {
             }
         }
 
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: Receiver()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(Receiver()).wait())
 
         // This is a hypothetical HTTP/2.0 protocol response, assuming it is
         // byte for byte identical (which such a protocol would never be).
@@ -241,14 +241,14 @@ class HTTPDecoderTest: XCTestCase {
                 switch part {
                 case .end:
                     // ignore
-                    _ = ctx.pipeline.remove(name: "decoder")
+                    _ = ctx.pipeline.removeHandler(name: "decoder")
                 default:
                     break
                 }
             }
         }
-        XCTAssertNoThrow(try channel.pipeline.add(name: "decoder", handler: HTTPRequestDecoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: Receiver()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder(), name: "decoder").wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(Receiver()).wait())
 
         var buffer = channel.allocator.buffer(capacity: 64)
         buffer.writeStaticString("OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\nXXXX")
@@ -270,7 +270,7 @@ class HTTPDecoderTest: XCTestCase {
             }
 
             func handlerAdded(ctx: ChannelHandlerContext) {
-                _ = ctx.pipeline.remove(name: "decoder")
+                _ = ctx.pipeline.removeHandler(name: "decoder")
             }
 
             func handlerRemoved(ctx: ChannelHandlerContext) {
@@ -286,8 +286,8 @@ class HTTPDecoderTest: XCTestCase {
                 let part = self.unwrapInboundIn(data)
                 switch part {
                 case .end:
-                    _ = ctx.pipeline.remove(handler: self).flatMap { _ in
-                        ctx.pipeline.add(handler: self.collector)
+                    _ = ctx.pipeline.removeHandler(self).flatMap { _ in
+                        ctx.pipeline.addHandler(self.collector)
                     }
                 default:
                     // ignore
@@ -295,8 +295,9 @@ class HTTPDecoderTest: XCTestCase {
                 }
             }
         }
-        XCTAssertNoThrow(try channel.pipeline.add(name: "decoder", handler: HTTPRequestDecoder(leftOverBytesStrategy: .forwardBytes)).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: Receiver()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder(leftOverBytesStrategy: .forwardBytes),
+                                                         name: "decoder").wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(Receiver()).wait())
 
         // This connect call is semantically wrong, but it's how you active embedded channels properly right now.
         XCTAssertNoThrow(try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 8888)).wait())
@@ -321,7 +322,7 @@ class HTTPDecoderTest: XCTestCase {
             }
             
             func handlerAdded(ctx: ChannelHandlerContext) {
-                _ = ctx.pipeline.remove(name: "decoder")
+                _ = ctx.pipeline.removeHandler(name: "decoder")
             }
             
             func handlerRemoved(ctx: ChannelHandlerContext) {
@@ -347,8 +348,8 @@ class HTTPDecoderTest: XCTestCase {
                 let part = self.unwrapInboundIn(data)
                 switch part {
                 case .end:
-                    _ = ctx.pipeline.remove(handler: self).flatMap { _ in
-                        ctx.pipeline.add(handler: ByteCollector())
+                    _ = ctx.pipeline.removeHandler(self).flatMap { _ in
+                        ctx.pipeline.addHandler(ByteCollector())
                     }
                     break
                 default:
@@ -358,8 +359,9 @@ class HTTPDecoderTest: XCTestCase {
             }
         }
         
-        XCTAssertNoThrow(try channel.pipeline.add(name: "decoder", handler: HTTPResponseDecoder(leftOverBytesStrategy: .forwardBytes)).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: Receiver()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseDecoder(leftOverBytesStrategy: .forwardBytes),
+                                                         name: "decoder").wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(Receiver()).wait())
         
         XCTAssertNoThrow(try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 8888)).wait())
         
@@ -372,7 +374,7 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testExtraCRLF() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // This is a simple HTTP/1.1 request with a few too many CRLFs before it, to trigger
         // https://github.com/nodejs/http-parser/pull/432.
@@ -401,7 +403,7 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testSOURCEDoesntExplodeUs() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // This is a simple HTTP/1.1 request with the SOURCE verb which is newly added to
         // http_parser.
@@ -430,7 +432,7 @@ class HTTPDecoderTest: XCTestCase {
     }
 
     func testExtraCarriageReturnBetweenSubsequentRequests() throws {
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestDecoder()).wait())
 
         // This is a simple HTTP/1.1 request with an extra \r between first and second message, designed to hit the code
         // changed in https://github.com/nodejs/http-parser/pull/432 .

--- a/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
@@ -29,7 +29,7 @@ class HTTPRequestEncoderTests: XCTestCase {
             XCTAssertEqual(.some(false), try? channel.finish())
         }
 
-        try channel.pipeline.add(handler: HTTPRequestEncoder()).wait()
+        try channel.pipeline.addHandler(HTTPRequestEncoder()).wait()
         var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: method, uri: "/uri")
         request.headers = headers
         try channel.writeOutbound(HTTPClientRequestPart.head(request))
@@ -78,7 +78,7 @@ class HTTPRequestEncoderTests: XCTestCase {
             XCTAssertEqual(.some(false), try? channel.finish())
         }
 
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
 
         // This request contains neither Transfer-Encoding: chunked or Content-Length.
         let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:0), method: .GET, uri: "/uri")
@@ -94,7 +94,7 @@ class HTTPRequestEncoderTests: XCTestCase {
             XCTAssertEqual(.some(false), try? channel.finish())
         }
 
-        try channel.pipeline.add(handler: HTTPRequestEncoder()).wait()
+        try channel.pipeline.addHandler(HTTPRequestEncoder()).wait()
         var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .POST, uri: "/uri")
         request.headers.add(name: "content-length", value: "4")
 
@@ -117,7 +117,7 @@ class HTTPRequestEncoderTests: XCTestCase {
         }
 
         let uri = "server.example.com:80"
-        try channel.pipeline.add(handler: HTTPRequestEncoder()).wait()
+        try channel.pipeline.addHandler(HTTPRequestEncoder()).wait()
         var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .CONNECT, uri: uri)
         request.headers.add(name: "Host", value: uri)
 

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
@@ -333,8 +333,8 @@ class HTTPResponseCompressorTest: XCTestCase {
 
     private func compressionChannel() throws -> EmbeddedChannel {
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseCompressor()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseCompressor()).wait())
         return channel
     }
 

--- a/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
@@ -29,7 +29,7 @@ class HTTPResponseEncoderTests: XCTestCase {
             XCTAssertEqual(.some(false), try? channel.finish())
         }
 
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait())
         var switchingResponse = HTTPResponseHead(version: HTTPVersion(major: 1, minor:1), status: status)
         switchingResponse.headers = headers
         XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(switchingResponse)))
@@ -98,7 +98,7 @@ class HTTPResponseEncoderTests: XCTestCase {
             XCTAssertEqual(.some(false), try? channel.finish())
         }
 
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait())
 
         // This response contains neither Transfer-Encoding: chunked or Content-Length.
         let response = HTTPResponseHead(version: HTTPVersion(major: 1, minor:0), status: .ok)

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -338,7 +338,7 @@ class HTTPServerClientTest : XCTestCase {
             .childChannelInitializer { channel in
                 // Ensure we don't read faster then we can write by adding the BackPressureHandler into the pipeline.
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
-                    channel.pipeline.add(handler: httpHandler)
+                    channel.pipeline.addHandler(httpHandler)
                 }
             }.bind(host: "127.0.0.1", port: 0).wait())
 
@@ -349,7 +349,7 @@ class HTTPServerClientTest : XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers().flatMap {
-                    channel.pipeline.add(handler: accumulation)
+                    channel.pipeline.addHandler(accumulation)
                 }
             }
             .connect(to: serverChannel.localAddress!)
@@ -396,7 +396,7 @@ class HTTPServerClientTest : XCTestCase {
             .childChannelInitializer { channel in
                 // Ensure we don't read faster then we can write by adding the BackPressureHandler into the pipeline.
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
-                    channel.pipeline.add(handler: httpHandler)
+                    channel.pipeline.addHandler(httpHandler)
                 }
             }.bind(host: "127.0.0.1", port: 0).wait())
 
@@ -407,7 +407,7 @@ class HTTPServerClientTest : XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers().flatMap {
-                    channel.pipeline.add(handler: accumulation)
+                    channel.pipeline.addHandler(accumulation)
                 }
             }
             .connect(to: serverChannel.localAddress!)
@@ -454,7 +454,7 @@ class HTTPServerClientTest : XCTestCase {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
-                    channel.pipeline.add(handler: httpHandler)
+                    channel.pipeline.addHandler(httpHandler)
                 }
             }.bind(host: "127.0.0.1", port: 0).wait())
 
@@ -465,7 +465,7 @@ class HTTPServerClientTest : XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers().flatMap {
-                    channel.pipeline.add(handler: accumulation)
+                    channel.pipeline.addHandler(accumulation)
                 }
             }
             .connect(to: serverChannel.localAddress!)
@@ -513,7 +513,7 @@ class HTTPServerClientTest : XCTestCase {
             .childChannelInitializer { channel in
                 // Ensure we don't read faster then we can write by adding the BackPressureHandler into the pipeline.
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
-                    channel.pipeline.add(handler: httpHandler)
+                    channel.pipeline.addHandler(httpHandler)
                 }
             }.bind(host: "127.0.0.1", port: 0).wait())
         defer {
@@ -521,7 +521,7 @@ class HTTPServerClientTest : XCTestCase {
         }
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
-            .channelInitializer({ $0.pipeline.add(handler: accumulation) })
+            .channelInitializer({ $0.pipeline.addHandler(accumulation) })
             .connect(to: serverChannel.localAddress!)
             .wait())
         defer {
@@ -553,7 +553,7 @@ class HTTPServerClientTest : XCTestCase {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
-                    channel.pipeline.add(handler: httpHandler)
+                    channel.pipeline.addHandler(httpHandler)
                 }
             }.bind(host: "127.0.0.1", port: 0).wait())
         defer {
@@ -563,7 +563,7 @@ class HTTPServerClientTest : XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers().flatMap {
-                    channel.pipeline.add(handler: accumulation)
+                    channel.pipeline.addHandler(accumulation)
                 }
             }
             .connect(to: serverChannel.localAddress!)
@@ -598,7 +598,7 @@ class HTTPServerClientTest : XCTestCase {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
-                    channel.pipeline.add(handler: httpHandler)
+                    channel.pipeline.addHandler(httpHandler)
                 }
             }.bind(host: "127.0.0.1", port: 0).wait())
         defer {
@@ -608,7 +608,7 @@ class HTTPServerClientTest : XCTestCase {
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers().flatMap {
-                    channel.pipeline.add(handler: accumulation)
+                    channel.pipeline.addHandler(accumulation)
                 }
             }
             .connect(to: serverChannel.localAddress!)

--- a/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
@@ -96,11 +96,11 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         self.readRecorder = ReadRecorder()
         self.readCounter = ReadCountingHandler()
         self.writeRecorder = WriteRecorder()
-        XCTAssertNoThrow(try channel.pipeline.add(handler: self.readCounter).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseEncoder()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: self.writeRecorder).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPServerPipelineHandler()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: self.readRecorder).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(self.readCounter).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(self.writeRecorder).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPServerPipelineHandler()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(self.readRecorder).wait())
 
         self.requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: "/path")
         self.requestHead.headers.add(name: "Host", value: "example.com")
@@ -460,7 +460,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         }
 
         let handler = VerifyOrderHandler()
-        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         for f in 1...3 {
             XCTAssertNoThrow(try self.channel.writeInbound(HTTPServerRequestPart.head(makeRequestHead(uri: "/req_\(f)"))))
@@ -730,8 +730,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         }
 
         let handler = VerifyOrderHandler()
-        XCTAssertNoThrow(try self.channel.pipeline.add(handler: HTTPServerProtocolErrorHandler()).wait())
-        XCTAssertNoThrow(try self.channel.pipeline.add(handler: handler).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTPServerProtocolErrorHandler()).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(handler).wait())
 
         self.channel.pipeline.fireErrorCaught(HTTPParserError.headerOverflow)
 
@@ -790,8 +790,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         }
 
         let handler = VerifyOrderHandler()
-        XCTAssertNoThrow(try self.channel.pipeline.add(handler: HTTPServerProtocolErrorHandler()).wait())
-        XCTAssertNoThrow(try self.channel.pipeline.add(handler: handler).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTPServerProtocolErrorHandler()).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(handler).wait())
 
         XCTAssertNoThrow(try self.channel.writeInbound(HTTPServerRequestPart.head(makeRequestHead(uri: "/one"))))
         XCTAssertNoThrow(try self.channel.writeInbound(HTTPServerRequestPart.end(nil)))

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -114,7 +114,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         }
         let channel = EmbeddedChannel()
         XCTAssertNoThrow(try channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
-            channel.pipeline.add(handler: DelayWriteHandler())
+            channel.pipeline.addHandler(DelayWriteHandler())
         }.wait())
 
         var buffer = channel.allocator.buffer(capacity: 1024)

--- a/Tests/NIOHTTP1Tests/HTTPTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest.swift
@@ -78,10 +78,10 @@ class HTTPTest: XCTestCase {
             defer {
                 XCTAssertNoThrow(try channel.finish())
             }
-            try channel.pipeline.add(handler: HTTPRequestDecoder()).wait()
+            try channel.pipeline.addHandler(HTTPRequestDecoder()).wait()
             var bodyData: [UInt8]? = nil
             var allBodyDatas: [[UInt8]] = []
-            try channel.pipeline.add(handler: TestChannelInboundHandler { reqPart in
+            try channel.pipeline.addHandler(TestChannelInboundHandler { reqPart in
                 switch reqPart {
                 case .head(var req):
                     XCTAssertEqual((index * 2), step)

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -84,7 +84,7 @@ private func serverHTTPChannelWithAutoremoval(group: EventLoopGroup,
             p.succeed(channel)
             let upgradeConfig = (upgraders: upgraders, completionHandler: upgradeCompletionHandler)
             return channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: pipelining, withServerUpgrade: upgradeConfig).flatMap {
-                let futureResults = extraHandlers.map { channel.pipeline.add(handler: $0) }
+                let futureResults = extraHandlers.map { channel.pipeline.addHandler($0) }
                 return EventLoopFuture.andAllSucceed(futureResults, on: channel.eventLoop)
             }
         }.bind(host: "127.0.0.1", port: 0).wait()
@@ -354,7 +354,7 @@ class HTTPUpgradeTestCase: XCTestCase {
         }
         let data = HTTPServerRequestPart.body(ByteBuffer.forString("hello"))
 
-        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         do {
             try channel.writeInbound(data)
@@ -402,7 +402,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(())
         }
-        XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
 
         // This request is safe to upgrade.
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
@@ -507,7 +507,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(())
         }
-        XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
 
         // This request is safe to upgrade.
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto, exploder\r\nKafkaesque: yup\r\nConnection: upgrade, kafkaesque\r\n\r\n"
@@ -551,7 +551,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(())
         }
-        XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
 
         // This request is safe to upgrade.
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade,kafkaesque\r\n\r\n"
@@ -612,7 +612,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(())
         }
-        XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
 
         // This request is safe to upgrade.
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: noproto,myproto\r\nKafkaesque: yup\r\nConnection: upgrade, kafkaesque\r\n\r\n"
@@ -658,7 +658,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(())
         }
-        XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
 
         // This request is safe to upgrade.
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nWeirdcase: yup\r\nConnection: upgrade,weirdcase\r\n\r\n"
@@ -692,7 +692,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(())
         }
-        XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
 
         // This request is safe to upgrade.
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\n"
@@ -735,7 +735,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(())
         }
-        XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
 
         // This request is safe to upgrade, but is immediately followed by non-HTTP data that will probably
         // blow up the HTTP parser.
@@ -885,7 +885,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                                                                                         XCTAssertNil(upgradeRequest)
                                                                                         upgradeHandlerCbFired = true
                                                                                         
-                                                                                        _ = ctx.channel.pipeline.add(handler: CheckWeReadInlineAndExtraData(firstByteDonePromise: firstByteDonePromise,
+                                                                                        _ = ctx.channel.pipeline.addHandler(CheckWeReadInlineAndExtraData(firstByteDonePromise: firstByteDonePromise,
                                                                                                                                                             secondByteDonePromise: secondByteDonePromise,
                                                                                                                                                             allDonePromise: allDonePromise))
         }
@@ -901,7 +901,7 @@ class HTTPUpgradeTestCase: XCTestCase {
                              expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
             completePromise.succeed(())
         }
-        XCTAssertNoThrow(try client.pipeline.add(handler: clientHandler).wait())
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
         
         // This request is safe to upgrade.
         var request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"

--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
@@ -43,7 +43,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
             return loop.makeSucceededFuture(())
         }
 
-        try channel.pipeline.add(handler: handler).wait()
+        try channel.pipeline.addHandler(handler).wait()
 
         // Fire a pair of events that should be ignored.
         channel.pipeline.fireUserInboundEventTriggered(EventType.basic)
@@ -69,7 +69,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
             return continuePromise.futureResult
         }
 
-        try channel.pipeline.add(handler: handler).wait()
+        try channel.pipeline.addHandler(handler).wait()
 
         // Fire the handshake complete event.
         channel.pipeline.fireUserInboundEventTriggered(TLSUserEvent.handshakeCompleted(negotiatedProtocol: "h2"))
@@ -105,7 +105,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
             return loop.makeSucceededFuture(())
         }
 
-        try channel.pipeline.add(handler: handler).wait()
+        try channel.pipeline.addHandler(handler).wait()
 
         // The data we write should not be buffered.
         try channel.writeInbound("hello")
@@ -123,7 +123,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
             continuePromise.futureResult
         }
 
-        try channel.pipeline.add(handler: handler).wait()
+        try channel.pipeline.addHandler(handler).wait()
 
         // Fire in the event.
         channel.pipeline.fireUserInboundEventTriggered(TLSUserEvent.handshakeCompleted(negotiatedProtocol: "h2"))
@@ -155,8 +155,8 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         }
         let readCompleteHandler = ReadCompletedHandler()
 
-        try channel.pipeline.add(handler: handler).wait()
-        try channel.pipeline.add(handler: readCompleteHandler).wait()
+        try channel.pipeline.addHandler(handler).wait()
+        try channel.pipeline.addHandler(readCompleteHandler).wait()
 
         // Fire in the event.
         channel.pipeline.fireUserInboundEventTriggered(TLSUserEvent.handshakeCompleted(negotiatedProtocol: "h2"))
@@ -182,8 +182,8 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         }
         let readCompleteHandler = ReadCompletedHandler()
 
-        try channel.pipeline.add(handler: handler).wait()
-        try channel.pipeline.add(handler: readCompleteHandler).wait()
+        try channel.pipeline.addHandler(handler).wait()
+        try channel.pipeline.addHandler(readCompleteHandler).wait()
 
         // Fire in the event.
         channel.pipeline.fireUserInboundEventTriggered(TLSUserEvent.handshakeCompleted(negotiatedProtocol: "h2"))

--- a/Tests/NIOTLSTests/SNIHandlerTests.swift
+++ b/Tests/NIOTLSTests/SNIHandlerTests.swift
@@ -270,7 +270,7 @@ class SNIHandlerTest: XCTestCase {
             return continuePromise.futureResult
         })
 
-        try channel.pipeline.add(handler: handler).wait()
+        try channel.pipeline.addHandler(handler).wait()
 
         // The handler will run when the last byte of the extension data is sent.
         // We don't know when that is, so don't try to predict it. However,
@@ -321,7 +321,7 @@ class SNIHandlerTest: XCTestCase {
             return continuePromise.futureResult
         })
 
-        try channel.pipeline.add(handler: handler).wait()
+        try channel.pipeline.addHandler(handler).wait()
 
         // Ok, let's go.
         try channel.writeInbound(buffer)
@@ -361,7 +361,7 @@ class SNIHandlerTest: XCTestCase {
             return loop.makeSucceededFuture(())
         })
 
-        try channel.pipeline.add(handler: handler).wait()
+        try channel.pipeline.addHandler(handler).wait()
 
         // Ok, let's go.
         try channel.writeInbound(buffer)

--- a/Tests/NIOTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOTests/AcceptBackoffHandlerTest.swift
@@ -95,7 +95,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
             return readCountHandler.readCount
         }.wait())
 
-        XCTAssertNoThrow(try serverChannel.pipeline.remove(name: acceptHandlerName).wait())
+        XCTAssertNoThrow(try serverChannel.pipeline.removeHandler(name: acceptHandlerName).wait())
 
         if read {
             // Removal should have triggered a read.
@@ -174,7 +174,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
         }, errors: [ENFILE])
 
         let inactiveVerificationHandler = InactiveVerificationHandler(promise: serverChannel.eventLoop.makePromise())
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: inactiveVerificationHandler).wait())
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(inactiveVerificationHandler).wait())
 
         XCTAssertEqual(0, try serverChannel.eventLoop.submit {
             serverChannel.readable()
@@ -253,8 +253,9 @@ public class AcceptBackoffHandlerTest: XCTestCase {
                                                                            group: group))
 
         XCTAssertNoThrow(try serverChannel.setOption(ChannelOptions.autoRead, value: false).wait())
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: readCountHandler).flatMap { _ in
-            serverChannel.pipeline.add(name: self.acceptHandlerName, handler: AcceptBackoffHandler(backoffProvider: backoffProvider))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(readCountHandler).flatMap { _ in
+            serverChannel.pipeline.addHandler(AcceptBackoffHandler(backoffProvider: backoffProvider),
+                                              name: self.acceptHandlerName)
         }.wait())
 
         XCTAssertNoThrow(try eventLoop.submit {

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -296,17 +296,17 @@ class ChannelNotificationTest: XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .serverChannelInitializer { channel in
-                channel.pipeline.add(handler: ServerSocketChannelLifecycleVerificationHandler())
+                channel.pipeline.addHandler(ServerSocketChannelLifecycleVerificationHandler())
             }
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: AcceptedSocketChannelLifecycleVerificationHandler(acceptedChannelPromise))
+                channel.pipeline.addHandler(AcceptedSocketChannelLifecycleVerificationHandler(acceptedChannelPromise))
             }
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
-                channel.pipeline.add(handler: SocketChannelLifecycleVerificationHandler())
+                channel.pipeline.addHandler(SocketChannelLifecycleVerificationHandler())
             }
             .connect(to: serverChannel.localAddress!).wait())
         XCTAssertNoThrow(try clientChannel.close().wait())
@@ -379,7 +379,7 @@ class ChannelNotificationTest: XCTestCase {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: true)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: OrderVerificationHandler(promise))
+                channel.pipeline.addHandler(OrderVerificationHandler(promise))
             }
             .bind(host: "127.0.0.1", port: 0).wait())
 

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -55,6 +55,7 @@ extension ChannelPipelineTest {
                 ("testTeardownDuringFormalRemovalProcess", testTeardownDuringFormalRemovalProcess),
                 ("testVariousChannelRemovalAPIsGoThroughRemovableChannelHandler", testVariousChannelRemovalAPIsGoThroughRemovableChannelHandler),
                 ("testNonRemovableChannelHandlerIsNotRemovable", testNonRemovableChannelHandlerIsNotRemovable),
+                ("testAddMultipleHandlers", testAddMultipleHandlers),
            ]
    }
 }

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -90,7 +90,7 @@ final class DatagramChannelTests: XCTestCase {
         return try DatagramBootstrap(group: group)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .channelInitializer { channel in
-                channel.pipeline.add(name: "ByteReadRecorder", handler: DatagramReadRecorder<ByteBuffer>())
+                channel.pipeline.addHandler(DatagramReadRecorder<ByteBuffer>(), name: "ByteReadRecorder")
             }
             .bind(host: "127.0.0.1", port: 0)
             .wait()
@@ -405,7 +405,7 @@ final class DatagramChannelTests: XCTestCase {
         let channel = try DatagramChannel(socket: socket, eventLoop: group.next() as! SelectableEventLoop)
         let promise = channel.eventLoop.makePromise(of: IOError.self)
         XCTAssertNoThrow(try channel.register().wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: RecvFromHandler(promise)).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(RecvFromHandler(promise)).wait())
         XCTAssertNoThrow(try channel.bind(to: SocketAddress.init(ipAddress: "127.0.0.1", port: 0)).wait())
 
         XCTAssertEqual(active, try channel.eventLoop.submit {

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -30,7 +30,7 @@ class EchoServerClientTest : XCTestCase {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
 
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: countingHandler)
+                channel.pipeline.addHandler(countingHandler)
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -65,7 +65,7 @@ class EchoServerClientTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: WriteALotHandler())
+                channel.pipeline.addHandler(WriteALotHandler())
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -75,8 +75,8 @@ class EchoServerClientTest : XCTestCase {
         let promise = group.next().makePromise(of: ByteBuffer.self)
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
-                channel.pipeline.add(handler: WriteOnConnectHandler(toWrite: "X")).flatMap { v2 in
-                    channel.pipeline.add(handler: ByteCountingHandler(numBytes: 10000, promise: promise))
+                channel.pipeline.addHandler(WriteOnConnectHandler(toWrite: "X")).flatMap { v2 in
+                    channel.pipeline.addHandler(ByteCountingHandler(numBytes: 10000, promise: promise))
                 }
             }
             .connect(to: serverChannel.localAddress!).wait())
@@ -108,7 +108,7 @@ class EchoServerClientTest : XCTestCase {
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
                 // Ensure we don't read faster then we can write by adding the BackPressureHandler into the pipeline.
-                channel.pipeline.add(handler: countingHandler)
+                channel.pipeline.addHandler(countingHandler)
             }.bind(unixDomainSocketPath: udsTempDir + "/server.sock").wait())
 
         defer {
@@ -152,7 +152,7 @@ class EchoServerClientTest : XCTestCase {
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: countingHandler)
+                channel.pipeline.addHandler(countingHandler)
             }.bind(unixDomainSocketPath: udsTempDir + "/server.sock").wait())
 
         defer {
@@ -194,7 +194,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
-            .channelInitializer { $0.pipeline.add(handler: handler) }
+            .channelInitializer { $0.pipeline.addHandler(handler) }
             .connect(to: serverChannel.localAddress!).wait())
 
         defer {
@@ -213,7 +213,7 @@ class EchoServerClientTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: EchoServer())
+                channel.pipeline.addHandler(EchoServer())
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -223,7 +223,7 @@ class EchoServerClientTest : XCTestCase {
         let numBytes = 16 * 1024
         let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
-            .channelInitializer { $0.pipeline.add(handler: countingHandler) }
+            .channelInitializer { $0.pipeline.addHandler(countingHandler) }
             .connect(to: serverChannel.localAddress!).wait())
 
         defer {
@@ -410,7 +410,7 @@ class EchoServerClientTest : XCTestCase {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
 
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: handler)
+                channel.pipeline.addHandler(handler)
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -445,10 +445,10 @@ class EchoServerClientTest : XCTestCase {
             .childChannelInitializer { channel in
                 // When we've received all the bytes we know the connection is up. Remove the handler.
                 _ = bytesReceivedPromise.futureResult.flatMap { (_: ByteBuffer) in
-                    channel.pipeline.remove(handler: byteCountingHandler)
+                    channel.pipeline.removeHandler(byteCountingHandler)
                 }
 
-                return channel.pipeline.add(handler: byteCountingHandler)
+                return channel.pipeline.addHandler(byteCountingHandler)
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -487,7 +487,7 @@ class EchoServerClientTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: EchoServer())
+                channel.pipeline.addHandler(EchoServer())
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -498,8 +498,8 @@ class EchoServerClientTest : XCTestCase {
         let promise = group.next().makePromise(of: ByteBuffer.self)
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
-                channel.pipeline.add(handler: WriteOnConnectHandler(toWrite: stringToWrite)).flatMap {
-                    channel.pipeline.add(handler: ByteCountingHandler(numBytes: stringToWrite.utf8.count, promise: promise))
+                channel.pipeline.addHandler(WriteOnConnectHandler(toWrite: stringToWrite)).flatMap {
+                    channel.pipeline.addHandler(ByteCountingHandler(numBytes: stringToWrite.utf8.count, promise: promise))
                 }
             }
             .connect(to: serverChannel.localAddress!).wait())
@@ -521,7 +521,7 @@ class EchoServerClientTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: WriteOnConnectHandler(toWrite: stringToWrite))
+                channel.pipeline.addHandler(WriteOnConnectHandler(toWrite: stringToWrite))
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -531,7 +531,7 @@ class EchoServerClientTest : XCTestCase {
         let promise = group.next().makePromise(of: ByteBuffer.self)
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
             .channelInitializer { channel in
-                channel.pipeline.add(handler: ByteCountingHandler(numBytes: stringToWrite.utf8.count, promise: promise))
+                channel.pipeline.addHandler(ByteCountingHandler(numBytes: stringToWrite.utf8.count, promise: promise))
             }
             .connect(to: serverChannel.localAddress!).wait())
 
@@ -554,7 +554,7 @@ class EchoServerClientTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: EchoAndEchoAgainAfterSomeTimeServer(time: .seconds(1), secondWriteDoneHandler: {
+                channel.pipeline.addHandler(EchoAndEchoAgainAfterSomeTimeServer(time: .seconds(1), secondWriteDoneHandler: {
                     dpGroup.leave()
                 }))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -566,7 +566,7 @@ class EchoServerClientTest : XCTestCase {
         let str = "hi there"
         let countingHandler = ByteCountingHandler(numBytes: str.utf8.count, promise: group.next().makePromise())
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
-            .channelInitializer { $0.pipeline.add(handler: countingHandler) }
+            .channelInitializer { $0.pipeline.addHandler(countingHandler) }
             .connect(to: serverChannel.localAddress!).wait())
 
         var buffer = clientChannel.allocator.buffer(capacity: str.utf8.count)
@@ -644,7 +644,7 @@ class EchoServerClientTest : XCTestCase {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: WriteWhenActiveHandler(str, dpGroup))
+                channel.pipeline.addHandler(WriteWhenActiveHandler(str, dpGroup))
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -656,8 +656,8 @@ class EchoServerClientTest : XCTestCase {
             //.channelOption(ChannelOptions.autoRead, value: false)
             .channelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 2))
             .channelInitializer { channel in
-                channel.pipeline.add(handler: WriteHandler()).flatMap {
-                    channel.pipeline.add(handler: countingHandler)
+                channel.pipeline.addHandler(WriteHandler()).flatMap {
+                    channel.pipeline.addHandler(countingHandler)
                 }
             }.connect(to: serverChannel.localAddress!).wait())
         defer {
@@ -708,7 +708,7 @@ class EchoServerClientTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: ErrorHandler(promise))
+                channel.pipeline.addHandler(ErrorHandler(promise))
             }.bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -789,7 +789,7 @@ class EchoServerClientTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: countingHandler)
+                channel.pipeline.addHandler(countingHandler)
             }
             .bind(host: "127.0.0.1", port: 0)
             .wait())

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -42,7 +42,7 @@ class EmbeddedChannelTest: XCTestCase {
 
     func testWriteInboundByteBufferReThrow() throws {
         let channel = EmbeddedChannel()
-        _ = try channel.pipeline.add(handler: ExceptionThrowingInboundHandler()).wait()
+        _ = try channel.pipeline.addHandler(ExceptionThrowingInboundHandler()).wait()
         do {
             try channel.writeInbound("msg")
             XCTFail()
@@ -54,7 +54,7 @@ class EmbeddedChannelTest: XCTestCase {
 
     func testWriteOutboundByteBufferReThrow() throws {
         let channel = EmbeddedChannel()
-        _ = try channel.pipeline.add(handler: ExceptionThrowingOutboundHandler()).wait()
+        _ = try channel.pipeline.addHandler(ExceptionThrowingOutboundHandler()).wait()
         do {
             try channel.writeOutbound("msg")
             XCTFail()
@@ -80,7 +80,7 @@ class EmbeddedChannelTest: XCTestCase {
     func testCloseOnInactiveIsOk() throws {
         let channel = EmbeddedChannel()
         let inactiveHandler = CloseInChannelInactiveHandler()
-        _ = try channel.pipeline.add(handler: inactiveHandler).wait()
+        _ = try channel.pipeline.addHandler(inactiveHandler).wait()
         XCTAssertFalse(try channel.finish())
 
         // channelInactive should fire only once.

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -349,7 +349,7 @@ public class EventLoopTest : XCTestCase {
         let serverChannelUp = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: WedgeOpenHandler(channelActivePromise: serverChannelUp) { promise in
+                channel.pipeline.addHandler(WedgeOpenHandler(channelActivePromise: serverChannelUp) { promise in
                     promiseQueue.sync { promises.append(promise) }
                 })
             }
@@ -365,7 +365,7 @@ public class EventLoopTest : XCTestCase {
         }
         let channel = try SocketChannel(eventLoop: loop, protocolFamily: AF_INET)
         try channel.eventLoop.submit {
-            channel.pipeline.add(handler: wedgeHandler).flatMap {
+            channel.pipeline.addHandler(wedgeHandler).flatMap {
                 channel.register()
             }.flatMap {
                 // connecting here to stop epoll from throwing EPOLLHUP at us
@@ -515,7 +515,7 @@ public class EventLoopTest : XCTestCase {
             .bind(host: "localhost", port: 0).wait())
         let channel = try assertNoThrowWithValue(SocketChannel(eventLoop: eventLoop as! SelectableEventLoop,
                                                                protocolFamily: serverSocket.localAddress!.protocolFamily))
-        XCTAssertNoThrow(try channel.pipeline.add(handler: assertHandler).wait() as Void)
+        XCTAssertNoThrow(try channel.pipeline.addHandler(assertHandler).wait() as Void)
         XCTAssertNoThrow(try channel.eventLoop.submit {
             channel.register().flatMap {
                 channel.connect(to: serverSocket.localAddress!)

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -35,7 +35,7 @@ class FileRegionTest : XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .childChannelInitializer { $0.pipeline.add(handler: countingHandler) }
+            .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
 
@@ -75,7 +75,7 @@ class FileRegionTest : XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .childChannelInitializer { $0.pipeline.add(handler: countingHandler) }
+            .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
 
@@ -126,7 +126,7 @@ class FileRegionTest : XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .childChannelInitializer { $0.pipeline.add(handler: countingHandler) }
+            .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
 

--- a/Tests/NIOTests/HappyEyeballsTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest.swift
@@ -214,7 +214,7 @@ extension DummyResolver.Event: Equatable {
 
 private func defaultChannelBuilder(loop: EventLoop, family: Int32) -> EventLoopFuture<Channel> {
     let channel = EmbeddedChannel(loop: loop as! EmbeddedEventLoop)
-    XCTAssertNoThrow(try channel.pipeline.add(name: CONNECT_RECORDER, handler: ConnectRecorder()).wait())
+    XCTAssertNoThrow(try channel.pipeline.addHandler(ConnectRecorder(), name: CONNECT_RECORDER).wait())
     return loop.makeSucceededFuture(channel)
 }
 
@@ -562,7 +562,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80, connectTimeout: .hours(1)) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -631,7 +631,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80, connectTimeout: .hours(1)) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -701,7 +701,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80, connectTimeout: .hours(1)) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -784,7 +784,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80, connectTimeout: .milliseconds(100)) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -829,7 +829,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80, connectTimeout: .milliseconds(100)) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -884,7 +884,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80, connectTimeout: .hours(1)) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -930,7 +930,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80, connectTimeout: .milliseconds(100)) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -975,7 +975,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -1025,7 +1025,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -1145,7 +1145,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80, connectTimeout: .milliseconds(250)) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture
@@ -1194,7 +1194,7 @@ public class HappyEyeballsTest : XCTestCase {
         let (eyeballer, resolver, loop) = buildEyeballer(host: "example.com", port: 80, connectTimeout: .milliseconds(50)) {
             let channelFuture = defaultChannelBuilder(loop: $0, family: $1)
             channelFuture.whenSuccess { channel in
-                try! channel.pipeline.add(name: CONNECT_DELAYER, handler: ConnectionDelayer(), first: true).wait()
+                try! channel.pipeline.addHandler(ConnectionDelayer(), name: CONNECT_DELAYER, position: .first).wait()
                 channels.append(channel)
             }
             return channelFuture

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -77,8 +77,8 @@ class IdleStateHandlerTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: handler).flatMap { f in
-                    channel.pipeline.add(handler: TestWriteHandler(writeToChannel, assertEventFn))
+                channel.pipeline.addHandler(handler).flatMap { f in
+                    channel.pipeline.addHandler(TestWriteHandler(writeToChannel, assertEventFn))
                 }
             }.bind(host: "127.0.0.1", port: 0).wait())
 
@@ -161,8 +161,8 @@ class IdleStateHandlerTest : XCTestCase {
         }
         let eventHandler = EventHandler()
         let channel = EmbeddedChannel()
-        XCTAssertNoThrow(try channel.pipeline.add(handler: IdleStateHandler()).wait())
-        XCTAssertNoThrow(try channel.pipeline.add(handler: eventHandler).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(IdleStateHandler()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(eventHandler).wait())
         
         channel.pipeline.fireChannelRegistered()
         channel.pipeline.fireChannelActive()

--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -27,7 +27,7 @@ final class PromiseOnReadHandler: ChannelInboundHandler {
 
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         self.promise.succeed(self.unwrapInboundIn(data))
-        _ = ctx.pipeline.remove(ctx: ctx)
+        _ = ctx.pipeline.removeHandler(ctx: ctx)
     }
 }
 
@@ -120,7 +120,7 @@ final class MulticastTest: XCTestCase {
 
     private func assertDatagramReaches(multicastChannel: Channel, sender: Channel, multicastAddress: SocketAddress, file: StaticString = #file, line: UInt = #line) throws {
         let receivedMulticastDatagram = multicastChannel.eventLoop.makePromise(of: AddressedEnvelope<ByteBuffer>.self)
-        XCTAssertNoThrow(try multicastChannel.pipeline.add(handler: PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
+        XCTAssertNoThrow(try multicastChannel.pipeline.addHandler(PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
 
         var messageBuffer = sender.allocator.buffer(capacity: 24)
         messageBuffer.writeStaticString("hello, world!")
@@ -143,7 +143,7 @@ final class MulticastTest: XCTestCase {
                                             file: StaticString = #file, line: UInt = #line) throws {
         let timeoutPromise = multicastChannel.eventLoop.makePromise(of: Void.self)
         let receivedMulticastDatagram = multicastChannel.eventLoop.makePromise(of: AddressedEnvelope<ByteBuffer>.self)
-        XCTAssertNoThrow(try multicastChannel.pipeline.add(handler: PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
+        XCTAssertNoThrow(try multicastChannel.pipeline.addHandler(PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
 
         // If we receive a datagram, or the reader promise fails, we must fail the timeoutPromise.
         receivedMulticastDatagram.futureResult.map { (_: AddressedEnvelope<ByteBuffer>) in

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -255,7 +255,7 @@ class SelectorTest: XCTestCase {
                     reconnectedChannelsHaveRead.append(p.futureResult)
                     let newChannel = ClientBootstrap(group: ctx.eventLoop)
                         .channelInitializer { channel in
-                            channel.pipeline.add(handler: HappyWhenReadHandler(hasReConnectEventLoopTickFinished: self.hasReConnectEventLoopTickFinished,
+                            channel.pipeline.addHandler(HappyWhenReadHandler(hasReConnectEventLoopTickFinished: self.hasReConnectEventLoopTickFinished,
                                                                                didReadPromise: p)).map {
                                                                                 hasBeenAdded = true
                             }
@@ -337,7 +337,7 @@ class SelectorTest: XCTestCase {
         let tempDir = createTemporaryDirectory()
         let secondServerChannel = try! ServerBootstrap(group: el)
             .childChannelInitializer { channel in
-                channel.pipeline.add(handler: ServerHandler(allServerChannels: allServerChannels,
+                channel.pipeline.addHandler(ServerHandler(allServerChannels: allServerChannels,
                                                             numberOfConnectedChannels: numberOfConnectedChannels))
             }
             .bind(to: SocketAddress(unixDomainSocketPath: "\(tempDir)/server-sock.uds"))
@@ -349,7 +349,7 @@ class SelectorTest: XCTestCase {
                 ClientBootstrap(group: el)
                     .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
                     .channelInitializer { channel in
-                        channel.pipeline.add(handler: CloseEveryOtherAndOpenNewOnesHandler(allChannels: allChannels,
+                        channel.pipeline.addHandler(CloseEveryOtherAndOpenNewOnesHandler(allChannels: allChannels,
                                                                                            hasReConnectEventLoopTickFinished: hasReConnectEventLoopTickFinished,
                                                                                            serverAddress: secondServerChannel.localAddress!,
                                                                                            everythingWasReadPromise: everythingWasReadPromise))

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -154,7 +154,7 @@ public class SocketChannelTest : XCTestCase {
         let promise = serverChannel.eventLoop.makePromise(of: IOError.self)
 
         XCTAssertNoThrow(try serverChannel.eventLoop.submit {
-            serverChannel.pipeline.add(handler: AcceptHandler(promise)).flatMap {
+            serverChannel.pipeline.addHandler(AcceptHandler(promise)).flatMap {
                 serverChannel.register()
             }.flatMap {
                 serverChannel.bind(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 0))
@@ -236,7 +236,7 @@ public class SocketChannelTest : XCTestCase {
                                                                eventLoop: eventLoop as! SelectableEventLoop))
         let promise = channel.eventLoop.makePromise(of: Void.self)
 
-        XCTAssertNoThrow(try channel.pipeline.add(handler: ActiveVerificationHandler(promise)).flatMap {
+        XCTAssertNoThrow(try channel.pipeline.addHandler(ActiveVerificationHandler(promise)).flatMap {
             channel.register()
         }.flatMap {
             channel.connect(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 9999))
@@ -451,7 +451,7 @@ public class SocketChannelTest : XCTestCase {
             XCTAssertFalse(closePromise.futureResult.isFulfilled)
         }
 
-        XCTAssertNoThrow(try channel.pipeline.add(handler: NotificationOrderHandler()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(NotificationOrderHandler()).wait())
 
         // We need to call submit {...} here to ensure then {...} is called while on the EventLoop already to not have
         // a ECONNRESET sneak in.
@@ -523,7 +523,7 @@ public class SocketChannelTest : XCTestCase {
 
         let handler = AddressVerificationHandler(promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .childChannelInitializer { $0.pipeline.add(handler: handler) }
+            .childChannelInitializer { $0.pipeline.addHandler(handler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
         defer { XCTAssertNoThrow(try serverChannel.close().wait()) }
@@ -595,7 +595,7 @@ public class SocketChannelTest : XCTestCase {
                 .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
                 .serverChannelOption(ChannelOptions.backlog, value: 256)
                 .serverChannelOption(ChannelOptions.autoRead, value: false)
-                .serverChannelInitializer { channel in channel.pipeline.add(handler: ErrorHandler(serverPromise)) }
+                .serverChannelInitializer { channel in channel.pipeline.addHandler(ErrorHandler(serverPromise)) }
                 .bind(host: "127.0.0.1", port: 0)
                 .wait())
 

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -340,7 +340,7 @@ class EndToEndTests: XCTestCase {
         let recorder = WebSocketRecorderHandler()
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
                                               upgradePipelineHandler: { (channel, req) in
-                                                channel.pipeline.add(handler: recorder)
+                                                channel.pipeline.addHandler(recorder)
 
         })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
@@ -360,7 +360,7 @@ class EndToEndTests: XCTestCase {
                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
 
         // Put a frame encoder in the client pipeline.
-        XCTAssertNoThrow(try client.pipeline.add(handler: WebSocketFrameEncoder()).wait())
+        XCTAssertNoThrow(try client.pipeline.addHandler(WebSocketFrameEncoder()).wait())
 
         var data = client.allocator.buffer(capacity: 12)
         data.writeString("hello, world")
@@ -405,7 +405,7 @@ class EndToEndTests: XCTestCase {
         let recorder = WebSocketRecorderHandler()
         let basicUpgrader = WebSocketUpgrader(shouldUpgrade: { head in HTTPHeaders() },
                                               upgradePipelineHandler: { (channel, req) in
-                                                channel.pipeline.add(handler: recorder)
+                                                channel.pipeline.addHandler(recorder)
 
         })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])
@@ -451,7 +451,7 @@ class EndToEndTests: XCTestCase {
         let basicUpgrader = WebSocketUpgrader(automaticErrorHandling: false,
                                               shouldUpgrade: { head in HTTPHeaders() },
                                               upgradePipelineHandler: { (channel, req) in
-                                                channel.pipeline.add(handler: recorder)
+                                                channel.pipeline.addHandler(recorder)
 
         })
         let (loop, server, client) = createTestFixtures(upgraders: [basicUpgrader])

--- a/Tests/NIOWebSocketTests/WebSocketFrameEncoderTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameEncoderTest.swift
@@ -39,7 +39,7 @@ public class WebSocketFrameEncoderTest: XCTestCase {
     public override func setUp() {
         self.channel = EmbeddedChannel()
         self.buffer = channel.allocator.buffer(capacity: 128)
-        XCTAssertNoThrow(try self.channel.pipeline.add(handler: WebSocketFrameEncoder()).wait())
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(WebSocketFrameEncoder()).wait())
     }
 
     public override func tearDown() {

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -58,3 +58,8 @@
 - `CircularBuffer` and `MarkedCircularBuffer`'s indices are now opaque
 - all `ChannelOption`s are now required to be  `Equatable`
 - rename `FileHandle` to `NIOFileHandle`
+- rename all `ChannelPipeline.add(name:handler:...)`s to `ChannelPipeline.addHandler(_:name:...)`
+- rename all `ChannelPipeline.remove(...)`s to `ChannelPipeline.removeHandler(...)`
+- change `ChannelPipeline.addHandler[s](_:first:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`
+- change  `ChannelPipeline.addHandler(_:before:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`
+- change  `ChannelPipeline.addHandler(_:after:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`


### PR DESCRIPTION
Motivation:

- `ChannelPipeline.add(name:handler:...)` had a strange order of arguments
- `remove(handler:)` and `remove(ctx:)` both remove `ChannelHandler`s
  but they read like they remove different things

So let's just fix the argument order and name them `addHandler` and
`removeHandler` making clear what they do.

Modifications:

- rename all `ChannelPipeline.add(name:handler:...)`s to `ChannelPipeline.addHandler(_:name:...)`
- rename all `ChannelPipeline.remove(...)`s to `ChannelPipeline.removeHandler(...)`
- instead of `first: Bool` and `before/after: ChannelHandler` now `position: .first/.last/.before(handler)/.after(handler)`

Result:

more readable and consistent code
