### PR TITLE
Prefer handlerAdded/handlerRemoved in websocket example

### DIFF
--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -46,13 +46,13 @@ private final class HTTPHandler: ChannelInboundHandler, RemovableChannelHandler 
 
     private var responseBody: ByteBuffer!
 
-    func channelRegistered(context: ChannelHandlerContext) {
+    func handlerAdded(context: ChannelHandlerContext) {
         var buffer = context.channel.allocator.buffer(capacity: websocketResponse.utf8.count)
         buffer.writeString(websocketResponse)
         self.responseBody = buffer
     }
 
-    func channelUnregistered(context: ChannelHandlerContext) {
+    func handlerRemoved(context: ChannelHandlerContext) {
         self.responseBody = nil
     }
 


### PR DESCRIPTION
**Motivation:**

@Lukasa  recently mentioned that

> handlerAdded is generally a better choice for a "setup" function than
> channelRegistered, as a handler is always guaranteed to receive
> handlerAdded, but is not guaranteed to receive channelRegistered
> (depending on specifics of pipeline setup).

Thus using the better way in examples is good.

**Modifications:**

- change `channelRegistered` to `handlerAdded`

**Result:**

- More idiomatic example app
