### PR TITLE
add an allocation counter test for scheduling tasks

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_10000_tasks.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import NIO
+
+func run(identifier: String) {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let loop = group.next()
+    let dg = DispatchGroup()
+
+    measure(identifier: identifier) {
+        loop.execute {
+            for _ in 0..<10_000 {
+                dg.enter()
+                loop.scheduleTask(in: .nanoseconds(0)) { dg.leave() }
+            }
+        }
+        dg.wait()
+        return 10_000
+    }
+
+    try! group.syncShutdownGracefully()
+}

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_10000_tasks.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -32,6 +32,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=110050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -32,7 +32,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=110050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -32,6 +32,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=110050
 
   performance-test:
     image: swift-nio:18.04-5.0

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -32,7 +32,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=110050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
 
   performance-test:
     image: swift-nio:18.04-5.0


### PR DESCRIPTION
Motivation:

Scheduling tasks is important so we should have an allocation counter
test.

Modifications:

add one

Result:

more alloc counter tests