### PR TITLE
don't close server socket if fcntl(O_NONBLOCK) throws EINVAL

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -349,6 +349,13 @@ public enum ChannelError: Error {
 
 extension ChannelError: Equatable { }
 
+/// `NIOFailedToSetSocketNonBlockingError` indicates that NIO was unable to set a socket to non-blocking mode, either
+/// when connecting a socket as a client or when accepting a socket as a server.
+///
+/// This error should never happen because a socket should always be able to be set to non-blocking mode. Unfortunately,
+/// we have seen this happen on Darwin.
+public struct NIOFailedToSetSocketNonBlockingError: Error {}
+
 /// An `Channel` related event that is passed through the `ChannelPipeline` to notify the user.
 public enum ChannelEvent: Equatable {
     /// `ChannelOptions.allowRemoteHalfClosure` is `true` and input portion of the `Channel` was closed.

--- a/Sources/NIO/ServerSocket.swift
+++ b/Sources/NIO/ServerSocket.swift
@@ -89,7 +89,13 @@
             let sock = Socket(descriptor: fd)
             #if !os(Linux)
             if setNonBlocking {
-                try sock.setNonBlocking()
+                do {
+                    try sock.setNonBlocking()
+                } catch {
+                    // best effort
+                    try? sock.close()
+                    throw error
+                }
             }
             #endif
             return sock

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -49,6 +49,7 @@ extension SocketChannelTest {
                 ("testUnprocessedOutboundUserEventFailsOnServerSocketChannel", testUnprocessedOutboundUserEventFailsOnServerSocketChannel),
                 ("testUnprocessedOutboundUserEventFailsOnSocketChannel", testUnprocessedOutboundUserEventFailsOnSocketChannel),
                 ("testSetSockOptDoesNotOverrideExistingFlags", testSetSockOptDoesNotOverrideExistingFlags),
+                ("testServerChannelDoesNotBreakIfAcceptingFailsWithEINVAL", testServerChannelDoesNotBreakIfAcceptingFailsWithEINVAL),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Darwin does sometimes hand us back an (as of the docs) illegal error
code of EINVAL. So far, NIO has done the non-sensical thing of closing
the server socket as a result.

Modifications:

Just close the accepted socket, leave the server socket open, and fire
the error through the pipeline.

Result:

- fixes #1030
- better behaviour