### PR TITLE
NonBlockingFileIO: add multi write test

### DIFF
--- a/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
@@ -46,6 +46,7 @@ extension NonBlockingFileIOTest {
                 ("testReadFromNonBlockingPipeFails", testReadFromNonBlockingPipeFails),
                 ("testSeekPointerIsSetToFront", testSeekPointerIsSetToFront),
                 ("testWriting", testWriting),
+                ("testWriteMultipleTimes", testWriteMultipleTimes),
                 ("testFileOpenWorks", testFileOpenWorks),
                 ("testFileOpenWorksWithEmptyFile", testFileOpenWorksWithEmptyFile),
                 ("testFileOpenFails", testFileOpenFails),


### PR DESCRIPTION
Motivation:

The behaviour of multiple writes followed by each other is important so
we should have a unit test for that.

Modifications:

Add a unit test that shows that we just write to where ever the seek
pointer is.

Result:

More test coverage.