### PR TITLE
nil out writeRecorder, same as all other fields in teardown

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
@@ -139,8 +139,9 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         }
         self.requestHead = nil
         self.responseHead = nil
-        self.readCounter = nil
         self.readRecorder = nil
+        self.readCounter = nil
+        self.writeRecorder = nil
         self.pipelineHandler = nil
         self.quiesceEventRecorder = nil
     }


### PR DESCRIPTION
Motivation:

Without niling out it may linger around once the last test has
completed, and keep some messages in memory which will not be inspected
anymore

Modifications:

nil out the writeRecorder same as all other fields are currently nilled
out

Result:

In case XCTest keeps the class around, not keeping around the messages
stored by the writeRecorder
