### PR TITLE
Correct NIOHTTPWebClientSocketUpgrader to NIOHTTPWebSocketClientUpgrader

### DIFF
--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -20,7 +20,7 @@ import NIOHTTP1
 /// This upgrader assumes that the `HTTPClientUpgradeHandler` will create and send the upgrade request. 
 /// This upgrader also assumes that the `HTTPClientUpgradeHandler` will appropriately mutate the
 /// pipeline to remove the HTTP `ChannelHandler`s.
-public final class NIOWebClientSocketUpgrader: NIOHTTPClientProtocolUpgrader {
+public final class NIOWebSocketClientUpgrader: NIOHTTPClientProtocolUpgrader {
     
     /// RFC 6455 specs this as the required entry in the Upgrade header.
     public let supportedProtocol: String = "websocket"

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -15,6 +15,9 @@
 import NIO
 import NIOHTTP1
 
+@available(*, deprecated, renamed: "NIOWebSocketClientUpgrader")
+typealias NIOWebClientSocketUpgrader = NIOWebSocketClientUpgrader
+
 /// A `HTTPClientProtocolUpgrader` that knows how to do the WebSocket upgrade dance.
 ///
 /// This upgrader assumes that the `HTTPClientUpgradeHandler` will create and send the upgrade request. 

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -16,7 +16,7 @@ import NIO
 import NIOHTTP1
 
 @available(*, deprecated, renamed: "NIOWebSocketClientUpgrader")
-typealias NIOWebClientSocketUpgrader = NIOWebSocketClientUpgrader
+public  typealias NIOWebClientSocketUpgrader = NIOWebSocketClientUpgrader
 
 /// A `HTTPClientProtocolUpgrader` that knows how to do the WebSocket upgrade dance.
 ///

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -16,7 +16,7 @@ import NIO
 import NIOHTTP1
 
 @available(*, deprecated, renamed: "NIOWebSocketClientUpgrader")
-public  typealias NIOWebClientSocketUpgrader = NIOWebSocketClientUpgrader
+public typealias NIOWebClientSocketUpgrader = NIOWebSocketClientUpgrader
 
 /// A `HTTPClientProtocolUpgrader` that knows how to do the WebSocket upgrade dance.
 ///

--- a/Sources/NIOWebSocketClient/main.swift
+++ b/Sources/NIOWebSocketClient/main.swift
@@ -166,7 +166,7 @@ let bootstrap = ClientBootstrap(group: group)
         
         let httpHandler = HTTPInitialRequestHandler()
         
-        let websocketUpgrader = NIOWebClientSocketUpgrader(requestKey: "OfS0wDaT5NoxF2gqm7Zj2YtetzM=",
+        let websocketUpgrader = NIOWebSocketClientUpgrader(requestKey: "OfS0wDaT5NoxF2gqm7Zj2YtetzM=",
                                                            upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
             channel.pipeline.addHandler(WebSocketPingPongHandler())
         })

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -531,3 +531,6 @@ extension WebSocketFrameDecoder {
         self.init(maxFrameSize: maxFrameSize)
     }
 }
+
+@available(*, deprecated, renamed: "NIOWebSocketClientUpgrader")
+typealias NIOWebClientSocketUpgrader = NIOWebSocketClientUpgrader

--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -531,6 +531,3 @@ extension WebSocketFrameDecoder {
         self.init(maxFrameSize: maxFrameSize)
     }
 }
-
-@available(*, deprecated, renamed: "NIOWebSocketClientUpgrader")
-typealias NIOWebClientSocketUpgrader = NIOWebSocketClientUpgrader

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -168,7 +168,7 @@ class WebSocketClientEndToEndTests: XCTestCase {
         let requestKey = "OfS0wDaT5NoxF2gqm7Zj2YtetzM="
         let responseKey = "yKEqitDFPE81FyIhKTm+ojBqigk="
 
-        let basicUpgrader = NIOWebClientSocketUpgrader(requestKey: requestKey,
+        let basicUpgrader = NIOWebSocketClientUpgrader(requestKey: requestKey,
                                                        upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
                 channel.pipeline.addHandler(WebSocketRecorderHandler())
         })
@@ -221,7 +221,7 @@ class WebSocketClientEndToEndTests: XCTestCase {
         
         let requestKey = "OfS0wDaT5NoxF2gqm7Zj2YtetzM="
         
-        let basicUpgrader = NIOWebClientSocketUpgrader(requestKey: requestKey,
+        let basicUpgrader = NIOWebSocketClientUpgrader(requestKey: requestKey,
                                                        upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
                                                         channel.pipeline.addHandler(WebSocketRecorderHandler())
         })
@@ -252,7 +252,7 @@ class WebSocketClientEndToEndTests: XCTestCase {
         let requestKey = "OfS0wDaT5NoxF2gqm7Zj2YtetzM="
         let responseKey = "notACorrectKeyL1am=F1y=nn="
         
-        let basicUpgrader = NIOWebClientSocketUpgrader(requestKey: requestKey,
+        let basicUpgrader = NIOWebSocketClientUpgrader(requestKey: requestKey,
                                                        upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
                                                         channel.pipeline.addHandler(WebSocketRecorderHandler())
         })
@@ -283,7 +283,7 @@ class WebSocketClientEndToEndTests: XCTestCase {
         let requestKey = "OfS0wDaT5NoxF2gqm7Zj2YtetzM="
         let responseKey = "yKEqitDFPE81FyIhKTm+ojBqigk="
         
-        let basicUpgrader = NIOWebClientSocketUpgrader(requestKey: requestKey,
+        let basicUpgrader = NIOWebSocketClientUpgrader(requestKey: requestKey,
                                                        upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
                                                         channel.pipeline.addHandler(WebSocketRecorderHandler())
         })
@@ -313,7 +313,7 @@ class WebSocketClientEndToEndTests: XCTestCase {
         
         let handler = WebSocketRecorderHandler()
         
-        let basicUpgrader = NIOWebClientSocketUpgrader(requestKey: "OfS0wDaT5NoxF2gqm7Zj2YtetzM=",
+        let basicUpgrader = NIOWebSocketClientUpgrader(requestKey: "OfS0wDaT5NoxF2gqm7Zj2YtetzM=",
                                                        upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
                                                         channel.pipeline.addHandler(handler)
         })


### PR DESCRIPTION
Correct 'NIOHTTPWebClientSocketUpgrader' class name to 'NIOHTTPWebSocketClientUpgrader' class name.

### Motivation:

The class name was a typo.
It is a client upgrader that upgrades WebSocket connections, so the updated name suits better.

### Modifications:

Change class name of ‘NIOHTTPWebClientSocketUpgrader’ to ‘NIOHTTPWebSocketClientUpgrader’.
Update the WebSocket client example that uses this class.
Add a typealias to allow the old class name to be used.

### Result:

Improved naming.