### PR TITLE
make illegal SelectableEventLoop.shutdown impossible

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -914,22 +914,10 @@ internal final class SelectableEventLoop: EventLoop {
 
     @usableFromInline
     func shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {
-        self.closeGently().map {
-            do {
-                try self.close0()
-                queue.async {
-                    callback(nil)
-                }
-            } catch {
-                queue.async {
-                    callback(error)
-                }
-            }
-        }.whenFailure { error in
-            _ = try? self.close0()
-            queue.async {
-                callback(error)
-            }
+        // This function is never called legally because the only possibly owner of an `SelectableEventLoop` is
+        // `MultiThreadedEventLoopGroup` which calls `closeGently`.
+        queue.async {
+            callback(EventLoopError.unsupportedOperation)
         }
     }
 }

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -53,6 +53,7 @@ extension EventLoopTest {
                 ("testAndAllCompleteWithZeroFutures", testAndAllCompleteWithZeroFutures),
                 ("testAndAllSucceedWithZeroFutures", testAndAllSucceedWithZeroFutures),
                 ("testCancelledScheduledTasksDoNotHoldOnToRunClosure", testCancelledScheduledTasksDoNotHoldOnToRunClosure),
+                ("testIllegalCloseOfEventLoopFails", testIllegalCloseOfEventLoopFails),
            ]
    }
 }

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -330,9 +330,10 @@ class SelectorTest: XCTestCase {
                 }
             }
         }
-        let el = MultiThreadedEventLoopGroup(numberOfThreads: 1).next()
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let el = elg.next()
         defer {
-            XCTAssertNoThrow(try el.syncShutdownGracefully())
+            XCTAssertNoThrow(try elg.syncShutdownGracefully())
         }
         XCTAssertNoThrow(try withTemporaryUnixDomainSocketPathName { udsPath in
             let secondServerChannel = try! ServerBootstrap(group: el)


### PR DESCRIPTION
Motivation:

It's illegal to shut down a SelectableEventLoop because the only valid
owner is a MultiThreadedEventLoopGroup which never uses
shutdownGracefully on its EventLoops.

Modifications:

Fail shutdown attempts instead of running some random, untested code.

Result:

Fail illegal calls rather than running some dangerous code which will
lead to deadlocks further down the line.