### PR TITLE
assert EventLoopGroup::syncShutdownGracefully is not called on the event loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Package.pins
 Package.resolved
 .podspecs
 DerivedData
+.swiftpm

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -986,6 +986,13 @@ extension EventLoopGroup {
     }
 
     public func syncShutdownGracefully() throws {
+        if let eventLoop = MultiThreadedEventLoopGroup.currentEventLoop {
+            preconditionFailure("""
+            BUG DETECTED: syncShutdownGracefully() must not be called when on an EventLoop.
+            Calling syncShutdownGracefully() on any EventLoop can lead to deadlocks.
+            Current eventLoop: \(eventLoop)
+            """)
+        }
         let errorStorageLock = Lock()
         var errorStorage: Error? = nil
         let continuation = DispatchWorkItem {}


### PR DESCRIPTION
motivation: calling syncShutdownGracefully on the event loop can lead to deadlock

changes: assert before calling syncShutdownGracefully that no eventloop context exists
