### PR TITLE
undo tiny public API breakage

### DIFF
--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -366,6 +366,11 @@ public final class ByteToMessageHandler<Decoder: ByteToMessageDecoder> {
     private var seenEOF: Bool = false
     private var selfAsCanDequeueWrites: CanDequeueWrites? = nil
 
+    /// @see: ByteToMessageHandler.init(_:maximumBufferSize)
+    public convenience init(_ decoder: Decoder) {
+        self.init(decoder, maximumBufferSize: nil)
+    }
+
     /// Initialize a `ByteToMessageHandler`.
     ///
     /// - parameters:


### PR DESCRIPTION
Motivation:

In #957 we accidentally broke the API just a little bit. We turned the
`ByteToMessageHandler.init` from

    public init(_ decoder: Decoder)

into

    public init(_ decoder: Decoder, maximumBufferSize: Int? = nil)

This looks totally benign and in almost all cases because of the default
argument, you wouldn't notice the API breakage. However, it's possible
to write code that works in NIO 2.0.0 but breaks in NIO 2.1.0. For
example

    let g: (Dummy) -> ByteToMessageHandler<Dummy> = ByteToMessageHandler<Dummy>.init
    let h: (Dummy) -> ByteToMessageHandler<Dummy> = ByteToMessageHandler<Dummy>.init(_:)

Modifications:

According to SemVer, this releases a patch that unbreaks the public API.

Result:

No API breakages (checked with `swift-api-digester` which also found the
breakage in the first place).