### PR TITLE
`ByteBuffer.clear` should reset the `ByteBuffer._slice`.

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -663,6 +663,7 @@ public struct ByteBuffer {
         if !isKnownUniquelyReferenced(&self._storage) {
             self._storage = self._storage.allocateStorage()
         }
+        self._slice = self._storage.fullSlice
         self._moveWriterIndex(to: 0)
         self._moveReaderIndex(to: 0)
     }

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -107,6 +107,8 @@ extension ByteBufferTest {
                 ("testWritableBytesAccountsForSlicing", testWritableBytesAccountsForSlicing),
                 ("testClearDupesStorageIfTheresTwoBuffersSharingStorage", testClearDupesStorageIfTheresTwoBuffersSharingStorage),
                 ("testClearDoesNotDupeStorageIfTheresOnlyOneBuffer", testClearDoesNotDupeStorageIfTheresOnlyOneBuffer),
+                ("testClearResetsTheSliceCapacityIfTheresOnlyOneBuffer", testClearResetsTheSliceCapacityIfTheresOnlyOneBuffer),
+                ("testClearResetsTheSliceCapacityIfTheresTwoSlicesSharingStorage", testClearResetsTheSliceCapacityIfTheresTwoSlicesSharingStorage),
                 ("testWeUseFastWriteForContiguousCollections", testWeUseFastWriteForContiguousCollections),
                 ("testUnderestimatingSequenceWorks", testUnderestimatingSequenceWorks),
                 ("testZeroSizeByteBufferResizes", testZeroSizeByteBufferResizes),

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -238,7 +238,7 @@ class ByteBufferTest: XCTestCase {
 
     func testWithMutableWritePointerWithMinimumSpecifiedAdjustsCapacity() {
         XCTAssertEqual(0, buf.writerIndex)
-        XCTAssertEqual(512, buf.capacity)
+        XCTAssertEqual(1024, buf.capacity)
 
         var bytesWritten = buf.writeWithUnsafeMutableBytes(minimumWritableBytes: 256) {
             XCTAssertTrue($0.count >= 256)
@@ -246,7 +246,7 @@ class ByteBufferTest: XCTestCase {
         }
         XCTAssertEqual(256, bytesWritten)
         XCTAssertEqual(256, buf.writerIndex)
-        XCTAssertEqual(512, buf.capacity)
+        XCTAssertEqual(1024, buf.capacity)
 
         bytesWritten += buf.writeWithUnsafeMutableBytes(minimumWritableBytes: 1024) {
             XCTAssertTrue($0.count >= 1024)
@@ -260,7 +260,7 @@ class ByteBufferTest: XCTestCase {
 
     func testWithMutableWritePointerWithMinimumSpecifiedWhileAtMaxCapacity() {
         XCTAssertEqual(0, buf.writerIndex)
-        XCTAssertEqual(512, buf.capacity)
+        XCTAssertEqual(1024, buf.capacity)
 
         var bytesWritten = buf.writeWithUnsafeMutableBytes(minimumWritableBytes: 512) {
             XCTAssertTrue($0.count >= 512)
@@ -268,7 +268,7 @@ class ByteBufferTest: XCTestCase {
         }
         XCTAssertEqual(512, bytesWritten)
         XCTAssertEqual(512, buf.writerIndex)
-        XCTAssertEqual(512, buf.capacity)
+        XCTAssertEqual(1024, buf.capacity)
 
         bytesWritten += buf.writeWithUnsafeMutableBytes(minimumWritableBytes: 1) {
             XCTAssertTrue($0.count >= 1)
@@ -1226,6 +1226,32 @@ class ByteBufferTest: XCTestCase {
             bufPtrValPost = UInt(bitPattern: ptr.baseAddress!)
         }
         XCTAssertEqual(bufPtrValPre, bufPtrValPost)
+    }
+
+    func testClearResetsTheSliceCapacityIfTheresOnlyOneBuffer() {
+        let alloc = ByteBufferAllocator()
+        var buf = alloc.buffer(capacity: 16)
+        buf.writeString("qwertyuiop")
+        XCTAssertEqual(buf.capacity, 16)
+
+        var slice = buf.getSlice(at: 3, length: 4)!
+        XCTAssertEqual(slice.capacity, 4)
+
+        slice.clear()
+        XCTAssertEqual(slice.capacity, 16)
+    }
+
+    func testClearResetsTheSliceCapacityIfTheresTwoSlicesSharingStorage() {
+        let alloc = ByteBufferAllocator()
+        var buf = alloc.buffer(capacity: 16)
+        buf.writeString("qwertyuiop")
+
+        var slice1 = buf.getSlice(at: 3, length: 4)!
+        let slice2 = slice1
+
+        slice1.clear()
+        XCTAssertEqual(slice1.capacity, 16)
+        XCTAssertEqual(slice2.capacity, 4)
     }
 
     func testWeUseFastWriteForContiguousCollections() throws {


### PR DESCRIPTION
Closes #1202. `ByteBuffer.clear` should reset the `ByteBuffer._slice`.

### Motivation:

`ByteBuffer.clear` doesn't reset the `ByteBuffer._slice`. Imagine having a byte buffer slice (`ByteBuffer.getSlice`). Calling `ByteBuffer.clear` on the slice will reset the reader and writer, but the `ByteBuffer.capacity` will return the old slice size, not the full storage capacity. After this change `ByteBuffer.clear` will also reset the `ByteBuffer._slice` to regain the whole `ByteBuffer._storage`.

### Modifications:

Just setting the full storage slice in the `ByteBuffer.clear` method.

### Result:

After that change `ByteBuffer.clear` will reset byte buffer slice to full capacity of underlying storage.
