### PR TITLE
HTTP/1 headers simplification & cleanup

### DIFF
--- a/IntegrationTests/tests_01_http/test_07_headers_work.sh
+++ b/IntegrationTests/tests_01_http/test_07_headers_work.sh
@@ -19,7 +19,7 @@ token=$(create_token)
 start_server "$token"
 do_curl "$token" -H "foo: bar" --http1.0 \
     "http://foobar.com/dynamic/info" > "$tmp/out"
-if ! grep -q '("foo", "bar")' "$tmp/out"; then
+if ! grep -q '(name: "foo", value: "bar")' "$tmp/out"; then
     fail "couldn't find header in response"
 fi
 stop_server "$token"

--- a/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPUpgradeHandler.swift
@@ -144,7 +144,7 @@ public class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableChannelHa
 
         // Ok, we have a HTTP request. Check if it's an upgrade. If it's not, we want to pass it on and remove ourselves
         // from the channel pipeline.
-        let requestedProtocols = request.headers[canonicalForm: "upgrade"]
+        let requestedProtocols = request.headers[canonicalForm: "upgrade"].map(String.init)
         guard requestedProtocols.count > 0 else {
             self.notUpgrading(context: context, data: requestPart)
             return

--- a/Sources/NIOWebSocket/WebSocketUpgrader.swift
+++ b/Sources/NIOWebSocket/WebSocketUpgrader.swift
@@ -44,7 +44,7 @@ fileprivate extension HTTPHeaders {
         guard fields.count == 1 else {
             throw NIOWebSocketUpgradeError.invalidUpgradeHeader
         }
-        return fields.first!
+        return String(fields.first!)
     }
 }
 

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -314,6 +314,13 @@ extension HTTPVersion {
     }
 }
 
