### PR TITLE
B2MD: fast-path to reduce allocations

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -104,25 +104,45 @@ private final class PingHandler: ChannelInboundHandler {
 }
 
 private final class PongHandler: ChannelInboundHandler {
-    typealias InboundIn = ByteBuffer
+    typealias InboundIn = UInt8
     typealias OutboundOut = ByteBuffer
 
     private var pongBuffer: ByteBuffer!
     public static let pongCode: UInt8 = 0xef
 
-    public func channelActive(context: ChannelHandlerContext) {
+    public func handlerAdded(context: ChannelHandlerContext) {
         self.pongBuffer = context.channel.allocator.buffer(capacity: 1)
         self.pongBuffer.writeInteger(PongHandler.pongCode)
     }
 
-    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        var buf = self.unwrapInboundIn(data)
-        if buf.readableBytes == 1 &&
-            buf.readInteger(as: UInt8.self) == PingHandler.pingCode {
-            context.writeAndFlush(self.wrapOutboundOut(self.pongBuffer), promise: nil)
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let data = self.unwrapInboundIn(data)
+        if data == PingHandler.pingCode {
+            context.writeAndFlush(NIOAny(self.pongBuffer), promise: nil)
         } else {
             context.close(promise: nil)
         }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        context.close(promise: nil)
+    }
+}
+
+private final class PongDecoder: ByteToMessageDecoder {
+    typealias InboundOut = UInt8
+
+    public func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) -> DecodingState {
+        if let ping = buffer.readInteger(as: UInt8.self) {
+            context.fireChannelRead(self.wrapInboundOut(ping))
+            return .continue
+        } else {
+            return .needMoreData
+        }
+    }
+
+    public func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
+        return .needMoreData
     }
 }
 
@@ -253,7 +273,9 @@ public func swiftMain() -> Int {
             .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .childChannelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))
             .childChannelInitializer { channel in
-                channel.pipeline.addHandler(PongHandler())
+                channel.pipeline.addHandler(ByteToMessageHandler(PongDecoder())).flatMap {
+                    channel.pipeline.addHandler(PongHandler())
+                }
             }.bind(host: "127.0.0.1", port: 0).wait()
 
         defer {

--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -207,14 +207,17 @@ extension B2MDBuffer {
     }
 
 
-    mutating func finishProcessing(remainder buffer: ByteBuffer) -> Void {
+    mutating func finishProcessing(remainder buffer: inout ByteBuffer) -> Void {
         assert(self.state == .processingInProgress)
         self.state = .ready
+        if buffer.readableBytes == 0 && self.buffers.count == 0 {
+            // fast path, no bytes left and no other buffers, just return
+            return
+        }
         if buffer.readableBytes > 0 {
             self.buffers.prepend(buffer)
         } else {
-            var buffer = buffer
-            buffer.clear()
+            buffer.discardReadBytes()
             buffer.writeBuffers(self.buffers)
             self.buffers.removeAll(keepingCapacity: self.buffers.capacity < 16) // don't grow too much
             self.buffers.append(buffer)
@@ -369,6 +372,7 @@ extension ByteToMessageHandler: CanDequeueWrites where Decoder: WriteObservingBy
 
 // MARK: ByteToMessageHandler's Main API
 extension ByteToMessageHandler {
+    @inline(__always) // allocations otherwise (reconsider with Swift 5.1)
     private func withNextBuffer(allowEmptyBuffer: Bool, _ body: (inout Decoder, inout ByteBuffer) throws -> DecodingState) rethrows -> B2MDBuffer.BufferProcessingResult {
         switch self.buffer.startProcessing(allowEmptyBuffer: allowEmptyBuffer) {
         case .bufferAlreadyBeingProcessed:
@@ -388,7 +392,7 @@ extension ByteToMessageHandler {
                         buffer.discardReadBytes()
                     }
                 }
-                self.buffer.finishProcessing(remainder: buffer)
+                self.buffer.finishProcessing(remainder: &buffer)
             }
             return .didProcess(try body(&decoder!, &buffer))
         }


### PR DESCRIPTION
Motivation:

B2MD has an important fast path:
- everything was consumed
- no buffers collected during re-entrancy

In this case we should short-circuit and move on as quickly as possible.

Modifications:

If everything was consumed in `decode` and no buffers were collected in
re-entrancy, returning a buffer isn't actually useful, we should just
drop it and not risk taking an allocation for a useless `clear`.

Result:

faster & fewer allocs