### PR TITLE
Add 2 missing server readme docs.

### DIFF
--- a/Sources/NIOUDPEchoServer/README.md
+++ b/Sources/NIOUDPEchoServer/README.md
@@ -1,0 +1,11 @@
+# NIOUDPEchoServer
+
+This sample application provides a simple UDP echo server that sends clients back whatever data they send it. Invoke it using one of the following syntaxes:
+
+```bash
+swift run NIOEchoServer  # Binds the server on ::1, port 9999.
+swift run NIOEchoServer 9899  # Binds the server on ::1, port 9899
+swift run NIOEchoServer /path/to/unix/socket  # Binds the server using the given UNIX socket
+swift run NIOEchoServer 192.168.0.5 9899  # Binds the server on 192.168.0.5:9899
+```
+

--- a/Sources/NIOUDPEchoServer/README.md
+++ b/Sources/NIOUDPEchoServer/README.md
@@ -3,9 +3,9 @@
 This sample application provides a simple UDP echo server that sends clients back whatever data they send it. Invoke it using one of the following syntaxes:
 
 ```bash
-swift run NIOEchoServer  # Binds the server on ::1, port 9999.
-swift run NIOEchoServer 9899  # Binds the server on ::1, port 9899
-swift run NIOEchoServer /path/to/unix/socket  # Binds the server using the given UNIX socket
-swift run NIOEchoServer 192.168.0.5 9899  # Binds the server on 192.168.0.5:9899
+swift run NIOUDPEchoServer  # Binds the server on ::1, port 9999.
+swift run NIOUDPEchoServer 9899  # Binds the server on ::1, port 9899
+swift run NIOUDPEchoServer /path/to/unix/socket  # Binds the server using the given UNIX socket
+swift run NIOUDPEchoServer 192.168.0.5 9899  # Binds the server on 192.168.0.5:9899
 ```
 

--- a/Sources/NIOWebSocketServer/README.md
+++ b/Sources/NIOWebSocketServer/README.md
@@ -3,10 +3,10 @@
 This sample application provides a simple WebSocket server which replies to a limited number of WebSocket message types. Initially, it sends clients back a test page response to a valid HTTP1 GET request. A 405 error will be reported for any other type of request. Once upgraded to WebSocket responses it will respond to a number of WebSocket message opcodes. Invoke it using one of the following syntaxes:
 
 ```bash
-swift run NIOEchoServer  # Binds the server on 'localhost', port 8888.
-swift run NIOEchoServer 9899  # Binds the server on 'localhost', port 9899
-swift run NIOEchoServer /path/to/unix/socket  # Binds the server using the given UNIX socket
-swift run NIOEchoServer 192.168.0.5 9899  # Binds the server on 192.168.0.5:9899
+swift run NIOWebSocketServer  # Binds the server on 'localhost', port 8888.
+swift run NIOWebSocketServer 9899  # Binds the server on 'localhost', port 9899
+swift run NIOWebSocketServer /path/to/unix/socket  # Binds the server using the given UNIX socket
+swift run NIOWebSocketServer 192.168.0.5 9899  # Binds the server on 192.168.0.5:9899
 ```
 
 ## Message Type Opcodes

--- a/Sources/NIOWebSocketServer/README.md
+++ b/Sources/NIOWebSocketServer/README.md
@@ -1,0 +1,20 @@
+# NIOWebSocketServer
+
+This sample application provides a simple WebSocket server which replies to a limited number of WebSocket message types. Initially, it sends clients back a test page response to a valid HTTP1 GET request. A 405 error will be reported for any other type of request. Once upgraded to WebSocket responses it will respond to a number of WebSocket message opcodes. Invoke it using one of the following syntaxes:
+
+```bash
+swift run NIOEchoServer  # Binds the server on 'localhost', port 8888.
+swift run NIOEchoServer 9899  # Binds the server on 'localhost', port 9899
+swift run NIOEchoServer /path/to/unix/socket  # Binds the server using the given UNIX socket
+swift run NIOEchoServer 192.168.0.5 9899  # Binds the server on 192.168.0.5:9899
+```
+
+## Message Type Opcodes
+
+The WebSocket server responds to the following message type opcodes:
+
+- `connectionClose`: closes the connection.
+- `ping`: replies with a 'pong' message containing frame data matching the received message.
+- `text`: prints the received string out on the server console.
+
+All other message types are ignored.


### PR DESCRIPTION
Add missing server readme docs for WebSocket server and UDP echo server.

### Motivation:

With the exception of these two samples, all client and server examples have helpful readme docs.
The readme docs provide a brief description of the purpose of the sample code and how to run it.

### Modifications:

Adds a readme to NIOUDPEchoServer.
Adds a readme to NIOWebSocketServer.

### Result:

The samples for NIOUDPEchoServer and NIOWebSocketServer have a little explanation.
