### PR TITLE
Add first(name:) to HTTPHeaders

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -420,6 +420,25 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
         }
     }
 
+    /// Retrieves the first value for a given header field name from the block.
+    ///
+    /// This method uses case-insensitive comparisons for the header field name. It
+    /// does not return the first value from a maximally-decomposed list of the header fields,
+    /// but instead returns the first value from the original representation: that means
+    /// that a comma-separated header field list may contain more than one entry, some of
+    /// which contain commas and some do not. If you want a representation of the header fields
+    /// suitable for performing computation on, consider `getCanonicalForm`.
+    ///
+    /// - Parameter name: The header field name whose first value should be retrieved.
+    /// - Returns: The first value for the header field name.
+    public func first(name: String) -> String? {
+        guard !self.headers.isEmpty else {
+            return nil
+        }
+
+        return self.headers.first { header in header.0.isEqualCaseInsensitiveASCIIBytes(to: name) }?.1
+    }
+
     /// Checks if a header is present
     ///
     /// - parameters:

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -37,6 +37,7 @@ extension HTTPHeadersTest {
                 ("testTrimWhitespaceWorksOnOnlyWhitespace", testTrimWhitespaceWorksOnOnlyWhitespace),
                 ("testTrimWorksWithCharactersInTheMiddleAndWhitespaceAround", testTrimWorksWithCharactersInTheMiddleAndWhitespaceAround),
                 ("testContains", testContains),
+                ("testFirst", testFirst),
                 ("testKeepAliveStateStartsWithClose", testKeepAliveStateStartsWithClose),
                 ("testKeepAliveStateStartsWithKeepAlive", testKeepAliveStateStartsWithKeepAlive),
                 ("testKeepAliveStateHasKeepAlive", testKeepAliveStateHasKeepAlive),

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -174,6 +174,20 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertTrue(headers.contains(name: "X-Header"))
         XCTAssertFalse(headers.contains(name: "X-NonExistingHeader"))
     }
+
+    func testFirst() throws {
+        let headers = HTTPHeaders([
+            (":method", "GET"),
+            ("foo", "bar"),
+            ("foo", "baz"),
+            ("custom-key", "value-1,value-2")
+        ])
+
+        XCTAssertEqual(headers.first(name: ":method"), "GET")
+        XCTAssertEqual(headers.first(name: "Foo"), "bar")
+        XCTAssertEqual(headers.first(name: "custom-key"), "value-1,value-2")
+        XCTAssertNil(headers.first(name: "not-present"))
+    }
     
     func testKeepAliveStateStartsWithClose() {
         var headers = HTTPHeaders([("Connection", "close")])


### PR DESCRIPTION
Motivation:

In some cases you only expect (or care about) a single value for a
header. However, getting this value without allocating an array or
traversing the whole array requres using first(where:) provided by
Sequence. This is not very ergonomic as it requires users to do the
case-insensitive comparison and then exctact the value from the
HTTPHeaders. Additionally, users cannot use NIO's case insensitive
ASCII comparison.

Modifications:

- Provide a first(name:) method on HTTPHeaders which returns the value
  from the first header whose name is a case insentive match of the
  subscript parameter.

Result:

It's easier to get the first value from HTTPHeaders matching a given
name.