### PR TITLE
B2MD: Don't deliver data after error

### DIFF
--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -48,6 +48,8 @@ extension ByteToMessageDecoderTest {
                 ("testDecodeLastHasSeenEOFTrueOnChannelInactive", testDecodeLastHasSeenEOFTrueOnChannelInactive),
                 ("testWriteObservingByteToMessageDecoderBasic", testWriteObservingByteToMessageDecoderBasic),
                 ("testWriteObservingByteToMessageDecoderWhereWriteIsReentrantlyCalled", testWriteObservingByteToMessageDecoderWhereWriteIsReentrantlyCalled),
+                ("testDecodeMethodsNoLongerCalledIfErrorInDecode", testDecodeMethodsNoLongerCalledIfErrorInDecode),
+                ("testDecodeMethodsNoLongerCalledIfErrorInDecodeLast", testDecodeMethodsNoLongerCalledIfErrorInDecodeLast),
            ]
    }
 }

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -48,6 +48,7 @@
 - `EventLoopPromise.succeed(result: Value)` lost its label so is now `EventLoopPromise.succeed(Value)`
 - `EventLoopPromise.fail(error: Error)` lost its label so is now `EventLoopPromise.fail(Error)`
 - renamed `HTTPProtocolUpgrader` to `HTTPServerProtocolUpgrader`
+- `ByteToMessageDecoder`s no longer automatically close the connection on error.
 - `EventLoopFuture.cascade(promise: EventLoopPromise)` had its label changed to `EventLoopFuture.cascade(to: EventLoopPromise)`
 - `EventLoopFuture.cascadeFailure(promise: EventLoopPromise)` had its label changed to `EventLoopFuture.cascade(to: EventLoopPromise)`
 - renamed `EventLoopFuture.andAll(_:eventLoop:)` to `EventLoopFuture.andAllSucceed(_:on:)`


### PR DESCRIPTION
Motivation:

B2MD should never call any of the decode functions after the user has
thrown an error.

Modifications:

introduce an error state and make sure we don't call out if in error
state

Result:

B2MD more correct
