### PR TITLE
Scheduled: Don't hold onto cancellationTask

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -21,7 +21,6 @@ import Dispatch
 /// will be notified once the execution is complete.
 public struct Scheduled<T> {
     private let promise: EventLoopPromise<T>
-    private let cancellationTask: () -> Void
 
     public init(promise: EventLoopPromise<T>, cancellationTask: @escaping () -> Void) {
         self.promise = promise
@@ -33,7 +32,6 @@ public struct Scheduled<T> {
                 cancellationTask()
             }
         }
-        self.cancellationTask = cancellationTask
     }
 
     /// Try to cancel the execution of the scheduled task.

--- a/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
@@ -40,6 +40,7 @@ extension EmbeddedEventLoopTest {
                 ("testScheduledTasksFuturesFire", testScheduledTasksFuturesFire),
                 ("testScheduledTasksFuturesError", testScheduledTasksFuturesError),
                 ("testTaskOrdering", testTaskOrdering),
+                ("testCancelledScheduledTasksDoNotHoldOnToRunClosure", testCancelledScheduledTasksDoNotHoldOnToRunClosure),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -52,6 +52,7 @@ extension EventLoopTest {
                 ("testRepeatedTaskThatCancelsItselfNotifiesOnlyWhenFinished", testRepeatedTaskThatCancelsItselfNotifiesOnlyWhenFinished),
                 ("testAndAllCompleteWithZeroFutures", testAndAllCompleteWithZeroFutures),
                 ("testAndAllSucceedWithZeroFutures", testAndAllSucceedWithZeroFutures),
+                ("testCancelledScheduledTasksDoNotHoldOnToRunClosure", testCancelledScheduledTasksDoNotHoldOnToRunClosure),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -752,4 +752,30 @@ public class EventLoopTest : XCTestCase {
         }
         done.wait()
     }
+
+    func testCancelledScheduledTasksDoNotHoldOnToRunClosure() {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        class Thing {}
+
+        weak var weakThing: Thing? = nil
+
+        func make() -> Scheduled<Never> {
+            let aThing = Thing()
+            weakThing = aThing
+            return group.next().scheduleTask(in: .hours(1)) {
+                preconditionFailure("this should definitely not run: \(aThing)")
+            }
+        }
+
+        let scheduled = make()
+        scheduled.cancel()
+        assert(weakThing == nil, within: .seconds(1))
+        XCTAssertThrowsError(try scheduled.futureResult.wait()) { error in
+            XCTAssertEqual(EventLoopError.cancelled, error as? EventLoopError)
+        }
+    }
 }

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -230,7 +230,7 @@ func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testI
     } while (NIODeadline.now() < endTime)
 
     if !condition() {
-        XCTFail(message)
+        XCTFail(message, file: file, line: line)
     }
 }
 


### PR DESCRIPTION
Motivation:

For whatever reason, Scheduled stored the cancellationTask in two
places, one of them it never even used :).

Modifications:

only have the promise have a reference to the cancellationTask

Result:

- don't hold onto things longer than necessary
- shrink Scheduled by one word :)