### PR TITLE
Fix hanging thread when shutting down an already closed EventLoopGroup

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -1131,8 +1131,6 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
             }
         }
 
-        self.shutdownLock.unlock()
-
         var error: Error? = nil
 
         for loop in self.eventLoops {

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -1113,8 +1113,6 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
         let g = DispatchGroup()
         let q = DispatchQueue(label: "nio.shutdownGracefullyQueue", target: queue)
         let wasRunning: Bool = self.shutdownLock.withLock {
-            defer { shutdownLock.unlock() }
-
             switch self.runState {
             case .running:
                 self.runState = .closing([])

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -55,6 +55,8 @@ extension EventLoopTest {
                 ("testCancelledScheduledTasksDoNotHoldOnToRunClosure", testCancelledScheduledTasksDoNotHoldOnToRunClosure),
                 ("testIllegalCloseOfEventLoopFails", testIllegalCloseOfEventLoopFails),
                 ("testSubtractingDeadlineFromPastAndFuturesDeadlinesWorks", testSubtractingDeadlineFromPastAndFuturesDeadlinesWorks),
+                ("testCallingSyncShutdownGracefullyMultipleTimesShouldNotHang", testCallingSyncShutdownGracefullyMultipleTimesShouldNotHang),
+                ("testCallingShutdownGracefullyMultipleTimesShouldExecuteAllCallbacks", testCallingShutdownGracefullyMultipleTimesShouldExecuteAllCallbacks),
            ]
    }
 }


### PR DESCRIPTION
Resolves: #1081 

Adds a check to `MultithreadedEventLoopGroup.shutdownGracefully` to see if the ELG has already been closed or is in the process of closing. And handles it gracefully.

In case it is in the process of closing, the callback of the second call will be registered and executed after the group has been closed.

In case it is already closed, the callback will be executed immediately.