### PR TITLE
Add conditional conformances of CircularBuffer to Equatable and Hashable

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -692,3 +692,17 @@ extension CircularBuffer {
         return self.verifyInvariants() && self.unreachableAreNil()
     }
 }
+
+extension CircularBuffer: Equatable where Element: Equatable {
+    public static func ==(lhs: CircularBuffer, rhs: CircularBuffer) -> Bool {
+        return lhs.count == rhs.count && zip(lhs, rhs).allSatisfy(==)
+    }
+}
+
+extension CircularBuffer: Hashable where Element: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        for element in self {
+            hasher.combine(element)
+        }
+    }
+}

--- a/Tests/NIOTests/CircularBufferTests+XCTest.swift
+++ b/Tests/NIOTests/CircularBufferTests+XCTest.swift
@@ -73,6 +73,8 @@ extension CircularBufferTests {
                 ("testLotsOfInsertAtEnd", testLotsOfInsertAtEnd),
                 ("testPopLast", testPopLast),
                 ("testModify", testModify),
+                ("testEquality", testEquality),
+                ("testHash", testHash),
            ]
    }
 }

--- a/Tests/NIOTests/CircularBufferTests.swift
+++ b/Tests/NIOTests/CircularBufferTests.swift
@@ -912,4 +912,63 @@ class CircularBufferTests: XCTestCase {
         }
         XCTAssertEqual([0, 5, 2, 3], Array(buf))
     }
+    
+    func testEquality() {
+        // Empty buffers
+        let emptyA = CircularBuffer<Int>()
+        let emptyB = CircularBuffer<Int>()
+        XCTAssertEqual(emptyA, emptyB)
+        
+        var buffA = CircularBuffer<Int>()
+        var buffB = CircularBuffer<Int>()
+        var buffC = CircularBuffer<Int>()
+        var buffD = CircularBuffer<Int>()
+        buffA.append(contentsOf: 1...10)
+        buffB.append(contentsOf: 1...10)
+        buffC.append(contentsOf: 2...11) // Same count different values
+        buffD.append(contentsOf: 1...2) // Different count
+        XCTAssertEqual(buffA, buffB)
+        XCTAssertNotEqual(buffA, buffC)
+        XCTAssertNotEqual(buffA, buffD)
+        
+        // Will make internal head/tail indexes different
+        var prependBuff = CircularBuffer<Int>()
+        var appendBuff = CircularBuffer<Int>()
+        for i in (1...100).reversed() {
+            prependBuff.prepend(i)
+        }
+        for i in 1...100 {
+            appendBuff.append(i)
+        }
+        // But the contents are still the same
+        XCTAssertEqual(prependBuff, appendBuff)
+    }
+    
+    func testHash() {
+        let emptyA = CircularBuffer<Int>()
+        let emptyB = CircularBuffer<Int>()
+        XCTAssertEqual(Set([emptyA,emptyB]).count, 1)
+        
+        var buffA = CircularBuffer<Int>()
+        var buffB = CircularBuffer<Int>()
+        buffA.append(contentsOf: 1...10)
+        buffB.append(contentsOf: 1...10)
+        XCTAssertEqual(Set([buffA,buffB]).count, 1)
+        buffB.append(123)
+        XCTAssertEqual(Set([buffA,buffB]).count, 2)
+        buffA.append(1)
+        XCTAssertEqual(Set([buffA,buffB]).count, 2)
+        
+        // Will make internal head/tail indexes different
+        var prependBuff = CircularBuffer<Int>()
+        var appendBuff = CircularBuffer<Int>()
+        for i in (1...100).reversed() {
+            prependBuff.prepend(i)
+        }
+        for i in 1...100 {
+            appendBuff.append(i)
+        }
+        XCTAssertEqual(Set([prependBuff,appendBuff]).count, 1)
+    }
+    
 }


### PR DESCRIPTION
CircularBuffer is now `Equatable` when its `Element` is `Equatable`, and `Hashable` when its `Element` is `Hashable`

Solves #1098 