### PR TITLE
fix NIODeadline/TimeAmount maths

### DIFF
--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -20,7 +20,7 @@ private enum SelectorLifecycleState {
 
 private extension timespec {
     init(timeAmount amount: TimeAmount) {
-        let nsecPerSec: TimeAmount.Value = 1_000_000_000
+        let nsecPerSec: Int64 = 1_000_000_000
         let ns = amount.nanoseconds
         let sec = ns / nsecPerSec
         self = timespec(tv_sec: Int(sec), tv_nsec: Int(ns - sec * nsecPerSec))

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -250,7 +250,7 @@ private final class HTTPHandler: ChannelInboundHandler {
             return { context, req in
                 self.handleJustWrite(context: context,
                                      request: req, string: self.defaultResponse,
-                                     delay: TimeAmount.Value(howLong).map { .milliseconds($0) } ?? .seconds(0))
+                                     delay: Int64(howLong).map { .milliseconds($0) } ?? .seconds(0))
             }
         }
 

--- a/Tests/NIOTests/EmbeddedEventLoopTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest.swift
@@ -110,7 +110,7 @@ public final class EmbeddedEventLoopTest: XCTestCase {
         var sentinel = 0
         let loop = EmbeddedEventLoop()
         for index in 1...10 {
-            _ = loop.scheduleTask(in: .nanoseconds(TimeAmount.Value(index))) {
+            _ = loop.scheduleTask(in: .nanoseconds(Int64(index))) {
                 sentinel = index
             }
         }

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -57,6 +57,9 @@ extension EventLoopTest {
                 ("testSubtractingDeadlineFromPastAndFuturesDeadlinesWorks", testSubtractingDeadlineFromPastAndFuturesDeadlinesWorks),
                 ("testCallingSyncShutdownGracefullyMultipleTimesShouldNotHang", testCallingSyncShutdownGracefullyMultipleTimesShouldNotHang),
                 ("testCallingShutdownGracefullyMultipleTimesShouldExecuteAllCallbacks", testCallingShutdownGracefullyMultipleTimesShouldExecuteAllCallbacks),
+                ("testEdgeCasesNIODeadlineMinusNIODeadline", testEdgeCasesNIODeadlineMinusNIODeadline),
+                ("testEdgeCasesNIODeadlinePlusTimeAmount", testEdgeCasesNIODeadlinePlusTimeAmount),
+                ("testEdgeCasesNIODeadlineMinusTimeAmount", testEdgeCasesNIODeadlineMinusTimeAmount),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously the maths on NIODeadline/TimeAmount could sometimes crash and
weren't always right.

Modifications:

- Fix the maths and add tests.
- deprecate `NIODeadline/TimeAmount.Value` which didn't serve any purpose.

Result:

Fewer crashes, more happy times.