### PR TITLE
Fix incorrect closure names in documentation.

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -216,7 +216,7 @@ extension ByteBuffer {
     // MARK: Other APIs
 
     /// Yields an immutable buffer pointer containing this `ByteBuffer`'s readable bytes. Will move the reader index
-    /// by the number of bytes returned by `fn`.
+    /// by the number of bytes returned by `body`.
     ///
     /// - warning: Do not escape the pointer from the closure for later use.
     ///
@@ -232,13 +232,13 @@ extension ByteBuffer {
     }
 
     /// Yields an immutable buffer pointer containing this `ByteBuffer`'s readable bytes. Will move the reader index
-    /// by the number of bytes `fn` returns in the first tuple component.
+    /// by the number of bytes `body` returns in the first tuple component.
     ///
     /// - warning: Do not escape the pointer from the closure for later use.
     ///
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and returns the number of bytes it processed along with some other value.
-    /// - returns: The value `fn` returned in the second tuple component.
+    /// - returns: The value `body` returned in the second tuple component.
     @inlinable
     public mutating func readWithUnsafeReadableBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> (Int, T)) rethrows -> T {
         let (bytesRead, ret) = try self.withUnsafeReadableBytes(body)
@@ -247,7 +247,7 @@ extension ByteBuffer {
     }
 
     /// Yields a mutable buffer pointer containing this `ByteBuffer`'s readable bytes. You may modify the yielded bytes.
-    /// Will move the reader index by the number of bytes returned by `fn` but leave writer index as it was.
+    /// Will move the reader index by the number of bytes returned by `body` but leave writer index as it was.
     ///
     /// - warning: Do not escape the pointer from the closure for later use.
     ///
@@ -263,13 +263,13 @@ extension ByteBuffer {
     }
 
     /// Yields a mutable buffer pointer containing this `ByteBuffer`'s readable bytes. You may modify the yielded bytes.
-    /// Will move the reader index by the number of bytes `fn` returns in the first tuple component but leave writer index as it was.
+    /// Will move the reader index by the number of bytes `body` returns in the first tuple component but leave writer index as it was.
     ///
     /// - warning: Do not escape the pointer from the closure for later use.
     ///
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and returns the number of bytes it processed along with some other value.
-    /// - returns: The value `fn` returned in the second tuple component.
+    /// - returns: The value `body` returned in the second tuple component.
     @inlinable
     public mutating func readWithUnsafeMutableReadableBytes<T>(_ body: (UnsafeMutableRawBufferPointer) throws -> (Int, T)) rethrows -> T {
         let (bytesRead, ret) = try self.withUnsafeMutableReadableBytes(body)

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -466,7 +466,7 @@ public struct ByteBuffer {
     ///
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes.
-    /// - returns: The value returned by `fn`.
+    /// - returns: The value returned by `body`.
     @inlinable
     public mutating func withUnsafeMutableReadableBytes<T>(_ body: (UnsafeMutableRawBufferPointer) throws -> T) rethrows -> T {
         self._copyStorageAndRebaseIfNeeded()
@@ -523,7 +523,7 @@ public struct ByteBuffer {
     ///
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes.
-    /// - returns: The value returned by `fn`.
+    /// - returns: The value returned by `body`.
     @inlinable
     public func withUnsafeReadableBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
         let readerIndex = self.readerIndex
@@ -540,7 +540,7 @@ public struct ByteBuffer {
     ///
     /// - parameters:
     ///     - body: The closure that will accept the yielded bytes and the `storageManagement`.
-    /// - returns: The value returned by `fn`.
+    /// - returns: The value returned by `body`.
     @inlinable
     public func withUnsafeReadableBytesWithStorageManagement<T>(_ body: (UnsafeRawBufferPointer, Unmanaged<AnyObject>) throws -> T) rethrows -> T {
         let storageReference: Unmanaged<AnyObject> = Unmanaged.passUnretained(self._storage)

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -469,7 +469,7 @@ final class Selector<R: Registration> {
         }
     }
 
-    /// Apply the given `SelectorStrategy` and execute `fn` once it's complete (which may produce `SelectorEvent`s to handle).
+    /// Apply the given `SelectorStrategy` and execute `body` once it's complete (which may produce `SelectorEvent`s to handle).
     ///
     /// - parameters:
     ///     - strategy: The `SelectorStrategy` to apply

--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -54,7 +54,7 @@ final class NIOThread {
     ///
     /// - parameters:
     ///     - body: The closure that will accept the `pthread_t`.
-    /// - returns: The value returned by `fn`.
+    /// - returns: The value returned by `body`.
     func withUnsafePthread<T>(_ body: (pthread_t) throws -> T) rethrows -> T {
         return try body(self.pthread)
     }


### PR DESCRIPTION
Motivation:

I noticed some closures were referred to by the wrong name in the
documentation.

Modifications:

Updated the documentation to use the correct names.

Result:

More correct documentation.