### PR TITLE
EmbeddedChannel: remove mystery bools

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -132,7 +132,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         // Prime the decoder with a GET and consume it.
-        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: version, method: .GET, uri: "/"))))
+        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: version, method: .GET, uri: "/"))).isFull)
         XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
 
         // We now want to send a HTTP/1.1 response. This response has no content-length, no transfer-encoding,
@@ -166,7 +166,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertTrue(handler.receivedEnd)
         XCTAssertTrue(handler.eof)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func testHTTP11SemanticEOFOnChannelInactive() throws {
@@ -197,7 +197,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         // Prime the decoder with a request and consume it.
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
                                                                                            method: requestMethod,
-                                                                                           uri: "/"))))
+                                                                                           uri: "/"))).isFull)
         XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
 
         // We now want to send a HTTP/1.1 response. This response may contain some length framing fields that RFC 7230 says MUST
@@ -222,7 +222,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertFalse(handler.seenBody)
         XCTAssert(handler.seenEnd)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func testIgnoresTransferEncodingFieldOnCONNECTResponses() throws {
@@ -305,7 +305,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertFalse(handler.seenBody)
         XCTAssert(handler.seenEnd)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func testMultipleTEWithChunkedLastHasNoBodyOnRequest() throws {
@@ -336,7 +336,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         // Prime the decoder with a request and consume it.
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
                                                                                            method: .GET,
-                                                                                           uri: "/"))))
+                                                                                           uri: "/"))).isFull)
         XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
 
         // Send a 200 with the appropriate Transfer Encoding header. We should see the request,
