### PR TITLE
[1.13] Selector: make sure timerfd is level triggered

### DIFF
--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -300,7 +300,7 @@ final class Selector<R: Registration> {
         try Epoll.epoll_ctl(epfd: self.fd, op: Epoll.EPOLL_CTL_ADD, fd: eventfd, event: &ev)
 
         var timerev = Epoll.epoll_event()
-        timerev.events = Epoll.EPOLLIN | Epoll.EPOLLERR | Epoll.EPOLLRDHUP | Epoll.EPOLLET
+        timerev.events = Epoll.EPOLLIN | Epoll.EPOLLERR | Epoll.EPOLLRDHUP
         timerev.data.fd = timerfd
         try Epoll.epoll_ctl(epfd: self.fd, op: Epoll.EPOLL_CTL_ADD, fd: timerfd, event: &timerev)
 #else
@@ -488,7 +488,7 @@ final class Selector<R: Registration> {
         case .now:
             ready = Int(try Epoll.epoll_wait(epfd: self.fd, events: events, maxevents: Int32(eventsCapacity), timeout: 0))
         case .blockUntilTimeout(let timeAmount):
-            // Only call timerfd_settime if we not already scheduled one that will cover it.
+            // Only call timerfd_settime if we're not already scheduled one that will cover it.
             // This guards against calling timerfd_settime if not needed as this is generally speaking
             // expensive.
             let next = DispatchTime.now().uptimeNanoseconds + UInt64(timeAmount.nanoseconds)

--- a/Tests/NIOTests/SelectorTest+XCTest.swift
+++ b/Tests/NIOTests/SelectorTest+XCTest.swift
@@ -29,6 +29,7 @@ extension SelectorTest {
                 ("testDeregisterWhileProcessingEvents", testDeregisterWhileProcessingEvents),
                 ("testDeregisterAndCloseWhileProcessingEvents", testDeregisterAndCloseWhileProcessingEvents),
                 ("testWeDoNotDeliverEventsForPreviouslyClosedChannels", testWeDoNotDeliverEventsForPreviouslyClosedChannels),
+                ("testTimerFDIsLevelTriggered", testTimerFDIsLevelTriggered),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

In the Selector (because of the deregistrationsHappened workaround) we
expect all events to be level triggered. If there are deregistrations,
we just expect epoll/kqueue to deliver the event again. But timerfd was
configured as `EPOLLET`. That means is a timer fires after some
deregistrations, we lose it.

Modifications:

make timerfd level triggered

Result:

- no more timer stalls
- fixes #872

(cherry picked from commit c8ac593b397de08813dcd1db169de16fb2824173)

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
