### PR TITLE
fix new Swift compiler warnings

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -396,7 +396,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - context: the `ChannelHandlerContext` that belongs to `ChannelHandler` that should be removed.
     ///     - promise: An `EventLoopPromise` that will complete when the `ChannelHandler` is removed.
     public func removeHandler(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
-        guard let handler = context.handler as? RemovableChannelHandler else {
+        guard context.handler is RemovableChannelHandler else {
             promise?.fail(ChannelError.unremovableHandler)
             return
         }

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -116,7 +116,7 @@ public struct NonBlockingFileIO {
                             allocator: ByteBufferAllocator,
                             eventLoop: EventLoop, chunkHandler: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
         precondition(chunkSize > 0, "chunkSize must be > 0 (is \(chunkSize))")
-        var remainingReads = 1 + (byteCount / chunkSize)
+        let remainingReads = 1 + (byteCount / chunkSize)
         let lastReadSize = byteCount % chunkSize
 
         func _read(remainingReads: Int) -> EventLoopFuture<Void> {

--- a/Sources/NIO/PendingDatagramWritesManager.swift
+++ b/Sources/NIO/PendingDatagramWritesManager.swift
@@ -99,7 +99,7 @@ private func doPendingDatagramWriteVectorOperation(pending: PendingDatagramWrite
             let addressLen = p.copySocketAddress(addresses.baseAddress! + c)
             iovecs[c] = iovec(iov_base: UnsafeMutableRawPointer(mutating: ptr.baseAddress!), iov_len: numericCast(toWriteForThisBuffer))
 
-            var msg = msghdr(msg_name: addresses.baseAddress! + c,
+            let msg = msghdr(msg_name: addresses.baseAddress! + c,
                              msg_namelen: addressLen,
                              msg_iov: iovecs.baseAddress! + c,
                              msg_iovlen: 1,

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -291,7 +291,6 @@ measureAndPrint(desc: "bytebuffer_lots_of_rw") {
         DispatchData(bytes: UnsafeRawBufferPointer(start: UnsafeRawPointer(ptr.baseAddress), count: ptr.count))
     }
     var buffer = ByteBufferAllocator().buffer(capacity: 7 * 1024 * 1024)
-    let foundationData = "A".data(using: .utf8)!
     @inline(never)
     func doWrites(buffer: inout ByteBuffer) {
         /* all of those should be 0 allocations */

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -347,7 +347,6 @@ class HTTPServerClientTest : XCTestCase {
         let expectedHeaders = maybeExpectedHeaders ?? HTTPHeaders([("content-length", "14"), ("connection", "close")])
         let accumulation = HTTPClientResponsePartAssertHandler(httpVersion, .ok, expectedHeaders, "Hello World!\r\n")
 
-        let numBytes = 16 * 1024
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -405,7 +404,6 @@ class HTTPServerClientTest : XCTestCase {
 
         let accumulation = HTTPClientResponsePartAssertHandler(HTTPVersion(major: 1, minor: 1), .ok, expectedHeaders, "12345678910")
 
-        let numBytes = 16 * 1024
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -466,7 +464,6 @@ class HTTPServerClientTest : XCTestCase {
 
         let accumulation = HTTPClientResponsePartAssertHandler(HTTPVersion(major: 1, minor: 1), .ok, expectedHeaders, "12345678910", expectedTrailers)
 
-        let numBytes = 16 * 1024
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -565,7 +562,6 @@ class HTTPServerClientTest : XCTestCase {
 
         let accumulation = HTTPClientResponsePartAssertHandler(HTTPVersion(major: 1, minor: 1), .ok, expectedHeaders, "")
 
-        let numBytes = 16 * 1024
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -610,7 +606,6 @@ class HTTPServerClientTest : XCTestCase {
 
         let accumulation = HTTPClientResponsePartAssertHandler(HTTPVersion(major: 1, minor: 1), .noContent, expectedHeaders, "")
 
-        let numBytes = 16 * 1024
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -452,8 +452,8 @@ class HTTPServerUpgradeTestCase: XCTestCase {
             upgraderCbFired = true
         }
 
-        let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
-                                                                                    extraHandlers: []) { (context) in
+        let (group, _, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
+                                                                               extraHandlers: []) { (context) in
             // This is called before the upgrader gets called.
             XCTAssertNil(upgradeRequest)
             upgradeHandlerCbFired = true
@@ -558,8 +558,8 @@ class HTTPServerUpgradeTestCase: XCTestCase {
             upgraderCbFired = true
         }
 
-        let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [explodingUpgrader, successfulUpgrader],
-                                                                                    extraHandlers: []) { context in
+        let (group, _, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [explodingUpgrader, successfulUpgrader],
+                                                                               extraHandlers: []) { context in
             // This is called before the upgrader gets called.
             XCTAssertNil(upgradeRequest)
             upgradeHandlerCbFired = true
@@ -606,8 +606,8 @@ class HTTPServerUpgradeTestCase: XCTestCase {
             XCTAssertEqual(eventSaver.events.count, 0)
         }
 
-        let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
-                                                                                    extraHandlers: [eventSaver]) { context in
+        let (group, _, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
+                                                                               extraHandlers: [eventSaver]) { context in
             XCTAssertEqual(eventSaver.events.count, 0)
             context.close(promise: nil)
         }
@@ -663,8 +663,8 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         }
         let errorCatcher = ErrorSaver()
 
-        let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [explodingUpgrader, successfulUpgrader],
-                                                                                    extraHandlers: [errorCatcher]) { context in
+        let (group, _, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [explodingUpgrader, successfulUpgrader],
+                                                                               extraHandlers: [errorCatcher]) { context in
             // This is called before the upgrader gets called.
             XCTAssertNil(upgradeRequest)
             upgradeHandlerCbFired = true
@@ -714,8 +714,8 @@ class HTTPServerUpgradeTestCase: XCTestCase {
 
     func testUpgradeIsCaseInsensitive() throws {
         let upgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: ["WeIrDcAsE"]) { req in }
-        let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
-                                                                                    extraHandlers: []) { context in
+        let (group, _, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
+                                                                               extraHandlers: []) { context in
             context.close(promise: nil)
         }
         defer {
@@ -792,7 +792,8 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         let upgrader = UpgradeDelayer(forProtocol: "myproto")
         let dataRecorder = DataRecorder<ByteBuffer>()
 
-        let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader], extraHandlers: [dataRecorder]) { context in
+        let (group, server, client, _) = try setUpTestWithAutoremoval(upgraders: [upgrader],
+                                                                      extraHandlers: [dataRecorder]) { context in
             g.leave()
         }
         defer {
@@ -1111,9 +1112,9 @@ class HTTPServerUpgradeTestCase: XCTestCase {
 
     func testRemovesAllHTTPRelatedHandlersAfterUpgrade() throws {
         let upgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: []) { req in }
-        let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(pipelining: true,
-                                                                                    upgraders: [upgrader],
-                                                                                    extraHandlers: []) { context in }
+        let (group, _, client, connectedServer) = try setUpTestWithAutoremoval(pipelining: true,
+                                                                               upgraders: [upgrader],
+                                                                               extraHandlers: []) { context in }
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1222,15 +1223,15 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         let firstByteDonePromise = promiseGroup.next().makePromise(of: Void.self)
         let secondByteDonePromise = promiseGroup.next().makePromise(of: Void.self)
         let allDonePromise = promiseGroup.next().makePromise(of: Void.self)
-        let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
-                                                                                    extraHandlers: []) { (context) in
-                                                                                        // This is called before the upgrader gets called.
-                                                                                        XCTAssertNil(upgradeRequest)
-                                                                                        upgradeHandlerCbFired = true
-                                                                                        
-                                                                                        _ = context.channel.pipeline.addHandler(CheckWeReadInlineAndExtraData(firstByteDonePromise: firstByteDonePromise,
-                                                                                                                                                            secondByteDonePromise: secondByteDonePromise,
-                                                                                                                                                            allDonePromise: allDonePromise))
+        let (group, _, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
+                                                                               extraHandlers: []) { (context) in
+            // This is called before the upgrader gets called.
+            XCTAssertNil(upgradeRequest)
+            upgradeHandlerCbFired = true
+
+            _ = context.channel.pipeline.addHandler(CheckWeReadInlineAndExtraData(firstByteDonePromise: firstByteDonePromise,
+                                                                                  secondByteDonePromise: secondByteDonePromise,
+                                                                                  allDonePromise: allDonePromise))
         }
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
@@ -1384,14 +1385,14 @@ class HTTPServerUpgradeTestCase: XCTestCase {
             upgraderCbFired = true
         }
 
-        let (group, server, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
-                                                                                    extraHandlers: []) { (context) in
-                                                                                        // This is called before the upgrader gets called.
-                                                                                        XCTAssertNil(upgradeRequest)
-                                                                                        upgradeHandlerCbFired = true
+        let (group, _, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
+                                                                               extraHandlers: []) { (context) in
+                                                                                // This is called before the upgrader gets called.
+            XCTAssertNil(upgradeRequest)
+            upgradeHandlerCbFired = true
 
-                                                                                        // We're closing the connection now.
-                                                                                        context.close(promise: nil)
+            // We're closing the connection now.
+            context.close(promise: nil)
         }
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2583,7 +2583,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try singleThreadedELG.syncShutdownGracefully())
         }
         var numberOfAcceptedChannel = 0
-        var acceptedChannels: [EventLoopPromise<Channel>] = [singleThreadedELG.next().makePromise(),
+        let acceptedChannels: [EventLoopPromise<Channel>] = [singleThreadedELG.next().makePromise(),
                                                              singleThreadedELG.next().makePromise(),
                                                              singleThreadedELG.next().makePromise()]
         let server = try assertNoThrowWithValue(ServerBootstrap(group: singleThreadedELG)
@@ -2718,8 +2718,7 @@ public final class ChannelTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try singleThreadedELG.syncShutdownGracefully())
         }
-        var numberOfAcceptedChannel = 0
-        var acceptedChannel = singleThreadedELG.next().makePromise(of: Channel.self)
+        let acceptedChannel = singleThreadedELG.next().makePromise(of: Channel.self)
         let server = try assertNoThrowWithValue(ServerBootstrap(group: singleThreadedELG)
             .childChannelInitializer { channel in
                 acceptedChannel.succeed(channel)

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -483,7 +483,7 @@ public final class ByteToMessageDecoderTest: XCTestCase {
             var state: Int = 1
 
             mutating func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
-                if let slice = buffer.readSlice(length: self.state) {
+                if buffer.readSlice(length: self.state) != nil {
                     defer {
                         self.state += 1
                     }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -331,7 +331,7 @@ public final class EventLoopTest : XCTestCase {
 
     public func testEventLoopMakeIterator() throws {
         let eventLoop = EmbeddedEventLoop()
-        var iterator = eventLoop.makeIterator()
+        let iterator = eventLoop.makeIterator()
         defer {
             XCTAssertNoThrow(try eventLoop.syncShutdownGracefully())
         }
@@ -614,8 +614,6 @@ public final class EventLoopTest : XCTestCase {
     }
 
     public func testScheduleMultipleTasks() throws {
-        let nanos: NIODeadline = .now()
-        let amount: TimeAmount = .seconds(1)
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -203,7 +203,6 @@ class FileRegionTest : XCTestCase {
 
     func testFileRegionDuplicatesShareSeekPointer() throws {
         try withTemporaryFile(content: "0123456789") { fh1, path in
-            let fr1 = FileRegion(fileHandle: fh1, readerIndex: 0, endIndex: 10)
             let fh2 = try fh1.duplicate()
 
             var fr1Bytes: [UInt8] = Array(repeating: 0, count: 5)

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -296,7 +296,7 @@ class SelectorTest: XCTestCase {
         // all of the following are boxed as we need mutable references to them, they can only be read/written on the
         // event loop `el`.
         let allServerChannels: Box<[Channel]> = Box([])
-        var allChannels: Box<[Channel]> = Box([])
+        let allChannels: Box<[Channel]> = Box([])
         let hasReConnectEventLoopTickFinished: Box<Bool> = Box(false)
         let numberOfConnectedChannels: Box<Int> = Box(0)
 

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -561,7 +561,7 @@ func withCrossConnectedUnixDomainSocketChannels<R>(file: StaticString = #file,
                                                    line: UInt = #line,
                                                    _ body: (Channel, Channel) throws -> R) throws -> R {
     return try withTemporaryDirectory { tempDir in
-        let bindTarget = try SocketAddress(unixDomainSocketPath: tempDir + "/server.sock")
+        let bindTarget = try SocketAddress(unixDomainSocketPath: tempDir + "/s")
         return try withCrossConnectedSockAddrChannels(bindTarget: bindTarget, body)
     }
 }


### PR DESCRIPTION
Motivation:

Very recent Swift compilers have more warnings.

Modifications:

Fix the warnings.

Result:

No warnings when compiling.