### PR TITLE
improve ChannelPipeline debug print

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -1557,17 +1557,13 @@ extension ChannelPipeline: CustomDebugStringConvertible {
     
     private struct ChannelHandlerDebugInfo {
         let handler: ChannelHandler
-        
         let name: String
-        
         var isIncoming: Bool {
             return self.handler is _ChannelInboundHandler
         }
-        
         var isOutgoing: Bool {
             return self.handler is _ChannelOutboundHandler
         }
-        
         var typeName: String {
             return "\(type(of: self.handler))"
         }

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -56,7 +56,7 @@ extension ChannelPipelineTest {
                 ("testVariousChannelRemovalAPIsGoThroughRemovableChannelHandler", testVariousChannelRemovalAPIsGoThroughRemovableChannelHandler),
                 ("testNonRemovableChannelHandlerIsNotRemovable", testNonRemovableChannelHandlerIsNotRemovable),
                 ("testAddMultipleHandlers", testAddMultipleHandlers),
-                ("testPipelineDebugDescription", testPipelineDebugDescription)
+                ("testPipelineDebugDescription", testPipelineDebugDescription),
            ]
    }
 }

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -56,6 +56,7 @@ extension ChannelPipelineTest {
                 ("testVariousChannelRemovalAPIsGoThroughRemovableChannelHandler", testVariousChannelRemovalAPIsGoThroughRemovableChannelHandler),
                 ("testNonRemovableChannelHandlerIsNotRemovable", testNonRemovableChannelHandlerIsNotRemovable),
                 ("testAddMultipleHandlers", testAddMultipleHandlers),
+                ("testPipelineDebugDescription", testPipelineDebugDescription)
            ]
    }
 }


### PR DESCRIPTION
This PR improves `ChannelPipeline`'s `CustomDebugStringConvertible` conformance:

```swift
print(someChannel.pipeline)
``` 

```
ChannelPipeline[0x0000000000000000]:
                     [I] ↓↑ [O]
 <incoming handler type> ↓↑                         [<name>]
                         ↓↑ <outgoing handler type> [<name>]
   <duplex handler type> ↓↑ <duplex handler type>   [<name>]
```

See #848 for more information. 