### PR TITLE
Adds a couple of missing example server projects to the README file. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ There are currently several example projects that demonstrate how to use SwiftNI
 - **echo client** https://github.com/apple/swift-nio/tree/master/Sources/NIOEchoClient
 - **echo server** https://github.com/apple/swift-nio/tree/master/Sources/NIOEchoServer
 - **HTTP server** https://github.com/apple/swift-nio/tree/master/Sources/NIOHTTP1Server
+- **UDP echo server** https://github.com/apple/swift-nio/tree/master/Sources/NIOUDPEchoServer
+- **WebSocket server** https://github.com/apple/swift-nio/tree/master/Sources/NIOWebSocketServer
 
 ## Getting Started
 


### PR DESCRIPTION
Adds a couple of missing example server projects to the README file to complete the list of the examples included in the project folder.

### Motivation:

The README file example list is missing a couple of examples which are actually in the project, namely the UDP and WebSocket server example projects.

### Modifications:

Added UDP and WebSocket server example projects to the README.

### Result:

A full list of examples is now included in the README file.