### PR TITLE
Remove unused wrapper functions for atomic_flag

### DIFF
--- a/Sources/CNIOAtomics/src/c-atomics.c
+++ b/Sources/CNIOAtomics/src/c-atomics.c
@@ -21,25 +21,6 @@
 #include "../include/CNIOAtomics.h"
 #include "../include/cpp_magic.h"
 
-struct catmc_atomic_flag {
-    atomic_flag _flag;
-};
-
-struct catmc_atomic_flag *catmc_atomic_flag_create(bool value) {
-    struct catmc_atomic_flag *flag = malloc(sizeof(*flag));
-    flag->_flag = (__typeof__(flag->_flag))ATOMIC_FLAG_INIT;
-    if (value) {
-        (void)atomic_flag_test_and_set_explicit(&flag->_flag, memory_order_relaxed);
-    } else {
-        atomic_flag_clear_explicit(&flag->_flag, memory_order_relaxed);
-    }
-    return flag;
-}
-
-void catmc_atomic_flag_destroy(struct catmc_atomic_flag *flag) {
-    free(flag);
-}
-
 #define MAKE(type) /*
 */ struct catmc_atomic_##type { /*
 */     _Atomic type value; /*


### PR DESCRIPTION
## Remove unused and unusable `atomic_flag` wrapper struct and helper functions

### Motivation:

The `atomic_flag` wrappers (`catmc_atomic_flag` structure, `catmc_atomic_flag_create` helper, and `catmc_atomic_flag_destroy` helper) are not referenced from anywhere else in the NIO source tree. They have no corresponding declarations in any header; there is no way to reference or invoke them. Finally, under sufficiently strict C compiler settings, they cause compilation failure due to the functions lacking prototypes and not being `static`.

### Modifications:

Removes the three declarations from `c-atomics.c`.

### Result:

Nothing changes. If something did, that would be a reason not to do this.