### PR TITLE
fix a number of memory leaks in the test suite

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -273,6 +273,9 @@ class EmbeddedChannelCore: ChannelCore {
 /// `EmbeddedChannel` is in unit tests when you want to feed the inbound events
 /// and check the outbound events manually.
 ///
+/// Please remember to call `finish()` when you are no longer using this
+/// `EmbeddedChannel`.
+///
 /// To feed events through an `EmbeddedChannel`'s `ChannelPipeline` use
 /// `EmbeddedChannel.writeInbound` which accepts data of any type. It will then
 /// forward that data through the `ChannelPipeline` and the subsequent
@@ -392,15 +395,23 @@ public final class EmbeddedChannel: Channel {
 
     /// Synchronously closes the `EmbeddedChannel`.
     ///
-    /// This method will throw if the `Channel` hit any unconsumed errors or if the `close` fails. Errors in the
-    /// `EmbeddedChannel` can be consumed using `throwIfErrorCaught`.
+    /// Errors in the `EmbeddedChannel` can be consumed using `throwIfErrorCaught`.
     ///
+    /// - parameters:
+    ///     - acceptAlreadyClosed: Whether `finish` should throw if the `EmbeddedChannel` has been previously `close`d.
     /// - returns: The `LeftOverState` of the `EmbeddedChannel`. If all the inbound and outbound events have been
     ///            consumed (using `readInbound` / `readOutbound`) and there are no pending outbound events (unflushed
     ///            writes) this will be `.clean`. If there are any unconsumed inbound, outbound, or pending outbound
     ///            events, the `EmbeddedChannel` will returns those as `.leftOvers(inbound:outbound:pendingOutbound:)`.
-    public func finish() throws -> LeftOverState {
-        try close().wait()
+    public func finish(acceptAlreadyClosed: Bool) throws -> LeftOverState {
+        do {
+            try close().wait()
+        } catch let error as ChannelError {
+            guard error == .alreadyClosed && acceptAlreadyClosed else {
+                throw error
+            }
+        }
+        self.embeddedEventLoop.advanceTime(by: .nanoseconds(.max))
         self.embeddedEventLoop.run()
         try throwIfErrorCaught()
         let c = self.channelcore
@@ -411,6 +422,19 @@ public final class EmbeddedChannel: Channel {
                               outbound: c.outboundBuffer,
                               pendingOutbound: c.pendingOutboundBuffer.map { $0.0 })
         }
+    }
+
+    /// Synchronously closes the `EmbeddedChannel`.
+    ///
+    /// This method will throw if the `Channel` hit any unconsumed errors or if the `close` fails. Errors in the
+    /// `EmbeddedChannel` can be consumed using `throwIfErrorCaught`.
+    ///
+    /// - returns: The `LeftOverState` of the `EmbeddedChannel`. If all the inbound and outbound events have been
+    ///            consumed (using `readInbound` / `readOutbound`) and there are no pending outbound events (unflushed
+    ///            writes) this will be `.clean`. If there are any unconsumed inbound, outbound, or pending outbound
+    ///            events, the `EmbeddedChannel` will returns those as `.leftOvers(inbound:outbound:pendingOutbound:)`.
+    public func finish() throws -> LeftOverState {
+        return try self.finish(acceptAlreadyClosed: false)
     }
 
     private var _pipeline: ChannelPipeline!

--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -50,16 +50,17 @@ private class MessageEndHandler<Head: Equatable, Body: Equatable>: ChannelInboun
 /// Mostly tests assertions in [RFC 7230 § 3.3.3](https://tools.ietf.org/html/rfc7230#section-3.3.3).
 class HTTPDecoderLengthTest: XCTestCase {
     private var channel: EmbeddedChannel!
-    private var loop: EmbeddedEventLoop!
+    private var loop: EmbeddedEventLoop {
+        return self.channel.embeddedEventLoop
+    }
 
     override func setUp() {
         self.channel = EmbeddedChannel()
-        self.loop = channel.embeddedEventLoop
     }
 
     override func tearDown() {
+        XCTAssertNoThrow(try self.channel?.finish(acceptAlreadyClosed: true))
         self.channel = nil
-        self.loop = nil
     }
 
     /// The mechanism by which EOF is being sent.

--- a/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
@@ -134,7 +134,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
 
     override func tearDown() {
         if let channel = self.channel {
-            XCTAssertNoThrow(try channel.finish())
+            XCTAssertNoThrow(try channel.finish(acceptAlreadyClosed: true))
             self.channel = nil
         }
         self.requestHead = nil
@@ -504,7 +504,6 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
         self.channel.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
         XCTAssertFalse(self.channel.isActive)
-        self.channel = nil
         XCTAssertEqual(self.quiesceEventRecorder.quiesceCount, 0)
     }
 
@@ -530,7 +529,6 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
         self.channel.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
         XCTAssertFalse(self.channel.isActive)
-        self.channel = nil
         XCTAssertEqual(self.quiesceEventRecorder.quiesceCount, 0)
     }
 
@@ -560,7 +558,6 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertNoThrow(try self.channel.writeInbound(HTTPServerRequestPart.end(nil)))
 
         XCTAssertFalse(self.channel.isActive)
-        self.channel = nil
         XCTAssertEqual(self.quiesceEventRecorder.quiesceCount, 0)
     }
 
@@ -590,7 +587,6 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                        self.writeRecorder.writes)
 
         XCTAssertFalse(self.channel.isActive)
