### PR TITLE
ByteBuffer get* now respects reader/writer indexes

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -562,20 +562,17 @@ public struct ByteBuffer {
     /// will correspond to index `0` in the returned `ByteBuffer`.
     /// The `readerIndex` of the returned `ByteBuffer` will be `0`, the `writerIndex` will be `length`.
     ///
-    /// - note: Please consider using `readSlice` which is a safer alternative that automatically maintains the
-    ///         `readerIndex` and won't allow you to slice off uninitialized memory.
-    /// - warning: This method allows the user to slice out any of the bytes in the `ByteBuffer`'s storage, including
-    ///           _uninitialized_ ones. To use this API in a safe way the user needs to make sure all the requested
-    ///           bytes have been written before and are therefore initialized. Note that bytes between (including)
-    ///           `readerIndex` and (excluding) `writerIndex` are always initialized by contract and therefore must be
-    ///           safe to read.
+    /// The selected bytes must be readable or else `nil` will be returned.
+    ///
     /// - parameters:
     ///     - index: The index the requested slice starts at.
     ///     - length: The length of the requested slice.
+    /// - returns: A `ByteBuffer` containing the selected bytes as readable bytes or `nil` if the selected bytes were
+    ///            not readable in the initial `ByteBuffer`.
     public func getSlice(at index: Int, length: Int) -> ByteBuffer? {
         precondition(index >= 0, "index must not be negative")
         precondition(length >= 0, "length must not be negative")
-        guard index <= self.capacity - length else {
+        guard index >= self.readerIndex && index <= self.writerIndex - length else {
             return nil
         }
         let index = _toIndex(index)

--- a/Sources/NIO/DatagramVectorReadManager.swift
+++ b/Sources/NIO/DatagramVectorReadManager.swift
@@ -113,7 +113,10 @@ struct DatagramVectorReadManager {
             assert(messagesProcessed == 0)
             return .none
         case .processed(let messagesProcessed):
-            return self.buildMessages(messageCount: messagesProcessed, sliceSize: messageSize, buffer: &buffer)
+            buffer.moveWriterIndex(to: messageSize * messagesProcessed)
+            return self.buildMessages(messageCount: messagesProcessed,
+                                      sliceSize: messageSize,
+                                      buffer: &buffer)
         }
     }
 

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -52,31 +52,27 @@ extension ByteBuffer {
         guard self.readableBytes >= length else {
             return nil
         }
-        let data = self.getData(at: self.readerIndex, length: length)! /* must work, enough readable bytes */
-        self.moveReaderIndex(forwardBy: length)
-        return data
+        return self.getData(at: self.readerIndex, length: length).map {
+            self.moveReaderIndex(forwardBy: length)
+            return $0
+        }
     }
 
     /// Return `length` bytes starting at `index` and return the result as `Data`. This will not change the reader index.
+    /// The selected bytes must be readable or else `nil` will be returned.
     ///
-    /// - note: Please consider using `readData` which is a safer alternative that automatically maintains the
-    ///         `readerIndex` and won't allow you to read uninitialized memory.
-    /// - warning: This method allows the user to read any of the bytes in the `ByteBuffer`'s storage, including
-    ///           _uninitialized_ ones. To use this API in a safe way the user needs to make sure all the requested
-    ///           bytes have been written before and are therefore initialized. Note that bytes between (including)
-    ///           `readerIndex` and (excluding) `writerIndex` are always initialized by contract and therefore must be
-    ///           safe to read.
     /// - parameters:
     ///     - index: The starting index of the bytes of interest into the `ByteBuffer`
     ///     - length: The number of bytes of interest
-    /// - returns: A `Data` value containing the bytes of interest or `nil` if the `ByteBuffer` doesn't contain those bytes.
-    public func getData(at index: Int, length: Int) -> Data? {
+    /// - returns: A `Data` value containing the bytes of interest or `nil` if the selected bytes are not readable.
+    public func getData(at index0: Int, length: Int) -> Data? {
         precondition(length >= 0, "length must not be negative")
-        precondition(index >= 0, "index must not be negative")
-        guard index <= self.capacity - length else {
+        precondition(index0 >= 0, "index must not be negative")
+        let index = index0 - self.readerIndex
+        guard index >= 0 && index <= self.readableBytes - length else {
             return nil
         }
-        return self.withVeryUnsafeBytesWithStorageManagement { ptr, storageRef in
+        return self.withUnsafeReadableBytesWithStorageManagement { ptr, storageRef in
             _ = storageRef.retain()
             return Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: ptr.baseAddress!.advanced(by: index)),
                         count: Int(length),
@@ -85,20 +81,14 @@ extension ByteBuffer {
     }
 
     /// Get a `String` decoding `length` bytes starting at `index` with `encoding`. This will not change the reader index.
+    /// The selected bytes must be readable or else `nil` will be returned.
     ///
-    /// - note: Please consider using `readString` which is a safer alternative that automatically maintains the
-    ///         `readerIndex` and won't allow you to read uninitialized memory.
-    /// - warning: This method allows the user to read any of the bytes in the `ByteBuffer`'s storage, including
-    ///           _uninitialized_ ones. To use this API in a safe way the user needs to make sure all the requested
-    ///           bytes have been written before and are therefore initialized. Note that bytes between (including)
-    ///           `readerIndex` and (excluding) `writerIndex` are always initialized by contract and therefore must be
-    ///           safe to read.
     /// - parameters:
     ///     - index: The starting index of the bytes of interest into the `ByteBuffer`.
     ///     - length: The number of bytes of interest.
     ///     - encoding: The `String` encoding to be used.
-    /// - returns: A `String` value containing the bytes of interest or `nil` if the `ByteBuffer` doesn't contain those bytes,
-    ///     or if those bytes cannot be decoded with the given encoding.
+    /// - returns: A `String` value containing the bytes of interest or `nil` if the selected bytes are not readable or
+    ///            cannot be decoded with the given encoding.
     public func getString(at index: Int, length: Int, encoding: String.Encoding) -> String? {
         guard let data = self.getData(at: index, length: length) else {
             return nil

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -470,7 +470,12 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
     ///     - idx: The index into the underlying storage.
     /// - returns: The value.
     private func string(idx: HTTPHeaderIndex) -> String {
-        return self.buffer.getString(at: idx.start, length: idx.length)!
+        var hackBuffer = self.buffer
+        hackBuffer.moveReaderIndex(to: 0)
+        hackBuffer.moveWriterIndex(to: hackBuffer.capacity)
+        return hackBuffer.getString(at: idx.start, length: idx.length)!
+
+//        return self.buffer.getString(at: idx.start, length: idx.length)!
     }
 
     /// Return all names.

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -135,6 +135,7 @@ extension ByteBufferTest {
                 ("testGetDispatchDataWorks", testGetDispatchDataWorks),
                 ("testGetDispatchDataReadWrite", testGetDispatchDataReadWrite),
                 ("testVariousContiguousStorageAccessors", testVariousContiguousStorageAccessors),
+                ("testGetBytesThatAreNotReadable", testGetBytesThatAreNotReadable),
            ]
    }
 }

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -136,6 +136,7 @@ public class ByteToMessageDecoderTest: XCTestCase {
         channel.pipeline.fireChannelRead(NIOAny(buffer))
         XCTAssertNoThrow(XCTAssertNil(try channel.readInbound()))
 
+        buffer.moveWriterIndex(to: writerIndex)
         channel.pipeline.fireChannelRead(NIOAny(buffer.getSlice(at: writerIndex - 1, length: 1)!))
 
         var buffer2 = channel.allocator.buffer(capacity: 32)
@@ -265,7 +266,6 @@ public class ByteToMessageDecoderTest: XCTestCase {
 
             func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
                 self.numberOfDecodeCalls += 1
-                print("\(numberOfDecodeCalls): \(String(decoding: buffer.readableBytesView, as: UTF8.self))")
                 var reentrantWriteBuffer = context.channel.allocator.buffer(capacity: 1)
                 if self.numberOfDecodeCalls == 2 {
                     // this is the first time, let's fireChannelRead


### PR DESCRIPTION
Motivation:

Previously, ByteBuffers get* methods would get bytes from anywhere, even
if the bytes were not readable. That can lead to security issues in code
that doesn't expect this. NIO shouldn't contain such unsafe methods
without the word 'unsafe'.

Modifications:

Made all `get*` methods respect reader/writerIndex.

Result:

- safer user code
- fixes #669 
