### PR TITLE
Bind Before Connect functionality for a SocketChannel

### DIFF
--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -93,6 +93,13 @@ public struct BacklogOption: ChannelOption {
     public init() {}
 }
 
+/// `BindToSocketAddressBeforeConnectOption` specifies local address to be bound before connecting to remote.
+public struct BindToSocketAddressBeforeConnectOption: ChannelOption {
+    public typealias Value = SocketAddress
+
+    public init() {}
+}
+
 /// `DatagramVectorReadMessageCountOption` allows users to configure the number of messages to attempt to read in a single syscall on a
 /// datagram `Channel`.
 ///
@@ -218,6 +225,9 @@ public struct ChannelOptions {
 
     /// - seealso: `DatagramVectorReadMessageCountOption`
     public static let datagramVectorReadMessageCount = DatagramVectorReadMessageCountOption()
+
+    /// - seealso: `BindToSocketAddressBeforeConnectOption`.
+    public static let bindToSocketAddressBeforeConnect = BindToSocketAddressBeforeConnectOption()
 }
 
 extension ChannelOptions {

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -53,6 +53,7 @@ extension SocketChannelTest {
                 ("testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheServerSide", testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheServerSide),
                 ("testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheClientSide", testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheClientSide),
                 ("testServerClosesTheConnectionImmediately", testServerClosesTheConnectionImmediately),
+                ("testBindBeforeConnect", testBindBeforeConnect),
            ]
    }
 }


### PR DESCRIPTION
Bind Before Connect functionality for a SocketChannel

### Motivation:

The current implementation lacks the ability of binding the TCP socket before connecting to a remote endpoint, thus we cannot chose which port (e.g.) we should initiate the connection from.

### Modifications:

* Added a `BindToSocketAddressBeforeConnectOption` to ChannelOptions with a `SocketAddress` value
* Changed the mechanism of `connectSocket()` in `SocketChannel` so it binds first

### Result:

After these changes we can observe that newly created SocketChannel with the specified option are initiated from a given port.
