### PR TITLE
Change the byte to message decoder verifier example to be correct. Bug #1243

### DIFF
--- a/Sources/NIOTestUtils/ByteToMessageDecoderVerifier.swift
+++ b/Sources/NIOTestUtils/ByteToMessageDecoderVerifier.swift
@@ -47,8 +47,8 @@ public enum ByteToMessageDecoderVerifier {
     ///     exampleInput1.writeString("example-in1")
     ///     var exampleInput2 = channel.allocator.buffer(capacity: 16)
     ///     exampleInput2.writeString("example-in2")
-    ///     let expectedInOuts = [(exampleInput1, ExampleDecoderOutput("1")),
-    ///                           (exampleInput2, ExampleDecoderOutput("2"))
+    ///     let expectedInOuts = [(exampleInput1, [ExampleDecoderOutput("1")]),
+    ///                           (exampleInput2, [ExampleDecoderOutput("2")])
     ///                          ]
     ///     XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(inputOutputPairs: expectedInOuts,
     ///                                                                     decoderFactory: { ExampleDecoder() }))


### PR DESCRIPTION
Change the byte to message decoder verifier example to be correct.

### Motivation:

The byte to message decoder example on the ‘verifyDecoder’ method was not compiling.

### Modifications:

Added the example output objects to an array so that they match the method signature.

### Result:

The example is now compiling and can serve as the basis for creating an implementation from the example.