### PR TITLE
namespace ChannelOptions types (#1148)

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -480,13 +480,13 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         }
 
         switch option {
-        case let option as SocketOption:
+        case let option as ChannelOptions.Types.SocketOption:
             try self.setSocketOption0(level: option.level, name: option.name, value: value)
-        case _ as AllocatorOption:
+        case _ as ChannelOptions.Types.AllocatorOption:
             bufferAllocator = value as! ByteBufferAllocator
-        case _ as RecvAllocatorOption:
+        case _ as ChannelOptions.Types.RecvAllocatorOption:
             recvAllocator = value as! RecvByteBufferAllocator
-        case _ as AutoReadOption:
+        case _ as ChannelOptions.Types.AutoReadOption:
             let auto = value as! Bool
             let old = self.autoRead
             self.autoRead = auto
@@ -500,7 +500,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
                     pauseRead0()
                 }
             }
-        case _ as MaxMessagesPerReadOption:
+        case _ as ChannelOptions.Types.MaxMessagesPerReadOption:
             maxMessagesPerRead = value as! UInt
         default:
             fatalError("option \(option) not supported")
@@ -527,15 +527,15 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         }
 
         switch option {
-        case let option as SocketOption:
+        case let option as ChannelOptions.Types.SocketOption:
             return try self.getSocketOption0(level: option.level, name: option.name)
-        case _ as AllocatorOption:
+        case _ as ChannelOptions.Types.AllocatorOption:
             return bufferAllocator as! Option.Value
-        case _ as RecvAllocatorOption:
+        case _ as ChannelOptions.Types.RecvAllocatorOption:
             return recvAllocator as! Option.Value
-        case _ as AutoReadOption:
+        case _ as ChannelOptions.Types.AutoReadOption:
             return autoRead as! Option.Value
-        case _ as MaxMessagesPerReadOption:
+        case _ as ChannelOptions.Types.MaxMessagesPerReadOption:
             return maxMessagesPerRead as! Option.Value
         default:
             fatalError("option \(option) not supported")

--- a/Sources/NIO/BaseStreamSocketChannel.swift
+++ b/Sources/NIO/BaseStreamSocketChannel.swift
@@ -41,12 +41,12 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         }
 
         switch option {
-        case _ as AllowRemoteHalfClosureOption:
+        case _ as ChannelOptions.Types.AllowRemoteHalfClosureOption:
             self.allowRemoteHalfClosure = value as! Bool
-        case _ as WriteSpinOption:
+        case _ as ChannelOptions.Types.WriteSpinOption:
             self.pendingWrites.writeSpinCount = value as! UInt
-        case _ as WriteBufferWaterMarkOption:
-            self.pendingWrites.waterMark = value as! WriteBufferWaterMark
+        case _ as ChannelOptions.Types.WriteBufferWaterMarkOption:
+            self.pendingWrites.waterMark = value as! ChannelOptions.Types.WriteBufferWaterMark
         default:
             try super.setOption0(option, value: value)
         }
