### PR TITLE
remove platform availability again

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -77,9 +77,6 @@ var targets: [PackageDescription.Target] = [
 
 let package = Package(
     name: "swift-nio",
-    platforms: [
-        .macOS(.v10_12), .iOS(.v10), .watchOS(.v3), .tvOS(.v10),
-    ],
     products: [
         .executable(name: "NIOEchoServer", targets: ["NIOEchoServer"]),
         .executable(name: "NIOEchoClient", targets: ["NIOEchoClient"]),

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -106,7 +106,11 @@ var temporaryDirectory: String {
 #elseif os(Linux)
         return "/tmp"
 #else
-        return FileManager.default.temporaryDirectory.path
+        if #available(OSX 10.12, *) {
+            return FileManager.default.temporaryDirectory.path
+        } else {
+            return "/tmp"
+        }
 #endif
     }
 }


### PR DESCRIPTION
Motivation:

The platform availability that we recently introduced caused problems
because it would require all downstream projects to define the same or
narrower platform availability to still compile with NIO which would
make this very disrupting and also SemVer major.

Modifications:

Remove the platform availability declarations.

Result:

No SemVer breakages.