### PR TITLE
make-single-file-spm: support lines ending in `n`

### DIFF
--- a/dev/make-single-file-spm
+++ b/dev/make-single-file-spm
@@ -151,7 +151,7 @@ all_dependencies=()
 all_dependency_modules=()
 number_of_lines=0
 
-while IFS="\n" read -r line; do
+while IFS="" read -r line; do
     if [[ "$line" =~ ^//\ MODULE:\ (.*)$ ]]; then
         module=${BASH_REMATCH[1]}
 


### PR DESCRIPTION
Motivation:

make-single-file-spm has a weird bug where it would chop off trailing
`n` characters in all lines due to a badly set `IFS` bash variable.

Modifications:

Set `IFS=""` which is correct.

Result:

make-single-file-spm will not chop off trailing `n`s.