### PR TITLE
Add 'Show on GitHub' link to API docs

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -58,7 +58,7 @@ jazzy_args=(--clean
             --author_url https://github.com/apple/swift-nio
             --github_url https://github.com/apple/swift-nio
             --theme fullwidth
-            --github-file-prefix https://github.com/apple/swift-nio/tree/$version \
+            --github-file-prefix https://github.com/apple/swift-nio/tree/$version
             --xcodebuild-arguments -scheme,swift-nio-Package)
 cat > "$module_switcher" <<"EOF"
 # SwiftNIO Docs

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -58,6 +58,7 @@ jazzy_args=(--clean
             --author_url https://github.com/apple/swift-nio
             --github_url https://github.com/apple/swift-nio
             --theme fullwidth
+            --github-file-prefix https://github.com/apple/swift-nio/tree/$version \
             --xcodebuild-arguments -scheme,swift-nio-Package)
 cat > "$module_switcher" <<"EOF"
 # SwiftNIO Docs


### PR DESCRIPTION
Addresses #955

![nio-docs](https://user-images.githubusercontent.com/474794/56461642-35be2f00-6384-11e9-8d8a-a59aaa3efc18.gif)

### Motivation:

Allowing readers of the API documentation to drill into the implementation of documented declarations can be educational and helpful for debugging, among several other reasons.

### Modifications:

Add `--github-file-prefix` appending the current version in order to keep stable links. This means that documentation generated from any non-release revision may resolve incorrectly. This can be refined in the doc generation script later if it is deemed problematic by resolving to the commit sha if it doesn't exactly align with the version.

### Result:

Users will be able to click a  'Show on GitHub' for all documented API declarations.