### PR TITLE
Accept dictionary literals for HTTPHeaders

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -430,7 +430,7 @@ private extension UInt8 {
 /// field when needed. It also supports recomposing headers to a maximally joined
 /// or split representation, such that header fields that are able to be repeated
 /// can be represented appropriately.
-public struct HTTPHeaders: CustomStringConvertible {
+public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiteral {
 
     private final class _Storage {
         var buffer: ByteBuffer
@@ -556,6 +556,14 @@ public struct HTTPHeaders: CustomStringConvertible {
         }
     }
     
+    /// Construct a `HTTPHeaders` structure.
+    ///
+    /// - parameters
+    ///     - elements: name, value pairs provided by a dictionary literal.
+    public init(dictionaryLiteral elements: (String, String)...) {
+        self.init(elements)
+    }
+
     private func isConnectionHeader(_ header: HTTPHeaderIndex) -> Bool {
          return self.buffer.equalCaseInsensitiveASCII(view: "connection".utf8, at: header)
     }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -27,6 +27,7 @@ extension HTTPHeadersTest {
    static var allTests : [(String, (HTTPHeadersTest) -> () throws -> Void)] {
       return [
                 ("testCasePreservedButInsensitiveLookup", testCasePreservedButInsensitiveLookup),
+                ("testDictionaryLiteralAlternative", testDictionaryLiteralAlternative),
                 ("testWriteHeadersSeparately", testWriteHeadersSeparately),
                 ("testRevealHeadersSeparately", testRevealHeadersSeparately),
                 ("testSubscriptDoesntSplitHeaders", testSubscriptDoesntSplitHeaders),

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -50,6 +50,37 @@ class HTTPHeadersTest : XCTestCase {
         }
     }
 
+    func testDictionaryLiteralAlternative() {
+        let headers: HTTPHeaders = [ "User-Agent": "1",
+                                     "host": "2",
+                                     "X-SOMETHING": "3",
+                                     "SET-COOKIE": "foo=bar",
+                                     "Set-Cookie": "buz=cux"]
+
+        // looking up headers value is case-insensitive
+        XCTAssertEqual(["1"], headers["User-Agent"])
+        XCTAssertEqual(["1"], headers["User-agent"])
+        XCTAssertEqual(["2"], headers["Host"])
+        XCTAssertEqual(["foo=bar", "buz=cux"], headers["set-cookie"])
+
+        for (key,value) in headers {
+            switch key {
+            case "User-Agent":
+                XCTAssertEqual("1", value)
+            case "host":
+                XCTAssertEqual("2", value)
+            case "X-SOMETHING":
+                XCTAssertEqual("3", value)
+            case "SET-COOKIE":
+                XCTAssertEqual("foo=bar", value)
+            case "Set-Cookie":
+                XCTAssertEqual("buz=cux", value)
+            default:
+                XCTFail("Unexpected key: \(key)")
+            }
+        }
+    }
+
     func testWriteHeadersSeparately() {
         let originalHeaders = [ ("User-Agent", "1"),
                                 ("host", "2"),


### PR DESCRIPTION
Just an idea - be able to provide dictionary literals where an HTTPHeader struct is expected. I could add the conformance in an extension if you prefer.

### Motivation:

A convenience/shorthand  for developers.

### Modifications:

Add conformance to ExpressibleByDictionaryLiteral along with implementation.

### Result:

The following is would then be legal in Vapor:
```
        return HTTPResponse(status: .ok, headers: ["Content-Type": "text/html"],
                            body: "<table border=1><tr><td><i>Hello</i>, plugin!")
```