### PR TITLE
fix EVFILT_EXCEPT loop if autoRead is off on Darwin

### DIFF
--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -747,6 +747,13 @@ public final class SocketChannelTest : XCTestCase {
     }
 
     func testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheServerSide() throws {
+        guard isEarlyEOFDeliveryWorkingOnThisOS else {
+            #if os(Linux)
+            preconditionFailure("this should only ever be entered on Darwin.")
+            #else
+            return
+            #endif
+        }
         // This test makes sure that we notice EOFs early, even if we never register for read (by dropping all the reads
         // on the floor. This is the same test as below but this one is for TCP servers.
         for mode in [DropAllReadsOnTheFloorHandler.Mode.halfClosureEnabled, .halfClosureDisabled] {
@@ -796,6 +803,13 @@ public final class SocketChannelTest : XCTestCase {
     }
 
     func testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheClientSide() throws {
+        guard isEarlyEOFDeliveryWorkingOnThisOS else {
+            #if os(Linux)
+            preconditionFailure("this should only ever be entered on Darwin.")
+            #else
+            return
+            #endif
+        }
         // This test makes sure that we notice EOFs early, even if we never register for read (by dropping all the reads
         // on the floor. This is the same test as above but this one is for TCP clients.
         enum Mode {

--- a/Tests/NIOTests/StreamChannelsTest+XCTest.swift
+++ b/Tests/NIOTests/StreamChannelsTest+XCTest.swift
@@ -35,6 +35,7 @@ extension StreamChannelTest {
                 ("testDoubleShutdownOutput", testDoubleShutdownOutput),
                 ("testWriteFailsAfterOutputClosed", testWriteFailsAfterOutputClosed),
                 ("testVectorWrites", testVectorWrites),
+                ("testLotsOfWritesWhilstOtherSideNotReading", testLotsOfWritesWhilstOtherSideNotReading),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Due to rdar://53656794, we sometimes (especially on UNIX Domain Sockets)
see EVFILT_EXCEPT firing when data is available to read depite the fact
that we're setting the low watermark to CInt.max. This means that
EVFILT_EXCEPT becomes essentially unusable.

Modifications:

- Don't use EVFILT_EXCEPT on Darwin
- We lose early EOF delivery on Darwin

Result:

Fewer possibilities of a spin loop on Darwin.