### PR TITLE
Add ApplicationProtocolNegotiationHandler init that takes a closure that receives the Channel (#1195)

### DIFF
--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests+XCTest.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests+XCTest.swift
@@ -26,6 +26,7 @@ extension ApplicationProtocolNegotiationHandlerTests {
 
    static var allTests : [(String, (ApplicationProtocolNegotiationHandlerTests) -> () throws -> Void)] {
       return [
+                ("testChannelProvidedToCallback", testChannelProvidedToCallback),
                 ("testIgnoresUnknownUserEvents", testIgnoresUnknownUserEvents),
                 ("testCallbackReflectsNotificationResult", testCallbackReflectsNotificationResult),
                 ("testCallbackNotesFallbackForNoNegotiation", testCallbackNotesFallbackForNoNegotiation),


### PR DESCRIPTION
Motivation:

Currently ApplicationProtocolNegotiationHandler accepts a closure that takes only one argument, the ALPN result. This forces the user to capture the Channel in the closure so that it can be mutated.

Modifications:

Add a new init which takes a closure that has both the result and the Channel as parameters. Modify the original init to call the new init (wrapping the passed in closure.)

Result:

New APNL init available that takes a 2 parameter closure. Original APNL init will now be a convenience init.