### PR TITLE
Make SocketAddress.port mutable

### DIFF
--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -149,7 +149,7 @@ public enum SocketAddress: CustomStringConvertible {
     /// Get and set the port associated with the address, if defined.
     /// When setting to `nil` the port will default to `0` for compatible sockets. The rationale for this is that both `nil` and `0` can
     /// be interpreted as "no preference".
-    /// Setting a non-nil value to a unix port is invalid and will result in a fatal error.
+    /// Setting a non-nil value for a unix domain socket is invalid and will result in a fatal error.
     public var port: Int? {
         get {
             switch self {

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -149,6 +149,7 @@ public enum SocketAddress: CustomStringConvertible {
     /// Get and set the port associated with the address, if defined.
     /// When setting to `nil` the port will default to `0` for compatible sockets. The rationale for this is that both `nil` and `0` can
     /// be interpreted as "no preference".
+    /// Setting a non-nil value to a unix port is invalid and will result in a fatal error.
     public var port: Int? {
         get {
             switch self {
@@ -173,8 +174,7 @@ public enum SocketAddress: CustomStringConvertible {
                 mutAddr.sin6_port = in_port_t(newValue ?? 0).bigEndian
                 self = .v6(.init(address: mutAddr, host: addr.host))
             case .unixDomainSocket:
-                // ignore
-                break
+                precondition(newValue == nil, "attempting to set a non-nil value to a unix socket is not valid")
             }
         }
     }

--- a/Tests/NIOTests/SocketAddressTest+XCTest.swift
+++ b/Tests/NIOTests/SocketAddressTest+XCTest.swift
@@ -44,6 +44,7 @@ extension SocketAddressTest {
                 ("testUnequalAcrossFamilies", testUnequalAcrossFamilies),
                 ("testPortAccessor", testPortAccessor),
                 ("testCanMutateSockaddrStorage", testCanMutateSockaddrStorage),
+                ("testPortIsMutable", testPortIsMutable),
            ]
    }
 }

--- a/Tests/NIOTests/SocketAddressTest.swift
+++ b/Tests/NIOTests/SocketAddressTest.swift
@@ -378,11 +378,9 @@ class SocketAddressTest: XCTestCase {
 
         ipV4.port = 81
         ipV6.port = 81
-        unix.port = 1
-        
+
         XCTAssertEqual(ipV4.port, 81)
         XCTAssertEqual(ipV6.port, 81)
-        XCTAssertNil(unix.port)
 
         ipV4.port = nil
         ipV6.port = nil

--- a/Tests/NIOTests/SocketAddressTest.swift
+++ b/Tests/NIOTests/SocketAddressTest.swift
@@ -370,4 +370,26 @@ class SocketAddressTest: XCTestCase {
         }
         XCTAssertEqual(storage.ss_family, sa_family_t(AF_UNIX))
     }
+
+    func testPortIsMutable() throws {
+        var ipV4 = try SocketAddress(ipAddress: "127.0.0.1", port: 80)
+        var ipV6 = try SocketAddress(ipAddress: "::1", port: 80)
+        var unix = try SocketAddress(unixDomainSocketPath: "/definitely/a/path")
+
+        ipV4.port = 81
+        ipV6.port = 81
+        unix.port = 1
+        
+        XCTAssertEqual(ipV4.port, 81)
+        XCTAssertEqual(ipV6.port, 81)
+        XCTAssertNil(unix.port)
+
+        ipV4.port = nil
+        ipV6.port = nil
+        unix.port = nil
+
+        XCTAssertEqual(ipV4.port, 0)
+        XCTAssertEqual(ipV6.port, 0)
+        XCTAssertNil(unix.port)
+    }
 }


### PR DESCRIPTION
Make SocketAddress.port mutable

### Motivation:

Previously the port was read only. Fixes #1189.
 
### Modifications:

In case of IPv4 and IPv6 the port will be set to the new value or defaulted to 0 when setting it with the value `nil`. The rationale for this is that both `nil` and `0` can be interpreted as "no preference". When the underlying socket is a unix socket the incoming value is ignored.

### Result:

SocketAddress.port can now be written to as well as be read.
