### PR TITLE
EventLoopPromise.completeWith(Future), mirroring ELF.cascade(to:) #1052

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -183,6 +183,19 @@ public struct EventLoopPromise<Value> {
     public func fail(_ error: Error) {
         self._resolve(value: .failure(error))
     }
+    
+    /// Complete the promise with the passed in `EventLoopFuture<Value>`.
+    ///
+    /// This method is equivalent to invoking `future.cascade(to: promise)`,
+    /// but sometimes may read better than its cascade counterpart.
+    /// 
+    /// - parameters:
+    ///     - future: The future whose value will be used to succeed or fail this promise.
+    /// - seealso: `EventLoopFuture.cascade(to:)`
+    @inlinable
+    public func completeWith(_ future: EventLoopFuture<Value>) {
+        future.cascade(to: self)
+    }
 
     /// Fire the associated `EventLoopFuture` on the appropriate event loop.
     ///
@@ -794,6 +807,7 @@ extension EventLoopFuture {
     /// ```
     ///
     /// - Parameter to: The `EventLoopPromise` to fulfill with the results of this future.
+    /// - SeeAlso: `EventLoopPromise.completeWith(_:)`
     @inlinable
     public func cascade(to promise: EventLoopPromise<Value>?) {
         guard let promise = promise else { return }

--- a/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
@@ -72,6 +72,8 @@ extension EventLoopFutureTest {
                 ("testWhenAllCompleteResolvesAfterFutures", testWhenAllCompleteResolvesAfterFutures),
                 ("testAlways", testAlways),
                 ("testAlwaysWithFailingPromise", testAlwaysWithFailingPromise),
+                ("testPromiseCompletedWithSuccessfulFuture", testPromiseCompletedWithSuccessfulFuture),
+                ("testPromiseCompletedWithFailedFuture", testPromiseCompletedWithFailedFuture),
            ]
    }
 }


### PR DESCRIPTION
Adds `EventLoopPromise.completeWith(ELF)`

### Motivation:

Easier discoverability of the promise / future combining APIs.

### Result:
Resolves https://github.com/apple/swift-nio/issues/1052

Now possible to write `promise.completeWith(future)`, which may also be easier to discover using autocomplete, when looking at `promise.succeed / fail` etc.

cc @weissi @Lukasa, let me know if any more docs required etc.