### PR TITLE
NIOPerformanceTester: more precision and resiliency

### DIFF
--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -15,7 +15,6 @@
 import NIO
 import NIOHTTP1
 import NIOFoundationCompat
-import Foundation
 import Dispatch
 
 // MARK: Test Harness
@@ -29,12 +28,12 @@ assert({
     return true
     }())
 
-public func measure(_ fn: () throws -> Int) rethrows -> [TimeInterval] {
-    func measureOne(_ fn: () throws -> Int) rethrows -> TimeInterval {
-        let start = Date()
+public func measure(_ fn: () throws -> Int) rethrows -> [Double] {
+    func measureOne(_ fn: () throws -> Int) rethrows -> Double {
+        let start = DispatchTime.now().uptimeNanoseconds
         _ = try fn()
-        let end = Date()
-        return end.timeIntervalSince(start)
+        let end = DispatchTime.now().uptimeNanoseconds
+        return Double(end - start) / Double(TimeAmount.seconds(1).nanoseconds)
     }
 
     _ = try measureOne(fn) /* pre-heat and throw away */


### PR DESCRIPTION
Motivation:

Previously, NIOPerformanceTester would use Foundation.Date twice to
calculate the time spend in a given function. This is less precise as it
can be but more importantly, it's not resilient against the user
changing the clock or the computer going to sleep.

Modifications:

Use DispatchTime.now().uptimeNanoseconds

Result:

More precise and resilient benchmark measurements.