### PR TITLE
docker: support Swift 5.2 dev snapshots

### DIFF
--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -1,0 +1,43 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio:18.04-5.2
+    build:
+      args:
+        ubuntu_version: "bionic"
+        swift_version: "5.2"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2020-01-14-a"
+        swift_builds_suffix: "branch"
+
+  unit-tests:
+    image: swift-nio:18.04-5.2
+
+  integration-tests:
+    image: swift-nio:18.04-5.2
+
+  test:
+    image: swift-nio:18.04-5.2
+    environment:
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30600
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=592100
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
+      - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
+      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
+      - SANITIZER_ARG=--sanitize=thread
+
+  performance-test:
+    image: swift-nio:18.04-5.2
+
+  shell:
+    image: swift-nio:18.04-5.2
+
+  echo:
+    image: swift-nio:18.04-5.2
+
+  http:
+    image: swift-nio:18.04-5.2


### PR DESCRIPTION
Motivation:

We need to test on 5.2.

Modifications:

Add 5.2 dev snapshots to the docker setup.

Result:

More testing.