### PR TITLE
Fail promise in MessageToByteHandler write error cases

### DIFF
--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -767,6 +767,7 @@ extension MessageToByteHandler {
         case .notInChannelYet:
             preconditionFailure("MessageToByteHandler.write called before it was added to a Channel")
         case .error(let error):
+            promise?.fail(error)
             context.fireErrorCaught(error)
             return
         case .done:
@@ -784,6 +785,7 @@ extension MessageToByteHandler {
             context.write(self.wrapOutboundOut(self.buffer!), promise: promise)
         } catch {
             self.state = .error(error)
+            promise?.fail(error)
             context.fireErrorCaught(error)
         }
     }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -75,6 +75,7 @@ import XCTest
          testCase(IntegerTypesTest.allTests),
          testCase(MarkedCircularBufferTests.allTests),
          testCase(MessageToByteEncoderTest.allTests),
+         testCase(MessageToByteHandlerTest.allTests),
          testCase(MulticastTest.allTests),
          testCase(NIOAnyDebugTest.allTests),
          testCase(NIOCloseOnErrorHandlerTest.allTests),

--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -74,3 +74,12 @@ extension MessageToByteEncoderTest {
    }
 }
 
+extension MessageToByteHandlerTest {
+
+   static var allTests : [(String, (MessageToByteHandlerTest) -> () throws -> Void)] {
+      return [
+                ("testThrowingEncoderFailsPromises", testThrowingEncoderFailsPromises),
+           ]
+   }
+}
+


### PR DESCRIPTION
This fails the `write` promise in `MessageToByteHandler` for all write error cases.

### Motivation:
The promise is leaked if the encoder fails or if the handler is an error state.

### Modifications:
Call `fail` on the `write` promise if the encoder fails or if the handler is an error state.

### Result:
The `write` promise will now fail in all error cases.

### Additional Information
I debated on if the promise should be failed before or after `context.fireErrorCaught`. I found some prior art, here: https://github.com/apple/swift-nio-http2/blob/master/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift#L98

I also debated on if the promise should be failed before or after the state in the handler has been changed to `error`. I decided to fail it after changing the state to `error` since I was concerned about the promise failing, calling write again, and triggering another error before the first error state was set.