### PR TITLE
additional ByteBuffer(Allocator) test

### DIFF
--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -143,6 +143,7 @@ extension ByteBufferTest {
                 ("testDataByteTransferStrategyAutomaticMayNotCopy", testDataByteTransferStrategyAutomaticMayNotCopy),
                 ("testDataByteTransferStrategyAutomaticMayCopy", testDataByteTransferStrategyAutomaticMayCopy),
                 ("testViewBytesIsHappyWithNegativeValues", testViewBytesIsHappyWithNegativeValues),
+                ("testByteBufferAllocatorSize1Capacity", testByteBufferAllocatorSize1Capacity),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1970,6 +1970,11 @@ class ByteBufferTest: XCTestCase {
         XCTAssertNil(self.buf.viewBytes(at: 0, length: -1))
         XCTAssertNil(self.buf.viewBytes(at: -1, length: -1))
     }
+
+    func testByteBufferAllocatorSize1Capacity() {
+        let buffer = ByteBufferAllocator().buffer(capacity: 1)
+        XCTAssertEqual(1, buffer.capacity)
+    }
 }
 
 private enum AllocationExpectationState: Int {

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -80,6 +80,7 @@ extension ChannelTests {
                 ("testAcceptHandlerDoesNotSwallowCloseErrorsWhenQuiescing", testAcceptHandlerDoesNotSwallowCloseErrorsWhenQuiescing),
                 ("testTCP_NODELAYisOnByDefault", testTCP_NODELAYisOnByDefault),
                 ("testDescriptionCanBeCalledFromNonEventLoopThreads", testDescriptionCanBeCalledFromNonEventLoopThreads),
+                ("testFixedSizeRecvByteBufferAllocatorSizeIsConstant", testFixedSizeRecvByteBufferAllocatorSizeIsConstant),
            ]
    }
 }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2767,6 +2767,18 @@ public final class ChannelTests: XCTestCase {
             g.wait()
         })
     }
+
+    func testFixedSizeRecvByteBufferAllocatorSizeIsConstant() {
+        let actualAllocator = ByteBufferAllocator()
+        var allocator = FixedSizeRecvByteBufferAllocator(capacity: 1)
+        let b1 = allocator.buffer(allocator: actualAllocator)
+        XCTAssertFalse(allocator.record(actualReadBytes: 1024))
+        let b2 = allocator.buffer(allocator: actualAllocator)
+        XCTAssertEqual(1, b1.capacity)
+        XCTAssertEqual(1, b2.capacity)
+        XCTAssertEqual(1, allocator.capacity)
+
+    }
 }
 
 fileprivate final class FailRegistrationAndDelayCloseHandler: ChannelOutboundHandler {


### PR DESCRIPTION
Motivation:

Whilst debugging an async-http-client test bug, I wrote two tests for
ByteBuffer.

Modifications:

Add two tests.

Result:

More tests.