### PR TITLE
add socketpair to the POSIX wrappers

### DIFF
--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -85,6 +85,7 @@ private let sysAF_INET = AF_INET
 private let sysAF_INET6 = AF_INET6
 private let sysAF_UNIX = AF_UNIX
 private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
+private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>?) -> CInt = socketpair
 
 #if os(Linux)
 private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>) -> CInt = fstat
@@ -495,6 +496,16 @@ internal enum Posix {
     public static func fstat(descriptor: CInt, outStat: UnsafeMutablePointer<stat>) throws {
         _ = try wrapSyscall {
             sysFstat(descriptor, outStat)
+        }
+    }
+
+    @inline(never)
+    public static func socketpair(domain: CInt,
+                                  type: CInt,
+                                  protocol: CInt,
+                                  socketVector: UnsafeMutablePointer<CInt>?) throws {
+        _ = try wrapSyscall {
+            sysSocketpair(domain, type, `protocol`, socketVector)
         }
     }
 }

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -143,12 +143,10 @@ class BootstrapTest: XCTestCase {
 
     func testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
         var socketFDs: [CInt] = [-1, -1]
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        let err = socketpair(PF_LOCAL, SOCK_STREAM, 0, &socketFDs)
-        #else
-        let err = socketpair(PF_LOCAL, CInt(SOCK_STREAM.rawValue), 0, &socketFDs)
-        #endif
-        XCTAssertEqual(0, err)
+        XCTAssertNoThrow(try Posix.socketpair(domain: PF_LOCAL,
+                                              type: Posix.SOCK_STREAM,
+                                              protocol: 0,
+                                              socketVector: &socketFDs))
         defer {
             // 0 is closed together with the Channel below.
             XCTAssertNoThrow(try Posix.close(descriptor: socketFDs[1]))

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -386,12 +386,10 @@ class SelectorTest: XCTestCase {
             }
         }
         var socketFDs: [CInt] = [-1, -1]
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        let err = socketpair(PF_LOCAL, SOCK_STREAM, 0, &socketFDs)
-        #else
-        let err = socketpair(PF_LOCAL, CInt(SOCK_STREAM.rawValue), 0, &socketFDs)
-        #endif
-        XCTAssertEqual(0, err)
+        XCTAssertNoThrow(try Posix.socketpair(domain: PF_LOCAL,
+                                              type: Posix.SOCK_STREAM,
+                                              protocol: 0,
+                                              socketVector: &socketFDs))
 
         let numberFires = Atomic<Int>(value: 0)
         let el = group.next() as! SelectableEventLoop


### PR DESCRIPTION
Motivation:

For some reason, we never added `socketpair` to the POSIX wrappers but
it should be there.

Modifications:

Add socketpair to the POSIX wrappers and make use of it.

Result:

Nicer code base.