### PR TITLE
B2MD: Stop parsing loop correctly on EOF

### DIFF
--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -427,9 +427,10 @@ extension ByteToMessageHandler {
     private func decodeLoop(context: ChannelHandlerContext, decodeMode: DecodeMode) throws -> B2MDBuffer.BufferProcessingResult {
         assert(!self.state.isError)
         var allowEmptyBuffer = decodeMode == .last
-        while decodeMode == .last || self.removalState == .notBeingRemoved {
+        while (self.state.isActive && self.removalState == .notBeingRemoved) || decodeMode == .last {
             let result = try self.withNextBuffer(allowEmptyBuffer: allowEmptyBuffer) { decoder, buffer in
                 if decodeMode == .normal {
+                    assert(self.state.isActive, "illegal state for normal decode: \(self.state)")
                     return try decoder.decode(context: context, buffer: &buffer)
                 } else {
                     allowEmptyBuffer = false

--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -51,6 +51,8 @@ extension ByteToMessageDecoderTest {
                 ("testDecodeMethodsNoLongerCalledIfErrorInDecode", testDecodeMethodsNoLongerCalledIfErrorInDecode),
                 ("testDecodeMethodsNoLongerCalledIfErrorInDecodeLast", testDecodeMethodsNoLongerCalledIfErrorInDecodeLast),
                 ("testBasicLifecycle", testBasicLifecycle),
+                ("testDecodeLoopStopsOnChannelInactive", testDecodeLoopStopsOnChannelInactive),
+                ("testDecodeLoopStopsOnInboundHalfClosure", testDecodeLoopStopsOnInboundHalfClosure),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Introduced in #767 we would never interrupt a parsing loop unless the
decoder was removed, that's wrong and we need to interrupt also if we
seen `channelInactive` or inbound half closure.

Modifications:

interrupt the parsing loop on EOF.

Result:

more correct B2MD
