### PR TITLE
optional max payload size for ByteToMessageDecoder

### DIFF
--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -58,6 +58,7 @@ extension ByteToMessageDecoderTest {
                 ("testWeAreOkayWithReceivingDataAfterHalfClosureEOF", testWeAreOkayWithReceivingDataAfterHalfClosureEOF),
                 ("testWeAreOkayWithReceivingDataAfterFullClose", testWeAreOkayWithReceivingDataAfterFullClose),
                 ("testPayloadTooLarge", testPayloadTooLarge),
+                ("testPayloadTooLargeButHandlerOk", testPayloadTooLargeButHandlerOk),
            ]
    }
 }

--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -57,6 +57,7 @@ extension ByteToMessageDecoderTest {
                 ("testErrorInDecodeLastWhenCloseIsReceivedReentrantlyInDecode", testErrorInDecodeLastWhenCloseIsReceivedReentrantlyInDecode),
                 ("testWeAreOkayWithReceivingDataAfterHalfClosureEOF", testWeAreOkayWithReceivingDataAfterHalfClosureEOF),
                 ("testWeAreOkayWithReceivingDataAfterFullClose", testWeAreOkayWithReceivingDataAfterFullClose),
+                ("testPayloadTooLarge", testPayloadTooLarge),
            ]
    }
 }

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -1420,9 +1420,8 @@ public final class ByteToMessageDecoderTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: max + 1)
         buffer.writeString(String(repeating: "*", count: max + 1))
         XCTAssertThrowsError(try channel.writeInbound(buffer)) { error in
-            guard case ByteToMessageDecoderError.payloadTooLarge = error else {
-                XCTFail("expected ByteToMessageDecoderError.payloadTooLarge")
-                return
+            guard case ByteToMessageDecoderDataError.payloadTooLarge = error else {
+                return XCTFail("expected ByteToMessageDecoderDataError.payloadTooLarge")
             }
         }
     }


### PR DESCRIPTION
Motivation:

ByteToMessageDecoder aggregate data in memory as part of their normal operation. the ability to limit how much they aggregate is critical in many real-life applications

Modifications:

* add optional maximumBufferSize argument to ByteToMessageDecoder initializer
* test for buffer size when maximumBufferSize is set and throw ByteToMessageDecoderError.payloadTooLarge error

Result:

users can limit how much memory ByteToMessageDecoder takes and handle the exception on their end
