### PR TITLE
HTTPDecoder: remove rawURI

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -530,7 +530,7 @@ public class HTTPDecoder<In, Out>: ByteToMessageDecoder, HTTPDecoderDelegate {
         case .request:
             let reqHead = HTTPRequestHead(version: .init(major: versionMajor, minor: versionMinor),
                                           method: HTTPMethod.from(httpParserMethod: method),
-                                          rawURI: .string(self.url!),
+                                          uri: self.url!,
                                           headers: HTTPHeaders(self.headers,
                                                                keepAliveState: keepAliveState))
             message = NIOAny(HTTPServerRequestPart.head(reqHead))


### PR DESCRIPTION
Motivation:

Before native UTF-8, the rawURI was a performance optimisation but
that's no longer true. Before this patch, we still had the rawURIs but
weren't using them at all.

Modifications:

remove any mention of rawURI

Result:

less clutter