### PR TITLE
alloc tests: hook posix_memalign & reallocf (#782)

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/template/HookedFunctions/Sources/HookedFunctions/include/hooked-functions.h
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/HookedFunctions/Sources/HookedFunctions/include/hooked-functions.h
@@ -21,5 +21,8 @@ void *replacement_malloc(size_t size);
 void replacement_free(void *ptr);
 void *replacement_calloc(size_t nmemb, size_t size);
 void *replacement_realloc(void *ptr, size_t size);
+void *replacement_reallocf(void *ptr, size_t size);
+void *replacement_valloc(size_t size);
+int replacement_posix_memalign(void **memptr, size_t alignment, size_t size);
 
 #endif

--- a/IntegrationTests/tests_04_performance/test_01_resources/template/HookedFunctions/Sources/HookedFunctions/src/hooked-functions.c
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/HookedFunctions/Sources/HookedFunctions/src/hooked-functions.c
@@ -153,9 +153,36 @@ void *replacement_calloc(size_t count, size_t size) {
     return ptr;
 }
 
+void *replacement_reallocf(void *ptr, size_t size) {
+    void *new_ptr = replacement_realloc(ptr, size);
+    if (!new_ptr) {
+        replacement_free(new_ptr);
+    }
+    return new_ptr;
+}
+
+void *replacement_valloc(size_t size) {
+    // not aligning correctly (should be PAGE_SIZE) but good enough
+    return replacement_malloc(size);
+}
+
+int replacement_posix_memalign(void **memptr, size_t alignment, size_t size) {
+    // not aligning correctly (should be `alignment`) but good enough
+    void *ptr = replacement_malloc(size);
+    if (ptr && memptr) {
+        *memptr = ptr;
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
 #if __APPLE__
 DYLD_INTERPOSE(replacement_free, free)
 DYLD_INTERPOSE(replacement_malloc, malloc)
 DYLD_INTERPOSE(replacement_realloc, realloc)
 DYLD_INTERPOSE(replacement_calloc, calloc)
+DYLD_INTERPOSE(replacement_reallocf, reallocf)
+DYLD_INTERPOSE(replacement_valloc, valloc)
+DYLD_INTERPOSE(replacement_posix_memalign, posix_memalign)
 #endif

--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/bootstrap/main.c
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/bootstrap/main.c
@@ -32,6 +32,15 @@ void *calloc(size_t nmemb, size_t size) {
 void *realloc(void *ptr, size_t size) {
     return replacement_realloc(ptr, size);
 }
+void *reallocf(void *ptr, size_t size) {
+    return replacement_reallocf(ptr, size);
+}
+void *valloc(size_t size) {
+    return replacement_valloc(size);
+}
+int posix_memalign(void **memptr, size_t alignment, size_t size) {
+    return replacement_posix_memalign(memptr, alignment, size);
+}
 #endif
 
 void swift_main(void);


### PR DESCRIPTION
Motivation:

Swift started using posix_memalign very recently (Jan 2019) so we need
to hook that too to get correct results.

Modifications:

Hook posix_memalign, reallocf & valloc

Result:

alloc tests should pass again

(cherry picked from commit de8d3e260e54ee27d55d82d48a552236d57a704e)