### PR TITLE
analyze_performance_results: switch to "min" instead of "mean"

### DIFF
--- a/scripts/analyze_performance_results.rb
+++ b/scripts/analyze_performance_results.rb
@@ -14,7 +14,7 @@
 ##===----------------------------------------------------------------------===##
 require 'optparse'
 
-METRIC="mean" # used for comparison
+METRIC="min" # used for comparison
 
 module Enumerable
   def sum


### PR DESCRIPTION
Motivation:

Mean is not a great aggregation function because it's not resilient
against outliers at all, so let's switch to min.

Modifications:

Switch 'mean' to 'min' for aggregation.

Result:

Aggregation function that's more resilient against outliers.