### PR TITLE
alloc test: don't delete tmpdir

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
+++ b/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
@@ -287,4 +287,3 @@ for f in "${files[@]}"; do
     swift run "${build_opts[@]}" "$(module_name_from_path "$f")"
 done
 )
-rm -rf "$working_dir"


### PR DESCRIPTION
Motivation:

The allocation tests shouldn't delete their working directory because
that's where you would navigate to debug them. Usually, they're run
through the integration tests which automatically clean up anyway.

Modifications:

Don't delete work dir

Result:

Easier to debug