### PR TITLE
Allow channel handlers to respond to Expect: 100-continue requests

### DIFF
--- a/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
@@ -299,9 +299,11 @@ public final class HTTPServerPipelineHandler: ChannelDuplexHandler, RemovableCha
         debugOnly {
             let res = self.unwrapOutboundIn(data)
             switch res {
-            case .head:
+            case .head(let head):
                 assert(self.nextExpectedOutboundMessage == .head)
-                self.nextExpectedOutboundMessage = .bodyOrEnd
+                if head.status != .`continue` {
+                    self.nextExpectedOutboundMessage = .bodyOrEnd
+                }
             case .body:
                 assert(self.nextExpectedOutboundMessage == .bodyOrEnd)
             case .end:

--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -58,9 +58,11 @@ public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler, Removab
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let res = self.unwrapOutboundIn(data)
         switch res {
-        case .head:
-            precondition(!self.hasUnterminatedResponse)
-            self.hasUnterminatedResponse = true
+        case .head(let head):
+            if head.status != .`continue` || self.hasUnterminatedResponse {
+                precondition(!self.hasUnterminatedResponse)
+                self.hasUnterminatedResponse = true
+            }
         case .body:
             precondition(self.hasUnterminatedResponse)
         case .end:

--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -59,8 +59,8 @@ public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler, Removab
         let res = self.unwrapOutboundIn(data)
         switch res {
         case .head(let head):
-            if head.status != .`continue` || self.hasUnterminatedResponse {
-                precondition(!self.hasUnterminatedResponse)
+            precondition(!self.hasUnterminatedResponse)
+            if head.status != .`continue` {
                 self.hasUnterminatedResponse = true
             }
         case .body:


### PR DESCRIPTION
Changed the HTTP response flow preconditions to allow for 100-continue heads

### Motivation:

Channel handlers need to be able to respond to Expect: 100-continue requests.

Easy to reproduce w/ curl, e.g.:
```
$ curl --verbose  -F a=10 -F b=20 http://localhost:1337/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 1337 (#0)
> POST / HTTP/1.1
> Host: localhost:1337
> User-Agent: curl/7.54.0
> Accept: */*
> Content-Length: 230
> Expect: 100-continue             // need to be able to respond to this
> Content-Type: multipart/form-data; boundary=------------------------0546700c49d7551e
> 
< HTTP/1.1 100 Continue           // w/ the patch
< HTTP/1.1 200 OK
< Content-Type: text/html
< transfer-encoding: chunked
```

Without the patch curl still works, but will wait a second or so w/ sending the request body until some timeout. Other clients may just timeout.

BTW: Not sure, maybe NIOHTTP2 needs the same patch?

### Modifications:

This doesn't change any actual code, just the incorrect assumptions in the preconditions.
100-continue heads can be sent multiple times until the actual response head is sent out.

### Result:

Channel handlers can write 100-continue heads to the NIOHTTP1 pipeline.