### PR TITLE
remove WebSocketFrameDecoder inline error handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import PackageDescription
 
 var targets: [PackageDescription.Target] = [
     .target(name: "_NIO1APIShims",
-            dependencies: ["NIO", "NIOHTTP1", "NIOTLS", "NIOFoundationCompat"]),
+            dependencies: ["NIO", "NIOHTTP1", "NIOTLS", "NIOFoundationCompat", "NIOWebSocket"]),
     .target(name: "NIO",
             dependencies: ["CNIOLinux",
                            "CNIODarwin",

--- a/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
@@ -231,12 +231,6 @@ public final class WebSocketFrameDecoder: ByteToMessageDecoder {
     /// Our parser state.
     private var parser = WSParser()
 
-    /// Whether we should continue to parse.
-    private var shouldKeepParsing = true
-
-    /// Whether this `ChannelHandler` should be performing automatic error handling.
-    private let automaticErrorHandling: Bool
-
     /// Construct a new `WebSocketFrameDecoder`
     ///
     /// - parameters:
@@ -252,68 +246,31 @@ public final class WebSocketFrameDecoder: ByteToMessageDecoder {
     ///     - automaticErrorHandling: Whether this `ChannelHandler` should automatically handle
     ///         protocol errors in frame serialization, or whether it should allow the pipeline
     ///         to handle them.
-    public init(maxFrameSize: Int = 1 << 14, automaticErrorHandling: Bool = true) {
+    public init(maxFrameSize: Int = 1 << 14) {
         precondition(maxFrameSize <= UInt32.max, "invalid overlarge max frame size")
         self.maxFrameSize = maxFrameSize
-        self.automaticErrorHandling = automaticErrorHandling
     }
 
-    public func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) -> DecodingState  {
+    public func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState  {
         // Even though the calling code will loop around calling us in `decode`, we can't quite
         // rely on that: sometimes we have zero-length elements to parse, and the caller doesn't
         // guarantee to call us with zero-length bytes.
-        parseLoop: while self.shouldKeepParsing {
+        while true {
             switch parser.parseStep(&buffer) {
             case .result(let frame):
                 context.fireChannelRead(self.wrapInboundOut(frame))
+                return .continue
             case .continueParsing:
-                do {
-                    try self.parser.validateState(maxFrameSize: self.maxFrameSize)
-                } catch {
-                    self.handleError(error, context: context)
-                }
+                try self.parser.validateState(maxFrameSize: self.maxFrameSize)
+                // loop again, might be 'waiting' for 0 bytes
             case .insufficientData:
-                break parseLoop
+                return .needMoreData
             }
         }
-
-        // We parse eagerly, so once we get here we definitionally need more data.
-        return .needMoreData
     }
 
     public func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
         // EOF is not semantic in WebSocket, so ignore this.
         return .needMoreData
-    }
-
-
-
-    /// We hit a decoding error, we're going to tear things down now. To do this we're
-    /// basically going to send an error frame and then close the connection. Once we're
-    /// in this state we do no further parsing.
-    ///
-    /// A clean websocket shutdown is not really supposed to have an immediate close,
-    /// but we're doing that because the remote peer has prevented us from doing
-    /// further frame parsing, so we can't really wait for the next frame.
-    private func handleError(_ error: Error, context: ChannelHandlerContext) {
-        guard let error = error as? NIOWebSocketError else {
-            fatalError("Can only handle NIOWebSocketErrors")
-        }
-        self.shouldKeepParsing = false
-
-        // If we've been asked to handle the errors here, we should.
-        // TODO(cory): Remove this in 2.0, in favour of `WebSocketProtocolErrorHandler`.
-        if self.automaticErrorHandling {
-            var data = context.channel.allocator.buffer(capacity: 2)
-            data.write(webSocketErrorCode: WebSocketErrorCode(error))
-            let frame = WebSocketFrame(fin: true,
-                                       opcode: .connectionClose,
-                                       data: data)
-            context.writeAndFlush(self.wrapInboundOut(frame)).whenComplete { (_: Result<Void, Error>) in
-                context.close(promise: nil)
-            }
-        }
-
-        context.fireErrorCaught(error)
     }
 }

--- a/Sources/NIOWebSocket/WebSocketUpgrader.swift
+++ b/Sources/NIOWebSocket/WebSocketUpgrader.swift
@@ -170,7 +170,7 @@ public final class WebSocketUpgrader: HTTPServerProtocolUpgrader {
         /// We never use the automatic error handling feature of the WebSocketFrameDecoder: we always use the separate channel
         /// handler.
         var upgradeFuture = context.pipeline.addHandler(WebSocketFrameEncoder()).flatMap {
-            context.pipeline.addHandler(ByteToMessageHandler(WebSocketFrameDecoder(maxFrameSize: self.maxFrameSize, automaticErrorHandling: false)))
+            context.pipeline.addHandler(ByteToMessageHandler(WebSocketFrameDecoder(maxFrameSize: self.maxFrameSize)))
         }
 
         if self.automaticErrorHandling {

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -18,6 +18,7 @@ import NIO
 import NIOFoundationCompat
 import NIOHTTP1
 import NIOTLS
+import NIOWebSocket
 
 #if !NIO_CI_BUILD
 #warning("""
@@ -530,3 +531,10 @@ public typealias HTTPUpgradeErrors = HTTPServerUpgradeErrors
 
 @available(*, deprecated, renamed: "NIOThreadPool")
 public typealias BlockingIOThreadPool = NIOThreadPool
+
+extension WebSocketFrameDecoder {
+    @available(*, deprecated, message: "automaticErrorHandling deprecated, use WebSocketProtocolErrorHandler instead")
+    public convenience init(maxFrameSize: Int = 1 << 14, automaticErrorHandling: Bool) {
+        self.init(maxFrameSize: maxFrameSize)
+    }
+}

--- a/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest+XCTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest+XCTest.swift
@@ -47,6 +47,7 @@ extension WebSocketFrameDecoderTest {
                 ("testDecoderRejectsFragmentedControlFramesWithSeparateErrorHandling", testDecoderRejectsFragmentedControlFramesWithSeparateErrorHandling),
                 ("testDecoderRejectsMultibyteControlFrameLengthsWithSeparateErrorHandling", testDecoderRejectsMultibyteControlFrameLengthsWithSeparateErrorHandling),
                 ("testIgnoresFurtherDataAfterRejectedFrameWithSeparateErrorHandling", testIgnoresFurtherDataAfterRejectedFrameWithSeparateErrorHandling),
+                ("testErrorHandlerDoesNotSwallowRandomErrors", testErrorHandlerDoesNotSwallowRandomErrors),
            ]
    }
 }

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -77,6 +77,7 @@
 - `HTTPHeader` has been removed, without replacement
 - `HTTPHeaders[canonicalForm:]` now returns `[Substring]` instead of `[String]`
 - `HTTPListHeaderIterator` has been removed, without replacement
+- `WebSocketFrameDecoder`'s `automaticErrorHandling:` parameter has been deprecated. Remove if `false`, add `WebSocketProtocolErrorHandler` to your pipeline instead if `true`
 - rename `FileHandle` to `NIOFileHandle`
 - rename all `ChannelPipeline.add(name:handler:...)`s to `ChannelPipeline.addHandler(_:name:...)`
 - rename all `ChannelPipeline.remove(...)`s to `ChannelPipeline.removeHandler(...)`
@@ -84,4 +85,4 @@
 - change  `ChannelPipeline.addHandler(_:before:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`
 - change  `ChannelPipeline.addHandler(_:after:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`
 - Change `HTTPServerProtocolUpgrader` `protocol` to require `buildUpgradeResponse` to take a `channel` and return an `EventLoopFuture<HTTPHeaders>`.
-
+- `EmbeddedChannel.writeInbound/Outbound` are now `throwing`


### PR DESCRIPTION
Motivation:

Follows on from the work done in #528 for #527: we have moved the the
default error handling out of WebSocketFrameDecoder, but had to leave
the code there for backward compatibility reasons. We can remove that
code now.

Modifications:

Removed automatic error handling code in WebSocketFrameDecoder.

Result:

- fixes #534
