### PR TITLE
add tests for opening files RW

### DIFF
--- a/Sources/NIO/FileHandle.swift
+++ b/Sources/NIO/FileHandle.swift
@@ -118,9 +118,19 @@ extension NIOFileHandle {
         /// Allows file creation when opening file for writing. File owner is set to the effective user ID of the process.
         ///
         /// - parameters:
-        ///     - posixMode: `file mode` applied when file is created. Default permissions are: read and write for file owner, read for owners group and others.
+        ///     - posixMode: `file mode` applied when file is created. Default permissions are: read and write for fileowner, read for owners group and others.
         public static func allowFileCreation(posixMode: mode_t = S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH) -> Flags {
             return Flags(posixMode: posixMode, posixFlags: O_CREAT)
+        }
+
+        /// Allows the specification of POSIX flags (e.g. `O_TRUNC`) and mode (e.g. `S_IWUSR`)
+        ///
+        /// - parameters:
+        ///     - flags: The POSIX open flags (the second parameter for `open(2)`).
+        ///     - mode: The POSIX mode (the third parameter for `open(2)`).
+        /// - returns: A `NIOFileHandle.Mode` equivalent to the given POSIX flags and mode.
+        public static func posix(flags: CInt, mode: mode_t) -> Flags {
+            return Flags(posixMode: mode, posixFlags: flags)
         }
     }
 

--- a/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
@@ -49,6 +49,12 @@ extension NonBlockingFileIOTest {
                 ("testFileOpenWorks", testFileOpenWorks),
                 ("testFileOpenWorksWithEmptyFile", testFileOpenWorksWithEmptyFile),
                 ("testFileOpenFails", testFileOpenFails),
+                ("testOpeningFilesForWriting", testOpeningFilesForWriting),
+                ("testOpeningFilesForWritingFailsIfWeDontAllowItExplicitly", testOpeningFilesForWritingFailsIfWeDontAllowItExplicitly),
+                ("testOpeningFilesForWritingDoesNotAllowReading", testOpeningFilesForWritingDoesNotAllowReading),
+                ("testOpeningFilesForWritingAndReading", testOpeningFilesForWritingAndReading),
+                ("testOpeningFilesForWritingDoesNotImplyTruncation", testOpeningFilesForWritingDoesNotImplyTruncation),
+                ("testOpeningFilesForWritingCanUseTruncation", testOpeningFilesForWritingCanUseTruncation),
            ]
    }
 }

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -28,6 +28,14 @@ func withPipe(_ body: (NIO.NIOFileHandle, NIO.NIOFileHandle) -> [NIO.NIOFileHand
     }
 }
 
+func withTemporaryDirectory<T>(_ body: (String) throws -> T) rethrows -> T {
+    let dir = createTemporaryDirectory()
+    defer {
+        try? FileManager.default.removeItem(atPath: dir)
+    }
+    return try body(dir)
+}
+
 func withTemporaryFile<T>(content: String? = nil, _ body: (NIO.NIOFileHandle, String) throws -> T) rethrows -> T {
     let (fd, path) = openTemporaryFile()
     let fileHandle = NIOFileHandle(descriptor: fd)
@@ -70,6 +78,7 @@ var temporaryDirectory: String {
 #endif
     }
 }
+
 func createTemporaryDirectory() -> String {
     let template = "\(temporaryDirectory)/.NIOTests-temp-dir_XXXXXX"
 


### PR DESCRIPTION
Motivation:

The new file RW opening facilities didn't have any tests and it didn't
let you specify arbitrary POSIX flags.

Modifications:

- Add tests.
- Let users specify both POSIX flags & mode.

Result:

Better code quality.