### PR TITLE
[nio-1.13] Make `NIOAny` log the contents of its storage when encountering fatal unwrapping errors.

### DIFF
--- a/Sources/NIO/NIOAny.swift
+++ b/Sources/NIO/NIOAny.swift
@@ -98,7 +98,7 @@ public struct NIOAny {
         if let v = tryAsByteBuffer() {
             return v
         } else {
-            fatalError("tried to decode as type \(ByteBuffer.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType)")
+            fatalError("tried to decode as type \(ByteBuffer.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType) with contents \(self._storage)")
         }
     }
 
@@ -122,7 +122,7 @@ public struct NIOAny {
         if let v = tryAsIOData() {
             return v
         } else {
-            fatalError("tried to decode as type \(IOData.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType)")
+            fatalError("tried to decode as type \(IOData.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType) with contents \(self._storage)")
         }
     }
 
@@ -146,7 +146,7 @@ public struct NIOAny {
         if let v = tryAsFileRegion() {
             return v
         } else {
-            fatalError("tried to decode as type \(FileRegion.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType)")
+            fatalError("tried to decode as type \(FileRegion.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType) with contents \(self._storage)")
         }
     }
 
@@ -170,7 +170,7 @@ public struct NIOAny {
         if let e = tryAsByteEnvelope() {
             return e
         } else {
-            fatalError("tried to decode as type \(AddressedEnvelope<ByteBuffer>.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType)")
+            fatalError("tried to decode as type \(AddressedEnvelope<ByteBuffer>.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType) with contents \(self._storage)")
         }
     }
 
@@ -194,7 +194,7 @@ public struct NIOAny {
         if let v = tryAsOther(type: type) {
             return v
         } else {
-            fatalError("tried to decode as type \(T.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType)")
+            fatalError("tried to decode as type \(T.self) but found \(Mirror(reflecting: Mirror(reflecting: self._storage).children.first!.value).subjectType) with contents \(self._storage)")
         }
     }
 


### PR DESCRIPTION
_Make `NIOAny` log the contents of its storage when encountering fatal unwrapping errors._

### Motivation:

This should make debugging crashes easier, as knowing the contents of the badly-unwrapped `NIOAny` should make it more clear where exactly it could have been written. Personally I'd prefer this to never cause a fatal error, but I assume that would need more discussion.

### Modifications:

See above.

### Result:

Fatal errors caused by unwrapping `NIOAny` will show the actual contents of the badly-unwrapped `NIOAny` object, not just its type.