### PR TITLE
Add an benchmark for WebSocket frame decoder

### DIFF
--- a/Sources/NIOPerformanceTester/WebSocketFrameDecoderBenchmark.swift
+++ b/Sources/NIOPerformanceTester/WebSocketFrameDecoderBenchmark.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOWebSocket
+
+
+final class WebSocketFrameDecoderBenchmark {
+
+    private let channel: EmbeddedChannel
+    private let runCount: Int
+    private var data: ByteBuffer
+
+    init(dataSize: Int, runCount: Int) {
+        self.channel = EmbeddedChannel()
+        self.data = ByteBufferAllocator().buffer(capacity: dataSize)
+        self.runCount = runCount
+    }
+}
+
+extension WebSocketFrameDecoderBenchmark: Benchmark {
+
+    func setUp() throws {
+        self.data.writeBytes([0x81, 0x00]) // empty websocket
+        try self.channel.pipeline.addHandler(ByteToMessageHandler(WebSocketFrameDecoder())).wait()
+    }
+
+    func tearDown() {
+        _ = try! self.channel.finish()
+    }
+
+    func run() throws  -> Int{
+        for _ in 0..<runCount {
+            try self.channel.writeInbound(self.data)
+            let _: WebSocketFrame? =  try self.channel.readInbound()
+        }
+        return 1
+    }
+}

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -738,3 +738,5 @@ try measureAndPrint(desc: "websocket_encode_50b_no_space_at_front_10k_frames",
 
 try measureAndPrint(desc: "websocket_encode_1kb_no_space_at_front_1k_frames",
                     benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 1_000, dataStrategy: .noSpaceAtFront, cowStrategy: .never))
+
+try measureAndPrint(desc: "websocket_decode", benchmark: WebSocketFrameDecoderBenchmark(dataSize: 1024, runCount: 100_000))


### PR DESCRIPTION
Motivation:

It's important to know how websocket frame decoder perform.

Modification:

- Wrote simple benchmark for WebSocket frame decoding.

Result:

Better insight
