### PR TITLE
ServerDatagramChannel implementation (also in a Connected Mode)

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -345,6 +345,9 @@ public enum ChannelError: Error {
 
     /// An attempt was made to remove a ChannelHandler that is not removable.
     case unremovableHandler
+
+    /// A `DatagramChannel` entry is not present in `(DataramChannel, SocketAddress)` pair cache (when in connected mode)
+    case datagramChannelNotPresent
 }
 
 extension ChannelError: Equatable { }

--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -93,6 +93,13 @@ public struct BacklogOption: ChannelOption {
     public init() {}
 }
 
+/// `ShouldConnetAfterBindOption` allows users to let the newly created (by `ServerDatagramChannel`) datagram channel operate in connected mode. If set to `false`, it will create a new DatagramChannel per each incoming `AddressedEnvelope`'s remoteAddress, only to split the load across `EventLoopGroup`'s threads.
+public struct ShouldConnectAfterBindOption: ChannelOption {
+    public typealias Value = Bool
+
+    public init() {}
+}
+
 /// `DatagramVectorReadMessageCountOption` allows users to configure the number of messages to attempt to read in a single syscall on a
 /// datagram `Channel`.
 ///
@@ -218,6 +225,9 @@ public struct ChannelOptions {
 
     /// - seealso: `DatagramVectorReadMessageCountOption`
     public static let datagramVectorReadMessageCount = DatagramVectorReadMessageCountOption()
+
+    /// - seealso: `ShouldConnectAfterBindOption`.
+    public static let shouldConnectAfterBind = ShouldConnectAfterBindOption()
 }
 
 extension ChannelOptions {

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -579,6 +579,7 @@ extension EventLoop {
 enum NIORegistration: Registration {
     case serverSocketChannel(ServerSocketChannel, SelectorEventSet)
     case socketChannel(SocketChannel, SelectorEventSet)
+    case serverDatagramChannel(ServerDatagramChannel, SelectorEventSet)
     case datagramChannel(DatagramChannel, SelectorEventSet)
 
     /// The `SelectorEventSet` in which this `NIORegistration` is interested in.
@@ -589,6 +590,8 @@ enum NIORegistration: Registration {
                 self = .serverSocketChannel(c, newValue)
             case .socketChannel(let c, _):
                 self = .socketChannel(c, newValue)
+            case .serverDatagramChannel(let c, _):
+                self = .serverDatagramChannel(c, newValue)
             case .datagramChannel(let c, _):
                 self = .datagramChannel(c, newValue)
             }
@@ -598,6 +601,8 @@ enum NIORegistration: Registration {
             case .serverSocketChannel(_, let i):
                 return i
             case .socketChannel(_, let i):
+                return i
+            case .serverDatagramChannel(_, let i):
                 return i
             case .datagramChannel(_, let i):
                 return i
@@ -858,6 +863,8 @@ internal final class SelectableEventLoop: EventLoop {
                     case .serverSocketChannel(let chan, _):
                         self.handleEvent(ev.io, channel: chan)
                     case .socketChannel(let chan, _):
+                        self.handleEvent(ev.io, channel: chan)
+                    case .serverDatagramChannel(let chan, _):
                         self.handleEvent(ev.io, channel: chan)
                     case .datagramChannel(let chan, _):
                         self.handleEvent(ev.io, channel: chan)

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -679,6 +679,8 @@ extension Selector where R == NIORegistration {
                 return closeChannel(chan)
             case .socketChannel(let chan, _):
                 return closeChannel(chan)
+            case .serverDatagramChannel(let chan, _):
+                return closeChannel(chan)
             case .datagramChannel(let chan, _):
                 return closeChannel(chan)
             }

--- a/Tests/NIOTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOTests/DatagramChannelTests+XCTest.swift
@@ -49,6 +49,7 @@ extension DatagramChannelTests {
                 ("testBasicMultipleReads", testBasicMultipleReads),
                 ("testMmsgWillTruncateWithoutChangeToAllocator", testMmsgWillTruncateWithoutChangeToAllocator),
                 ("testRecvMmsgForMultipleCycles", testRecvMmsgForMultipleCycles),
+                ("testServerDatagramConnectedMode", testServerDatagramConnectedMode),
            ]
    }
 }


### PR DESCRIPTION
ServerDatagramChannel implementation (also in a Connected Mode)

### Motivation:

An implementation of a similar mechanism to a `ServerSocketChannel` but for datagram sockets has not been implemented yet. 

This implementation creates a new `DatagramChannel` (and a socket) for each first message which comes from the same source address, so kernel can delegate all future messages to the given socket (`DatagramChannel`).

If connected mode is not specified to be used, it only creates a number of `DatagramChannel`s to distribute the load across multiple threads.

### Modifications:

* Added `ServerDatagramBootstrap` which is an updated copy of `ServerBootstrap`
* Added a `ShouldConnectAfterBindOption` to a `ChannelOptions`
* Updated `EventLoop` and `Selector` so it handles the new type of a `Channel` (`ServerDatagramChannel`)
* Updated `DatagramChannel` so it uses two promises for notifying when the channel has been initiated and activated - for queueing and ordering purposes
* Added a `ServerDatagramChannel` which a mixture of an existing `ServerSocketChannel` and `DatagramChannel` + a mechanism of creating new socket and `DatagramChannel` and optionally connecting it

### Result:

After implementing these changes we can observe, that the `ServerDatagramBootstrap` and `ServerDatagramChannel` behave in the similar way as their TCP counterparts.
