### PR TITLE
add swift-api-digester docker setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
 
 # basic dependencies
-RUN apt-get update && apt-get install -y wget git build-essential software-properties-common pkg-config locales
+RUN apt-get update && apt-get install -y wget git jq build-essential software-properties-common pkg-config locales
 RUN apt-get update && apt-get install -y libicu-dev libblocksruntime0
 RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools # used by integration tests
 
@@ -41,11 +41,7 @@ RUN [ -z $install_curl_from_source ] || ( cd $HOME/.curl && ./configure --with-s
 RUN [ -z $install_curl_from_source ] || ldconfig
 
 # ruby and jazzy for docs generation
-ARG skip_ruby_from_ppa
-RUN [ -n "$skip_ruby_from_ppa" ] || apt-add-repository -y ppa:brightbox/ruby-ng
-RUN [ -n "$skip_ruby_from_ppa" ] || { apt-get update && apt-get install -y ruby2.4 ruby2.4-dev; }
-RUN [ -z "$skip_ruby_from_ppa" ] || { apt-get update && apt-get install -y ruby ruby-dev; }
-RUN apt-get update && apt-get install -y libsqlite3-dev
+RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
 RUN gem install jazzy --no-ri --no-rdoc
 
 # swift

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -8,9 +8,8 @@ services:
       args:
         ubuntu_version: "16.04"
         swift_version: "5.1"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-07-09-a"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-07-13-a"
         swift_builds_suffix: "branch"
-        skip_ruby_from_ppa: "true"
 
   unit-tests:
     image: swift-nio:16.04-5.1

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -8,7 +8,7 @@ services:
       args:
         ubuntu_version: "16.04"
         swift_version: "5.1"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-07-13-a"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-07-09-a"
         swift_builds_suffix: "branch"
 
   unit-tests:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,7 +8,6 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        skip_ruby_from_ppa: "true"
 
   unit-tests:
     image: swift-nio:18.04-5.0


### PR DESCRIPTION
motivation: prepare to run swift-api-digester in ci

changes:
* add jq to docker setup
* update to a swift 5.1 version that includes swift-api-digester
* remove redundant ruby setting from docker file
