### PR TITLE
when making a socket non-blocking, get & OR flags

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -269,7 +269,8 @@ class BaseSocket: Selectable {
         #if !os(Linux)
         if setNonBlocking {
             do {
-                let ret = try Posix.fcntl(descriptor: sock, command: F_SETFL, value: O_NONBLOCK)
+                let flags = try Posix.fcntl(descriptor: sock, command: F_GETFL, value: 0)
+                let ret = try Posix.fcntl(descriptor: sock, command: F_SETFL, value: flags | O_NONBLOCK)
                 assert(ret == 0, "unexpectedly, fcntl(\(sock), F_SETFL, O_NONBLOCK) returned \(ret)")
             } catch {
                 // best effort close
@@ -319,7 +320,8 @@ class BaseSocket: Selectable {
     /// throws: An `IOError` if the operation failed.
     final func setNonBlocking() throws {
         return try withUnsafeFileDescriptor { fd in
-            let ret = try Posix.fcntl(descriptor: fd, command: F_SETFL, value: O_NONBLOCK)
+            let flags = try Posix.fcntl(descriptor: fd, command: F_GETFL, value: 0)
+            let ret = try Posix.fcntl(descriptor: fd, command: F_SETFL, value: flags | O_NONBLOCK)
             assert(ret == 0, "unexpectedly, fcntl(\(fd), F_SETFL, O_NONBLOCK) returned \(ret)")
         }
     }

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -405,7 +405,8 @@ class NonBlockingFileIOTest: XCTestCase {
         try withPipe { readFH, writeFH in
             do {
                 try readFH.withUnsafeFileDescriptor { readFD in
-                    let ret = try Posix.fcntl(descriptor: readFD, command: F_SETFL, value: O_NONBLOCK)
+                    let flags = try Posix.fcntl(descriptor: readFD, command: F_GETFL, value: 0)
+                    let ret = try Posix.fcntl(descriptor: readFD, command: F_SETFL, value: flags | O_NONBLOCK)
                     assert(ret == 0, "unexpectedly, fcntl(\(readFD), F_SETFL, O_NONBLOCK) returned \(ret)")
                 }
                 try self.fileIO.readChunked(fileHandle: readFH,

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -48,6 +48,7 @@ extension SocketChannelTest {
                 ("testInstantTCPConnectionResetThrowsError", testInstantTCPConnectionResetThrowsError),
                 ("testUnprocessedOutboundUserEventFailsOnServerSocketChannel", testUnprocessedOutboundUserEventFailsOnServerSocketChannel),
                 ("testUnprocessedOutboundUserEventFailsOnSocketChannel", testUnprocessedOutboundUserEventFailsOnSocketChannel),
+                ("testSetSockOptDoesNotOverrideExistingFlags", testSetSockOptDoesNotOverrideExistingFlags),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously, we would just `F_SETFL, O_NONBLOCK` which would erase all
possibly pre-existing flags which isn't great.

Modifications:

First get the existing flags and then do `F_SETFL, existingFlags |
O_NONBLOCK`.

Result:

Possibly helps with #1030, definitely better style.