### PR TITLE
rename FileHandle to NIOFileHandle

### DIFF
--- a/Sources/NIO/FileHandle.swift
+++ b/Sources/NIO/FileHandle.swift
@@ -12,21 +12,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A `FileHandle` is a handle to an open file.
+/// A `NIOFileHandle` is a handle to an open file.
 ///
-/// When creating a `FileHandle` it takes ownership of the underlying file descriptor. When a `FileHandle` is no longer
+/// When creating a `NIOFileHandle` it takes ownership of the underlying file descriptor. When a `NIOFileHandle` is no longer
 /// needed you must `close` it or take back ownership of the file descriptor using `takeDescriptorOwnership`.
 ///
-/// - note: One underlying file descriptor should usually be managed by one `FileHandle` only.
+/// - note: One underlying file descriptor should usually be managed by one `NIOFileHandle` only.
 ///
-/// - warning: Failing to manage the lifetime of a `FileHandle` correctly will result in undefined behaviour.
+/// - warning: Failing to manage the lifetime of a `NIOFileHandle` correctly will result in undefined behaviour.
 ///
-/// - warning: `FileHandle` objects are not thread-safe and are mutable. They also cannot be fully thread-safe as they refer to a global underlying file descriptor.
-public final class FileHandle: FileDescriptor {
+/// - warning: `NIOFileHandle` objects are not thread-safe and are mutable. They also cannot be fully thread-safe as they refer to a global underlying file descriptor.
+public final class NIOFileHandle: FileDescriptor {
     public private(set) var isOpen: Bool
     private let descriptor: CInt
 
-    /// Create a `FileHandle` taking ownership of `descriptor`. You must call `FileHandle.close` or `FileHandle.takeDescriptorOwnership` before
+    /// Create a `NIOFileHandle` taking ownership of `descriptor`. You must call `NIOFileHandle.close` or `NIOFileHandle.takeDescriptorOwnership` before
     /// this object can be safely released.
     public init(descriptor: CInt) {
         self.descriptor = descriptor
@@ -34,25 +34,25 @@ public final class FileHandle: FileDescriptor {
     }
 
     deinit {
-        assert(!self.isOpen, "leaked open FileHandle(descriptor: \(self.descriptor)). Call `close()` to close or `takeDescriptorOwnership()` to take ownership and close by some other means.")
+        assert(!self.isOpen, "leaked open NIOFileHandle(descriptor: \(self.descriptor)). Call `close()` to close or `takeDescriptorOwnership()` to take ownership and close by some other means.")
     }
 
-    /// Duplicates this `FileHandle`. This means that a new `FileHandle` object with a new underlying file descriptor
-    /// is returned. The caller takes ownership of the returned `FileHandle` and is responsible for closing it.
+    /// Duplicates this `NIOFileHandle`. This means that a new `NIOFileHandle` object with a new underlying file descriptor
+    /// is returned. The caller takes ownership of the returned `NIOFileHandle` and is responsible for closing it.
     ///
-    /// - warning: The returned `FileHandle` is not fully independent, the seek pointer is shared as documented by `dup(2)`.
+    /// - warning: The returned `NIOFileHandle` is not fully independent, the seek pointer is shared as documented by `dup(2)`.
     ///
-    /// - returns: A new `FileHandle` with a fresh underlying file descriptor but shared seek pointer.
-    public func duplicate() throws -> FileHandle {
+    /// - returns: A new `NIOFileHandle` with a fresh underlying file descriptor but shared seek pointer.
+    public func duplicate() throws -> NIOFileHandle {
         return try withUnsafeFileDescriptor { fd in
-            FileHandle(descriptor: try Posix.dup(descriptor: fd))
+            NIOFileHandle(descriptor: try Posix.dup(descriptor: fd))
         }
     }
 
     /// Take the ownership of the underlying file descriptor. This is similar to `close()` but the underlying file
     /// descriptor remains open. The caller is responsible for closing the file descriptor by some other means.
     ///
-    /// After calling this, the `FileHandle` cannot be used for anything else and all the operations will throw.
+    /// After calling this, the `NIOFileHandle` cannot be used for anything else and all the operations will throw.
     ///
     /// - returns: The underlying file descriptor, now owned by the caller.
     public func takeDescriptorOwnership() throws -> CInt {
@@ -80,11 +80,11 @@ public final class FileHandle: FileDescriptor {
     }
 }
 
-extension FileHandle {
-    /// Open a new `FileHandle`.
+extension NIOFileHandle {
+    /// Open a new `NIOFileHandle`.
     ///
     /// - parameters:
-    ///     - path: the path of the file to open. The ownership of the file descriptor is transferred to this `FileHandle` and so it will be closed once `close` is called.
+    ///     - path: the path of the file to open. The ownership of the file descriptor is transferred to this `NIOFileHandle` and so it will be closed once `close` is called.
     public convenience init(path: String) throws {
         let fd = try Posix.open(file: path, oFlag: O_RDONLY | O_CLOEXEC)
         self.init(descriptor: fd)

--- a/Sources/NIO/FileRegion.swift
+++ b/Sources/NIO/FileRegion.swift
@@ -22,11 +22,11 @@
 /// One important note, depending your `ChannelPipeline` setup it may not be possible to use a `FileRegion` as a `ChannelHandler` may
 /// need access to the bytes (in a `ByteBuffer`) to transform these.
 ///
-/// - note: It is important to manually manage the lifetime of the `FileHandle` used to create a `FileRegion`.
+/// - note: It is important to manually manage the lifetime of the `NIOFileHandle` used to create a `FileRegion`.
 public struct FileRegion {
 
-    /// The `FileHandle` that is used by this `FileRegion`.
-    public let fileHandle: FileHandle
+    /// The `NIOFileHandle` that is used by this `FileRegion`.
+    public let fileHandle: NIOFileHandle
 
     private let _endIndex: UInt64
     private var _readerIndex: _UInt56
@@ -46,13 +46,13 @@ public struct FileRegion {
         return Int(self._endIndex)
     }
 
-    /// Create a new `FileRegion` from an open `FileHandle`.
+    /// Create a new `FileRegion` from an open `NIOFileHandle`.
     ///
     /// - parameters:
-    ///     - fileHandle: the `FileHandle` to use.
+    ///     - fileHandle: the `NIOFileHandle` to use.
     ///     - readerIndex: the index (offset) on which the reading will start.
     ///     - endIndex: the index which represent the end of the readable portion.
-    public init(fileHandle: FileHandle, readerIndex: Int, endIndex: Int) {
+    public init(fileHandle: NIOFileHandle, readerIndex: Int, endIndex: Int) {
         precondition(readerIndex <= endIndex, "readerIndex(\(readerIndex) must be <= endIndex(\(endIndex).")
 
         self.fileHandle = fileHandle
@@ -77,8 +77,8 @@ extension FileRegion {
     /// Create a new `FileRegion` forming a complete file.
     ///
     /// - parameters:
-    ///     - fileHandle: An open `FileHandle` to the file.
-    public init(fileHandle: FileHandle) throws {
+    ///     - fileHandle: An open `NIOFileHandle` to the file.
+    public init(fileHandle: NIOFileHandle) throws {
         let eof = try fileHandle.withUnsafeFileDescriptor { (fd: CInt) throws -> off_t in
             let eof = try Posix.lseek(descriptor: fd, offset: 0, whence: SEEK_END)
             try Posix.lseek(descriptor: fd, offset: 0, whence: SEEK_SET)

--- a/Sources/NIO/LinuxCPUSet.swift
+++ b/Sources/NIO/LinuxCPUSet.swift
@@ -44,9 +44,9 @@ import CNIOLinux
 
     extension LinuxCPUSet: Equatable {}
 
-    /// Linux specific extension to `Thread`.
-    extension Thread {
-        /// Specify the thread-affinity of the `Thread` itself.
+    /// Linux specific extension to `NIOThread`.
+    extension NIOThread {
+        /// Specify the thread-affinity of the `NIOThread` itself.
         var affinity: LinuxCPUSet {
             get {
                 var cpuset = cpu_set_t()
@@ -81,10 +81,10 @@ import CNIOLinux
 
     extension MultiThreadedEventLoopGroup {
 
-        /// Create a new `MultiThreadedEventLoopGroup` that create as many `Thread`s as `pinnedCPUIds`. Each `Thread` will be pinned to the CPU with the id.
+        /// Create a new `MultiThreadedEventLoopGroup` that create as many `NIOThread`s as `pinnedCPUIds`. Each `NIOThread` will be pinned to the CPU with the id.
         ///
         /// - arguments:
-        ///     - pinnedCPUIds: The CPU ids to apply to the `Thread`s.
+        ///     - pinnedCPUIds: The CPU ids to apply to the `NIOThread`s.
         convenience init(pinnedCPUIds: [Int]) {
             let initializers: [ThreadInitializer]  = pinnedCPUIds.map { id in
                 // This will also take care of validation of the provided id.

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -100,17 +100,17 @@ public struct NonBlockingFileIO {
     ///
     /// The allocation and reading of a subsequent chunk will only be attempted when `chunkHandler` succeeds.
     ///
-    /// - note: `readChunked(fileRegion:chunkSize:allocator:eventLoop:chunkHandler:)` should be preferred as it uses `FileRegion` object instead of raw `FileHandle`s.
+    /// - note: `readChunked(fileRegion:chunkSize:allocator:eventLoop:chunkHandler:)` should be preferred as it uses `FileRegion` object instead of raw `NIOFileHandle`s.
     ///
     /// - parameters:
-    ///   - fileHandle: The `FileHandle` to read from.
+    ///   - fileHandle: The `NIOFileHandle` to read from.
     ///   - byteCount: The number of bytes to read from `fileHandle`.
     ///   - chunkSize: The size of the individual chunks to deliver.
     ///   - allocator: A `ByteBufferAllocator` used to allocate space for the chunks.
     ///   - eventLoop: The `EventLoop` to call `chunkHandler` on.
     ///   - chunkHandler: Called for every chunk read. The next chunk will be read upon successful completion of the returned `EventLoopFuture`. If the returned `EventLoopFuture` fails, the overall operation is aborted.
     /// - returns: An `EventLoopFuture` which is the result of the overall operation. If either the reading of `fileHandle` or `chunkHandler` fails, the `EventLoopFuture` will fail too. If the reading of `fileHandle` as well as `chunkHandler` always succeeded, the `EventLoopFuture` will succeed too.
-    public func readChunked(fileHandle: FileHandle,
+    public func readChunked(fileHandle: NIOFileHandle,
                             byteCount: Int,
                             chunkSize: Int = NonBlockingFileIO.defaultChunkSize,
                             allocator: ByteBufferAllocator,
@@ -171,15 +171,15 @@ public struct NonBlockingFileIO {
     /// case the `ByteBuffer` will contain the bytes available to read.
     ///
     /// - note: Only use this function for small enough `byteCount`s as it will need to allocate enough memory to hold `byteCount` bytes.
-    /// - note: `read(fileRegion:allocator:eventLoop:)` should be preferred as it uses `FileRegion` object instead of raw `FileHandle`s.
+    /// - note: `read(fileRegion:allocator:eventLoop:)` should be preferred as it uses `FileRegion` object instead of raw `NIOFileHandle`s.
     ///
     /// - parameters:
-    ///   - fileHandle: The `FileHandle` to read.
+    ///   - fileHandle: The `NIOFileHandle` to read.
     ///   - byteCount: The number of bytes to read from `fileHandle`.
     ///   - allocator: A `ByteBufferAllocator` used to allocate space for the returned `ByteBuffer`.
     ///   - eventLoop: The `EventLoop` to create the returned `EventLoopFuture` from.
     /// - returns: An `EventLoopFuture` which delivers a `ByteBuffer` if the read was successful or a failure on error.
-    public func read(fileHandle: FileHandle, byteCount: Int, allocator: ByteBufferAllocator, eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
+    public func read(fileHandle: NIOFileHandle, byteCount: Int, allocator: ByteBufferAllocator, eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
         guard byteCount > 0 else {
             return eventLoop.makeSucceededFuture(allocator.buffer(capacity: 0))
         }
@@ -216,11 +216,11 @@ public struct NonBlockingFileIO {
     /// Write `buffer` to `fileHandle` in `NonBlockingFileIO`'s private thread pool which is separate from any `EventLoop` thread.
     ///
     /// - parameters:
-    ///   - fileHandle: The `FileHandle` to write to.
+    ///   - fileHandle: The `NIOFileHandle` to write to.
     ///   - buffer: The `ByteBuffer` to write.
     ///   - eventLoop: The `EventLoop` to create the returned `EventLoopFuture` from.
     /// - returns: An `EventLoopFuture` which is fulfilled if the write was successful or fails on error.
-    public func write(fileHandle: FileHandle,
+    public func write(fileHandle: NIOFileHandle,
                       buffer: ByteBuffer,
                       eventLoop: EventLoop) -> EventLoopFuture<()> {
         var byteCount = buffer.readableBytes
@@ -255,18 +255,18 @@ public struct NonBlockingFileIO {
 
     /// Open the file at `path` on a private thread pool which is separate from any `EventLoop` thread.
     ///
-    /// This function will return (a future) of the `FileHandle` associated with the file opened and a `FileRegion`
-    /// comprising of the whole file. The caller must close the returned `FileHandle` when it's no longer needed.
+    /// This function will return (a future) of the `NIOFileHandle` associated with the file opened and a `FileRegion`
+    /// comprising of the whole file. The caller must close the returned `NIOFileHandle` when it's no longer needed.
     ///
-    /// - note: The reason this returns the `FileHandle` and the `FileRegion` is that both the opening of a file as well as the querying of its size are blocking.
+    /// - note: The reason this returns the `NIOFileHandle` and the `FileRegion` is that both the opening of a file as well as the querying of its size are blocking.
     ///
     /// - parameters:
     ///     - path: The path of the file to be opened.
     ///     - eventLoop: The `EventLoop` on which the returned `EventLoopFuture` will fire.
-    /// - returns: An `EventLoopFuture` containing the `FileHandle` and the `FileRegion` comprising the whole file.
-    public func openFile(path: String, eventLoop: EventLoop) -> EventLoopFuture<(FileHandle, FileRegion)> {
+    /// - returns: An `EventLoopFuture` containing the `NIOFileHandle` and the `FileRegion` comprising the whole file.
+    public func openFile(path: String, eventLoop: EventLoop) -> EventLoopFuture<(NIOFileHandle, FileRegion)> {
         return self.threadPool.runIfActive(eventLoop: eventLoop) {
-            let fh = try FileHandle(path: path)
+            let fh = try NIOFileHandle(path: path)
             do {
                 let fr = try FileRegion(fileHandle: fh)
                 return (fh, fr)

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -48,6 +48,9 @@ public typealias SniResult = SNIResult
 @available(*, deprecated, renamed: "SNIHandler")
 public typealias SniHandler = SNIHandler
 
+@available(*, deprecated, renamed: "NIOFileHandle")
+public typealias FileHandle = NIOFileHandle
+
 @available(*, deprecated, message: "don't use the StaticString: Collection extension please")
 extension StaticString: Collection {
     @available(*, deprecated, message: "don't use the StaticString: Collection extension please")

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -101,7 +101,7 @@ class HTTPServerClientTest : XCTestCase {
 
                 let content = buffer.getData(at: 0, length: buffer.readableBytes)!
                 XCTAssertNoThrow(try content.write(to: URL(fileURLWithPath: filePath)))
-                let fh = try! FileHandle(path: filePath)
+                let fh = try! NIOFileHandle(path: filePath)
                 let region = FileRegion(fileHandle: fh,
                                              readerIndex: 0,
                                              endIndex: buffer.readableBytes)

--- a/Tests/NIOTests/BaseObjectsTest.swift
+++ b/Tests/NIOTests/BaseObjectsTest.swift
@@ -51,7 +51,7 @@ class BaseObjectTest: XCTestCase {
     }
 
     func testNIOFileRegionConversion() {
-        let handle = FileHandle(descriptor: -1)
+        let handle = NIOFileHandle(descriptor: -1)
         let expected = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
         defer {
             // fake descriptor, so shouldn't be closed.
@@ -73,7 +73,7 @@ class BaseObjectTest: XCTestCase {
     }
 
     func testBadConversions() {
-        let handle = FileHandle(descriptor: -1)
+        let handle = NIOFileHandle(descriptor: -1)
         let bb = ByteBufferAllocator().buffer(capacity: 1024)
         let fr = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
         defer {
@@ -94,7 +94,7 @@ class BaseObjectTest: XCTestCase {
     }
 
     func testFileRegionFromIOData() {
-        let handle = FileHandle(descriptor: -1)
+        let handle = NIOFileHandle(descriptor: -1)
         let expected = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
         defer {
             // fake descriptor, so shouldn't be closed.
@@ -105,7 +105,7 @@ class BaseObjectTest: XCTestCase {
     }
 
     func testIODataEquals() {
-        let handle = FileHandle(descriptor: -1)
+        let handle = NIOFileHandle(descriptor: -1)
         var bb1 = ByteBufferAllocator().buffer(capacity: 1024)
         let bb2 = ByteBufferAllocator().buffer(capacity: 1024)
         bb1.writeString("hello")

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -208,7 +208,7 @@ class ChannelPipelineTest: XCTestCase {
 
         XCTAssertTrue(loop.inEventLoop)
         do {
-            let handle = FileHandle(descriptor: -1)
+            let handle = NIOFileHandle(descriptor: -1)
             let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 0)
             defer {
                 // fake descriptor, so shouldn't be closed.

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -604,7 +604,7 @@ public class ChannelTests: XCTestCase {
             let numberOfWrites = Int(1 /* first write */ + pwm.writeSpinCount /* the spins */ + 1 /* so one byte remains at the end */)
             buffer.clear()
             buffer.writeBytes(Array<UInt8>(repeating: 0xff, count: 1))
-            let handle = FileHandle(descriptor: -1)
+            let handle = NIOFileHandle(descriptor: -1)
             defer {
                 /* fake file handle, so don't actually close */
                 XCTAssertNoThrow(try handle.takeDescriptorOwnership())
@@ -748,8 +748,8 @@ public class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.makePromise() }
 
-            let fh1 = FileHandle(descriptor: -1)
-            let fh2 = FileHandle(descriptor: -2)
+            let fh1 = NIOFileHandle(descriptor: -1)
+            let fh2 = NIOFileHandle(descriptor: -2)
             let fr1 = FileRegion(fileHandle: fh1, readerIndex: 12, endIndex: 14)
             let fr2 = FileRegion(fileHandle: fh2, readerIndex: 0, endIndex: 2)
             defer {
@@ -797,7 +797,7 @@ public class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.makePromise() }
 
-            let fh = FileHandle(descriptor: -1)
+            let fh = NIOFileHandle(descriptor: -1)
             let fr = FileRegion(fileHandle: fh, readerIndex: 99, endIndex: 99)
             defer {
                 // fake descriptor, so shouldn't be closed.
@@ -826,8 +826,8 @@ public class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<5).map { (_: Int) in el.makePromise() }
 
-            let fh1 = FileHandle(descriptor: -1)
-            let fh2 = FileHandle(descriptor: -1)
+            let fh1 = NIOFileHandle(descriptor: -1)
+            let fh2 = NIOFileHandle(descriptor: -1)
             let fr1 = FileRegion(fileHandle: fh1, readerIndex: 99, endIndex: 99)
             let fr2 = FileRegion(fileHandle: fh1, readerIndex: 0, endIndex: 10)
             defer {
@@ -1028,7 +1028,7 @@ public class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.makePromise() }
 
-            let fh = FileHandle(descriptor: -1)
+            let fh = NIOFileHandle(descriptor: -1)
             let fr = FileRegion(fileHandle: fh, readerIndex: 0, endIndex: 8192)
             defer {
                 // fake descriptor, so shouldn't be closed.

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -145,7 +145,7 @@ class EmbeddedChannelTest: XCTestCase {
         let channel = EmbeddedChannel()
         let buffer = ByteBufferAllocator().buffer(capacity: 5)
         let socketAddress = try SocketAddress(unixDomainSocketPath: "path")
-        let handle = FileHandle(descriptor: 1)
+        let handle = NIOFileHandle(descriptor: 1)
         let fileRegion = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
         defer {
             // fake descriptor, so shouldn't be closed.

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -436,7 +436,7 @@ public class EventLoopTest : XCTestCase {
             let group = MultiThreadedEventLoopGroup(pinnedCPUIds: [0])
             let eventLoop = group.next()
             let set = try eventLoop.submit {
-                NIO.Thread.current.affinity
+                NIOThread.current.affinity
             }.wait()
 
             XCTAssertEqual(LinuxCPUSet(0), set)

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -52,7 +52,7 @@ class FileRegionTest : XCTestCase {
         }
 
         try withTemporaryFile { _, filePath in
-            let handle = try FileHandle(path: filePath)
+            let handle = try NIOFileHandle(path: filePath)
             let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: bytes.count)
             defer {
                 XCTAssertNoThrow(try handle.close())
@@ -92,7 +92,7 @@ class FileRegionTest : XCTestCase {
         }
 
         try withTemporaryFile { _, filePath in
-            let handle = try FileHandle(path: filePath)
+            let handle = try NIOFileHandle(path: filePath)
             let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 0)
             defer {
                 XCTAssertNoThrow(try handle.close())
@@ -143,8 +143,8 @@ class FileRegionTest : XCTestCase {
         }
 
         try withTemporaryFile { fd, filePath in
-            let fh1 = try FileHandle(path: filePath)
-            let fh2 = try FileHandle(path: filePath)
+            let fh1 = try NIOFileHandle(path: filePath)
+            let fh2 = try NIOFileHandle(path: filePath)
             let fr1 = FileRegion(fileHandle: fh1, readerIndex: 0, endIndex: bytes.count)
             let fr2 = FileRegion(fileHandle: fh2, readerIndex: 0, endIndex: bytes.count)
             defer {
@@ -177,7 +177,7 @@ class FileRegionTest : XCTestCase {
 
     func testWholeFileFileRegion() throws {
         try withTemporaryFile(content: "hello") { fd, path in
-            let handle = try FileHandle(path: path)
+            let handle = try NIOFileHandle(path: path)
             let region = try FileRegion(fileHandle: handle)
             defer {
                 XCTAssertNoThrow(try handle.close())
@@ -190,7 +190,7 @@ class FileRegionTest : XCTestCase {
 
     func testWholeEmptyFileFileRegion() throws {
         try withTemporaryFile(content: "") { _, path in
-            let handle = try FileHandle(path: path)
+            let handle = try NIOFileHandle(path: path)
             let region = try FileRegion(fileHandle: handle)
             defer {
                 XCTAssertNoThrow(try handle.close())

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -200,7 +200,7 @@ class NonBlockingFileIOTest: XCTestCase {
 
     func testFailedIO() throws {
         enum DummyError: Error { case dummy }
-        let unconnectedSockFH = FileHandle(descriptor: socket(AF_UNIX, Posix.SOCK_STREAM, 0))
+        let unconnectedSockFH = NIOFileHandle(descriptor: socket(AF_UNIX, Posix.SOCK_STREAM, 0))
         defer {
             XCTAssertNoThrow(try unconnectedSockFH.close())
         }

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -15,22 +15,22 @@
 import XCTest
 @testable import NIO
 
-func withPipe(_ body: (NIO.FileHandle, NIO.FileHandle) -> [NIO.FileHandle]) throws {
+func withPipe(_ body: (NIO.NIOFileHandle, NIO.NIOFileHandle) -> [NIO.NIOFileHandle]) throws {
     var fds: [Int32] = [-1, -1]
     fds.withUnsafeMutableBufferPointer { ptr in
         XCTAssertEqual(0, pipe(ptr.baseAddress!))
     }
-    let readFH = FileHandle(descriptor: fds[0])
-    let writeFH = FileHandle(descriptor: fds[1])
+    let readFH = NIOFileHandle(descriptor: fds[0])
+    let writeFH = NIOFileHandle(descriptor: fds[1])
     let toClose = body(readFH, writeFH)
     try toClose.forEach { fh in
         XCTAssertNoThrow(try fh.close())
     }
 }
 
-func withTemporaryFile<T>(content: String? = nil, _ body: (NIO.FileHandle, String) throws -> T) rethrows -> T {
+func withTemporaryFile<T>(content: String? = nil, _ body: (NIO.NIOFileHandle, String) throws -> T) rethrows -> T {
     let (fd, path) = openTemporaryFile()
-    let fileHandle = FileHandle(descriptor: fd)
+    let fileHandle = NIOFileHandle(descriptor: fd)
     defer {
         XCTAssertNoThrow(try fileHandle.close())
         XCTAssertEqual(0, unlink(path))

--- a/Tests/NIOTests/ThreadTest.swift
+++ b/Tests/NIOTests/ThreadTest.swift
@@ -20,7 +20,7 @@ import Dispatch
 class ThreadTest: XCTestCase {
     func testCurrentThreadWorks() throws {
         let s = DispatchSemaphore(value: 0)
-        Thread.spawnAndRun { t in
+        NIOThread.spawnAndRun { t in
             XCTAssertTrue(t.isCurrent)
             s.signal()
         }
@@ -29,8 +29,8 @@ class ThreadTest: XCTestCase {
 
     func testCurrentThreadIsNotTrueOnOtherThread() throws {
         let s = DispatchSemaphore(value: 0)
-        Thread.spawnAndRun { t1 in
-            Thread.spawnAndRun { t2 in
+        NIOThread.spawnAndRun { t1 in
+            NIOThread.spawnAndRun { t2 in
                 XCTAssertFalse(t1.isCurrent)
                 XCTAssertTrue(t2.isCurrent)
                 s.signal()
@@ -42,7 +42,7 @@ class ThreadTest: XCTestCase {
     func testThreadSpecificsAreNilWhenNotPresent() throws {
         class SomeClass {}
         let s = DispatchSemaphore(value: 0)
-        Thread.spawnAndRun { (_: NIO.Thread) in
+        NIOThread.spawnAndRun { (_: NIO.NIOThread) in
             let tsv: ThreadSpecificVariable<SomeClass> = ThreadSpecificVariable()
             XCTAssertNil(tsv.currentValue)
             s.signal()
@@ -53,7 +53,7 @@ class ThreadTest: XCTestCase {
     func testThreadSpecificsWorks() throws {
         class SomeClass {}
         let s = DispatchSemaphore(value: 0)
-        Thread.spawnAndRun { (_: NIO.Thread) in
+        NIOThread.spawnAndRun { (_: NIO.NIOThread) in
             let tsv: ThreadSpecificVariable<SomeClass> = ThreadSpecificVariable()
             XCTAssertNil(tsv.currentValue)
             let expected = SomeClass()
@@ -67,12 +67,12 @@ class ThreadTest: XCTestCase {
     func testThreadSpecificsAreNotAvailableOnADifferentThread() throws {
         class SomeClass {}
         let s = DispatchSemaphore(value: 0)
-        Thread.spawnAndRun { (_: NIO.Thread) in
+        NIOThread.spawnAndRun { (_: NIO.NIOThread) in
             let tsv = ThreadSpecificVariable<SomeClass>()
             XCTAssertNil(tsv.currentValue)
             tsv.currentValue = SomeClass()
             XCTAssertNotNil(tsv.currentValue)
-            Thread.spawnAndRun { t2 in
+            NIOThread.spawnAndRun { t2 in
                 XCTAssertNil(tsv.currentValue)
                 s.signal()
             }
@@ -90,7 +90,7 @@ class ThreadTest: XCTestCase {
             }
         }
         weak var weakSome: SomeClass? = nil
-        Thread.spawnAndRun { (_: NIO.Thread) in
+        NIOThread.spawnAndRun { (_: NIO.NIOThread) in
             let some = SomeClass(sem: s)
             weakSome = some
             let tsv = ThreadSpecificVariable<SomeClass>()
@@ -111,7 +111,7 @@ class ThreadTest: XCTestCase {
             }
         }
         weak var weakSome: SomeClass? = nil
-        Thread.spawnAndRun { (_: NIO.Thread) in
+        NIOThread.spawnAndRun { (_: NIO.NIOThread) in
             let some = SomeClass(sem: s)
             weakSome = some
             let tsv = ThreadSpecificVariable<SomeClass>()
@@ -137,7 +137,7 @@ class ThreadTest: XCTestCase {
         weak var weakSome1: SomeClass? = nil
         weak var weakSome2: SomeClass? = nil
         weak var weakSome3: SomeClass? = nil
-        Thread.spawnAndRun { (_: NIO.Thread) in
+        NIOThread.spawnAndRun { (_: NIO.NIOThread) in
             let some1 = SomeClass(sem: s1)
             weakSome1 = some1
             let some2 = SomeClass(sem: s2)
@@ -171,12 +171,12 @@ class ThreadTest: XCTestCase {
             }
         }
         weak var weakSome: SomeClass? = nil
-        Thread.spawnAndRun { (_: NIO.Thread) in
+        NIOThread.spawnAndRun { (_: NIO.NIOThread) in
             let some = SomeClass(sem: s)
             weakSome = some
             let tsv = ThreadSpecificVariable<SomeClass>()
             for _ in 0..<10 {
-                Thread.spawnAndRun { (_: NIO.Thread) in
+                NIOThread.spawnAndRun { (_: NIO.NIOThread) in
                     tsv.currentValue = some
                 }
             }

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -51,3 +51,4 @@
 - `EventLoopFuture.reduce(into:_:eventLoop:_:)` had its label signature changed to `EventLoopFuture.reduce(into:_:on:_:)`
 - `EventLoopFuture.reduce(_:_:eventLoop:_:` had its label signature changed to `EventLoopFuture.reduce(_:_:on:_:)`
 - all `ChannelOption`s are now required to be  `Equatable`
+- rename `FileHandle` to `NIOFileHandle`


### PR DESCRIPTION
Motivation:

Collisions with Foundation and other standard libraries is painful.

Modifications:

- rename `FileHandle` to `NIOFileHandle`
- rename `Thread` to `NIOThread` (only exposed in docs)

Result:

fewer collisions