### PR TITLE
flushes from channelWritabilityChanged callbacks get lost

### DIFF
--- a/Sources/NIO/BaseStreamSocketChannel.swift
+++ b/Sources/NIO/BaseStreamSocketChannel.swift
@@ -150,11 +150,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         }, scalarFileWriteOperation: { descriptor, index, endIndex in
             try self.socket.sendFile(fd: descriptor, offset: index, count: endIndex - index)
         })
-        if result.writable {
-            // writable again
-            self.pipeline.fireChannelWritabilityChanged0()
-        }
-        return result.writeResult
+        return result
     }
 
     final override func close0(error: Error, mode: CloseMode, promise: EventLoopPromise<Void>?) {

--- a/Sources/NIO/PendingDatagramWritesManager.swift
+++ b/Sources/NIO/PendingDatagramWritesManager.swift
@@ -429,7 +429,7 @@ final class PendingDatagramWritesManager: PendingWritesManager {
     ///     - vectorWriteOperation: An operation that writes multiple contiguous arrays of bytes (usually `sendmmsg`).
     /// - returns: The `WriteResult` and whether the `Channel` is now writable.
     func triggerAppropriateWriteOperations(scalarWriteOperation: (UnsafeRawBufferPointer, UnsafePointer<sockaddr>, socklen_t) throws -> IOResult<Int>,
-                                           vectorWriteOperation: (UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int>) throws -> (writeResult: OverallWriteResult, writable: Bool) {
+                                           vectorWriteOperation: (UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int>) throws -> OverallWriteResult {
         return try self.triggerWriteOperations { writeMechanism in
             switch writeMechanism {
             case .scalarBufferWrite:

--- a/Sources/NIO/PendingWritesManager.swift
+++ b/Sources/NIO/PendingWritesManager.swift
@@ -85,12 +85,17 @@ internal enum OneWriteOperationResult {
 
 /// The result of trying to write all the outstanding flushed data. That naturally includes all `ByteBuffer`s and
 /// `FileRegions` and the individual writes have potentially been retried (see `WriteSpinOption`).
-internal enum OverallWriteResult {
-    /// Wrote all the data that was flushed. When receiving this result, we can unsubscribe from 'writable' notification.
-    case writtenCompletely
+internal struct OverallWriteResult {
+    enum WriteOutcome {
+        /// Wrote all the data that was flushed. When receiving this result, we can unsubscribe from 'writable' notification.
+        case writtenCompletely
 
-    /// Could not write everything. Before attempting further writes the eventing system should send a 'writable' notification.
-    case couldNotWriteEverything
+        /// Could not write everything. Before attempting further writes the eventing system should send a 'writable' notification.
+        case couldNotWriteEverything
+    }
+
+    internal var writeResult: WriteOutcome
+    internal var writabilityChange: Bool
 }
 
 /// This holds the states of the currently pending stream writes. The core is a `MarkedCircularBuffer` which holds all the
@@ -330,7 +335,7 @@ final class PendingStreamWritesManager: PendingWritesManager {
     /// - returns: The `OneWriteOperationResult` and whether the `Channel` is now writable.
     func triggerAppropriateWriteOperations(scalarBufferWriteOperation: (UnsafeRawBufferPointer) throws -> IOResult<Int>,
                                            vectorBufferWriteOperation: (UnsafeBufferPointer<IOVector>) throws -> IOResult<Int>,
-                                           scalarFileWriteOperation: (CInt, Int, Int) throws -> IOResult<Int>) throws -> (writeResult: OverallWriteResult, writable: Bool) {
+                                           scalarFileWriteOperation: (CInt, Int, Int) throws -> IOResult<Int>) throws -> OverallWriteResult {
         return try self.triggerWriteOperations { writeMechanism in
             switch writeMechanism {
             case .scalarBufferWrite:
@@ -460,15 +465,15 @@ extension PendingWritesManager {
         return self.channelWritabilityFlag.load()
     }
 
-    internal func triggerWriteOperations(triggerOneWriteOperation: (WriteMechanism) throws -> OneWriteOperationResult) throws -> (OverallWriteResult, Bool) {
+    internal func triggerWriteOperations(triggerOneWriteOperation: (WriteMechanism) throws -> OneWriteOperationResult) throws -> OverallWriteResult {
         let wasWritable = self.isWritable
-        var result: OverallWriteResult = .couldNotWriteEverything
+        var result = OverallWriteResult(writeResult: .couldNotWriteEverything, writabilityChange: false)
 
         writeSpinLoop: for _ in 0...self.writeSpinCount {
             var oneResult: OneWriteOperationResult
             repeat {
                 guard self.isOpen && self.isFlushPending else {
-                    result = .writtenCompletely
+                    result.writeResult = .writtenCompletely
                     break writeSpinLoop
                 }
 
@@ -481,8 +486,8 @@ extension PendingWritesManager {
 
         if !wasWritable {
             // Was not writable before so signal back to the caller the possible state change
-            return (result, self.isWritable)
+            result.writabilityChange = self.isWritable
         }
-        return (result, false)
+        return result
     }
 }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -590,12 +590,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         }, vectorWriteOperation: { msgs in
             try self.socket.sendmmsg(msgs: msgs)
         })
-        if result.writable {
-            // writable again
-            assert(self.isActive)
-            self.pipeline.fireChannelWritabilityChanged0()
-        }
-        return result.writeResult
+        return result
     }
 
     // MARK: Datagram Channel overrides not required by BaseSocketChannel

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -261,7 +261,7 @@ public final class ChannelTests: XCTestCase {
         var singleState = 0
         var multiState = 0
         var fileState = 0
-        let (result, _) = try pwm.triggerAppropriateWriteOperations(scalarBufferWriteOperation: { buf in
+        let result = try pwm.triggerAppropriateWriteOperations(scalarBufferWriteOperation: { buf in
             defer {
                 singleState += 1
                 everythingState += 1
@@ -395,7 +395,7 @@ public final class ChannelTests: XCTestCase {
 
             XCTAssertFalse(pwm.isEmpty)
             XCTAssertFalse(pwm.isFlushPending)
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                promises: ps,
@@ -404,7 +404,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: nil,
                                                returns: [],
                                                promiseStates: [[true, false]])
-            XCTAssertEqual(OverallWriteResult.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             pwm.markFlushCheckpoint()
 
@@ -415,7 +415,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: nil,
                                                returns: [.processed(0)],
                                                promiseStates: [[true, true]])
-            XCTAssertEqual(OverallWriteResult.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -441,7 +441,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: nil,
                                                    returns: [.processed(8)],
                                                    promiseStates: [[true, true, false]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             pwm.markFlushCheckpoint()
 
@@ -452,7 +452,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: nil,
                                                returns: [.processed(0)],
                                                promiseStates: [[true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -479,7 +479,7 @@ public final class ChannelTests: XCTestCase {
                                                    returns: [.processed(1), .wouldBlock(0)],
                 promiseStates: [[false, false, false, false], [false, false, false, false]])
 
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                promises: ps,
                                                expectedSingleWritabilities: nil,
@@ -489,7 +489,7 @@ public final class ChannelTests: XCTestCase {
                                                promiseStates: [[true, true, false, false], [true, true, false, false]]
 
                                                )
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
 
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                promises: ps,
@@ -498,7 +498,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: nil,
                                                returns: [.processed(8)],
                                                promiseStates: [[true, true, true, true], [true, true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -526,7 +526,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: nil,
                                                    returns: Array(repeating: .processed(1), count: numberOfBytes),
                                                    promiseStates: Array(repeating: [false], count: numberOfBytes))
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
 
             /* we'll now write the one last byte and assert that all the writes are complete */
             result = try assertExpectedWritability(pendingWritesManager: pwm,
@@ -536,7 +536,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: nil,
                                                returns: [.processed(1)],
                                                promiseStates: [[true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -581,7 +581,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: nil,
                                                    returns: Array(repeating: .processed(1), count: numberOfBytes),
                                                    promiseStates: expectedPromiseStates)
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
 
             /* we'll now write the one last byte and assert that all the writes are complete */
             result = try assertExpectedWritability(pendingWritesManager: pwm,
@@ -591,7 +591,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: nil,
                                                returns: [.processed(1)],
                                                promiseStates: [Array(repeating: true, count: numberOfBytes)])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -630,7 +630,7 @@ public final class ChannelTests: XCTestCase {
                                                        expectedFileWritabilities: Array(repeating: (0, 1), count: numberOfWrites / 2),
                                                        returns: Array(repeating: .processed(1), count: numberOfWrites),
                                                        promiseStates: expectedPromiseStates)
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -656,7 +656,7 @@ public final class ChannelTests: XCTestCase {
                                                        expectedFileWritabilities: nil,
                                                        returns: [.processed(2), .wouldBlock(0)],
                                                        promiseStates: [[false, false, false], [false, false, false]])
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
 
             pwm.failAll(error: ChannelError.operationUnsupported, close: true)
 
@@ -692,7 +692,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: nil,
                                                    returns: [.processed(2 * halfTheWriteVLimit), .processed(halfTheWriteVLimit)],
                                                    promiseStates: [[true, true, false], [true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -739,7 +739,7 @@ public final class ChannelTests: XCTestCase {
                                                     /*  Xcode   */ [true, false, false],
                                                     /*  needs   */ [true, false, false],
                                                     /*  help    */ [true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
             pwm.markFlushCheckpoint()
         }
     }
@@ -769,7 +769,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: [(12, 14)],
                                                    returns: [.processed(2)],
                                                    promiseStates: [[true, false]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                promises: ps,
@@ -778,7 +778,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: nil,
                                                returns: [],
                                                promiseStates: [[true, false]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             pwm.markFlushCheckpoint()
 
@@ -789,7 +789,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: [(0, 2), (1, 2)],
                                                returns: [.processed(1), .processed(1)],
                                                promiseStates: [[true, false], [true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -814,7 +814,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: [(99, 99)],
                                                    returns: [.processed(0)],
                                                    promiseStates: [[true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -860,7 +860,7 @@ public final class ChannelTests: XCTestCase {
                                                                    [true, true, true, true, false],
                                                                    [true, true, true, true, false],
                                                                    [true, true, true, true, false]])
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
 
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                promises: ps,
@@ -869,7 +869,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: [(6, 10)],
                                                returns: [.processed(4)],
                                                promiseStates: [[true, true, true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -910,7 +910,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: nil,
                                                    returns: [.processed(8)],
                                                    promiseStates: [[true, true, false]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             pwm.markFlushCheckpoint()
 
@@ -921,7 +921,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: nil,
                                                    returns: [.processed(0)],
                                                    promiseStates: [[true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -945,7 +945,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: nil,
                                                    returns: [.processed(0)],
                                                    promiseStates: [[true, true, false]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             pwm.markFlushCheckpoint()
 
@@ -956,7 +956,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: nil,
                                                returns: [.processed(0)],
                                                promiseStates: [[true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -984,7 +984,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: nil,
                                                    returns: [.processed(4)],
                                                    promiseStates: [[true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
             XCTAssertNoThrow(try ps[0].futureResult.wait())
             XCTAssertThrowsError(try ps[1].futureResult.wait())
             XCTAssertThrowsError(try ps[2].futureResult.wait())
@@ -1012,7 +1012,7 @@ public final class ChannelTests: XCTestCase {
                                                    returns: [.processed(4 * Socket.writevLimitIOVectors), .wouldBlock(0)],
                                                    promiseStates: [Array(repeating: true, count: Socket.writevLimitIOVectors) + [false],
                                                                    Array(repeating: true, count: Socket.writevLimitIOVectors) + [false]])
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                promises: ps,
                                                expectedSingleWritabilities: [4],
@@ -1020,7 +1020,7 @@ public final class ChannelTests: XCTestCase {
                                                expectedFileWritabilities: nil,
                                                returns: [.processed(4)],
                                                promiseStates: [Array(repeating: true, count: Socket.writevLimitIOVectors + 1)])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -1046,7 +1046,7 @@ public final class ChannelTests: XCTestCase {
                                                    expectedFileWritabilities: [(0, 8192)],
                                                    returns: [.wouldBlock(8192)],
                                                    promiseStates: [[true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
@@ -175,7 +175,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                     return IOResult.wouldBlock(-1 * (everythingState + 1))
                 }
             })
-            result = r.writeResult
+            result = r
         } catch {
             err = error
         }
@@ -248,7 +248,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
 
             XCTAssertFalse(pwm.isEmpty)
             XCTAssertFalse(pwm.isFlushPending)
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                    promises: ps,
@@ -256,7 +256,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    expectedVectorWritabilities: nil,
                                                    returns: [],
                                                    promiseStates: [[true, false]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             pwm.markFlushCheckpoint()
 
@@ -266,7 +266,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    expectedVectorWritabilities: nil,
                                                    returns: [.success(.processed(0))],
                                                    promiseStates: [[true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -293,7 +293,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        expectedVectorWritabilities: [[(4, firstAddress), (4, secondAddress)]],
                                                        returns: [.success(.processed(2))],
                                                        promiseStates: [[true, true, false]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             pwm.markFlushCheckpoint()
 
@@ -303,7 +303,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    expectedVectorWritabilities: nil,
                                                    returns: [.success(.processed(0))],
                                                    promiseStates: [[true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -334,7 +334,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        returns: [.success(.processed(1)), .success(.wouldBlock(0))],
                                                        promiseStates: [[true, false, false, false], [true, false, false, false]])
 
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                    promises: ps,
                                                    expectedSingleWritabilities: [(4, secondAddress)],
@@ -345,7 +345,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    promiseStates: [[true, true, true, false], [true, true, true, false]]
 
             )
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
 
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                    promises: ps,
@@ -353,7 +353,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    expectedVectorWritabilities: nil,
                                                    returns: [.success(.processed(4))],
                                                    promiseStates: [[true, true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -383,7 +383,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        expectedVectorWritabilities: Array(actualVectorWritabilities),
                                                        returns: Array(repeating: .success(.processed(1)), count: ps.count - 1),
                                                        promiseStates: actualPromiseStates)
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
 
             /* we'll now write the one last datagram and assert that all the writes are complete */
             result = try assertExpectedWritability(pendingWritesManager: pwm,
@@ -392,7 +392,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    expectedVectorWritabilities: nil,
                                                    returns: [.success(.processed(12))],
                                                    promiseStates: [Array(repeating: true, count: ps.count - 1) + [true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -417,7 +417,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        expectedVectorWritabilities: [[(4, address), (4, address)]],
                                                        returns: [.success(.wouldBlock(0))],
                                                        promiseStates: [[false, false, false], [false, false, false]])
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
 
             pwm.failAll(error: ChannelError.operationUnsupported, close: true)
 
@@ -453,7 +453,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        expectedVectorWritabilities: [[(halfTheWriteVLimit, address), (halfTheWriteVLimit, address)]],
                                                        returns: [.success(.processed(2)), .success(.processed(1))],
                                                        promiseStates: [[true, true, false], [true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -496,7 +496,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                             .success(.processed(1))],
                                                        promiseStates: [[true, false, false], [true, true, false], [true, true, true]])
 
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             XCTAssertNoThrow(try ps[1].futureResult.wait())
             XCTAssertNoThrow(try ps[2].futureResult.wait())
@@ -531,7 +531,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        expectedVectorWritabilities: [[(0, address), (0, address)]],
                                                        returns: [.success(.processed(2))],
                                                        promiseStates: [[true, true, false]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
 
             pwm.markFlushCheckpoint()
 
@@ -541,7 +541,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                    expectedVectorWritabilities: nil,
                                                    returns: [.success(.processed(0))],
                                                    promiseStates: [[true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 
@@ -569,7 +569,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        expectedVectorWritabilities: [[(4, address), (4, address)]],
                                                        returns: [.success(.processed(1))],
                                                        promiseStates: [[true, true, true]])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
             XCTAssertNoThrow(try ps[0].futureResult.wait())
             XCTAssertThrowsError(try ps[1].futureResult.wait())
             XCTAssertThrowsError(try ps[2].futureResult.wait())
@@ -597,14 +597,14 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                                        returns: [.success(.processed(Socket.writevLimitIOVectors)), .success(.wouldBlock(0))],
                                                        promiseStates: [Array(repeating: true, count: Socket.writevLimitIOVectors) + [false],
                                                                        Array(repeating: true, count: Socket.writevLimitIOVectors) + [false]])
-            XCTAssertEqual(.couldNotWriteEverything, result)
+            XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
             result = try assertExpectedWritability(pendingWritesManager: pwm,
                                                    promises: ps,
                                                    expectedSingleWritabilities: [(4, address)],
                                                    expectedVectorWritabilities: nil,
                                                    returns: [.success(.processed(4))],
                                                    promiseStates: [Array(repeating: true, count: Socket.writevLimitIOVectors + 1)])
-            XCTAssertEqual(.writtenCompletely, result)
+            XCTAssertEqual(.writtenCompletely, result.writeResult)
         }
     }
 }

--- a/Tests/NIOTests/StreamChannelsTest+XCTest.swift
+++ b/Tests/NIOTests/StreamChannelsTest+XCTest.swift
@@ -36,6 +36,9 @@ extension StreamChannelTest {
                 ("testWriteFailsAfterOutputClosed", testWriteFailsAfterOutputClosed),
                 ("testVectorWrites", testVectorWrites),
                 ("testLotsOfWritesWhilstOtherSideNotReading", testLotsOfWritesWhilstOtherSideNotReading),
+                ("testFlushInWritePromise", testFlushInWritePromise),
+                ("testWriteAndFlushInChannelWritabilityChangedToTrue", testWriteAndFlushInChannelWritabilityChangedToTrue),
+                ("testWritabilityChangedDoesNotGetCalledOnSimpleWrite", testWritabilityChangedDoesNotGetCalledOnSimpleWrite),
            ]
    }
 }


### PR DESCRIPTION
### Motivation:

In SwiftNIO, when we send `channelWritabilityChanged` notifications, we are still in `flushNow`. If we now see a `writeAndFlush` from that user callout, we will re-enter `flushNow` which `flushNow` protects against. Therefore, we can lose `flush`es if the user does a `writeAndFlush` from `channelWritabilityChanged` which is very bad.

### Modifications:

- fix the issue
- add a regression test

### Result:

- fixes rdar://58571521