### PR TITLE
CircBuffer: docs: add that indices are no longer Strideable

### DIFF
--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -71,7 +71,7 @@
 - renamed `EventLoopFuture.hopTo(eventLoop:)` to `EventLoopFuture.hop(to:)`
 - `EventLoopFuture.reduce(into:_:eventLoop:_:)` had its label signature changed to `EventLoopFuture.reduce(into:_:on:_:)`
 - `EventLoopFuture.reduce(_:_:eventLoop:_:` had its label signature changed to `EventLoopFuture.reduce(_:_:on:_:)`
-- `CircularBuffer` and `MarkedCircularBuffer`'s indices are now opaque
+- `CircularBuffer` and `MarkedCircularBuffer`'s indices are now opaque and no longer `Strideable`, use `CircularBuffer.index(...)` for index calculations
 - all `ChannelOption`s are now required to be  `Equatable`
 - `HTTPHeaderIndex` has been removed, without replacement
 - `HTTPHeader` has been removed, without replacement


### PR DESCRIPTION
Motivation:

CircularBuffer indices are no longer `Strideable`, document this.

Modifications:

added to the public api changes doc

Result:

better docs