### PR TITLE
save allocations on connect

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=491050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=490050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30990
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=963050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=962050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4500
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010


### PR DESCRIPTION
Motivation:

ClientBootstrap.connect was needlessly overallocaing (for a needless
promise and a needless cascade).

Modifications:

Remove the needless allocations.

Result:

Fewer allocations.