### PR TITLE
EventLoopFuture: more tests for andAll/whenAllComplete

### DIFF
--- a/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest+XCTest.swift
@@ -77,6 +77,12 @@ extension EventLoopFutureTest {
                 ("testPromiseCompletedWithFailedFuture", testPromiseCompletedWithFailedFuture),
                 ("testPromiseCompletedWithSuccessfulResult", testPromiseCompletedWithSuccessfulResult),
                 ("testPromiseCompletedWithFailedResult", testPromiseCompletedWithFailedResult),
+                ("testAndAllCompleteWithZeroFutures", testAndAllCompleteWithZeroFutures),
+                ("testAndAllSucceedWithZeroFutures", testAndAllSucceedWithZeroFutures),
+                ("testAndAllCompleteWithPreSucceededFutures", testAndAllCompleteWithPreSucceededFutures),
+                ("testAndAllCompleteWithPreFailedFutures", testAndAllCompleteWithPreFailedFutures),
+                ("testAndAllCompleteWithMixOfPreSuccededAndNotYetCompletedFutures", testAndAllCompleteWithMixOfPreSuccededAndNotYetCompletedFutures),
+                ("testWhenAllCompleteWithMixOfPreSuccededAndNotYetCompletedFutures", testWhenAllCompleteWithMixOfPreSuccededAndNotYetCompletedFutures),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -51,8 +51,6 @@ extension EventLoopTest {
                 ("testRepeatedTaskThatIsImmediatelyCancelledNotifies", testRepeatedTaskThatIsImmediatelyCancelledNotifies),
                 ("testRepeatedTaskThatIsCancelledAfterRunningAtLeastTwiceNotifies", testRepeatedTaskThatIsCancelledAfterRunningAtLeastTwiceNotifies),
                 ("testRepeatedTaskThatCancelsItselfNotifiesOnlyWhenFinished", testRepeatedTaskThatCancelsItselfNotifiesOnlyWhenFinished),
-                ("testAndAllCompleteWithZeroFutures", testAndAllCompleteWithZeroFutures),
-                ("testAndAllSucceedWithZeroFutures", testAndAllSucceedWithZeroFutures),
                 ("testCancelledScheduledTasksDoNotHoldOnToRunClosure", testCancelledScheduledTasksDoNotHoldOnToRunClosure),
                 ("testIllegalCloseOfEventLoopFails", testIllegalCloseOfEventLoopFails),
                 ("testSubtractingDeadlineFromPastAndFuturesDeadlinesWorks", testSubtractingDeadlineFromPastAndFuturesDeadlinesWorks),

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -738,32 +738,6 @@ public final class EventLoopTest : XCTestCase {
         XCTAssertEqual(XCTWaiter.wait(for: [expect1, expect2], timeout: 0.5), .completed)
     }
 
-    func testAndAllCompleteWithZeroFutures() {
-        let eventLoop = EmbeddedEventLoop()
-        let done = DispatchWorkItem {}
-        EventLoopFuture<Void>.andAllComplete([], on: eventLoop).whenComplete { (result: Result<Void, Error>) in
-            _ = result.mapError { error -> Error in
-                XCTFail("unexpected error \(error)")
-                return error
-            }
-            done.perform()
-        }
-        done.wait()
-    }
-
-    func testAndAllSucceedWithZeroFutures() {
-        let eventLoop = EmbeddedEventLoop()
-        let done = DispatchWorkItem {}
-        EventLoopFuture<Void>.andAllSucceed([], on: eventLoop).whenComplete { result in
-            _ = result.mapError { error -> Error in
-                XCTFail("unexpected error \(error)")
-                return error
-            }
-            done.perform()
-        }
-        done.wait()
-    }
-
     func testCancelledScheduledTasksDoNotHoldOnToRunClosure() {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {


### PR DESCRIPTION
Motivation:

andAllComplete and whenAllComplete weren't very well tested but have
fairly complex code.

Modifications:

- add more tests
- move two tests that were in the wrong file

Result:

better test coverage