### PR TITLE
fail unhandled outbound user events

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -814,7 +814,7 @@ class BaseSocketChannel<T: BaseSocket>: SelectableChannel, ChannelCore {
     }
 
     public final func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
-        promise?.succeed(())
+        promise?.fail(ChannelError.operationUnsupported)
     }
 
     // Methods invoked from the EventLoop itself

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -239,7 +239,7 @@ class EmbeddedChannelCore: ChannelCore {
     }
 
     public final func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
-        promise?.succeed(())
+        promise?.fail(ChannelError.operationUnsupported)
     }
 
     func channelRead0(_ data: NIOAny) {

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -77,6 +77,7 @@ extension ChannelTests {
                 ("testTryingToBindOnPortThatIsAlreadyBoundFailsButDoesNotCrash", testTryingToBindOnPortThatIsAlreadyBoundFailsButDoesNotCrash),
                 ("testCloseInReadTriggeredByDrainingTheReceiveBufferBecauseOfWriteError", testCloseInReadTriggeredByDrainingTheReceiveBufferBecauseOfWriteError),
                 ("testApplyingTwoDistinctSocketOptionsOfSameTypeWorks", testApplyingTwoDistinctSocketOptionsOfSameTypeWorks),
+                ("testUnprocessedOutboundUserEventFailsOnServerSocketChannel", testUnprocessedOutboundUserEventFailsOnServerSocketChannel),
            ]
    }
 }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2014,7 +2014,13 @@ public class ChannelTests: XCTestCase {
             }
         }
         withChannel { channel in
-            XCTAssertNoThrow(try channel.triggerUserOutboundEvent("foo").wait())
+            XCTAssertThrowsError(try channel.triggerUserOutboundEvent("foo").wait()) { error in
+                if let error = error as? ChannelError {
+                    XCTAssertEqual(ChannelError.operationUnsupported, error)
+                } else {
+                    XCTFail("wrong error: \(error)")
+                }
+            }
         }
         withChannel { channel in
             XCTAssertFalse(channel.isActive)
@@ -2670,6 +2676,23 @@ public class ChannelTests: XCTestCase {
         XCTAssertTrue(try getBoolSocketOption(channel: accepted3, level: SOL_SOCKET, name: SO_KEEPALIVE))
 
         XCTAssertTrue(try getBoolSocketOption(channel: accepted3, level: IPPROTO_TCP, name: TCP_NODELAY))
+    }
+
+    func testUnprocessedOutboundUserEventFailsOnServerSocketChannel() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        let channel = try ServerSocketChannel(eventLoop: group.next() as! SelectableEventLoop,
+                                              group: group,
+                                              protocolFamily: AF_INET)
+        XCTAssertThrowsError(try channel.triggerUserOutboundEvent("event").wait()) { (error: Error) in
+            if let error = error as? ChannelError {
+                XCTAssertEqual(ChannelError.operationUnsupported, error)
+            } else {
+                XCTFail("unexpected error: \(error)")
+            }
+        }
     }
 }
 

--- a/Tests/NIOTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOTests/DatagramChannelTests+XCTest.swift
@@ -42,6 +42,7 @@ extension DatagramChannelTests {
                 ("testSetGetOptionClosedDatagramChannel", testSetGetOptionClosedDatagramChannel),
                 ("testWritesAreAccountedCorrectly", testWritesAreAccountedCorrectly),
                 ("testSettingTwoDistinctChannelOptionsWorksForDatagramChannel", testSettingTwoDistinctChannelOptionsWorksForDatagramChannel),
+                ("testUnprocessedOutboundUserEventFailsOnDatagramChannel", testUnprocessedOutboundUserEventFailsOnDatagramChannel),
            ]
    }
 }

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -39,6 +39,7 @@ extension EmbeddedChannelTest {
                 ("testWriteWithoutFlushDoesNotWrite", testWriteWithoutFlushDoesNotWrite),
                 ("testSetLocalAddressAfterSuccessfulBind", testSetLocalAddressAfterSuccessfulBind),
                 ("testSetRemoteAddressAfterSuccessfulConnect", testSetRemoteAddressAfterSuccessfulConnect),
+                ("testUnprocessedOutboundUserEventFailsOnEmbeddedChannel", testUnprocessedOutboundUserEventFailsOnEmbeddedChannel),
            ]
    }
 }

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -213,4 +213,15 @@ class EmbeddedChannelTest: XCTestCase {
         }
         try connectPromise.futureResult.wait()
     }
+
+    func testUnprocessedOutboundUserEventFailsOnEmbeddedChannel() {
+        let channel = EmbeddedChannel()
+        XCTAssertThrowsError(try channel.triggerUserOutboundEvent("event").wait()) { (error: Error) in
+            if let error = error as? ChannelError {
+                XCTAssertEqual(ChannelError.operationUnsupported, error)
+            } else {
+                XCTFail("unexpected error: \(error)")
+            }
+        }
+    }
 }

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -46,6 +46,8 @@ extension SocketChannelTest {
                 ("testLocalAndRemoteAddressNotNilInChannelInactiveAndHandlerRemoved", testLocalAndRemoteAddressNotNilInChannelInactiveAndHandlerRemoved),
                 ("testSocketFlagNONBLOCKWorks", testSocketFlagNONBLOCKWorks),
                 ("testInstantTCPConnectionResetThrowsError", testInstantTCPConnectionResetThrowsError),
+                ("testUnprocessedOutboundUserEventFailsOnServerSocketChannel", testUnprocessedOutboundUserEventFailsOnServerSocketChannel),
+                ("testUnprocessedOutboundUserEventFailsOnSocketChannel", testUnprocessedOutboundUserEventFailsOnSocketChannel),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Unhandled outbound user events should be failed but previously they were
succeeded.

Modifications:

Succeeding them is odd because nothing happened to them, so they should
be failed.

Result:

fixes #487
