### PR TITLE
B2MD: actually call decoderRemoved

### DIFF
--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -468,6 +468,9 @@ extension ByteToMessageHandler: ChannelInboundHandler {
         if !self.state.isFinalState {
             self.state = .done
         }
+        // here we can force it because we know that the decoder isn't in use because the removal is always
+        // eventLoop.execute'd
+        self.decoder!.decoderRemoved(context: context)
     }
 
     /// Calls `decode` until there is nothing left to decode.

--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -50,6 +50,7 @@ extension ByteToMessageDecoderTest {
                 ("testWriteObservingByteToMessageDecoderWhereWriteIsReentrantlyCalled", testWriteObservingByteToMessageDecoderWhereWriteIsReentrantlyCalled),
                 ("testDecodeMethodsNoLongerCalledIfErrorInDecode", testDecodeMethodsNoLongerCalledIfErrorInDecode),
                 ("testDecodeMethodsNoLongerCalledIfErrorInDecodeLast", testDecodeMethodsNoLongerCalledIfErrorInDecodeLast),
+                ("testBasicLifecycle", testBasicLifecycle),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

decoderRemoved was never actually called...

Modifications:

call decoderRemoved on removal

Result:

more correct B2MD
