### PR TITLE
accept: don't do unnecessary dodgy pointer things

### DIFF
--- a/Sources/NIO/Linux.swift
+++ b/Sources/NIO/Linux.swift
@@ -121,7 +121,10 @@ internal enum Linux {
     static let SOCK_NONBLOCK = CInt(bitPattern: Glibc.SOCK_NONBLOCK.rawValue)
 #endif
     @inline(never)
-    public static func accept4(descriptor: CInt, addr: UnsafeMutablePointer<sockaddr>, len: UnsafeMutablePointer<socklen_t>, flags: Int32) throws -> CInt? {
+    public static func accept4(descriptor: CInt,
+                               addr: UnsafeMutablePointer<sockaddr>?,
+                               len: UnsafeMutablePointer<socklen_t>?,
+                               flags: CInt) throws -> CInt? {
         let result: IOResult<CInt> = try wrapSyscallMayBlock {
             CNIOLinux.CNIOLinux_accept4(descriptor, addr, len, flags)
         }

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -297,7 +297,9 @@ internal enum Posix {
     }
 
     @inline(never)
-    public static func accept(descriptor: CInt, addr: UnsafeMutablePointer<sockaddr>, len: UnsafeMutablePointer<socklen_t>) throws -> CInt? {
+    public static func accept(descriptor: CInt,
+                              addr: UnsafeMutablePointer<sockaddr>?,
+                              len: UnsafeMutablePointer<socklen_t>?) throws -> CInt? {
         let result: IOResult<CInt> = try wrapSyscallMayBlock {
             let fd = sysAccept(descriptor, addr, len)
 


### PR DESCRIPTION
Motivation:

We never look at the socket address that accept(4) returns so we
shouldn't ask for it. Additionally, it wasn't always the right size (in
IPv6 case) and also the pointer operations were dodgy.

Thanks to @milseman for the pointer.

Modifications:

Remove the whole socket address pointer stuff for accept.

Result:

Cleaner code.