### PR TITLE
test non-ASCII header name/value

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -41,6 +41,8 @@ extension HTTPDecoderTest {
                 ("testExtraCRLF", testExtraCRLF),
                 ("testSOURCEDoesntExplodeUs", testSOURCEDoesntExplodeUs),
                 ("testExtraCarriageReturnBetweenSubsequentRequests", testExtraCarriageReturnBetweenSubsequentRequests),
+                ("testIllegalHeaderNamesCauseError", testIllegalHeaderNamesCauseError),
+                ("testNonASCIIWorksAsHeaderValue", testNonASCIIWorksAsHeaderValue),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Couldn't find a non-ASCII header name/value test.

Modifications:

added one

Result:

better tests