### PR TITLE
prepare tests for throwing readIn/Outbound

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -328,11 +328,11 @@ public class EmbeddedChannel: Channel {
     // Embedded channels never have parents.
     public let parent: Channel? = nil
 
-    public func readOutbound<T>(as type: T.Type = T.self) -> T? {
+    public func readOutbound<T>(as type: T.Type = T.self) throws -> T? {
         return readFromBuffer(buffer: &channelcore.outboundBuffer)
     }
 
-    public func readInbound<T>(as type: T.Type = T.self) -> T? {
+    public func readInbound<T>(as type: T.Type = T.self) throws -> T? {
         return readFromBuffer(buffer: &channelcore.inboundBuffer)
     }
 

--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -133,7 +133,7 @@ class HTTPDecoderLengthTest: XCTestCase {
 
         // Prime the decoder with a GET and consume it.
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: version, method: .GET, uri: "/"))))
-        XCTAssertNotNil(channel.readOutbound(as: ByteBuffer.self))
+        XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
 
         // We now want to send a HTTP/1.1 response. This response has no content-length, no transfer-encoding,
         // is not a response to a HEAD request, is not a 2XX response to CONNECT, and is not 1XX, 204, or 304.
@@ -198,7 +198,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
                                                                                            method: requestMethod,
                                                                                            uri: "/"))))
-        XCTAssertNotNil(channel.readOutbound(as: ByteBuffer.self))
+        XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
 
         // We now want to send a HTTP/1.1 response. This response may contain some length framing fields that RFC 7230 says MUST
         // be ignored.
@@ -337,7 +337,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
                                                                                            method: .GET,
                                                                                            uri: "/"))))
