### PR TITLE
alloc counters: disallow too high limits

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_allocation_counts.sh
+++ b/IntegrationTests/tests_04_performance/test_01_allocation_counts.sh
@@ -46,6 +46,8 @@ for test in "${all_tests[@]}"; do
             warn "    export $max_allowed_env_name=$total_allocations"
         fi
     else
-        assert_less_than_or_equal "$total_allocations" "${!max_allowed_env_name}"
+        max_allowed=${!max_allowed_env_name}
+        assert_less_than_or_equal "$total_allocations" "$max_allowed"
+        assert_greater_than "$total_allocations" "$(( max_allowed - 1000))"
     fi
 done

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -20,7 +20,7 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1155050 # was: 685050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1053050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100


### PR DESCRIPTION
Motivation:

For the allocation counter tests to be as useful as possible, we should
disallow limits that are too high, we should capture the allocation
count very close to where it actually is.

Modifications:

Don't allow any allocation counter test to allocate fewer than
'limit - 1000' allocations.

Result:

Better limits.