### PR TITLE
convert NIOWebSocketUpgradeError from enum to struct

### DIFF
--- a/Sources/NIOWebSocket/WebSocketUpgrader.swift
+++ b/Sources/NIOWebSocket/WebSocketUpgrader.swift
@@ -19,13 +19,23 @@ import NIOHTTP1
 private let magicWebSocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 /// Errors that can be thrown by `NIOWebSocket` during protocol upgrade.
-public enum NIOWebSocketUpgradeError: Error {
+public struct NIOWebSocketUpgradeError: Error, Equatable {
+    private enum ActualError {
+        case invalidUpgradeHeader
+        case unsupportedWebSocketTarget
+    }
+
+    private let actualError: ActualError
+
+    private init(actualError: ActualError) {
+        self.actualError = actualError
+    }
     /// A HTTP header on the upgrade request was invalid.
-    case invalidUpgradeHeader
+    public static let invalidUpgradeHeader = NIOWebSocketUpgradeError(actualError: .invalidUpgradeHeader)
 
     /// The HTTP request targets a websocket pipeline that does not support
     /// it in some way.
-    case unsupportedWebSocketTarget
+    public static let unsupportedWebSocketTarget = NIOWebSocketUpgradeError(actualError: .unsupportedWebSocketTarget)
 }
 
 fileprivate extension HTTPHeaders {

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -185,7 +185,7 @@ class EndToEndTests: XCTestCase {
         do {
             try server.writeInbound(buffer)
             XCTFail("Did not throw")
-        } catch NIOWebSocketUpgradeError.unsupportedWebSocketTarget {
+        } catch let error as NIOWebSocketUpgradeError where error == .unsupportedWebSocketTarget {
             // ok
         } catch {
             XCTFail("Unexpected error hit: \(error)")
@@ -256,7 +256,7 @@ class EndToEndTests: XCTestCase {
         do {
             try server.writeInbound(buffer)
             XCTFail("Did not throw")
-        } catch NIOWebSocketUpgradeError.invalidUpgradeHeader {
+        } catch let error as NIOWebSocketUpgradeError where error == .invalidUpgradeHeader {
             // ok
         } catch {
             XCTFail("Unexpected error hit: \(error)")
@@ -284,7 +284,7 @@ class EndToEndTests: XCTestCase {
         do {
             try server.writeInbound(buffer)
             XCTFail("Did not throw")
-        } catch NIOWebSocketUpgradeError.invalidUpgradeHeader {
+        } catch let error as NIOWebSocketUpgradeError where error == .invalidUpgradeHeader {
             // ok
         } catch {
             XCTFail("Unexpected error hit: \(error)")
@@ -312,7 +312,7 @@ class EndToEndTests: XCTestCase {
         do {
             try server.writeInbound(buffer)
             XCTFail("Did not throw")
-        } catch NIOWebSocketUpgradeError.invalidUpgradeHeader {
+        } catch let error as NIOWebSocketUpgradeError where error == .invalidUpgradeHeader {
             // ok
         } catch {
             XCTFail("Unexpected error hit: \(error)")

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -21,6 +21,7 @@
   `SocketAddress.newAddressResolving(host:port:)`
 - changed all ports to `Int` (from `UInt16`)
 - changed `HTTPVersion`'s `major` and `minor` properties to `Int` (from `UInt16`)
+- `NIOWebSocketUpgradeError` is now a `struct` rather than an `enum`
 - renamed the generic parameter name to `Bytes` where we're talking about a
   generic collection of bytes
 - Moved error `ChannelLifecycleError.inappropriateOperationForState` to `ChannelError.inappropriateOperationForState`.


### PR DESCRIPTION
Motivation:

We need to fix #577 sometime soon and in preparation of that we'll
change convert NIOWebSocketUpgradeError from enum to struct.

Modifications:

convert NIOWebSocketUpgradeError from enum to struct

Result:

- NIOWebSocketUpgradeError can be adjusted without SemVer major breaking
  changes
- fixes #839