### PR TITLE
make localAddress and remoteAddress testable in EmbeddedChannel

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -318,8 +318,8 @@ public class EmbeddedChannel: Channel {
     public var allocator: ByteBufferAllocator = ByteBufferAllocator()
     public var eventLoop: EventLoop = EmbeddedEventLoop()
 
-    public let localAddress: SocketAddress? = nil
-    public let remoteAddress: SocketAddress? = nil
+    public var localAddress: SocketAddress? = nil
+    public var remoteAddress: SocketAddress? = nil
 
     // Embedded channels never have parents.
     public let parent: Channel? = nil
@@ -395,5 +395,19 @@ public class EmbeddedChannel: Channel {
             return self.eventLoop.makeSucceededFuture(true as! Option.Value)
         }
         fatalError("option \(option) not supported")
+    }
+
+    public func bind(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
+        promise?.futureResult.whenSuccess {
+            self.localAddress = address
+        }
+        pipeline.bind(to: address, promise: promise)
+    }
+
+    public func connect(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
+        promise?.futureResult.whenSuccess {
+            self.remoteAddress = address
+        }
+        pipeline.connect(to: address, promise: promise)
     }
 }

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -37,6 +37,8 @@ extension EmbeddedChannelTest {
                 ("testSendingAnythingOnEmbeddedChannel", testSendingAnythingOnEmbeddedChannel),
                 ("testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires", testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires),
                 ("testWriteWithoutFlushDoesNotWrite", testWriteWithoutFlushDoesNotWrite),
+                ("testSetLocalAddressAfterSuccessfulBind", testSetLocalAddressAfterSuccessfulBind),
+                ("testSetRemoteAddressAfterSuccessfulConnect", testSetRemoteAddressAfterSuccessfulConnect),
            ]
    }
 }

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -191,4 +191,26 @@ class EmbeddedChannelTest: XCTestCase {
         XCTAssertTrue(writeFuture.isFulfilled)
         XCTAssertNoThrow(try XCTAssertFalse(channel.finish()))
     }
+
+    func testSetLocalAddressAfterSuccessfulBind() throws {
+        let channel = EmbeddedChannel()
+        let bindPromise = channel.eventLoop.makePromise(of: Void.self)
+        let socketAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
+        channel.bind(to: socketAddress, promise: bindPromise)
+        bindPromise.futureResult.whenComplete { _ in
+            XCTAssertEqual(channel.localAddress, socketAddress)
+        }
+        try bindPromise.futureResult.wait()
+    }
+
+    func testSetRemoteAddressAfterSuccessfulConnect() throws {
+        let channel = EmbeddedChannel()
+        let connectPromise = channel.eventLoop.makePromise(of: Void.self)
+        let socketAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
+        channel.connect(to: socketAddress, promise: connectPromise)
+        connectPromise.futureResult.whenComplete { _ in
+            XCTAssertEqual(channel.remoteAddress, socketAddress)
+        }
+        try connectPromise.futureResult.wait()
+    }
 }


### PR DESCRIPTION
### Motivation:

Testing channel handlers that rely on `Channel.localAddress` or `Channel.remoteAddress` is currently quite inconvenient as one cannot set test values for `localeAddress` or `remoteAddress` on `EmbeddedChannel`.

### Modifications:

Change `localAddress` and `remoteAddress` to variables instead of constants and set the address values in `bind()` and `connect()` as proposed in #829.

### Result:

Arbitrary values for `localAddress` or `remoteAddress` can be set on `EmbeddedChannel`.
