### PR TITLE
add Swift 5.1 docker file

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -1,0 +1,42 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio:16.04-5.1
+    build:
+      args:
+        ubuntu_version: "16.04"
+        swift_version: "5.1"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-05-01-a"
+        swift_builds_suffix: "branch"
+        skip_ruby_from_ppa: "true"
+
+  unit-tests:
+    image: swift-nio:16.04-5.1
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors"
+
+  integration-tests:
+    image: swift-nio:16.04-5.1
+    environment:
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1177050 # was: 685050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
+
+  test:
+    image: swift-nio:16.04-5.1
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors && ./scripts/integration_tests.sh"
+    environment:
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1177050 # was: 685050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
+
+  echo:
+    image: swift-nio:16.04-5.1
+
+  http:
+    image: swift-nio:16.04-5.1


### PR DESCRIPTION
Motivation:

We should test all available Swift versions, including snapshots.

Modifications:

Add docker compose file for Swift 5.1.

Result:

More testing.