### PR TITLE
stop using AtomicBox

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=522050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=501050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30990
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=1005050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=973050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4500
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010


### PR DESCRIPTION
Motivation:

AtomicBox doesn't properly work (#1286) and despite fixing it in #1287,
it's really not worth using AtomicBox (which as of #1287 instroduces a
CAS loop) anymore.

Modifications:

Remove the two uses of AtomicBox.

Result:

No usage of broken/slow data types.