### PR TITLE
Save the performance tests from the OOM killer

### DIFF
--- a/Sources/NIOPerformanceTester/WebSocketFrameEncoderBenchmark.swift
+++ b/Sources/NIOPerformanceTester/WebSocketFrameEncoderBenchmark.swift
@@ -54,6 +54,7 @@ extension WebSocketFrameEncoderBenchmark {
 extension WebSocketFrameEncoderBenchmark: Benchmark {
     func setUp() throws {
         // We want the pipeline walk to have some cost.
+        try! self.channel.pipeline.addHandler(WriteConsumingHandler()).wait()
         for _ in 0..<3 {
             try! self.channel.pipeline.addHandler(NoOpOutboundHandler()).wait()
         }
@@ -116,4 +117,14 @@ extension ByteBufferAllocator {
 fileprivate final class NoOpOutboundHandler: ChannelOutboundHandler {
     typealias OutboundIn = Any
     typealias OutboundOut = Any
+}
+
+
+fileprivate final class WriteConsumingHandler: ChannelOutboundHandler {
+    typealias OutboundIn = Any
+    typealias OutboundOut = Never
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        promise?.succeed(())
+    }
 }


### PR DESCRIPTION
Motivation:

A dark force walks abroad our lands. In a place where well-behaved
processes close their blinds, lock their doors, and try not to make
noise late at night, processes that shine just a little too brightly,
consume just a little too much RAM, attract the attention of a dark
force whose name is spoken only in whispers. Some call this force a
myth, but others say that the deniers of this force have whispered dark
incantations, invoking the power word "oom_adj".

It is time we intervened to keep the law-abiding processes in our CI
systems safe.

Modifications:

- Prevent the websocket performance tests comnsuming 4GB of RAM.

Result:

Peace will reign.
