### PR TITLE
Disallow zero EventLoop threads

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -1130,6 +1130,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     /// - arguments:
     ///     - numberOfThreads: The number of `Threads` to use.
     public convenience init(numberOfThreads: Int) {
+        precondition(numberOfThreads > 0, "numberOfThreads must be positive")
         let initializers: [ThreadInitializer] = Array(repeating: { _ in }, count: numberOfThreads)
         self.init(threadInitializers: initializers)
     }


### PR DESCRIPTION
Motivation:

Zero EventLoop threads makes no sense and leads to a crash (fixes #1223)

Modifications:

Add a precondition

Result:

Initializing EventLoop with zero threads will fail precondition rather than crash later.