### PR TITLE
Fix misleading comment on ELF.map

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -525,7 +525,10 @@ extension EventLoopFuture {
     ///
     /// Operations performed in `map` should not block, or they will block the entire event
     /// loop. `map` is intended for use when you have a data-driven function that performs
-    /// a simple data transformation that can potentially error.
+    /// a simple data transformation that cannot error.
+    ///
+    /// If you have a data-driven function that can throw, you should use `flatMapThrowing`
+    /// instead.
     ///
     /// ```
     /// let future1 = eventually()


### PR DESCRIPTION
Motivation:

We left a doc comment on EventLoopFuture.map that caused confusion by
misleadingly claiming that it could handle throwing functions. The
operation that handles throwing functions is flatMapThrowing.

Modifications:

- Removed the misleading comment and pointed users to flatMapThrowing
    instead.

Result:

Less user confusion.

Resolves #1011.