### PR TITLE
B2MD: check that EOF events are forwarded

### DIFF
--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -53,6 +53,7 @@ extension ByteToMessageDecoderTest {
                 ("testBasicLifecycle", testBasicLifecycle),
                 ("testDecodeLoopStopsOnChannelInactive", testDecodeLoopStopsOnChannelInactive),
                 ("testDecodeLoopStopsOnInboundHalfClosure", testDecodeLoopStopsOnInboundHalfClosure),
+                ("testWeForwardReadEOFAndChannelInactive", testWeForwardReadEOFAndChannelInactive),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Basically I just wasn't 100% sure that I implemented that the EOF events
are not only handled but also forwarded to the next handler in the
pipeline. Quite important.

Modifications:

To figure out if I had implemented that or not I just wrote a test which
this PR is adding.

Result:

One more test, nothing else. Turns out I had implemented that correctly.