### PR TITLE
ByteBuffer: slight improvement in the capacity docs

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -84,8 +84,10 @@ public struct ByteBufferAllocator {
 
     /// Request a freshly allocated `ByteBuffer` of size `capacity` or larger.
     ///
+    /// - note: The passed `capacity` is the `ByteBuffer`'s initial capacity, it will grow automatically if necessary.
+    ///
     /// - parameters:
-    ///     - capacity: The capacity of the returned `ByteBuffer`.
+    ///     - capacity: The initial capacity of the returned `ByteBuffer`.
     public func buffer(capacity: Int) -> ByteBuffer {
         return ByteBuffer(allocator: self, startingCapacity: capacity)
     }


### PR DESCRIPTION
Motivation:

ByteBuffer didn't document well that its capacity is really an initial
capacity only.

Modifications:

Clearly state that it's an initial capacity.

Result:

Better docs.