### PR TITLE
AcceptHandler: don't swallow close errors when quiescing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ var targets: [PackageDescription.Target] = [
     .target(name: "NIOTestUtils",
             dependencies: ["NIO"]),
     .testTarget(name: "NIOTests",
-                dependencies: ["NIO", "NIOFoundationCompat"]),
+                dependencies: ["NIO", "NIOFoundationCompat", "NIOTestUtils", "NIOConcurrencyHelpers"]),
     .testTarget(name: "NIOConcurrencyHelpersTests",
                 dependencies: ["NIOConcurrencyHelpers"]),
     .testTarget(name: "NIOHTTP1Tests",

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -249,7 +249,9 @@ public final class ServerBootstrap {
 
         func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
             if event is ChannelShouldQuiesceEvent {
-                context.channel.close(promise: nil)
+                context.channel.close().whenFailure { error in
+                    context.fireErrorCaught(error)
+                }
             }
             context.fireUserInboundEventTriggered(event)
         }

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -77,6 +77,7 @@ extension ChannelTests {
                 ("testCloseInReadTriggeredByDrainingTheReceiveBufferBecauseOfWriteError", testCloseInReadTriggeredByDrainingTheReceiveBufferBecauseOfWriteError),
                 ("testApplyingTwoDistinctSocketOptionsOfSameTypeWorks", testApplyingTwoDistinctSocketOptionsOfSameTypeWorks),
                 ("testUnprocessedOutboundUserEventFailsOnServerSocketChannel", testUnprocessedOutboundUserEventFailsOnServerSocketChannel),
+                ("testAcceptHandlerDoesNotSwallowCloseErrorsWhenQuiescing", testAcceptHandlerDoesNotSwallowCloseErrorsWhenQuiescing),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When receiving the ChannelShouldQuiesceEvent event, the AcceptHandler
correctly closes the ServerChannel. However, if that fails, it swallows
the error which is incorrect.

Modifications:

Don't swallow the error, send it through the pipeline.

Result:

More correct.