### PR TITLE
less confusion for Jazzy

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -25,10 +25,10 @@ private final class EmbeddedScheduledTask {
 }
 
 extension EmbeddedScheduledTask: Comparable {
-    public static func < (lhs: EmbeddedScheduledTask, rhs: EmbeddedScheduledTask) -> Bool {
+    static func < (lhs: EmbeddedScheduledTask, rhs: EmbeddedScheduledTask) -> Bool {
         return lhs.readyTime < rhs.readyTime
     }
-    public static func == (lhs: EmbeddedScheduledTask, rhs: EmbeddedScheduledTask) -> Bool {
+    static func == (lhs: EmbeddedScheduledTask, rhs: EmbeddedScheduledTask) -> Bool {
         return lhs === rhs
     }
 }

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -988,7 +988,7 @@ typealias ThreadInitializer = (NIOThread) -> Void
 ///            tests. In those cases it's important to shut the `MultiThreadedEventLoopGroup` down at the end of the
 ///            test. A good place to start a `MultiThreadedEventLoopGroup` is the `setUp` method of your `XCTestCase`
 ///            subclass, a good place to shut it down is the `tearDown` method.
-final public class MultiThreadedEventLoopGroup: EventLoopGroup {
+public final class MultiThreadedEventLoopGroup: EventLoopGroup {
 
     private static let threadSpecificEventLoop = ThreadSpecificVariable<SelectableEventLoop>()
 
@@ -1148,11 +1148,11 @@ extension ScheduledTask: CustomStringConvertible {
 }
 
 extension ScheduledTask: Comparable {
-    public static func < (lhs: ScheduledTask, rhs: ScheduledTask) -> Bool {
+    static func < (lhs: ScheduledTask, rhs: ScheduledTask) -> Bool {
         return lhs.readyTime < rhs.readyTime
     }
 
-    public static func == (lhs: ScheduledTask, rhs: ScheduledTask) -> Bool {
+    static func == (lhs: ScheduledTask, rhs: ScheduledTask) -> Bool {
         return lhs === rhs
     }
 }

--- a/Sources/NIO/Heap.swift
+++ b/Sources/NIO/Heap.swift
@@ -183,7 +183,7 @@ internal struct Heap<T: Comparable> {
 }
 
 extension Heap: CustomDebugStringConvertible {
-    public var debugDescription: String {
+    var debugDescription: String {
         guard self.storage.count > 0 else {
             return "<empty heap>"
         }

--- a/Sources/NIO/PriorityQueue.swift
+++ b/Sources/NIO/PriorityQueue.swift
@@ -59,7 +59,7 @@ extension PriorityQueue: Equatable {
 }
 
 extension PriorityQueue: Sequence {
-    public struct Iterator: IteratorProtocol {
+    struct Iterator: IteratorProtocol {
 
         private var queue: PriorityQueue<Element>
         fileprivate init(queue: PriorityQueue<Element>) {
@@ -71,7 +71,7 @@ extension PriorityQueue: Sequence {
         }
     }
 
-    public func makeIterator() -> Iterator {
+    func makeIterator() -> Iterator {
         return Iterator(queue: self)
     }
 }
@@ -83,7 +83,7 @@ extension PriorityQueue {
 }
 
 extension PriorityQueue: CustomStringConvertible {
-    public var description: String {
+    var description: String {
         return "PriorityQueue(count: \(self.underestimatedCount)): \(Array(self))"
     }
 }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -829,7 +829,7 @@ extension DatagramChannel: MulticastChannel {
         }
     }
 
-    public func joinGroup(_ group: SocketAddress, interface: NIONetworkInterface?, promise: EventLoopPromise<Void>?) {
+    func joinGroup(_ group: SocketAddress, interface: NIONetworkInterface?, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
             self.performGroupOperation0(group, interface: interface, promise: promise, operation: .join)
         } else {
@@ -839,7 +839,7 @@ extension DatagramChannel: MulticastChannel {
         }
     }
 
-    public func leaveGroup(_ group: SocketAddress, interface: NIONetworkInterface?, promise: EventLoopPromise<Void>?) {
+    func leaveGroup(_ group: SocketAddress, interface: NIONetworkInterface?, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
             self.performGroupOperation0(group, interface: interface, promise: promise, operation: .leave)
         } else {

--- a/Sources/NIO/SocketOptionProvider.swift
+++ b/Sources/NIO/SocketOptionProvider.swift
@@ -235,7 +235,7 @@ extension SocketOptionProvider {
 
 
 extension BaseSocketChannel: SocketOptionProvider {
-    public func unsafeSetSocketOption<Value>(level: SocketOptionLevel, name: SocketOptionName, value: Value) -> EventLoopFuture<Void> {
+    func unsafeSetSocketOption<Value>(level: SocketOptionLevel, name: SocketOptionName, value: Value) -> EventLoopFuture<Void> {
         if eventLoop.inEventLoop {
             let promise = eventLoop.makePromise(of: Void.self)
             executeAndComplete(promise) {
@@ -249,7 +249,7 @@ extension BaseSocketChannel: SocketOptionProvider {
         }
     }
 
-    public func unsafeGetSocketOption<Value>(level: SocketOptionLevel, name: SocketOptionName) -> EventLoopFuture<Value> {
+    func unsafeGetSocketOption<Value>(level: SocketOptionLevel, name: SocketOptionName) -> EventLoopFuture<Value> {
         if eventLoop.inEventLoop {
             let promise = eventLoop.makePromise(of: Value.self)
             executeAndComplete(promise) {


### PR DESCRIPTION
[looks like a SemVer major change but isn't (or it really shouldn't be)]

Motivation:

Jazzy adds everything that has a `public` modifier to the documentation,
even if a type is `internal` or `private`. So conforming and internal
type to some protocol and making all those functions `public` has the
effect of essentially documenting stuff that you can't call (as it's not
actually public).

Modifications:

- remove `public` from functions in extensions on types that aren't
  public
- change one `final public` to `public final` because Jazzy doesn't
  normalise that

Result:

better docs