### PR TITLE
use flatSubmit part 2

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -545,7 +545,7 @@ public final class ClientBootstrap {
         if eventLoop.inEventLoop {
             return setupChannel()
         } else {
-            return eventLoop.submit(setupChannel).flatMap { $0 }
+            return eventLoop.flatSubmit(setupChannel)
         }
     }
 }


### PR DESCRIPTION
Motivation:

One flatSubmit replacement caused more allocations for unknown reasons.

Modifications:

Try to fix that.

Result:

More consistent flatSubmit use.