### PR TITLE
slight improvements to the allocation tests

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/AtomicCounter/Package.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/AtomicCounter/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //===----------------------------------------------------------------------===//
 //

--- a/IntegrationTests/tests_04_performance/test_01_resources/template/HookedFunctions/Package.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/HookedFunctions/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //===----------------------------------------------------------------------===//
 //

--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Package.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+let localhostPickPort = try! SocketAddress.makeAddressResolvingHost("127.0.0.1", port: 0)
+
 import NIO
 import NIOHTTP1
 import Foundation
@@ -243,7 +245,7 @@ public func swiftMain() -> Int {
                                                              withErrorHandling: false).flatMap {
                     channel.pipeline.addHandler(SimpleHTTPServer())
                 }
-            }.bind(host: "127.0.0.1", port: 0).wait()
+            }.bind(to: localhostPickPort).wait()
 
         defer {
             try! serverChannel.close().wait()

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -20,7 +20,7 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=692050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=685050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
@@ -30,7 +30,7 @@ services:
     command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors -Xswiftc -DNIO_CI_BUILD && ./scripts/integration_tests.sh"
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=692050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=685050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100


### PR DESCRIPTION
Motivation:

The allocation tests were needlessly running the resolver within the
allocation counted loop.

Modifications:

- bump to Swift version 5.0
- take the resolving out of the allocation counting loop

Result:

more accurate results
