### PR TITLE
ByteBuffer.viewBytes now returns an Optional

### DIFF
--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -74,13 +74,20 @@ extension ByteBuffer {
         return ByteBufferView(buffer: self, range: self.readerIndex ..< self.readerIndex + self.readableBytes)
     }
 
-    /// Returns a view into some portion of a `ByteBuffer`.
+    /// Returns a view into some portion of the readable bytes of a `ByteBuffer`.
     ///
     /// - parameters:
     ///   - index: The index the view should start at
     ///   - length: The length of the view (in bytes)
-    /// - returns A view into a portion of a `ByteBuffer`.
-    public func viewBytes(at index: Int, length: Int) -> ByteBufferView {
-        return ByteBufferView(buffer: self, range: index ..< index+length)
+    /// - returns A view into a portion of a `ByteBuffer` or `nil` if the requested bytes were not readable.
+    public func viewBytes(at index0: Int, length: Int) -> ByteBufferView? {
+        precondition(index0 >= 0, "index must not be negative")
+        precondition(length >= 0, "length must not be negative")
+        let index = index0 - self.readerIndex
+        guard index >= 0 && index <= self.readableBytes - length else {
+            return nil
+        }
+
+        return ByteBufferView(buffer: self, range: index0 ..< index0+length)
     }
 }

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -49,7 +49,7 @@ public struct HTTPListHeaderIterator: Sequence, IteratorProtocol {
         for (idx, currentHeader) in headers.headers.enumerated().dropFirst(current + 1) {
             let view = headers.buffer.viewBytes(at: currentHeader.name.start,
                                                 length: currentHeader.name.length)
-            if view.compareCaseInsensitiveASCIIBytes(to: headerName) {
+            if view!.compareCaseInsensitiveASCIIBytes(to: headerName) {
                 return idx
             }
         }
@@ -68,7 +68,7 @@ public struct HTTPListHeaderIterator: Sequence, IteratorProtocol {
             self.currentHeaderIndex = index
             self.singleValueViewIterator = headers.buffer
                 .viewBytes(at: headers.headers[currentHeaderIndex].value.start,
-                           length: headers.headers[currentHeaderIndex].value.length)
+                           length: headers.headers[currentHeaderIndex].value.length)!
                 .split(separator: comma)
                 .makeIterator()
             return self.next()


### PR DESCRIPTION
Motivation:

ByteBuffer.viewBytes would unconditionally return a ByteBufferView even
if the requested bytes were not readable.

Modifications:

- make it return an `Optional<ByteBufferView>`

Result:

- safer, better APIs
- fixed #877 
