### PR TITLE
Make ChannelOptions.Storage initializer public.

### DIFF
--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -227,6 +227,8 @@ extension ChannelOptions {
         @usableFromInline
         internal var _storage: [(Any, (Any, (Channel) -> (Any, Any) -> EventLoopFuture<Void>))] = []
 
+        public init() { }
+
         /// Add `Options`, a `ChannelOption` to the `ChannelOptions.Storage`.
         ///
         /// - parameters:

--- a/Tests/NIOTests/ChannelOptionStorageTest.swift
+++ b/Tests/NIOTests/ChannelOptionStorageTest.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-@testable import NIO
+import NIO
 
 class ChannelOptionStorageTest: XCTestCase {
     func testWeStartWithNoOptions() throws {


### PR DESCRIPTION
Motivation:

Structures that users can't create don't give them much value.

Modifications:

- Make the initializer public.
- Remove that godforsaken @testable import.

Result:

ChannelOptions.Storage sparks joy.
