### PR TITLE
CircularBuffer: debug-only index validation

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -57,6 +57,7 @@ public struct CircularBuffer<Element>: CustomStringConvertible {
 
     public struct Index: Comparable {
         @usableFromInline var _backingIndex: UInt32
+        @usableFromInline var _backingCheck: _UInt24 = .max
         @usableFromInline var isIndexGEQHeadIndex: Bool
 
         @inlinable
@@ -65,9 +66,14 @@ public struct CircularBuffer<Element>: CustomStringConvertible {
         }
 
         @inlinable
-        internal init(backingIndex: Int, backingIndexOfHead: Int) {
+        internal init(backingIndex: Int, backingCount: Int, backingIndexOfHead: Int) {
             self.isIndexGEQHeadIndex = backingIndex >= backingIndexOfHead
             self._backingIndex = UInt32(backingIndex)
+            debugOnly {
+                // if we can, we store the check for the backing here
+                self._backingCheck = backingCount < Int(_UInt24.max) ? _UInt24(UInt32(backingCount)) : .max
+            }
+            assert(MemoryLayout.size(ofValue: self) == MemoryLayout<Int>.size)
         }
         
         @inlinable
@@ -82,6 +88,11 @@ public struct CircularBuffer<Element>: CustomStringConvertible {
                 return lhs.backingIndex < rhs.backingIndex
             }
         }
+
+        @usableFromInline
+        internal func isValidIndex(for ring: CircularBuffer<Element>) -> Bool {
+            return self._backingCheck == _UInt24.max || Int(self._backingCheck) == ring.count
+         }
     }
 }
 
