### PR TITLE
Allow adding a sequence of headers to HTTPHeaders

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -278,6 +278,7 @@ extension HTTPHeaders {
 /// or split representation, such that header fields that are able to be repeated
 /// can be represented appropriately.
 public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiteral {
+    @usableFromInline
     internal var headers: [(String, String)]
     internal var keepAliveState: KeepAliveState = .unknown
 

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -320,8 +320,7 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
     /// Add a header name/value pair to the block.
     ///
     /// This method is strictly additive: if there are other values for the given header name
-    /// already in the block, this will add a new entry. `add` performs case-insensitive
-    /// comparisons on the header field name.
+    /// already in the block, this will add a new entry.
     ///
     /// - Parameter name: The header field name. For maximum compatibility this should be an
     ///     ASCII string. For future-proofing with HTTP/2 lowercase header names are strongly
@@ -338,12 +337,12 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
     /// Add a sequence of header name/value pairs to the block.
     ///
     /// This method is strictly additive: if there are other entries with the same header
-    /// name already in the block, this will add new entries. `add` performs case-insensitive
-    /// comparisons on the header field names.
+    /// name already in the block, this will add new entries.
     ///
     /// - Parameter contentsOf: The sequence of header name/value pairs. For maximum compatibility
     ///     the header should be an ASCII string. For future-proofing with HTTP/2 lowercase header
     ///     names are strongly recommended.
+    @inlinable
     public mutating func add<S: Sequence>(contentsOf other: S) where S.Element == (String, String) {
         precondition(!other.contains { !$0.0.utf8.contains(where: { !$0.isASCII }) }, "names must be ASCII")
         self.headers.append(contentsOf: other)

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -344,10 +344,9 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
     ///     names are strongly recommended.
     @inlinable
     public mutating func add<S: Sequence>(contentsOf other: S) where S.Element == (String, String) {
-        precondition(!other.contains { !$0.0.utf8.contains(where: { !$0.isASCII }) }, "names must be ASCII")
-        self.headers.append(contentsOf: other)
-        if other.contains(where: { self.isConnectionHeader($0.0) }) {
-            self.keepAliveState = .unknown
+        self.headers.reserveCapacity(self.headers.count + other.underestimatedCount)
+        for (name, value) in other {
+            self.add(name: name, value: value)
         }
     }
 

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -325,12 +325,39 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
     ///
     /// - Parameter name: The header field name. For maximum compatibility this should be an
     ///     ASCII string. For future-proofing with HTTP/2 lowercase header names are strongly
-    //      recommended.
+    ///     recommended.
     /// - Parameter value: The header field value to add for the given name.
     public mutating func add(name: String, value: String) {
         precondition(!name.utf8.contains(where: { !$0.isASCII }), "name must be ASCII")
         self.headers.append((name, value))
         if self.isConnectionHeader(name) {
+            self.keepAliveState = .unknown
+        }
+    }
+
+    /// Add a sequence of header name/value pairs to the block.
+    ///
+    /// This method is strictly additive: if there are other entries with the same header
+    /// name already in the block, this will add new entries. `add` performs case-insensitive
+    /// comparisons on the header field names.
+    ///
+    /// - Parameter contentsOf: The sequence of header name/value pairs. For maximum compatibility
+    ///     the header should be an ASCII string. For future-proofing with HTTP/2 lowercase header
+    ///     names are strongly recommended.
+    public mutating func add<S: Sequence>(contentsOf other: S) where S.Element == (String, String) {
+        precondition(!other.contains { !$0.0.utf8.contains(where: { !$0.isASCII }) }, "names must be ASCII")
+        self.headers.append(contentsOf: other)
+        if other.contains(where: { self.isConnectionHeader($0.0) }) {
+            self.keepAliveState = .unknown
+        }
+    }
+
+    /// Add another block of headers to the block.
+    ///
+    /// - Parameter contentsOf: The block of headers to add to these headers.
+    public mutating func add(contentsOf other: HTTPHeaders) {
+        self.headers.append(contentsOf: other.headers)
+        if other.keepAliveState == .unknown {
             self.keepAliveState = .unknown
         }
     }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -47,6 +47,8 @@ extension HTTPHeadersTest {
                 ("testSeedGetsUpdatedToDefaultOnConnectionHeaderModification", testSeedGetsUpdatedToDefaultOnConnectionHeaderModification),
                 ("testSeedGetsUpdatedToWhateverTheHeaderSaysIfPresent", testSeedGetsUpdatedToWhateverTheHeaderSaysIfPresent),
                 ("testWeDefaultToCloseIfDoesNotMakeSense", testWeDefaultToCloseIfDoesNotMakeSense),
+                ("testAddingSequenceOfPairs", testAddingSequenceOfPairs),
+                ("testAddingOtherHTTPHeader", testAddingOtherHTTPHeader),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -321,6 +321,26 @@ class HTTPHeadersTest : XCTestCase {
         nonSenseInMultipleHeadersKC.add(name: "connection", value: "close")
         XCTAssertEqual(false, nonSenseInMultipleHeadersKC.isKeepAlive(version: .init(major: 1, minor: 1)))
         XCTAssertEqual(false, nonSenseInMultipleHeadersKC.isKeepAlive(version: .init(major: 1, minor: 0)))
+    }
 
+    func testAddingSequenceOfPairs() {
+        var headers = HTTPHeaders([], keepAliveState: .keepAlive)
+        let fooBar = [("foo", "bar"), ("bar", "qux"), ("connection", "foo")]
+        headers.add(contentsOf: fooBar)
+
+        XCTAssertEqual(["bar"], headers["foo"])
+        XCTAssertEqual(["qux"], headers["bar"])
+        XCTAssertEqual(.unknown, headers.keepAliveState)
+    }
+
+    func testAddingOtherHTTPHeader() {
+        var fooBarHeaders = HTTPHeaders([("foo", "bar"), ("bar", "qux")], keepAliveState: .keepAlive)
+        let bazHeaders = HTTPHeaders([("bar", "baz"), ("baz", "bazzy")], keepAliveState: .unknown)
+        fooBarHeaders.add(contentsOf: bazHeaders)
+
+        XCTAssertEqual(["bar"], fooBarHeaders["foo"])
+        XCTAssertEqual(["qux", "baz"], fooBarHeaders["bar"])
+        XCTAssertEqual(["bazzy"], fooBarHeaders["baz"])
+        XCTAssertEqual(.unknown, fooBarHeaders.keepAliveState)
     }
 }


### PR DESCRIPTION
Motivation:

When combining two collections of headers, adding each pair one-by-one
using add(name:value:) can cause multiple unnecessary reallocations of
the underlying array.

Modifications:

Provide two additional add methods to HTTPHeaders: one to add a sequence
of name/value pairs and another to add the headers from another
HTTPHeaders, both of which use `append(contentsOf:)` on the underlying
array to avoid additional reallocations.

Result:

Fewer reallocations when adding multiple headers.