### PR TITLE
Thread's == was public by accident

### DIFF
--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -176,7 +176,7 @@ public struct ThreadSpecificVariable<T: AnyObject> {
 }
 
 extension Thread: Equatable {
-    public static func ==(lhs: Thread, rhs: Thread) -> Bool {
+    static func ==(lhs: Thread, rhs: Thread) -> Bool {
         return pthread_equal(lhs.pthread, rhs.pthread) != 0
     }
 }


### PR DESCRIPTION
Motivation:

Thread's equality function was public by accident.

Modifications:

make Thread's equality function internal

Result:

Thread remains internal
