### PR TITLE
Add a way to get a handler from a pipeline

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -1555,6 +1555,20 @@ extension ChannelPipeline: CustomDebugStringConvertible {
         return desc.joined(separator: "\n")
     }
     
+    /// Returns the first `ChannelHandler` of the given type.
+    ///
+    /// - parameters:
+    ///     - handlerType: the type of `ChannelHandler` to return.
+    public func handler<Handler: ChannelHandler>(type _: Handler.Type) -> EventLoopFuture<Handler> {
+        return self.context(handlerType: Handler.self).map { context in
+            guard let typedContext = context.handler as? Handler else {
+                preconditionFailure("Expected channel handler of type \(Handler.self), got \(type(of: context.handler)) instead.")
+            }
+            
+            return typedContext
+        }
+    }
+    
     private struct ChannelHandlerDebugInfo {
         let handler: ChannelHandler
         let name: String

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -26,6 +26,9 @@ extension ChannelPipelineTest {
 
    static var allTests : [(String, (ChannelPipelineTest) -> () throws -> Void)] {
       return [
+                ("testGetHandler", testGetHandler),
+                ("testGetFirstHandler", testGetFirstHandler),
+                ("testGetNotAddedHandler", testGetNotAddedHandler),
                 ("testAddAfterClose", testAddAfterClose),
                 ("testOutboundOrdering", testOutboundOrdering),
                 ("testConnectingDoesntCallBind", testConnectingDoesntCallBind),

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -69,6 +69,67 @@ private extension EmbeddedChannel {
 
 class ChannelPipelineTest: XCTestCase {
 
+    class SimpleTypedHandler1: ChannelInboundHandler {
+        typealias InboundIn = NIOAny
+    }
+    class SimpleTypedHandler2: ChannelInboundHandler {
+        typealias InboundIn = NIOAny
+    }
+    class SimpleTypedHandler3: ChannelInboundHandler {
+        typealias InboundIn = NIOAny
+    }
+
+    func testGetHandler() throws {
+        let handler1 = SimpleTypedHandler1()
+        let handler2 = SimpleTypedHandler2()
+        let handler3 = SimpleTypedHandler3()
+        
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandlers([
+            handler1,
+            handler2,
+            handler3
+        ]).wait()
+        
+        let result1 = try channel.pipeline.handler(type: SimpleTypedHandler1.self).wait()
+        XCTAssertTrue(result1 === handler1)
+        
+        let result2 = try channel.pipeline.handler(type: SimpleTypedHandler2.self).wait()
+        XCTAssertTrue(result2 === handler2)
+
+        let result3 = try channel.pipeline.handler(type: SimpleTypedHandler3.self).wait()
+        XCTAssertTrue(result3 === handler3)
+    }
+    
+    func testGetFirstHandler() throws {
+        let sameTypeHandler1 = SimpleTypedHandler1()
+        let sameTypeHandler2 = SimpleTypedHandler1()
+        let otherHandler = SimpleTypedHandler2()
+
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandlers([
+            sameTypeHandler1,
+            sameTypeHandler2,
+            otherHandler
+        ]).wait()
+        
+        let result = try channel.pipeline.handler(type: SimpleTypedHandler1.self).wait()
+        XCTAssertTrue(result === sameTypeHandler1)
+    }
+    
+    func testGetNotAddedHandler() throws {
+        let handler1 = SimpleTypedHandler1()
+        let handler2 = SimpleTypedHandler2()
+        
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandlers([
+            handler1,
+            handler2,
+        ]).wait()
+        
+        XCTAssertThrowsError(try channel.pipeline.handler(type: SimpleTypedHandler3.self).wait()) { XCTAssertTrue($0 is ChannelPipelineError )}
+    }
+    
     func testAddAfterClose() throws {
 
         let channel = EmbeddedChannel()


### PR DESCRIPTION
Motivation:

https://github.com/apple/swift-nio/issues/966

Modifications:

- Add a `handler(type:)` method on ChannelPipeline
- Add a test in ChannelPipelineTest

Result:

Provides a nicer way to get a typed handler directly from the pipeline

Closes #966