### PR TITLE
NIOThreadPool: backed by NIOThreads (pthreads) instead of DispatchQueues

### DIFF
--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -71,12 +71,18 @@ final class NIOThread {
         }
     }
 
+    func join() {
+        let err = pthread_join(self.pthread, nil)
+        assert(err == 0, "pthread_join failed with \(err)")
+    }
+
     /// Spawns and runs some task in a `NIOThread`.
     ///
     /// - arguments:
     ///     - name: The name of the `NIOThread` or `nil` if no specific name should be set.
     ///     - body: The function to execute within the spawned `NIOThread`.
-    static func spawnAndRun(name: String? = nil, body: @escaping (NIOThread) -> Void) {
+    ///     - detach: Whether to detach the thread. If the thread is not detached it must be `join`ed.
+    static func spawnAndRun(name: String? = nil, detachThread: Bool = true, body: @escaping (NIOThread) -> Void) {
         // Unfortunately the pthread_create method take a different first argument depending on if it's on Linux or macOS, so ensure we use the correct one.
         #if os(Linux)
             var pt: pthread_t = pthread_t()
@@ -107,8 +113,10 @@ final class NIOThread {
 
         precondition(res == 0, "Unable to create thread: \(res)")
 
-        let detachError = pthread_detach((pt as pthread_t?)!)
-        precondition(detachError == 0, "pthread_detach failed with error \(detachError)")
+        if detachThread {
+            let detachError = pthread_detach((pt as pthread_t?)!)
+            precondition(detachError == 0, "pthread_detach failed with error \(detachError)")
+        }
     }
 
     /// Returns `true` if the calling thread is the same as this one.


### PR DESCRIPTION
Motivation:

NIOThreadPool was grossly abusing Dispatch to block a large number of
threads for (usually) blocking IO work.

Modifications:

Back the NIOThreadPool by NIOThreads (pthreads) instead of
DispatchQueues.

Result:

Less abuse.