### PR TITLE
EmbeddedChannel: expose EmbeddedEventLoop

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -309,14 +309,18 @@ public class EmbeddedChannel: Channel {
 
     public func finish() throws -> Bool {
         try close().wait()
-        (self.eventLoop as! EmbeddedEventLoop).run()
+        self.embeddedEventLoop.run()
         try throwIfErrorCaught()
         return !channelcore.outboundBuffer.isEmpty || !channelcore.inboundBuffer.isEmpty || !channelcore.pendingOutboundBuffer.isEmpty
     }
 
     private var _pipeline: ChannelPipeline!
     public var allocator: ByteBufferAllocator = ByteBufferAllocator()
-    public var eventLoop: EventLoop = EmbeddedEventLoop()
+    public var eventLoop: EventLoop {
+        return self.embeddedEventLoop
+    }
+
+    public var embeddedEventLoop: EmbeddedEventLoop = EmbeddedEventLoop()
 
     public var localAddress: SocketAddress? = nil
     public var remoteAddress: SocketAddress? = nil
@@ -373,7 +377,7 @@ public class EmbeddedChannel: Channel {
     ///     - handler: The `ChannelHandler` to add to the `ChannelPipeline` before register or `nil` if none should be added.
     ///     - loop: The `EmbeddedEventLoop` to use.
     public init(handler: ChannelHandler? = nil, loop: EmbeddedEventLoop = EmbeddedEventLoop()) {
-        self.eventLoop = loop
+        self.embeddedEventLoop = loop
         self._pipeline = ChannelPipeline(channel: self)
 
         if let handler = handler {

--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -54,7 +54,7 @@ class HTTPDecoderLengthTest: XCTestCase {
 
     override func setUp() {
         self.channel = EmbeddedChannel()
-        self.loop = (channel.eventLoop as! EmbeddedEventLoop)
+        self.loop = channel.embeddedEventLoop
     }
 
     override func tearDown() {
@@ -412,7 +412,7 @@ class HTTPDecoderLengthTest: XCTestCase {
 
         // Must spin the loop.
         XCTAssertFalse(channel.isActive)
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
     }
 
     func testResponseWithTEAndContentLengthErrors() throws {
@@ -436,7 +436,7 @@ class HTTPDecoderLengthTest: XCTestCase {
 
         // Must spin the loop.
         XCTAssertFalse(channel.isActive)
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
     }
 
     private func assertRequestWithInvalidCLErrors(contentLengthField: String) throws {
@@ -456,7 +456,7 @@ class HTTPDecoderLengthTest: XCTestCase {
 
         // Must spin the loop.
         XCTAssertFalse(channel.isActive)
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
     }
 
     func testRequestWithMultipleDifferentContentLengthsFails() throws {
@@ -489,7 +489,7 @@ class HTTPDecoderLengthTest: XCTestCase {
 
         // Must spin the loop.
         XCTAssertFalse(channel.isActive)
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
     }
 
     func testRequestWithMultipleIdenticalContentLengthFieldsErrors() throws {
@@ -508,7 +508,7 @@ class HTTPDecoderLengthTest: XCTestCase {
 
         // Must spin the loop.
         XCTAssertFalse(channel.isActive)
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
     }
 
     func testRequestWithoutExplicitLengthIsZeroLength() throws {

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -22,7 +22,7 @@ class HTTPDecoderTest: XCTestCase {
 
     override func setUp() {
         self.channel = EmbeddedChannel()
-        self.loop = (channel.eventLoop as! EmbeddedEventLoop)
+        self.loop = channel.embeddedEventLoop
     }
 
     override func tearDown() {

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -28,7 +28,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         } catch HTTPParserError.invalidContentLength {
             // This error is expected
         }
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
 
         // The channel should be closed at this stage.
         XCTAssertNoThrow(try channel.closeFuture.wait())
@@ -121,7 +121,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         buffer.writeStaticString("GET / HTTP/1.1\r\n\r\nGET / HTTP/1.1\r\n\r\nGET / HT")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.close().wait())
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
 
         // The channel should be closed at this stage.
         XCTAssertNoThrow(try channel.closeFuture.wait())

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -526,7 +526,7 @@ class ChannelPipelineTest: XCTestCase {
         let handler = IndexWritingHandler(1)
         XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
         XCTAssertNoThrow(try channel.close().wait())
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
 
         do {
             try channel.pipeline.addHandler(IndexWritingHandler(2), position: .after(handler)).wait()
@@ -554,7 +554,7 @@ class ChannelPipelineTest: XCTestCase {
         let handler = IndexWritingHandler(1)
         XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
         XCTAssertNoThrow(try channel.close().wait())
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
 
         do {
             try channel.pipeline.addHandler(IndexWritingHandler(2), position: .before(handler)).wait()

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -319,7 +319,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
             }
         }
 
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
         XCTAssertEqual("1", readOneInboundString())
         XCTAssertEqual("2", readOneInboundString())
         XCTAssertEqual("3", readOneInboundString())
@@ -369,7 +369,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         buffer.clear()
         buffer.writeStaticString("4567890")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
         XCTAssertFalse(channel.isActive)
 
         XCTAssertEqual("1", channel.readInbound(as: ByteBuffer.self).map { String(decoding: $0.readableBytesView, as: Unicode.UTF8.self) })
@@ -438,7 +438,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         XCTAssertEqual("78", channel.readInbound(as: ByteBuffer.self).map { String(decoding: $0.readableBytesView, as: Unicode.UTF8.self) })
         XCTAssertEqual("90", channel.readInbound(as: ByteBuffer.self).map { String(decoding: $0.readableBytesView, as: Unicode.UTF8.self) })
         XCTAssertNil(channel.readInbound())
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
 
         XCTAssertNoThrow(XCTAssertEqual("x", String(decoding: try lastPromise.futureResult.wait().readableBytesView,
                                                     as: Unicode.UTF8.self)))
@@ -592,7 +592,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         XCTAssertEqual("0123456789abcdef", (channel.readInbound() as ByteBuffer?).map { String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)})
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
         XCTAssertEqual("QWER", (channel.readInbound() as ByteBuffer?).map { String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)})
         XCTAssertNil(channel.readInbound())
     }
@@ -632,7 +632,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         XCTAssertEqual("0123456789abcdef", (channel.readInbound() as ByteBuffer?).map { String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)})
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
         XCTAssertNil(channel.readInbound()) // no leftovers are forwarded
     }
 
@@ -677,7 +677,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 9)
         buffer.writeStaticString("012345678")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
         XCTAssertEqual(1, handler.decoder?.callsToDecode)
         XCTAssertEqual(2, handler.decoder?.callsToDecodeLast)
         ["0", "1234#1", "5678#2"].forEach {
@@ -784,7 +784,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         let removalFuture = channel.pipeline.context(handlerType: ByteToMessageHandler<Decoder>.self).flatMap {
             channel.pipeline.removeHandler(context: $0)
         }
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
         XCTAssertNoThrow(try removalFuture.wait())
         XCTAssertEqual(1, decoder.decodeLastCalls)
     }
@@ -814,7 +814,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         let removalFuture = channel.pipeline.context(handlerType: ByteToMessageHandler<Decoder>.self).flatMap {
             channel.pipeline.removeHandler(context: $0)
         }
-        (channel.eventLoop as! EmbeddedEventLoop).run()
+        channel.embeddedEventLoop.run()
         XCTAssertNoThrow(try removalFuture.wait())
         XCTAssertEqual(1, decoder.decodeLastCalls)
     }


### PR DESCRIPTION
Motivation:

There's just too much test code that has

(channel.eventLoop as! EmbeddedEventLoop).run()

Modifications:

have EmbeddedChannel expose its EmbeddedEventLoop

Result:

easier test code