@@ -125,9 +136,15 @@ extension CircularBuffer: Collection, MutableCollection {
     @inlinable
     public subscript(position: Index) -> Element {
         get {
+            assert(position.isValidIndex(for: self),
+                   "illegal index used, index was for CircularBuffer with count \(position._backingCheck), " +
+                   "but actual count is \(self.count)")
             return self._buffer[position.backingIndex]!
         }
         set {
+            assert(position.isValidIndex(for: self),
+                   "illegal index used, index was for CircularBuffer with count \(position._backingCheck), " +
+                   "but actual count is \(self.count)")
             self._buffer[position.backingIndex] = newValue
         }
     }
@@ -137,7 +154,9 @@ extension CircularBuffer: Collection, MutableCollection {
     /// If the `CircularBuffer` is empty, `startIndex` is equal to `endIndex`.
     @inlinable
     public var startIndex: Index {
-        return .init(backingIndex: self.headBackingIndex, backingIndexOfHead: self.headBackingIndex)
+        return .init(backingIndex: self.headBackingIndex,
+                     backingCount: self.count,
+                     backingIndexOfHead: self.headBackingIndex)
     }
 
     /// The `CircularBuffer`'s "past the end" position---that is, the position one
@@ -151,7 +170,9 @@ extension CircularBuffer: Collection, MutableCollection {
     /// If the `CircularBuffer` is empty, `endIndex` is equal to `startIndex`.
     @inlinable
     public var endIndex: Index {
-        return .init(backingIndex: self.tailBackingIndex, backingIndexOfHead: self.headBackingIndex)
+        return .init(backingIndex: self.tailBackingIndex,
+                     backingCount: self.count,
+                     backingIndexOfHead: self.headBackingIndex)
     }
 
     /// Returns the distance between two indices.
@@ -193,6 +214,7 @@ extension CircularBuffer: RandomAccessCollection {
     @inlinable
     public func index(_ i: Index, offsetBy distance: Int) -> Index {
         return .init(backingIndex: (i.backingIndex + distance) & self.mask,
+                     backingCount: self.count,
                      backingIndexOfHead: self.headBackingIndex)
     }
 
@@ -509,7 +531,14 @@ extension CircularBuffer: RangeReplaceableCollection {
     /// *O(m)* where _m_ is the combined length of the collection and _newElements_
     @inlinable
     public mutating func replaceSubrange<C: Collection>(_ subrange: Range<Index>, with newElements: C) where Element == C.Element {
-        precondition(subrange.lowerBound >= self.startIndex && subrange.upperBound <= self.endIndex, "Subrange out of bounds")
+        precondition(subrange.lowerBound >= self.startIndex && subrange.upperBound <= self.endIndex,
+                     "Subrange out of bounds")
+        assert(subrange.lowerBound.isValidIndex(for: self),
+               "illegal index used, index was for CircularBuffer with count \(subrange.lowerBound._backingCheck), " +
+               "but actual count is \(self.count)")
+        assert(subrange.upperBound.isValidIndex(for: self),
+               "illegal index used, index was for CircularBuffer with count \(subrange.upperBound._backingCheck), " +
+               "but actual count is \(self.count)")
 
         let subrangeCount = self.distance(from: subrange.lowerBound, to: subrange.upperBound)
 
@@ -574,6 +603,9 @@ extension CircularBuffer: RangeReplaceableCollection {
     @discardableResult
     @inlinable
     public mutating func remove(at position: Index) -> Element {
+        assert(position.isValidIndex(for: self),
+               "illegal index used, index was for CircularBuffer with count \(position._backingCheck), " +
+               "but actual count is \(self.count)")
         defer {
             assert(self.verifyInvariants())
         }

--- a/Sources/NIO/IntegerTypes.swift
+++ b/Sources/NIO/IntegerTypes.swift
@@ -23,26 +23,29 @@ struct _UInt24: ExpressibleByIntegerLiteral {
     @usableFromInline var b12: UInt16
     @usableFromInline var b3: UInt8
 
-    private init(b12: UInt16, b3: UInt8) {
+    @inlinable
+    init(_b12 b12: UInt16, b3: UInt8) {
         self.b12 = b12
         self.b3 = b3
     }
 
-    @usableFromInline
+    @inlinable
     init(integerLiteral value: UInt16) {
-        self.init(b12: value, b3: 0)
+        self.init(_b12: value, b3: 0)
     }
 
     static let bitWidth: Int = 24
 
+    @inlinable
     static var max: _UInt24 {
-        return .init(b12: .max, b3: .max)
+        return .init(_b12: .max, b3: .max)
     }
 
     static let min: _UInt24 = 0
 }
 
 extension UInt32 {
+    @inlinable
     init(_ value: _UInt24) {
         var newValue: UInt32 = 0
         newValue  = UInt32(value.b12)
@@ -52,6 +55,7 @@ extension UInt32 {
 }
 
 extension Int {
+    @inlinable
     init(_ value: _UInt24) {
         var newValue: Int = 0
         newValue  = Int(value.b12)
@@ -61,6 +65,7 @@ extension Int {
 }
 
 extension _UInt24 {
+    @inlinable
     init(_ value: UInt32) {
         assert(value & 0xff_00_00_00 == 0, "value \(value) too large for _UInt24")
         self.b12 = UInt16(truncatingIfNeeded: value & 0xff_ff)

--- a/Tests/NIOTests/CircularBufferTests.swift
+++ b/Tests/NIOTests/CircularBufferTests.swift
@@ -741,19 +741,19 @@ class CircularBufferTests: XCTestCase {
         var bufferOfBackingSize4 = CircularBuffer<Int>(initialCapacity: 4)
         XCTAssertEqual(3, bufferOfBackingSize4.indexBeforeHeadIdx())
         
-        let index1 = CircularBuffer<Int>.Index(backingIndex: 0, backingIndexOfHead: 0)
-        let index2 = CircularBuffer<Int>.Index(backingIndex: 1, backingIndexOfHead: 0)
+        let index1 = CircularBuffer<Int>.Index(backingIndex: 0, backingCount: 4, backingIndexOfHead: 0)
+        let index2 = CircularBuffer<Int>.Index(backingIndex: 1, backingCount: 4, backingIndexOfHead: 0)
         XCTAssertEqual(bufferOfBackingSize4.distance(from: index1, to: index2), 1)
         
         bufferOfBackingSize4.append(1)
         XCTAssertEqual(1, bufferOfBackingSize4.removeFirst())
         XCTAssertEqual(1, bufferOfBackingSize4.headBackingIndex)
-        let index3 = CircularBuffer<Int>.Index(backingIndex: 2, backingIndexOfHead: 1)
-        let index4 = CircularBuffer<Int>.Index(backingIndex: 0, backingIndexOfHead: 1)
+        let index3 = CircularBuffer<Int>.Index(backingIndex: 2, backingCount: 4, backingIndexOfHead: 1)
+        let index4 = CircularBuffer<Int>.Index(backingIndex: 0, backingCount: 4, backingIndexOfHead: 1)
         XCTAssertEqual(bufferOfBackingSize4.distance(from: index3, to: index4), 2)
         
-        let index5 = CircularBuffer<Int>.Index(backingIndex: 0, backingIndexOfHead: 1)
-        let index6 = CircularBuffer<Int>.Index(backingIndex: 2, backingIndexOfHead: 1)
+        let index5 = CircularBuffer<Int>.Index(backingIndex: 0, backingCount: 4, backingIndexOfHead: 1)
+        let index6 = CircularBuffer<Int>.Index(backingIndex: 2, backingCount: 4, backingIndexOfHead: 1)
         XCTAssertEqual(bufferOfBackingSize4.distance(from: index5, to: index6), -2)
 
         bufferOfBackingSize4.append(2)
@@ -761,8 +761,8 @@ class CircularBufferTests: XCTestCase {
         XCTAssertEqual(2, bufferOfBackingSize4.removeFirst())
         XCTAssertEqual(3, bufferOfBackingSize4.removeFirst())
         XCTAssertEqual(3, bufferOfBackingSize4.headBackingIndex)
-        let index7 = CircularBuffer<Int>.Index(backingIndex: 0, backingIndexOfHead: 3)
-        let index8 = CircularBuffer<Int>.Index(backingIndex: 2, backingIndexOfHead: 3)
+        let index7 = CircularBuffer<Int>.Index(backingIndex: 0, backingCount: 4, backingIndexOfHead: 3)
+        let index8 = CircularBuffer<Int>.Index(backingIndex: 2, backingCount: 4, backingIndexOfHead: 3)
         XCTAssertEqual(bufferOfBackingSize4.distance(from: index7, to: index8), 2)
     }
     
@@ -770,7 +770,7 @@ class CircularBufferTests: XCTestCase {
         var bufferOfBackingSize4 = CircularBuffer<Int>(initialCapacity: 4)
         XCTAssertEqual(3, bufferOfBackingSize4.indexBeforeHeadIdx())
 
-        let index1 = CircularBuffer<Int>.Index(backingIndex: 0, backingIndexOfHead: 0)
+        let index1 = CircularBuffer<Int>.Index(backingIndex: 0, backingCount: 4, backingIndexOfHead: 0)
         let index2 = bufferOfBackingSize4.index(after: index1)
         XCTAssertEqual(index2.backingIndex, 1)
         XCTAssertEqual(index2.isIndexGEQHeadIndex, true)
@@ -781,19 +781,19 @@ class CircularBufferTests: XCTestCase {
         XCTAssertEqual(2, bufferOfBackingSize4.removeFirst())
         XCTAssertEqual(2, bufferOfBackingSize4.headBackingIndex)
 
-        let index3 = CircularBuffer<Int>.Index(backingIndex: 3, backingIndexOfHead: 2)
+        let index3 = CircularBuffer<Int>.Index(backingIndex: 3, backingCount: 4, backingIndexOfHead: 2)
         let index4 = bufferOfBackingSize4.index(after: index3)
         XCTAssertEqual(index4.backingIndex, 0)
         XCTAssertEqual(index4.isIndexGEQHeadIndex, false)
 
         bufferOfBackingSize4.prepend(3)
         XCTAssertEqual(1, bufferOfBackingSize4.headBackingIndex)
-        let index5 = CircularBuffer<Int>.Index(backingIndex: 0, backingIndexOfHead: 1)
+        let index5 = CircularBuffer<Int>.Index(backingIndex: 0, backingCount: 4, backingIndexOfHead: 1)
         let index6 = bufferOfBackingSize4.index(before: index5)
         XCTAssertEqual(index6.backingIndex, 3)
         XCTAssertEqual(index6.isIndexGEQHeadIndex, true)
         
-        let index7 = CircularBuffer<Int>.Index(backingIndex: 2, backingIndexOfHead: 1)
+        let index7 = CircularBuffer<Int>.Index(backingIndex: 2, backingCount: 4, backingIndexOfHead: 1)
         let index8 = bufferOfBackingSize4.index(before: index7)
         XCTAssertEqual(index8.backingIndex, 1)
         XCTAssertEqual(index8.isIndexGEQHeadIndex, true)


### PR DESCRIPTION
Motivation:

In the new CircularBuffer indices we had 24 spare bits, let's do
something useful with them: If it fits we can store the expected
collection size there and compare when an element is accessed through
that index.

Modifications:

add collection count to CircularBuffer.Index

Result:

we can somewhat validate the correct use of CircularBuffer indices