### PR TITLE
add two ELF.reduce benchmarks

### DIFF
--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -700,4 +700,19 @@ measureAndPrint(desc: "future_whenallcomplete_100k_deferred_on_loop") {
     return allSucceeded.count
 }
 
+measureAndPrint(desc: "future_reduce_10k_futures") {
+    let el1 = group.next()
+
+    let oneHundredFutures = (1 ... 10_000).map { i in el1.makeSucceededFuture(i) }
+    return try! EventLoopFuture<Int>.reduce(0, oneHundredFutures, on: el1, +).wait()
+}
+
+measureAndPrint(desc: "future_reduce_into_10k_futures") {
+    let el1 = group.next()
+
+    let oneHundredFutures = (1 ... 10_000).map { i in el1.makeSucceededFuture(i) }
+    return try! EventLoopFuture<Int>.reduce(into: 0, oneHundredFutures, on: el1, { $0 += $1 }).wait()
+}
+
+
 try measureAndPrint(desc: "channel_pipeline_1m_events", benchmark: ChannelPipelineBenchmark.self)


### PR DESCRIPTION
Motivation:

As #1054 shows, we have some low-hanging performance fruit regarding
off-EventLoop future reduces. We should quantify those.

Modifications:

Add benchmarks to quantify the potential wins.

Result:

More benchmarks.