### PR TITLE
opaque indices for (Marked)CircularBuffer

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -23,9 +23,9 @@ protocol AppendableCollection: Collection {
 /// An automatically expanding ring buffer implementation backed by a `ContiguousArray`. Even though this implementation
 /// will automatically expand if more elements than `initialCapacity` are stored, it's advantageous to prevent
 /// expansions from happening frequently. Expansions will always force an allocation and a copy to happen.
-public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
+public struct CircularBuffer<Element>: CustomStringConvertible, AppendableCollection {
     public typealias RangeType<Bound> = Range<Bound> where Bound: Strideable, Bound.Stride: SignedInteger
-    private var buffer: ContiguousArray<E?>
+    private var buffer: ContiguousArray<Element?>
 
     /// The index into the buffer of the first item
     private(set) /* private but tests */ internal var headIdx = 0
@@ -33,6 +33,45 @@ public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     /// The index into the buffer of the next free slot
     private(set) /* private but tests */ internal var tailIdx = 0
 
+    public struct Index: Strideable, Comparable {
+        @usableFromInline
+        var _value: Int
+
+        public typealias Stride = Int
+
+        @inlinable
+        internal init(_value: Int) {
+            self._value = _value
+        }
+
+        @inlinable
+        public func distance(to other: Index) -> Int {
+            return self._value.distance(to: other._value)
+        }
+
+        @inlinable
+        public func advanced(by n: Int) -> Index {
+            return Index(_value: self._value + n)
+        }
+
+        @inlinable
+        public static func < (lhs: Index, rhs: Index) -> Bool {
+            return lhs._value < rhs._value
+        }
+
+        @inlinable
+        public static func <= (lhs: Index, rhs: Index) -> Bool {
+            return lhs._value <= rhs._value
+        }
+
+        @inlinable
+        public static func == (lhs: Index, rhs: Index) -> Bool {
+            return lhs._value == rhs._value
+        }
+    }
+}
+
+extension CircularBuffer {
     /// Bitmask used for calculating the tailIdx / headIdx based on the fact that the underlying storage
     /// has always a size of power of two.
     private var mask: Int {
@@ -43,7 +82,7 @@ public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     /// the buffer. When the ring grows to more than `initialCapacity` elements the buffer will be expanded.
     public init(initialCapacity: Int) {
         let capacity = Int(UInt32(initialCapacity).nextPowerOf2())
-        self.buffer = ContiguousArray<E?>(repeating: nil, count: capacity)
+        self.buffer = ContiguousArray<Element?>(repeating: nil, count: capacity)
         assert(self.buffer.count == capacity)
     }
 
@@ -55,7 +94,7 @@ public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     /// Append an element to the end of the ring buffer.
     ///
     /// Amortized *O(1)*
-    public mutating func append(_ value: E) {
+    public mutating func append(_ value: Element) {
         self.buffer[self.tailIdx] = value
         self.tailIdx = (self.tailIdx + 1) & self.mask
 
@@ -68,7 +107,7 @@ public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     /// Prepend an element to the front of the ring buffer.
     ///
     /// Amortized *O(1)*
-    public mutating func prepend(_ value: E) {
+    public mutating func prepend(_ value: Element) {
         let idx = (self.headIdx - 1) & mask
         self.buffer[idx] = value
         self.headIdx = idx
@@ -81,7 +120,7 @@ public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
 
     /// Double the capacity of the buffer and adjust the headIdx and tailIdx.
     private mutating func doubleCapacity() {
-        var newBacking: ContiguousArray<E?> = []
+        var newBacking: ContiguousArray<Element?> = []
         let newCapacity = self.buffer.count << 1 // Double the storage.
         precondition(newCapacity > 0, "Can't double capacity of \(self.buffer.count)")
         assert(newCapacity % 2 == 0)
@@ -101,7 +140,7 @@ public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     /// Return element `index` of the ring.
     ///
     /// *O(1)*
-    public subscript(index: Int) -> E {
+    public subscript(index: Index) -> Element {
         get {
             return self.buffer[self.bufferIndex(ofIndex: index)]!
         }
@@ -111,8 +150,8 @@ public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     }
 
     /// Return all valid indices of the ring.
-    public var indices: RangeType<Int> {
-        return 0..<self.count
+    public var indices: RangeType<Index> {
+        return self.startIndex ..< self.endIndex
     }
 
     /// Returns whether the ring is empty.
@@ -131,33 +170,33 @@ public struct CircularBuffer<E>: CustomStringConvertible, AppendableCollection {
     }
 
     /// Returns the index of the first element of the ring.
-    public var startIndex: Int {
-        return 0
+    public var startIndex: Index {
+        return Index(_value: 0)
     }
 
     /// Returns the ring's "past the end" position -- that is, the position one greater than the last valid subscript argument.
-    public var endIndex: Int {
-        return self.count
+    public var endIndex: Index {
+        return Index(_value: self.count)
     }
 
     /// Returns the next index after `index`.
-    public func index(after: Int) -> Int {
-        let nextIndex = after + 1
+    public func index(after: Index) -> Index {
+        let nextIndex = after.advanced(by: 1)
         precondition(nextIndex <= self.endIndex)
         return nextIndex
     }
 
     /// Returns the index before `index`.
-    public func index(before: Int) -> Int {
-        precondition(before > 0)
-        return before - 1
+    public func index(before: Index) -> Index {
+        precondition(before._value > 0)
+        return before.advanced(by: -1)
     }
 
     /// Removes all members from the circular buffer whist keeping the capacity.
     public mutating func removeAll(keepingCapacity: Bool = false) {
         if keepingCapacity {
             for index in 0..<self.count {
-                self.buffer[self.bufferIndex(ofIndex: index)] = nil
+                self.buffer[self.bufferIndex(ofIndex: Index(_value: index))] = nil
             }
         } else {
             self.buffer.removeAll(keepingCapacity: false)
@@ -199,7 +238,7 @@ extension CircularBuffer: BidirectionalCollection, RandomAccessCollection, Range
     /// *O(n)* where _n_ is the length of the new elements collection if the subrange equals to _n_
     ///
     /// *O(m)* where _m_ is the combined length of the collection and _newElements_
-    public mutating func replaceSubrange<C>(_ subrange: Range<Index>, with newElements: C) where C : Collection, E == C.Element {
+    public mutating func replaceSubrange<C>(_ subrange: Range<Index>, with newElements: C) where C : Collection, Element == C.Element {
         precondition(subrange.lowerBound >= self.startIndex && subrange.upperBound <= self.endIndex, "Subrange out of bounds")
 
         if subrange.count == newElements.count {
@@ -212,7 +251,7 @@ extension CircularBuffer: BidirectionalCollection, RandomAccessCollection, Range
         } else if subrange.count == self.count && newElements.isEmpty {
             self.removeSubrange(subrange)
         } else {
-            var newBuffer: ContiguousArray<E?> = []
+            var newBuffer: ContiguousArray<Element?> = []
             let neededNewCapacity = self.count + newElements.count - subrange.count + 1 /* always one spare */
             let newCapacity = Swift.max(self.capacity, neededNewCapacity.nextPowerOf2())
             newBuffer.reserveCapacity(newCapacity)
@@ -220,7 +259,7 @@ extension CircularBuffer: BidirectionalCollection, RandomAccessCollection, Range
             // This mapping is required due to an inconsistent ability to append sequences of non-optional
             // to optional sequences.
             // https://bugs.swift.org/browse/SR-7921
-            newBuffer.append(contentsOf: self[0..<subrange.lowerBound].lazy.map { $0 })
+            newBuffer.append(contentsOf: self[self.startIndex ..< subrange.lowerBound].lazy.map { $0 })
             newBuffer.append(contentsOf: newElements.lazy.map { $0 })
             newBuffer.append(contentsOf: self[subrange.upperBound..<self.endIndex].lazy.map { $0 })
 
@@ -237,7 +276,7 @@ extension CircularBuffer: BidirectionalCollection, RandomAccessCollection, Range
     /// Removes the elements in the specified subrange from the circular buffer.
     ///
     /// - Parameter bounds: The range of the circular buffer to be removed. The bounds of the range must be valid indices of the collection.
-    public mutating func removeSubrange(_ bounds: Range<Int>) {
+    public mutating func removeSubrange(_ bounds: Range<Index>) {
         precondition(bounds.upperBound >= self.startIndex && bounds.upperBound <= self.endIndex, "Invalid bounds.")
         switch bounds.count {
         case 1:
@@ -257,7 +296,7 @@ extension CircularBuffer: BidirectionalCollection, RandomAccessCollection, Range
         var idx = self.tailIdx
         for _ in 0 ..< n {
             self.buffer[idx] = nil
-            idx = self.bufferIndex(before: idx)
+            idx = self.bufferIndex(before: Index(_value: idx))
         }
         self.tailIdx = (self.tailIdx - n) & self.mask
     }
@@ -270,27 +309,27 @@ extension CircularBuffer: BidirectionalCollection, RandomAccessCollection, Range
     /// otherwise
     /// *O(n)* where *n* is the number of elements between `position` and `tailIdx`.
     @discardableResult
-    public mutating func remove(at position: Int) -> E {
+    public mutating func remove(at position: Index) -> Element {
         precondition(self.indices.contains(position), "Position out of bounds.")
         var bufferIndex = self.bufferIndex(ofIndex: position)
         let element = self.buffer[bufferIndex]!
 
         switch bufferIndex {
         case self.headIdx:
-            self.headIdx = self.bufferIndex(after: self.headIdx)
+            self.headIdx = self.bufferIndex(after: Index(_value: self.headIdx))
             self.buffer[bufferIndex] = nil
         case self.tailIdx - 1:
-            self.tailIdx = self.bufferIndex(before: self.tailIdx)
+            self.tailIdx = self.bufferIndex(before: Index(_value: self.tailIdx))
             self.buffer[bufferIndex] = nil
         default:
-            var nextIndex = self.bufferIndex(after: bufferIndex)
+            var nextIndex = self.bufferIndex(after: Index(_value: bufferIndex))
             while nextIndex != self.tailIdx {
                 self.buffer[bufferIndex] = self.buffer[nextIndex]
                 bufferIndex = nextIndex
-                nextIndex = self.bufferIndex(after: bufferIndex)
+                nextIndex = self.bufferIndex(after: Index(_value: bufferIndex))
             }
             self.buffer[nextIndex] = nil
-            self.tailIdx = self.bufferIndex(before: self.tailIdx)
+            self.tailIdx = self.bufferIndex(before: Index(_value: self.tailIdx))
         }
 
         return element
@@ -300,18 +339,18 @@ extension CircularBuffer: BidirectionalCollection, RandomAccessCollection, Range
 // MARK: - Private functions
 
 private extension CircularBuffer {
-    func bufferIndex(ofIndex index: Int) -> Int {
-        precondition(index < self.count, "index out of range")
-        return (self.headIdx + index) & self.mask
+    func bufferIndex(ofIndex index: Index) -> Int {
+        precondition(index._value < self.count, "index out of range")
+        return (self.headIdx + index._value) & self.mask
     }
 
     /// Returns the internal buffer next index after `index`.
-    func bufferIndex(after: Int) -> Int {
-        return (after + 1) & self.mask
+    func bufferIndex(after: Index) -> Int {
+        return (after._value + 1) & self.mask
     }
 
     /// Returns the internal buffer index before `index`.
-    func bufferIndex(before: Int) -> Int {
-        return (before - 1) & self.mask
+    func bufferIndex(before: Index) -> Int {
+        return (before._value - 1) & self.mask
     }
 }

--- a/Sources/NIO/MarkedCircularBuffer.swift
+++ b/Sources/NIO/MarkedCircularBuffer.swift
@@ -17,11 +17,12 @@
 /// This object is used extensively within SwiftNIO to handle flushable buffers. It can be used to store buffered
 /// writes and mark how far through the buffer the user has flushed, and therefore how far through the buffer is
 /// safe to write.
-public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollection {
+public struct MarkedCircularBuffer<Element>: CustomStringConvertible, AppendableCollection {
     public typealias RangeType<Bound> = Range<Bound> where Bound: Strideable, Bound.Stride: SignedInteger
+    public typealias Index = CircularBuffer<Element>.Index
 
-    private var buffer: CircularBuffer<E>
-    private var markedIndex: Int = -1 /* negative: nothing marked */
+    private var buffer: CircularBuffer<Element>
+    private var markedIndex: Index? = nil /* nil: nothing marked */
 
     /// Create a new instance.
     ///
@@ -34,21 +35,25 @@ public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollec
     // MARK: Forwarding
 
     /// Appends an entry to the buffer, expanding it if needed.
-    public mutating func append(_ value: E) {
+    public mutating func append(_ value: Element) {
         self.buffer.append(value)
     }
 
     /// Removes the first element from the buffer.
-    public mutating func removeFirst() -> E {
+    public mutating func removeFirst() -> Element {
         assert(self.buffer.count > 0)
-        if self.markedIndex != -1 {
-            self.markedIndex -= 1
+        if let markedIndex = self.markedIndex {
+            if markedIndex == self.startIndex {
+                self.markedIndex = nil
+            } else {
+                self.markedIndex = markedIndex.advanced(by: -1)
+            }
         }
         return self.buffer.removeFirst()
     }
 
     /// The first element in the buffer.
-    public var first: E? {
+    public var first: Element? {
         return self.buffer.first
     }
 
@@ -63,7 +68,7 @@ public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollec
     }
 
     /// Retrieves the element at the given index from the buffer, without removing it.
-    public subscript(index: Int) -> E {
+    public subscript(index: Index) -> Element {
         get {
             return self.buffer[index]
         }
@@ -73,15 +78,15 @@ public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollec
     }
 
     /// The valid indices into the buffer.
-    public var indices: RangeType<Int> {
+    public var indices: RangeType<Index> {
         return self.buffer.indices
     }
 
-    public var startIndex: Int { return self.buffer.startIndex }
+    public var startIndex: Index { return self.buffer.startIndex }
 
-    public var endIndex: Int { return self.buffer.endIndex }
+    public var endIndex: Index { return self.buffer.endIndex }
 
-    public func index(after i: Int) -> Int {
+    public func index(after i: Index) -> Index {
         return self.buffer.index(after: i)
     }
 
@@ -95,42 +100,31 @@ public struct MarkedCircularBuffer<E>: CustomStringConvertible, AppendableCollec
     public mutating func mark() {
         let count = self.buffer.count
         if count > 0 {
-            self.markedIndex = count - 1
+            self.markedIndex = self.endIndex.advanced(by: -1)
         } else {
-            assert(self.markedIndex == -1, "marked index is \(self.markedIndex)")
+            assert(self.markedIndex == nil, "marked index is \(self.markedIndex.debugDescription)")
         }
     }
 
     /// Returns true if the buffer is currently marked at the given index.
-    public func isMarked(index: Int) -> Bool {
-        precondition(index >= 0, "index must not be negative")
-        precondition(index < self.buffer.count, "index \(index) out of range (0..<\(self.buffer.count))")
+    public func isMarked(index: Index) -> Bool {
+        assert(index >= self.startIndex, "index must not be negative")
+        precondition(index < self.endIndex, "index \(index) out of range (0..<\(self.buffer.count))")
         return self.markedIndex == index
     }
 
     /// Returns the index of the marked element.
-    public var markedElementIndex: Int? {
-        let markedIndex = self.markedIndex
-        if markedIndex >= 0 {
-            return markedIndex
-        } else {
-            assert(markedIndex == -1, "marked index is \(markedIndex)")
-            return nil
-        }
+    public var markedElementIndex: Index? {
+        return self.markedIndex
     }
 
     /// Returns the marked element.
-    public var markedElement: E? {
+    public var markedElement: Element? {
         return self.markedElementIndex.map { self.buffer[$0] }
     }
 
     /// Returns true if the buffer has been marked at all.
     public var hasMark: Bool {
-        if self.markedIndex < 0 {
-            assert(self.markedIndex == -1, "marked index is \(self.markedIndex)")
-            return false
-        } else {
-            return true
-        }
+        return self.markedIndex != nil
     }
 }

--- a/Sources/NIO/PendingWritesManager.swift
+++ b/Sources/NIO/PendingWritesManager.swift
@@ -106,7 +106,7 @@ private struct PendingStreamWritesState {
     public private(set) var bytes: Int64 = 0
 
     public var flushedChunks: Int {
-        return self.pendingWrites.markedElementIndex.map { $0 + 1 } ?? 0
+        return self.pendingWrites.markedElementIndex.map { self.pendingWrites.startIndex.distance(to: $0) + 1 } ?? 0
     }
 
     /// Subtract `bytes` from the number of outstanding bytes to write.
@@ -130,7 +130,7 @@ private struct PendingStreamWritesState {
     /// - parameters:
     ///     - bytes: How many bytes of the item were written.
     private mutating func partiallyWrittenFirst(bytes: Int) {
-        self.pendingWrites[0].data.moveReaderIndex(forwardBy: bytes)
+        self.pendingWrites[self.pendingWrites.startIndex].data.moveReaderIndex(forwardBy: bytes)
         self.subtractOutstanding(bytes: bytes)
     }
 
@@ -162,7 +162,7 @@ private struct PendingStreamWritesState {
 
     /// Get the outstanding write at `index`.
     public subscript(index: Int) -> PendingStreamWrite {
-        return self.pendingWrites[index]
+        return self.pendingWrites[self.pendingWrites.startIndex.advanced(by: index)]
     }
 
     /// Mark the flush checkpoint.
@@ -190,7 +190,7 @@ private struct PendingStreamWritesState {
             assert(written >= 0, "allegedly written a negative amount of bytes: \(written)")
             var unaccountedWrites = written
             for _ in 0..<itemCount {
-                let headItemReadableBytes = self.pendingWrites[0].data.readableBytes
+                let headItemReadableBytes = self.pendingWrites.first!.data.readableBytes
                 if unaccountedWrites >= headItemReadableBytes {
                     unaccountedWrites -= headItemReadableBytes
                     /* we wrote at least the whole head item, so drop it and succeed the promise */
@@ -245,14 +245,15 @@ private struct PendingStreamWritesState {
         case 0:
             return .nothingToBeWritten
         case 1:
-            switch self.pendingWrites[0].data {
+            switch self.pendingWrites.first!.data {
             case .byteBuffer:
                 return .scalarBufferWrite
             case .fileRegion:
                 return .scalarFileWrite
             }
         default:
-            switch (self.pendingWrites[0].data, self.pendingWrites[1].data) {
+            let startIndex = self.pendingWrites.startIndex
+            switch (self.pendingWrites[startIndex].data, self.pendingWrites[startIndex.advanced(by: 1)].data) {
             case (.byteBuffer, .byteBuffer):
                 return .vectorBufferWrite
             case (.byteBuffer, .fileRegion):

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -196,18 +196,45 @@ extension EventLoopGroup {
 }
 
 extension MarkedCircularBuffer {
+    @available(*, deprecated, renamed: "Element")
+    public typealias E = Element
+
+    func _makeIndex(value: Int) -> Index {
+        return self.startIndex.advanced(by: value)
+    }
+
+    @available(*, deprecated, renamed: "init(initialCapacity:)")
+    public init(initialRingCapacity: Int) {
+        self = .init(initialCapacity: initialRingCapacity)
+    }
+
+    @available(*, deprecated, message: "please use MarkedCircularBuffer.Index instead of Int")
+    public func index(after i: Int) -> Int {
+        return i + 1
+    }
+
+    @available(*, deprecated, message: "please use MarkedCircularBuffer.Index instead of Int")
+    public func index(before: Int) -> Int {
+        return before - 1
+    }
+
+    @available(*, deprecated, message: "please use MarkedCircularBuffer.Index instead of Int")
+    public func isMarked(index: Int) -> Bool {
+        return self.isMarked(index: self._makeIndex(value: index))
+    }
+
     @available(*, deprecated, message: "hasMark is now a property, remove `()`")
     public func hasMark() -> Bool {
         return self.hasMark
     }
 
     @available(*, deprecated, message: "markedElement is now a property, remove `()`")
-    public func markedElement() -> Element? {
+    public func markedElement() -> E? {
         return self.markedElement
     }
 
     @available(*, deprecated, message: "markedElementIndex is now a property, remove `()`")
-    public func markedElementIndex() -> Int? {
+    public func markedElementIndex() -> Index? {
         return self.markedElementIndex
     }
 }
@@ -282,16 +309,41 @@ extension SocketAddress {
 }
 
 extension CircularBuffer {
+    func _makeIndex(value: Int) -> Index {
+        return self.startIndex.advanced(by: value)
+    }
+
+    @available(*, deprecated, renamed: "Element")
+    public typealias E = Element
+
     @available(*, deprecated, renamed: "init(initialCapacity:)")
     public init(initialRingCapacity: Int) {
         self = .init(initialCapacity: initialRingCapacity)
     }
-}
 
-extension MarkedCircularBuffer {
-    @available(*, deprecated, renamed: "init(initialCapacity:)")
-    public init(initialRingCapacity: Int) {
-        self = .init(initialCapacity: initialRingCapacity)
+    @available(*, deprecated, message: "please use CircularBuffer.Index instead of Int")
+    public subscript(index: Int) -> E {
+        return self[_makeIndex(value: index)]
+    }
+
+    @available(*, deprecated, message: "please use CircularBuffer.Index instead of Int")
+    public func index(after: Int) -> Int {
+        return after + 1
+    }
+
+    @available(*, deprecated, message: "please use CircularBuffer.Index instead of Int")
+    public func index(before: Int) -> Int {
+        return before - 1
+    }
+
+    @available(*, deprecated, message: "please use CircularBuffer.Index instead of Int")
+    public mutating func removeSubrange(_ bounds: Range<Int>) {
+        return self.removeSubrange(_makeIndex(value: bounds.lowerBound) ..< _makeIndex(value: bounds.upperBound))
+    }
+
+    @available(*, deprecated, message: "please use CircularBuffer.Index instead of Int")
+    public mutating func remove(at position: Int) -> E {
+        return self.remove(at: _makeIndex(value: position))
     }
 }
 

--- a/Tests/NIOTests/CircularBufferTests.swift
+++ b/Tests/NIOTests/CircularBufferTests.swift
@@ -58,7 +58,7 @@ class CircularBufferTests: XCTestCase {
         }
 
         XCTAssertEqual(7, ring.count)
-        _ = ring.remove(at: 1)
+        _ = ring.remove(at: ring.startIndex.advanced(by: 1))
         XCTAssertEqual(6, ring.count)
         XCTAssertEqual(0, ring.last)
     }
@@ -69,7 +69,7 @@ class CircularBufferTests: XCTestCase {
             ring.prepend(idx)
         }
 
-        let last = ring.remove(at: ring.endIndex - 1)
+        let last = ring.remove(at: ring.endIndex.advanced(by: -1))
         XCTAssertEqual(0, last)
         XCTAssertEqual(1, ring.last)
     }
@@ -79,7 +79,7 @@ class CircularBufferTests: XCTestCase {
         ring.prepend(99)
         ring.prepend(98)
         XCTAssertEqual(2, ring.count)
-        XCTAssertEqual(99, ring.remove(at: ring.endIndex - 1))
+        XCTAssertEqual(99, ring.remove(at: ring.endIndex.advanced(by: -1)))
         XCTAssertFalse(ring.isEmpty)
         XCTAssertEqual(1, ring.count)
         XCTAssertEqual(98, ring.last)
@@ -92,72 +92,72 @@ class CircularBufferTests: XCTestCase {
             ring.prepend(idx)
         }
 
-        let first = ring.remove(at: 0)
+        let first = ring.remove(at: ring.startIndex)
         XCTAssertEqual(6, first)
         XCTAssertEqual(5, ring.first)
     }
 
     func testHarderExpansion() {
         var ring = CircularBuffer<Int>(initialCapacity: 3)
-        XCTAssertEqual(ring.indices, 0..<0)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex)
 
         ring.append(1)
         XCTAssertEqual(ring.count, 1)
-        XCTAssertEqual(ring[0], 1)
-        XCTAssertEqual(ring.indices, 0..<1)
+        XCTAssertEqual(ring[ring.startIndex], 1)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex.advanced(by: 1))
 
         ring.append(2)
         XCTAssertEqual(ring.count, 2)
-        XCTAssertEqual(ring[0], 1)
-        XCTAssertEqual(ring[1], 2)
-        XCTAssertEqual(ring.indices, 0..<2)
+        XCTAssertEqual(ring[ring.startIndex], 1)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 1)], 2)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex.advanced(by: 2))
 
         ring.append(3)
         XCTAssertEqual(ring.count, 3)
-        XCTAssertEqual(ring[0], 1)
-        XCTAssertEqual(ring[1], 2)
-        XCTAssertEqual(ring[2], 3)
-        XCTAssertEqual(ring.indices, 0..<3)
+        XCTAssertEqual(ring[ring.startIndex], 1)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 1)], 2)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 2)], 3)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex.advanced(by: 3))
 
 
         XCTAssertEqual(1, ring.removeFirst())
         XCTAssertEqual(ring.count, 2)
-        XCTAssertEqual(ring[0], 2)
-        XCTAssertEqual(ring[1], 3)
-        XCTAssertEqual(ring.indices, 0..<2)
+        XCTAssertEqual(ring[ring.startIndex], 2)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 1)], 3)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex.advanced(by: 2))
 
         XCTAssertEqual(2, ring.removeFirst())
         XCTAssertEqual(ring.count, 1)
-        XCTAssertEqual(ring[0], 3)
-        XCTAssertEqual(ring.indices, 0..<1)
+        XCTAssertEqual(ring[ring.startIndex], 3)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex.advanced(by: 1))
 
         ring.append(5)
         XCTAssertEqual(ring.count, 2)
-        XCTAssertEqual(ring[0], 3)
-        XCTAssertEqual(ring[1], 5)
-        XCTAssertEqual(ring.indices, 0..<2)
+        XCTAssertEqual(ring[ring.startIndex], 3)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 1)], 5)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex.advanced(by: 2))
 
         ring.append(6)
         XCTAssertEqual(ring.count, 3)
-        XCTAssertEqual(ring[0], 3)
-        XCTAssertEqual(ring[1], 5)
-        XCTAssertEqual(ring[2], 6)
-        XCTAssertEqual(ring.indices, 0..<3)
+        XCTAssertEqual(ring[ring.startIndex], 3)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 1)], 5)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 2)], 6)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex.advanced(by: 3))
 
         ring.append(7)
         XCTAssertEqual(ring.count, 4)
-        XCTAssertEqual(ring[0], 3)
-        XCTAssertEqual(ring[1], 5)
-        XCTAssertEqual(ring[2], 6)
-        XCTAssertEqual(ring[3], 7)
-        XCTAssertEqual(ring.indices, 0..<4)
+        XCTAssertEqual(ring[ring.startIndex], 3)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 1)], 5)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 2)], 6)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 3)], 7)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex.advanced(by: 4))
     }
 
     func testCollection() {
         var ring = CircularBuffer<Int>(initialCapacity: 4)
-        XCTAssertEqual(ring.indices, 0..<0)
-        XCTAssertEqual(ring.startIndex, 0)
-        XCTAssertEqual(ring.endIndex, 0)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex)
+        XCTAssertEqual(0, ring.startIndex.distance(to: ring.endIndex))
+        XCTAssertEqual(0, ring.endIndex.distance(to: ring.startIndex))
 
         for idx in 0..<5 {
             ring.append(idx)
@@ -166,12 +166,12 @@ class CircularBufferTests: XCTestCase {
         XCTAssertFalse(ring.isEmpty)
         XCTAssertEqual(5, ring.count)
 
-        XCTAssertEqual(ring.indices, 0..<5)
-        XCTAssertEqual(ring.startIndex, 0)
-        XCTAssertEqual(ring.endIndex, 5)
+        XCTAssertEqual(ring.indices, ring.startIndex ..< ring.startIndex.advanced(by: 5))
+        XCTAssertEqual(ring.startIndex, ring.startIndex)
+        XCTAssertEqual(ring.endIndex, ring.startIndex.advanced(by: 5))
 
-        XCTAssertEqual(ring.index(after: 1), 2)
-        XCTAssertEqual(ring.index(before: 3), 2)
+        XCTAssertEqual(ring.index(after: ring.startIndex.advanced(by: 1)), ring.startIndex.advanced(by: 2))
+        XCTAssertEqual(ring.index(before: ring.startIndex.advanced(by: 3)), ring.startIndex.advanced(by: 2))
         
         let actualValues = [Int](ring)
         let expectedValues = [0, 1, 2, 3, 4]
@@ -184,12 +184,12 @@ class CircularBufferTests: XCTestCase {
             ring.prepend(idx)
         }
         XCTAssertEqual(50, ring.count)
-        ring.replaceSubrange(20..<25, with: [99])
+        ring.replaceSubrange(ring.startIndex.advanced(by: 20) ..< ring.startIndex.advanced(by: 25), with: [99])
 
         XCTAssertEqual(ring.count, 46)
-        XCTAssertEqual(ring[19], 30)
-        XCTAssertEqual(ring[20], 99)
-        XCTAssertEqual(ring[21], 24)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 19)], 30)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 20)], 99)
+        XCTAssertEqual(ring[ring.startIndex.advanced(by: 21)], 24)
     }
 
     func testReplaceSubrangeAllElementsWithFewerElements() {
@@ -212,7 +212,7 @@ class CircularBufferTests: XCTestCase {
         }
         XCTAssertEqual(50, ring.count)
 
-        ring.replaceSubrange(0..<0, with: [])
+        ring.replaceSubrange(ring.startIndex ..< ring.startIndex, with: [])
         XCTAssertEqual(50, ring.count)
     }
 
@@ -281,7 +281,7 @@ class CircularBufferTests: XCTestCase {
             ring.append(idx)
         }
         for idx in 0..<5 {
-            XCTAssertEqual(idx, ring[idx])
+            XCTAssertEqual(idx, ring[ring.startIndex.advanced(by: idx)])
         }
     }
 
@@ -292,23 +292,23 @@ class CircularBufferTests: XCTestCase {
         }
         /* the underlying buffer should now be filled from 0 to max */
         for idx in 0..<4 {
-            XCTAssertEqual(idx, ring[idx])
+            XCTAssertEqual(idx, ring[ring.startIndex.advanced(by: idx)])
         }
         XCTAssertEqual(0, ring.removeFirst())
         /* now the first element is gone, ie. the ring starts at index 1 now */
         for idx in 0..<3 {
-            XCTAssertEqual(idx + 1, ring[idx])
+            XCTAssertEqual(idx + 1, ring[ring.startIndex.advanced(by: idx)])
         }
         ring.append(4)
         XCTAssertEqual(1, ring.first!)
         /* now the last element should be at ring position 0 */
         for idx in 0..<4 {
-            XCTAssertEqual(idx + 1, ring[idx])
+            XCTAssertEqual(idx + 1, ring[ring.startIndex.advanced(by: idx)])
         }
         /* and now we'll make it expand */
         ring.append(5)
         for idx in 0..<5 {
-            XCTAssertEqual(idx + 1, ring[idx])
+            XCTAssertEqual(idx + 1, ring[ring.startIndex.advanced(by: idx)])
         }
     }
 
@@ -318,7 +318,7 @@ class CircularBufferTests: XCTestCase {
             ring.append(idx)
         }
         for idx in 0..<4 {
-            XCTAssertEqual(idx, ring[idx])
+            XCTAssertEqual(idx, ring[ring.startIndex.advanced(by: idx)])
         }
         for idx in 0..<4 {
             XCTAssertEqual(idx, ring.removeFirst())
@@ -338,7 +338,7 @@ class CircularBufferTests: XCTestCase {
             changes.append((idx, element * 2))
         }
         for change in changes {
-            ring[change.0] = change.1
+            ring[ring.startIndex.advanced(by: change.0)] = change.1
         }
         for (idx, element) in ring.enumerated() {
             XCTAssertEqual(idx * 2, element)
@@ -351,9 +351,9 @@ class CircularBufferTests: XCTestCase {
             ring.append(idx)
         }
 
-        let slice = ring[25..<30]
+        let slice = ring[ring.startIndex.advanced(by: 25) ..< ring.startIndex.advanced(by: 30)]
         for (idx, element) in slice.enumerated() {
-            XCTAssertEqual(idx + 25, element)
+            XCTAssertEqual(ring.startIndex.advanced(by: idx + 25), ring.startIndex.advanced(by: element))
         }
     }
 
@@ -512,7 +512,7 @@ class CircularBufferTests: XCTestCase {
 
         // Now we want to replace the last subrange with two elements. This should
         // force an increase in size.
-        ring.replaceSubrange(0..<1, with: [3, 4])
+        ring.replaceSubrange(ring.startIndex ..< ring.startIndex.advanced(by: 1), with: [3, 4])
         XCTAssertEqual(ring.capacity, 4)
     }
 

--- a/Tests/NIOTests/MarkedCircularBufferTests.swift
+++ b/Tests/NIOTests/MarkedCircularBufferTests.swift
@@ -37,11 +37,11 @@ class MarkedCircularBufferTests: XCTestCase {
 
         XCTAssertTrue(buf.hasMark)
         XCTAssertEqual(buf.markedElement, 4)
-        XCTAssertEqual(buf.markedElementIndex, 3)
+        XCTAssertEqual(buf.markedElementIndex, buf.startIndex.advanced(by: 3))
 
-        for i in 0..<3 { XCTAssertFalse(buf.isMarked(index: i)) }
-        XCTAssertTrue(buf.isMarked(index: 3))
-        for i in 4..<8 { XCTAssertFalse(buf.isMarked(index: i)) }
+        for i in 0..<3 { XCTAssertFalse(buf.isMarked(index: buf.startIndex.advanced(by: i))) }
+        XCTAssertTrue(buf.isMarked(index: buf.startIndex.advanced(by: 3)))
+        for i in 4..<8 { XCTAssertFalse(buf.isMarked(index: buf.startIndex.advanced(by: i))) }
     }
 
     func testPassingTheMark() throws {
@@ -55,7 +55,7 @@ class MarkedCircularBufferTests: XCTestCase {
             XCTAssertEqual(buf.removeFirst(), j)
             XCTAssertTrue(buf.hasMark)
             XCTAssertEqual(buf.markedElement, 4)
-            XCTAssertEqual(buf.markedElementIndex, 3 - j)
+            XCTAssertEqual(buf.markedElementIndex, buf.startIndex.advanced(by: 3 - j))
         }
 
         XCTAssertEqual(buf.removeFirst(), 4)
@@ -73,8 +73,8 @@ class MarkedCircularBufferTests: XCTestCase {
 
             XCTAssertTrue(buf.hasMark)
             XCTAssertEqual(buf.markedElement, i)
-            XCTAssertEqual(buf.markedElementIndex, i - 1)
-            XCTAssertTrue(buf.isMarked(index: i - 1))
+            XCTAssertEqual(buf.markedElementIndex, buf.startIndex.advanced(by: i - 1))
+            XCTAssertTrue(buf.isMarked(index: buf.startIndex.advanced(by: i - 1)))
         }
     }
     func testIndices() throws {
@@ -82,7 +82,7 @@ class MarkedCircularBufferTests: XCTestCase {
         for i in 1...4 {
             buf.append(i)
         }
-        XCTAssertEqual(buf.indices, 0..<4)
+        XCTAssertEqual(buf.indices, buf.startIndex ..< buf.startIndex.advanced(by: 4))
     }
 
     func testFirst() throws {
@@ -106,8 +106,8 @@ class MarkedCircularBufferTests: XCTestCase {
         for i in 1...4 {
             buf.append(i)
         }
-        XCTAssertEqual(buf[0], 1)
-        XCTAssertEqual(buf[3], 4)
+        XCTAssertEqual(buf[buf.startIndex], 1)
+        XCTAssertEqual(buf[buf.startIndex.advanced(by: 3)], 4)
     }
 
     func testIsEmpty() throws {

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -49,3 +49,4 @@
 - renamed `EventLoopFuture.hopTo(eventLoop:)` to `EventLoopFuture.hop(to:)`
 - `EventLoopFuture.reduce(into:_:eventLoop:_:)` had its label signature changed to `EventLoopFuture.reduce(into:_:on:_:)`
 - `EventLoopFuture.reduce(_:_:eventLoop:_:` had its label signature changed to `EventLoopFuture.reduce(_:_:on:_:)`
+- `CircularBuffer` and `MarkedCircularBuffer`'s indices are now opaque


### PR DESCRIPTION
Motivation:

Opaque indices are a good idea for collections, (Marked)CircularBuffer
should use those too.

Modifications:

Cheapest possible implementation for opaque indices, could be much
improved. This is the cheapest possible implementation for opaque
indices and this could be much improved later, see #682 but the
improvements won't be SemVer major :).

Result:

first stab at #682