### PR TITLE
ByteBuffer implements Hashable

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -890,6 +890,15 @@ extension ByteBuffer: Equatable {
     }
 }
 
+extension ByteBuffer: Hashable {
+    /// The hash value for the readable bytes.
+    public func hash(into hasher: inout Hasher) {
+        self.withUnsafeReadableBytes { ptr in
+            hasher.combine(bytes: ptr)
+        }
+    }
+}
+
 extension ByteBuffer {
     /// Modify this `ByteBuffer` if this `ByteBuffer` is known to uniquely own its storage.
     ///

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -29,6 +29,7 @@ extension ByteBufferTest {
       return [
                 ("testAllocateAndCount", testAllocateAndCount),
                 ("testEqualsComparesReadBuffersOnly", testEqualsComparesReadBuffersOnly),
+                ("testHasherUsesReadBuffersOnly", testHasherUsesReadBuffersOnly),
                 ("testSimpleReadTest", testSimpleReadTest),
                 ("testSimpleWrites", testSimpleWrites),
                 ("testMakeSureUniquelyOwnedSliceDoesNotGetReallocatedOnWrite", testMakeSureUniquelyOwnedSliceDoesNotGetReallocatedOnWrite),

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -71,6 +71,31 @@ class ByteBufferTest: XCTestCase {
         otherBuffer.writeString("oh hi")
         XCTAssertEqual(otherBuffer, buf)
     }
+    
+    func testHasherUsesReadBuffersOnly() {
+        // Only cares about the read buffer
+        self.buf.clear()
+        self.buf.writeString("oh hi")
+
+        var hasher = Hasher()
+        // We need to force unwrap the implicitly unwrapped optional here in order to
+        // mark it as unwrapped for the compiler *before* the function call. Otherwise
+        // the implementation of the optional's conditional conformance is triggered,
+        // that will change the hash. For more information please see:
+        // https://github.com/apple/swift-nio/pull/1326
+        // https://bugs.swift.org/browse/SR-11975
+        hasher.combine(self.buf!)
+        let hash = hasher.finalize()
+        
+        var otherBuffer = allocator.buffer(capacity: 6)
+        otherBuffer.writeString("oh hi")
+
+        var otherHasher = Hasher()
+        otherHasher.combine(otherBuffer)
+        let otherHash = otherHasher.finalize()
+        
+        XCTAssertEqual(hash, otherHash)
+    }
 
     func testSimpleReadTest() throws {
         buf.withUnsafeReadableBytes { ptr in


### PR DESCRIPTION
Motivation:

`ByteBuffer` should implement the `Hashable` protocol as stated by: https://github.com/apple/swift-nio/issues/1320

Modifications:

Implemented the `Hashable` protocol for `ByteBuffer` and added a test `testHasherUsesReadBuffersOnly`.

Result:

`ByteBuffer` implements the `Hashable` protocol. The test `testHasherUsesReadBuffersOnly` is failing for the moment though.