### PR TITLE
add descriptions to EventLoop and NIOThread

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -249,6 +249,12 @@ public protocol EventLoop: EventLoopGroup {
     func preconditionInEventLoop(file: StaticString, line: UInt)
 }
 
+extension EventLoopGroup {
+    public var description: String {
+        return String(describing: self)
+    }
+}
+
 /// Represents a time _interval_.
 ///
 /// - note: `TimeAmount` should not be used to represent a point in time.
@@ -754,6 +760,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
 
     private static let threadSpecificEventLoop = ThreadSpecificVariable<SelectableEventLoop>()
 
+    private let myGroupID: Int
     private let index = NIOAtomic<Int>.makeAtomic(value: 0)
     private let eventLoops: [SelectableEventLoop]
     private let shutdownLock: Lock = Lock()
@@ -812,6 +819,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     ///     - threadInitializers: The `ThreadInitializer`s to use.
     internal init(threadInitializers: [ThreadInitializer]) {
         let myGroupID = nextEventLoopGroupID.add(1)
+        self.myGroupID = myGroupID
         var idx = 0
         self.eventLoops = threadInitializers.map { initializer in
             // Maximum name length on linux is 16 by default.
@@ -942,6 +950,12 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
                 }
             }
         }
+    }
+}
+
+extension MultiThreadedEventLoopGroup: CustomStringConvertible {
+    public var description: String {
+        return "MultiThreadedEventLoopGroup { threadPattern = NIO-ELT-\(self.myGroupID)-#* }"
     }
 }
 

--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -478,7 +478,7 @@ extension SelectableEventLoop: CustomStringConvertible {
     @usableFromInline
     var description: String {
         return self._tasksLock.withLock {
-            return "SelectableEventLoop { selector = \(self._selector), scheduledTasks = \(self._scheduledTasks.description) }"
+            return "SelectableEventLoop { selector = \(self._selector), thread = \(self.thread), scheduledTasks = \(self._scheduledTasks.description) }"
         }
     }
 }

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -65,6 +65,8 @@ extension EventLoopTest {
                 ("testSchedulingTaskOnTheEventLoopWithinTheEventLoopsOnlyIOOperation", testSchedulingTaskOnTheEventLoopWithinTheEventLoopsOnlyIOOperation),
                 ("testCancellingTheLastOutstandingTask", testCancellingTheLastOutstandingTask),
                 ("testSchedulingTaskOnTheEventLoopWithinTheEventLoopsOnlyScheduledTask", testSchedulingTaskOnTheEventLoopWithinTheEventLoopsOnlyScheduledTask),
+                ("testSelectableEventLoopDescription", testSelectableEventLoopDescription),
+                ("testMultiThreadedEventLoopGroupDescription", testMultiThreadedEventLoopGroupDescription),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -1047,4 +1047,33 @@ public final class EventLoopTest : XCTestCase {
         }
         g.wait()
     }
+
+    func testSelectableEventLoopDescription() {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try elg.syncShutdownGracefully())
+        }
+
+        let el: EventLoop = elg.next()
+        let expectedPrefix = "SelectableEventLoop { selector = Selector { descriptor ="
+        let expectedContains = "thread = NIOThread(name = NIO-ELT-"
+        let expectedSuffix = ", scheduledTasks = PriorityQueue(count: 0): [] }"
+        let desc = el.description
+        XCTAssert(el.description.starts(with: expectedPrefix), desc)
+        XCTAssert(el.description.reversed().starts(with: expectedSuffix.reversed()), desc)
+        // let's check if any substring contains the `expectedContains`
+        XCTAssert(desc.indices.contains { startIndex in
+            desc[startIndex...].starts(with: expectedContains)
+        }, desc)
+    }
+
+    func testMultiThreadedEventLoopGroupDescription() {
+        let elg: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try elg.syncShutdownGracefully())
+        }
+
+        XCTAssert(elg.description.starts(with: "MultiThreadedEventLoopGroup { threadPattern = NIO-ELT-"),
+                  elg.description)
+    }
 }


### PR DESCRIPTION
Motivation:

Certain issues are easier debugged if we can print the thread names.

Modifications:

- add the thread name to SelectableEventLoop's description
- make EventLoop and NIOThread CustomStringConvertible

Result:

easier debugging.