### PR TITLE
Fix typo in Endianness docs

### DIFF
--- a/Sources/NIO/ByteBuffer-int.swift
+++ b/Sources/NIO/ByteBuffer-int.swift
@@ -138,7 +138,7 @@ extension UInt32 {
 }
 
 /// Endianness refers to the sequential order in which bytes are arranged into larger numerical values when stored in
-/// 	memory or when transmitted over digital links.
+/// memory or when transmitted over digital links.
 public enum Endianness {
     /// The endianness of the machine running this program.
     public static let host: Endianness = hostEndianness0()
@@ -148,10 +148,10 @@ public enum Endianness {
         return number == number.bigEndian ? .big : .little
     }
 
-    /// big endian, the most significat byte (MSB) is at the lowest address
+    /// big endian, the most significant byte (MSB) is at the lowest address
     case big
 
-    /// little endian, the least significat byte (LSB) is at the lowest address
+    /// little endian, the least significant byte (LSB) is at the lowest address
     case little
 }
 


### PR DESCRIPTION
Fix typo in Endianness docs

Motivation:

Slight typo in docs of Endianness

Modifications:

`significat` -> `significant`

Result:

Less typos, happier users.
