### PR TITLE
Deprecate and replace ByteBuffer.set(buffer:at:)

### DIFF
--- a/Sources/NIO/ByteBuffer-aux.swift
+++ b/Sources/NIO/ByteBuffer-aux.swift
@@ -284,7 +284,19 @@ extension ByteBuffer {
     ///     - index: The index for the first byte.
     /// - returns: The number of bytes written.
     @discardableResult
+    @available(*, deprecated, renamed: "setBuffer(_:at:)")
     public mutating func set(buffer: ByteBuffer, at index: Int) -> Int {
+        return self.setBuffer(buffer, at: index)
+    }
+
+    /// Copy `buffer`'s readable bytes into this `ByteBuffer` starting at `index`. Does not move any of the reader or writer indices.
+    ///
+    /// - parameters:
+    ///     - buffer: The `ByteBuffer` to copy.
+    ///     - index: The index for the first byte.
+    /// - returns: The number of bytes written.
+    @discardableResult
+    public mutating func setBuffer(_ buffer: ByteBuffer, at index: Int) -> Int {
         return buffer.withUnsafeReadableBytes{ p in
             self.setBytes(p, at: index)
         }
@@ -298,7 +310,7 @@ extension ByteBuffer {
     /// - returns: The number of bytes written to this `ByteBuffer` which is equal to the number of bytes read from `buffer`.
     @discardableResult
     public mutating func writeBuffer(_ buffer: inout ByteBuffer) -> Int {
-        let written = set(buffer: buffer, at: writerIndex)
+        let written = self.setBuffer(buffer, at: writerIndex)
         self._moveWriterIndex(forwardBy: written)
         buffer._moveReaderIndex(forwardBy: written)
         return written

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -726,7 +726,7 @@ class ByteBufferTest: XCTestCase {
         var src = self.allocator.buffer(capacity: 4)
         src.writeBytes(Data([0, 1, 2, 3]))
 
-        self.buf.set(buffer: src, at: 1)
+        self.buf.setBuffer(src, at: 1)
 
         /* Should bit increase the writerIndex of the src buffer */
         XCTAssertEqual(4, src.readableBytes)


### PR DESCRIPTION
Motivation:

In NIO2 we tried to adopt the Swift convention of avoiding functions
that differ only by the word of their first label where that label is
describing their type. Sadly, we missed one.

Modifications:

- Wrote setBuffer(_:at:)
- Deprecated set(buffer:at:) in favour of the new function.

Result:

Users will get some deprecation warnings I guess.
