### PR TITLE
fix double remove of handlers

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -500,7 +500,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
 
         guard inThePipeline else {
-            // if both next and prev are nil already, the we were previously removed from the pipeline
+            // if both next and prev are nil already, then we were previously removed from the pipeline
             promise?.succeed(())
             return
         }

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -488,11 +488,21 @@ public final class ChannelPipeline: ChannelInvoker {
 
         let nextCtx = context.next
         let prevCtx = context.prev
+        var inThePipeline = false
+
         if let prevCtx = prevCtx {
+            inThePipeline = true
             prevCtx.next = nextCtx
         }
         if let nextCtx = nextCtx {
+            inThePipeline = true
             nextCtx.prev = prevCtx
+        }
+
+        guard inThePipeline else {
+            // if both next and prev are nil already, the we were previously removed from the pipeline
+            promise?.succeed(())
+            return
         }
 
         do {

--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -59,6 +59,7 @@ extension ByteToMessageDecoderTest {
                 ("testWeAreOkayWithReceivingDataAfterFullClose", testWeAreOkayWithReceivingDataAfterFullClose),
                 ("testPayloadTooLarge", testPayloadTooLarge),
                 ("testPayloadTooLargeButHandlerOk", testPayloadTooLargeButHandlerOk),
+                ("testRemoveHandlerBecauseOfChannelTearDownWhilstUserTriggeredRemovalIsInProgress", testRemoveHandlerBecauseOfChannelTearDownWhilstUserTriggeredRemovalIsInProgress),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously, it was possible that a handler was removed twice: Once by
Channel teardown and another time by a user-trigger removal that wasn't
instantaneous. This racy situation can happen in the real world. NIO
behaved wrongly in two ways:

1. we would call `handlerRemoved` twiced
2. ByteToMessageHandler would fail an assertion about the current
   removal state

Modifications:

- Only call `handlerRemoved` when the handler actually gets removed.
- Fix the assertion.

Result:

fewer bugs & crashes