@@ -362,7 +362,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssert(handler.seenBody)
         XCTAssert(handler.seenEnd)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func testMultipleTEWithChunkedLastHasEOFBodyOnResponseWithChannelInactive() throws {
@@ -422,7 +422,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         // Prime the decoder with a request.
         XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
                                                                                            method: .GET,
-                                                                                           uri: "/"))))
+                                                                                           uri: "/"))).isFull)
 
         // Send a 200 OK with the invalid headers.
         do {
@@ -524,6 +524,6 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertFalse(handler.seenBody)
         XCTAssert(handler.seenEnd)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -102,7 +102,7 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertTrue(writtenBytes.contains("SET-COOKIE: foo=bar\r\n"))
         XCTAssertTrue(writtenBytes.contains("Set-Cookie: buz=cux\r\n"))
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func testRevealHeadersSeparately() {

--- a/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
@@ -26,7 +26,7 @@ class HTTPRequestEncoderTests: XCTestCase {
     private func sendRequest(withMethod method: HTTPMethod, andHeaders headers: HTTPHeaders) throws -> ByteBuffer {
         let channel = EmbeddedChannel()
         defer {
-            XCTAssertEqual(.some(false), try? channel.finish())
+            XCTAssertEqual(true, try? channel.finish().isClean)
         }
 
         try channel.pipeline.addHandler(HTTPRequestEncoder()).wait()
@@ -75,7 +75,7 @@ class HTTPRequestEncoderTests: XCTestCase {
     func testNoChunkedEncodingForHTTP10() throws {
         let channel = EmbeddedChannel()
         defer {
-            XCTAssertEqual(.some(false), try? channel.finish())
+            XCTAssertEqual(true, try? channel.finish().isClean)
         }
 
         XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
@@ -91,7 +91,7 @@ class HTTPRequestEncoderTests: XCTestCase {
     func testBody() throws {
         let channel = EmbeddedChannel()
         defer {
-            XCTAssertEqual(.some(false), try? channel.finish())
+            XCTAssertEqual(true, try? channel.finish().isClean)
         }
 
         try channel.pipeline.addHandler(HTTPRequestEncoder()).wait()
@@ -113,7 +113,7 @@ class HTTPRequestEncoderTests: XCTestCase {
     func testCONNECT() throws {
         let channel = EmbeddedChannel()
         defer {
-            XCTAssertEqual(.some(false), try? channel.finish())
+            XCTAssertEqual(true, try? channel.finish().isClean)
         }
 
         let uri = "server.example.com:80"

--- a/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
@@ -26,7 +26,7 @@ class HTTPResponseEncoderTests: XCTestCase {
     private func sendResponse(withStatus status: HTTPResponseStatus, andHeaders headers: HTTPHeaders) -> ByteBuffer {
         let channel = EmbeddedChannel()
         defer {
-            XCTAssertEqual(.some(false), try? channel.finish())
+            XCTAssertEqual(true, try? channel.finish().isClean)
         }
 
         XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait())
@@ -102,7 +102,7 @@ class HTTPResponseEncoderTests: XCTestCase {
     func testNoChunkedEncodingForHTTP10() throws {
         let channel = EmbeddedChannel()
         defer {
-            XCTAssertEqual(.some(false), try? channel.finish())
+            XCTAssertEqual(true, try? channel.finish().isClean)
         }
 
         XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait())

--- a/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPUpgradeTests.swift
@@ -376,7 +376,7 @@ class HTTPUpgradeTestCase: XCTestCase {
     func testUpgradeHandlerBarfsOnUnexpectedOrdering() throws {
         let channel = EmbeddedChannel()
         defer {
-            XCTAssertEqual(.some(false), try? channel.finish())
+            XCTAssertEqual(true, try? channel.finish().isClean)
         }
 
         let handler = HTTPServerUpgradeHandler(upgraders: [ExplodingUpgrader(forProtocol: "myproto")],
@@ -844,7 +844,7 @@ class HTTPUpgradeTestCase: XCTestCase {
         defer {
             do {
                 let complete = try channel.finish()
-                XCTAssertFalse(complete)
+                XCTAssertTrue(complete.isClean)
             } catch No.no {
                 // ok
             } catch {
@@ -911,8 +911,8 @@ class HTTPUpgradeTestCase: XCTestCase {
         let channel = EmbeddedChannel()
         defer {
             do {
-                let complete = try channel.finish()
-                XCTAssertFalse(complete)
+                let isCleanOnFinish = try channel.finish().isClean
+                XCTAssertTrue(isCleanOnFinish)
             } catch No.no {
                 // ok
             } catch {
@@ -982,8 +982,8 @@ class HTTPUpgradeTestCase: XCTestCase {
         let channel = EmbeddedChannel()
         defer {
             do {
-                let complete = try channel.finish()
-                XCTAssertFalse(complete)
+                let isCleanOnFinish = try channel.finish().isClean
+                XCTAssertTrue(isCleanOnFinish)
             } catch No.no {
                 // ok
             } catch {

--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests.swift
@@ -52,7 +52,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         // The channel handler should still be in the pipeline.
         try channel.pipeline.assertContains(handler: handler)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     private func negotiateTest(event: TLSUserEvent, expectedResult: ALPNResult) throws {
@@ -85,7 +85,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         // Now the handler should have removed itself from the pipeline.
         try channel.pipeline.assertDoesNotContain(handler: handler)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func testCallbackReflectsNotificationResult() throws {
@@ -111,7 +111,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         try channel.writeInbound("hello")
         XCTAssertNoThrow(XCTAssertEqual(try channel.readInbound()!, "hello"))
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func testBufferingWhileWaitingForFuture() throws {
@@ -142,7 +142,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertEqual(try channel.readInbound()!, "are"))
         XCTAssertNoThrow(XCTAssertEqual(try channel.readInbound()!, "buffered"))
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func testNothingBufferedDoesNotFireReadCompleted() throws {
@@ -169,7 +169,7 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
         continuePromise.succeed(())
         XCTAssertEqual(readCompleteHandler.readCompleteCount, 0)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func testUnbufferingFiresReadCompleted() throws {
@@ -200,6 +200,6 @@ class ApplicationProtocolNegotiationHandlerTests: XCTestCase {
 
         XCTAssertEqual(readCompleteHandler.readCompleteCount, 2)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 }

--- a/Tests/NIOTLSTests/SNIHandlerTests.swift
+++ b/Tests/NIOTLSTests/SNIHandlerTests.swift
@@ -303,7 +303,7 @@ class SNIHandlerTest: XCTestCase {
 
         try channel.pipeline.assertDoesNotContain(handler: handler)
 
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     /// Blasts the client hello in as a single string. This is not expected to reveal bugs
@@ -348,7 +348,7 @@ class SNIHandlerTest: XCTestCase {
         }
 
         try channel.pipeline.assertDoesNotContain(handler: handler)
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
     }
 
     func assertIncompleteInput(clientHello: String) throws {

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -175,7 +175,7 @@ class IdleStateHandlerTest : XCTestCase {
         channel.pipeline.fireChannelInactive()
         channel.pipeline.fireChannelUnregistered()
         
-        XCTAssertFalse(try channel.finish())
+        XCTAssertTrue(try channel.finish().isClean)
         eventHandler.assertAllEventsReceived()
     }
 }

--- a/Tests/NIOWebSocketTests/EndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/EndToEndTests.swift
@@ -29,8 +29,8 @@ extension EmbeddedChannel {
 
     func finishAcceptingAlreadyClosed() throws {
         do {
-            let res = try self.finish()
-            XCTAssertFalse(res)
+            let result = try self.finish().isClean
+            XCTAssertTrue(result)
         } catch ChannelError.alreadyClosed {
             // ok
         }

--- a/docs/public-api-changes-NIO1-to-NIO2.md
+++ b/docs/public-api-changes-NIO1-to-NIO2.md
@@ -86,4 +86,5 @@
 - change  `ChannelPipeline.addHandler(_:after:)` to  `ChannelPipeline.addHandler(_:postion:)` where `position` can be `.first`, `.last`, `.before(ChannelHandler)`, and `.after(ChannelHandler)`
 - Change `HTTPServerProtocolUpgrader` `protocol` to require `buildUpgradeResponse` to take a `channel` and return an `EventLoopFuture<HTTPHeaders>`.
 - `EmbeddedChannel.writeInbound/Outbound` are now `throwing`
+- `EmbeddedChannel.finish/writeInbound/writeOutbound` now return an `enum` representation of their effects rather than mystery bools.
 - `HTTPMethod.hasRequestBody` and the `HTTPMethod.HasBody` type have been removed from the public API


### PR DESCRIPTION
Motivation:

EmbeddedChannel.finish/writeInbound/writeOutbound returned some mystery
bools. I always had to check the code to remember what they actually
meaned.

Whilst this is technically a breaking change, I couldn't find any users
of the return values on Github that are using the convergence releases.

Modifications:

Replace them by enums giving you all the information.

Result:

- fixes #916
- clearer APIs