### PR TITLE
remove overloading from scheduleRepeatedTask

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -462,7 +462,8 @@ extension EventLoop {
         // Do nothing
     }
 
-    /// Schedule a repeated task to be executed by the `EventLoop` with a fixed delay between the end and start of each task.
+    /// Schedule a repeated task to be executed by the `EventLoop` with a fixed delay between the end and start of each
+    /// task.
     ///
     /// - parameters:
     ///     - initialDelay: The delay after which the first task is executed.
@@ -480,10 +481,16 @@ extension EventLoop {
                 return self.makeFailedFuture(error)
             }
         }
-        return self.scheduleRepeatedTask(initialDelay: initialDelay, delay: delay, notifying: promise, futureTask)
+        return self.scheduleRepeatedAsyncTask(initialDelay: initialDelay, delay: delay, notifying: promise, futureTask)
     }
 
-    /// Schedule a repeated task to be executed by the `EventLoop` with a fixed delay between the end and start of each task.
+    /// Schedule a repeated asynchronous task to be executed by the `EventLoop` with a fixed delay between the end and
+    /// start of each task.
+    ///
+    /// - note: The delay is measured from the completion of one run's returned future to the start of the execution of
+    ///         the next run. For example: If you schedule a task once per second but your task takes two seconds to
+    ///         complete, the time interval between two subsequent runs will actually be three seconds (2s run time plus
+    ///         the 1s delay.)
     ///
     /// - parameters:
     ///     - initialDelay: The delay after which the first task is executed.
@@ -492,7 +499,10 @@ extension EventLoop {
     ///     - task: The closure that will be executed.
     /// - return: `RepeatedTask`
     @discardableResult
-    public func scheduleRepeatedTask(initialDelay: TimeAmount, delay: TimeAmount, notifying promise: EventLoopPromise<Void>? = nil, _ task: @escaping (RepeatedTask) -> EventLoopFuture<Void>) -> RepeatedTask {
+    public func scheduleRepeatedAsyncTask(initialDelay: TimeAmount,
+                                          delay: TimeAmount,
+                                          notifying promise: EventLoopPromise<Void>? = nil,
+                                          _ task: @escaping (RepeatedTask) -> EventLoopFuture<Void>) -> RepeatedTask {
         let repeated = RepeatedTask(interval: delay, eventLoop: self, cancellationPromise: promise, task: task)
         repeated.begin(in: initialDelay)
         return repeated

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -152,6 +152,14 @@ extension EventLoop {
     public func newFailedFuture<T>(error: Error) -> EventLoopFuture<T> {
         return self.makeFailedFuture(error)
     }
+
+    @available(*, deprecated, renamed: "scheduleRepeatedAsyncTask")
+    public func scheduleRepeatedTask(initialDelay: TimeAmount,
+                                     delay: TimeAmount,
+                                     notifying promise: EventLoopPromise<Void>? = nil,
+                                     _ task: @escaping (RepeatedTask) -> EventLoopFuture<Void>) -> RepeatedTask {
+        return self.scheduleRepeatedAsyncTask(initialDelay: initialDelay, delay: delay, task)
+    }
 }
 
 extension EventLoopFuture {

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -35,6 +35,7 @@ extension EventLoopTest {
                 ("testScheduleRepeatedTaskCancelFromDifferentThread", testScheduleRepeatedTaskCancelFromDifferentThread),
                 ("testScheduleRepeatedTaskToNotRetainRepeatedTask", testScheduleRepeatedTaskToNotRetainRepeatedTask),
                 ("testScheduleRepeatedTaskToNotRetainEventLoop", testScheduleRepeatedTaskToNotRetainEventLoop),
+                ("testScheduledRepeatedAsyncTask", testScheduledRepeatedAsyncTask),
                 ("testEventLoopGroupMakeIterator", testEventLoopGroupMakeIterator),
                 ("testEventLoopMakeIterator", testEventLoopMakeIterator),
                 ("testMultipleShutdown", testMultipleShutdown),

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -57,6 +57,7 @@
 - renamed `EventLoopFuture.thenThrowing` to `EventLoopFuture.flatMapThrowing`
 - renamed `EventLoopFuture`'s generic parameter from `T` to `Value`
 - renamed `EventLoopFuture.and(result:)` to `EventLoopFuture.and(value:)`
+- the asynchronous task version of `EventLoop.scheduleRepeatedTask` has been renamed to `scheduleRepeatedAsyncTask`
 - `EventLoopPromise.succeed(result: Value)` lost its label so is now `EventLoopPromise.succeed(Value)`
 - `EventLoopPromise.fail(error: Error)` lost its label so is now `EventLoopPromise.fail(Error)`
 - renamed `HTTPProtocolUpgrader` to `HTTPServerProtocolUpgrader`


### PR DESCRIPTION
Motivation:

scheduleRepeatedTask had two overloads: for synchronous and asynchronous
tasks. They however had the same name so they were pretty much
impossible to use.

Modifications:

rename the asynchronous version of scheduleRepeatedTask to
scheduleRepeatedAsyncTask

Result:

- NIO easier to use
- fixes #882
