### PR TITLE
replace redundant commands in docker-compose files with generic one

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -14,14 +14,12 @@ services:
 
   unit-tests:
     image: swift-nio:16.04-5.1
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors"
 
   integration-tests:
     image: swift-nio:16.04-5.1
 
   test:
     image: swift-nio:16.04-5.1
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors && ./scripts/integration_tests.sh"
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30600
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=583100

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -12,14 +12,12 @@ services:
 
   unit-tests:
     image: swift-nio:18.04-5.0
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors"
 
   integration-tests:
     image: swift-nio:18.04-5.0
 
   test:
     image: swift-nio:18.04-5.0
-    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors && ./scripts/integration_tests.sh"
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1155050 # was: 685050

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
 
   unit-tests:
     <<: *common
-    command: /bin/bash -cl "swift test -Xswiftc -DNIO_CI_BUILD"
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors"
 
   integration-tests:
     <<: *common
@@ -33,7 +33,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -cl "swift test -Xswiftc -DNIO_CI_BUILD && ./scripts/integration_tests.sh"
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors && ./scripts/integration_tests.sh"
 
   echo:
     <<: *common


### PR DESCRIPTION
Motivation: keep it DRY

Modifications: move redundant commands from 18-04-5.0 and 16.04-5.1 to the generic task definitions
