### PR TITLE
fix new Swift 5 warnings for NIO 1

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -365,7 +365,7 @@ class BaseSocket: Selectable {
             let storage = UnsafeMutableRawBufferPointer.allocate(byteCount: MemoryLayout<T>.stride,
                                                                  alignment: MemoryLayout<T>.alignment)
             // write zeroes into the memory as Linux's getsockopt doesn't zero them out
-            storage.initializeMemory(as: UInt8.self, repeating: 0)
+            _ = storage.initializeMemory(as: UInt8.self, repeating: 0)
             var val = storage.bindMemory(to: T.self).baseAddress!
             // initialisation will be done by getsockopt
             defer {

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -29,7 +29,7 @@ let sysFree: @convention(c) (UnsafeMutableRawPointer?) -> Void = free
 
         internal func initializeMemory<T>(as type: T.Type, repeating repeatedValue: T) -> UnsafeMutableBufferPointer<T> {
             let ptr = self.bindMemory(to: T.self)
-            ptr.initialize(from: repeatElement(repeatedValue, count: self.count / MemoryLayout<T>.stride))
+            _ = ptr.initialize(from: repeatElement(repeatedValue, count: self.count / MemoryLayout<T>.stride))
             return ptr
         }
 
@@ -59,6 +59,7 @@ let sysFree: @convention(c) (UnsafeMutableRawPointer?) -> Void = free
 #endif
 
 extension _ByteBufferSlice: Equatable {
+    @_versioned
     static func ==(_ lhs: _ByteBufferSlice, _ rhs: _ByteBufferSlice) -> Bool {
         return lhs._begin == rhs._begin && lhs.upperBound == rhs.upperBound
     }
@@ -237,10 +238,10 @@ public struct ByteBuffer {
     public typealias _Index = UInt32
     public typealias _Capacity = UInt32
 
-    @_versioned private(set) var _storage: _Storage
-    @_versioned private(set) var _readerIndex: _Index = 0
-    @_versioned private(set) var _writerIndex: _Index = 0
-    @_versioned private(set) var _slice: Slice
+    @_versioned var _storage: _Storage
+    @_versioned var _readerIndex: _Index = 0
+    @_versioned var _writerIndex: _Index = 0
+    @_versioned var _slice: Slice
 
     // MARK: Internal _Storage for CoW
     @_versioned final class _Storage {

--- a/Sources/NIO/IntegerTypes.swift
+++ b/Sources/NIO/IntegerTypes.swift
@@ -17,24 +17,31 @@
 /// A 24-bit unsigned integer value type.
 @_versioned
 struct _UInt24: ExpressibleByIntegerLiteral {
+#if swift(>=4.1.50) // Swift 4.2 or better compiler in Swift 4 mode
+    @_versioned
     typealias IntegerLiteralType = UInt16
+#else
+    typealias IntegerLiteralType = UInt16
+#endif
 
     @_versioned var b12: UInt16
     @_versioned var b3: UInt8
 
-    private init(b12: UInt16, b3: UInt8) {
+    @_versioned
+    init(_b12 b12: UInt16, b3: UInt8) {
         self.b12 = b12
         self.b3 = b3
     }
 
+    @_versioned
     init(integerLiteral value: UInt16) {
-        self.init(b12: value, b3: 0)
+        self.init(_b12: value, b3: 0)
     }
 
     static let bitWidth: Int = 24
 
     static var max: _UInt24 {
-        return .init(b12: .max, b3: .max)
+        return .init(_b12: .max, b3: .max)
     }
 
     static let min: _UInt24 = 0
@@ -67,12 +74,14 @@ extension _UInt24 {
 }
 
 extension _UInt24: Equatable {
+    @_versioned
     static func ==(_ lhs: _UInt24, _ rhs: _UInt24) -> Bool {
         return lhs.b12 == rhs.b12 && lhs.b3 == rhs.b3
     }
 }
 
 extension _UInt24: CustomStringConvertible {
+    @_versioned
     var description: String {
         return Int(self).description
     }

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -122,21 +122,19 @@ class ChannelPipelineTest: XCTestCase {
         XCTAssertFalse(try channel.finish())
     }
 
-    func testConnectingDoesntCallBind() throws {
+    func testConnectingDoesntCallBind() {
         let channel = EmbeddedChannel()
         var ipv4SocketAddress = sockaddr_in()
         ipv4SocketAddress.sin_port = (12345 as UInt16).bigEndian
         let sa = SocketAddress(ipv4SocketAddress, host: "foobar.com")
 
-        _ = try channel.pipeline.add(handler: NoBindAllowed()).wait()
-        _ = try channel.pipeline.add(handler: TestChannelOutboundHandler<ByteBuffer, ByteBuffer> { data in
+        XCTAssertNoThrow(try channel.pipeline.add(handler: NoBindAllowed()).wait())
+        XCTAssertNoThrow(try channel.pipeline.add(handler: TestChannelOutboundHandler<ByteBuffer, ByteBuffer> { data in
             data
-        }).wait()
+        }).wait())
 
-        _ = try channel.connect(to: sa).wait()
-        defer {
-            XCTAssertFalse(try channel.finish())
-        }
+        XCTAssertNoThrow(try channel.connect(to: sa).wait())
+        XCTAssertNoThrow(XCTAssertFalse(try channel.finish()))
     }
 
     private final class TestChannelOutboundHandler<In, Out>: ChannelOutboundHandler {


### PR DESCRIPTION
Motivation:

Swift 5 brought a bunch of new warnings for NIO 1.

Modifications:

fix the warnings

Result:

happier compiles