### PR TITLE
ByteBuffer: improve and simplify get* implementations

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -570,9 +570,7 @@ public struct ByteBuffer {
     /// - returns: A `ByteBuffer` containing the selected bytes as readable bytes or `nil` if the selected bytes were
     ///            not readable in the initial `ByteBuffer`.
     public func getSlice(at index: Int, length: Int) -> ByteBuffer? {
-        precondition(index >= 0, "index must not be negative")
-        precondition(length >= 0, "length must not be negative")
-        guard index >= self.readerIndex && index <= self.writerIndex - length else {
+        guard index >= 0 && length >= 0 && index >= self.readerIndex && index <= self.writerIndex - length else {
             return nil
         }
         let index = _toIndex(index)
@@ -774,5 +772,16 @@ extension ByteBuffer: Equatable {
                 return memcmp(lPtr.baseAddress!, rPtr.baseAddress!, lPtr.count) == 0
             }
         }
+    }
+}
+
+extension ByteBuffer {
+    @inlinable
+    func rangeWithinReadableBytes(index: Int, length: Int) -> Range<Int>? {
+        let indexFromReaderIndex = index - self.readerIndex
+        guard indexFromReaderIndex >= 0 && length >= 0 && indexFromReaderIndex <= self.readableBytes - length else {
+            return nil
+        }
+        return indexFromReaderIndex ..< (indexFromReaderIndex+length)
     }
 }

--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -80,14 +80,11 @@ extension ByteBuffer {
     ///   - index: The index the view should start at
     ///   - length: The length of the view (in bytes)
     /// - returns A view into a portion of a `ByteBuffer` or `nil` if the requested bytes were not readable.
-    public func viewBytes(at index0: Int, length: Int) -> ByteBufferView? {
-        precondition(index0 >= 0, "index must not be negative")
-        precondition(length >= 0, "length must not be negative")
-        let index = index0 - self.readerIndex
-        guard index >= 0 && index <= self.readableBytes - length else {
+    public func viewBytes(at index: Int, length: Int) -> ByteBufferView? {
+        guard index >= self.readerIndex && index <= self.writerIndex - length else {
             return nil
         }
 
-        return ByteBufferView(buffer: self, range: index0 ..< index0+length)
+        return ByteBufferView(buffer: self, range: index ..< (index + length))
     }
 }

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -48,10 +48,6 @@ extension ByteBuffer {
     ///     - length: The number of bytes to be read from this `ByteBuffer`.
     /// - returns: A `Data` value containing `length` bytes or `nil` if there aren't at least `length` bytes readable.
     public mutating func readData(length: Int) -> Data? {
-        precondition(length >= 0, "length must not be negative")
-        guard self.readableBytes >= length else {
-            return nil
-        }
         return self.getData(at: self.readerIndex, length: length).map {
             self.moveReaderIndex(forwardBy: length)
             return $0
@@ -66,10 +62,8 @@ extension ByteBuffer {
     ///     - length: The number of bytes of interest
     /// - returns: A `Data` value containing the bytes of interest or `nil` if the selected bytes are not readable.
     public func getData(at index0: Int, length: Int) -> Data? {
-        precondition(length >= 0, "length must not be negative")
-        precondition(index0 >= 0, "index must not be negative")
         let index = index0 - self.readerIndex
-        guard index >= 0 && index <= self.readableBytes - length else {
+        guard index >= 0 && length >= 0 && index <= self.readableBytes - length else {
             return nil
         }
         return self.withUnsafeReadableBytesWithStorageManagement { ptr, storageRef in

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -944,19 +944,28 @@ class ByteBufferTest: XCTestCase {
             XCTAssertNil(body(Int.max - 1, 2), file: file, line: line)
             XCTAssertNil(body(1, Int.max), file: file, line: line)
             XCTAssertNil(body(2, Int.max - 1), file: file, line: line)
+            XCTAssertNil(body(Int.max, Int.max), file: file, line: line)
+            XCTAssertNil(body(Int.min, Int.min), file: file, line: line)
+            XCTAssertNil(body(Int.max, Int.min), file: file, line: line)
+            XCTAssertNil(body(Int.min, Int.max), file: file, line: line)
         }
 
         func testIndexOrLengthFunc<T>(_ body: (Int) -> T?, file: StaticString = #file, line: UInt = #line) {
             XCTAssertNil(body(Int.max))
             XCTAssertNil(body(Int.max - 1))
+            XCTAssertNil(body(Int.min))
         }
 
-        testIndexOrLengthFunc({ x in buf.getInteger(at: x) as UInt16? })
-        testIndexOrLengthFunc({ buf.readSlice(length: $0) })
         testIndexOrLengthFunc({ buf.readBytes(length: $0) })
         testIndexOrLengthFunc({ buf.readData(length: $0) })
+        testIndexOrLengthFunc({ buf.readSlice(length: $0) })
+        testIndexOrLengthFunc({ buf.readString(length: $0) })
         testIndexOrLengthFunc({ buf.readDispatchData(length: $0) })
 
+        testIndexOrLengthFunc({ buf.getInteger(at: $0, as: UInt8.self) })
+        testIndexOrLengthFunc({ buf.getInteger(at: $0, as: UInt16.self) })
+        testIndexOrLengthFunc({ buf.getInteger(at: $0, as: UInt32.self) })
+        testIndexOrLengthFunc({ buf.getInteger(at: $0, as: UInt64.self) })
         testIndexAndLengthFunc(buf.getBytes)
         testIndexAndLengthFunc(buf.getData)
         testIndexAndLengthFunc(buf.getSlice)


### PR DESCRIPTION
Motivation:

For historic reasons, the get* implementations checked the same indices
repeatedly and the checks were also repetitive.

Modifications:

unify and de-deplicate get* range checks

Result:

- fixes #884
- fixes #883