### PR TITLE
Make hopTo public again

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -1053,7 +1053,7 @@ extension EventLoopFuture {
     /// - parameters:
     ///     - target: The `EventLoop` that the returned `EventLoopFuture` will run on.
     /// - returns: An `EventLoopFuture` whose callbacks run on `target` instead of the original loop.
-    func hopTo(eventLoop target: EventLoop) -> EventLoopFuture<T> {
+    public func hopTo(eventLoop target: EventLoop) -> EventLoopFuture<T> {
         if target === self.eventLoop {
             // We're already on that event loop, nothing to do here. Save an allocation.
             return self


### PR DESCRIPTION
This makes the `hopTo(eventLoop:)` function `public` again.

### Motivation:

In combination of 6b914e891f6c30f332b14dc15bcc78a1985942f5 and 26bee216743165ee6ce32e27a7c6e82a2b0e52e5, the `hopTo(eventLoop:)` function was accidentally made `internal`, because the `public` modified was removed from both, the `extension` and the `func` itself.

### Modifications:

Re-add `public` to the definition of `hopTo(eventLoop:)`.

### Result:

Projects using `hopTo(eventLoop:)` will build fine again. They're broken with the current 1.14.0 release.