-        self.channel = nil
         XCTAssertEqual(self.quiesceEventRecorder.quiesceCount, 0)
     }
 
@@ -619,7 +615,6 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                        self.writeRecorder.writes)
 
         XCTAssertFalse(self.channel.isActive)
-        self.channel = nil
         XCTAssertEqual(self.quiesceEventRecorder.quiesceCount, 0)
     }
 
@@ -656,7 +651,6 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertNoThrow(try self.channel.writeInbound(HTTPServerRequestPart.end(nil)))
 
         XCTAssertFalse(self.channel.isActive)
-        self.channel = nil
         XCTAssertEqual(self.quiesceEventRecorder.quiesceCount, 0)
     }
 
@@ -694,7 +688,6 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertNoThrow(try self.channel.writeInbound(HTTPServerRequestPart.end(nil)))
 
         XCTAssertFalse(self.channel.isActive)
-        self.channel = nil
         XCTAssertEqual(self.quiesceEventRecorder.quiesceCount, 0)
     }
 
@@ -734,7 +727,6 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         .channelRead(HTTPServerRequestPart.end(nil))])
 
         XCTAssertFalse(self.channel.isActive)
-        self.channel = nil
         XCTAssertEqual(self.quiesceEventRecorder.quiesceCount, 0)
     }
 

