### PR TITLE
EventLoopFuture: save one allocation per future

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -1380,7 +1380,6 @@ public final class ChannelHandlerContext: ChannelInvoker {
 
     fileprivate func invokeRegister(promise: EventLoopPromise<Void>?) {
         self.eventLoop.assertInEventLoop()
-        assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
             outboundHandler.register(context: self, promise: promise)
@@ -1391,7 +1390,6 @@ public final class ChannelHandlerContext: ChannelInvoker {
 
    fileprivate func invokeBind(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         self.eventLoop.assertInEventLoop()
-        assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
             outboundHandler.bind(context: self, to: address, promise: promise)
@@ -1402,7 +1400,6 @@ public final class ChannelHandlerContext: ChannelInvoker {
 
     fileprivate func invokeConnect(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         self.eventLoop.assertInEventLoop()
-        assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
             outboundHandler.connect(context: self, to: address, promise: promise)
@@ -1413,7 +1410,6 @@ public final class ChannelHandlerContext: ChannelInvoker {
 
     fileprivate func invokeWrite(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         self.eventLoop.assertInEventLoop()
-        assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
             outboundHandler.write(context: self, data: data, promise: promise)
@@ -1434,7 +1430,6 @@ public final class ChannelHandlerContext: ChannelInvoker {
 
     fileprivate func invokeWriteAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         self.eventLoop.assertInEventLoop()
-        assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
             outboundHandler.write(context: self, data: data, promise: promise)
@@ -1456,7 +1451,6 @@ public final class ChannelHandlerContext: ChannelInvoker {
 
     fileprivate func invokeClose(mode: CloseMode, promise: EventLoopPromise<Void>?) {
         self.eventLoop.assertInEventLoop()
-        assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
             outboundHandler.close(context: self, mode: mode, promise: promise)
@@ -1467,7 +1461,6 @@ public final class ChannelHandlerContext: ChannelInvoker {
 
     fileprivate func invokeTriggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {
         self.eventLoop.assertInEventLoop()
-        assert(promise.map { !$0.futureResult.isFulfilled } ?? true, "Promise \(promise!) already fulfilled")
 
         if let outboundHandler = self.outboundHandler {
             outboundHandler.triggerUserOutboundEvent(context: self, event: event, promise: promise)

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -624,3 +624,32 @@ func forEachCrossConnectedStreamChannelPair<R>(file: StaticString = #file,
     let r3 = try withCrossConnectedUnixDomainSocketChannels(body)
     return [r1, r2, r3]
 }
+
+extension EventLoopFuture {
+    var isFulfilled: Bool {
+        if self.eventLoop.inEventLoop {
+            // Easy, we're on the EventLoop. Let's just use our knowledge that we run completed future callbacks
+            // immediately.
+            var fulfilled = false
+            self.whenComplete { _ in
+                fulfilled = true
+            }
+            return fulfilled
+        } else {
+            let lock = Lock()
+            let group = DispatchGroup()
+            var fulfilled = false // protected by lock
+
+            group.enter()
+            self.eventLoop.execute {
+                let isFulfilled = self.isFulfilled // This will now enter the above branch.
+                lock.withLock {
+                    fulfilled = isFulfilled
+                }
+                group.leave()
+            }
+            group.wait() // this is very nasty but this is for tests only, so...
+            return lock.withLock { fulfilled }
+        }
+    }
+}

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -18,11 +18,11 @@ services:
   test:
     image: swift-nio:16.04-5.1
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30600
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=594100
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30550
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=533050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4450
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -18,11 +18,11 @@ services:
   test:
     image: swift-nio:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31200
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1055050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30970
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=994050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4480
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50


### PR DESCRIPTION
Motivation:

Every EventLoopFuture was allocating an atomic boolean (which needs to
heap allocate because Swift) literally just to make the leakage checker
work. But the leakage checker is only active in debug mode so there's no
reason to be so wasteful. Furthermore, NIO doesn't require this `isFulfilled`
property in normal operation.

Modifications:

Remove the `isFulfilled` atomic which removes the allocation.
 
Result:

Fewer allocations