### PR TITLE
lower allocation limits for Swift 5.1

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -19,8 +19,8 @@ services:
   integration-tests:
     image: swift-nio:16.04-5.1
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1177050 # was: 685050
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30600
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=583100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
@@ -29,8 +29,8 @@ services:
     image: swift-nio:16.04-5.1
     command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors && ./scripts/integration_tests.sh"
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1177050 # was: 685050
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30600
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=583100
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100


### PR DESCRIPTION
Motivation:

Swift 5.1 shows much fewer allocations, let's tighten the limits.

Modifications:

Tighten the allocation limits on 5.1.

Result:

We'll catch allocation regressions much more easily.