### PR TITLE
disable NIO1APIShim's warning

### DIFF
--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -19,23 +19,16 @@ import NIOFoundationCompat
 import NIOHTTP1
 import NIOTLS
 
-#if !NIO_CI_BUILD
-#warning("""
-         If you are a user: Please ignore this warning, it's the SwiftNIO team's fault.
-
-         If you are developer of a package depending on NIO:
-            You're using NIO 2's 'NIO1 API Shims' module.
-            Please note that _NIO1APIShimsHelpers is a transitional module that is untested and
-            is not part of the public API. Before NIO 2.0.0 gets released it's still very useful
-            to `import _NIO1APIShimsHelpers` because it will make it easier for you to keep up
-            with NIO2 API changes until the API will stabilise and we will start tagging versions.
-
-            Sorry for causing you extra work but we believe the public API changes we're introducing
-            will eventually help us all becoming a better ecosystem.
-
-            💜 the SwiftNIO team.
-        """)
-#endif
+// This is NIO 2's 'NIO1 API Shims' module.
+//
+// Please note that _NIO1APIShimsHelpers is a transitional module that is untested and
+// is not part of the public API. Before NIO 2.0.0 gets released it's still very useful
+// to `import _NIO1APIShimsHelpers` because it will make it easier for you to keep up
+// with NIO2 API changes until the API will stabilise and we will start tagging versions.
+//
+// Please do not depend on this module in tagged versions.
+//
+//   💜 the SwiftNIO team.
 
 @available(*, deprecated, message: "ContiguousCollection does not exist in NIO2")
 public protocol ContiguousCollection: Collection {

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,13 +8,13 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-03-04-a"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-03-06-a"
         swift_builds_suffix: "branch"
         skip_ruby_from_ppa: "true"
 
   unit-tests:
     image: swift-nio:18.04-5.0
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors -Xswiftc -DNIO_CI_BUILD"
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors"
 
   integration-tests:
     image: swift-nio:18.04-5.0
@@ -27,7 +27,7 @@ services:
 
   test:
     image: swift-nio:18.04-5.0
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors -Xswiftc -DNIO_CI_BUILD && ./scripts/integration_tests.sh"
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors && ./scripts/integration_tests.sh"
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1177050 # was: 685050


### PR DESCRIPTION
Motivation:

We shouldn't put warnings in developer's code in the convergence phase.

Modifications:

- remove NIO1APIShims warning
- update Swift

Result:

fewer warnings