### PR TITLE
use Swift 5.0-RELEASE

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,8 +8,6 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-03-10-a"
-        swift_builds_suffix: "branch"
         skip_ruby_from_ppa: "true"
 
   unit-tests:


### PR DESCRIPTION
Motivation:

Now that Swift 5 is released, we should use the release version.

Modifications:

switch to Swift 5.0-RELEASE.

Result:

newer, shinier