### PR TITLE
Backport `whenAll[Succeed]` to NIO 1

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -862,24 +862,6 @@ extension EventLoopFuture {
         }
         return body
     }
-}
-
-extension EventLoopFuture {
-    /// Returns a new `EventLoopFuture` that fires only when all the provided futures complete.
-    ///
-    /// This extension is only available when you have a collection of `EventLoopFuture`s that do not provide
-    /// result data: that is, they are completion notifiers. In this case, you can wait for all of them. The
-    /// returned `EventLoopFuture` will fail as soon as any of the futures fails: otherwise, it will succeed
-    /// only when all of them do.
-    ///
-    /// - parameters:
-    ///     - futures: An array of `EventLoopFuture<Void>` to wait for.
-    ///     - eventLoop: The `EventLoop` on which the new `EventLoopFuture` callbacks will fire.
-    /// - returns: A new `EventLoopFuture`.
-    public static func andAll(_ futures: [EventLoopFuture<Void>], eventLoop: EventLoop) -> EventLoopFuture<Void> {
-        let body = EventLoopFuture<Void>.reduce((), futures, eventLoop: eventLoop) { (_: (), _: ()) in }
-        return body
-    }
 
     /// Returns a new `EventLoopFuture` that fires only when all the provided futures complete.
     /// The new `EventLoopFuture` contains the result of reducing the `initialResult` with the
@@ -951,7 +933,7 @@ extension EventLoopFuture {
 }
 
 // "fail fast" reduce
-public extension EventLoopFuture {
+extension EventLoopFuture {
     /// Returns a new `EventLoopFuture` that succeeds only if all of the provided futures succeed.
     ///
     /// This method acts as a successful completion notifier - values fulfilled by each future are discarded.
@@ -963,8 +945,8 @@ public extension EventLoopFuture {
     ///     - futures: An array of homogenous `EventLoopFutures`s to wait for.
     ///     - on: The `EventLoop` on which the new `EventLoopFuture` callbacks will execute on.
     /// - Returns: A new `EventLoopFuture` that waits for the other futures to succeed.
-    public static func andAllSucceed(_ futures: [EventLoopFuture<Value>], on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
+    public static func andAll(_ futures: [EventLoopFuture<T>], eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        let promise = eventLoop.newPromise(of: Void.self)
 
         if eventLoop.inEventLoop {
             self._reduceSuccesses0(promise, futures, eventLoop, onValue: { _, _ in })
@@ -985,11 +967,11 @@ public extension EventLoopFuture {
     ///     - futures: An array of homogenous `EventLoopFuture`s to wait on for fulfilled values.
     ///     - on: The `EventLoop` on which the new `EventLoopFuture` callbacks will fire.
     /// - Returns: A new `EventLoopFuture` with all of the values fulfilled by the provided futures.
-    public static func whenAllSucceed(_ futures: [EventLoopFuture<Value>], on eventLoop: EventLoop) -> EventLoopFuture<[Value]> {
-        let promise = eventLoop.makePromise(of: Void.self)
+    public static func whenAll(_ futures: [EventLoopFuture<T>], eventLoop: EventLoop) -> EventLoopFuture<[T]> {
+        let promise = eventLoop.newPromise(of: Void.self)
 
-        var results: [Value?] = .init(repeating: nil, count: futures.count)
-        let callback = { (index: Int, result: Value) in
+        var results: [T?] = .init(repeating: nil, count: futures.count)
+        let callback = { (index: Int, result: T) in
             results[index] = result
         }
 
@@ -1022,29 +1004,29 @@ public extension EventLoopFuture {
         var remainingCount = futures.count
 
         if remainingCount == 0 {
-            promise.succeed(())
+            promise.succeed(result: ())
             return
         }
 
         // Sends the result to `onValue` in case of success and succeeds/fails the input promise, if appropriate.
-        func processResult(_ index: Int, _ result: Result<InputValue, Error>) {
+        func processResult(_ index: Int, _ result: EventLoopFutureValue<InputValue>) {
             switch result {
             case .success(let result):
                 onValue(index, result)
                 remainingCount -= 1
 
                 if remainingCount == 0 {
-                    promise.succeed(())
+                    promise.succeed(result: ())
                 }
             case .failure(let error):
-                promise.fail(error)
+                promise.fail(error: error)
             }
         }
         // loop through the futures to chain callbacks to execute on the initiating event loop and grab their index
         // in the "futures" to pass their result to the caller
         for (index, future) in futures.enumerated() {
             if future.eventLoop.inEventLoop,
-                let result = future._value {
+                let result = future.value {
                 // Fast-track already-fulfilled results without the overhead of calling `whenComplete`. This can yield a
                 // ~20% performance improvement in the case of large arrays where all elements are already fulfilled.
                 processResult(index, result)
@@ -1052,115 +1034,8 @@ public extension EventLoopFuture {
                     return  // Once the promise is failed, future results do not need to be processed.
                 }
             } else {
-                future.hop(to: eventLoop)
-                    .whenComplete { result in processResult(index, result) }
-            }
-        }
-    }
-}
-
-// "fail slow" reduce
-extension EventLoopFuture {
-    /// Returns a new `EventLoopFuture` that succeeds when all of the provided `EventLoopFuture`s complete.
-    ///
-    /// The returned `EventLoopFuture` always succeeds, acting as a completion notification.
-    /// Values fulfilled by each future are discarded.
-    ///
-    /// If the results are needed, use `whenAllComplete` instead.
-    /// - Parameters:
-    ///     - futures: An array of homogenous `EventLoopFuture`s to wait for.
-    ///     - on: The `EventLoop` on which the new `EventLoopFuture` callbacks will execute on.
-    /// - Returns: A new `EventLoopFuture` that succeeds after all futures complete.
-    public static func andAllComplete(_ futures: [EventLoopFuture<Value>], on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
-
-        if eventLoop.inEventLoop {
-            self._reduceCompletions0(promise, futures, eventLoop, onResult: { _, _ in })
-        } else {
-            eventLoop.execute {
-                self._reduceCompletions0(promise, futures, eventLoop, onResult: { _, _ in })
-            }
-        }
-
-        return promise.futureResult
-    }
-
-    /// Returns a new `EventLoopFuture` that succeeds when all of the provided `EventLoopFuture`s complete.
-    /// The new `EventLoopFuture` will contain an array of results, maintaining ordering for each of the `EventLoopFuture`s.
-    ///
-    /// The returned `EventLoopFuture` always succeeds, regardless of any failures from the waiting futures.
-    ///
-    /// If it is desired to flatten them into a single `EventLoopFuture` that fails on the first `EventLoopFuture` failure,
-    /// use one of the `reduce` methods instead.
-    /// - Parameters:
-    ///     - futures: An array of homogenous `EventLoopFuture`s to gather results from.
-    ///     - on: The `EventLoop` on which the new `EventLoopFuture` callbacks will fire.
-    /// - Returns: A new `EventLoopFuture` with all the results of the provided futures.
-    public static func whenAllComplete(_ futures: [EventLoopFuture<Value>],
-                                       on eventLoop: EventLoop) -> EventLoopFuture<[Result<Value, Error>]> {
-        let promise = eventLoop.makePromise(of: Void.self)
-
-        var results: [Result<Value, Error>] = .init(repeating: .failure(OperationPlaceholderError()), count: futures.count)
-        let callback = { (index: Int, result: Result<Value, Error>) in
-            results[index] = result
-        }
-
-        if eventLoop.inEventLoop {
-            self._reduceCompletions0(promise, futures, eventLoop, onResult: callback)
-        } else {
-            eventLoop.execute {
-                self._reduceCompletions0(promise, futures, eventLoop, onResult: callback)
-            }
-        }
-
-        return promise.futureResult.map {
-            // verify that all operations have been completed
-            assert(!results.contains(where: {
-                guard case let .failure(error) = $0 else { return false }
-                return error is OperationPlaceholderError
-            }))
-
-            return results
-        }
-    }
-
-    /// Loops through the futures array and attaches callbacks to execute `onResult` on the provided `EventLoop` when
-    /// they complete. The `onResult` will receive the index of the future that fulfilled the provided `Result`.
-    ///
-    /// Once all the futures have completed, the provided promise will succeed.
-    private static func _reduceCompletions0<InputValue>(_ promise: EventLoopPromise<Void>,
-                                                        _ futures: [EventLoopFuture<InputValue>],
-                                                        _ eventLoop: EventLoop,
-                                                        onResult: @escaping (Int, Result<InputValue, Error>) -> Void) {
-        eventLoop.assertInEventLoop()
-
-        var remainingCount = futures.count
-
-        if remainingCount == 0 {
-            promise.succeed(())
-            return
-        }
-
-        // Sends the result to `onResult` in case of success and succeeds the input promise, if appropriate.
-        func processResult(_ index: Int, _ result: Result<InputValue, Error>) {
-            onResult(index, result)
-            remainingCount -= 1
-
-            if remainingCount == 0 {
-                promise.succeed(())
-            }
-        }
-        // loop through the futures to chain callbacks to execute on the initiating event loop and grab their index
-        // in the "futures" to pass their result to the caller
-        for (index, future) in futures.enumerated() {
-            if future.eventLoop.inEventLoop,
-                let result = future._value {
-                // Fast-track already-fulfilled results without the overhead of calling `whenComplete`. This can yield a
-                // ~30% performance improvement in the case of large arrays where all elements are already fulfilled.
-                processResult(index, result)
-            } else {
-                future.hop(to: eventLoop)
-                    .whenComplete { result in processResult(index, result) }
+                future.hopTo(eventLoop: eventLoop)
+                    ._whenCompleteWithValue { result in processResult(index, result) }
             }
         }
     }

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -614,3 +614,90 @@ measureAndPrint(desc: "http1_10k_reqs_100_conns") {
     }
     return reqs.reduce(0, +) / reqsPerConn
 }
+
+measureAndPrint(desc: "future_whenallsucceed_100k_immediately_succeeded_off_loop") {
+    let loop = group.next()
+    let expected = Array(0..<100_000)
+    let futures = expected.map { loop.makeSucceededFuture($0) }
+    let allSucceeded = try! EventLoopFuture.whenAllSucceed(futures, on: loop).wait()
+    return allSucceeded.count
+}
+
+measureAndPrint(desc: "future_whenallsucceed_100k_immediately_succeeded_on_loop") {
+    let loop = group.next()
+    let expected = Array(0..<100_000)
+    let allSucceeded = try! loop.makeSucceededFuture(()).flatMap { _ -> EventLoopFuture<[Int]> in
+        let futures = expected.map { loop.makeSucceededFuture($0) }
+        return EventLoopFuture.whenAllSucceed(futures, on: loop)
+        }.wait()
+    return allSucceeded.count
+}
+
+measureAndPrint(desc: "future_whenallsucceed_100k_deferred_off_loop") {
+    let loop = group.next()
+    let expected = Array(0..<100_000)
+    let promises = expected.map { _ in loop.makePromise(of: Int.self) }
+    let allSucceeded = EventLoopFuture.whenAllSucceed(promises.map { $0.futureResult }, on: loop)
+    for (index, promise) in promises.enumerated() {
+        promise.succeed(index)
+    }
+    return try! allSucceeded.wait().count
+}
+
+measureAndPrint(desc: "future_whenallsucceed_100k_deferred_on_loop") {
+    let loop = group.next()
+    let expected = Array(0..<100_000)
+    let promises = expected.map { _ in loop.makePromise(of: Int.self) }
+    let allSucceeded = try! loop.makeSucceededFuture(()).flatMap { _ -> EventLoopFuture<[Int]> in
+        let result = EventLoopFuture.whenAllSucceed(promises.map { $0.futureResult }, on: loop)
+        for (index, promise) in promises.enumerated() {
+            promise.succeed(index)
+        }
+        return result
+        }.wait()
+    return allSucceeded.count
+}
+
+
+measureAndPrint(desc: "future_whenallcomplete_100k_immediately_succeeded_off_loop") {
+    let loop = group.next()
+    let expected = Array(0..<100_000)
+    let futures = expected.map { loop.makeSucceededFuture($0) }
+    let allSucceeded = try! EventLoopFuture.whenAllComplete(futures, on: loop).wait()
+    return allSucceeded.count
+}
+
+measureAndPrint(desc: "future_whenallcomplete_100k_immediately_succeeded_on_loop") {
+    let loop = group.next()
+    let expected = Array(0..<100_000)
+    let allSucceeded = try! loop.makeSucceededFuture(()).flatMap { _ -> EventLoopFuture<[Result<Int, Error>]> in
+        let futures = expected.map { loop.makeSucceededFuture($0) }
+        return EventLoopFuture.whenAllComplete(futures, on: loop)
+        }.wait()
+    return allSucceeded.count
+}
+
+measureAndPrint(desc: "future_whenallcomplete_100k_deferred_off_loop") {
+    let loop = group.next()
+    let expected = Array(0..<100_000)
+    let promises = expected.map { _ in loop.makePromise(of: Int.self) }
+    let allSucceeded = EventLoopFuture.whenAllComplete(promises.map { $0.futureResult }, on: loop)
+    for (index, promise) in promises.enumerated() {
+        promise.succeed(index)
+    }
+    return try! allSucceeded.wait().count
+}
+
+measureAndPrint(desc: "future_whenallcomplete_100k_deferred_on_loop") {
+    let loop = group.next()
+    let expected = Array(0..<100_000)
+    let promises = expected.map { _ in loop.makePromise(of: Int.self) }
+    let allSucceeded = try! loop.makeSucceededFuture(()).flatMap { _ -> EventLoopFuture<[Result<Int, Error>]> in
+        let result = EventLoopFuture.whenAllComplete(promises.map { $0.futureResult }, on: loop)
+        for (index, promise) in promises.enumerated() {
+            promise.succeed(index)
+        }
+        return result
+        }.wait()
+    return allSucceeded.count
+}

--- a/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
@@ -62,6 +62,14 @@ extension EventLoopFutureTest {
                 ("testLoopHoppingHelperSuccess", testLoopHoppingHelperSuccess),
                 ("testLoopHoppingHelperFailure", testLoopHoppingHelperFailure),
                 ("testLoopHoppingHelperNoHopping", testLoopHoppingHelperNoHopping),
+                ("testFlatMapResultHappyPath", testFlatMapResultHappyPath),
+                ("testFlatMapResultFailurePath", testFlatMapResultFailurePath),
+                ("testWhenAllSucceedFailsImmediately", testWhenAllSucceedFailsImmediately),
+                ("testWhenAllSucceedResolvesAfterFutures", testWhenAllSucceedResolvesAfterFutures),
+                ("testWhenAllSucceedIsIndependentOfFulfillmentOrder", testWhenAllSucceedIsIndependentOfFulfillmentOrder),
+                ("testWhenAllCompleteResultsWithFailuresStillSucceed", testWhenAllCompleteResultsWithFailuresStillSucceed),
+                ("testWhenAllCompleteResults", testWhenAllCompleteResults),
+                ("testWhenAllCompleteResolvesAfterFutures", testWhenAllCompleteResolvesAfterFutures),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
@@ -62,14 +62,9 @@ extension EventLoopFutureTest {
                 ("testLoopHoppingHelperSuccess", testLoopHoppingHelperSuccess),
                 ("testLoopHoppingHelperFailure", testLoopHoppingHelperFailure),
                 ("testLoopHoppingHelperNoHopping", testLoopHoppingHelperNoHopping),
-                ("testFlatMapResultHappyPath", testFlatMapResultHappyPath),
-                ("testFlatMapResultFailurePath", testFlatMapResultFailurePath),
-                ("testWhenAllSucceedFailsImmediately", testWhenAllSucceedFailsImmediately),
-                ("testWhenAllSucceedResolvesAfterFutures", testWhenAllSucceedResolvesAfterFutures),
-                ("testWhenAllSucceedIsIndependentOfFulfillmentOrder", testWhenAllSucceedIsIndependentOfFulfillmentOrder),
-                ("testWhenAllCompleteResultsWithFailuresStillSucceed", testWhenAllCompleteResultsWithFailuresStillSucceed),
-                ("testWhenAllCompleteResults", testWhenAllCompleteResults),
-                ("testWhenAllCompleteResolvesAfterFutures", testWhenAllCompleteResolvesAfterFutures),
+                ("testWhenAllFailsImmediately", testWhenAllFailsImmediately),
+                ("testWhenAllResolvesAfterFutures", testWhenAllResolvesAfterFutures),
+                ("testWhenAllIsIndependentOfFulfillmentOrder", testWhenAllIsIndependentOfFulfillmentOrder),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -826,68 +826,37 @@ class EventLoopFutureTest : XCTestCase {
         let noHoppingPromise = loop1.newPromise(of: Void.self)
         let noHoppingFuture = noHoppingPromise.futureResult.hopTo(eventLoop: loop1)
         XCTAssertTrue(noHoppingFuture === noHoppingPromise.futureResult)
-        noHoppingPromise.succeed(())
+        noHoppingPromise.succeed(result: ())
     }
 
-    func testFlatMapResultHappyPath() {
-        let el = EmbeddedEventLoop()
-        defer {
-            XCTAssertNoThrow(try el.syncShutdownGracefully())
-        }
-
-        let p = el.makePromise(of: Int.self)
-        let f = p.futureResult.flatMapResult { (_: Int) in
-            return Result<String, Never>.success("hello world")
-        }
-        p.succeed(1)
-        XCTAssertNoThrow(XCTAssertEqual("hello world", try f.wait()))
-    }
-
-    func testFlatMapResultFailurePath() {
-        struct DummyError: Error {}
-        let el = EmbeddedEventLoop()
-        defer {
-            XCTAssertNoThrow(try el.syncShutdownGracefully())
-        }
-
-        let p = el.makePromise(of: Int.self)
-        let f = p.futureResult.flatMapResult { (_: Int) in
-            return Result<Int, Error>.failure(DummyError())
-        }
-        p.succeed(1)
-        XCTAssertThrowsError(try f.wait()) { error in
-            XCTAssert(type(of: error) == DummyError.self)
-        }
-    }
-
-    func testWhenAllSucceedFailsImmediately() {
+    func testWhenAllFailsImmediately() {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let promises = [group.next().makePromise(of: Int.self),
-                        group.next().makePromise(of: Int.self)]
-        let future = EventLoopFuture.whenAllSucceed(promises.map { $0.futureResult }, on: group.next())
-        promises[0].fail(EventLoopFutureTestError.example)
+        let promises = [group.next().newPromise(of: Int.self),
+                        group.next().newPromise(of: Int.self)]
+        let future = EventLoopFuture.whenAll(promises.map { $0.futureResult }, eventLoop: group.next())
+        promises[0].fail(error: EventLoopFutureTestError.example)
         XCTAssertThrowsError(try future.wait()) { error in
             XCTAssert(type(of: error) == EventLoopFutureTestError.self)
         }
     }
 
-    func testWhenAllSucceedResolvesAfterFutures() throws {
+    func testWhenAllResolvesAfterFutures() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 6)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let promises = (0..<5).map { _ in group.next().makePromise(of: Int.self) }
+        let promises = (0..<5).map { _ in group.next().newPromise(of: Int.self) }
         let futures = promises.map { $0.futureResult }
 
         var succeeded = false
         var completedPromises = false
 
-        let mainFuture = EventLoopFuture.whenAllSucceed(futures, on: group.next())
+        let mainFuture = EventLoopFuture.whenAll(futures, eventLoop: group.next())
         mainFuture.whenSuccess { _ in
             XCTAssertTrue(completedPromises)
             XCTAssertFalse(succeeded)
@@ -899,7 +868,7 @@ class EventLoopFutureTest : XCTestCase {
 
         // complete the first four promises
         for (index, promise) in promises.dropLast().enumerated() {
-            promise.succeed(index)
+            promise.succeed(result: index)
         }
 
         // Should still be false, as one promise hasn't completed yet
@@ -907,26 +876,26 @@ class EventLoopFutureTest : XCTestCase {
 
         // Complete the last promise
         completedPromises = true
-        promises.last!.succeed(4)
+        promises.last!.succeed(result: 4)
 
         let results = try assertNoThrowWithValue(mainFuture.wait())
         XCTAssertEqual(results, [0, 1, 2, 3, 4])
     }
 
-    func testWhenAllSucceedIsIndependentOfFulfillmentOrder() throws {
+    func testWhenAllIsIndependentOfFulfillmentOrder() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 6)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
         let expected = Array(0..<1000)
-        let promises = expected.map { _ in group.next().makePromise(of: Int.self) }
+        let promises = expected.map { _ in group.next().newPromise(of: Int.self) }
         let futures = promises.map { $0.futureResult }
 
         var succeeded = false
         var completedPromises = false
 
-        let mainFuture = EventLoopFuture.whenAllSucceed(futures, on: group.next())
+        let mainFuture = EventLoopFuture.whenAll(futures, eventLoop: group.next())
         mainFuture.whenSuccess { _ in
             XCTAssertTrue(completedPromises)
             XCTAssertFalse(succeeded)
@@ -937,83 +906,10 @@ class EventLoopFutureTest : XCTestCase {
             if index == 0 {
                 completedPromises = true
             }
-            promises[index].succeed(index)
+            promises[index].succeed(result: index)
         }
 
         let results = try assertNoThrowWithValue(mainFuture.wait())
         XCTAssertEqual(results, expected)
-    }
-
-    func testWhenAllCompleteResultsWithFailuresStillSucceed() {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
-        defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
-        }
-
-        let future = EventLoopFuture.whenAllComplete([
-            group.next().makeFailedFuture(EventLoopFutureTestError.example),
-            group.next().makeSucceededFuture(true)
-        ], on: group.next())
-        XCTAssertNoThrow(try future.wait())
-    }
-
-    func testWhenAllCompleteResults() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
-        defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
-        }
-
-        let results = try EventLoopFuture.whenAllComplete([
-            group.next().makeSucceededFuture(3),
-            group.next().makeFailedFuture(EventLoopFutureTestError.example),
-            group.next().makeSucceededFuture(10),
-            group.next().makeFailedFuture(EventLoopFutureTestError.example),
-            group.next().makeSucceededFuture(5)
-        ], on: group.next()).wait()
-
-        XCTAssertEqual(try results[0].get(), 3)
-        XCTAssertThrowsError(try results[1].get())
-        XCTAssertEqual(try results[2].get(), 10)
-        XCTAssertThrowsError(try results[3].get())
-        XCTAssertEqual(try results[4].get(), 5)
-    }
-
-    func testWhenAllCompleteResolvesAfterFutures() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 6)
-        defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
-        }
-
-        let promises = (0..<5).map { _ in group.next().makePromise(of: Int.self) }
-        let futures = promises.map { $0.futureResult }
-
-        var succeeded = false
-        var completedPromises = false
-
-        let mainFuture = EventLoopFuture.whenAllComplete(futures, on: group.next())
-        mainFuture.whenSuccess { _ in
-            XCTAssertTrue(completedPromises)
-            XCTAssertFalse(succeeded)
-            succeeded = true
-        }
-
-        // Should be false, as none of the promises have completed yet
-        XCTAssertFalse(succeeded)
-
-        // complete the first four promises
-        for (index, promise) in promises.dropLast().enumerated() {
-            promise.succeed(index)
-        }
-
-        // Should still be false, as one promise hasn't completed yet
-        XCTAssertFalse(succeeded)
-
-        // Complete the last promise
-        completedPromises = true
-        promises.last!.succeed(4)
-
-        let results = try assertNoThrowWithValue(mainFuture.wait().map { try $0.get() })
-        XCTAssertEqual(results, [0, 1, 2, 3, 4])
->>>>>>> 77d90255... Significantly improve the performance of `EventLoopFuture.{and,when}AllSucceed`. (#943)
     }
 }


### PR DESCRIPTION
See https://github.com/apple/swift-nio/pull/943. `{and,when}AllComplete` were omitted because `Result` is not available in Swift 4, and `whenAll` should be sufficient for Vapor's needs. (I guess we don't want to add more functionality to NIO 1 than necessary.)

Performance results on NIO 1 (nearly identical to NIO 2):

```
measuring: future_whenall_100k_immediately_succeeded_off_loop: 0.13129901885986328, 0.13130605220794678, 0.12960290908813477, 0.12814700603485107, 0.1288670301437378, 0.13253700733184814, 0.1318880319595337, 0.13585007190704346, 0.13087499141693115, 0.13029694557189941, 
measuring: future_whenall_100k_immediately_succeeded_on_loop: 0.13315296173095703, 0.12973999977111816, 0.13161206245422363, 0.13184499740600586, 0.13040506839752197, 0.13026797771453857, 0.12884008884429932, 0.129052996635437, 0.12953698635101318, 0.12920796871185303, 
measuring: future_whenall_100k_deferred_off_loop: 0.8608689308166504, 0.8739509582519531, 0.8166019916534424, 0.8779599666595459, 0.8566949367523193, 0.834915041923523, 0.8747600317001343, 0.8622258901596069, 0.8150960206985474, 0.8113300800323486, 
measuring: future_whenall_100k_deferred_on_loop: 0.20211589336395264, 0.20115602016448975, 0.20297491550445557, 0.2031630277633667, 0.20395588874816895, 0.1977750062942505, 0.20329594612121582, 0.20048999786376953, 0.19947195053100586, 0.20047104358673096, 
```

No baseline because `whenAll` did not previously exist in NIO 1.