### PR TITLE
Add setSubstring/writeSubstring to ByteBuffer

### DIFF
--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -37,6 +37,8 @@ extension ByteBufferTest {
                 ("testReadWrite", testReadWrite),
                 ("testStaticStringReadTests", testStaticStringReadTests),
                 ("testString", testString),
+                ("testWriteSubstring", testWriteSubstring),
+                ("testSetSubstring", testSetSubstring),
                 ("testSliceEasy", testSliceEasy),
                 ("testWriteStringMovesWriterIndex", testWriteStringMovesWriterIndex),
                 ("testSetExpandsBufferOnUpperBoundsCheckFailure", testSetExpandsBufferOnUpperBoundsCheckFailure),

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -201,6 +201,35 @@ class ByteBufferTest: XCTestCase {
         let string = buf.getString(at: 0, length: written)
         XCTAssertEqual("Hello", string)
     }
+    
+    func testWriteSubstring() {
+        var text = "Hello"
+        let written = buf.writeSubstring(text[...])
+        var string = buf.getString(at: 0, length: written)
+        XCTAssertEqual(text, string)
+        
+        text = ""
+        buf.writeSubstring(text[...])
+        string = buf.getString(at: 0, length: written)
+        XCTAssertEqual("Hello", string)
+    }
+    
+    func testSetSubstring() {
+        let text = "Hello"
+        buf.writeSubstring(text[...])
+        
+        var written = buf.setSubstring(text[...], at: 0)
+        var string = buf.getString(at: 0, length: written)
+        XCTAssertEqual(text, string)
+        
+        written = buf.setSubstring(text[text.index(after: text.startIndex)...], at: 1)
+        string = buf.getString(at: 0, length: written + 1)
+        XCTAssertEqual(text, string)
+        
+        written = buf.setSubstring(text[text.index(after: text.startIndex)...], at: 0)
+        string = buf.getString(at: 0, length: written)
+        XCTAssertEqual("ello", string)
+    }
 
     func testSliceEasy() {
         buf.writeString("0123456789abcdefg")


### PR DESCRIPTION
### Motivation:

The `ByteBuffer` API currently has `setString`/`writeString` support for the `String`
type but no support for the `Substring` type (see #1332).

### Modifications:

Add `setSubstring`/`writeSubstring` functions to `ByteBuffer`. We do not change
the exisiting set-/writeString API to take a generic `StringProtocol` argument
as it would change the ABI and adds performance overhead. We also do not let
`setString` call into `setSubstring` for now, as Substring currently (as of
Swift 5.1.3) has no fast access to the backing storage and this therefore would
introduce a performance regression.

### Result:

ByteBuffer API for writing Substrings.