### PR TITLE
Drain scheduled tasks on EmbeddedChannel finish()

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -48,7 +48,7 @@ extension EmbeddedScheduledTask: Comparable {
 ///     unsynchronized fashion.
 public final class EmbeddedEventLoop: EventLoop {
     /// The current "time" for this event loop. This is an amount in nanoseconds.
-    private var now: NIODeadline = .uptimeNanoseconds(0)
+    /* private but tests */ internal var _now: NIODeadline = .uptimeNanoseconds(0)
 
     private var scheduledTasks = PriorityQueue<EmbeddedScheduledTask>(ascending: true)
 
@@ -87,13 +87,13 @@ public final class EmbeddedEventLoop: EventLoop {
     /// - see: `EventLoop.scheduleTask(in:_:)`
     @discardableResult
     public func scheduleTask<T>(in: TimeAmount, _ task: @escaping () throws -> T) -> Scheduled<T> {
-        return scheduleTask(deadline: self.now + `in`, task)
+        return scheduleTask(deadline: self._now + `in`, task)
     }
 
     /// On an `EmbeddedEventLoop`, `execute` will simply use `scheduleTask` with a deadline of _now_. This means that
     /// `task` will be run the next time you call `EmbeddedEventLoop.run`.
     public func execute(_ task: @escaping () -> Void) {
-        self.scheduleTask(deadline: self.now, task)
+        self.scheduleTask(deadline: self._now, task)
     }
 
     /// Run all tasks that have previously been submitted to this `EmbeddedEventLoop`, either by calling `execute` or
@@ -109,7 +109,7 @@ public final class EmbeddedEventLoop: EventLoop {
     /// Runs the event loop and moves "time" forward by the given amount, running any scheduled
     /// tasks that need to be run.
     public func advanceTime(by: TimeAmount) {
-        let newTime = self.now + by
+        let newTime = self._now + by
 
         while let nextTask = self.scheduledTasks.peek() {
             guard nextTask.readyTime <= newTime else {
@@ -126,7 +126,7 @@ public final class EmbeddedEventLoop: EventLoop {
 
             // Set the time correctly before we call into user code, then
             // call in for all tasks.
-            self.now = nextTask.readyTime
+            self._now = nextTask.readyTime
 
             for task in tasks {
                 task.task()
@@ -134,7 +134,19 @@ public final class EmbeddedEventLoop: EventLoop {
         }
 
         // Finally ensure we got the time right.
-        self.now = newTime
+        self._now = newTime
+    }
+
+    internal func drainScheduledTasksByRunningAllCurrentlyScheduledTasks() {
+        var currentlyScheduledTasks = self.scheduledTasks
+        while let nextTask = currentlyScheduledTasks.pop() {
+            self._now = nextTask.readyTime
+            nextTask.task()
+        }
+        // Just drop all the remaining scheduled tasks. Despite having run all the tasks that were
+        // scheduled when we entered the method this may still contain tasks as running the tasks
+        // may have enqueued more tasks.
+        while self.scheduledTasks.pop() != nil {}
     }
 
     /// - see: `EventLoop.close`
@@ -416,7 +428,7 @@ public final class EmbeddedChannel: Channel {
                 throw error
             }
         }
-        self.embeddedEventLoop.advanceTime(by: .nanoseconds(.max))
+        self.embeddedEventLoop.drainScheduledTasksByRunningAllCurrentlyScheduledTasks()
         self.embeddedEventLoop.run()
         try throwIfErrorCaught()
         let c = self.channelcore

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -47,6 +47,7 @@ extension EmbeddedChannelTest {
                 ("testSetRemoteAddressAfterSuccessfulConnect", testSetRemoteAddressAfterSuccessfulConnect),
                 ("testUnprocessedOutboundUserEventFailsOnEmbeddedChannel", testUnprocessedOutboundUserEventFailsOnEmbeddedChannel),
                 ("testEmbeddedChannelWritabilityIsWritable", testEmbeddedChannelWritabilityIsWritable),
+                ("testFinishWithRecursivelyScheduledTasks", testFinishWithRecursivelyScheduledTasks),
            ]
    }
 }

--- a/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
@@ -42,6 +42,8 @@ extension EmbeddedEventLoopTest {
                 ("testScheduledTasksFuturesError", testScheduledTasksFuturesError),
                 ("testTaskOrdering", testTaskOrdering),
                 ("testCancelledScheduledTasksDoNotHoldOnToRunClosure", testCancelledScheduledTasksDoNotHoldOnToRunClosure),
+                ("testDrainScheduledTasks", testDrainScheduledTasks),
+                ("testDrainScheduledTasksDoesNotRunNewlyScheduledTasks", testDrainScheduledTasksDoesNotRunNewlyScheduledTasks),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

EmbeddedChannel advanced time to the distant future so that all
scheduled tasks would be run. However, if tasks were recursively
scheduled by executing the already scheduled tasks then the channel
would never finish.

Modifications:

When calling finish() on EmbeddedChannel, only run the tasks which have
been scheduled at that point in time.

Result:

Recursively scheduled tasks terminate when finish-ing the
EmbeddedChannel.
