### PR TITLE
HTTP1TestServer: close accepted channel on `stop`

### DIFF
--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -276,6 +276,8 @@ extension NIOHTTP1TestServer {
                 guard self.inboundBuffer.isEmpty else {
                     throw NonEmptyInboundBufferOnStop()
                 }
+            }.always { _ in
+                self.currentClientChannel?.close(promise: nil)
             }
         }.wait()
     }

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest+XCTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest+XCTest.swift
@@ -30,6 +30,7 @@ extension NIOHTTP1TestServerTest {
                 ("testSimpleRequest", testSimpleRequest),
                 ("testConcurrentRequests", testConcurrentRequests),
                 ("testTestWebServerCanBeReleased", testTestWebServerCanBeReleased),
+                ("testStopClosesAcceptedChannel", testStopClosesAcceptedChannel),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

The HTTP1TestServer forgot to actually close the accepted channel on
`stop`.

Modifications:

Close the accepted Channel on stop.

Result:

Fewer bugs.