### PR TITLE
Added parentheses in TimeAmount constructors to generate optimal code…

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -286,7 +286,7 @@ public struct TimeAmount: Equatable {
     ///     - amount: the amount of milliseconds this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
     public static func milliseconds(_ amount: Int64) -> TimeAmount {
-        return TimeAmount(amount * 1000 * 1000)
+        return TimeAmount(amount * (1000 * 1000))
     }
 
     /// Creates a new `TimeAmount` for the given amount of seconds.
@@ -295,7 +295,7 @@ public struct TimeAmount: Equatable {
     ///     - amount: the amount of seconds this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
     public static func seconds(_ amount: Int64) -> TimeAmount {
-        return TimeAmount(amount * 1000 * 1000 * 1000)
+        return TimeAmount(amount * (1000 * 1000 * 1000))
     }
 
     /// Creates a new `TimeAmount` for the given amount of minutes.
@@ -304,7 +304,7 @@ public struct TimeAmount: Equatable {
     ///     - amount: the amount of minutes this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
     public static func minutes(_ amount: Int64) -> TimeAmount {
-        return TimeAmount(amount * 1000 * 1000 * 1000 * 60)
+        return TimeAmount(amount * (1000 * 1000 * 1000 * 60))
     }
 
     /// Creates a new `TimeAmount` for the given amount of hours.
@@ -313,7 +313,7 @@ public struct TimeAmount: Equatable {
     ///     - amount: the amount of hours this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
     public static func hours(_ amount: Int64) -> TimeAmount {
-        return TimeAmount(amount * 1000 * 1000 * 1000 * 60 * 60)
+        return TimeAmount(amount * (1000 * 1000 * 1000 * 60 * 60))
     }
 }
 


### PR DESCRIPTION
…. As Per issue #1249

Motivation:

For better codegen for TimeAmount struct.
After this change overflow will not be checked at each multiplication stage.

Modifications:

- Added parentheses in static constructors of `TimeAmount`

Result:

No change logically except better codegen
