### PR TITLE
Make EmbeddedChannel.isWritable mutable.

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -395,9 +395,7 @@ public final class EmbeddedChannel: Channel {
     }
 
     /// - see: `Channel.isWritable`
-    public var isWritable: Bool {
-        return true
-    }
+    public var isWritable: Bool = true
 
     /// Synchronously closes the `EmbeddedChannel`.
     ///

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -43,6 +43,7 @@ extension EmbeddedChannelTest {
                 ("testSetLocalAddressAfterSuccessfulBind", testSetLocalAddressAfterSuccessfulBind),
                 ("testSetRemoteAddressAfterSuccessfulConnect", testSetRemoteAddressAfterSuccessfulConnect),
                 ("testUnprocessedOutboundUserEventFailsOnEmbeddedChannel", testUnprocessedOutboundUserEventFailsOnEmbeddedChannel),
+                ("testEmbeddedChannelWritabilityIsWritable", testEmbeddedChannelWritabilityIsWritable),
            ]
    }
 }

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -324,4 +324,15 @@ class EmbeddedChannelTest: XCTestCase {
             }
         }
     }
+
+    func testEmbeddedChannelWritabilityIsWritable() {
+        let channel = EmbeddedChannel()
+        let opaqueChannel: Channel = channel
+        XCTAssertTrue(channel.isWritable)
+        XCTAssertTrue(opaqueChannel.isWritable)
+        channel.isWritable = false
+        XCTAssertFalse(channel.isWritable)
+        XCTAssertFalse(opaqueChannel.isWritable)
+    }
+
 }


### PR DESCRIPTION
Motivation:

When testing programs that check flow control state, it's useful to be
able to control the results of that check. However, right now it's not
possible to set the flow control state of an EmbeddedChannel: it's just
always true. That's not super helpful.

Modifications:

Make EmbeddedChannel.isWritable a stored property that can be changed.

Result:

Better testing.
