### PR TITLE
ChannelPipeline: fail double removal of handler

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -356,6 +356,9 @@ extension ChannelError: Equatable { }
 /// we have seen this happen on Darwin.
 public struct NIOFailedToSetSocketNonBlockingError: Error {}
 
+/// The removal of a `ChannelHandler` using `ChannelPipeline.removeHandler` has been attempted more than once.
+public struct NIOAttemptedToRemoveHandlerMultipleTimesError: Error {}
+
 /// An `Channel` related event that is passed through the `ChannelPipeline` to notify the user.
 public enum ChannelEvent: Equatable {
     /// `ChannelOptions.allowRemoteHalfClosure` is `true` and input portion of the `Channel` was closed.

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -61,6 +61,7 @@ extension ChannelPipelineTest {
                 ("testAddMultipleHandlers", testAddMultipleHandlers),
                 ("testPipelineDebugDescription", testPipelineDebugDescription),
                 ("testWeDontCallHandlerRemovedTwiceIfAHandlerCompletesRemovalOnlyAfterChannelTeardown", testWeDontCallHandlerRemovedTwiceIfAHandlerCompletesRemovalOnlyAfterChannelTeardown),
+                ("testWeFailTheSecondRemoval", testWeFailTheSecondRemoval),
            ]
    }
 }


### PR DESCRIPTION
### Motivation:

If a user attempted to double remove a handler, we would make this the user's handler's problem. That would lead to pretty random situations, sometimes crashed because assertions were violated.

### Modifications:

Fail every removal attempt as soon as the removal has begun.

### Result:

Much more predictable outcome of problems in user code around double removal.