### PR TITLE
ByteBuffer: viewBytes should handle negative values

### DIFF
--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -81,7 +81,7 @@ extension ByteBuffer {
     ///   - length: The length of the view (in bytes)
     /// - returns: A view into a portion of a `ByteBuffer` or `nil` if the requested bytes were not readable.
     public func viewBytes(at index: Int, length: Int) -> ByteBufferView? {
-        guard index >= self.readerIndex && index <= self.writerIndex - length else {
+        guard length >= 0 && index >= self.readerIndex && index <= self.writerIndex - length else {
             return nil
         }
 

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -142,6 +142,7 @@ extension ByteBufferTest {
                 ("testDataByteTransferStrategyCopy", testDataByteTransferStrategyCopy),
                 ("testDataByteTransferStrategyAutomaticMayNotCopy", testDataByteTransferStrategyAutomaticMayNotCopy),
                 ("testDataByteTransferStrategyAutomaticMayCopy", testDataByteTransferStrategyAutomaticMayCopy),
+                ("testViewBytesIsHappyWithNegativeValues", testViewBytesIsHappyWithNegativeValues),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -971,6 +971,7 @@ class ByteBufferTest: XCTestCase {
         testIndexAndLengthFunc(buf.getSlice)
         testIndexAndLengthFunc(buf.getString)
         testIndexAndLengthFunc(buf.getDispatchData)
+        testIndexAndLengthFunc(buf.viewBytes(at:length:))
     }
 
     func testWriteForContiguousCollections() throws {
@@ -1954,6 +1955,20 @@ class ByteBufferTest: XCTestCase {
         }
 
         XCTAssertNotEqual(byteBufferPointerValue, dataPointerValue)
+    }
+
+    func testViewBytesIsHappyWithNegativeValues() {
+        self.buf.clear()
+        XCTAssertNil(self.buf.viewBytes(at: -1, length: 0))
+        XCTAssertNil(self.buf.viewBytes(at: 0, length: -1))
+        XCTAssertNil(self.buf.viewBytes(at: -1, length: -1))
+
+        self.buf.writeString("hello world")
+        self.buf.moveWriterIndex(forwardBy: 6)
+
+        XCTAssertNil(self.buf.viewBytes(at: -1, length: 0))
+        XCTAssertNil(self.buf.viewBytes(at: 0, length: -1))
+        XCTAssertNil(self.buf.viewBytes(at: -1, length: -1))
     }
 }
 


### PR DESCRIPTION
Motivation:

All ByteBuffer API that is used to parse potentially untrusted data
should be resilient against negative indices, offsets, and lenghts.
Unfortunately, ByteBuffer.viewBytes(at:length:) was not.

Modifications:

Make ByteBuffer.viewBytes(at:length:) resilient against negative values.

Result:

Fewer crashes.