### PR TITLE
Initializing HTTPMethod with String picks explicit value over catch all RAW(value)

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -1416,6 +1416,5 @@ extension HTTPMethod: RawRepresentable {
             default:
                 self = .RAW(value: rawValue)
         }
-        self = .RAW(value: rawValue)
     }
 }

--- a/Tests/NIOHTTP1Tests/HTTPTypesTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTypesTest+XCTest.swift
@@ -29,6 +29,7 @@ extension HTTPTypesTest {
       return [
                 ("testConvertToString", testConvertToString),
                 ("testConvertFromString", testConvertFromString),
+                ("testConvertFromStringToExplicitValue", testConvertFromStringToExplicitValue),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPTypesTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTypesTest.swift
@@ -92,5 +92,16 @@ final class HTTPTypesTest: XCTestCase {
         XCTAssertEqual(HTTPMethod(rawValue: "SOURCE"), .SOURCE)
         XCTAssertEqual(HTTPMethod(rawValue: "SOMETHINGELSE"), HTTPMethod.RAW(value: "SOMETHINGELSE"))
     }
+  
+    func testConvertFromStringToExplicitValue() {
+        switch HTTPMethod(rawValue: "GET") {
+        case .RAW(value: "GET"):
+            XCTFail("Expected \"GET\" to map to explicit .GET value and not .RAW(value: \"GET\")")
+        case .GET:
+            break // everything is awesome
+        default:
+            XCTFail("Unexpected case")
+        }
+    }
 }
 


### PR DESCRIPTION
Motivation:

When initializing an `HTTPMethod` with a `String` we currently switch over all expected values to pick an explicit value, only to overwrite the found explicit value with a catchall `RAW(value: String)`. This doesn’t make a ton of sense. This went unnoticed because we use the conditional conformance on `RawRepresentable` to be `Equatable`. But `switch`es  don’t use the `Equatable` protocol to match enums. The issue is visible there.

Modifications:

Added a testcase with a switch that fails, if the `.RAW(value: String)` value is used for `”GET”`. Removed the final overwrite in HTTPMethod(rawValue: String). Therefore the new test passes.

Result:

We can initialize the HTTPMethod with a String and get an explicit value.