### PR TITLE
[1.14 backport] Simplify Heap implementation.

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_allocation_counts_for_http1.sh
+++ b/IntegrationTests/tests_04_performance/test_01_allocation_counts_for_http1.sh
@@ -58,7 +58,7 @@ cd ..
 "$swift_bin" run -c release | tee "$tmp/output"
 )
 
-for test in 1000_reqs_1_conn 1_reqs_1000_conn ping_pong_1000_reqs_1_conn bytebuffer_lots_of_rw future_lots_of_callbacks; do
+for test in 1000_reqs_1_conn 1_reqs_1000_conn ping_pong_1000_reqs_1_conn bytebuffer_lots_of_rw future_lots_of_callbacks scheduling_10000_executions; do
     cat "$tmp/output"  # helps debugging
     total_allocations=$(grep "^$test.total_allocations:" "$tmp/output" | cut -d: -f2 | sed 's/ //g')
     not_freed_allocations=$(grep "^$test.remaining_allocations:" "$tmp/output" | cut -d: -f2 | sed 's/ //g')

--- a/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/template/Sources/SwiftBootstrap/SwiftMain.swift
@@ -16,7 +16,7 @@ import NIO
 import NIOHTTP1
 import Foundation
 import AtomicCounter
-import Dispatch // needed for Swift 4.0 on Linux only
+import Dispatch
 
 private final class SimpleHTTPServer: ChannelInboundHandler {
     typealias InboundIn = HTTPServerRequestPart
@@ -408,6 +408,22 @@ public func swiftMain() -> Int {
             doAnd(loop: el)
         }
         return 1000
+    }
+
+    measureAndPrint(desc: "scheduling_10000_executions") {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let loop = group.next()
+        let dg = DispatchGroup()
+
+        try! loop.submit {
+            for _ in 0..<10_000 {
+                dg.enter()
+                loop.execute { dg.leave() }
+            }
+        }.wait()
+        dg.wait()
+        try! group.syncShutdownGracefully()
+        return 10_000
     }
 
     return 0

--- a/Tests/NIOTests/SystemCallWrapperHelpers.swift
+++ b/Tests/NIOTests/SystemCallWrapperHelpers.swift
@@ -114,7 +114,7 @@ func runSystemCallWrapperPerformanceTest(testAssertFunction: (@autoclosure () ->
         return preventCompilerOptimisation
     }
 
-    let allowedOverheadPercent: Int = isDebugMode ? 1000 : 20
+    let allowedOverheadPercent: Int = isDebugMode ? 1000 : 100
     if allowedOverheadPercent > 100 {
         precondition(isDebugMode)
         print("WARNING: Syscall wrapper test: Over 100% overhead allowed. Running in debug assert configuration which allows \(allowedOverheadPercent)% overhead :(. Consider running in Release mode.")

--- a/docker/docker-compose.1804.42.yaml
+++ b/docker/docker-compose.1804.42.yaml
@@ -17,19 +17,21 @@ services:
     image: swift-nio:18.04-4.2
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2150
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=603000
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4550
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
 
   test:
     image: swift-nio:18.04-4.2
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=36750
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=698050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2150
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=603000
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4550
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
 
   echo:
     image: swift-nio:18.04-4.2


### PR DESCRIPTION
Motivation:

Our original Heap implementation used a bunch of static functions
in order to make it clear how it related to textbook heap
implementations. This was primarily done to ensure that it was easier
to see the correctness of the code.

However, we've long been satisfied with the correctness of the code,
and the Heap is one of the best tested parts of NIO. For this reason,
we should be free to refactor it.

Given https://bugs.swift.org/browse/SR-10346, we've been given an
incentive to do that refactor right now. This is because the Heap
is causing repeated CoW operations each time we enqueue new work
onto the event loop. That's a substantial performance cost: well
worth fixing with a small rewrite.

Modifications:

- Removed all static funcs from Heap
- Rewrote some into instance funcs
- Merged the implementation of insert into append.
- Added an allocation test to avoid regressing this change.

Result:

Faster Heap, happier users, sadder textbook authors.

(cherry picked from commit f79c7ae / PR #960)