### PR TITLE
Add API for whether BB operations may CoW.

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -775,6 +775,18 @@ extension ByteBuffer: Equatable {
 }
 
 extension ByteBuffer {
+    /// Whether this `ByteBuffer` is known to be able to be modified without
+    /// requiring a new allocation for the backing storage.
+    ///
+    /// This property is conservative: it is possible that it will return false negatives.
+    public var canBeModifiedWithoutAllocation: Bool {
+        mutating get {
+            return isKnownUniquelyReferenced(&self._storage)
+        }
+    }
+}
+
+extension ByteBuffer {
     @inlinable
     func rangeWithinReadableBytes(index: Int, length: Int) -> Range<Int>? {
         let indexFromReaderIndex = index - self.readerIndex

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -144,6 +144,7 @@ extension ByteBufferTest {
                 ("testDataByteTransferStrategyAutomaticMayCopy", testDataByteTransferStrategyAutomaticMayCopy),
                 ("testViewBytesIsHappyWithNegativeValues", testViewBytesIsHappyWithNegativeValues),
                 ("testByteBufferAllocatorSize1Capacity", testByteBufferAllocatorSize1Capacity),
+                ("testByteBufferModifiedWithoutAllocationLogic", testByteBufferModifiedWithoutAllocationLogic),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1975,6 +1975,19 @@ class ByteBufferTest: XCTestCase {
         let buffer = ByteBufferAllocator().buffer(capacity: 1)
         XCTAssertEqual(1, buffer.capacity)
     }
+
+    func testByteBufferModifiedWithoutAllocationLogic() {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1)
+        XCTAssertTrue(buffer.canBeModifiedWithoutAllocation)
+
+        withExtendedLifetime(buffer) {
+            var localCopy = buffer
+            XCTAssertFalse(localCopy.canBeModifiedWithoutAllocation)
+            XCTAssertFalse(buffer.canBeModifiedWithoutAllocation)
+        }
+
+        XCTAssertTrue(buffer.canBeModifiedWithoutAllocation)
+    }
 }
 
 private enum AllocationExpectationState: Int {


### PR DESCRIPTION
Motivation:

From time to time a NIO application holds a ByteBuffer that it may want
to edit. Whether it wants to do that may potentially be contingent on
whether having to do so will cause an allocation, as it may be
preferable to prefer a different operation.

Modifications:

- Added API for asking BB if it thinks it'll CoW.

Result:

People can ask the question.
