### PR TITLE
bootstraps: tolerate random EventLoops

### DIFF
--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -27,6 +27,10 @@ extension BootstrapTest {
    static var allTests : [(String, (BootstrapTest) -> () throws -> Void)] {
       return [
                 ("testBootstrapsCallInitializersOnCorrectEventLoop", testBootstrapsCallInitializersOnCorrectEventLoop),
+                ("testTCPBootstrapsTolerateFuturesFromDifferentEventLoopsReturnedInInitializers", testTCPBootstrapsTolerateFuturesFromDifferentEventLoopsReturnedInInitializers),
+                ("testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
+                ("testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
+                ("testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
            ]
    }
 }

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -13,9 +13,41 @@
 //===----------------------------------------------------------------------===//
 
 @testable import NIO
+import NIOConcurrencyHelpers
 import XCTest
 
 class BootstrapTest: XCTestCase {
+    var groupBag: [MultiThreadedEventLoopGroup]? = nil // protected by `self.lock`
+    let lock = Lock()
+
+    override func setUp() {
+        self.lock.withLock {
+            XCTAssertNil(self.groupBag)
+            self.groupBag = []
+        }
+    }
+
+    override func tearDown() {
+        XCTAssertNoThrow(try self.lock.withLock {
+            guard let groupBag = self.groupBag else {
+                XCTFail()
+                return
+            }
+            XCTAssertNoThrow(try groupBag.forEach {
+                XCTAssertNoThrow(try $0.syncShutdownGracefully())
+            })
+            self.groupBag = nil
+        })
+    }
+
+    func freshEventLoop() -> EventLoop {
+        let group: MultiThreadedEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        self.lock.withLock {
+            self.groupBag!.append(group)
+        }
+        return group.next()
+    }
+
     func testBootstrapsCallInitializersOnCorrectEventLoop() throws {
         for numThreads in [1 /* everything on one event loop */,
                            2 /* some stuff has shared event loops */,
@@ -57,5 +89,122 @@ class BootstrapTest: XCTestCase {
             XCTAssertNoThrow(try childChannelDone.futureResult.wait())
             XCTAssertNoThrow(try serverChannelDone.futureResult.wait())
         }
+    }
+
+    func testTCPBootstrapsTolerateFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
+        let childChannelDone = self.freshEventLoop().makePromise(of: Void.self)
+        let serverChannelDone = self.freshEventLoop().makePromise(of: Void.self)
+        let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: self.freshEventLoop())
+            .childChannelInitializer { channel in
+                XCTAssert(channel.eventLoop.inEventLoop)
+                defer {
+                    childChannelDone.succeed(())
+                }
+                return self.freshEventLoop().makeSucceededFuture(())
+            }
+            .serverChannelInitializer { channel in
+                XCTAssert(channel.eventLoop.inEventLoop)
+                defer {
+                    serverChannelDone.succeed(())
+                }
+                return self.freshEventLoop().makeSucceededFuture(())
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .wait())
+        defer {
+            XCTAssertNoThrow(try serverChannel.close().wait())
+        }
+
+        let client = try assertNoThrowWithValue(ClientBootstrap(group: self.freshEventLoop())
+            .channelInitializer { channel in
+                XCTAssert(channel.eventLoop.inEventLoop)
+                return self.freshEventLoop().makeSucceededFuture(())
+            }
+            .connect(to: serverChannel.localAddress!)
+            .wait())
+        defer {
+            XCTAssertNoThrow(try client.syncCloseAcceptingAlreadyClosed())
+        }
+        XCTAssertNoThrow(try childChannelDone.futureResult.wait())
+        XCTAssertNoThrow(try serverChannelDone.futureResult.wait())
+    }
+
+    func testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
+        XCTAssertNoThrow(try DatagramBootstrap(group: self.freshEventLoop())
+            .channelInitializer { channel in
+                XCTAssert(channel.eventLoop.inEventLoop)
+                return self.freshEventLoop().makeSucceededFuture(())
+        }
+        .bind(host: "127.0.0.1", port: 0)
+        .wait()
+        .close()
+        .wait())
+    }
+
+    func testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
+        var socketFDs: [CInt] = [-1, -1]
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        let err = socketpair(PF_LOCAL, SOCK_STREAM, 0, &socketFDs)
+        #else
+        let err = socketpair(PF_LOCAL, CInt(SOCK_STREAM.rawValue), 0, &socketFDs)
+        #endif
+        XCTAssertEqual(0, err)
+        defer {
+            // 0 is closed together with the Channel below.
+            XCTAssertNoThrow(try Posix.close(descriptor: socketFDs[1]))
+        }
+
+        XCTAssertNoThrow(try ClientBootstrap(group: self.freshEventLoop())
+            .channelInitializer { channel in
+                XCTAssert(channel.eventLoop.inEventLoop)
+                return self.freshEventLoop().makeSucceededFuture(())
+            }
+            .withConnectedSocket(descriptor: socketFDs[0])
+            .wait()
+            .close()
+            .wait())
+    }
+
+    func testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
+        let socket = try Posix.socket(domain: AF_INET, type: Posix.SOCK_STREAM, protocol: 0)
+
+        let serverAddress = try assertNoThrowWithValue(SocketAddress.makeAddressResolvingHost("127.0.0.1", port: 0))
+        try serverAddress.withSockAddr { serverAddressPtr, size in
+            try Posix.bind(descriptor: socket, ptr: serverAddressPtr,
+                           bytes: size)
+        }
+
+        let childChannelDone = self.freshEventLoop().next().makePromise(of: Void.self)
+        let serverChannelDone = self.freshEventLoop().next().makePromise(of: Void.self)
+
+        let serverChannel = try assertNoThrowWithValue(try ServerBootstrap(group: self.freshEventLoop())
+            .childChannelInitializer { channel in
+                XCTAssert(channel.eventLoop.inEventLoop)
+                defer {
+                    childChannelDone.succeed(())
+                }
+                return self.freshEventLoop().makeSucceededFuture(())
+            }
+            .serverChannelInitializer { channel in
+                XCTAssert(channel.eventLoop.inEventLoop)
+                defer {
+                    serverChannelDone.succeed(())
+                }
+                return self.freshEventLoop().makeSucceededFuture(())
+            }
+            .withBoundSocket(descriptor: socket)
+            .wait())
+        let client = try assertNoThrowWithValue(ClientBootstrap(group: self.freshEventLoop())
+            .channelInitializer { channel in
+                XCTAssert(channel.eventLoop.inEventLoop)
+                return self.freshEventLoop().makeSucceededFuture(())
+            }
+            .connect(to: serverChannel.localAddress!)
+            .wait())
+        defer {
+            XCTAssertNoThrow(try client.syncCloseAcceptingAlreadyClosed())
+        }
+        XCTAssertNoThrow(try childChannelDone.futureResult.wait())
+        XCTAssertNoThrow(try serverChannelDone.futureResult.wait())
     }
 }


### PR DESCRIPTION
Motivation:

Although that's a rare usecase, the Bootstraps must support random
EventLoops. That includes the EventLoops they're called on but also the
EventLoops of the futures returned from the channel initializers.
Thanks to @adtrevor for reporting the initial bug which also served as a tree
to be shaken for more  bugs.

Modifications:

Make sure we're always on the correct EventLoop.

Result:

Fewer crashes and bugs.