### PR TITLE
Deliver HTTPServerUpgradeHandler data on removal.

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests+XCTest.swift
@@ -45,6 +45,8 @@ extension HTTPServerUpgradeTestCase {
                 ("testDelayedUpgradeResponseDeliversFullRequestAndPendingBits", testDelayedUpgradeResponseDeliversFullRequestAndPendingBits),
                 ("testRemovesAllHTTPRelatedHandlersAfterUpgrade", testRemovesAllHTTPRelatedHandlersAfterUpgrade),
                 ("testUpgradeWithUpgradePayloadInlineWithRequestWorks", testUpgradeWithUpgradePayloadInlineWithRequestWorks),
+                ("testDeliversBytesWhenRemovedDuringPartialUpgrade", testDeliversBytesWhenRemovedDuringPartialUpgrade),
+                ("testDeliversBytesWhenReentrantlyCalledInChannelReadCompleteOnRemoval", testDeliversBytesWhenReentrantlyCalledInChannelReadCompleteOnRemoval),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

There is currently a pair of windows in which it is possible for the
HTTPServerUpgradeHandler to buffer some data without replaying it. This
can happen if it is reentrantly called just after it finishes
unbuffering data, which is not great.

To avoid this, we move to execute this data delivery while we're
removing ourselves. This ensures that we are confident that we cannot be
reentrantly called after our last outcall, meaning we can be confident
of 100% data delivery.

Modifications:

- Moved delayed data delivery to removeHandler.

Result:

Less chance of quiet data loss
