### PR TITLE
fix subtracting NIODeadlines

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -394,7 +394,7 @@ extension NIODeadline: CustomStringConvertible {
 
 extension NIODeadline {
     public static func - (lhs: NIODeadline, rhs: NIODeadline) -> TimeAmount {
-        return .nanoseconds(TimeAmount.Value(lhs.uptimeNanoseconds - rhs.uptimeNanoseconds))
+        return .nanoseconds(TimeAmount.Value(lhs.uptimeNanoseconds) - TimeAmount.Value(rhs.uptimeNanoseconds))
     }
 
     public static func + (lhs: NIODeadline, rhs: TimeAmount) -> NIODeadline {

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -54,6 +54,7 @@ extension EventLoopTest {
                 ("testAndAllSucceedWithZeroFutures", testAndAllSucceedWithZeroFutures),
                 ("testCancelledScheduledTasksDoNotHoldOnToRunClosure", testCancelledScheduledTasksDoNotHoldOnToRunClosure),
                 ("testIllegalCloseOfEventLoopFails", testIllegalCloseOfEventLoopFails),
+                ("testSubtractingDeadlineFromPastAndFuturesDeadlinesWorks", testSubtractingDeadlineFromPastAndFuturesDeadlinesWorks),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -795,4 +795,13 @@ public final class EventLoopTest : XCTestCase {
             }
         }
     }
+
+    func testSubtractingDeadlineFromPastAndFuturesDeadlinesWorks() {
+        let older = NIODeadline.now()
+        Thread.sleep(until: Date().addingTimeInterval(0.02))
+        let newer = NIODeadline.now()
+
+        XCTAssertLessThan(older - newer, .nanoseconds(0))
+        XCTAssertGreaterThan(newer - older, .nanoseconds(0))
+    }
 }


### PR DESCRIPTION
Motivation:

Subtracting deadlines should just work, no matter if the result is
positive or negative.

Modifications:

Don't crash on earlierDeadline - laterDeadline.

Result:

- fewer crashes
- fixes https://github.com/swift-server/async-http-client/issues/71