### PR TITLE
simplify ChannelOptions

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -122,7 +122,7 @@ public final class ServerBootstrap {
     ///     - option: The option to be applied.
     ///     - value: The value for the option.
     @inlinable
-    public func serverChannelOption<Option: ChannelOption>(_ option: Option, value: Option.OptionType) -> Self {
+    public func serverChannelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
         self._serverChannelOptions.put(key: option, value: value)
         return self
     }
@@ -133,7 +133,7 @@ public final class ServerBootstrap {
     ///     - option: The option to be applied.
     ///     - value: The value for the option.
     @inlinable
-    public func childChannelOption<Option: ChannelOption>(_ option: Option, value: Option.OptionType) -> Self {
+    public func childChannelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
         self._childChannelOptions.put(key: option, value: value)
         return self
     }
@@ -391,7 +391,7 @@ public final class ClientBootstrap {
     ///     - option: The option to be applied.
     ///     - value: The value for the option.
     @inlinable
-    public func channelOption<Option: ChannelOption>(_ option: Option, value: Option.OptionType) -> Self {
+    public func channelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
         self._channelOptions.put(key: option, value: value)
         return self
     }
@@ -589,7 +589,7 @@ public final class DatagramBootstrap {
     ///     - option: The option to be applied.
     ///     - value: The value for the option.
     @inlinable
-    public func channelOption<Option: ChannelOption>(_ option: Option, value: Option.OptionType) -> Self {
+    public func channelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
         self._channelOptions.put(key: option, value: value)
         return self
     }
@@ -686,17 +686,17 @@ public final class DatagramBootstrap {
     internal var _storage: [(Any, (Any, (Channel) -> (Any, Any) -> EventLoopFuture<Void>))] = []
 
     @inlinable
-    mutating func put<K: ChannelOption>(key: K,
-                                        value newValue: K.OptionType) {
-        func applier(_ t: Channel) -> (Any, Any) -> EventLoopFuture<Void> {
-            return { (x, y) in
-                return t.setOption(option: x as! K, value: y as! K.OptionType)
+    mutating func put<Option: ChannelOption>(key: Option,
+                                             value newValue: Option.Value) {
+        func applier(_ channel: Channel) -> (Any, Any) -> EventLoopFuture<Void> {
+            return { (option, value) in
+                return channel.setOption(option as! Option, value: value as! Option.Value)
             }
         }
         var hasSet = false
         self._storage = self._storage.map { typeAndValue in
             let (type, value) = typeAndValue
-            if type is K && type as! K == key {
+            if type is Option && type as! Option == key {
                 hasSet = true
                 return (key, (newValue, applier))
             } else {

--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -123,10 +123,10 @@ public protocol Channel: class, ChannelOutboundInvoker {
     var parent: Channel? { get }
 
     /// Set `option` to `value` on this `Channel`.
-    func setOption<T: ChannelOption>(option: T, value: T.OptionType) -> EventLoopFuture<Void>
+    func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> EventLoopFuture<Void>
 
     /// Get the value of `option` for this `Channel`.
-    func getOption<T: ChannelOption>(option: T) -> EventLoopFuture<T.OptionType>
+    func getOption<Option: ChannelOption>(_ option: Option) -> EventLoopFuture<Option.Value>
 
     /// Returns if this `Channel` is currently writable.
     var isWritable: Bool { get }

--- a/Sources/NIO/DeadChannel.swift
+++ b/Sources/NIO/DeadChannel.swift
@@ -103,11 +103,11 @@ internal final class DeadChannel: Channel {
 
     let parent: Channel? = nil
 
-    func setOption<T>(option: T, value: T.OptionType) -> EventLoopFuture<Void> where T: ChannelOption {
+    func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> EventLoopFuture<Void> {
         return EventLoopFuture(eventLoop: self.pipeline.eventLoop, error: ChannelError.ioOnClosedChannel, file: #file, line: #line)
     }
 
-    func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T: ChannelOption {
+    func getOption<Option: ChannelOption>(_ option: Option) -> EventLoopFuture<Option.Value> {
         return eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
     }
 

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -385,14 +385,14 @@ public class EmbeddedChannel: Channel {
         try! register().wait()
     }
 
-    public func setOption<T>(option: T, value: T.OptionType) -> EventLoopFuture<Void> where T: ChannelOption {
+    public func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> EventLoopFuture<Void> {
         // No options supported
         fatalError("no options supported")
     }
 
-    public func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T: ChannelOption {
+    public func getOption<Option: ChannelOption>(_ option: Option) -> EventLoopFuture<Option.Value>  {
         if option is AutoReadOption {
-            return self.eventLoop.makeSucceededFuture(true as! T.OptionType)
+            return self.eventLoop.makeSucceededFuture(true as! Option.Value)
         }
         fatalError("option \(option) not supported")
     }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -70,7 +70,7 @@ final class SocketChannel: BaseSocketChannel<Socket> {
         assert(pendingWrites.isEmpty)
     }
 
-    override func setOption0<T: ChannelOption>(option: T, value: T.OptionType) throws {
+    override func setOption0<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
@@ -87,11 +87,11 @@ final class SocketChannel: BaseSocketChannel<Socket> {
         case _ as WriteBufferWaterMarkOption:
             pendingWrites.waterMark = value as! WriteBufferWaterMark
         default:
-            try super.setOption0(option: option, value: value)
+            try super.setOption0(option, value: value)
         }
     }
 
-    override func getOption0<T: ChannelOption>(option: T) throws -> T.OptionType {
+    override func getOption0<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
@@ -100,15 +100,15 @@ final class SocketChannel: BaseSocketChannel<Socket> {
 
         switch option {
         case _ as ConnectTimeoutOption:
-            return connectTimeout as! T.OptionType
+            return connectTimeout as! Option.Value
         case _ as AllowRemoteHalfClosureOption:
-            return allowRemoteHalfClosure as! T.OptionType
+            return allowRemoteHalfClosure as! Option.Value
         case _ as WriteSpinOption:
-            return pendingWrites.writeSpinCount as! T.OptionType
+            return pendingWrites.writeSpinCount as! Option.Value
         case _ as WriteBufferWaterMarkOption:
-            return pendingWrites.waterMark as! T.OptionType
+            return pendingWrites.waterMark as! Option.Value
         default:
-            return try super.getOption0(option: option)
+            return try super.getOption0(option)
         }
     }
 
@@ -338,7 +338,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         return .serverSocketChannel(self, interested)
     }
 
-    override func setOption0<T: ChannelOption>(option: T, value: T.OptionType) throws {
+    override func setOption0<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
@@ -349,11 +349,11 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         case _ as BacklogOption:
             backlog = value as! Int32
         default:
-            try super.setOption0(option: option, value: value)
+            try super.setOption0(option, value: value)
         }
     }
 
-    override func getOption0<T: ChannelOption>(option: T) throws -> T.OptionType {
+    override func getOption0<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
@@ -362,9 +362,9 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
 
         switch option {
         case _ as BacklogOption:
-            return backlog as! T.OptionType
+            return backlog as! Option.Value
         default:
-            return try super.getOption0(option: option)
+            return try super.getOption0(option)
         }
     }
 
@@ -544,7 +544,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
     // MARK: Datagram Channel overrides required by BaseSocketChannel
 
-    override func setOption0<T: ChannelOption>(option: T, value: T.OptionType) throws {
+    override func setOption0<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
@@ -557,11 +557,11 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         case _ as WriteBufferWaterMarkOption:
             pendingWrites.waterMark = value as! WriteBufferWaterMark
         default:
-            try super.setOption0(option: option, value: value)
+            try super.setOption0(option, value: value)
         }
     }
 
-    override func getOption0<T: ChannelOption>(option: T) throws -> T.OptionType {
+    override func getOption0<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
@@ -570,11 +570,11 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
         switch option {
         case _ as WriteSpinOption:
-            return pendingWrites.writeSpinCount as! T.OptionType
+            return pendingWrites.writeSpinCount as! Option.Value
         case _ as WriteBufferWaterMarkOption:
-            return pendingWrites.waterMark as! T.OptionType
+            return pendingWrites.waterMark as! Option.Value
         default:
-            return try super.getOption0(option: option)
+            return try super.getOption0(option)
         }
     }
 

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -377,6 +377,21 @@ extension Channel {
     var _unsafe: ChannelCore {
         return self._channelCore
     }
+
+    @available(*, deprecated, renamed: "setOption(_:value:)")
+    func setOption<Option: ChannelOption>(option: Option, value: Option.Value) -> EventLoopFuture<Void> {
+        return self.setOption(option, value: value)
+    }
+
+    @available(*, deprecated, renamed: "getOption(_:)")
+    func getOption<Option: ChannelOption>(option: Option) -> EventLoopFuture<Option.Value> {
+        return self.getOption(option)
+    }
+}
+
+extension ChannelOption {
+    @available(*, deprecated, renamed: "Value")
+    public typealias OptionType = Value
 }
 
 @available(*, deprecated, renamed: "HTTPServerProtocolUpgrader")

--- a/Tests/NIOTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOTests/AcceptBackoffHandlerTest.swift
@@ -252,7 +252,7 @@ public class AcceptBackoffHandlerTest: XCTestCase {
                                                                            eventLoop: eventLoop,
                                                                            group: group))
 
-        XCTAssertNoThrow(try serverChannel.setOption(option: ChannelOptions.autoRead, value: false).wait())
+        XCTAssertNoThrow(try serverChannel.setOption(ChannelOptions.autoRead, value: false).wait())
         XCTAssertNoThrow(try serverChannel.pipeline.add(handler: readCountHandler).flatMap { _ in
             serverChannel.pipeline.add(name: self.acceptHandlerName, handler: AcceptBackoffHandler(backoffProvider: backoffProvider))
         }.wait())

--- a/Tests/NIOTests/ChannelOptionStorageTest.swift
+++ b/Tests/NIOTests/ChannelOptionStorageTest.swift
@@ -78,12 +78,12 @@ class OptionsCollectingChannel: Channel {
 
     var parent: Channel? { fatalError() }
 
-    func setOption<T>(option: T, value: T.OptionType) -> EventLoopFuture<Void> where T : ChannelOption {
+    func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> EventLoopFuture<Void> {
         self.allOptions.append((option, value))
         return self.eventLoop.makeSucceededFuture(())
     }
 
-    func getOption<T>(option: T) -> EventLoopFuture<T.OptionType> where T : ChannelOption {
+    func getOption<Option: ChannelOption>(_ option: Option) -> EventLoopFuture<Option.Value> {
         fatalError()
     }
 

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2531,7 +2531,7 @@ public class ChannelTests: XCTestCase {
                     XCTAssertTrue(serverChannel.isActive)
                     // we allow auto-read again to make sure that the socket buffer is drained on write error
                     // (cf. https://github.com/apple/swift-nio/issues/593)
-                    ctx.channel.setOption(option: ChannelOptions.autoRead, value: true).flatMap {
+                    ctx.channel.setOption(ChannelOptions.autoRead, value: true).flatMap {
                         // let's trigger the write error
                         var buffer = ctx.channel.allocator.buffer(capacity: 16)
                         buffer.writeStaticString("THIS WILL FAIL ANYWAY")
@@ -2584,8 +2584,8 @@ public class ChannelTests: XCTestCase {
         let c = try assertNoThrowWithValue(SocketChannel(socket: WriteAlwaysFailingSocket(),
                                                          parent: nil,
                                                          eventLoop: singleThreadedELG.next() as! SelectableEventLoop))
-        XCTAssertNoThrow(try c.setOption(option: ChannelOptions.autoRead, value: false).wait())
-        XCTAssertNoThrow(try c.setOption(option: ChannelOptions.allowRemoteHalfClosure, value: true).wait())
+        XCTAssertNoThrow(try c.setOption(ChannelOptions.autoRead, value: false).wait())
+        XCTAssertNoThrow(try c.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).wait())
         XCTAssertNoThrow(try c.pipeline.add(handler: MakeChannelInactiveInReadCausedByWriteErrorHandler(serverChannel: serverChannelAvailablePromise.futureResult,
                                                                                                         allDonePromise: allDonePromise)).wait())
         XCTAssertNoThrow(try c.register().wait())

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -154,7 +154,7 @@ final class DatagramChannelTests: XCTestCase {
     }
 
     func testDatagramChannelHasWatermark() throws {
-        _ = try self.firstChannel.setOption(option: ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 1, high: 1024)).wait()
+        _ = try self.firstChannel.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 1, high: 1024)).wait()
 
         var buffer = self.firstChannel.allocator.buffer(capacity: 256)
         buffer.writeBytes([UInt8](repeating: 5, count: 256))

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -212,7 +212,7 @@ class SelectorTest: XCTestCase {
 
             func channelActive(ctx: ChannelHandlerContext) {
                 // collect all the channels
-                ctx.channel.getOption(option: ChannelOptions.allowRemoteHalfClosure).whenSuccess { halfClosureAllowed in
+                ctx.channel.getOption(ChannelOptions.allowRemoteHalfClosure).whenSuccess { halfClosureAllowed in
                     precondition(halfClosureAllowed,
                                  "the test configuration is bogus: half-closure is dis-allowed which breaks the setup of this test")
                 }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -54,12 +54,12 @@ public class SocketChannelTest : XCTestCase {
         let futureA = channelA.eventLoop.submit {
             _ = condition.add(1)
             while condition.load() < 2 { }
-            _ = channelB.setOption(option: ChannelOptions.backlog, value: 1)
+            _ = channelB.setOption(ChannelOptions.backlog, value: 1)
         }
         let futureB = channelB.eventLoop.submit {
             _ = condition.add(1)
             while condition.load() < 2 { }
-            _ = channelA.setOption(option: ChannelOptions.backlog, value: 1)
+            _ = channelA.setOption(ChannelOptions.backlog, value: 1)
         }
         try futureA.wait()
         try futureB.wait()

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -162,20 +162,20 @@ final class NonAcceptingServerSocket: ServerSocket {
     }
 }
 
-func assertSetGetOptionOnOpenAndClosed<T: ChannelOption>(channel: Channel, option: T, value: T.OptionType) throws {
-    _ = try channel.setOption(option: option, value: value).wait()
-    _ = try channel.getOption(option: option).wait()
+func assertSetGetOptionOnOpenAndClosed<Option: ChannelOption>(channel: Channel, option: Option, value: Option.Value) throws {
+    _ = try channel.setOption(option, value: value).wait()
+    _ = try channel.getOption(option).wait()
     try channel.close().wait()
     try channel.closeFuture.wait()
 
     do {
-        _ = try channel.setOption(option: option, value: value).wait()
+        _ = try channel.setOption(option, value: value).wait()
     } catch let err as ChannelError where err == .ioOnClosedChannel {
         // expected
     }
 
     do {
-        _ = try channel.getOption(option: option).wait()
+        _ = try channel.getOption(option).wait()
     } catch let err as ChannelError where err == .ioOnClosedChannel {
         // expected
     }
@@ -236,7 +236,7 @@ func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testI
 
 func getBoolSocketOption<IntType: SignedInteger>(channel: Channel, level: IntType, name: SocketOptionName,
                                                  file: StaticString = #file, line: UInt = #line) throws -> Bool {
-    return try assertNoThrowWithValue(channel.getOption(option: ChannelOptions.socket(SocketOptionLevel(level),
+    return try assertNoThrowWithValue(channel.getOption(ChannelOptions.socket(SocketOptionLevel(level),
                                                                                       name)),
                                       file: file,
                                       line: line).wait() != 0

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -23,6 +23,11 @@
 - Made `WebSocketOpcode` a struct. Removed `WebSocketOpcode.unknownControl` and
   `WebSocketOpcode.unknownNonControl` values: these should be replaced by
   simply instantiating `WebSocketOpcode` with the value.
+- `Channel.setOption(option:value:)` has been renamed `Channel.setOption(_:value:)`
+- `Channel.getOption(option:value:)` has been renamed `Channel.getOption(_:value:)`
+- `ChannelOption.AssociatedValueType` has been removed
+- `ChannelOption.OptionType` has been renamed `ChannelOption.Value`
+- the default `ChannelOption`s have been switched changed from `case FooOption { case const }` to a `struct FooOption { public init() {} }`
 - `markedElementIndex()`, `markedElement()` and `hasMark()` are now computed variables instead of functions.
 - `ByteBuffer.set(string:at:)` no longer returns an `Int?`, instead it
   returns `Int` and has had its return value made discardable.


### PR DESCRIPTION
Motivation:

ChannelOptions used a too complicated mechanism for what they are.

Modifications:

- change the ChannelOptions to a much simpler mechanism
- rename the generic parameters from T to Option

Result:

code easier to read and understand
