### PR TITLE
Add flatSubmit method to EventLoop (#426)

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -232,6 +232,13 @@ public protocol EventLoop: EventLoopGroup {
     /// - returns: `EventLoopFuture` that is notified once the task was executed.
     func submit<T>(_ task: @escaping () throws -> T) -> EventLoopFuture<T>
 
+    /// Submit a given task to be executed by the `EventLoop`. Once the execution is complete the returned `EventLoopFuture` is notified.
+    ///
+    /// - parameters:
+    ///     - task: The closure that will be submitted to the `EventLoop` for execution.
+    /// - returns: `EventLoopFuture` that is notified once the task was executed.
+    func flatSubmit<T>(_ task: @escaping () throws -> EventLoopFuture<T>) -> EventLoopFuture<T>
+
     /// Schedule a `task` that is executed by this `SelectableEventLoop` at the given time.
     @discardableResult
     func scheduleTask<T>(deadline: NIODeadline, _ task: @escaping () throws -> T) -> Scheduled<T>
@@ -463,6 +470,18 @@ extension EventLoop {
         }
 
         return promise.futureResult
+    }
+
+    /// Submit `task` to be run on this `EventLoop`.
+    ///
+    /// The returned `EventLoopFuture` will be completed when `task` has finished running. It will be identical to
+    ///  the `EventLoopFuture` returned by `task`.
+    ///
+    /// - parameters:
+    ///     - task: The synchronous task to run. As everything that runs on the `EventLoop`, it must not block.
+    /// - returns: An `EventLoopFuture` identical to the `EventLooopFuture` returned from `task`.
+    public func flatSubmit<T>(_ task: @escaping () throws -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+        return submit(task).flatMap { $0 }
     }
 
     /// Creates and returns a new `EventLoopPromise` that will be notified using this `EventLoop` as execution `NIOThread`.

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -232,13 +232,6 @@ public protocol EventLoop: EventLoopGroup {
     /// - returns: `EventLoopFuture` that is notified once the task was executed.
     func submit<T>(_ task: @escaping () throws -> T) -> EventLoopFuture<T>
 
-    /// Submit a given task to be executed by the `EventLoop`. Once the execution is complete the returned `EventLoopFuture` is notified.
-    ///
-    /// - parameters:
-    ///     - task: The closure that will be submitted to the `EventLoop` for execution.
-    /// - returns: `EventLoopFuture` that is notified once the task was executed.
-    func flatSubmit<T>(_ task: @escaping () throws -> EventLoopFuture<T>) -> EventLoopFuture<T>
-
     /// Schedule a `task` that is executed by this `SelectableEventLoop` at the given time.
     @discardableResult
     func scheduleTask<T>(deadline: NIODeadline, _ task: @escaping () throws -> T) -> Scheduled<T>
@@ -475,12 +468,12 @@ extension EventLoop {
     /// Submit `task` to be run on this `EventLoop`.
     ///
     /// The returned `EventLoopFuture` will be completed when `task` has finished running. It will be identical to
-    ///  the `EventLoopFuture` returned by `task`.
+    /// the `EventLoopFuture` returned by `task`.
     ///
     /// - parameters:
     ///     - task: The synchronous task to run. As everything that runs on the `EventLoop`, it must not block.
     /// - returns: An `EventLoopFuture` identical to the `EventLooopFuture` returned from `task`.
-    public func flatSubmit<T>(_ task: @escaping () throws -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+    public func flatSubmit<T>(_ task: @escaping () -> EventLoopFuture<T>) -> EventLoopFuture<T> {
         return submit(task).flatMap { $0 }
     }
 

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -46,6 +46,7 @@ extension EventLoopTest {
                 ("testCurrentEventLoop", testCurrentEventLoop),
                 ("testShutdownWhileScheduledTasksNotReady", testShutdownWhileScheduledTasksNotReady),
                 ("testCloseFutureNotifiedBeforeUnblock", testCloseFutureNotifiedBeforeUnblock),
+                ("testFlatSubmitCloseFutureNotifiedBeforeUnblock", testFlatSubmitCloseFutureNotifiedBeforeUnblock),
                 ("testScheduleMultipleTasks", testScheduleMultipleTasks),
                 ("testRepeatedTaskThatIsImmediatelyCancelledNotifies", testRepeatedTaskThatIsImmediatelyCancelledNotifies),
                 ("testRepeatedTaskThatIsCancelledAfterRunningAtLeastTwiceNotifies", testRepeatedTaskThatIsCancelledAfterRunningAtLeastTwiceNotifies),

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -46,7 +46,6 @@ extension EventLoopTest {
                 ("testCurrentEventLoop", testCurrentEventLoop),
                 ("testShutdownWhileScheduledTasksNotReady", testShutdownWhileScheduledTasksNotReady),
                 ("testCloseFutureNotifiedBeforeUnblock", testCloseFutureNotifiedBeforeUnblock),
-                ("testFlatSubmitCloseFutureNotifiedBeforeUnblock", testFlatSubmitCloseFutureNotifiedBeforeUnblock),
                 ("testScheduleMultipleTasks", testScheduleMultipleTasks),
                 ("testRepeatedTaskThatIsImmediatelyCancelledNotifies", testRepeatedTaskThatIsImmediatelyCancelledNotifies),
                 ("testRepeatedTaskThatIsCancelledAfterRunningAtLeastTwiceNotifies", testRepeatedTaskThatIsCancelledAfterRunningAtLeastTwiceNotifies),
@@ -61,6 +60,10 @@ extension EventLoopTest {
                 ("testEdgeCasesNIODeadlineMinusNIODeadline", testEdgeCasesNIODeadlineMinusNIODeadline),
                 ("testEdgeCasesNIODeadlinePlusTimeAmount", testEdgeCasesNIODeadlinePlusTimeAmount),
                 ("testEdgeCasesNIODeadlineMinusTimeAmount", testEdgeCasesNIODeadlineMinusTimeAmount),
+                ("testSuccessfulFlatSubmit", testSuccessfulFlatSubmit),
+                ("testFailingFlatSubmit", testFailingFlatSubmit),
+                ("testFlatSubmitOnShutdownLoopGroup", testFlatSubmitOnShutdownLoopGroup),
+                ("testSubmitOnShutdownLoopGroup", testSubmitOnShutdownLoopGroup),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -62,8 +62,6 @@ extension EventLoopTest {
                 ("testEdgeCasesNIODeadlineMinusTimeAmount", testEdgeCasesNIODeadlineMinusTimeAmount),
                 ("testSuccessfulFlatSubmit", testSuccessfulFlatSubmit),
                 ("testFailingFlatSubmit", testFailingFlatSubmit),
-                ("testFlatSubmitOnShutdownLoopGroup", testFlatSubmitOnShutdownLoopGroup),
-                ("testSubmitOnShutdownLoopGroup", testSubmitOnShutdownLoopGroup),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -950,26 +950,4 @@ public final class EventLoopTest : XCTestCase {
             XCTAssertEqual(.failed, error as? TestError)
         }
     }
-
-    func testFlatSubmitOnShutdownLoopGroup() {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let eventLoop = eventLoopGroup.next()
-        XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-
-        let _ = eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
-            eventLoop.makeSucceededFuture(XCTFail())
-        }
-        Thread.sleep(until: .init(timeIntervalSinceNow: 0.1))
-    }
-
-    func testSubmitOnShutdownLoopGroup() {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let eventLoop = eventLoopGroup.next()
-        XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-
-        let _ = eventLoop.submit {
-            XCTFail()
-        }
-        Thread.sleep(until: .init(timeIntervalSinceNow: 0.1))
-    }
 }


### PR DESCRIPTION
Add flatSubmit method to EventLoop (#426)

### Motivation:

Calling EventLoop's submit method with a task that returns an EventLoopFuture results in a double future. flatSubmit provides an alternative which does not return a double future.

### Modifications:

Added a flatSubmit() default implementation that returns the result of calling flatMap { $0 } on the EventLoopFuture returned from task.

### Result:

Additive change only. flatSubmit method on EventLoop will be available for use.
