### PR TITLE
Read exactly UInt64's size from timerfd

### DIFF
--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -547,9 +547,9 @@ final class Selector<R: Registration> {
                 _ = try EventFd.eventfd_read(fd: self.eventFD, value: &val)
             case self.timerFD:
                 // Consume event
-                var val: UInt = 0
+                var val: UInt64 = 0
                 // We are not interested in the result
-                _ = Glibc.read(self.timerFD, &val, MemoryLayout<UInt>.size)
+                _ = Glibc.read(self.timerFD, &val, MemoryLayout.size(ofValue: val))
 
                 // Processed the earliest set timer so reset it.
                 self.earliestTimer = .distantFuture


### PR DESCRIPTION
On 32-bit systems we would try to read 4 byte, which is incorrect. From `man timerfd_read`:
> (...) then the buffer given to read(2) returns an unsigned 8-byte integer (uint64_t) containing the number of expirations that  have  occurred (...)
> A  read(2) will fail with the error EINVAL if the size of the supplied buffer is less than 8 bytes.

See #1337.