### PR TITLE
Fix running run-nio-alloc-counter-tests.sh for a single test

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/run-nio-alloc-counter-tests.sh
+++ b/IntegrationTests/tests_04_performance/test_01_resources/run-nio-alloc-counter-tests.sh
@@ -34,7 +34,7 @@ shift $((OPTIND-1))
 tests_to_run=("$here"/test_*.swift)
 
 if [[ $# -gt 0 ]]; then
-    tests_to_run=$@
+    tests_to_run=("$@")
 fi
 
 "$here/../../allocation-counter-tests-framework/run-allocation-counter.sh" \


### PR DESCRIPTION
Motivation:

Using the single test argument with the run-nio-alloc-counter-tests.sh
does not work as expected as the given test would just replace the first
test in the list.

Modifications:

Replace the tests to run with a single-element array containing the test
provided as an argument.

Result:

- A single test can be run when specified as a command line arg.