### PR TITLE
Fix dead link to process_test_files.rb in NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -40,7 +40,8 @@ This product contains a derivation of the Tony Stone's 'process_test_files.rb'.
   * LICENSE (Apache License 2.0):
     * https://www.apache.org/licenses/LICENSE-2.0
   * HOMEPAGE:
-    * https://codegists.com/snippet/ruby/generate_xctest_linux_runnerrb_tonystone_ruby
+    * https://github.com/tonystone/build-tools/commit/6c417b7569df24597a48a9aa7b505b636e8f73a1
+    * https://github.com/tonystone/build-tools/blob/master/source/xctest_tool.rb
 
 ---
 


### PR DESCRIPTION
Fix dead link in NOTICE.txt

### Motivation:

Previous link is dead, so we might want to point to a specific commit that introduced what our scripts are based on.

### Modifications:

- add new links to same authors script

### Result:

- up to date and more "future-proof" links in NOTICE