### PR TITLE
Make `EventLoopFuture.hopTo(eventLoop:)` public again.

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -1053,7 +1053,7 @@ extension EventLoopFuture {
     /// - parameters:
     ///     - target: The `EventLoop` that the returned `EventLoopFuture` will run on.
     /// - returns: An `EventLoopFuture` whose callbacks run on `target` instead of the original loop.
-    func hopTo(eventLoop target: EventLoop) -> EventLoopFuture<T> {
+    public func hopTo(eventLoop target: EventLoop) -> EventLoopFuture<T> {
         if target === self.eventLoop {
             // We're already on that event loop, nothing to do here. Save an allocation.
             return self


### PR DESCRIPTION
This was accidentally made `internal` with https://github.com/apple/swift-nio/pull/947.

Maybe there should be a separate test case file (with a non-`@testable` `import`) that verifies that all `public` interfaces are still present?