### PR TITLE
Fix documentation block for viewBytes method

### DIFF
--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -79,7 +79,7 @@ extension ByteBuffer {
     /// - parameters:
     ///   - index: The index the view should start at
     ///   - length: The length of the view (in bytes)
-    /// - returns A view into a portion of a `ByteBuffer` or `nil` if the requested bytes were not readable.
+    /// - returns: A view into a portion of a `ByteBuffer` or `nil` if the requested bytes were not readable.
     public func viewBytes(at index: Int, length: Int) -> ByteBufferView? {
         guard index >= self.readerIndex && index <= self.writerIndex - length else {
             return nil


### PR DESCRIPTION
Fixed documentation for `ByteBuffer`s `viewBytes` method.

### Motivation:

The documentation popup for viewBytes did not correctly
show what the method returns.

### Modifications:

I added a colon after the return doc-block keyword.

### Result:

The documentation popup for viewBytes will now correctly show
what the method returns.