### PR TITLE
DatagramChannel in Connected Mode

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -345,6 +345,9 @@ public enum ChannelError: Error {
 
     /// An attempt was made to remove a ChannelHandler that is not removable.
     case unremovableHandler
+
+    /// An attempt to connect datagram socket after it was bound did not succeed.
+    case connectAfterBindNotAllowed
 }
 
 extension ChannelError: Equatable { }

--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -93,6 +93,13 @@ public struct BacklogOption: ChannelOption {
     public init() {}
 }
 
+/// `ConnectToSocketAddressAfterBindOption` determines whether socket should be connected after bind or not.
+public struct ConnectToSocketAddressAfterBindOption: ChannelOption {
+    public typealias Value = SocketAddress
+
+    public init() {}
+}
+
 /// `DatagramVectorReadMessageCountOption` allows users to configure the number of messages to attempt to read in a single syscall on a
 /// datagram `Channel`.
 ///
@@ -218,6 +225,9 @@ public struct ChannelOptions {
 
     /// - seealso: `DatagramVectorReadMessageCountOption`
     public static let datagramVectorReadMessageCount = DatagramVectorReadMessageCountOption()
+
+    /// - seealso: `connectToSocketAddressAfterBindOption`.
+    public static let connectToSocketAddressAfterBind = ConnectToSocketAddressAfterBindOption()
 }
 
 extension ChannelOptions {

--- a/Tests/NIOTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOTests/DatagramChannelTests+XCTest.swift
@@ -49,6 +49,7 @@ extension DatagramChannelTests {
                 ("testBasicMultipleReads", testBasicMultipleReads),
                 ("testMmsgWillTruncateWithoutChangeToAllocator", testMmsgWillTruncateWithoutChangeToAllocator),
                 ("testRecvMmsgForMultipleCycles", testRecvMmsgForMultipleCycles),
+                ("testConnectAfterBind", testConnectAfterBind),
            ]
    }
 }


### PR DESCRIPTION
DatagramChannel in Connected Mode

### Motivation:

Current implementation has no support for datagram sockets in connected mode. In order to fix that, here is an proposition of an implementation.

### Modifications:

* Added a `ConnectToSocketAddressAfterBindOption` to `ChannelOptions`
* Added a “cache” (`self.updateCachedAddressesFromSocket`) to store already connected channels
* Changed the implementation of `bind0()` in `DatagramChannel` so it connects the socket after a successful bind

### Result:

After these changes we are able to connect `DatagramChannel`s to a remote address after they bind to a local address.
