### PR TITLE
Conform CircularBuffer to ExpressibleByArrayLiteral

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -706,3 +706,9 @@ extension CircularBuffer: Hashable where Element: Hashable {
         }
     }
 }
+
+extension CircularBuffer: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Element...) {
+        self.init(elements)
+    }
+}

--- a/Tests/NIOTests/CircularBufferTests+XCTest.swift
+++ b/Tests/NIOTests/CircularBufferTests+XCTest.swift
@@ -75,6 +75,7 @@ extension CircularBufferTests {
                 ("testModify", testModify),
                 ("testEquality", testEquality),
                 ("testHash", testHash),
+                ("testArrayLiteralInit", testArrayLiteralInit),
            ]
    }
 }

--- a/Tests/NIOTests/CircularBufferTests.swift
+++ b/Tests/NIOTests/CircularBufferTests.swift
@@ -971,4 +971,17 @@ class CircularBufferTests: XCTestCase {
         XCTAssertEqual(Set([prependBuff,appendBuff]).count, 1)
     }
     
+    func testArrayLiteralInit() {
+        let empty: CircularBuffer<Int> = []
+        XCTAssert(empty.isEmpty)
+        
+        let increasingInts: CircularBuffer = [1, 2, 3, 4, 5]
+        XCTAssertEqual(increasingInts.count, 5)
+        XCTAssert(zip(increasingInts, 1...5).allSatisfy(==))
+        
+        let someIntsArray = [-9, 384, 2, 10, 0, 0, 0]
+        let someInts: CircularBuffer = [-9, 384, 2, 10, 0, 0, 0]
+        XCTAssertEqual(someInts.count, 7)
+        XCTAssert(zip(someInts, someIntsArray).allSatisfy(==))
+    }
 }


### PR DESCRIPTION
# Motivation
Making `CircularBuffer` conform to `ExpressibleByArrayLiteral` enables directly initializing it from an array literal, which can sometimes make its use simpler and more natural, for instance:
```swift
foo.circularBuffer = [1,2,3] // vs = CircularBuffer([1,2,3])
Foo(circularBuffer: [a, b, c]) // vs : CircularBuffer([a, b, c])
```
This is consistent with other standard Swift collections, such as
`Set`, as well as existing NIO types (eg: `WebSocketMaskingKey`).

# Modifications
Extend `CircularBuffer` to conform to `ExpressibleByArrayLiteral`

# Result
`CircularBuffer` can now be initialized from array literals