### PR TITLE
remove extension public/internal modifiers

### DIFF
--- a/Sources/NIO/BlockingIOThreadPool.swift
+++ b/Sources/NIO/BlockingIOThreadPool.swift
@@ -181,7 +181,7 @@ public final class BlockingIOThreadPool {
     }
 }
 
-public extension BlockingIOThreadPool {
+extension BlockingIOThreadPool {
     /// Runs the submitted closure if the thread pool is still active, otherwise fails the promise.
     /// The closure will be run on the thread pool so can do blocking work.
     ///
@@ -189,7 +189,7 @@ public extension BlockingIOThreadPool {
     ///     - eventLoop: The `EventLoop` the returned `EventLoopFuture` will fire on.
     ///     - body: The closure which performs some blocking work to be done on the thread pool.
     /// - returns: The `EventLoopFuture` of `promise` fulfilled with the result (or error) of the passed closure.
-    func runIfActive<T>(eventLoop: EventLoop, _ body: @escaping () throws -> T) -> EventLoopFuture<T> {
+    public func runIfActive<T>(eventLoop: EventLoop, _ body: @escaping () throws -> T) -> EventLoopFuture<T> {
         let promise = eventLoop.makePromise(of: T.self)
         self.submit { shouldRun in
             guard case shouldRun = BlockingIOThreadPool.WorkItemState.active else {

--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -61,9 +61,9 @@ public struct ByteBufferView: RandomAccessCollection {
     }
 }
 
-public extension ByteBuffer {
+extension ByteBuffer {
     /// A view into the readable bytes of the `ByteBuffer`.
-    var readableBytesView: ByteBufferView {
+    public var readableBytesView: ByteBufferView {
         return ByteBufferView(buffer: self, range: self.readerIndex ..< self.readerIndex + self.readableBytes)
     }
 
@@ -73,7 +73,7 @@ public extension ByteBuffer {
     ///   - index: The index the view should start at
     ///   - length: The length of the view (in bytes)
     /// - returns A view into a portion of a `ByteBuffer`.
-    func viewBytes(at index: Int, length: Int) -> ByteBufferView {
+    public func viewBytes(at index: Int, length: Int) -> ByteBufferView {
         return ByteBufferView(buffer: self, range: index ..< index+length)
     }
 }

--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -221,26 +221,26 @@ extension Channel {
 
 
 /// Provides special extension to make writing data to the `Channel` easier by removing the need to wrap data in `NIOAny` manually.
-public extension Channel {
+extension Channel {
 
     /// Write data into the `Channel`, automatically wrapping with `NIOAny`.
     ///
     /// - seealso: `ChannelOutboundInvoker.write`.
-    func write<T>(_ any: T) -> EventLoopFuture<Void> {
+    public func write<T>(_ any: T) -> EventLoopFuture<Void> {
         return self.write(NIOAny(any))
     }
 
     /// Write data into the `Channel`, automatically wrapping with `NIOAny`.
     ///
     /// - seealso: `ChannelOutboundInvoker.write`.
-    func write<T>(_ any: T, promise: EventLoopPromise<Void>?) {
+    public func write<T>(_ any: T, promise: EventLoopPromise<Void>?) {
         self.write(NIOAny(any), promise: promise)
     }
 
     /// Write and flush data into the `Channel`, automatically wrapping with `NIOAny`.
     ///
     /// - seealso: `ChannelOutboundInvoker.writeAndFlush`.
-    func writeAndFlush<T>(_ any: T) -> EventLoopFuture<Void> {
+    public func writeAndFlush<T>(_ any: T) -> EventLoopFuture<Void> {
         return self.writeAndFlush(NIOAny(any))
     }
 
@@ -248,12 +248,12 @@ public extension Channel {
     /// Write and flush data into the `Channel`, automatically wrapping with `NIOAny`.
     ///
     /// - seealso: `ChannelOutboundInvoker.writeAndFlush`.
-    func writeAndFlush<T>(_ any: T, promise: EventLoopPromise<Void>?) {
+    public func writeAndFlush<T>(_ any: T, promise: EventLoopPromise<Void>?) {
         self.writeAndFlush(NIOAny(any), promise: promise)
     }
 }
 
-public extension ChannelCore {
+extension ChannelCore {
     /// Unwraps the given `NIOAny` as a specific concrete type.
     ///
     /// This method is intended for use when writing custom `ChannelCore` implementations.
@@ -270,7 +270,7 @@ public extension ChannelCore {
     ///     - as: The type to extract from the `NIOAny`.
     /// - returns: The content of the `NIOAny`.
     @inlinable
-    func unwrapData<T>(_ data: NIOAny, as: T.Type = T.self) -> T {
+    public func unwrapData<T>(_ data: NIOAny, as: T.Type = T.self) -> T {
         return data.forceAs()
     }
 
@@ -283,7 +283,7 @@ public extension ChannelCore {
     ///
     /// - parameters:
     ///     - channel: The `Channel` whose `ChannelPipeline` will be closed.
-    func removeHandlers(channel: Channel) {
+    public func removeHandlers(channel: Channel) {
         channel.pipeline.removeHandlers()
     }
 }

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -1101,7 +1101,7 @@ extension EventLoopFuture {
     }
 }
 
-public extension EventLoopFuture {
+extension EventLoopFuture {
     /// Returns an `EventLoopFuture` that fires when this future completes, but executes its callbacks on the
     /// target event loop instead of the original one.
     ///
@@ -1113,7 +1113,7 @@ public extension EventLoopFuture {
     /// - parameters:
     ///     - to: The `EventLoop` that the returned `EventLoopFuture` will run on.
     /// - returns: An `EventLoopFuture` whose callbacks run on `target` instead of the original loop.
-    func hop(to target: EventLoop) -> EventLoopFuture<Value> {
+    public func hop(to target: EventLoop) -> EventLoopFuture<Value> {
         if target === self.eventLoop {
             // We're already on that event loop, nothing to do here. Save an allocation.
             return self

--- a/Sources/NIO/LinuxCPUSet.swift
+++ b/Sources/NIO/LinuxCPUSet.swift
@@ -45,7 +45,7 @@ import CNIOLinux
     extension LinuxCPUSet: Equatable {}
 
     /// Linux specific extension to `Thread`.
-    internal extension Thread {
+    extension Thread {
         /// Specify the thread-affinity of the `Thread` itself.
         var affinity: LinuxCPUSet {
             get {

--- a/Sources/NIO/MulticastChannel.swift
+++ b/Sources/NIO/MulticastChannel.swift
@@ -56,34 +56,34 @@ public protocol MulticastChannel: Channel {
 
 
 // MARK:- Default implementations for MulticastChannel
-public extension MulticastChannel {
-    func joinGroup(_ group: SocketAddress, promise: EventLoopPromise<Void>?) {
+extension MulticastChannel {
+    public func joinGroup(_ group: SocketAddress, promise: EventLoopPromise<Void>?) {
         self.joinGroup(group, interface: nil, promise: promise)
     }
 
-    func joinGroup(_ group: SocketAddress) -> EventLoopFuture<Void> {
+    public func joinGroup(_ group: SocketAddress) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         self.joinGroup(group, promise: promise)
         return promise.futureResult
     }
 
-    func joinGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
+    public func joinGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         self.joinGroup(group, interface: interface, promise: promise)
         return promise.futureResult
     }
 
-    func leaveGroup(_ group: SocketAddress, promise: EventLoopPromise<Void>?) {
+    public func leaveGroup(_ group: SocketAddress, promise: EventLoopPromise<Void>?) {
         self.leaveGroup(group, interface: nil, promise: promise)
     }
 
-    func leaveGroup(_ group: SocketAddress) -> EventLoopFuture<Void> {
+    public func leaveGroup(_ group: SocketAddress) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         self.leaveGroup(group, promise: promise)
         return promise.futureResult
     }
 
-    func leaveGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
+    public func leaveGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         self.leaveGroup(group, interface: interface, promise: promise)
         return promise.futureResult

--- a/Sources/NIO/PriorityQueue.swift
+++ b/Sources/NIO/PriorityQueue.swift
@@ -76,7 +76,7 @@ extension PriorityQueue: Sequence {
     }
 }
 
-internal extension PriorityQueue {
+extension PriorityQueue {
     var count: Int {
         return self.heap.count
     }

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -657,7 +657,7 @@ struct SelectorEvent<R> {
     }
 }
 
-internal extension Selector where R == NIORegistration {
+extension Selector where R == NIORegistration {
     /// Gently close the `Selector` after all registered `Channel`s are closed.
     func closeGently(eventLoop: EventLoop) -> EventLoopFuture<Void> {
         guard self.lifecycleState == .open else {

--- a/Sources/NIO/SocketOptionProvider.swift
+++ b/Sources/NIO/SocketOptionProvider.swift
@@ -81,14 +81,14 @@ public protocol SocketOptionProvider {
 // around. As a result, if you change one, you should probably change them all.
 //
 // You are welcome to add more helper methods here, but each helper method you add must be tested.
-public extension SocketOptionProvider {
+extension SocketOptionProvider {
     /// Sets the socket option SO_LINGER to `value`.
     ///
     /// - parameters:
     ///     - value: The value to set SO_LINGER to.
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
-    func setSoLinger(_ value: linger) -> EventLoopFuture<Void> {
+    public func setSoLinger(_ value: linger) -> EventLoopFuture<Void> {
         return self.unsafeSetSocketOption(level: SocketOptionLevel(SOL_SOCKET), name: SO_LINGER, value: value)
     }
 
@@ -96,7 +96,7 @@ public extension SocketOptionProvider {
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
-    func getSoLinger() -> EventLoopFuture<linger> {
+    public func getSoLinger() -> EventLoopFuture<linger> {
         return self.unsafeGetSocketOption(level: SocketOptionLevel(SOL_SOCKET), name: SO_LINGER)
     }
 
@@ -106,7 +106,7 @@ public extension SocketOptionProvider {
     ///     - value: The value to set IP_MULTICAST_IF to.
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
-    func setIPMulticastIF(_ value: in_addr) -> EventLoopFuture<Void> {
+    public func setIPMulticastIF(_ value: in_addr) -> EventLoopFuture<Void> {
         return self.unsafeSetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_IF, value: value)
     }
 
@@ -114,7 +114,7 @@ public extension SocketOptionProvider {
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
-    func getIPMulticastIF() -> EventLoopFuture<in_addr> {
+    public func getIPMulticastIF() -> EventLoopFuture<in_addr> {
         return self.unsafeGetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_IF)
     }
 
@@ -124,7 +124,7 @@ public extension SocketOptionProvider {
     ///     - value: The value to set IP_MULTICAST_TTL to.
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
-    func setIPMulticastTTL(_ value: CUnsignedChar) -> EventLoopFuture<Void> {
+    public func setIPMulticastTTL(_ value: CUnsignedChar) -> EventLoopFuture<Void> {
         return self.unsafeSetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_TTL, value: value)
     }
 
@@ -132,7 +132,7 @@ public extension SocketOptionProvider {
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
-    func getIPMulticastTTL() -> EventLoopFuture<CUnsignedChar> {
+    public func getIPMulticastTTL() -> EventLoopFuture<CUnsignedChar> {
         return self.unsafeGetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_TTL)
     }
 
@@ -142,7 +142,7 @@ public extension SocketOptionProvider {
     ///     - value: The value to set IP_MULTICAST_LOOP to.
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
-    func setIPMulticastLoop(_ value: CUnsignedChar) -> EventLoopFuture<Void> {
+    public func setIPMulticastLoop(_ value: CUnsignedChar) -> EventLoopFuture<Void> {
         return self.unsafeSetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_LOOP, value: value)
     }
 
@@ -150,7 +150,7 @@ public extension SocketOptionProvider {
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
-    func getIPMulticastLoop() -> EventLoopFuture<CUnsignedChar> {
+    public func getIPMulticastLoop() -> EventLoopFuture<CUnsignedChar> {
         return self.unsafeGetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_LOOP)
     }
 
@@ -160,7 +160,7 @@ public extension SocketOptionProvider {
     ///     - value: The value to set IPV6_MULTICAST_IF to.
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
-    func setIPv6MulticastIF(_ value: CUnsignedInt) -> EventLoopFuture<Void> {
+    public func setIPv6MulticastIF(_ value: CUnsignedInt) -> EventLoopFuture<Void> {
         return self.unsafeSetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_IF, value: value)
     }
 
@@ -168,7 +168,7 @@ public extension SocketOptionProvider {
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
-    func getIPv6MulticastIF() -> EventLoopFuture<CUnsignedInt> {
+    public func getIPv6MulticastIF() -> EventLoopFuture<CUnsignedInt> {
         return self.unsafeGetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_IF)
     }
 
@@ -178,7 +178,7 @@ public extension SocketOptionProvider {
     ///     - value: The value to set IPV6_MULTICAST_HOPS to.
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
-    func setIPv6MulticastHops(_ value: CInt) -> EventLoopFuture<Void> {
+    public func setIPv6MulticastHops(_ value: CInt) -> EventLoopFuture<Void> {
         return self.unsafeSetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_HOPS, value: value)
     }
 
@@ -186,7 +186,7 @@ public extension SocketOptionProvider {
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
-    func getIPv6MulticastHops() -> EventLoopFuture<CInt> {
+    public func getIPv6MulticastHops() -> EventLoopFuture<CInt> {
         return self.unsafeGetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_HOPS)
     }
 
@@ -196,7 +196,7 @@ public extension SocketOptionProvider {
     ///     - value: The value to set IPV6_MULTICAST_LOOP to.
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
-    func setIPv6MulticastLoop(_ value: CUnsignedInt) -> EventLoopFuture<Void> {
+    public func setIPv6MulticastLoop(_ value: CUnsignedInt) -> EventLoopFuture<Void> {
         return self.unsafeSetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_LOOP, value: value)
     }
 
@@ -204,7 +204,7 @@ public extension SocketOptionProvider {
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
-    func getIPv6MulticastLoop() -> EventLoopFuture<CUnsignedInt> {
+    public func getIPv6MulticastLoop() -> EventLoopFuture<CUnsignedInt> {
         return self.unsafeGetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_LOOP)
     }
 
@@ -215,7 +215,7 @@ public extension SocketOptionProvider {
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
-    func getTCPInfo() -> EventLoopFuture<tcp_info> {
+    public func getTCPInfo() -> EventLoopFuture<tcp_info> {
         return self.unsafeGetSocketOption(level: IPPROTO_TCP, name: TCP_INFO)
     }
     #endif
@@ -227,7 +227,7 @@ public extension SocketOptionProvider {
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
-    func getTCPConnectionInfo() -> EventLoopFuture<tcp_connection_info> {
+    public func getTCPConnectionInfo() -> EventLoopFuture<tcp_connection_info> {
         return self.unsafeGetSocketOption(level: IPPROTO_TCP, name: TCP_CONNECTION_INFO)
     }
     #endif

--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -20,14 +20,15 @@ import NIO
 /// properties.
 public typealias HTTPUpgradeConfiguration = (upgraders: [HTTPServerProtocolUpgrader], completionHandler: (ChannelHandlerContext) -> Void)
 
-public extension ChannelPipeline {
+extension ChannelPipeline {
     /// Configure a `ChannelPipeline` for use as a HTTP client.
     ///
     /// - parameters:
     ///     - first: Whether to add the HTTP client at the head of the channel pipeline,
     ///              or at the tail.
     /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
-    func addHTTPClientHandlers(first: Bool = false, leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes) -> EventLoopFuture<Void> {
+    public func addHTTPClientHandlers(first: Bool = false,
+                                      leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes) -> EventLoopFuture<Void> {
         return addHandlers(HTTPRequestEncoder(), HTTPResponseDecoder(leftOverBytesStrategy: leftOverBytesStrategy), first: first)
     }
 
@@ -57,10 +58,10 @@ public extension ChannelPipeline {
     ///     - errorHandling: Whether to provide assistance handling protocol errors (e.g.
     ///         failure to parse the HTTP request) by sending 400 errors. Defaults to `true`.
     /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
-    func configureHTTPServerPipeline(first: Bool = false,
-                                     withPipeliningAssistance pipelining: Bool = true,
-                                     withServerUpgrade upgrade: HTTPUpgradeConfiguration? = nil,
-                                     withErrorHandling errorHandling: Bool = true) -> EventLoopFuture<Void> {
+    public func configureHTTPServerPipeline(first: Bool = false,
+                                            withPipeliningAssistance pipelining: Bool = true,
+                                            withServerUpgrade upgrade: HTTPUpgradeConfiguration? = nil,
+                                            withErrorHandling errorHandling: Bool = true) -> EventLoopFuture<Void> {
         let responseEncoder = HTTPResponseEncoder()
         let requestDecoder = HTTPRequestDecoder(leftOverBytesStrategy: upgrade == nil ? .dropBytes : .forwardBytes)
 

--- a/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+++ b/Sources/NIOHTTP1/HTTPResponseCompressor.swift
@@ -15,7 +15,7 @@
 import CNIOZlib
 import NIO
 
-internal extension String {
+extension String {
     /// Test if this `Collection` starts with the unicode scalars of `needle`.
     ///
     /// - note: This will be faster than `String.startsWith` as no unicode normalisations are performed.

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -397,7 +397,7 @@ private extension UInt8 {
     }
 }
 
-/* private but tests */ internal extension HTTPHeaders {
+extension HTTPHeaders {
     func isKeepAlive(version: HTTPVersion) -> Bool {
         switch self._storage.keepAliveState {
         case .close:
@@ -714,7 +714,7 @@ public struct HTTPHeaders: CustomStringConvertible {
     }
 }
 
-internal extension ByteBuffer {
+extension ByteBuffer {
 
     /// Serializes this HTTP header block to bytes suitable for writing to the wire.
     ///
@@ -738,6 +738,7 @@ internal extension ByteBuffer {
         self.writeStaticString(crlf)
     }
 }
+
 extension HTTPHeaders: Sequence {
     public typealias Element = (name: String, value: String)
 
@@ -762,13 +763,13 @@ extension HTTPHeaders: Sequence {
     }
 }
 
-/* private but tests */ internal extension Character {
+extension Character {
     var isASCIIWhitespace: Bool {
         return self == " " || self == "\t" || self == "\r" || self == "\n" || self == "\r\n"
     }
 }
 
-/* private but tests */ internal extension String {
+extension String {
     func trimASCIIWhitespace() -> Substring {
         return self.dropFirst(0).trimWhitespace()
     }

--- a/Sources/NIOWebSocket/Base64.swift
+++ b/Sources/NIOWebSocket/Base64.swift
@@ -24,7 +24,7 @@ private let base64Table: [Unicode.Scalar] = [
     "4", "5", "6", "7", "8", "9", "+", "/",
 ]
 
-internal extension String {
+extension String {
     /// Base64 encode an array of UInt8 to a string, without the use of Foundation.
     ///
     /// This function performs the world's most naive Base64 encoding: no attempts to use a larger

--- a/Sources/NIOWebSocket/WebSocketErrorCodes.swift
+++ b/Sources/NIOWebSocket/WebSocketErrorCodes.swift
@@ -125,13 +125,13 @@ public enum WebSocketErrorCode {
 
 extension WebSocketErrorCode: Equatable {}
 
-public extension ByteBuffer {
+extension ByteBuffer {
     /// Read a websocket error code from a byte buffer.
     ///
     /// This method increments the reader index.
     ///
     /// - returns: The error code, or `nil` if there were not enough readable bytes.
-    mutating func readWebSocketErrorCode() -> WebSocketErrorCode? {
+    public mutating func readWebSocketErrorCode() -> WebSocketErrorCode? {
         return self.readInteger(as: UInt16.self).map { WebSocketErrorCode(networkInteger: $0) }
     }
 
@@ -143,7 +143,7 @@ public extension ByteBuffer {
     /// - parameters:
     ///     - index: The index into the buffer to read the error code from.
     /// - returns: The error code, or `nil` if there were not enough bytes at that index.
-    func getWebSocketErrorCode(at index: Int) -> WebSocketErrorCode? {
+    public func getWebSocketErrorCode(at index: Int) -> WebSocketErrorCode? {
         return self.getInteger(at: index, as: UInt16.self).map { WebSocketErrorCode(networkInteger: $0) }
     }
 
@@ -151,17 +151,17 @@ public extension ByteBuffer {
     ///
     /// - parameters:
     ///     - code: The code to write into the buffer.
-    mutating func write(webSocketErrorCode code: WebSocketErrorCode) {
+    public mutating func write(webSocketErrorCode code: WebSocketErrorCode) {
         self.writeInteger(UInt16(webSocketErrorCode: code))
     }
 }
 
-public extension UInt16 {
+extension UInt16 {
     /// Create a UInt16 corresponding to a given `WebSocketErrorCode`.
     ///
     /// - parameters:
     ///     - code: The `WebSocketErrorCode`.
-    init(webSocketErrorCode code: WebSocketErrorCode) {
+    public init(webSocketErrorCode code: WebSocketErrorCode) {
         switch code {
         case .normalClosure:
             self = 1000

--- a/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
@@ -27,7 +27,7 @@ public enum NIOWebSocketError: Error {
     case multiByteControlFrameLength
 }
 
-internal extension WebSocketErrorCode {
+extension WebSocketErrorCode {
     init(_ error: NIOWebSocketError) {
         switch error {
         case .invalidFrameLength:
@@ -39,12 +39,12 @@ internal extension WebSocketErrorCode {
     }
 }
 
-public extension ByteBuffer {
+extension ByteBuffer {
     /// Applies the WebSocket unmasking operation.
     ///
     /// - parameters:
     ///     - maskingKey: The masking key.
-    mutating func webSocketUnmask(_ maskingKey: WebSocketMaskingKey, indexOffset: Int = 0) {
+    public mutating func webSocketUnmask(_ maskingKey: WebSocketMaskingKey, indexOffset: Int = 0) {
         /// Shhhh: secretly unmasking and masking are the same operation!
         webSocketMask(maskingKey, indexOffset: indexOffset)
     }
@@ -57,7 +57,7 @@ public extension ByteBuffer {
     ///         This is used when masking multiple "contiguous" byte buffers, to ensure that
     ///         the masking key is applied uniformly to the collection rather than from the
     ///         start each time.
-    mutating func webSocketMask(_ maskingKey: WebSocketMaskingKey, indexOffset: Int = 0) {
+    public mutating func webSocketMask(_ maskingKey: WebSocketMaskingKey, indexOffset: Int = 0) {
         self.withUnsafeMutableReadableBytes {
             for (index, byte) in $0.enumerated() {
                 $0[index] = byte ^ maskingKey[(index + indexOffset) % 4]

--- a/Sources/NIOWebSocket/WebSocketOpcode.swift
+++ b/Sources/NIOWebSocket/WebSocketOpcode.swift
@@ -81,7 +81,7 @@ extension WebSocketOpcode: CustomStringConvertible {
     }
 }
 
-public extension UInt8 {
+extension UInt8 {
     /// Create a UInt8 corresponding to a given `WebSocketOpcode`.
     ///
     /// This places the opcode in the four least-significant bits, in
@@ -89,18 +89,18 @@ public extension UInt8 {
     ///
     /// - parameters:
     ///     - opcode: The `WebSocketOpcode`.
-    init(webSocketOpcode opcode: WebSocketOpcode) {
+    public init(webSocketOpcode opcode: WebSocketOpcode) {
         precondition(opcode.networkRepresentation < 0x10)
         self = opcode.networkRepresentation
     }
 }
 
-public extension Int {
+extension Int {
     /// Create a UInt8 corresponding to the integer value for a given `WebSocketOpcode`.
     ///
     /// - parameters:
     ///     - opcode: The `WebSocketOpcode`.
-    init(webSocketOpcode opcode: WebSocketOpcode) {
+    public init(webSocketOpcode opcode: WebSocketOpcode) {
         precondition(opcode.networkRepresentation < 0x10)
         self = Int(opcode.networkRepresentation)
     }

--- a/Tests/NIOTLSTests/SNIHandlerTests.swift
+++ b/Tests/NIOTLSTests/SNIHandlerTests.swift
@@ -226,7 +226,7 @@ private let ludicrouslyTruncatedPacket = "FgMBAAEB"
 
 private let fuzzingInputOne = "FgMAAAQAAgo="
 
-internal extension ChannelPipeline {
+extension ChannelPipeline {
     func contains(handler: ChannelHandler) throws -> Bool {
         do {
             _ = try self.context(handler: handler).wait()

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -98,7 +98,7 @@ func openTemporaryFile() -> (CInt, String) {
     return (fd, String(decoding: templateBytes, as: Unicode.UTF8.self))
 }
 
-internal extension Channel {
+extension Channel {
     func syncCloseAcceptingAlreadyClosed() throws {
         do {
             try self.close().wait()


### PR DESCRIPTION
Motivation:

public/internal modifiers for `extension`s are confusing as a
`func foo` is public if within a `public extension`.

Modifications:

remove all `internal` (redundant) and `public` (dangerous) modifiers for
`extensions`.

Result:

- code easier to read
- code much easier to review in a small diff