### PR TITLE
don't use `public extension`

### DIFF
--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -63,8 +63,8 @@ public typealias ConnectTimeoutOption = ChannelOptions.Types.ConnectTimeoutOptio
 @available(*, deprecated, renamed: "ChannelOptions.Types.AllowRemoteHalfClosureOption")
 public typealias AllowRemoteHalfClosureOption = ChannelOptions.Types.AllowRemoteHalfClosureOption
 
-public extension ChannelOptions {
-    enum Types {
+extension ChannelOptions {
+    public enum Types {
 
         /// `SocketOption` allows users to specify configuration settings that are directly applied to the underlying socket file descriptor.
         ///


### PR DESCRIPTION
Motivation:

`public extension`s are very dangerous because the make it so easy to
slip in public API by accident.

Modifications:

Don't use `public extension`.

Result:

Fewer chances to accidentally make stuff public.