### PR TITLE
fix NIOAny.tryAsOther

### DIFF
--- a/Sources/NIO/NIOAny.swift
+++ b/Sources/NIO/NIOAny.swift
@@ -179,10 +179,13 @@ public struct NIOAny {
     /// returns: The wrapped `T` or `nil` if the wrapped message is not a `T`.
     @inlinable
     func tryAsOther<T>(type: T.Type = T.self) -> T? {
-        if case .other(let any) = self._storage {
-            return any as? T
-        } else {
-            return nil
+        switch self._storage {
+        case .bufferEnvelope(let v):
+            return v as? T
+        case .ioData(let v):
+            return v as? T
+        case .other(let v):
+            return v as? T
         }
     }
 

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -32,6 +32,7 @@ extension EmbeddedChannelTest {
                 ("testWriteOutboundByteBufferReThrow", testWriteOutboundByteBufferReThrow),
                 ("testReadOutboundWrongTypeThrows", testReadOutboundWrongTypeThrows),
                 ("testReadInboundWrongTypeThrows", testReadInboundWrongTypeThrows),
+                ("testWrongTypesWithFastpathTypes", testWrongTypesWithFastpathTypes),
                 ("testCloseMultipleTimesThrows", testCloseMultipleTimesThrows),
                 ("testCloseOnInactiveIsOk", testCloseOnInactiveIsOk),
                 ("testEmbeddedLifecycle", testEmbeddedLifecycle),


### PR DESCRIPTION
Motivation:

tryAsOther previously only returned the value if it was stored as the
.other case in NIOAny but we should do better.

Modifications:

also return the fastpath cases in tryOther (just slower than in the
actual fast path)

Result:

EmbeddedChannel.readIn/Outbound work properly