### PR TITLE
Add API ByteBuffer.clear(minimumCapacity:) (#1057)

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -235,7 +235,7 @@ public struct ByteBuffer {
             return self.allocateStorage(capacity: self.capacity)
         }
 
-        private func allocateStorage(capacity: _Capacity) -> _Storage {
+        fileprivate func allocateStorage(capacity: _Capacity) -> _Storage {
             let newCapacity = capacity == 0 ? 0 : capacity.nextPowerOf2ClampedToMax()
             return _Storage(bytesNoCopy: _Storage.allocateAndPrepareRawMemory(bytes: newCapacity, allocator: self.allocator),
                             capacity: newCapacity,
@@ -663,6 +663,22 @@ public struct ByteBuffer {
         if !isKnownUniquelyReferenced(&self._storage) {
             self._storage = self._storage.allocateStorage()
         }
+        self._moveWriterIndex(to: 0)
+        self._moveReaderIndex(to: 0)
+    }
+    
+    /// Works like `clear()` but ensure that the buffer has size for at least `minimumCapacity` bytes.
+    /// - Parameter minimumCapacity: The minimum number of bytes this buffer must be able to store.
+    public mutating func clear(minimumCapacity: Int) {
+        let targetCapacity = _toCapacity(minimumCapacity)
+        if !isKnownUniquelyReferenced(&self._storage) {
+            self._storage = self._storage.allocateStorage(capacity: targetCapacity)
+        } else if minimumCapacity > self._storage.capacity {
+            self._storage.reallocStorage(capacity: targetCapacity)
+        }
+        
+        self._slice = self._storage.fullSlice
+
         self._moveWriterIndex(to: 0)
         self._moveReaderIndex(to: 0)
     }


### PR DESCRIPTION
### Motivation:

This commit closes #1057.
The demand is a new API to ensure that the buffer has space for at least minimumCapacity after clearing the buffer.
In case the storage is not uniquely referenced, and the minimumCapacity is much smaller than the current capacity, this API can avoid allocating excessive memory.

### Modifications:

Add a new API ByteBuffer.clear(minimumCapacity:)

### Result:

More memory performant buffer clearing.