### PR TITLE
ByteBuffer.get/readData: Heuristic when to copy/not copy

### DIFF
--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -138,6 +138,10 @@ extension ByteBufferTest {
                 ("testVariousContiguousStorageAccessors", testVariousContiguousStorageAccessors),
                 ("testGetBytesThatAreNotReadable", testGetBytesThatAreNotReadable),
                 ("testByteBufferViewAsDataProtocol", testByteBufferViewAsDataProtocol),
+                ("testDataByteTransferStrategyNoCopy", testDataByteTransferStrategyNoCopy),
+                ("testDataByteTransferStrategyCopy", testDataByteTransferStrategyCopy),
+                ("testDataByteTransferStrategyAutomaticMayNotCopy", testDataByteTransferStrategyAutomaticMayNotCopy),
+                ("testDataByteTransferStrategyAutomaticMayCopy", testDataByteTransferStrategyAutomaticMayCopy),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously, ByteBuffer tried to never copy the bytes when transferring
to a `Data`. For small copies that's definitely not a good choice
because it means an extra allocation.

Modifications:

- introduce `ByteTransferStrategy` so the user can choose
- make a heuristic: copy is less than 256kB, try not to copy above

Result:

- More sensible defaults.
- fixes #935
