### PR TITLE
Create a ClientBootstrap protocol

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -330,6 +330,40 @@ private extension Channel {
     }
 }
 
+/// `NIOTCPClientBootstrap` is implemented by various underlying transport mechanisms. Typically,
+/// this will be the BSD Sockets API implemented by `ClientBootstrap`.
+public protocol NIOTCPClientBootstrap {
+    /// Initialize the connected `Channel` with `initializer`. The most common task in initializer is to add
+    /// `ChannelHandler`s to the `ChannelPipeline`.
+    ///
+    /// - parameters:
+    ///     - handler: A closure that initializes the provided `Channel`.
+    func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
+
+    /// Specifies a `ChannelOption` to be applied to the `Channel`.
+    ///
+    /// - parameters:
+    ///     - option: The option to be applied.
+    ///     - value: The value for the option.
+    @inlinable
+    func channelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
+
+    /// Specifies a timeout to apply to a connection attempt.
+    //
+    /// - parameters:
+    ///     - timeout: The timeout that will apply to the connection attempt.
+    func connectTimeout(_ timeout: TimeAmount) -> Self
+
+    /// Specify the `host` and `port` to connect to for the `Channel` that will be established.
+    ///
+    /// - parameters:
+    ///     - host: The host to connect to.
+    ///     - port: The port to connect to.
+    /// - returns: An `EventLoopFuture<Channel>` to deliver the `Channel` when connected.
+    func connect(host: String, port: Int) -> EventLoopFuture<Channel>
+}
+
+
 /// A `ClientBootstrap` is an easy way to bootstrap a `SocketChannel` when creating network clients.
 ///
 /// Usually you re-use a `ClientBootstrap` once you set it up and called `connect` multiple times on it.
@@ -356,7 +390,7 @@ private extension Channel {
 /// ```
 ///
 /// The connected `SocketChannel` will operate on `ByteBuffer` as inbound and on `IOData` as outbound messages.
-public final class ClientBootstrap {
+public final class ClientBootstrap: NIOTCPClientBootstrap {
 
     private let group: EventLoopGroup
     private var channelInitializer: Optional<ChannelInitializerCallback>

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -332,7 +332,7 @@ private extension Channel {
 
 /// `NIOTCPClientBootstrap` is implemented by various underlying transport mechanisms. Typically,
 /// this will be the BSD Sockets API implemented by `ClientBootstrap`.
-public protocol NIOTCPClientBootstrap {
+internal protocol NIOTCPClientBootstrap {
     /// Initialize the connected `Channel` with `initializer`. The most common task in initializer is to add
     /// `ChannelHandler`s to the `ChannelPipeline`.
     ///

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -60,6 +60,11 @@ public final class EmbeddedEventLoop: EventLoop {
     /// Initialize a new `EmbeddedEventLoop`.
     public init() { }
 
+    /// Provide a valid `ClientBootstrap` to setup an `EmbeddedEventLoop`.
+    public func makeTCPClientBootstrap() -> NIOTCPClientBootstrap {
+        return ClientBootstrap(group: self)
+    }
+
     /// - see: `EventLoop.scheduleTask(deadline:_:)`
     @discardableResult
     public func scheduleTask<T>(deadline: NIODeadline, _ task: @escaping () throws -> T) -> Scheduled<T> {

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -61,7 +61,7 @@ public final class EmbeddedEventLoop: EventLoop {
     public init() { }
 
     /// Provide a valid `ClientBootstrap` to setup an `EmbeddedEventLoop`.
-    public func makeTCPClientBootstrap() -> NIOTCPClientBootstrap {
+    internal func makeTCPClientBootstrap() -> NIOTCPClientBootstrap {
         return ClientBootstrap(group: self)
     }
 

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -745,7 +745,7 @@ internal final class SelectableEventLoop: EventLoop {
     }
 
     /// Provide a valid `ClientBootstrap` to setup this `SelectableEventLoop` with a `SocketChannel`.
-    public func makeTCPClientBootstrap() -> NIOTCPClientBootstrap {
+    internal func makeTCPClientBootstrap() -> NIOTCPClientBootstrap {
         return ClientBootstrap(group: self)
     }
 
@@ -1134,7 +1134,7 @@ extension EventLoopGroup {
 }
 
 /// The default, non-functional implementation used to encourage EventLoopGroup implementations to conform to `NIOTCPClientBootstrap`.
-struct CannotBootstrap: NIOTCPClientBootstrap {
+internal struct CannotBootstrap: NIOTCPClientBootstrap {
     /// Thrown when an EventLoopGroup has not implemented `NIOTCPClientBootstrap` properly.
     public struct CannotBootstrapError: Error {
         let message: String
@@ -1167,9 +1167,9 @@ struct CannotBootstrap: NIOTCPClientBootstrap {
     }
 }
 
-extension EventLoopGroup {
+internal extension EventLoopGroup {
     /// If implemented, this provides the corresponding `Bootstrap` to create the `Channel` associated with this `EventLoopGroup`
-    public func makeTCPClientBootstrap() -> NIOTCPClientBootstrap {
+    func makeTCPClientBootstrap() -> NIOTCPClientBootstrap {
         return CannotBootstrap(group: self)
     }
 }
@@ -1271,7 +1271,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     }
 
     /// Provide a `ClientBootstrap` to setup this `MultiThreadedEventLoopGroup` with a `SocketChannel`.
-    public func makeTCPClientBootstrap() -> NIOTCPClientBootstrap? {
+    internal func makeTCPClientBootstrap() -> NIOTCPClientBootstrap? {
         return ClientBootstrap(group: self)
     }
 

--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -32,7 +32,7 @@ extension BootstrapTest {
                 ("testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
                 ("testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
                 ("testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
-                ("testClientStreamBootstrapAllowsConformanceCorrectly", testClientStreamBootstrapAllowsConformanceCorrectly),
+                ("testTCPClientBootstrapAllowsConformanceCorrectly", testTCPClientBootstrapAllowsConformanceCorrectly),
            ]
    }
 }

--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -32,6 +32,7 @@ extension BootstrapTest {
                 ("testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
                 ("testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
                 ("testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
+                ("testClientStreamBootstrapAllowsConformanceCorrectly", testClientStreamBootstrapAllowsConformanceCorrectly),
            ]
    }
 }


### PR DESCRIPTION
Create a simple protocol for Client-side bootstrap implementations to conform to.

### Motivation:

As described in https://github.com/apple/swift-nio/issues/674, we want to make it easier to switch between `ClientBootstrap` and `NIOTSConnectionBootstrap`.

This is one approach that I'm intrigued by, but not necessarily overly fond of. We're still allowing folks to use the wrong type of `EventLoopGroup` with the bootstrap they choose. However, this simplifies the ability to use both types of bootstrap objects, and at the least serves as a strawman proposal.

### Modifications:

Created a `ClientTransportBootstrap` protocol. I think it makes sense to separate out a client vs. server since the usecases and surface area are so different.

### Result:

Users will be able to choose between either `ClientBootstrap` or `NIOTSConnectionBootstrap` much more easily.
