### PR TITLE
Allow single test to be specified as an argument to run-nio-alloc-counter-tests.sh.

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/run-nio-alloc-counter-tests.sh
+++ b/IntegrationTests/tests_04_performance/test_01_resources/run-nio-alloc-counter-tests.sh
@@ -18,25 +18,28 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 tmp_dir="/tmp"
 
-function die() {
-    echo >&2 "ERROR: $*"
-    exit 1
-}
-
 while getopts "t:" opt; do
     case "$opt" in
         t)
             tmp_dir="$OPTARG"
             ;;
-        \?)
-            die "unknown option $opt"
+        *)
+            exit 1
             ;;
     esac
 done
+
+shift $((OPTIND-1))
+
+tests_to_run=("$here"/test_*.swift)
+
+if [ $# -gt 0 ]; then
+    tests_to_run=$@
+fi
 
 "$here/../../allocation-counter-tests-framework/run-allocation-counter.sh" \
     -p "$here/../../.." \
     -m NIO -m NIOHTTP1 -m NIOWebSocket \
     -s "$here/shared.swift" \
     -t "$tmp_dir" \
-    "$here"/test_*.swift
+    "${tests_to_run[@]}"

--- a/IntegrationTests/tests_04_performance/test_01_resources/run-nio-alloc-counter-tests.sh
+++ b/IntegrationTests/tests_04_performance/test_01_resources/run-nio-alloc-counter-tests.sh
@@ -33,7 +33,7 @@ shift $((OPTIND-1))
 
 tests_to_run=("$here"/test_*.swift)
 
-if [ $# -gt 0 ]; then
+if [[ $# -gt 0 ]]; then
     tests_to_run=$@
 fi
 


### PR DESCRIPTION
### Motivation:

`run-nio-alloc-counter-tests.sh` currently runs all tests. When writing or
debugging a test, you commonly want to run a single test. At the moment the
common practice is to edit the script to hardcode a test to run, which is
annoying and error-prone.

### Modifications:

Add an optional argument to the script to specify the test to run.

### Result:

`$ ./run-nio-alloc-counter-tests.sh`

runs all tests.

`$ ./run-nio-alloc-counter-tests.sh test_decode_1000_ws_frames.swift`

runs only test_decode_1000_ws_frames.swift.