### PR TITLE
When testing for an IPv6 Loopack interface try resolving ::1

### DIFF
--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -51,7 +51,7 @@ final class MulticastTest: XCTestCase {
 
     private var supportsIPv6: Bool {
         do {
-            let ipv6Loopback = try SocketAddress(ipAddress: "::1", port: 0)
+            let ipv6Loopback = try SocketAddress.makeAddressResolvingHost("::1", port: 0)
             return try System.enumerateInterfaces().filter { $0.address == ipv6Loopback }.first != nil
         } catch {
             return false


### PR DESCRIPTION
Motivation:

On an Ubuntu18 system with a loopback interface configured with both
an IPv4 and IPv6 address, SocketAddress(ipAddress: "::1", port: 0) will
succeed, indicating that an IPv6 interface is configured. However if the
ethernet address has only an IPv4 address, getaddrinfo("::1", ...) will
fail even though the host resolution should work. This appears to be a
bug in the getaddrinfo() config.

This means that the tests will proceed assuming IPv6 is available, but
later tests that attempt to resolve "::1" will fail unexpectedly.

Modifications:

Change the ipv6Loopback test to attempt a resolution initially and if
this fails then assume that an IPv6 loopback is not available.

Result:

The Multicast.testCanJoinBasicMulticastGroupIPv6 test is skipped instead
of failing.
