### PR TITLE
Initialize a ByteBuffer from a ByteBufferView

### DIFF
--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -21,8 +21,8 @@ public struct ByteBufferView: RandomAccessCollection {
     public typealias Index = Int
     public typealias SubSequence = ByteBufferView
 
-    private let buffer: ByteBuffer
-    private let range: Range<Index>
+    fileprivate let buffer: ByteBuffer
+    fileprivate let range: Range<Index>
 
     internal init(buffer: ByteBuffer, range: Range<Index>) {
         precondition(range.lowerBound >= 0 && range.upperBound <= buffer.capacity)
@@ -86,5 +86,12 @@ extension ByteBuffer {
         }
 
         return ByteBufferView(buffer: self, range: index ..< (index + length))
+    }
+
+    /// Create a `ByteBuffer` from the given `ByteBufferView`s range.
+    ///
+    /// - parameter view: The `ByteBufferView` which you want to get a `ByteBuffer` from.
+    public init(_ view: ByteBufferView) {
+        self = view.buffer.getSlice(at: view.range.startIndex, length: view.range.count)!
     }
 }

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -120,6 +120,7 @@ extension ByteBufferTest {
                 ("testViewsStartIndexIsStable", testViewsStartIndexIsStable),
                 ("testSlicesOfByteBufferViewsAreByteBufferViews", testSlicesOfByteBufferViewsAreByteBufferViews),
                 ("testReadableBufferViewRangeEqualCapacity", testReadableBufferViewRangeEqualCapacity),
+                ("testByteBuffersCanBeInitializedFromByteBufferViews", testByteBuffersCanBeInitializedFromByteBufferViews),
                 ("testReserveCapacityWhenOversize", testReserveCapacityWhenOversize),
                 ("testReserveCapacitySameCapacity", testReserveCapacitySameCapacity),
                 ("testReserveCapacityLargerUniquelyReferencedCallsRealloc", testReserveCapacityLargerUniquelyReferencedCallsRealloc),

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1481,6 +1481,27 @@ class ByteBufferTest: XCTestCase {
         XCTAssertEqual(buf.readableBytes, viewSlice.count)
     }
 
+    func testByteBuffersCanBeInitializedFromByteBufferViews() throws {
+        self.buf.writeString("hello")
+
+        let readableByteBuffer = ByteBuffer(self.buf.readableBytesView)
+        XCTAssertEqual(self.buf, readableByteBuffer)
+
+        let sliceByteBuffer = self.buf.viewBytes(at: 1, length: 3).map(ByteBuffer.init)
+        XCTAssertEqual("ell", sliceByteBuffer.flatMap { $0.getString(at: 0, length: $0.readableBytes) })
+
+        self.buf.clear()
+
+        let emptyByteBuffer = ByteBuffer(self.buf.readableBytesView)
+        XCTAssertEqual(self.buf, emptyByteBuffer)
+
+        var fixedCapacityBuffer = self.allocator.buffer(capacity: 16)
+        let capacity = fixedCapacityBuffer.capacity
+        fixedCapacityBuffer.writeString(String(repeating: "x", count: capacity))
+        XCTAssertEqual(capacity, fixedCapacityBuffer.capacity)
+        XCTAssertEqual(fixedCapacityBuffer, ByteBuffer(fixedCapacityBuffer.readableBytesView))
+    }
+
     func testReserveCapacityWhenOversize() throws {
         let oldCapacity = buf.capacity
         let oldPtrVal = buf.withVeryUnsafeBytes {


### PR DESCRIPTION
### Motivation:

As @weissi previously said in (#946), there's no reason not be able to get a `ByteBuffer` from a `ByteBufferView`.

### Modifications:

I added a public initializer to `ByteBuffer` taking a `ByteBufferView` to create a slice of the view's buffer from the same range.

### Result:

`ByteBuffer` will have a public initializer to create a `ByteBuffer` from a `ByteBufferView`.

Closes #946 