### PR TITLE
alloc tests: improve ByteBuffer lots of RW test

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Package.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftBootstrap",
-            dependencies: ["NIO", "NIOHTTP1"]),
+            dependencies: ["NIO", "NIOHTTP1", "NIOFoundationCompat"]),
         .target(
             name: "bootstrap",
             dependencies: ["SwiftBootstrap", "HookedFunctions"]),

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -38,6 +38,39 @@ public enum ByteBufferFoundationError: Error {
  */
 
 extension ByteBuffer {
+    /// Copies `bytes` into this `ByteBuffer` at offset `index`.
+    ///
+    /// - parameters:
+    ///     - bytes: The bytes to copy.
+    ///     - index: The index to copy the bytes to.
+    /// - returns: The number of bytes copied.
+    ///
+    /// This is necessary to work around https://bugs.swift.org/browse/SR-10219
+    @discardableResult
+    @inlinable
+    public mutating func setBytes(_ bytes: Data, at index: Int) -> Int {
+        return bytes.withUnsafeBytes { ptr in
+            self.setBytes(ptr, at: index)
+        }
+    }
+
+    /// Copies `bytes` into this `ByteBuffer` starting at `writerIndex` and move `writerIndex`.
+    ///
+    /// After this method returns, `writerIndex` will have moved forward by the number of bytes written. The number
+    /// of bytes written is also returned by this method.
+    ///
+    /// - parameters:
+    ///     - bytes: The bytes to copy.
+    /// - returns: The number of bytes copied.
+    ///
+    /// This is necessary to work around https://bugs.swift.org/browse/SR-10219
+    @discardableResult
+    @inlinable
+    public mutating func writeBytes(_ bytes: Data) -> Int {
+        return bytes.withUnsafeBytes { ptr in
+            self.writeBytes(ptr)
+        }
+    }
 
     // MARK: Data APIs
 

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -20,7 +20,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1177050 # was: 685050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   test:
@@ -30,7 +30,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1177050 # was: 685050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=3100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
 
   echo:


### PR DESCRIPTION
Motivation:

Allocation profiles have changed with Swift 5, we should reflect this in
this test.

Modifications:

- fix the comments
- add `writeData` that should now be allocation free
- add `readData` that should be one allocation

Result:

better test coverage in the alloc tests