### PR TITLE
B2MDError: nest PayloadTooLargeError

### DIFF
--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -35,9 +35,12 @@ public enum ByteToMessageDecoderError: Error {
     case leftoverDataWhenDone(ByteBuffer)
 }
 
-// TODO (tomer): Merge into ByteToMessageDecoderError next major version
-/// This error can be thrown by `ByteToMessageDecoder`s if the incoming payload is larger than the max specified.
-public struct ByteToMessageDecoderPayloadTooLargeError: Error {}
+extension ByteToMessageDecoderError {
+    // TODO: For NIO 3, make this an enum case (or whatever best way for Errors we have come up with).
+    /// This error can be thrown by `ByteToMessageDecoder`s if the incoming payload is larger than the max specified.
+    public struct PayloadTooLargeError: Error {}
+}
+
 
 /// `ByteToMessageDecoder`s decode bytes in a stream-like fashion from `ByteBuffer` to another message type.
 ///
@@ -468,7 +471,7 @@ extension ByteToMessageHandler {
                     decoderResult = try decoder.decodeLast(context: context, buffer: &buffer, seenEOF: self.seenEOF)
                 }
                 if decoderResult == .needMoreData, let maximumBufferSize = self.maximumBufferSize, buffer.readableBytes > maximumBufferSize {
-                    throw ByteToMessageDecoderPayloadTooLargeError()
+                    throw ByteToMessageDecoderError.PayloadTooLargeError()
                 }
                 return decoderResult
             }

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -1420,7 +1420,7 @@ public final class ByteToMessageDecoderTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: max + 1)
         buffer.writeString(String(repeating: "*", count: max + 1))
         XCTAssertThrowsError(try channel.writeInbound(buffer)) { error in
-            XCTAssertTrue(error is ByteToMessageDecoderPayloadTooLargeError)
+            XCTAssertTrue(error is ByteToMessageDecoderError.PayloadTooLargeError)
         }
     }
 


### PR DESCRIPTION
Motivation:

New public NIO types must be nested in existing ones or `NIO` prefixed.
This wasn't the case for ByteToMessageDecoderPayloadTooLargeError

Modifications:

nest PayloadTooLargeError into ByteToMessageDecoderError

Result:

we stick to our rules.