### PR TITLE
address #186: rename BlockingIOThreadPool to NIOThreadPool

### DIFF
--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -42,13 +42,13 @@ public struct NonBlockingFileIO {
         case descriptorSetToNonBlocking
     }
 
-    private let threadPool: BlockingIOThreadPool
+    private let threadPool: NIOThreadPool
 
     /// Initialize a `NonBlockingFileIO` which uses the `BlockingIOThreadPool`.
     ///
     /// - parameters:
     ///   - threadPool: The `BlockingIOThreadPool` that will be used for all the IO.
-    public init(threadPool: BlockingIOThreadPool) {
+    public init(threadPool: NIOThreadPool) {
         self.threadPool = threadPool
     }
 

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -505,7 +505,7 @@ default:
 }
 
 let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-let threadPool = BlockingIOThreadPool(numberOfThreads: 6)
+let threadPool = NIOThreadPool(numberOfThreads: 6)
 threadPool.start()
 
 let fileIO = NonBlockingFileIO(threadPool: threadPool)

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -507,3 +507,6 @@ public typealias HTTPUpgradeEvents = HTTPServerUpgradeEvents
 
 @available(*, deprecated, renamed: "HTTPServerUpgradeErrors")
 public typealias HTTPUpgradeErrors = HTTPServerUpgradeErrors
+
+@available(*, deprecated, renamed: "NIOThreadPool")
+public typealias BlockingIOThreadPool = NIOThreadPool

--- a/Tests/NIOTests/BlockingIOThreadPoolTest.swift
+++ b/Tests/NIOTests/BlockingIOThreadPoolTest.swift
@@ -19,18 +19,18 @@ import Foundation
 
 class BlockingIOThreadPoolTest: XCTestCase {
     func testDoubleShutdownWorks() throws {
-        let threadPool = BlockingIOThreadPool(numberOfThreads: 17)
+        let threadPool = NIOThreadPool(numberOfThreads: 17)
         threadPool.start()
         try threadPool.syncShutdownGracefully()
         try threadPool.syncShutdownGracefully()
     }
 
     func testStateCancelled() throws {
-        let threadPool = BlockingIOThreadPool(numberOfThreads: 17)
+        let threadPool = NIOThreadPool(numberOfThreads: 17)
         let group = DispatchGroup()
         group.enter()
         threadPool.submit { state in
-            XCTAssertEqual(BlockingIOThreadPool.WorkItemState.cancelled, state)
+            XCTAssertEqual(NIOThreadPool.WorkItemState.cancelled, state)
             group.leave()
         }
         group.wait()
@@ -38,12 +38,12 @@ class BlockingIOThreadPoolTest: XCTestCase {
     }
 
     func testStateActive() throws {
-        let threadPool = BlockingIOThreadPool(numberOfThreads: 17)
+        let threadPool = NIOThreadPool(numberOfThreads: 17)
         threadPool.start()
         let group = DispatchGroup()
         group.enter()
         threadPool.submit { state in
-            XCTAssertEqual(BlockingIOThreadPool.WorkItemState.active, state)
+            XCTAssertEqual(NIOThreadPool.WorkItemState.active, state)
             group.leave()
         }
         group.wait()
@@ -55,7 +55,7 @@ class BlockingIOThreadPoolTest: XCTestCase {
         let allDoneSem = DispatchSemaphore(value: 0)
 
         ({
-            let threadPool = BlockingIOThreadPool(numberOfThreads: 2)
+            let threadPool = NIOThreadPool(numberOfThreads: 2)
             threadPool.start()
             threadPool.submit { _ in
                 Foundation.Thread.sleep(forTimeInterval: 0.1)
@@ -75,7 +75,7 @@ class BlockingIOThreadPoolTest: XCTestCase {
     func testDeadLockIfCalledOutWithLockHeld() throws {
         let blockRunningSem = DispatchSemaphore(value: 0)
         let blockOneThreadSem = DispatchSemaphore(value: 0)
-        let threadPool = BlockingIOThreadPool(numberOfThreads: 1)
+        let threadPool = NIOThreadPool(numberOfThreads: 1)
         let allDone = DispatchSemaphore(value: 0)
         threadPool.start()
         // enqueue one that'll block the whole pool (1 thread only)
@@ -104,9 +104,9 @@ class BlockingIOThreadPoolTest: XCTestCase {
         let taskRunningSem = DispatchSemaphore(value: 0)
         let doneSem = DispatchSemaphore(value: 0)
         let shutdownDoneSem = DispatchSemaphore(value: 0)
-        weak var weakThreadPool: BlockingIOThreadPool? = nil
+        weak var weakThreadPool: NIOThreadPool? = nil
         ({
-            let threadPool = BlockingIOThreadPool(numberOfThreads: 1)
+            let threadPool = NIOThreadPool(numberOfThreads: 1)
             weakThreadPool = threadPool
             threadPool.start()
             threadPool.submit { state in
@@ -134,7 +134,7 @@ class BlockingIOThreadPoolTest: XCTestCase {
     func testClosureReferenceDroppedAfterSingleWorkItemExecution() throws {
         let taskRunningSem = DispatchSemaphore(value: 0)
         let doneSem = DispatchSemaphore(value: 0)
-        let threadPool = BlockingIOThreadPool(numberOfThreads: 1)
+        let threadPool = NIOThreadPool(numberOfThreads: 1)
         threadPool.start()
         weak var referencedObject: SomeClass? = nil
         ({
@@ -156,7 +156,7 @@ class BlockingIOThreadPoolTest: XCTestCase {
     func testClosureReferencesDroppedAfterTwoConsecutiveWorkItemsExecution() throws {
         let taskRunningSem = DispatchSemaphore(value: 0)
         let doneSem = DispatchSemaphore(value: 0)
-        let threadPool = BlockingIOThreadPool(numberOfThreads: 1)
+        let threadPool = NIOThreadPool(numberOfThreads: 1)
         threadPool.start()
         weak var referencedObject1: SomeClass? = nil
         weak var referencedObject2: SomeClass? = nil

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -20,13 +20,13 @@ class NonBlockingFileIOTest: XCTestCase {
     private var eventLoop: EventLoop!
     private var allocator: ByteBufferAllocator!
     private var fileIO: NonBlockingFileIO!
-    private var threadPool: BlockingIOThreadPool!
+    private var threadPool: NIOThreadPool!
 
     override func setUp() {
         super.setUp()
         self.allocator = ByteBufferAllocator()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        self.threadPool = BlockingIOThreadPool(numberOfThreads: 6)
+        self.threadPool = NIOThreadPool(numberOfThreads: 6)
         self.threadPool.start()
         self.fileIO = NonBlockingFileIO(threadPool: threadPool)
         self.eventLoop = self.group.next()

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -10,6 +10,7 @@
 - `ByteToMessageDecoder`s now need to be wrapped in `ByteToMessageHandler`
   before they can be added to the pipeline.
   before: `pipeline.add(MyDecoder())`, after: `pipeline.add(ByteToMessageHandler(MyDecoder()))`
+- `BlockingIOThreadPool` has been renamed to `NIOThreadPool`
 - `ByteToMessageDecoder` now requires the implementation of `decodeLast`
 - `ByteToMessageDecoder.decodeLast` has a new parameter `seenEOF: Bool`
 - `EventLoop.makePromise`/`makeSucceededFuture`/`makeFailedFuture` instead of `new*`, also `result:`/`error:` labels dropped


### PR DESCRIPTION
Motivation:

The thread pool implementation can be used for many things not just
blocking IO.

Modifications:

rename BlockingIOThreadPool to NIOThreadPool

Result:

fixes #186