--- a/Tests/NIOTestUtilsTests/EventCounterHandlerTest.swift
+++ b/Tests/NIOTestUtilsTests/EventCounterHandlerTest.swift
@@ -27,9 +27,8 @@ class EventCounterHandlerTest: XCTestCase {
 
     override func tearDown() {
         self.handler = nil
-        if let channel = self.channel {
-            XCTAssertNoThrow(try channel.finish())
-        }
+        XCTAssertNoThrow(try self.channel?.finish())
+        self.channel = nil
     }
 
     func testNothingButEmbeddedChannelInit() {
@@ -134,6 +133,9 @@ class EventCounterHandlerTest: XCTestCase {
 
         for (fire, name) in noArgEvents {
             let channel = EmbeddedChannel()
+            defer {
+                XCTAssertNoThrow(try channel.finish())
+            }
             let handler = EventCounterHandler()
 
             XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())

--- a/Tests/NIOTests/ChannelPipelineTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest.swift
@@ -85,6 +85,9 @@ class ChannelPipelineTest: XCTestCase {
         let handler3 = SimpleTypedHandler3()
         
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(try channel.finish())
+        }
         try channel.pipeline.addHandlers([
             handler1,
             handler2,
@@ -107,6 +110,9 @@ class ChannelPipelineTest: XCTestCase {
         let otherHandler = SimpleTypedHandler2()
 
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(try channel.finish())
+        }
         try channel.pipeline.addHandlers([
             sameTypeHandler1,
             sameTypeHandler2,
@@ -122,6 +128,9 @@ class ChannelPipelineTest: XCTestCase {
         let handler2 = SimpleTypedHandler2()
         
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(try channel.finish())
+        }
         try channel.pipeline.addHandlers([
             handler1,
             handler2,
@@ -133,6 +142,9 @@ class ChannelPipelineTest: XCTestCase {
     func testAddAfterClose() throws {
 
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(try channel.finish(acceptAlreadyClosed: true))
+        }
         XCTAssertNoThrow(try channel.close().wait())
 
         channel.pipeline.removeHandlers()
@@ -271,6 +283,9 @@ class ChannelPipelineTest: XCTestCase {
     func testWriteAfterClose() throws {
 
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(XCTAssertTrue(try channel.finish(acceptAlreadyClosed: true).isClean))
+        }
         XCTAssertNoThrow(try channel.close().wait())
         let loop = channel.eventLoop as! EmbeddedEventLoop
         loop.run()
@@ -610,13 +625,8 @@ class ChannelPipelineTest: XCTestCase {
     func testAddBeforeWhileClosed() {
         let channel = EmbeddedChannel()
         defer {
-            do {
-                _ = try channel.finish()
-                XCTFail("Did not throw")
-            } catch ChannelError.alreadyClosed {
-                // Ok
-            } catch {
-                XCTFail("unexpected error \(error)")
+            XCTAssertThrowsError(try channel.finish()) { error in
+                XCTAssertEqual(.alreadyClosed, error as? ChannelError)
             }
         }
 
@@ -1071,6 +1081,9 @@ class ChannelPipelineTest: XCTestCase {
         }
 
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(XCTAssertTrue(try channel.finish().isClean))
+        }
         let allHandlers = [Handler(), Handler(), Handler()]
         XCTAssertNoThrow(try channel.pipeline.addHandler(allHandlers[0], name: "the first one to remove").wait())
         XCTAssertNoThrow(try channel.pipeline.addHandler(allHandlers[1]).wait())
@@ -1094,6 +1107,10 @@ class ChannelPipelineTest: XCTestCase {
         }
 
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(XCTAssertTrue(try channel.finish().isClean))
+        }
+
         let allHandlers = [NonRemovableHandler(), NonRemovableHandler(), NonRemovableHandler()]
         XCTAssertNoThrow(try channel.pipeline.addHandler(allHandlers[0], name: "1").wait())
         XCTAssertNoThrow(try channel.pipeline.addHandler(allHandlers[1], name: "2").wait())
@@ -1119,6 +1136,9 @@ class ChannelPipelineTest: XCTestCase {
     func testAddMultipleHandlers() {
         typealias Handler = TestAddMultipleHandlersHandlerWorkingAroundSR9956
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(XCTAssertTrue(try channel.finish().isClean))
+        }
         let a = Handler()
         let b = Handler()
         let c = Handler()
@@ -1155,6 +1175,9 @@ class ChannelPipelineTest: XCTestCase {
             typealias OutboundIn = Never
         }
         let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(XCTAssertTrue(try channel.finish().isClean))
+        }
         let parser = HTTPRequestParser()
         let serializer = HTTPResponseSerializer()
         let handler = HTTPHandler()

--- a/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
@@ -25,6 +25,7 @@ private class CloseSwallower: ChannelOutboundHandler, RemovableChannelHandler {
 
     public func allowClose() {
         self.context!.close(promise: self.closePromise)
+        self.context = nil
     }
 
     func close(context: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {


### PR DESCRIPTION
Motivation:

Memory leaks are bad, even in test suites.

Modifications:

Fix a number of memory leaks.

Result:

Fewer leaks.