### PR TITLE
Clean up some broken shims.

### DIFF
--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -153,7 +153,7 @@ extension EventLoopFuture {
     }
 
     @available(*, deprecated, renamed: "andAllSucceed(_:on:)")
-    public func andAll(_ futures: [EventLoopFuture<Void>], eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    public static func andAll(_ futures: [EventLoopFuture<Void>], eventLoop: EventLoop) -> EventLoopFuture<Void> {
         return .andAllSucceed(futures, on: eventLoop)
     }
 
@@ -429,17 +429,17 @@ extension ByteBuffer {
 
 extension Channel {
     @available(*, deprecated, renamed: "_channelCore")
-    var _unsafe: ChannelCore {
+    public var _unsafe: ChannelCore {
         return self._channelCore
     }
 
     @available(*, deprecated, renamed: "setOption(_:value:)")
-    func setOption<Option: ChannelOption>(option: Option, value: Option.Value) -> EventLoopFuture<Void> {
+    public func setOption<Option: ChannelOption>(option: Option, value: Option.Value) -> EventLoopFuture<Void> {
         return self.setOption(option, value: value)
     }
 
     @available(*, deprecated, renamed: "getOption(_:)")
-    func getOption<Option: ChannelOption>(option: Option) -> EventLoopFuture<Option.Value> {
+    public func getOption<Option: ChannelOption>(option: Option) -> EventLoopFuture<Option.Value> {
         return self.getOption(option)
     }
 }


### PR DESCRIPTION
Motivation:

A few shims were missing public access modifiers, and at least one
should have been static but wasn't. These would lead to hard compile
errors.

Modifications:

Threw the words "public" and "static" around. Like Java!

Result:

Fewer compile errors, more compile warnings.
