### PR TITLE
Tolerate unsolicited HTTP responses.

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -50,6 +50,8 @@ extension HTTPDecoderTest {
                 ("testBytesCanBeForwardedWhenHandlerRemoved", testBytesCanBeForwardedWhenHandlerRemoved),
                 ("testBytesCanBeFiredAsErrorWhenHandlerRemoved", testBytesCanBeFiredAsErrorWhenHandlerRemoved),
                 ("testBytesCanBeDroppedWhenHandlerRemoved", testBytesCanBeDroppedWhenHandlerRemoved),
+                ("testAppropriateErrorWhenReceivingUnsolicitedResponse", testAppropriateErrorWhenReceivingUnsolicitedResponse),
+                ("testAppropriateErrorWhenReceivingUnsolicitedResponseDoesNotRecover", testAppropriateErrorWhenReceivingUnsolicitedResponseDoesNotRecover),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Right now NIO clients will crash in the (admittedly unlikely) event that
a HTTP server sends an unsolicited extra response on a connection. This
seems pretty unnecessary, and fairly graceless.

Modifications:

- Replace a forcible pop with an optional one.
- Added NIOHTTPDecoderError type.

Result:

Removed a crash that we definitely don't want.