@@ -60,11 +60,11 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         }
 
         switch option {
-        case _ as AllowRemoteHalfClosureOption:
+        case _ as ChannelOptions.Types.AllowRemoteHalfClosureOption:
             return self.allowRemoteHalfClosure as! Option.Value
-        case _ as WriteSpinOption:
+        case _ as ChannelOptions.Types.WriteSpinOption:
             return self.pendingWrites.writeSpinCount as! Option.Value
-        case _ as WriteBufferWaterMarkOption:
+        case _ as ChannelOptions.Types.WriteBufferWaterMarkOption:
             return self.pendingWrites.waterMark as! Option.Value
         default:
             return try super.getOption0(option)

--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -27,197 +27,238 @@ public typealias SocketOptionName = Int32
     public typealias SocketOptionValue = Int32
 #endif
 
-/// `SocketOption` allows users to specify configuration settings that are directly applied to the underlying socket file descriptor.
-///
-/// Valid options are typically found in the various man pages like `man 4 tcp`.
-public struct SocketOption: ChannelOption, Equatable {
-    public typealias Value = (SocketOptionValue)
+@available(*, deprecated, renamed: "ChannelOptions.Types.SocketOption")
+public typealias SocketOption = ChannelOptions.Types.SocketOption
 
-    public var level: SocketOptionLevel
-    public var name: SocketOptionName
+@available(*, deprecated, renamed: "ChannelOptions.Types.AllocatorOption")
+public typealias AllocatorOption = ChannelOptions.Types.AllocatorOption
 
-    /// Create a new `SocketOption`.
-    ///
-    /// - parameters:
-    ///     - level: The level for the option as defined in `man setsockopt`, e.g. SO_SOCKET.
-    ///     - name: The name of the option as defined in `man setsockopt`, e.g. `SO_REUSEADDR`.
-    public init(level: SocketOptionLevel, name: SocketOptionName) {
-        self.level = level
-        self.name = name
+@available(*, deprecated, renamed: "ChannelOptions.Types.RecvAllocatorOption")
+public typealias RecvAllocatorOption = ChannelOptions.Types.RecvAllocatorOption
+
+@available(*, deprecated, renamed: "ChannelOptions.Types.AutoReadOption")
+public typealias AutoReadOption = ChannelOptions.Types.AutoReadOption
+
+@available(*, deprecated, renamed: "ChannelOptions.Types.WriteSpinOption")
+public typealias WriteSpinOption = ChannelOptions.Types.WriteSpinOption
+
+@available(*, deprecated, renamed: "ChannelOptions.Types.MaxMessagesPerReadOption")
+public typealias MaxMessagesPerReadOption = ChannelOptions.Types.MaxMessagesPerReadOption
+
+@available(*, deprecated, renamed: "ChannelOptions.Types.BacklogOption")
+public typealias BacklogOption = ChannelOptions.Types.BacklogOption
+
+@available(*, deprecated, renamed: "ChannelOptions.Types.DatagramVectorReadMessageCountOption")
+public typealias DatagramVectorReadMessageCountOption = ChannelOptions.Types.DatagramVectorReadMessageCountOption
+
+@available(*, deprecated, renamed: "ChannelOptions.Types.WriteBufferWaterMark")
+public typealias WriteBufferWaterMark = ChannelOptions.Types.WriteBufferWaterMark
+
+@available(*, deprecated, renamed: "ChannelOptions.Types.WriteBufferWaterMarkOption")
+public typealias WriteBufferWaterMarkOption = ChannelOptions.Types.WriteBufferWaterMarkOption
+
+@available(*, deprecated, renamed: "ChannelOptions.Types.ConnectTimeoutOption")
+public typealias ConnectTimeoutOption = ChannelOptions.Types.ConnectTimeoutOption
+
+@available(*, deprecated, renamed: "ChannelOptions.Types.AllowRemoteHalfClosureOption")
+public typealias AllowRemoteHalfClosureOption = ChannelOptions.Types.AllowRemoteHalfClosureOption
+
+public extension ChannelOptions {
+    enum Types {
+
+        /// `SocketOption` allows users to specify configuration settings that are directly applied to the underlying socket file descriptor.
+        ///
+        /// Valid options are typically found in the various man pages like `man 4 tcp`.
+        public struct SocketOption: ChannelOption, Equatable {
+            public typealias Value = (SocketOptionValue)
+
+            public var level: SocketOptionLevel
+            public var name: SocketOptionName
+
+            /// Create a new `SocketOption`.
+            ///
+            /// - parameters:
+            ///     - level: The level for the option as defined in `man setsockopt`, e.g. SO_SOCKET.
+            ///     - name: The name of the option as defined in `man setsockopt`, e.g. `SO_REUSEADDR`.
+            public init(level: SocketOptionLevel, name: SocketOptionName) {
+                self.level = level
+                self.name = name
+            }
+        }
+
+        /// `AllocatorOption` allows to specify the `ByteBufferAllocator` to use.
+        public struct AllocatorOption: ChannelOption {
+            public typealias Value = ByteBufferAllocator
+
+            public init() {}
+        }
+
+        /// `RecvAllocatorOption` allows users to specify the `RecvByteBufferAllocator` to use.
+        public struct RecvAllocatorOption: ChannelOption {
+            public typealias Value = RecvByteBufferAllocator
+
+            public init() {}
+        }
+
+        /// `AutoReadOption` allows users to configure if a `Channel` should automatically call `Channel.read` again once all data was read from the transport or
+        /// if the user is responsible to call `Channel.read` manually.
+        public struct AutoReadOption: ChannelOption {
+            public typealias Value = Bool
+
+            public init() {}
+        }
+
+        /// `WriteSpinOption` allows users to configure the number of repetitions of a only partially successful write call before considering the `Channel` not writable.
+        /// Setting this option to `0` means that we only issue one write call and if that call does not write all the bytes,
+        /// we consider the `Channel` not writable.
+        public struct WriteSpinOption: ChannelOption {
+            public typealias Value = UInt
+
+            public init() {}
+        }
+
+        /// `MaxMessagesPerReadOption` allows users to configure the maximum number of read calls to the underlying transport are performed before wait again until
+        /// there is more to read and be notified.
+        public struct MaxMessagesPerReadOption: ChannelOption {
+            public typealias Value = UInt
+
+            public init() {}
+        }
+
+        /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`. This is only useful for `ServerSocketChannel`s.
+        public struct BacklogOption: ChannelOption {
+            public typealias Value = Int32
+
+            public init() {}
+        }
+
+        /// `DatagramVectorReadMessageCountOption` allows users to configure the number of messages to attempt to read in a single syscall on a
+        /// datagram `Channel`.
+        ///
+        /// Some datagram `Channel`s have extremely high datagram throughput. This can occur when the single datagram socket is encapsulating
+        /// many logical "connections" (e.g. with QUIC) or when the datagram socket is simply serving an enormous number of consumers (e.g.
+        /// with a public-facing DNS server). In this case the overhead of one syscall per datagram is profoundly limiting. Using this
+        /// `ChannelOption` allows the `Channel` to read multiple datagrams at once.
+        ///
+        /// Note that simply increasing this number will not necessarily bring performance gains and may in fact cause data loss. Any increase
+        /// to this should be matched by increasing the size of the buffers allocated by the `Channel` `RecvByteBufferAllocator` (as set by
+        /// `ChannelOption.recvAllocator`) proportionally. For example, to receive 10 messages at a time, set the size of the buffers allocated
+        /// by the `RecvByteBufferAllocator` to at least 10x the size of the maximum datagram size you wish to receive.
+        ///
+        /// Naturally, this option is only valid on datagram channels.
+        ///
+        /// This option only works on the following platforms:
+        ///
+        /// - Linux
+        /// - FreeBSD
+        /// - Android
+        ///
+        /// On all other platforms, setting it has no effect.
+        ///
+        /// Set this option to 0 to disable vector reads and to use serial reads instead.
+        public struct DatagramVectorReadMessageCountOption: ChannelOption {
+            public typealias Value = Int
+
+            public init() { }
+        }
+
+        /// The watermark used to detect when `Channel.isWritable` returns `true` or `false`.
+        public struct WriteBufferWaterMark {
+            /// The low mark setting for a `Channel`.
+            ///
+            /// When the amount of buffered bytes in the `Channel`s outbound buffer drops below this value the `Channel` will be
+            /// marked as writable again (after it was non-writable).
+            public let low: Int
+
+            /// The high mark setting for a `Channel`.
+            ///
+            /// When the amount of buffered bytes in the `Channel`s outbound exceeds this value the `Channel` will be
+            /// marked as non-writable. It will be marked as writable again once the amount of buffered bytes drops below `low`.
+            public let high: Int
+
+            /// Create a new instance.
+            ///
+            /// Valid initialization is restricted to `1 <= low <= high`.
+            ///
+            /// - parameters:
+            ///      - low: The low watermark.
+            ///      - high: The high watermark.
+            public init(low: Int, high: Int) {
+                precondition(low >= 1, "low must be >= 1 but was \(low)")
+                precondition(high >= low, "low must be <= high, but was low: \(low) high: \(high)")
+                self.low = low
+                self.high = high
+            }
+        }
+
+        /// `WriteBufferWaterMarkOption` allows users to configure when a `Channel` should be marked as writable or not. Once the amount of bytes queued in a
+        /// `Channel`s outbound buffer is larger than `WriteBufferWaterMark.high` the channel will be marked as non-writable and so
+        /// `Channel.isWritable` will return `false`. Once we were able to write some data out of the outbound buffer and the amount of bytes queued
+        /// falls below `WriteBufferWaterMark.low` the `Channel` will become writable again. Once this happens `Channel.writable` will return
+        /// `true` again. These writability changes are also propagated through the `ChannelPipeline` and so can be intercepted via `ChannelInboundHandler.channelWritabilityChanged`.
+        public struct WriteBufferWaterMarkOption: ChannelOption {
+            public typealias Value = WriteBufferWaterMark
+
+            public init() {}
+        }
+
+        /// `ConnectTimeoutOption` allows users to configure the `TimeAmount` after which a connect will fail if it was not established in the meantime. May be
+        /// `nil`, in which case the connection attempt will never time out.
+        public struct ConnectTimeoutOption: ChannelOption {
+            public typealias Value = TimeAmount?
+
+            public init() {}
+        }
+
+        /// `AllowRemoteHalfClosureOption` allows users to configure whether the `Channel` will close itself when its remote
+        /// peer shuts down its send stream, or whether it will remain open. If set to `false` (the default), the `Channel`
+        /// will be closed automatically if the remote peer shuts down its send stream. If set to true, the `Channel` will
+        /// not be closed: instead, a `ChannelEvent.inboundClosed` user event will be sent on the `ChannelPipeline`,
+        /// and no more data will be received.
+        public struct AllowRemoteHalfClosureOption: ChannelOption {
+            public typealias Value = Bool
+
+            public init() {}
+        }
     }
-}
-
-/// `AllocatorOption` allows to specify the `ByteBufferAllocator` to use.
-public struct AllocatorOption: ChannelOption {
-    public typealias Value = ByteBufferAllocator
-
-    public init() {}
-}
-
-/// `RecvAllocatorOption` allows users to specify the `RecvByteBufferAllocator` to use.
-public struct RecvAllocatorOption: ChannelOption {
-    public typealias Value = RecvByteBufferAllocator
-
-    public init() {}
-}
-
-/// `AutoReadOption` allows users to configure if a `Channel` should automatically call `Channel.read` again once all data was read from the transport or
-/// if the user is responsible to call `Channel.read` manually.
-public struct AutoReadOption: ChannelOption {
-    public typealias Value = Bool
-
-    public init() {}
-}
-
-/// `WriteSpinOption` allows users to configure the number of repetitions of a only partially successful write call before considering the `Channel` not writable.
-/// Setting this option to `0` means that we only issue one write call and if that call does not write all the bytes,
-/// we consider the `Channel` not writable.
-public struct WriteSpinOption: ChannelOption {
-    public typealias Value = UInt
-
-    public init() {}
-}
-
-/// `MaxMessagesPerReadOption` allows users to configure the maximum number of read calls to the underlying transport are performed before wait again until
-/// there is more to read and be notified.
-public struct MaxMessagesPerReadOption: ChannelOption {
-    public typealias Value = UInt
-
-    public init() {}
-}
-
-/// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`. This is only useful for `ServerSocketChannel`s.
-public struct BacklogOption: ChannelOption {
-    public typealias Value = Int32
-
-    public init() {}
-}
-
-/// `DatagramVectorReadMessageCountOption` allows users to configure the number of messages to attempt to read in a single syscall on a
-/// datagram `Channel`.
-///
-/// Some datagram `Channel`s have extremely high datagram throughput. This can occur when the single datagram socket is encapsulating
-/// many logical "connections" (e.g. with QUIC) or when the datagram socket is simply serving an enormous number of consumers (e.g.
-/// with a public-facing DNS server). In this case the overhead of one syscall per datagram is profoundly limiting. Using this
-/// `ChannelOption` allows the `Channel` to read multiple datagrams at once.
-///
-/// Note that simply increasing this number will not necessarily bring performance gains and may in fact cause data loss. Any increase
-/// to this should be matched by increasing the size of the buffers allocated by the `Channel` `RecvByteBufferAllocator` (as set by
-/// `ChannelOption.recvAllocator`) proportionally. For example, to receive 10 messages at a time, set the size of the buffers allocated
-/// by the `RecvByteBufferAllocator` to at least 10x the size of the maximum datagram size you wish to receive.
-///
-/// Naturally, this option is only valid on datagram channels.
-///
-/// This option only works on the following platforms:
-///
-/// - Linux
-/// - FreeBSD
-/// - Android
-///
-/// On all other platforms, setting it has no effect.
-///
-/// Set this option to 0 to disable vector reads and to use serial reads instead.
-public struct DatagramVectorReadMessageCountOption: ChannelOption {
-    public typealias Value = Int
-
-    public init() { }
-}
-
-/// The watermark used to detect when `Channel.isWritable` returns `true` or `false`.
-public struct WriteBufferWaterMark {
-    /// The low mark setting for a `Channel`.
-    ///
-    /// When the amount of buffered bytes in the `Channel`s outbound buffer drops below this value the `Channel` will be
-    /// marked as writable again (after it was non-writable).
-    public let low: Int
-
-    /// The high mark setting for a `Channel`.
-    ///
-    /// When the amount of buffered bytes in the `Channel`s outbound exceeds this value the `Channel` will be
-    /// marked as non-writable. It will be marked as writable again once the amount of buffered bytes drops below `low`.
-    public let high: Int
-
-    /// Create a new instance.
-    ///
-    /// Valid initialization is restricted to `1 <= low <= high`.
-    ///
-    /// - parameters:
-    ///      - low: The low watermark.
-    ///      - high: The high watermark.
-    public init(low: Int, high: Int) {
-        precondition(low >= 1, "low must be >= 1 but was \(low)")
-        precondition(high >= low, "low must be <= high, but was low: \(low) high: \(high)")
-        self.low = low
-        self.high = high
-    }
-}
-
-/// `WriteBufferWaterMarkOption` allows users to configure when a `Channel` should be marked as writable or not. Once the amount of bytes queued in a
-/// `Channel`s outbound buffer is larger than `WriteBufferWaterMark.high` the channel will be marked as non-writable and so
-/// `Channel.isWritable` will return `false`. Once we were able to write some data out of the outbound buffer and the amount of bytes queued
-/// falls below `WriteBufferWaterMark.low` the `Channel` will become writable again. Once this happens `Channel.writable` will return
-/// `true` again. These writability changes are also propagated through the `ChannelPipeline` and so can be intercepted via `ChannelInboundHandler.channelWritabilityChanged`.
-public struct WriteBufferWaterMarkOption: ChannelOption {
-    public typealias Value = WriteBufferWaterMark
-
-    public init() {}
-}
-
-/// `ConnectTimeoutOption` allows users to configure the `TimeAmount` after which a connect will fail if it was not established in the meantime. May be
-/// `nil`, in which case the connection attempt will never time out.
-public struct ConnectTimeoutOption: ChannelOption {
-    public typealias Value = TimeAmount?
-
-    public init() {}
-}
-
-/// `AllowRemoteHalfClosureOption` allows users to configure whether the `Channel` will close itself when its remote
-/// peer shuts down its send stream, or whether it will remain open. If set to `false` (the default), the `Channel`
-/// will be closed automatically if the remote peer shuts down its send stream. If set to true, the `Channel` will
-/// not be closed: instead, a `ChannelEvent.inboundClosed` user event will be sent on the `ChannelPipeline`,
-/// and no more data will be received.
-public struct AllowRemoteHalfClosureOption: ChannelOption {
-    public typealias Value = Bool
-
-    public init() {}
 }
 
 /// Provides `ChannelOption`s to be used with a `Channel`, `Bootstrap` or `ServerBootstrap`.
 public struct ChannelOptions {
     /// - seealso: `SocketOption`.
-    public static let socket = { (level: SocketOptionLevel, name: SocketOptionName) -> SocketOption in
+    public static let socket = { (level: SocketOptionLevel, name: SocketOptionName) -> Types.SocketOption in
         .init(level: level, name: name)
     }
 
     /// - seealso: `AllocatorOption`.
-    public static let allocator = AllocatorOption()
+    public static let allocator = Types.AllocatorOption()
 
     /// - seealso: `RecvAllocatorOption`.
-    public static let recvAllocator = RecvAllocatorOption()
+    public static let recvAllocator = Types.RecvAllocatorOption()
 
     /// - seealso: `AutoReadOption`.
-    public static let autoRead = AutoReadOption()
+    public static let autoRead = Types.AutoReadOption()
 
     /// - seealso: `MaxMessagesPerReadOption`.
-    public static let maxMessagesPerRead = MaxMessagesPerReadOption()
+    public static let maxMessagesPerRead = Types.MaxMessagesPerReadOption()
 
     /// - seealso: `BacklogOption`.
-    public static let backlog = BacklogOption()
+    public static let backlog = Types.BacklogOption()
 
     /// - seealso: `WriteSpinOption`.
-    public static let writeSpin = WriteSpinOption()
+    public static let writeSpin = Types.WriteSpinOption()
 
     /// - seealso: `WriteBufferWaterMarkOption`.
-    public static let writeBufferWaterMark = WriteBufferWaterMarkOption()
+    public static let writeBufferWaterMark = Types.WriteBufferWaterMarkOption()
 
     /// - seealso: `ConnectTimeoutOption`.
-    public static let connectTimeout = ConnectTimeoutOption()
+    public static let connectTimeout = Types.ConnectTimeoutOption()
 
     /// - seealso: `AllowRemoteHalfClosureOption`.
-    public static let allowRemoteHalfClosure = AllowRemoteHalfClosureOption()
+    public static let allowRemoteHalfClosure = Types.AllowRemoteHalfClosureOption()
 
     /// - seealso: `DatagramVectorReadMessageCountOption`
-    public static let datagramVectorReadMessageCount = DatagramVectorReadMessageCountOption()
+    public static let datagramVectorReadMessageCount = Types.DatagramVectorReadMessageCountOption()
 }
 
 extension ChannelOptions {

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -545,7 +545,7 @@ public final class EmbeddedChannel: Channel {
 
     /// - see: `Channel.getOption`
     public func getOption<Option: ChannelOption>(_ option: Option) -> EventLoopFuture<Option.Value>  {
-        if option is AutoReadOption {
+        if option is ChannelOptions.Types.AutoReadOption {
             return self.eventLoop.makeSucceededFuture(true as! Option.Value)
         }
         fatalError("option \(option) not supported")

--- a/Sources/NIO/PendingDatagramWritesManager.swift
+++ b/Sources/NIO/PendingDatagramWritesManager.swift
@@ -359,7 +359,7 @@ final class PendingDatagramWritesManager: PendingWritesManager {
 
     private var state = PendingDatagramWritesState()
 
-    internal var waterMark: WriteBufferWaterMark = WriteBufferWaterMark(low: 32 * 1024, high: 64 * 1024)
+    internal var waterMark: ChannelOptions.Types.WriteBufferWaterMark = ChannelOptions.Types.WriteBufferWaterMark(low: 32 * 1024, high: 64 * 1024)
     internal let channelWritabilityFlag: Atomic<Bool> = Atomic(value: true)
     internal var writeSpinCount: UInt = 16
     private(set) var isOpen = true

--- a/Sources/NIO/PendingWritesManager.swift
+++ b/Sources/NIO/PendingWritesManager.swift
@@ -276,7 +276,7 @@ final class PendingStreamWritesManager: PendingWritesManager {
     private var iovecs: UnsafeMutableBufferPointer<IOVector>
     private var storageRefs: UnsafeMutableBufferPointer<Unmanaged<AnyObject>>
 
-    internal var waterMark: WriteBufferWaterMark = WriteBufferWaterMark(low: 32 * 1024, high: 64 * 1024)
+    internal var waterMark: ChannelOptions.Types.WriteBufferWaterMark = ChannelOptions.Types.WriteBufferWaterMark(low: 32 * 1024, high: 64 * 1024)
     internal let channelWritabilityFlag: Atomic<Bool> = Atomic(value: true)
 
     internal var writeSpinCount: UInt = 16

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -57,7 +57,7 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
         }
 
         switch option {
-        case _ as ConnectTimeoutOption:
+        case _ as ChannelOptions.Types.ConnectTimeoutOption:
             connectTimeout = value as? TimeAmount
         default:
             try super.setOption0(option, value: value)
@@ -72,7 +72,7 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
         }
 
         switch option {
-        case _ as ConnectTimeoutOption:
+        case _ as ChannelOptions.Types.ConnectTimeoutOption:
             return connectTimeout as! Option.Value
         default:
             return try super.getOption0(option)
@@ -165,7 +165,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         }
 
         switch option {
-        case _ as BacklogOption:
+        case _ as ChannelOptions.Types.BacklogOption:
             backlog = value as! Int32
         default:
             try super.setOption0(option, value: value)
@@ -180,7 +180,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         }
 
         switch option {
-        case _ as BacklogOption:
+        case _ as ChannelOptions.Types.BacklogOption:
             return backlog as! Option.Value
         default:
             return try super.getOption0(option)
@@ -403,11 +403,11 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         }
 
         switch option {
-        case _ as WriteSpinOption:
+        case _ as ChannelOptions.Types.WriteSpinOption:
             pendingWrites.writeSpinCount = value as! UInt
-        case _ as WriteBufferWaterMarkOption:
-            pendingWrites.waterMark = value as! WriteBufferWaterMark
-        case _ as DatagramVectorReadMessageCountOption:
+        case _ as ChannelOptions.Types.WriteBufferWaterMarkOption:
+            pendingWrites.waterMark = value as! ChannelOptions.Types.WriteBufferWaterMark
+        case _ as ChannelOptions.Types.DatagramVectorReadMessageCountOption:
             // We only support vector reads on these OSes. Let us know if there's another OS with this syscall!
             #if os(Linux) || os(FreeBSD) || os(Android)
             self.vectorReadManager.updateMessageCount(value as! Int)
@@ -427,11 +427,11 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         }
 
         switch option {
-        case _ as WriteSpinOption:
+        case _ as ChannelOptions.Types.WriteSpinOption:
             return pendingWrites.writeSpinCount as! Option.Value
-        case _ as WriteBufferWaterMarkOption:
+        case _ as ChannelOptions.Types.WriteBufferWaterMarkOption:
             return pendingWrites.waterMark as! Option.Value
-        case _ as DatagramVectorReadMessageCountOption:
+        case _ as ChannelOptions.Types.DatagramVectorReadMessageCountOption:
             return (self.vectorReadManager?.messageCount ?? 0) as! Option.Value
         default:
             return try super.getOption0(option)

--- a/Tests/NIOTests/ChannelOptionStorageTest.swift
+++ b/Tests/NIOTests/ChannelOptionStorageTest.swift
@@ -34,7 +34,7 @@ class ChannelOptionStorageTest: XCTestCase {
     }
 
     func testSetTwoOptionsOfSameType() throws {
-        let options: [(SocketOption, SocketOptionValue)] = [(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), 1),
+        let options: [(ChannelOptions.Types.SocketOption, SocketOptionValue)] = [(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), 1),
                                                             (ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEPORT), 2)]
         var cos = ChannelOptions.Storage()
         let optionsCollector = OptionsCollectingChannel()
@@ -44,9 +44,9 @@ class ChannelOptionStorageTest: XCTestCase {
         XCTAssertNoThrow(try cos.applyAllChannelOptions(to: optionsCollector).wait())
         XCTAssertEqual(2, optionsCollector.allOptions.count)
         XCTAssertEqual(options.map { $0.0 },
-                       (optionsCollector.allOptions as! [(SocketOption, SocketOptionValue)]).map { $0.0 })
+                       (optionsCollector.allOptions as! [(ChannelOptions.Types.SocketOption, SocketOptionValue)]).map { $0.0 })
         XCTAssertEqual(options.map { $0.1 },
-                       (optionsCollector.allOptions as! [(SocketOption, SocketOptionValue)]).map { $0.1 })
+                       (optionsCollector.allOptions as! [(ChannelOptions.Types.SocketOption, SocketOptionValue)]).map { $0.1 })
     }
 
     func testSetOneOptionTwice() throws {
@@ -57,9 +57,9 @@ class ChannelOptionStorageTest: XCTestCase {
         XCTAssertNoThrow(try cos.applyAllChannelOptions(to: optionsCollector).wait())
         XCTAssertEqual(1, optionsCollector.allOptions.count)
         XCTAssertEqual([ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR)],
-                       (optionsCollector.allOptions as! [(SocketOption, SocketOptionValue)]).map { $0.0 })
+                       (optionsCollector.allOptions as! [(ChannelOptions.Types.SocketOption, SocketOptionValue)]).map { $0.0 })
         XCTAssertEqual([SocketOptionValue(2)],
-                       (optionsCollector.allOptions as! [(SocketOption, SocketOptionValue)]).map { $0.1 })
+                       (optionsCollector.allOptions as! [(ChannelOptions.Types.SocketOption, SocketOptionValue)]).map { $0.1 })
     }
 }
 

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -174,7 +174,7 @@ final class DatagramChannelTests: XCTestCase {
     }
 
     func testDatagramChannelHasWatermark() throws {
-        _ = try self.firstChannel.setOption(ChannelOptions.writeBufferWaterMark, value: WriteBufferWaterMark(low: 1, high: 1024)).wait()
+        _ = try self.firstChannel.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 1, high: 1024)).wait()
 
         var buffer = self.firstChannel.allocator.buffer(capacity: 256)
         buffer.writeBytes([UInt8](repeating: 5, count: 256))


### PR DESCRIPTION
### Motivation:

ChannelOptions types like WriteBufferWaterMarkOption are global, public types. These types should be namespaced.

### Modifications:

Moved global, public ChannelOptions types into ChannelOptions.Types enum. Created global, public typealiases with deprecation attributes which point to the namespaced types. Switched usage of these types in the codebase to use the namespaced versions.

### Result:

Usage of the global, public versions of these types will cause deprecation warnings.