### PR TITLE
Add withContiguousStorageIfAvailable implementation to WebSocketMaskingKey

### DIFF
--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -746,6 +746,6 @@ try measureAndPrint(desc: "websocket_encode_1kb_no_space_at_front_1k_frames",
 
 try measureAndPrint(desc: "websocket_decode", benchmark: WebSocketFrameDecoderBenchmark(dataSize: 1024, runCount: 100_000))
 
-try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1kb", benchmark: ByteBufferBenchmark(iterations: 10000, bufferSize: 4))
+try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1kb", benchmark: ByteBufferBenchmark(iterations: 10000, bufferSize: 1024))
 
 try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1mb", benchmark: ByteBufferBenchmark(iterations: 20, bufferSize: 1024*1024))

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -718,7 +718,7 @@ try measureAndPrint(desc: "websocket_encode_50b_space_at_front_1m_frames_cow",
                     benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
 
 try measureAndPrint(desc: "websocket_encode_50b_space_at_front_1m_frames_cow_masking",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .always))
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .always))
 
 try measureAndPrint(desc: "websocket_encode_1kb_space_at_front_100k_frames_cow",
                     benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -715,31 +715,37 @@ measureAndPrint(desc: "future_reduce_into_10k_futures") {
 try measureAndPrint(desc: "channel_pipeline_1m_events", benchmark: ChannelPipelineBenchmark())
 
 try measureAndPrint(desc: "websocket_encode_50b_space_at_front_1m_frames_cow",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .spaceAtFront, cowStrategy: .always))
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
+
+try measureAndPrint(desc: "websocket_encode_50b_space_at_front_1m_frames_cow_masking",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .always))
 
 try measureAndPrint(desc: "websocket_encode_1kb_space_at_front_100k_frames_cow",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .always))
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
 
 try measureAndPrint(desc: "websocket_encode_50b_no_space_at_front_1m_frames_cow",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .noSpaceAtFront, cowStrategy: .always))
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .noSpaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
 
 try measureAndPrint(desc: "websocket_encode_1kb_no_space_at_front_100k_frames_cow",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 100_000, dataStrategy: .noSpaceAtFront, cowStrategy: .always))
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 100_000, dataStrategy: .noSpaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
 
 try measureAndPrint(desc: "websocket_encode_50b_space_at_front_10k_frames",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 10_000, dataStrategy: .spaceAtFront, cowStrategy: .never))
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 10_000, dataStrategy: .spaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
+
+try measureAndPrint(desc: "websocket_encode_50b_space_at_front_10k_frames_masking",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .never, maskingKeyStrategy: .always))
 
 try measureAndPrint(desc: "websocket_encode_1kb_space_at_front_1k_frames",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 1_000, dataStrategy: .spaceAtFront, cowStrategy: .never))
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 1_000, dataStrategy: .spaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
 
 try measureAndPrint(desc: "websocket_encode_50b_no_space_at_front_10k_frames",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 10_000, dataStrategy: .noSpaceAtFront, cowStrategy: .never))
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 10_000, dataStrategy: .noSpaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
 
 try measureAndPrint(desc: "websocket_encode_1kb_no_space_at_front_1k_frames",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 1_000, dataStrategy: .noSpaceAtFront, cowStrategy: .never))
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 1_000, dataStrategy: .noSpaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
 
 try measureAndPrint(desc: "websocket_decode", benchmark: WebSocketFrameDecoderBenchmark(dataSize: 1024, runCount: 100_000))
 
-try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1kb", benchmark: ByteBufferBenchmark(iterations: 10000, bufferSize: 1024))
+try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1kb", benchmark: ByteBufferBenchmark(iterations: 10000, bufferSize: 4))
 
 try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1mb", benchmark: ByteBufferBenchmark(iterations: 20, bufferSize: 1024*1024))

