### PR TITLE
improve and simplify MessageToByteEncoder

### DIFF
--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -81,6 +81,11 @@ extension ChannelPipeline {
         return self.addHandler(ByteToMessageHandler(decoder))
     }
 
+    @available(*, deprecated, message: "please use addHandler(MessageToByteHandler(myMessageToByteEncoder))")
+    public func add<Encoder: MessageToByteEncoder>(handler encoder: Encoder) -> EventLoopFuture<Void> {
+        return self.addHandler(MessageToByteHandler(encoder))
+    }
+
     @available(*, deprecated, renamed: "addHandler(_:position:)")
     public func add(handler: ChannelHandler, first: Bool = false) -> EventLoopFuture<Void> {
         return self.addHandler(handler, position: first ? .first : .last)

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -13,8 +13,14 @@
 - `ByteToMessageDecoder`s now need to be wrapped in `ByteToMessageHandler`
   before they can be added to the pipeline.
   before: `pipeline.add(MyDecoder())`, after: `pipeline.add(ByteToMessageHandler(MyDecoder()))`
+- `MessageToByteEncoder`s now need to be wrapped in `MessageToByteHandler`
+  before they can be added to the pipeline.
+  before: `pipeline.add(MyEncoder())`, after: `pipeline.add(MessageToByteHandler(MyEncoder()))`
 - `BlockingIOThreadPool` has been renamed to `NIOThreadPool`
 - `ByteToMessageDecoder` now requires the implementation of `decodeLast`
+- `MessageToByteEncoder` now requires the implementation of `encode`
+- `MessageToByteEncoder.allocateOutBuffer` was removed without replacement
+- `MessageToByteEncoder.encode` no longer gets access to the `ChannelHandlerContext`
 - `ByteToMessageDecoder.decodeLast` has a new parameter `seenEOF: Bool`
 - `EventLoop.makePromise`/`makeSucceededFuture`/`makeFailedFuture` instead of `new*`, also `result:`/`error:` labels dropped
 - `SocketAddress.makeAddressResolvingHost(:port:)` instead of


### PR DESCRIPTION
Motivation:

MessageToByteEncoder was a protocol that similar to ByteToMessageDecoder
was pretty hard to hold correctly (override some methods but not
others). This PR brings MessageToByteEncoder more in line with the new
ByteToMessageDecoder.

Modifications:

- refactor `MessageToByteEncoder`
- introduce `MessageToByteHandler`, similar to `ByteToMessageHandler`

Result:

- better API, more similar to ByteToMessageDecoder
- fixes #864