### PR TITLE
api breakage tester: fetch all refs

### DIFF
--- a/scripts/check_no_api_breakages.sh
+++ b/scripts/check_no_api_breakages.sh
@@ -35,7 +35,7 @@ function build_and_do() {
 
     (
     cd "$repodir"
-    git checkout -q "$tag" 
+    git checkout -q "$tag"
     swift build
     while read -r module; do
         swift api-digester -sdk "$sdk" -dump-sdk -module "$module" \
@@ -76,6 +76,7 @@ shift 2
 
 repodir="$tmpdir/repo"
 git clone "$repo_url" "$repodir"
+git -C "$repodir" fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
 errors=0
 
 for old_tag in "$@"; do


### PR DESCRIPTION
Motivation:

To be able to use SHA sums as git versions, we need to pull all the refs
to we get even the commit SHAs from PRs. That's important so CI can use
this script.

Modifications:

Fetch `+refs/pull/*:refs/remotes/origin/pr/*` refs.

Result:

Should be able to be usable in CI across forks.