### PR TITLE
Reduce allocations in WebSocketFrameEncoder.

### DIFF
--- a/Tests/NIOWebSocketTests/WebSocketFrameEncoderTest+XCTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameEncoderTest+XCTest.swift
@@ -32,6 +32,7 @@ extension WebSocketFrameEncoderTest {
                 ("testEncodesEachReservedBitProperly", testEncodesEachReservedBitProperly),
                 ("testEncodesExtensionDataCorrectly", testEncodesExtensionDataCorrectly),
                 ("testMasksDataCorrectly", testMasksDataCorrectly),
+                ("testFrameEncoderReusesHeaderBufferWherePossible", testFrameEncoderReusesHeaderBufferWherePossible),
            ]
    }
 }

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -26,10 +26,10 @@ services:
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=4010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=4010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=6010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=6010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=2010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=2010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=4010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -26,10 +26,10 @@ services:
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=4010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=4010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=6010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=6010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=2010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=2010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=4010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
 
   performance-test:
     image: swift-nio:18.04-5.0


### PR DESCRIPTION
Motivation:

The WebSocketFrameEncoder naively allocated a new block to write the
frame header into every time it wrote. This is excessive: in many cases
it would be able to re-use the same buffer as last time.

Modifications:

- Attempt to re-use the buffer we used for the last header.

Result:

Fewer allocations in some applications.
