### PR TITLE
check breakages: fail loudly when unable to checkout tag

### DIFF
--- a/scripts/check_no_api_breakages.sh
+++ b/scripts/check_no_api_breakages.sh
@@ -35,7 +35,7 @@ function build_and_do() {
 
     (
     cd "$repodir"
-    git checkout "$tag" 2> /dev/null
+    git checkout -q "$tag" 
     swift build
     while read -r module; do
         swift api-digester -dump-sdk -module "$module" \


### PR DESCRIPTION
One line description of your change

### Motivation:

When using the script ad hoc to verify something you may have forgotten to pull all tags,
the script then fails mysteriously in silence and no output. Detective work can then lead the script mysteriously stopping after a checkout:

```
+ cd /tmp/.check-api_1Q1rvO/repo
+ git checkout 1.1.0
$ ...
```

which reminds you to perform a fetch; it would be nicer if it told us about the issue explicitly though.

### Modifications:
Don't silence `git checkout` all error output, though use quiet mode so no progress is printed.

### Result:

Script fails nicer and reminds you to perform a git fetch if you forgot to do so.

e.g.

```
[5/5] Merging module Metrics
error: pathspec '1.1.0' did not match any file(s) known to git
```
