### PR TITLE
Fix Dash docset generation.

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -87,7 +87,7 @@ EOF
 for module in "${modules[@]}"; do
   args=("${jazzy_args[@]}"  --output "$root_path/docs/$version/$module" --module "$module"
         --module-version $version
-        --root-url "https://apple.github.io/swift-nio/docs/$version/$module")
+        --root-url "https://apple.github.io/swift-nio/docs/$version/$module/")
   if [[ -f "$root_path/.build/sourcekitten/$module.json" ]]; then
     args+=(--sourcekitten-sourcefile "$root_path/.build/sourcekitten/$module.json")
   fi


### PR DESCRIPTION
Motivation:

Jazzy generates Dash docsets for us, but currently they don't work. This
is because the URLs they generate aren't matching the URL scheme we
have. That makes them next to useless.

Modifications:

Add a trailing '/' to the root URL.

Result:

Calls to Ruby's URI.join won't blow away the final path component in the
root URL, which means that the docsets will have correct URLs going
forward.

Resolves #1254.