### PR TITLE
workaround failed associated type inference

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -112,6 +112,8 @@ public struct CircularBuffer<Element>: CustomStringConvertible {
 
 // MARK: Collection/MutableCollection implementation
 extension CircularBuffer: Collection, MutableCollection {
+    public typealias Element = Element
+    public typealias Indices = DefaultIndices<CircularBuffer<Element>>
     public typealias RangeType<Bound> = Range<Bound> where Bound: Strideable, Bound.Stride: SignedInteger
     public typealias SubSequence = CircularBuffer<Element>
 


### PR DESCRIPTION
Motivation:

Some Swift nightly snapshots fail to compile NIO in release mode
(rdar://57793267), this change is to work around this issue by telling
them compiler the associatedtypes explicitly.

Modifications:

- add `Element` and `Indices` typealises to `CircularBuffer` explicitly.

Result:

Compiles on all nightlies also in release mode.
