### PR TITLE
Use self as the decoder when decoding a ByteBuffer

### DIFF
--- a/Sources/NIOFoundationCompat/Codable+ByteBuffer.swift
+++ b/Sources/NIOFoundationCompat/Codable+ByteBuffer.swift
@@ -104,6 +104,7 @@ extension JSONDecoder {
     /// - returns: The decoded object.
     public func decode<T: Decodable>(_ type: T.Type, from buffer: ByteBuffer) throws -> T {
         return try buffer.getJSONDecodable(T.self,
+                                           decoder: self,
                                            at: buffer.readerIndex,
                                            length: buffer.readableBytes)! // must work, enough readable bytes
     }

--- a/Tests/NIOFoundationCompatTests/Codable+ByteBufferTest+XCTest.swift
+++ b/Tests/NIOFoundationCompatTests/Codable+ByteBufferTest+XCTest.swift
@@ -36,6 +36,8 @@ extension CodableByteBufferTest {
                 ("testReadWriteJSONDecodableWorks", testReadWriteJSONDecodableWorks),
                 ("testGetSetJSONDecodableWorks", testGetSetJSONDecodableWorks),
                 ("testFailingReadsDoNotChangeReaderIndex", testFailingReadsDoNotChangeReaderIndex),
+                ("testCustomEncoderIsRespected", testCustomEncoderIsRespected),
+                ("testCustomDecoderIsRespected", testCustomDecoderIsRespected),
            ]
    }
 }

--- a/Tests/NIOFoundationCompatTests/Codable+ByteBufferTest.swift
+++ b/Tests/NIOFoundationCompatTests/Codable+ByteBufferTest.swift
@@ -166,7 +166,7 @@ class CodableByteBufferTest: XCTestCase {
             try container.encode(date.timeIntervalSinceReferenceDate)
             strategyExpectation.fulfill()
         })
-        XCTAssertNoThrow(try encoder.encode(expectedDate, into: &self.buffer))
+        XCTAssertNoThrow(try encoder.encode(["date": expectedDate], into: &self.buffer))
         XCTAssertEqual(XCTWaiter().wait(for: [strategyExpectation], timeout: 0.0), .completed)
     }
 
@@ -184,8 +184,8 @@ class CodableByteBufferTest: XCTestCase {
             let container = try decoder.singleValueContainer()
             return Date(timeIntervalSinceReferenceDate: try container.decode(Double.self))
         })
-        XCTAssertNoThrow(try encoder.encode(expectedDate, into: &self.buffer))
-        XCTAssertNoThrow(XCTAssertEqual(expectedDate, try decoder.decode(Date.self, from: self.buffer)))
+        XCTAssertNoThrow(try encoder.encode(["date": expectedDate], into: &self.buffer))
+        XCTAssertNoThrow(XCTAssertEqual(["date": expectedDate], try decoder.decode(Dictionary<String, Date>.self, from: self.buffer)))
         XCTAssertEqual(XCTWaiter().wait(for: [strategyExpectation], timeout: 0.0), .completed)
     }
 }


### PR DESCRIPTION
Allow actually configuring the `JSONDecoder` used when decoding things from a `ByteBuffer` instead of being stuck with the often useless defaults.

### Motivation:

Parity with encoding, and most especially being able to configure a date decoding strategy.

### Modifications:

Passes the missing parameter to the `ByteBuffer` method.

### Result:

The invoked `JSONDecoder` will be used instead of a default-initialized one.
