### PR TITLE
don't use variable initialisation outside of `init`

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -59,9 +59,9 @@ public final class ServerBootstrap {
     private var serverChannelInit: ((Channel) -> EventLoopFuture<Void>)?
     private var childChannelInit: ((Channel) -> EventLoopFuture<Void>)?
     @usableFromInline
-    internal var _serverChannelOptions = ChannelOptions.Storage()
+    internal var _serverChannelOptions: ChannelOptions.Storage
     @usableFromInline
-    internal var _childChannelOptions = ChannelOptions.Storage()
+    internal var _childChannelOptions: ChannelOptions.Storage
 
     /// Create a `ServerBootstrap` for the `EventLoopGroup` `group`.
     ///
@@ -79,6 +79,8 @@ public final class ServerBootstrap {
     public init(group: EventLoopGroup, childGroup: EventLoopGroup) {
         self.group = group
         self.childGroup = childGroup
+        self._serverChannelOptions = ChannelOptions.Storage()
+        self._childChannelOptions = ChannelOptions.Storage()
         self._serverChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     }
 
@@ -354,7 +356,7 @@ public final class ClientBootstrap {
     private let group: EventLoopGroup
     private var channelInitializer: ((Channel) -> EventLoopFuture<Void>)?
     @usableFromInline
-    internal var _channelOptions = ChannelOptions.Storage()
+    internal var _channelOptions: ChannelOptions.Storage
     private var connectTimeout: TimeAmount = TimeAmount.seconds(10)
     private var resolver: Resolver?
 
@@ -364,6 +366,7 @@ public final class ClientBootstrap {
     ///     - group: The `EventLoopGroup` to use.
     public init(group: EventLoopGroup) {
         self.group = group
+        self._channelOptions = ChannelOptions.Storage()
         self._channelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     }
 
@@ -578,13 +581,14 @@ public final class DatagramBootstrap {
     private let group: EventLoopGroup
     private var channelInitializer: ((Channel) -> EventLoopFuture<Void>)?
     @usableFromInline
-    internal var _channelOptions = ChannelOptions.Storage()
+    internal var _channelOptions: ChannelOptions.Storage
 
     /// Create a `DatagramBootstrap` on the `EventLoopGroup` `group`.
     ///
     /// - parameters:
     ///     - group: The `EventLoopGroup` to use.
     public init(group: EventLoopGroup) {
+        self._channelOptions = ChannelOptions.Storage()
         self.group = group
     }
 
@@ -723,13 +727,14 @@ public final class NIOPipeBootstrap {
     private let group: EventLoopGroup
     private var channelInitializer: ((Channel) -> EventLoopFuture<Void>)?
     @usableFromInline
-    internal var _channelOptions = ChannelOptions.Storage()
+    internal var _channelOptions: ChannelOptions.Storage
 
     /// Create a `NIOPipeBootstrap` on the `EventLoopGroup` `group`.
     ///
     /// - parameters:
     ///     - group: The `EventLoopGroup` to use.
     public init(group: EventLoopGroup) {
+        self._channelOptions = ChannelOptions.Storage()
         self.group = group
     }
 

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -202,8 +202,8 @@ public struct ByteBuffer {
     public typealias _Capacity = UInt32
 
     @usableFromInline var _storage: _Storage
-    @usableFromInline var _readerIndex: _Index = 0
-    @usableFromInline var _writerIndex: _Index = 0
+    @usableFromInline var _readerIndex: _Index
+    @usableFromInline var _writerIndex: _Index
     @usableFromInline var _slice: Slice
 
     // MARK: Internal _Storage for CoW
@@ -409,6 +409,8 @@ public struct ByteBuffer {
 
     fileprivate init(allocator: ByteBufferAllocator, startingCapacity: Int) {
         let startingCapacity = _toCapacity(startingCapacity)
+        self._readerIndex = 0
+        self._writerIndex = 0
         self._storage = _Storage.reallocated(minimumCapacity: startingCapacity, allocator: allocator)
         self._slice = self._storage.fullSlice
     }

--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -266,9 +266,10 @@ extension ChannelOptions {
     /// `Channel` that needs to store `ChannelOption`s.
     public struct Storage {
         @usableFromInline
-        internal var _storage: [(Any, (Any, (Channel) -> (Any, Any) -> EventLoopFuture<Void>))] = []
+        internal var _storage: [(Any, (Any, (Channel) -> (Any, Any) -> EventLoopFuture<Void>))]
 
         public init() {
+            self._storage = []
             self._storage.reserveCapacity(2)
         }
 

--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -20,10 +20,10 @@ public struct CircularBuffer<Element>: CustomStringConvertible {
     internal var _buffer: ContiguousArray<Element?>
 
     @usableFromInline
-    internal var headBackingIndex: Int = 0
+    internal var headBackingIndex: Int
 
     @usableFromInline
-    internal var tailBackingIndex: Int = 0
+    internal var tailBackingIndex: Int
 
     @inlinable
     internal var mask: Int {
@@ -64,7 +64,7 @@ public struct CircularBuffer<Element>: CustomStringConvertible {
     ///         but remains valid when you replace one item by another using the subscript.
     public struct Index: Comparable {
         @usableFromInline var _backingIndex: UInt32
-        @usableFromInline var _backingCheck: _UInt24 = .max
+        @usableFromInline var _backingCheck: _UInt24
         @usableFromInline var isIndexGEQHeadIndex: Bool
 
         @inlinable
@@ -75,6 +75,7 @@ public struct CircularBuffer<Element>: CustomStringConvertible {
         @inlinable
         internal init(backingIndex: Int, backingCount: Int, backingIndexOfHead: Int) {
             self.isIndexGEQHeadIndex = backingIndex >= backingIndexOfHead
+            self._backingCheck = .max
             self._backingIndex = UInt32(backingIndex)
             debugOnly {
                 // if we can, we store the check for the backing here
@@ -277,6 +278,8 @@ extension CircularBuffer {
     @inlinable
     public init(initialCapacity: Int) {
         let capacity = Int(UInt32(initialCapacity).nextPowerOf2())
+        self.headBackingIndex = 0
+        self.tailBackingIndex = 0
         self._buffer = ContiguousArray<Element?>(repeating: nil, count: capacity)
         assert(self._buffer.count == capacity)
     }
@@ -284,7 +287,7 @@ extension CircularBuffer {
     /// Allocates an empty buffer.
     @inlinable
     public init() {
-        self.init(initialCapacity: 16)
+        self = .init(initialCapacity: 16)
     }
 
     /// Append an element to the end of the ring buffer.

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -382,12 +382,13 @@ public final class EventLoopFuture<Value> {
     /// they return any callbacks from those `EventLoopFuture`s so that we can run
     /// the entire chain from the top without recursing.
     @usableFromInline
-    internal var _callbacks: CallbackList = CallbackList()
+    internal var _callbacks: CallbackList
 
     @inlinable
     internal init(_eventLoop eventLoop: EventLoop, value: Result<Value, Error>?, file: StaticString, line: UInt) {
         self.eventLoop = eventLoop
         self._value = value
+        self._callbacks = .init()
 
         debugOnly {
             if let me = eventLoop as? SelectableEventLoop {

--- a/Sources/NIO/MarkedCircularBuffer.swift
+++ b/Sources/NIO/MarkedCircularBuffer.swift
@@ -19,7 +19,7 @@
 /// safe to write.
 public struct MarkedCircularBuffer<Element>: CustomStringConvertible {
     @usableFromInline internal var _buffer: CircularBuffer<Element>
-    @usableFromInline internal var _markedIndexOffset: Int? = nil /* nil: nothing marked */
+    @usableFromInline internal var _markedIndexOffset: Int? /* nil: nothing marked */
 
     /// Create a new instance.
     ///


### PR DESCRIPTION
Motivation:

The Swift compiler actively tries to make our live hard and puts all
initialisations of variables that are initialised using the shorthand
syntax

    @usableFromInline var myVar: MyVarType = .init()

into a _non-inlinable_ function

     variable initialization expression of MyModule.MyType.myVar : MyVarType

This means that the following pattern

    public struct MyType {
        @usableFromInline var myVar: MyVarType = .init()

        @inlinable public init() {
        }
    }

leads to code for the `init` that looks like

    CALL variable_initialization_expression_...

instead of also inlining the the code for the variable initialiser.

Modifications:

Don't use `@usableFromInline var myVar: MyVarType = ...` anywhere,
instead put it explicitly into the @inlinable `init`s which makes
actually inlinable.
I even removed that syntax from places where it doesn't matter
(eg. non-@inlinable inits) for consistency and in case someone were to
make the init inlinable later.

Result:

Minor performance wins working around https://bugs.swift.org/browse/SR-11768