### PR TITLE
don't assume realloc never happens

### DIFF
--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1358,18 +1358,12 @@ class ByteBufferTest: XCTestCase {
         let alloc = ByteBufferAllocator()
         var buf = alloc.buffer(capacity: 16)
 
-        var bufPtrValPre: UInt = 1
-        var bufPtrValPost: UInt = 2
-
         XCTAssertLessThan(buf.capacity, 32)
         let preCapacity = buf.capacity
 
-        bufPtrValPre = buf.storagePointerIntegerValue()
         buf.clear(minimumCapacity: 32)
-        bufPtrValPost = buf.storagePointerIntegerValue()
         let postCapacity = buf.capacity
 
-        XCTAssertNotEqual(bufPtrValPre, bufPtrValPost)
         XCTAssertGreaterThanOrEqual(buf.capacity, 32)
         XCTAssertNotEqual(preCapacity, postCapacity)
     }


### PR DESCRIPTION
Motivation:

testClearWithBiggerMinimumCapacityDoesNotDupeStorageIfTheresOnlyOneBuffer
assumed that the storage pointer always changes when growing. That's
only true if we were not using realloc.

Modifications:

Remove bogus assertion

Result:

Fixes #1291