### PR TITLE
fix tests in iOS Simulator

### DIFF
--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -111,6 +111,11 @@ func withTemporaryFile<T>(content: String? = nil, _ body: (NIO.NIOFileHandle, St
 }
 var temporaryDirectory: String {
     get {
+#if targetEnvironment(simulator)
+        // Simulator temp directories are so long (and contain the user name) that they're not usable
+        // for UNIX Domain Socket paths (which are limited to 103 bytes).
+        return "/tmp"
+#else
 #if os(Android)
         return "/data/local/tmp"
 #elseif os(Linux)
@@ -121,7 +126,8 @@ var temporaryDirectory: String {
         } else {
             return "/tmp"
         }
-#endif
+#endif // os
+#endif // targetEnvironment
     }
 }
 


### PR DESCRIPTION
Motivation:

The iOS Simulators have extremely long temp directory names that contain
the user name (which varies in length). UNIX Domain Socket paths however
are limited to 103 bytes.

Modifications:

Use /tmp as the temp directory for Simulator environments.

Result:

Tests run in iOS Simulators.