### PR TITLE
HTTPDecoder: don't crash if response has no headers

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -44,6 +44,7 @@ extension HTTPDecoderTest {
                 ("testIllegalHeaderNamesCauseError", testIllegalHeaderNamesCauseError),
                 ("testNonASCIIWorksAsHeaderValue", testNonASCIIWorksAsHeaderValue),
                 ("testDoesNotDeliverLeftoversUnnecessarily", testDoesNotDeliverLeftoversUnnecessarily),
+                ("testHTTPResponseWithoutHeaders", testHTTPResponseWithoutHeaders),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest+XCTest.swift
@@ -36,6 +36,7 @@ extension HTTPServerClientTest {
                 ("testMassiveResponseFileRegion", testMassiveResponseFileRegion),
                 ("testHead", testHead),
                 ("test204", test204),
+                ("testNoResponseHeaders", testNoResponseHeaders),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

With HTTP/1.0 and EOF framing it's possible to have a HTTP response that
doesn't have any headers. HTTPDecoder unfortunately fell flat on its
face and crashed the program if that happened.

Modifications:

- don't expect headers on responses
- add tests for that
- rename the state machine cases to reflect a request and response
  parsing

Result:

fewer crashes.