### PR TITLE
make withUnsafeFileDescriptor inlinable

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -211,6 +211,7 @@ class BaseSocket: Selectable {
         return descriptor >= 0
     }
 
+    @inline(__always)
     func withUnsafeFileDescriptor<T>(_ body: (CInt) throws -> T) throws -> T {
         guard self.isOpen else {
             throw IOError(errnoCode: EBADF, reason: "file descriptor already closed!")
@@ -339,7 +340,7 @@ class BaseSocket: Selectable {
             // most socket options settings so for the time being we'll just ignore this. Let's revisit for NIO 2.0.
             return
         }
-        return try withUnsafeFileDescriptor { fd in
+        return try self.withUnsafeFileDescriptor { fd in
             var val = value
 
             try Posix.setsockopt(

--- a/Sources/NIO/FileDescriptor.swift
+++ b/Sources/NIO/FileDescriptor.swift
@@ -23,6 +23,7 @@ public protocol FileDescriptor {
     /// - parameters:
     ///     - body: The closure to execute if the `FileDescriptor` is still open.
     /// - throws: If either the `FileDescriptor` was closed before or the closure throws by itself.
+    @inline(__always)
     func withUnsafeFileDescriptor<T>(_ body: (CInt) throws -> T) throws -> T
 
     /// `true` if this `FileDescriptor` is open (which means it was not closed yet).


### PR DESCRIPTION
Motivation:

withUnsafeFileDescriptor is called quite frequently in Channel creation,
for example in setOption and it allocated every time.

Modifications:

make withUnsafeFileDescriptor always inlined.

Result:

fewer allocations.