+extension HTTPHeaders {
+    @available(*, deprecated, message: "don't pass ByteBufferAllocator anymore")
+    public init(_ headers: [(String, String)] = [], allocator: ByteBufferAllocator) {
+        self.init(headers)
+    }
+}
+
 @available(*, deprecated, renamed: "ChannelError")
 public enum ChannelLifecycleError {
     @available(*, deprecated, message: "ChannelLifecycleError values are now available on ChannelError")

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -40,11 +40,13 @@ extension HTTPHeadersTest {
                 ("testKeepAliveStateStartsWithKeepAlive", testKeepAliveStateStartsWithKeepAlive),
                 ("testKeepAliveStateHasKeepAlive", testKeepAliveStateHasKeepAlive),
                 ("testKeepAliveStateHasClose", testKeepAliveStateHasClose),
-                ("testResolveNonContiguousHeaders", testResolveNonContiguousHeaders),
-                ("testStringBasedHTTPListHeaderIterator", testStringBasedHTTPListHeaderIterator),
-                ("testUnsafeBufferAccess", testUnsafeBufferAccess),
-                ("testCreateFromBufferAndLocations", testCreateFromBufferAndLocations),
                 ("testRandomAccess", testRandomAccess),
+                ("testCanBeSeededWithKeepAliveState", testCanBeSeededWithKeepAliveState),
+                ("testSeedDominatesActualValue", testSeedDominatesActualValue),
+                ("testSeedDominatesEvenAfterMutation", testSeedDominatesEvenAfterMutation),
+                ("testSeedGetsUpdatedToDefaultOnConnectionHeaderModification", testSeedGetsUpdatedToDefaultOnConnectionHeaderModification),
+                ("testSeedGetsUpdatedToWhateverTheHeaderSaysIfPresent", testSeedGetsUpdatedToWhateverTheHeaderSaysIfPresent),
+                ("testWeDefaultToCloseIfDoesNotMakeSense", testWeDefaultToCloseIfDoesNotMakeSense),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -176,36 +176,32 @@ class HTTPHeadersTest : XCTestCase {
     }
     
     func testKeepAliveStateStartsWithClose() {
-        var buffer = ByteBufferAllocator().buffer(capacity: 32)
-        buffer.writeString("Connection: close\r\n")
-        var headers = HTTPHeaders(buffer: buffer, headers: [HTTPHeader(name: HTTPHeaderIndex(start: 0, length: 10), value: HTTPHeaderIndex(start: 12, length: 5))], keepAliveState: .close)
-        
+        var headers = HTTPHeaders([("Connection", "close")])
+
         XCTAssertEqual("close", headers["connection"].first)
         XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
-        
+
         headers.replaceOrAdd(name: "connection", value: "keep-alive")
-        
+
         XCTAssertEqual("keep-alive", headers["connection"].first)
         XCTAssertTrue(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
-        
+
         headers.remove(name: "connection")
         XCTAssertTrue(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
         XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 0)))
     }
-    
+
     func testKeepAliveStateStartsWithKeepAlive() {
-        var buffer = ByteBufferAllocator().buffer(capacity: 32)
-        buffer.writeString("Connection: keep-alive\r\n")
-        var headers = HTTPHeaders(buffer: buffer, headers: [HTTPHeader(name: HTTPHeaderIndex(start: 0, length: 10), value: HTTPHeaderIndex(start: 12, length: 10))], keepAliveState: .keepAlive)
-        
+        var headers = HTTPHeaders([("Connection", "keep-alive")])
+
         XCTAssertEqual("keep-alive", headers["connection"].first)
         XCTAssertTrue(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
-        
+
         headers.replaceOrAdd(name: "connection", value: "close")
-        
+
         XCTAssertEqual("close", headers["connection"].first)
         XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
-        
+
         headers.remove(name: "connection")
         XCTAssertTrue(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
         XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 0)))
@@ -226,107 +222,7 @@ class HTTPHeadersTest : XCTestCase {
         
         XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
     }
-    
-    func testResolveNonContiguousHeaders() {
-        let headers = HTTPHeaders([("Connection", "x-options,  other"),
-                                   ("Content-Type", "text/html"),
-                                   ("Connection", "server,     close")])
-        var tokenSource = HTTPListHeaderIterator(
-            headerName: "Connection".utf8, headers: headers)
         
-        var currentToken = tokenSource.next()
-        XCTAssertEqual(String(decoding: currentToken!, as: Unicode.UTF8.self), "x-options")
-        currentToken = tokenSource.next()
-        XCTAssertEqual(String(decoding: currentToken!, as: Unicode.UTF8.self), "other")
-        currentToken = tokenSource.next()
-        XCTAssertEqual(String(decoding: currentToken!, as: Unicode.UTF8.self), "server")
-        currentToken = tokenSource.next()
-        XCTAssertEqual(String(decoding: currentToken!, as: Unicode.UTF8.self), "close")
-        currentToken = tokenSource.next()
-        XCTAssertNil(currentToken)
-    }
-
-    func testStringBasedHTTPListHeaderIterator() {
-        let headers = HTTPHeaders([("Connection", "x-options,  other"),
-                                   ("Content-Type", "text/html"),
-                                   ("Connection", "server,     close")])
-        var tokenSource = HTTPListHeaderIterator(
-            headerName: "Connection", headers: headers)
-        
-        var currentToken = tokenSource.next()
-        XCTAssertEqual(String(decoding: currentToken!, as: Unicode.UTF8.self), "x-options")
-        currentToken = tokenSource.next()
-        XCTAssertEqual(String(decoding: currentToken!, as: Unicode.UTF8.self), "other")
-        currentToken = tokenSource.next()
-        XCTAssertEqual(String(decoding: currentToken!, as: Unicode.UTF8.self), "server")
-        currentToken = tokenSource.next()
-        XCTAssertEqual(String(decoding: currentToken!, as: Unicode.UTF8.self), "close")
-        currentToken = tokenSource.next()
-        XCTAssertNil(currentToken)
-	}
-    
-    func testUnsafeBufferAccess() {
-        let originalHeaders = [ ("X-Header", "1"),
-                                ("X-SomeHeader", "3"),
-                                ("X-Header", "2")]
-        let originalHeadersString = "X-Header: 1\r\nX-SomeHeader: 3\r\nX-Header: 2\r\n"
-        var headers1 = HTTPHeaders(originalHeaders)
-        
-        // ensure we can access the underlying buffer and header locations
-        headers1.withUnsafeBufferAndIndices { (buf, locations, contiguous) in
-            XCTAssertTrue(contiguous)
-            XCTAssertEqual(locations.count, 3)
-            XCTAssertEqual(buf.readableBytes, originalHeadersString.utf8.count) // NB: String considers "\r\n" to be one character
-            
-            let str = buf.getString(at: 0, length: buf.readableBytes)
-            XCTAssertEqual(str, originalHeadersString)
-        }
-        
-        // remove a header
-        headers1.remove(name: "X-SomeHeader")
-        
-        // should no longer be contiguous
-        headers1.withUnsafeBufferAndIndices { (_, _, contiguous) in
-            XCTAssertFalse(contiguous)
-        }
-    }
-    
-    func testCreateFromBufferAndLocations() {
-        let originalHeaders = [ ("User-Agent", "1"),
-                                ("host", "2"),
-                                ("X-SOMETHING", "3"),
-                                ("X-Something", "4"),
-                                ("SET-COOKIE", "foo=bar"),
-                                ("Set-Cookie", "buz=cux")]
-        
-        // create our own buffer and location list
-        var buf = ByteBufferAllocator().buffer(capacity: 128)
-        var locations: [HTTPHeader] = []
-        for (name, value) in originalHeaders {
-            let nstart = buf.writerIndex
-            buf.writeString(name)
-            let nameLoc = HTTPHeaderIndex(start: nstart, length: buf.writerIndex - nstart)
-            buf.writeString(": ")
-            
-            let vstart = buf.writerIndex
-            buf.writeString(value)
-            let valueLoc = HTTPHeaderIndex(start: vstart, length: buf.writerIndex - vstart)
-            buf.writeString("\r\n")
-            
-            locations.append(HTTPHeader(name: nameLoc, value: valueLoc))
-        }
-        
-        // create HTTP headers
-        let headers = HTTPHeaders.createHeaderBlock(buffer: buf, headers: locations)
-        
-        // looking up headers value is case-insensitive
-        XCTAssertEqual(["1"], headers["User-Agent"])
-        XCTAssertEqual(["1"], headers["User-agent"])
-        XCTAssertEqual(["2"], headers["Host"])
-        XCTAssertEqual(["3", "4"], headers["X-Something"])
-        XCTAssertEqual(["foo=bar", "buz=cux"], headers["set-cookie"])
-    }
-    
     func testRandomAccess() {
         let originalHeaders = [ ("X-first", "one"),
                                 ("X-second", "two")]
@@ -344,5 +240,87 @@ class HTTPHeadersTest : XCTestCase {
         let afterFirst = headers[headers.index(after: headers.startIndex)]
         XCTAssertEqual(afterFirst.name, originalHeaders[originalHeaders.startIndex + 1].0)
         XCTAssertEqual(afterFirst.value, originalHeaders[originalHeaders.startIndex + 1].1)
+    }
+
+    func testCanBeSeededWithKeepAliveState() {
+        // we may later on decide that this test doesn't make sense but for now we want to keep the seeding behaviour.
+        let headersSeededWithClose = HTTPHeaders([], keepAliveState: .close)
+        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .init(major: 0, minor: 0)))
+
+        let headersSeededWithKeepAlive = HTTPHeaders([], keepAliveState: .keepAlive)
+        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 0, minor: 0)))
+    }
+
+    func testSeedDominatesActualValue() {
+        // we may later on decide that this test doesn't make sense but for now we want to keep the seeding behaviour
+        let headersSeededWithClose = HTTPHeaders([], keepAliveState: .close)
+        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 1)))
+
+        let headersSeededWithKeepAlive = HTTPHeaders([], keepAliveState: .keepAlive)
+        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 0)))
+    }
+
+    func testSeedDominatesEvenAfterMutation() {
+        // we may later on decide that this test doesn't make sense but for now we want to keep the seeding behaviour
+        var headersSeededWithClose = HTTPHeaders([], keepAliveState: .close)
+        headersSeededWithClose.add(name: "foo", value: "bar")
+        headersSeededWithClose.add(name: "bar", value: "qux")
+        headersSeededWithClose.remove(name: "bar")
+        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 1)))
+
+        var headersSeededWithKeepAlive = HTTPHeaders([], keepAliveState: .keepAlive)
+        headersSeededWithKeepAlive.add(name: "foo", value: "bar")
+        headersSeededWithKeepAlive.add(name: "bar", value: "qux")
+        headersSeededWithKeepAlive.remove(name: "bar")
+        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 0)))
+    }
+
+    func testSeedGetsUpdatedToDefaultOnConnectionHeaderModification() {
+        var headersSeededWithClose = HTTPHeaders([], keepAliveState: .close)
+        headersSeededWithClose.add(name: "connection", value: "bar")
+        XCTAssertEqual(true, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 0)))
+
+        var headersSeededWithKeepAlive = HTTPHeaders([], keepAliveState: .keepAlive)
+        headersSeededWithKeepAlive.add(name: "connection", value: "bar")
+        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(false, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 0)))
+    }
+
+    func testSeedGetsUpdatedToWhateverTheHeaderSaysIfPresent() {
+        var headersSeededWithClose = HTTPHeaders([], keepAliveState: .close)
+        headersSeededWithClose.add(name: "connection", value: "bar,keep-alive,true")
+        XCTAssertEqual(true, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(true, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 0)))
+
+        var headersSeededWithKeepAlive = HTTPHeaders([], keepAliveState: .keepAlive)
+        headersSeededWithKeepAlive.add(name: "connection", value: "bar,close,true")
+        XCTAssertEqual(false, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(false, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 0)))
+    }
+
+    func testWeDefaultToCloseIfDoesNotMakeSense() {
+        var nonSenseInOneHeaderCK = HTTPHeaders([])
+        nonSenseInOneHeaderCK.add(name: "connection", value: "close,keep-alive")
+        XCTAssertEqual(false, nonSenseInOneHeaderCK.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(false, nonSenseInOneHeaderCK.isKeepAlive(version: .init(major: 1, minor: 0)))
+
+        var nonSenseInMultipleHeadersCK = HTTPHeaders([])
+        nonSenseInMultipleHeadersCK.add(name: "connection", value: "close")
+        nonSenseInMultipleHeadersCK.add(name: "connection", value: "keep-alive")
+        XCTAssertEqual(false, nonSenseInMultipleHeadersCK.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(false, nonSenseInMultipleHeadersCK.isKeepAlive(version: .init(major: 1, minor: 0)))
+
+        var nonSenseInOneHeaderKC = HTTPHeaders([])
+        nonSenseInOneHeaderKC.add(name: "connection", value: "keep-alive,close")
+        XCTAssertEqual(false, nonSenseInOneHeaderKC.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(false, nonSenseInOneHeaderKC.isKeepAlive(version: .init(major: 1, minor: 0)))
+
+        var nonSenseInMultipleHeadersKC = HTTPHeaders([])
+        nonSenseInMultipleHeadersKC.add(name: "connection", value: "keep-alive")
+        nonSenseInMultipleHeadersKC.add(name: "connection", value: "close")
+        XCTAssertEqual(false, nonSenseInMultipleHeadersKC.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(false, nonSenseInMultipleHeadersKC.isKeepAlive(version: .init(major: 1, minor: 0)))
+
     }
 }

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,7 +19,7 @@ services:
   integration-tests:
     image: swift-nio:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=45750
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1177050 # was: 685050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
@@ -29,7 +29,7 @@ services:
     image: swift-nio:18.04-5.0
     command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors -Xswiftc -DNIO_CI_BUILD && ./scripts/integration_tests.sh"
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=45750
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1177050 # was: 685050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -72,6 +72,10 @@
 - `EventLoopFuture.reduce(_:_:eventLoop:_:` had its label signature changed to `EventLoopFuture.reduce(_:_:on:_:)`
 - `CircularBuffer` and `MarkedCircularBuffer`'s indices are now opaque
 - all `ChannelOption`s are now required to be  `Equatable`
+- `HTTPHeaderIndex` has been removed, without replacement
+- `HTTPHeader` has been removed, without replacement
+- `HTTPHeaders[canonicalForm:]` now returns `[Substring]` instead of `[String]`
+- `HTTPListHeaderIterator` has been removed, without replacement
 - rename `FileHandle` to `NIOFileHandle`
 - rename all `ChannelPipeline.add(name:handler:...)`s to `ChannelPipeline.addHandler(_:name:...)`
 - rename all `ChannelPipeline.remove(...)`s to `ChannelPipeline.removeHandler(...)`


### PR DESCRIPTION
Motivation:

The HTTP/1 headers were quite complicated, CoW-boxed and exposed their
guts (being a ByteBuffer). In Swift 5 this is no longer necessary
because of native UTF-8 Strings.

Modifications:

- make headers simply `[(String, String)]`
- remove `HTTPHeaderIndex`, `HTTPListHeaderIterator`, etc

Result:

- simpler and more performant code
- nice speedup:

before:

```
$ wrk http://localhost:8888
Running 10s test @ http://localhost:8888
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   162.88us   44.81us   1.79ms   75.12%
    Req/Sec    28.75k     2.22k   32.83k    80.20%
  577919 requests in 10.10s, 28.66MB read
Requests/sec:  57218.56
Transfer/sec:      2.84MB
$ tcpkali -em "GET / HTTP/1.1\r\nHost: google.com\r\n\r\n" -r 10000000000000 --latency-marker "HTTP/1.1" 127.0.0.1:8888
Destination: [127.0.0.1]:8888
Interface lo0 address [127.0.0.1]:0
Using interface lo0 to connect to [127.0.0.1]:8888
Ramped up to 1 connections.
Total data sent:     15.2 MiB (15916740 bytes)
Total data received: 20.8 MiB (21827312 bytes)
Bandwidth per channel: 30.174⇅ Mbps (3771.7 kBps)
Aggregate bandwidth: 17.449↓, 12.724↑ Mbps
Packet rate estimate: 40324.3↓, 1101.8↑ (1↓, 37↑ TCP MSS/op)
Message latency at percentiles: 672.7/691.5/695.5 ms (95/99/99.5%)
Test duration: 10.0071 s.
```

after:

```
$ wrk http://localhost:8888
Running 10s test @ http://localhost:8888
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   151.39us   47.03us   1.40ms   80.82%
    Req/Sec    30.72k     3.80k   53.58k    67.16%
  614191 requests in 10.10s, 30.46MB read
Requests/sec:  60814.41
Transfer/sec:      3.02MB
$ tcpkali -em "GET / HTTP/1.1\r\nHost: google.com\r\n\r\n" -r 10000000000000 --latency-marker "HTTP/1.1" 127.0.0.1:8888
Destination: [127.0.0.1]:8888
Interface lo0 address [127.0.0.1]:0
Using interface lo0 to connect to [127.0.0.1]:8888
Ramped up to 1 connections.
Total data sent:     18.1 MiB (18945684 bytes)
Total data received: 24.9 MiB (26158600 bytes)
Bandwidth per channel: 36.077⇅ Mbps (4509.6 kBps)
Aggregate bandwidth: 20.923↓, 15.154↑ Mbps
Packet rate estimate: 47387.0↓, 1316.9↑ (1↓, 37↑ TCP MSS/op)
Message latency at percentiles: 557.5/571.5/576.3 ms (95/99/99.5%)
Test duration: 10.0019 s.
```
