### PR TITLE
HTTP1 example server: don't crash on empty file served

### DIFF
--- a/IntegrationTests/tests_01_http/test_01_get_file.sh
+++ b/IntegrationTests/tests_01_http/test_01_get_file.sh
@@ -19,8 +19,11 @@ token=$(create_token)
 start_server "$token"
 htdocs=$(get_htdocs "$token")
 echo FOO BAR > "$htdocs/some_file.txt"
-for method in sendfile fileio; do
-    do_curl "$token" "http://foobar.com/$method/some_file.txt" > "$tmp/out.txt"
-    assert_equal_files "$htdocs/some_file.txt" "$tmp/out.txt"
+touch "$htdocs/empty"
+for file in some_file.txt empty; do
+    for method in sendfile fileio; do
+        do_curl "$token" "http://foobar.com/$method/$file" > "$tmp/out.txt"
+        assert_equal_files "$htdocs/$file" "$tmp/out.txt"
+    done
 done
 stop_server "$token"

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -333,6 +333,10 @@ private final class HTTPHandler: ChannelInboundHandler {
                 case .nonblockingFileIO:
                     var responseStarted = false
                     let response = responseHead(request: request, fileRegion: region)
+                    if region.readableBytes == 0 {
+                        responseStarted = true
+                        context.write(self.wrapOutboundOut(.head(response)), promise: nil)
+                    }
                     return self.fileIO.readChunked(fileRegion: region,
                                                    chunkSize: 32 * 1024,
                                                    allocator: context.channel.allocator,


### PR DESCRIPTION
Motivation:

The file-io implementation in the example HTTP1 server just crashed on
empty file ;).

Modifications:

- fix the crash
- add integration test

Result:

fewer crashes
