### PR TITLE
Fix `NIODeadline.Value` deprecation message typo

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -359,7 +359,7 @@ extension TimeAmount {
 ///
 /// - note: `NIODeadline` should not be used to represent a time interval
 public struct NIODeadline: Equatable, Hashable {
-    @available(*, deprecated, message: "This typealias doesn't server any purpose, please use UInt64 directly.")
+    @available(*, deprecated, message: "This typealias doesn't serve any purpose, please use UInt64 directly.")
     public typealias Value = UInt64
 
     // This really should be an UInt63 but we model it as Int64 with >=0 assert


### PR DESCRIPTION
Fixes a typo `doesn't server any purpose` -> `doesn't serve any purpose`

### Motivation:

Typos are bad.

### Modifications:

Simple correction to the deprecation message for `typealias Value = UInt64`

### Result:

No downstream impact and no patch release required. Can be rolled out with the next release.
