### PR TITLE
make SelectableEventLoop.description not take a lock

### DIFF
--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -474,9 +474,14 @@ internal final class SelectableEventLoop: EventLoop {
     }
 }
 
-extension SelectableEventLoop: CustomStringConvertible {
+extension SelectableEventLoop: CustomStringConvertible, CustomDebugStringConvertible {
     @usableFromInline
     var description: String {
+        return "SelectableEventLoop { selector = \(self._selector), thread = \(self.thread) }"
+    }
+
+    @usableFromInline
+    var debugDescription: String {
         return self._tasksLock.withLock {
             return "SelectableEventLoop { selector = \(self._selector), thread = \(self.thread), scheduledTasks = \(self._scheduledTasks.description) }"
         }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -1057,7 +1057,7 @@ public final class EventLoopTest : XCTestCase {
         let el: EventLoop = elg.next()
         let expectedPrefix = "SelectableEventLoop { selector = Selector { descriptor ="
         let expectedContains = "thread = NIOThread(name = NIO-ELT-"
-        let expectedSuffix = ", scheduledTasks = PriorityQueue(count: 0): [] }"
+        let expectedSuffix = " }"
         let desc = el.description
         XCTAssert(el.description.starts(with: expectedPrefix), desc)
         XCTAssert(el.description.reversed().starts(with: expectedSuffix.reversed()), desc)


### PR DESCRIPTION
Motivation:

SelectableEventLoop's description was taking a lock and would also lock
every single scheduled task. That's overkill.

Modifications:

Make it only log the thread and selector (which don't require locks).

Result:

better description