### PR TITLE
update http_parser

### DIFF
--- a/Sources/CNIOHTTPParser/include/c_nio_http_parser.h
+++ b/Sources/CNIOHTTPParser/include/c_nio_http_parser.h
@@ -29,8 +29,8 @@ extern "C" {
 
 /* Also update SONAME in the Makefile whenever you change these. */
 #define HTTP_PARSER_VERSION_MAJOR 2
-#define HTTP_PARSER_VERSION_MINOR 8
-#define HTTP_PARSER_VERSION_PATCH 1
+#define HTTP_PARSER_VERSION_MINOR 9
+#define HTTP_PARSER_VERSION_PATCH 0
 
 #include <stddef.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && \
@@ -432,6 +432,9 @@ void c_nio_http_parser_pause(http_parser *parser, int paused);
 
 /* Checks if this is the final chunk of the body. */
 int c_nio_http_body_is_final(const http_parser *parser);
+
+/* Change the maximum header size provided at compile time. */
+void c_nio_http_parser_set_max_header_size(uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/Sources/CNIOHTTPParser/update_and_patch_http_parser.sh
+++ b/Sources/CNIOHTTPParser/update_and_patch_http_parser.sh
@@ -61,6 +61,7 @@ for f in http_parser.c http_parser.h; do
         -e 's/\b\(http_parser_version\)/c_nio_\1/g' \
         -e 's/\b\(http_should_keep_alive\)/c_nio_\1/g' \
         -e 's/\b\(http_status_str\)/c_nio_\1/g' \
+        -e 's/\b\(http_parser_set_max_header_size\)/c_nio_\1/g' \
         "$here/c_nio_$f"
 done
 
@@ -73,6 +74,7 @@ num_non_nio=$(nm "$tmp/test.o" | grep ' T ' | grep -v c_nio | wc -l)
 
 test 0 -eq $num_non_nio || {
     echo "ERROR: $num_non_nio exported non-prefixed symbols found"
+    nm "$tmp/test.o" | grep ' T ' | grep -v c_nio
     exit 1
 }
 

--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -547,6 +547,8 @@ private extension ByteBuffer {
             self.writeStaticString("MKACTIVITY")
         case .UNSUBSCRIBE:
             self.writeStaticString("UNSUBSCRIBE")
+        case .SOURCE:
+            self.writeStaticString("SOURCE")
         case .RAW(let value):
             self.writeString(value)
         }

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -857,6 +857,7 @@ public enum HTTPMethod: Equatable {
     case MKCALENDAR
     case MKACTIVITY
     case UNSUBSCRIBE
+    case SOURCE
     case RAW(value: String)
 
     /// Whether requests with this verb may have a request body.


### PR DESCRIPTION
Motivation:

We should always use the latest http_parser.

Modifications:

- update http_parser
- add the `SOURCE` HTTP method

Result:

new, shiny stuff