### PR TITLE
NIONetworkInterface: Return if multicast is supported

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -337,6 +337,9 @@ public enum ChannelError: Error {
     /// address.
     case illegalMulticastAddress(SocketAddress)
 
+    /// Multicast is not supported on Interface
+    case multicastNotSupported(NIONetworkInterface)
+
     /// An operation that was inappropriate given the current `Channel` state was attempted.
     case inappropriateOperationForState
 

--- a/Sources/NIO/Interfaces.swift
+++ b/Sources/NIO/Interfaces.swift
@@ -62,6 +62,9 @@ public final class NIONetworkInterface {
     /// instead.
     public let pointToPointDestinationAddress: SocketAddress?
 
+    /// If the Interface supports Multicast
+    public let multicastSupported: Bool
+
     /// The index of the interface, as provided by `if_nametoindex`.
     public let interfaceIndex: Int
 
@@ -92,6 +95,12 @@ public final class NIONetworkInterface {
         } else {
             self.broadcastAddress = nil
             self.pointToPointDestinationAddress = nil
+        }
+
+        if (caddr.ifa_flags & UInt32(IFF_MULTICAST)) != 0 {
+            multicastSupported = true
+        } else {
+            multicastSupported = false
         }
 
         do {

--- a/Sources/NIO/Interfaces.swift
+++ b/Sources/NIO/Interfaces.swift
@@ -98,9 +98,9 @@ public final class NIONetworkInterface {
         }
 
         if (caddr.ifa_flags & UInt32(IFF_MULTICAST)) != 0 {
-            multicastSupported = true
+            self.multicastSupported = true
         } else {
-            multicastSupported = false
+            self.multicastSupported = false
         }
 
         do {

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -866,7 +866,7 @@ extension DatagramChannel: MulticastChannel {
         /// Check if the interface supports multicast
         if let interface = interface {
             guard interface.multicastSupported else {
-                promise?.fail(error: MulticastError.multicastNotSupported(interface))
+                promise?.fail(MulticastError.multicastNotSupported(interface))
                 return
             }
         }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -863,6 +863,14 @@ extension DatagramChannel: MulticastChannel {
             return
         }
 
+        /// Check if the interface supports multicast
+        if let interface = interface {
+            guard interface.multicastSupported else {
+                promise?.fail(error: MulticastError.multicastNotSupported(interface))
+                return
+            }
+        }
+
         // We need to check that we have the appropriate address types in all cases. They all need to overlap with
         // the address type of this channel, or this cannot work.
         guard let localAddress = self.localAddress else {

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -866,7 +866,7 @@ extension DatagramChannel: MulticastChannel {
         /// Check if the interface supports multicast
         if let interface = interface {
             guard interface.multicastSupported else {
-                promise?.fail(MulticastError.multicastNotSupported(interface))
+                promise?.fail(ChannelError.multicastNotSupported(interface))
                 return
             }
         }

--- a/Tests/NIOTests/NIOAnyDebugTest.swift
+++ b/Tests/NIOTests/NIOAnyDebugTest.swift
@@ -26,6 +26,9 @@ class NIOAnyDebugTest: XCTestCase {
         XCTAssertTrue(wrappedInNIOAnyBlock(bb).hasSuffix(" }"))
         
         let fileHandle = NIOFileHandle(descriptor: 1)
+        defer {
+            XCTAssertNoThrow(_ = try fileHandle.takeDescriptorOwnership())
+        }
         let fileRegion = FileRegion(fileHandle: fileHandle, readerIndex: 1, endIndex: 5)
         XCTAssertEqual(wrappedInNIOAnyBlock(fileRegion), wrappedInNIOAnyBlock("""
         FileRegion { \
@@ -37,7 +40,6 @@ class NIOAnyDebugTest: XCTestCase {
         readerIndex: \(fileRegion.readerIndex), \
         endIndex: \(fileRegion.endIndex) }
         """))
-        try fileHandle.close()
         
         let socketAddress = try SocketAddress(unixDomainSocketPath: "socketAdress")
         let envelopeByteBuffer = ByteBufferAllocator().byteBuffer(string: "envelope buffer")

--- a/Tests/NIOTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOTests/SocketOptionProviderTest.swift
@@ -70,7 +70,7 @@ final class SocketOptionProviderTest: XCTestCase {
         // Only run The setup if the Loopback supports multicast
         if v4LoopbackAddress.isMulticast {
             self.ipv4DatagramChannel = try? assertNoThrowWithValue(
-                DatagramBootstrap(group: group).bind(host: "127.0.0.12", port: 0).flatMap { channel in
+                DatagramBootstrap(group: group).bind(host: "127.0.0.1", port: 0).flatMap { channel in
                     return (channel as! MulticastChannel).joinGroup(try! SocketAddress(ipAddress: "224.0.2.66", port: 0), interface: v4LoopbackInterface).map { channel }
                     }.wait()
             )

--- a/Tests/NIOTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOTests/SocketOptionProviderTest.swift
@@ -63,26 +63,28 @@ final class SocketOptionProviderTest: XCTestCase {
         // joins/leaves that may eventually lead to an ENOMEM and a spurious test failure. As joining/leaving groups on loopback
         // interfaces does not require IGMP joins/leaves, forcing these joins onto the loopback interface saves us from this
         // risk.
-        let v4LoopbackAddress = try! SocketAddress(ipAddress: "127.0.0.1", port: 0)
-        let v6LoopbackAddress = try! SocketAddress(ipAddress: "::1", port: 0)
-        let v4LoopbackInterface = try! System.enumerateInterfaces().filter { $0.address == v4LoopbackAddress }.first!
+        let v4LoopbackAddress = try! assertNoThrowWithValue(SocketAddress(ipAddress: "127.0.0.1", port: 0))
+        let v6LoopbackAddress = try! assertNoThrowWithValue(SocketAddress(ipAddress: "::1", port: 0))
+        let v4LoopbackInterface = try! assertNoThrowWithValue(System.enumerateInterfaces().filter {
+            $0.address == v4LoopbackAddress
+        }.first)!
 
-        // Only run The setup if the Loopback supports multicast
+        // Only run the setup if the loopback interface supports multicast
         if v4LoopbackAddress.isMulticast {
             self.ipv4DatagramChannel = try? assertNoThrowWithValue(
                 DatagramBootstrap(group: group).bind(host: "127.0.0.1", port: 0).flatMap { channel in
                     return (channel as! MulticastChannel).joinGroup(try! SocketAddress(ipAddress: "224.0.2.66", port: 0), interface: v4LoopbackInterface).map { channel }
-                    }.wait()
+                }.wait()
             )
         }
 
-        // Only run The setup if the Loopback supports multicast
+        // Only run the setup if the loopback interface supports multicast
         if v6LoopbackAddress.isMulticast {
             // The IPv6 setup is allowed to fail, some hosts don't have IPv6.
-            let v6LoopbackInterface = try! System.enumerateInterfaces().filter { $0.address == v6LoopbackAddress }.first
+            let v6LoopbackInterface = try? assertNoThrowWithValue(System.enumerateInterfaces().filter { $0.address == v6LoopbackAddress }.first)
             self.ipv6DatagramChannel = try? DatagramBootstrap(group: group).bind(host: "::1", port: 0).flatMap { channel in
                 return (channel as! MulticastChannel).joinGroup(try! SocketAddress(ipAddress: "ff12::beeb", port: 0), interface: v6LoopbackInterface).map { channel }
-                }.wait()
+            }.wait()
         }
     }
 
@@ -165,15 +167,18 @@ final class SocketOptionProviderTest: XCTestCase {
     }
 
     func testSoIpMulticastIf() throws {
-        let channel = self.ipv4DatagramChannel!
+        guard let channel = self.ipv4DatagramChannel else {
+            // no multicast support
+            return
+        }
         let provider = try assertNoThrowWithValue(self.ipv4MulticastProvider())
 
         let address: in_addr
-        switch channel.localAddress! {
-        case .v4(let addr):
+        switch channel.localAddress {
+        case .some(.v4(let addr)):
             address = addr.address.sin_addr
         default:
-            XCTFail("Local address must be IPv4!")
+            XCTFail("Local address must be IPv4, but is \(channel.localAddress.debugDescription)")
             return
         }
 
@@ -185,6 +190,10 @@ final class SocketOptionProviderTest: XCTestCase {
     }
 
     func testIpMulticastTtl() throws {
+        guard self.ipv4DatagramChannel != nil else {
+            // alas, no multicast, let's skip.
+            return
+        }
         let provider = try assertNoThrowWithValue(self.ipv4MulticastProvider())
         XCTAssertNoThrow(try provider.setIPMulticastTTL(6).flatMap {
             provider.getIPMulticastTTL()
@@ -194,6 +203,10 @@ final class SocketOptionProviderTest: XCTestCase {
     }
 
     func testIpMulticastLoop() throws {
+        guard self.ipv4DatagramChannel != nil else {
+            // alas, no multicast, let's skip.
+            return
+        }
         let provider = try assertNoThrowWithValue(self.ipv4MulticastProvider())
         XCTAssertNoThrow(try provider.setIPMulticastLoop(1).flatMap {
             provider.getIPMulticastLoop()
@@ -205,6 +218,10 @@ final class SocketOptionProviderTest: XCTestCase {
     func testIpv6MulticastIf() throws {
         guard let provider = try assertNoThrowWithValue(self.ipv6MulticastProvider()) else {
             // Skip on systems without IPv6.
+            return
+        }
+        guard self.ipv6DatagramChannel != nil else {
+            // alas, no multicast, let's skip.
             return
         }
 
@@ -227,6 +244,10 @@ final class SocketOptionProviderTest: XCTestCase {
             // Skip on systems without IPv6.
             return
         }
+        guard self.ipv6DatagramChannel != nil else {
+            // alas, no multicast, let's skip.
+            return
+        }
 
         XCTAssertNoThrow(try provider.setIPv6MulticastHops(6).flatMap {
             provider.getIPv6MulticastHops()
@@ -238,6 +259,10 @@ final class SocketOptionProviderTest: XCTestCase {
     func testIPv6MulticastLoop() throws {
         guard let provider = try assertNoThrowWithValue(self.ipv6MulticastProvider()) else {
             // Skip on systems without IPv6.
+            return
+        }
+        guard self.ipv6DatagramChannel != nil else {
+            // alas, no multicast, let's skip.
             return
         }
 


### PR DESCRIPTION
this is a fixup and replacement of #650. We need to get this in because NIO converges.


Support for Interface to report if Multicast is supported. Channel can provide Error if Interface doesn't support Multicast.

Motivation:

Allows for checking if the interface you are setting up for Multicast even supports Multicast in the first place. In multiple projects we have done with Multicast it helps as we still run into some network managers that shutdown multicast support.

Modifications:

Interface exposes a new variable to determine if it supports Multicast.
performGroupOperation0 will check if interface is not nil and supports multicast, otherwise will throw error that the interface doesn't support Multicast

Result:

This should hopefully better inform if the Multicast attempt is going to even work.