### PR TITLE
really no double handlerRemoved calls

### DIFF
--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -60,6 +60,7 @@ extension ChannelPipelineTest {
                 ("testNonRemovableChannelHandlerIsNotRemovable", testNonRemovableChannelHandlerIsNotRemovable),
                 ("testAddMultipleHandlers", testAddMultipleHandlers),
                 ("testPipelineDebugDescription", testPipelineDebugDescription),
+                ("testWeDontCallHandlerRemovedTwiceIfAHandlerCompletesRemovalOnlyAfterChannelTeardown", testWeDontCallHandlerRemovedTwiceIfAHandlerCompletesRemovalOnlyAfterChannelTeardown),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

In #1091 we fixed the most common case of handlerRemoved being called
multiple times. There was still another (less likely) problem left which
is if a manual removal is triggered from _within_ the handlerRemoved
call from a pipeline teardown, then we would still call handlerRemoved
another time.

Modifications:

Properly guard against handlerRemoved being called twice.

Result:

Fewer bugs.