### PR TITLE
CircularBuffer.Index: remove bogus assert

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -80,9 +80,8 @@ public struct CircularBuffer<Element>: CustomStringConvertible {
                 // if we can, we store the check for the backing here
                 self._backingCheck = backingCount < Int(_UInt24.max) ? _UInt24(UInt32(backingCount)) : .max
             }
-            assert(MemoryLayout.size(ofValue: self) == MemoryLayout<Int>.size)
         }
-        
+
         @inlinable
         public static func < (lhs: Index, rhs: Index) -> Bool {
             if lhs.isIndexGEQHeadIndex && rhs.isIndexGEQHeadIndex {


### PR DESCRIPTION
Motivation:

CircularBuffer.Index was asserting that its size is the same as a word.
Whilst that's true on 64-bit architectures, the assert itself is bogus
and a left-over from development.

Modifications:

Remove bogus assert.

Result:

- Better 32-bit support.
- fixes #972 