### PR TITLE
fix/improve some NIO1APIShims

### DIFF
--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -76,7 +76,7 @@ extension StaticString: Collection {
 }
 
 extension ChannelPipeline {
-    @available(*, deprecated, message: "please use ByteToMessageHandler(myByteToMessageDecoder)")
+    @available(*, deprecated, message: "please use addHandler(ByteToMessageHandler(myByteToMessageDecoder))")
     public func add<Decoder: ByteToMessageDecoder>(handler decoder: Decoder) -> EventLoopFuture<Void> {
         return self.addHandler(ByteToMessageHandler(decoder))
     }
@@ -416,7 +416,7 @@ extension ByteBuffer {
         return self.writeString(string)
     }
 
-    @available(*, deprecated, renamed: "setString(at:)")
+    @available(*, deprecated, renamed: "setString(_:at:)")
     public mutating func set(string: String, at index: Int) -> Int {
         return self.setString(string, at: index)
     }
@@ -471,7 +471,7 @@ extension ByteBuffer {
         return try self.writeString(string, encoding: encoding)
     }
 
-    @available(*, deprecated, renamed: "setString(at:encoding:at:)")
+    @available(*, deprecated, renamed: "setString(_:encoding:at:)")
     public mutating func set(string: String, encoding: String.Encoding, at index: Int) throws -> Int {
         return try self.setString(string, encoding: encoding, at: index)
     }

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -35,7 +35,7 @@
 - `ChannelOption.OptionType` has been renamed `ChannelOption.Value`
 - the default `ChannelOption`s have been switched changed from `case FooOption { case const }` to a `struct FooOption { public init() {} }`
 - `markedElementIndex()`, `markedElement()` and `hasMark()` are now computed variables instead of functions.
-- `ByteBuffer.set(string:at:)` no longer returns an `Int?`, instead it
+- `ByteBuffer.setString(_:at:)` (used to be `set(string:at:)`) no longer returns an `Int?`, instead it
   returns `Int` and has had its return value made discardable.
 - `ByteBuffer.write(string:)` (now named `ByteBuffer.writeString(_:)`) no longer returns an `Int?`, instead it
   returns `Int` and has had its return value made discardable.


### PR DESCRIPTION
Motivation:

We had wrong/suboptimal API shims.

Modifications:

improve them

Result:

easier porting from NIO1 to NIO2
