### PR TITLE
make HTTPMethod.hasRequestBody internal

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -526,7 +526,7 @@ extension HTTPHeaders: Equatable {
 }
 
 public enum HTTPMethod: Equatable {
-    public enum HasBody {
+    internal enum HasBody {
         case yes
         case no
         case unlikely
@@ -569,7 +569,7 @@ public enum HTTPMethod: Equatable {
     case RAW(value: String)
 
     /// Whether requests with this verb may have a request body.
-    public var hasRequestBody: HasBody {
+    internal var hasRequestBody: HasBody {
         switch self {
         case .HEAD, .DELETE, .TRACE:
             return .no

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -86,3 +86,5 @@
 - change  `ChannelPipeline.addHandler(_:after:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`
 - Change `HTTPServerProtocolUpgrader` `protocol` to require `buildUpgradeResponse` to take a `channel` and return an `EventLoopFuture<HTTPHeaders>`.
 - `EmbeddedChannel.writeInbound/Outbound` are now `throwing`
+- `HTTPMethod.hasRequestBody` and the `HTTPMethod.HasBody` type have been removed from the public API
+- `CircularBuffer.Index` is no longer `Strideable`

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -87,4 +87,3 @@
 - Change `HTTPServerProtocolUpgrader` `protocol` to require `buildUpgradeResponse` to take a `channel` and return an `EventLoopFuture<HTTPHeaders>`.
 - `EmbeddedChannel.writeInbound/Outbound` are now `throwing`
 - `HTTPMethod.hasRequestBody` and the `HTTPMethod.HasBody` type have been removed from the public API
-- `CircularBuffer.Index` is no longer `Strideable`


### PR DESCRIPTION
Motivation:

HTTPMethod.hasRequestBody was unnecessarily public.

Modifications:

make it internal

Result:

fixes #151