### PR TITLE
make sure ByteToMessageHandler is happy never being in a pipeline

### DIFF
--- a/Tests/NIOTests/CodecTest+XCTest.swift
+++ b/Tests/NIOTests/CodecTest+XCTest.swift
@@ -72,6 +72,8 @@ extension MessageToByteEncoderTest {
       return [
                 ("testEncoderOverrideAllocateOutBuffer", testEncoderOverrideAllocateOutBuffer),
                 ("testEncoder", testEncoder),
+                ("testB2MHIsHappyNeverBeingAddedToAPipeline", testB2MHIsHappyNeverBeingAddedToAPipeline),
+                ("testM2BHIsHappyNeverBeingAddedToAPipeline", testM2BHIsHappyNeverBeingAddedToAPipeline),
            ]
    }
 }

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -1557,8 +1557,44 @@ public final class MessageToByteEncoderTest: XCTestCase {
         }
 
         XCTAssertTrue(try channel.finish().isClean)
-
     }
+
+    func testB2MHIsHappyNeverBeingAddedToAPipeline() {
+        @inline(never)
+        func createAndReleaseIt() {
+            struct Decoder: ByteToMessageDecoder {
+                typealias InboundOut = Never
+
+                func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
+                    XCTFail()
+                    return .needMoreData
+                }
+
+                func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
+                    XCTFail()
+                    return .needMoreData
+                }
+            }
+            _ = ByteToMessageHandler(Decoder())
+        }
+        createAndReleaseIt()
+    }
+
+    func testM2BHIsHappyNeverBeingAddedToAPipeline() {
+        @inline(never)
+        func createAndReleaseIt() {
+            struct Encoder: MessageToByteEncoder {
+                typealias OutboundIn = Void
+
+                func encode(data: Void, out: inout ByteBuffer) throws {
+                    XCTFail()
+                }
+            }
+            _ = MessageToByteHandler(Encoder())
+        }
+        createAndReleaseIt()
+    }
+
 }
 
 private class PairOfBytesDecoder: ByteToMessageDecoder {


### PR DESCRIPTION
Motivation:

ByteToMessageHandler was expecting to always be added to a
ChannelPipeline. That's mostly true but not always.

Modifications:

Make sure we don't crash if a ByteToMessageHandler was never added.

Result:

Fewer crashes.