### PR TITLE
Allow delaying HTTP upgrade decisions.

### DIFF
--- a/Sources/NIOWebSocket/WebSocketUpgrader.swift
+++ b/Sources/NIOWebSocket/WebSocketUpgrader.swift
@@ -57,7 +57,7 @@ public final class WebSocketUpgrader: HTTPServerProtocolUpgrader {
     /// which NIO requires. We check for these manually.
     public let requiredUpgradeHeaders: [String] = []
 
-    private let shouldUpgrade: (HTTPRequestHead) -> HTTPHeaders?
+    private let shouldUpgrade: (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>
     private let upgradePipelineHandler: (Channel, HTTPRequestHead) -> EventLoopFuture<Void>
     private let maxFrameSize: Int
     private let automaticErrorHandling: Bool
@@ -72,13 +72,13 @@ public final class WebSocketUpgrader: HTTPServerProtocolUpgrader {
     ///         upgraded. This callback is responsible for creating a `HTTPHeaders` object with
     ///         any headers that it needs on the response *except for* the `Upgrade`, `Connection`,
     ///         and `Sec-WebSocket-Accept` headers, which this upgrader will handle. Should return
-    ///         `nil` if the upgrade should be refused.
+    ///         an `EventLoopFuture` containing `nil` if the upgrade should be refused.
     ///     - upgradePipelineHandler: A function that will be called once the upgrade response is
     ///         flushed, and that is expected to mutate the `Channel` appropriately to handle the
     ///         websocket protocol. This only needs to add the user handlers: the
     ///         `WebSocketFrameEncoder` and `WebSocketFrameDecoder` will have been added to the
     ///         pipeline automatically.
-    public convenience init(automaticErrorHandling: Bool = true, shouldUpgrade: @escaping (HTTPRequestHead) -> HTTPHeaders?,
+    public convenience init(automaticErrorHandling: Bool = true, shouldUpgrade: @escaping (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>,
                 upgradePipelineHandler: @escaping (Channel, HTTPRequestHead) -> EventLoopFuture<Void>) {
         self.init(maxFrameSize: 1 << 14, automaticErrorHandling: automaticErrorHandling,
                   shouldUpgrade: shouldUpgrade, upgradePipelineHandler: upgradePipelineHandler)
@@ -99,13 +99,13 @@ public final class WebSocketUpgrader: HTTPServerProtocolUpgrader {
     ///         upgraded. This callback is responsible for creating a `HTTPHeaders` object with
     ///         any headers that it needs on the response *except for* the `Upgrade`, `Connection`,
     ///         and `Sec-WebSocket-Accept` headers, which this upgrader will handle. Should return
-    ///         `nil` if the upgrade should be refused.
+    ///         an `EventLoopFuture` containing `nil` if the upgrade should be refused.
     ///     - upgradePipelineHandler: A function that will be called once the upgrade response is
     ///         flushed, and that is expected to mutate the `Channel` appropriately to handle the
     ///         websocket protocol. This only needs to add the user handlers: the
     ///         `WebSocketFrameEncoder` and `WebSocketFrameDecoder` will have been added to the
     ///         pipeline automatically.
-    public init(maxFrameSize: Int, automaticErrorHandling: Bool = true, shouldUpgrade: @escaping (HTTPRequestHead) -> HTTPHeaders?,
+    public init(maxFrameSize: Int, automaticErrorHandling: Bool = true, shouldUpgrade: @escaping (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>,
                 upgradePipelineHandler: @escaping (Channel, HTTPRequestHead) -> EventLoopFuture<Void>) {
         precondition(maxFrameSize <= UInt32.max, "invalid overlarge max frame size")
         self.shouldUpgrade = shouldUpgrade
@@ -114,34 +114,46 @@ public final class WebSocketUpgrader: HTTPServerProtocolUpgrader {
         self.automaticErrorHandling = automaticErrorHandling
     }
 
-    public func buildUpgradeResponse(upgradeRequest: HTTPRequestHead, initialResponseHeaders: HTTPHeaders) throws -> HTTPHeaders {
-        let key = try upgradeRequest.headers.nonListHeader("Sec-WebSocket-Key")
-        let version = try upgradeRequest.headers.nonListHeader("Sec-WebSocket-Version")
+    public func buildUpgradeResponse(channel: Channel, upgradeRequest: HTTPRequestHead, initialResponseHeaders: HTTPHeaders) -> EventLoopFuture<HTTPHeaders> {
+        let key: String
+        let version: String
+
+        do {
+            key = try upgradeRequest.headers.nonListHeader("Sec-WebSocket-Key")
+            version = try upgradeRequest.headers.nonListHeader("Sec-WebSocket-Version")
+        } catch {
+            return channel.eventLoop.makeFailedFuture(error)
+        }
 
         // The version must be 13.
         guard version == "13" else {
-            throw NIOWebSocketUpgradeError.invalidUpgradeHeader
+            return channel.eventLoop.makeFailedFuture(NIOWebSocketUpgradeError.invalidUpgradeHeader)
         }
 
-        guard var extraHeaders = self.shouldUpgrade(upgradeRequest) else {
-            throw NIOWebSocketUpgradeError.unsupportedWebSocketTarget
+        return self.shouldUpgrade(channel, upgradeRequest).flatMapThrowing { extraHeaders in
+            guard let extraHeaders = extraHeaders else {
+                throw NIOWebSocketUpgradeError.unsupportedWebSocketTarget
+            }
+            return extraHeaders
+        }.map { (extraHeaders: HTTPHeaders) in
+            var extraHeaders = extraHeaders
+
+            // Cool, we're good to go! Let's do our upgrade. We do this by concatenating the magic
+            // GUID to the base64-encoded key and taking a SHA1 hash of the result.
+            let acceptValue: String
+            do {
+                var hasher = SHA1()
+                hasher.update(string: key)
+                hasher.update(string: magicWebSocketGUID)
+                acceptValue = String(base64Encoding: hasher.finish())
+            }
+
+            extraHeaders.replaceOrAdd(name: "Upgrade", value: "websocket")
+            extraHeaders.add(name: "Sec-WebSocket-Accept", value: acceptValue)
+            extraHeaders.replaceOrAdd(name: "Connection", value: "upgrade")
+
+            return extraHeaders
         }
-
-        // Cool, we're good to go! Let's do our upgrade. We do this by concatenating the magic
-        // GUID to the base64-encoded key and taking a SHA1 hash of the result.
-        let acceptValue: String
-        do {
-            var hasher = SHA1()
-            hasher.update(string: key)
-            hasher.update(string: magicWebSocketGUID)
-            acceptValue = String(base64Encoding: hasher.finish())
-        }
-
-        extraHeaders.replaceOrAdd(name: "Upgrade", value: "websocket")
-        extraHeaders.add(name: "Sec-WebSocket-Accept", value: acceptValue)
-        extraHeaders.replaceOrAdd(name: "Connection", value: "upgrade")
-
-        return extraHeaders
     }
 
     public func upgrade(context: ChannelHandlerContext, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<Void> {

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -202,7 +202,7 @@ private final class WebSocketTimeHandler: ChannelInboundHandler {
 
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
-let upgrader = WebSocketUpgrader(shouldUpgrade: { (head: HTTPRequestHead) in HTTPHeaders() },
+let upgrader = WebSocketUpgrader(shouldUpgrade: { (channel: Channel, head: HTTPRequestHead) in channel.eventLoop.makeSucceededFuture(HTTPHeaders()) },
                                  upgradePipelineHandler: { (channel: Channel, _: HTTPRequestHead) in
                                     channel.pipeline.addHandler(WebSocketTimeHandler())
                                  })

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests+XCTest.swift
@@ -39,6 +39,10 @@ extension HTTPUpgradeTestCase {
                 ("testUpgradeIsCaseInsensitive", testUpgradeIsCaseInsensitive),
                 ("testDelayedUpgradeBehaviour", testDelayedUpgradeBehaviour),
                 ("testBuffersInboundDataDuringDelayedUpgrade", testBuffersInboundDataDuringDelayedUpgrade),
+                ("testDelayedUpgradeResponse", testDelayedUpgradeResponse),
+                ("testChainsDelayedUpgradesAppropriately", testChainsDelayedUpgradesAppropriately),
+                ("testDelayedUpgradeResponseDeliversFullRequest", testDelayedUpgradeResponseDeliversFullRequest),
+                ("testDelayedUpgradeResponseDeliversFullRequestAndPendingBits", testDelayedUpgradeResponseDeliversFullRequestAndPendingBits),
                 ("testRemovesAllHTTPRelatedHandlersAfterUpgrade", testRemovesAllHTTPRelatedHandlersAfterUpgrade),
                 ("testUpgradeWithUpgradePayloadInlineWithRequestWorks", testUpgradeWithUpgradePayloadInlineWithRequestWorks),
            ]

--- a/Tests/NIOWebSocketTests/EndToEndTests+XCTest.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests+XCTest.swift
@@ -29,6 +29,7 @@ extension EndToEndTests {
                 ("testBasicUpgradeDance", testBasicUpgradeDance),
                 ("testUpgradeWithProtocolName", testUpgradeWithProtocolName),
                 ("testCanRejectUpgrade", testCanRejectUpgrade),
+                ("testCanDelayAcceptingUpgrade", testCanDelayAcceptingUpgrade),
                 ("testRequiresVersion13", testRequiresVersion13),
                 ("testRequiresVersionHeader", testRequiresVersionHeader),
                 ("testRequiresKeyHeader", testRequiresKeyHeader),

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -69,3 +69,5 @@
 - change `ChannelPipeline.addHandler[s](_:first:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`
 - change  `ChannelPipeline.addHandler(_:before:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`
 - change  `ChannelPipeline.addHandler(_:after:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`
+- Change `HTTPServerProtocolUpgrader` `protocol` to require `buildUpgradeResponse` to take a `channel` and return an `EventLoopFuture<HTTPHeaders>`.
+


### PR DESCRIPTION
Motivation:

While the HTTPServerUpgrader and WebSocketUpgrader allowed users to take
their time when reconfiguring the pipeline after they decided to upgrade,
users had to synchronously decide if they wanted to upgrade. This is a bit
inconvenient.

A particular limitation here is that some routes may want to upgrade
only if the upgrading user is authenticated. Checking authentication
credentials is almost always an I/O operation, and so cannot safely be done
on the event loop. Our original design made this impossible.

Modifications:

- Changed the shouldUpgrade callback to return a Future.
- Passed the shouldUpgrade callback the Channel that is upgrading, in
    no small part so that it has an EventLoop it can create Futures
    on.
- Rewrote the upgrader to handle this new state.

Result:

Users can delay decisions about when to upgrade.
Resolves #699.