### PR TITLE
Rename misnamed closure parameter argument in ServerBootstrap.bind0

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -202,7 +202,7 @@ public final class ServerBootstrap {
                                            protocolFamily: address.protocolFamily)
         }
 
-        return bind0(makeServerChannel: makeChannel) { (eventGroup, serverChannel) in
+        return bind0(makeServerChannel: makeChannel) { (eventLoop, serverChannel) in
             serverChannel.registerAndDoSynchronously { serverChannel in
                 serverChannel.bind(to: address)
             }


### PR DESCRIPTION
### Motivation:

Non-functional change: `bind0(_ makeSocketAddress: () throws -> SocketAddress)
-> EventLoopFuture<Channel>` calls `bind0` with a `register` closure that is
passed an event loop as first argument. However, the name of the first parameter
of the closure declaration is named "eventGroup" which is confusing. It should
therefore be renamed to "eventLoop" which is consistent with other closures
passed as `register` arguments at other callsites.

### Modifications:

Rename (unused) closure parameter "eventGroup" to "eventLoop".

### Result:

Improved code readability.