### PR TITLE
SocketChannel: allow bind before register

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -565,10 +565,6 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
             promise?.fail(ChannelError.ioOnClosedChannel)
             return
         }
-        guard self.lifecycleManager.isPreRegistered else {
-            promise?.fail(ChannelError.inappropriateOperationForState)
-            return
-        }
 
         executeAndComplete(promise) {
             try socket.bind(to: address)

--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -31,6 +31,7 @@ extension BootstrapTest {
                 ("testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
                 ("testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
                 ("testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
+                ("testCanBindOnClientConnection", testCanBindOnClientConnection),
            ]
    }
 }

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -207,4 +207,21 @@ class BootstrapTest: XCTestCase {
         XCTAssertNoThrow(try childChannelDone.futureResult.wait())
         XCTAssertNoThrow(try serverChannelDone.futureResult.wait())
     }
+
+    func testCanBindOnClientConnection() {
+        XCTAssertNoThrow(try withTCPServerChannel { serverChannel in
+            var maybeClient: Channel?
+            XCTAssertNoThrow(maybeClient = try ClientBootstrap(group: serverChannel.eventLoop)
+                .channelInitializer { childChannel in
+                    childChannel.bind(to: try! .init(ipAddress: "127.0.0.1", port: 12345))
+            }
+            .connect(to: serverChannel.localAddress!)
+            .wait())
+            guard let client = maybeClient else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(12345, client.localAddress?.port)
+        })
+    }
 }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2010,13 +2010,24 @@ public final class ChannelTests: XCTestCase {
             XCTAssertFalse(channel.isWritable)
         }
 
-        withChannel { channel in
+        withChannel(skipDatagram: true, skipServerSocket: true) { channel in
+            XCTAssertEqual(0, channel.localAddress?.port ?? 0xffff)
+            XCTAssertNil(channel.remoteAddress)
+            XCTAssertNoThrow(try channel.bind(to: SocketAddress(ipAddress: "127.0.0.1", port: 0)).wait(),
+                             "channel \(channel) not happy with bind before register")
+            XCTAssertNotEqual(0, channel.localAddress?.port ?? 0)
+            XCTAssertNotNil(channel.localAddress)
+            XCTAssertNil(channel.remoteAddress)
+        }
+
+        withChannel(skipStream: true) { channel in
+            XCTAssertEqual(0, channel.localAddress?.port ?? 0xffff)
+            XCTAssertNil(channel.remoteAddress)
             checkThatItThrowsInappropriateOperationForState {
-                XCTAssertEqual(0, channel.localAddress?.port ?? 0xffff)
-                XCTAssertNil(channel.remoteAddress)
                 try channel.bind(to: SocketAddress(ipAddress: "127.0.0.1", port: 0)).wait()
             }
         }
+
     }
 
     func testCloseSocketWhenReadErrorWasReceivedAndMakeSureNoReadCompleteArrives() throws {


### PR DESCRIPTION
Motivation:

In certain cases, on a client channel, the user might want to `bind` in
the `channelInitializer` which happens before the channel is registered
or active.

Modifications:

Allow `bind` in the `channelInitializer`.

Result:

Can `bind` before `connect`.