### PR TITLE
fix race in testConnect

### DIFF
--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -237,12 +237,16 @@ public final class SocketChannelTest : XCTestCase {
                                                                eventLoop: eventLoop as! SelectableEventLoop))
         let promise = channel.eventLoop.makePromise(of: Void.self)
 
-        XCTAssertNoThrow(try channel.pipeline.addHandler(ActiveVerificationHandler(promise)).flatMap {
-            channel.register()
-        }.flatMap {
-            channel.connect(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 9999))
-        }.flatMap {
-            channel.close()
+        XCTAssertNoThrow(try channel.eventLoop.flatSubmit {
+            // We need to hop to the EventLoop here to make sure that we don't get an ECONNRESET before we manage
+            // to close.
+            channel.pipeline.addHandler(ActiveVerificationHandler(promise)).flatMap {
+                channel.register()
+            }.flatMap {
+                channel.connect(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 9999))
+            }.flatMap {
+                channel.close()
+            }
         }.wait())
 
         XCTAssertNoThrow(try channel.closeFuture.wait())


### PR DESCRIPTION
Motivation:

`testConnect` assumed that it can leave a little bit of time between
registering a socket and connecting it for real (by stubbing out
`connect`). That's true on Darwin but not on Linux, we may get
ECONNRESET.

Modifications:

Hop to the EventLoop before registering to close the race.

Result:

- fixes #968