### PR TITLE
fix one EventLoopGroup leak in tests

### DIFF
--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -1963,6 +1963,9 @@ public final class ChannelTests: XCTestCase {
             }
         }
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try elg.syncShutdownGracefully())
+        }
 
         func withChannel(skipDatagram: Bool = false, skipStream: Bool = false, skipServerSocket: Bool = false, file: StaticString = #file, line: UInt = #line,  _ body: (Channel) throws -> Void) {
             XCTAssertNoThrow(try {


### PR DESCRIPTION
Motivation:

One test was leaking an ELG.

Modifications:

Don't leak it.

Result:

Fewer leaks in tests.