-        XCTAssertNotNil(channel.readOutbound(as: ByteBuffer.self))
+        XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
 
         // Send a 200 with the appropriate Transfer Encoding header. We should see the request,
         // but no body or end.

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -382,7 +382,7 @@ class HTTPDecoderTest: XCTestCase {
         buffer.writeStaticString("\r\nGET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
         try channel.writeInbound(buffer)
 
-        let message: HTTPServerRequestPart? = self.channel.readInbound()
+        let message: HTTPServerRequestPart? = try self.channel.readInbound()
         guard case .some(.head(let head)) = message else {
             XCTFail("Invalid message: \(String(describing: message))")
             return
@@ -393,7 +393,7 @@ class HTTPDecoderTest: XCTestCase {
         XCTAssertEqual(head.version, .init(major: 1, minor: 1))
         XCTAssertEqual(head.headers, HTTPHeaders([("Host", "example.com")]))
 
-        let secondMessage: HTTPServerRequestPart? = self.channel.readInbound()
+        let secondMessage: HTTPServerRequestPart? = try self.channel.readInbound()
         guard case .some(.end(.none)) = secondMessage else {
             XCTFail("Invalid second message: \(String(describing: secondMessage))")
             return
@@ -411,7 +411,7 @@ class HTTPDecoderTest: XCTestCase {
         buffer.writeStaticString("SOURCE / HTTP/1.1\r\nHost: example.com\r\n\r\n")
         try channel.writeInbound(buffer)
 
-        let message: HTTPServerRequestPart? = self.channel.readInbound()
+        let message: HTTPServerRequestPart? = try self.channel.readInbound()
         guard case .some(.head(let head)) = message else {
             XCTFail("Invalid message: \(String(describing: message))")
             return
@@ -422,7 +422,7 @@ class HTTPDecoderTest: XCTestCase {
         XCTAssertEqual(head.version, .init(major: 1, minor: 1))
         XCTAssertEqual(head.headers, HTTPHeaders([("Host", "example.com")]))
 
-        let secondMessage: HTTPServerRequestPart? = self.channel.readInbound()
+        let secondMessage: HTTPServerRequestPart? = try self.channel.readInbound()
         guard case .some(.end(.none)) = secondMessage else {
             XCTFail("Invalid second message: \(String(describing: secondMessage))")
             return
@@ -442,7 +442,7 @@ class HTTPDecoderTest: XCTestCase {
         buffer.writeStaticString("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
         try channel.writeInbound(buffer)
 
-        let message: HTTPServerRequestPart? = self.channel.readInbound()
+        let message: HTTPServerRequestPart? = try self.channel.readInbound()
         guard case .some(.head(let head)) = message else {
             XCTFail("Invalid message: \(String(describing: message))")
             return
@@ -453,7 +453,7 @@ class HTTPDecoderTest: XCTestCase {
         XCTAssertEqual(head.version, .init(major: 1, minor: 1))
         XCTAssertEqual(head.headers, HTTPHeaders([("Host", "example.com")]))
 
-        let secondMessage: HTTPServerRequestPart? = self.channel.readInbound()
+        let secondMessage: HTTPServerRequestPart? = try self.channel.readInbound()
         guard case .some(.end(.none)) = secondMessage else {
             XCTFail("Invalid second message: \(String(describing: secondMessage))")
             return

--- a/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseCompressorTest.swift
@@ -199,7 +199,7 @@ class HTTPResponseCompressorTest: XCTestCase {
         clientChannel.write(NIOAny(HTTPClientRequestPart.head(requestHead)), promise: nil)
         clientChannel.write(NIOAny(HTTPClientRequestPart.end(nil)), promise: nil)
 
-        while let b = channel.readOutbound(as: ByteBuffer.self) {
+        while let b = try channel.readOutbound(as: ByteBuffer.self) {
             try clientChannel.writeInbound(b)
         }
 
@@ -207,7 +207,7 @@ class HTTPResponseCompressorTest: XCTestCase {
         // the last, which is the end.
         var head: HTTPResponseHead? = nil
         var dataChunks = [ByteBuffer]()
-        loop: while let responsePart: HTTPClientResponsePart = clientChannel.readInbound() {
+        loop: while let responsePart: HTTPClientResponsePart = try clientChannel.readInbound() {
             switch responsePart {
             case .head(let h):
                 precondition(head == nil)

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -34,12 +34,12 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         XCTAssertNoThrow(try channel.closeFuture.wait())
 
         // We expect exactly one ByteBuffer in the output.
-        guard var written = channel.readOutbound(as: ByteBuffer.self) else {
+        guard var written = try channel.readOutbound(as: ByteBuffer.self) else {
             XCTFail("No writes")
             return
         }
 
-        XCTAssertNil(channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
 
         // Check the response.
         assertResponseIs(response: written.readString(length: written.readableBytes)!,
@@ -76,7 +76,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         XCTAssertNoThrow(try channel.writeAndFlush(res).wait())
         // now we have started a response but it's not complete yet, let's inject a parser error
         channel.pipeline.fireErrorCaught(HTTPParserError.invalidEOFState)
-        var allOutbound = channel.readAllOutboundBuffers()
+        var allOutbound = try channel.readAllOutboundBuffers()
         let allOutboundString = allOutbound.readString(length: allOutbound.readableBytes)
         // there should be no HTTP/1.1 400 or anything in here
         XCTAssertEqual("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n", allOutboundString)
@@ -127,12 +127,12 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         XCTAssertNoThrow(try channel.closeFuture.wait())
 
         // We expect exactly one ByteBuffer in the output.
-        guard var written = channel.readOutbound(as: ByteBuffer.self) else {
+        guard var written = try channel.readOutbound(as: ByteBuffer.self) else {
             XCTFail("No writes")
             return
         }
 
-        XCTAssertNil(channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
 
         // Check the response.
         assertResponseIs(response: written.readString(length: written.readableBytes)!,

--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
@@ -109,7 +109,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
 
         // The data we write should not be buffered.
         try channel.writeInbound("hello")
-        XCTAssertEqual(channel.readInbound()!, "hello")
+        XCTAssertNoThrow(XCTAssertEqual(try channel.readInbound()!, "hello"))
 
         XCTAssertFalse(try channel.finish())
     }
@@ -132,15 +132,15 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         try channel.writeInbound("writes")
         try channel.writeInbound("are")
         try channel.writeInbound("buffered")
-        XCTAssertNil(channel.readInbound())
+        XCTAssertNoThrow(XCTAssertNil(try channel.readInbound()))
 
         // Complete the pipeline swap.
         continuePromise.succeed(())
 
         // Now everything should have been unbuffered.
-        XCTAssertEqual(channel.readInbound()!, "writes")
-        XCTAssertEqual(channel.readInbound()!, "are")
-        XCTAssertEqual(channel.readInbound()!, "buffered")
+        XCTAssertNoThrow(XCTAssertEqual(try channel.readInbound()!, "writes"))
+        XCTAssertNoThrow(XCTAssertEqual(try channel.readInbound()!, "are"))
+        XCTAssertNoThrow(XCTAssertEqual(try channel.readInbound()!, "buffered"))
 
         XCTAssertFalse(try channel.finish())
     }
@@ -196,7 +196,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
 
         // Now satisfy the future, which forces data unbuffering. This should fire readComplete.
         continuePromise.succeed(())
-        XCTAssertEqual(channel.readInbound()!, "a write")
+        XCTAssertNoThrow(XCTAssertEqual(try channel.readInbound()!, "a write"))
 
         XCTAssertEqual(readCompleteHandler.readCompleteCount, 2)
 

--- a/Tests/NIOTLSTests/SNIHandlerTests.swift
+++ b/Tests/NIOTLSTests/SNIHandlerTests.swift
@@ -281,14 +281,14 @@ class SNIHandlerTest: XCTestCase {
             try channel.writeInbound(writeableData)
             loop.run()
 
-            XCTAssertNil(channel.readInbound())
+            XCTAssertNoThrow(XCTAssertNil(try channel.readInbound()))
             try channel.pipeline.assertContains(handler: handler)
         }
 
         // The callback should now have fired, but the handler should still not have
         // sent on any data and should still be in the pipeline.
         XCTAssertTrue(called)
-        XCTAssertNil(channel.readInbound())
+        XCTAssertNoThrow(XCTAssertNil(try channel.readInbound()))
         try channel.pipeline.assertContains(handler: handler)
 
         // Now we're going to complete the promise and run the loop. This should cause the complete
@@ -296,7 +296,7 @@ class SNIHandlerTest: XCTestCase {
         continuePromise.succeed(())
         loop.run()
 
-        let writtenBuffer: ByteBuffer = channel.readInbound() ?? channel.allocator.buffer(capacity: 0)
+        let writtenBuffer: ByteBuffer = try channel.readInbound() ?? channel.allocator.buffer(capacity: 0)
         let writtenData = writtenBuffer.getData(at: writtenBuffer.readerIndex, length: writtenBuffer.readableBytes)
         let expectedData = Data(base64Encoded: clientHello, options: .ignoreUnknownCharacters)!
         XCTAssertEqual(writtenData, expectedData)
@@ -330,7 +330,7 @@ class SNIHandlerTest: XCTestCase {
         // The callback should have fired, but the handler should not have
         // sent on any data and should still be in the pipeline.
         XCTAssertTrue(called)
-        XCTAssertNil(channel.readInbound(as: ByteBuffer.self))
+        XCTAssertNoThrow(XCTAssertNil(try channel.readInbound(as: ByteBuffer.self)))
         try channel.pipeline.assertContains(handler: handler)
 
         // Now we're going to complete the promise and run the loop. This should cause the complete
@@ -338,7 +338,7 @@ class SNIHandlerTest: XCTestCase {
         continuePromise.succeed(())
         loop.run()
 
-        let writtenBuffer: ByteBuffer? = channel.readInbound()
+        let writtenBuffer: ByteBuffer? = try channel.readInbound()
         if let writtenBuffer = writtenBuffer {
             let writtenData = writtenBuffer.getData(at: writtenBuffer.readerIndex, length: writtenBuffer.readableBytes)
             let expectedData = Data(base64Encoded: clientHello, options: .ignoreUnknownCharacters)!
@@ -369,7 +369,7 @@ class SNIHandlerTest: XCTestCase {
 
         // The callback should not have fired, the handler should still be in the pipeline,
         // and no data should have been written.
-        XCTAssertNil(channel.readInbound(as: ByteBuffer.self))
+        XCTAssertNoThrow(XCTAssertNil(try channel.readInbound(as: ByteBuffer.self)))
         try channel.pipeline.assertContains(handler: handler)
 
         XCTAssertNoThrow(try channel.finish())

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -23,9 +23,9 @@ class EmbeddedChannelTest: XCTestCase {
         
         XCTAssertTrue(try channel.writeOutbound(buf))
         XCTAssertTrue(try channel.finish())
-        XCTAssertEqual(buf, channel.readOutbound())
-        XCTAssertNil(channel.readOutbound())
-        XCTAssertNil(channel.readInbound())
+        XCTAssertNoThrow(XCTAssertEqual(buf, try channel.readOutbound()))
+        XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
+        XCTAssertNoThrow(XCTAssertNil(try channel.readInbound()))
     }
 
     func testWriteInboundByteBuffer() throws {
@@ -35,9 +35,9 @@ class EmbeddedChannelTest: XCTestCase {
 
         XCTAssertTrue(try channel.writeInbound(buf))
         XCTAssertTrue(try channel.finish())
-        XCTAssertEqual(buf, channel.readInbound())
-        XCTAssertNil(channel.readInbound())
-        XCTAssertNil(channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertEqual(buf, try channel.readInbound()))
+        XCTAssertNoThrow(XCTAssertNil(try channel.readInbound()))
+        XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
     }
 
     func testWriteInboundByteBufferReThrow() throws {
@@ -184,10 +184,10 @@ class EmbeddedChannelTest: XCTestCase {
         var buf = ByteBufferAllocator().buffer(capacity: 1)
         buf.writeBytes([1])
         let writeFuture = channel.write(buf)
-        XCTAssertNil(channel.readOutbound())
+        XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
         XCTAssertFalse(writeFuture.isFulfilled)
         channel.flush()
-        XCTAssertNotNil(channel.readOutbound(as: ByteBuffer.self))
+        XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
         XCTAssertTrue(writeFuture.isFulfilled)
         XCTAssertNoThrow(try XCTAssertFalse(channel.finish()))
     }

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -18,9 +18,9 @@ import NIOHTTP1
 @testable import NIOWebSocket
 
 extension EmbeddedChannel {
-    func readAllInboundBuffers() -> ByteBuffer {
+    func readAllInboundBuffers() throws -> ByteBuffer {
         var buffer = self.allocator.buffer(capacity: 100)
-        while var writtenData: ByteBuffer = self.readInbound() {
+        while var writtenData: ByteBuffer = try self.readInbound() {
             buffer.writeBuffer(&writtenData)
         }
 
@@ -57,11 +57,11 @@ private func interactInMemory(_ first: EmbeddedChannel, _ second: EmbeddedChanne
     repeat {
         operated = false
 
-        if let data = first.readOutbound(as: ByteBuffer.self) {
+        if let data = try first.readOutbound(as: ByteBuffer.self) {
             operated = true
             try second.writeInbound(data)
         }
-        if let data = second.readOutbound(as: ByteBuffer.self) {
+        if let data = try second.readOutbound(as: ByteBuffer.self) {
             operated = true
             try first.writeInbound(data)
         }
@@ -139,10 +139,9 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try client.writeString(upgradeRequest).wait())
         XCTAssertNoThrow(try interactInMemory(client, server))
 
-        let receivedResponse = client.readAllInboundBuffers().allAsString()
-        assertResponseIs(response: receivedResponse,
-                         expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
+        XCTAssertNoThrow(assertResponseIs(response: try client.readAllInboundBuffers().allAsString(),
+                                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"]))
     }
 
     func testUpgradeWithProtocolName() throws {
@@ -159,10 +158,9 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try client.writeString(upgradeRequest).wait())
         XCTAssertNoThrow(try interactInMemory(client, server))
 
-        let receivedResponse = client.readAllInboundBuffers().allAsString()
-        assertResponseIs(response: receivedResponse,
-                         expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
+        XCTAssertNoThrow(assertResponseIs(response: try client.readAllInboundBuffers().allAsString(),
+                                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"]))
     }
 
     func testCanRejectUpgrade() throws {
@@ -194,7 +192,7 @@ class EndToEndTests: XCTestCase {
         }
 
         // Nothing gets written.
-        XCTAssertEqual(server.readAllOutboundBuffers().allAsString(), "")
+        XCTAssertNoThrow(XCTAssertEqual(try server.readAllOutboundBuffers().allAsString(), ""))
     }
 
     func testCanDelayAcceptingUpgrade() throws {
@@ -227,7 +225,7 @@ class EndToEndTests: XCTestCase {
         XCTAssertNotNil(acceptPromise)
 
         // No upgrade should have occurred yet.
-        XCTAssertNil(client.readInbound(as: ByteBuffer.self))
+        XCTAssertNoThrow(XCTAssertNil(try client.readInbound(as: ByteBuffer.self)))
         XCTAssertFalse(upgradeComplete)
 
         // Satisfy the promise. This will cause the upgrade to complete.
@@ -235,10 +233,9 @@ class EndToEndTests: XCTestCase {
         XCTAssertTrue(upgradeComplete)
         XCTAssertNoThrow(try interactInMemory(client, server))
 
-        let receivedResponse = client.readAllInboundBuffers().allAsString()
-        assertResponseIs(response: receivedResponse,
-                         expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
+        XCTAssertNoThrow(assertResponseIs(response: try client.readAllInboundBuffers().allAsString(),
+                                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"]))
     }
 
     func testRequiresVersion13() throws {
@@ -266,7 +263,7 @@ class EndToEndTests: XCTestCase {
         }
 
         // Nothing gets written.
-        XCTAssertEqual(server.readAllOutboundBuffers().allAsString(), "")
+        XCTAssertNoThrow(XCTAssertEqual(try server.readAllOutboundBuffers().allAsString(), ""))
     }
 
     func testRequiresVersionHeader() throws {
@@ -294,7 +291,7 @@ class EndToEndTests: XCTestCase {
         }
 
         // Nothing gets written.
-        XCTAssertEqual(server.readAllOutboundBuffers().allAsString(), "")
+        XCTAssertNoThrow(XCTAssertEqual(try server.readAllOutboundBuffers().allAsString(), ""))
     }
 
     func testRequiresKeyHeader() throws {
@@ -322,7 +319,7 @@ class EndToEndTests: XCTestCase {
         }
 
         // Nothing gets written.
-        XCTAssertEqual(server.readAllOutboundBuffers().allAsString(), "")
+        XCTAssertNoThrow(XCTAssertEqual(try server.readAllOutboundBuffers().allAsString(), ""))
     }
 
     func testUpgradeMayAddCustomHeaders() throws {
@@ -343,10 +340,9 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try client.writeString(upgradeRequest).wait())
         XCTAssertNoThrow(try interactInMemory(client, server))
 
-        let receivedResponse = client.readAllInboundBuffers().allAsString()
-        assertResponseIs(response: receivedResponse,
-                         expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade", "TestHeader: TestValue"])
+        XCTAssertNoThrow(assertResponseIs(response: try client.readAllInboundBuffers().allAsString(),
+                                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade", "TestHeader: TestValue"]))
     }
 
     func testMayRegisterMultipleWebSocketEndpoints() throws {
@@ -374,10 +370,9 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try client.writeString(upgradeRequest).wait())
         XCTAssertNoThrow(try interactInMemory(client, server))
 
-        let receivedResponse = client.readAllInboundBuffers().allAsString()
-        assertResponseIs(response: receivedResponse,
-                         expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade", "Target: third"])
+        XCTAssertNoThrow(assertResponseIs(response: try client.readAllInboundBuffers().allAsString(),
+                                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade", "Target: third"]))
     }
 
     func testSendAFewFrames() throws {
@@ -398,10 +393,9 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try client.writeString(upgradeRequest).wait())
         XCTAssertNoThrow(try interactInMemory(client, server))
 
-        let receivedResponse = client.readAllInboundBuffers().allAsString()
-        assertResponseIs(response: receivedResponse,
-                         expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
+        XCTAssertNoThrow(assertResponseIs(response: try client.readAllInboundBuffers().allAsString(),
+                                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"]))
 
         // Put a frame encoder in the client pipeline.
         XCTAssertNoThrow(try client.pipeline.addHandler(WebSocketFrameEncoder()).wait())
@@ -436,10 +430,9 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try client.writeString(upgradeRequest).wait())
         XCTAssertNoThrow(try interactInMemory(client, server))
 
-        let receivedResponse = client.readAllInboundBuffers().allAsString()
-        assertResponseIs(response: receivedResponse,
-                         expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
+        XCTAssertNoThrow(assertResponseIs(response: try client.readAllInboundBuffers().allAsString(),
+                                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"]))
 
         let decoder = ((try server.pipeline.context(handlerType: ByteToMessageHandler<WebSocketFrameDecoder>.self).wait()).handler as! ByteToMessageHandler<WebSocketFrameDecoder>).decoder
         XCTAssertEqual(16, decoder?.maxFrameSize)
@@ -463,10 +456,9 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try client.writeString(upgradeRequest).wait())
         XCTAssertNoThrow(try interactInMemory(client, server))
 
-        let receivedResponse = client.readAllInboundBuffers().allAsString()
-        assertResponseIs(response: receivedResponse,
-                         expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
+        XCTAssertNoThrow(assertResponseIs(response: try client.readAllInboundBuffers().allAsString(),
+                                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"]))
 
         // Send a fake frame header that claims this is a ping frame with 126 bytes of data.
         var data = client.allocator.buffer(capacity: 12)
@@ -486,8 +478,7 @@ class EndToEndTests: XCTestCase {
         XCTAssertEqual(recorder.errors.first as? NIOWebSocketError, .some(.multiByteControlFrameLength))
 
         // The client should have received a close frame, if we'd continued interacting.
-        let errorFrame = server.readAllOutboundBytes()
-        XCTAssertEqual(errorFrame, [0x88, 0x02, 0x03, 0xEA])
+        XCTAssertNoThrow(XCTAssertEqual(try server.readAllOutboundBytes(), [0x88, 0x02, 0x03, 0xEA]))
     }
 
     func testNoAutomaticErrorHandling() throws {
@@ -509,10 +500,9 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try client.writeString(upgradeRequest).wait())
         XCTAssertNoThrow(try interactInMemory(client, server))
 
-        let receivedResponse = client.readAllInboundBuffers().allAsString()
-        assertResponseIs(response: receivedResponse,
-                         expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
-                         expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"])
+        XCTAssertNoThrow(assertResponseIs(response: try client.readAllInboundBuffers().allAsString(),
+                                          expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                                          expectedResponseHeaders: ["Upgrade: websocket", "Sec-WebSocket-Accept: OfS0wDaT5NoxF2gqm7Zj2YtetzM=", "Connection: upgrade"]))
 
         // Send a fake frame header that claims this is a ping frame with 126 bytes of data.
         var data = client.allocator.buffer(capacity: 12)
@@ -532,7 +522,6 @@ class EndToEndTests: XCTestCase {
         XCTAssertEqual(recorder.errors.first as? NIOWebSocketError, .some(.multiByteControlFrameLength))
 
         // The client should not have received a close frame, if we'd continued interacting.
-        let errorFrame = server.readAllOutboundBytes()
-        XCTAssertEqual(errorFrame, [])
+        XCTAssertNoThrow(XCTAssertEqual([], try server.readAllOutboundBytes()))
     }
 }


### PR DESCRIPTION
Motivation:

readInbound/Outbound will soon throw errors if the type isn't right.

Modifications:

prepare tests for throwing readIn/Outbound

Result:

@ianpartridge's PR should pretty much merge after this.