### PR TITLE
more compatibility with other platforms

### DIFF
--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -106,7 +106,7 @@ var temporaryDirectory: String {
 #elseif os(Linux)
         return "/tmp"
 #else
-        if #available(OSX 10.12, *) {
+        if #available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *) {
             return FileManager.default.temporaryDirectory.path
         } else {
             return "/tmp"


### PR DESCRIPTION
Motivation:

Everything should compile on as many platforms as possible.

Modifications:

Guard FileManager.temporaryDirectory behind
`#available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *)`
instead of just macOS 10.12.

Result:

Tests should build on iOS and friends too.