### PR TITLE
HTTPDecoder: don't deliver unsolicited responses

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -52,6 +52,7 @@ extension HTTPDecoderTest {
                 ("testBytesCanBeDroppedWhenHandlerRemoved", testBytesCanBeDroppedWhenHandlerRemoved),
                 ("testAppropriateErrorWhenReceivingUnsolicitedResponse", testAppropriateErrorWhenReceivingUnsolicitedResponse),
                 ("testAppropriateErrorWhenReceivingUnsolicitedResponseDoesNotRecover", testAppropriateErrorWhenReceivingUnsolicitedResponseDoesNotRecover),
+                ("testOneRequestTwoResponses", testOneRequestTwoResponses),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Despite the fact that we already stopped delivering unsolicited
responses for the HTTP response decoder, there was a window where we
would deliver a second .head for a response that come without a request.

Modifications:

Don't deliver a second .head even if send together with a first, legit
response.

Result:

Being a HTTP client using NIO is now easier.