### PR TITLE
alloc counters: propagate tmp dir

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_allocation_counts.sh
+++ b/IntegrationTests/tests_04_performance/test_01_allocation_counts.sh
@@ -26,7 +26,7 @@ for file in "$here/test_01_resources/"test_*.swift; do
     all_tests+=( "$test_name" )
 done
 
-"$here/test_01_resources/run-nio-alloc-counter-tests.sh" > "$tmp/output"
+"$here/test_01_resources/run-nio-alloc-counter-tests.sh" -t "$tmp" > "$tmp/output"
 
 for test in "${all_tests[@]}"; do
     cat "$tmp/output"  # helps debugging

--- a/IntegrationTests/tests_04_performance/test_01_resources/run-nio-alloc-counter-tests.sh
+++ b/IntegrationTests/tests_04_performance/test_01_resources/run-nio-alloc-counter-tests.sh
@@ -16,8 +16,27 @@
 set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+tmp_dir="/tmp"
+
+function die() {
+    echo >&2 "ERROR: $*"
+    exit 1
+}
+
+while getopts "t:" opt; do
+    case "$opt" in
+        t)
+            tmp_dir="$OPTARG"
+            ;;
+        \?)
+            die "unknown option $opt"
+            ;;
+    esac
+done
+
 "$here/../../allocation-counter-tests-framework/run-allocation-counter.sh" \
     -p "$here/../../.." \
     -m NIO -m NIOHTTP1 \
     -s "$here/shared.swift" \
+    -t "$tmp_dir" \
     "$here"/test_*.swift


### PR DESCRIPTION
Motivation:

The allocation counter tests should default to using the integration
tests' tmp dir.

Modifications:

Propagate the right tmp dir.

Result:

fewer orphaned tmp dirs lying around in case of error.