### PR TITLE
introduce WriteObservingByteToMessageDecoder

### DIFF
--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -46,6 +46,8 @@ extension ByteToMessageDecoderTest {
                 ("testDecodeLastHasSeenEOFFalseOnHandlerRemoved", testDecodeLastHasSeenEOFFalseOnHandlerRemoved),
                 ("testDecodeLastHasSeenEOFFalseOnHandlerRemovedEvenIfNoData", testDecodeLastHasSeenEOFFalseOnHandlerRemovedEvenIfNoData),
                 ("testDecodeLastHasSeenEOFTrueOnChannelInactive", testDecodeLastHasSeenEOFTrueOnChannelInactive),
+                ("testWriteObservingByteToMessageDecoderBasic", testWriteObservingByteToMessageDecoderBasic),
+                ("testWriteObservingByteToMessageDecoderWhereWriteIsReentrantlyCalled", testWriteObservingByteToMessageDecoderWhereWriteIsReentrantlyCalled),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Some B2MDs need to observe writes.

Modifications:

Make those B2MD's B2MHs ChannelOutboundHandlers and let the B2MDs
observe the writes.

Result:

HTTPDecoder can be expressed as B2MD.