--- a/Sources/NIOWebSocket/WebSocketFrame.swift
+++ b/Sources/NIOWebSocket/WebSocketFrame.swift
@@ -35,14 +35,14 @@ private extension UInt8 {
 /// a more convenient method of interacting with a masking key than simply by passing
 /// around a four-tuple.
 public struct WebSocketMaskingKey {
-    private let key: (UInt8, UInt8, UInt8, UInt8)
+    @usableFromInline internal let _key: (UInt8, UInt8, UInt8, UInt8)
 
     public init?<T: Collection>(_ buffer: T) where T.Element == UInt8 {
         guard buffer.count == 4 else {
             return nil
         }
 
-        self.key = (buffer[buffer.startIndex],
+        self._key = (buffer[buffer.startIndex],
                     buffer[buffer.index(buffer.startIndex, offsetBy: 1)],
                     buffer[buffer.index(buffer.startIndex, offsetBy: 2)],
                     buffer[buffer.index(buffer.startIndex, offsetBy: 3)])
@@ -55,7 +55,7 @@ public struct WebSocketMaskingKey {
     ///     - integer: The encoded network representation of the
     ///         masking key.
     internal init(networkRepresentation integer: UInt32) {
-        self.key = (UInt8((integer & 0xFF000000) >> 24),
+        self._key = (UInt8((integer & 0xFF000000) >> 24),
                     UInt8((integer & 0x00FF0000) >> 16),
                     UInt8((integer & 0x0000FF00) >> 8),
                     UInt8(integer & 0x000000FF))
@@ -73,7 +73,7 @@ extension WebSocketMaskingKey: ExpressibleByArrayLiteral {
 
 extension WebSocketMaskingKey: Equatable {
     public static func ==(lhs: WebSocketMaskingKey, rhs: WebSocketMaskingKey) -> Bool {
-        return lhs.key == rhs.key
+        return lhs._key == rhs._key
     }
 }
 
@@ -91,15 +91,26 @@ extension WebSocketMaskingKey: Collection {
     public subscript(index: Int) -> UInt8 {
         switch index {
         case 0:
-            return self.key.0
+            return self._key.0
         case 1:
-            return self.key.1
+            return self._key.1
         case 2:
-            return self.key.2
+            return self._key.2
         case 3:
-            return self.key.3
+            return self._key.3
         default:
             fatalError("Invalid index on WebSocketMaskingKey: \(index)")
+        }
+    }
+
+    @inlinable
+    public func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R? {
+        return try withUnsafeBytes(of: self._key) { ptr in
+            // this is boilerplate necessary to convert from UnsafeRawBufferPointer to UnsafeBufferPointer<UInt8>
+            // we know ptr is bound since we defined self._key as let
+            let typedPointer = ptr.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            let typedBufferPointer = UnsafeBufferPointer(start: typedPointer, count: ptr.count)
+            return try body(typedBufferPointer)
         }
     }
 }

--- a/Sources/NIOWebSocket/WebSocketFrame.swift
+++ b/Sources/NIOWebSocket/WebSocketFrame.swift
@@ -43,9 +43,9 @@ public struct WebSocketMaskingKey {
         }
 
         self._key = (buffer[buffer.startIndex],
-                    buffer[buffer.index(buffer.startIndex, offsetBy: 1)],
-                    buffer[buffer.index(buffer.startIndex, offsetBy: 2)],
-                    buffer[buffer.index(buffer.startIndex, offsetBy: 3)])
+                     buffer[buffer.index(buffer.startIndex, offsetBy: 1)],
+                     buffer[buffer.index(buffer.startIndex, offsetBy: 2)],
+                     buffer[buffer.index(buffer.startIndex, offsetBy: 3)])
     }
 
     /// Creates a websocket masking key from the network-encoded
@@ -56,9 +56,9 @@ public struct WebSocketMaskingKey {
     ///         masking key.
     internal init(networkRepresentation integer: UInt32) {
         self._key = (UInt8((integer & 0xFF000000) >> 24),
-                    UInt8((integer & 0x00FF0000) >> 16),
-                    UInt8((integer & 0x0000FF00) >> 8),
-                    UInt8(integer & 0x000000FF))
+                     UInt8((integer & 0x00FF0000) >> 16),
+                     UInt8((integer & 0x0000FF00) >> 8),
+                     UInt8(integer & 0x000000FF))
     }
 }
 


### PR DESCRIPTION
Motivation:

Add withContiguousStorageIfAvailable implementation to WebSocketMaskingKey because it's faster and contiguous storage is trivially available. Fixes #1234.

Modifications:

- Implement WebSocketMaskingKey.withContiguousStorageIfAvailable
- Make it @inlinable, requiring promoting WebSocketMaskingKey.key to internal
  so renamed to _key.
- Added tests using MaskingKey to WebSocketFrameEncoderBenchmark

Result:

Writing WebSocketMaskingKey into ByteBuffer is about 2x faster.