### PR TITLE
make use of EventLoop.flatSubmit

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -290,9 +290,9 @@ public final class ServerBootstrap {
             if childEventLoop === ctxEventLoop {
                 fireThroughPipeline(setupChildChannel())
             } else {
-                fireThroughPipeline(childEventLoop.submit {
+                fireThroughPipeline(childEventLoop.flatSubmit {
                     return setupChildChannel()
-                }.flatMap { $0 }.hop(to: ctxEventLoop))
+                }.hop(to: ctxEventLoop))
             }
         }
 
@@ -506,7 +506,7 @@ public final class ClientBootstrap {
         if eventLoop.inEventLoop {
             return setupChannel()
         } else {
-            return eventLoop.submit{ setupChannel() }.flatMap { $0 }
+            return eventLoop.flatSubmit { setupChannel() }
         }
     }
 
@@ -701,7 +701,9 @@ public final class DatagramBootstrap {
         if eventLoop.inEventLoop {
             return setupChannel()
         } else {
-            return eventLoop.submit(setupChannel).flatMap { $0 }
+            return eventLoop.flatSubmit {
+                setupChannel()
+            }
         }
     }
 }
@@ -814,7 +816,9 @@ public final class NIOPipeBootstrap {
         if eventLoop.inEventLoop {
             return setupChannel()
         } else {
-            return eventLoop.submit{ setupChannel() }.flatMap { $0 }
+            return eventLoop.flatSubmit {
+                setupChannel()
+            }
         }
     }
 }

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -347,7 +347,7 @@ extension TimeAmount {
 ///
 /// ```
 /// func doSomething(deadline: NIODeadline) -> EventLoopFuture<Void> {
-///     return step1(deadline: deadline).then {
+///     return step1(deadline: deadline).flatMap {
 ///         step2(deadline: deadline)
 ///     }
 /// }
@@ -474,7 +474,7 @@ extension EventLoop {
     ///     - task: The synchronous task to run. As everything that runs on the `EventLoop`, it must not block.
     /// - returns: An `EventLoopFuture` identical to the `EventLooopFuture` returned from `task`.
     public func flatSubmit<T>(_ task: @escaping () -> EventLoopFuture<T>) -> EventLoopFuture<T> {
-        return submit(task).flatMap { $0 }
+        return self.submit(task).flatMap { $0 }
     }
 
     /// Creates and returns a new `EventLoopPromise` that will be notified using this `EventLoop` as execution `NIOThread`.

--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -256,7 +256,7 @@ extension NIOHTTP1TestServer {
 
     public func stop() throws {
         assert(!self.eventLoop.inEventLoop)
-        try self.eventLoop.submit { () -> EventLoopFuture<Void> in
+        try self.eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             switch self.state {
             case .channelsAvailable(let channels):
                 self.state = .stopped
@@ -277,7 +277,7 @@ extension NIOHTTP1TestServer {
                     throw NonEmptyInboundBufferOnStop()
                 }
             }
-        }.wait().wait()
+        }.wait()
     }
 
     public func readInbound(deadline: NIODeadline = .now() + .seconds(10)) throws -> HTTPServerRequestPart {
@@ -289,13 +289,13 @@ extension NIOHTTP1TestServer {
 
     public func writeOutbound(_ data: HTTPServerResponsePart) throws {
         assert(!self.eventLoop.inEventLoop)
-        try self.eventLoop.submit { () -> EventLoopFuture<Void> in
+        try self.eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             if let channel = self.currentClientChannel {
                 return channel.writeAndFlush(data)
             } else {
                 return self.eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
             }
-        }.wait().wait()
+        }.wait()
     }
 
     public var serverPort: Int {

--- a/Tests/NIOTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOTests/AcceptBackoffHandlerTest.swift
@@ -258,7 +258,7 @@ public final class AcceptBackoffHandlerTest: XCTestCase {
                                               name: self.acceptHandlerName)
         }.wait())
 
-        XCTAssertNoThrow(try eventLoop.submit {
+        XCTAssertNoThrow(try eventLoop.flatSubmit {
             // this is pretty delicate at the moment:
             // `bind` must be _synchronously_ follow `register`, otherwise in our current implementation, `epoll` will
             // send us `EPOLLHUP`. To have it run synchronously, we need to invoke the `flatMap` on the eventloop that the
@@ -266,7 +266,7 @@ public final class AcceptBackoffHandlerTest: XCTestCase {
             serverChannel.register().flatMap { () -> EventLoopFuture<()> in
                 return serverChannel.bind(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 0))
             }
-        }.wait().wait() as Void)
+        }.wait() as Void)
         return serverChannel
     }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -600,11 +600,11 @@ public final class EventLoopTest : XCTestCase {
         let channel = try assertNoThrowWithValue(SocketChannel(eventLoop: eventLoop as! SelectableEventLoop,
                                                                protocolFamily: serverSocket.localAddress!.protocolFamily))
         XCTAssertNoThrow(try channel.pipeline.addHandler(assertHandler).wait() as Void)
-        XCTAssertNoThrow(try channel.eventLoop.submit {
+        XCTAssertNoThrow(try channel.eventLoop.flatSubmit {
             channel.register().flatMap {
                 channel.connect(to: serverSocket.localAddress!)
             }
-        }.wait().wait() as Void)
+        }.wait() as Void)
         XCTAssertFalse(channel.closeFuture.isFulfilled)
         XCTAssertNoThrow(try group.syncShutdownGracefully())
         XCTAssertTrue(assertHandler.groupIsShutdown.compareAndExchange(expected: false, desired: true))

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -154,13 +154,13 @@ public final class SocketChannelTest : XCTestCase {
                                                                            group: group))
         let promise = serverChannel.eventLoop.makePromise(of: IOError.self)
 
-        XCTAssertNoThrow(try serverChannel.eventLoop.submit {
+        XCTAssertNoThrow(try serverChannel.eventLoop.flatSubmit {
             serverChannel.pipeline.addHandler(AcceptHandler(promise)).flatMap {
                 serverChannel.register()
             }.flatMap {
                 serverChannel.bind(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 0))
             }
-        }.wait().wait() as Void)
+        }.wait() as Void)
 
         XCTAssertEqual(active, try serverChannel.eventLoop.submit {
             serverChannel.readable()
@@ -456,7 +456,7 @@ public final class SocketChannelTest : XCTestCase {
 
         // We need to call submit {...} here to ensure then {...} is called while on the EventLoop already to not have
         // a ECONNRESET sneak in.
-        XCTAssertNoThrow(try channel.eventLoop.submit {
+        XCTAssertNoThrow(try channel.eventLoop.flatSubmit {
             channel.register().map { () -> Void in
                 channel.connect(to: serverChannel.localAddress!, promise: connectPromise)
             }.map { () -> Void in
@@ -465,7 +465,7 @@ public final class SocketChannelTest : XCTestCase {
                 // before we have the chance to register it for .write.
                 channel.close(promise: closePromise)
             }
-        }.wait().wait() as Void)
+        }.wait() as Void)
 
         do {
             try connectPromise.futureResult.wait()


### PR DESCRIPTION
Motivation:

Since #1174 we've finally got EventLoop.flatSubmit and we should make
use of it to replace the silly `.wait().wait()` calls as well as the
similarly silly `.flatMap { $0 }`.

Modifications:

Use `flatSubmit` where appropriate.

Result:

Nicer codebase.