### PR TITLE
Update migration guide with now-converging repos.

### DIFF
--- a/docs/migration-guide-NIO1-to-NIO2.md
+++ b/docs/migration-guide-NIO1-to-NIO2.md
@@ -24,11 +24,8 @@ The already [converged](https://forums.swift.org/t/swiftnio-2-repository-converg
 - `swift-nio`: `.package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0-convergence.1")`
 - `swift-nio-extras`: `.package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0-convergence.1")`
 - `swift-nio-ssl`: `.package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0-convergence.1")`
-
-Still under active development (might break public API anytime):
-
-- `swift-nio-http2`: `.package(url: "https://github.com/apple/swift-nio-http2.git", .branch("master"))`
-- `swift-nio-transport-services`: `.package(url: "https://github.com/apple/swift-nio-transport-services.git", .branch("master"))`
+- `swift-nio-http2`: `.package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.0.0-convergence.1")`
+- `swift-nio-transport-services`: `.package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.0.0-convergence.1")`
 
 ---
 


### PR DESCRIPTION
Motivation:

swift-nio-http2 and swift-nio-transport-services are now converging.

Modifications:

Updated the migration guide.

Result:

Docs will be up to date.
