### PR TITLE
test that we tolerate out-of-band data

### DIFF
--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -134,7 +134,7 @@ typealias IOVector = iovec
     func sendto(pointer: UnsafeRawBufferPointer, destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int> {
         return try withUnsafeFileDescriptor { fd in
             try Posix.sendto(descriptor: fd, pointer: UnsafeMutableRawPointer(mutating: pointer.baseAddress!),
-                             size: pointer.count, destinationPtr: destinationPtr,
+                             size: pointer.count, flags: 0, destinationPtr: destinationPtr,
                              destinationSize: destinationSize)
         }
     }

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -194,6 +194,7 @@ internal enum Posix {
     static let SHUT_RD: CInt = CInt(Darwin.SHUT_RD)
     static let SHUT_WR: CInt = CInt(Darwin.SHUT_WR)
     static let SHUT_RDWR: CInt = CInt(Darwin.SHUT_RDWR)
+    static let MSG_OOB: CInt = Darwin.MSG_OOB
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 
 #if os(Android)
@@ -208,6 +209,7 @@ internal enum Posix {
     static let SHUT_RD: CInt = CInt(Glibc.SHUT_RD)
     static let SHUT_WR: CInt = CInt(Glibc.SHUT_WR)
     static let SHUT_RDWR: CInt = CInt(Glibc.SHUT_RDWR)
+    static let MSG_OOB: CInt = CInt(Glibc.MSG_OOB)
 #else
     static var SOCK_STREAM: CInt {
         fatalError("unsupported OS")
@@ -365,10 +367,13 @@ internal enum Posix {
     }
 
     @inline(never)
-    public static func sendto(descriptor: CInt, pointer: UnsafeRawPointer, size: size_t,
+    public static func sendto(descriptor: CInt,
+                              pointer: UnsafeRawPointer,
+                              size: size_t,
+                              flags: CInt,
                               destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int> {
         return try wrapSyscallMayBlock {
-            sysSendTo(descriptor, pointer, size, 0, destinationPtr, destinationSize)
+            sysSendTo(descriptor, pointer, size, flags,  destinationPtr, destinationSize)
         }
     }
 

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -82,6 +82,7 @@ extension ChannelTests {
                 ("testTCP_NODELAYisOnByDefault", testTCP_NODELAYisOnByDefault),
                 ("testDescriptionCanBeCalledFromNonEventLoopThreads", testDescriptionCanBeCalledFromNonEventLoopThreads),
                 ("testFixedSizeRecvByteBufferAllocatorSizeIsConstant", testFixedSizeRecvByteBufferAllocatorSizeIsConstant),
+                ("testWeTolerateOutOfBandData", testWeTolerateOutOfBandData),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

We don't support OOB data but we should make sure that nothing breaks if
OOB arrives.

Modifications:

Add a test that makes sure we tolerate OOB data.

Result:

More test coverage.