### PR TITLE
improve flushNow re-entrancy protection

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -415,6 +415,11 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         fatalError("this must be overridden by sub class")
     }
 
+    /// Returns if there are any flushed, pending writes to be sent over the network.
+    func hasFlushedPendingWrites() -> Bool {
+        fatalError("this must be overridden by sub class")
+    }
+
     /// Buffer a write in preparation for a flush.
     func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
         fatalError("this must be overridden by sub class")
@@ -471,43 +476,44 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
 
     /// Flush data to the underlying socket and return if this socket needs to be registered for write notifications.
     ///
-    /// - returns: If this socket should be registered for write notifications. Ie. `IONotificationState.register` if _not_ all data could be written, so notifications are necessary; and `IONotificationState.unregister` if everything was written and we don't need to be notified about writability at the moment.
+    /// This method can be called re-entrantly but it will return immediately because the first call is responsible
+    /// for sending all flushed writes, even the ones that are accumulated whilst `flushNow()` is running.
+    ///
+    /// - returns: If this socket should be registered for write notifications. Ie. `IONotificationState.register` if
+    ///            _not_ all data could be written, so notifications are necessary; and `IONotificationState.unregister`
+    ///             if everything was written and we don't need to be notified about writability at the moment.
     func flushNow() -> IONotificationState {
         self.eventLoop.assertInEventLoop()
+
         // Guard against re-entry as data that will be put into `pendingWrites` will just be picked up by
         // `writeToSocket`.
-        guard !self.inFlushNow && self.isOpen else {
+        guard !self.inFlushNow else {
             return .unregister
         }
 
-        do {
-            var writeResult: OverallWriteResult? = nil
+        assert(!self.inFlushNow)
+        self.inFlushNow = true
+        defer {
+            self.inFlushNow = false
+        }
 
-            defer {
-                if writeResult?.writabilityChange == .some(true) {
+        var newWriteRegistrationState: IONotificationState = .unregister
+        do {
+            while newWriteRegistrationState == .unregister && self.hasFlushedPendingWrites() && self.isOpen {
+                assert(self.lifecycleManager.isActive)
+                let writeResult = try self.writeToSocket()
+                switch writeResult.writeResult {
+                case .couldNotWriteEverything:
+                    newWriteRegistrationState = .register
+                case .writtenCompletely:
+                    newWriteRegistrationState = .unregister
+                }
+
+                if writeResult.writabilityChange {
                     // We went from not writable to writable.
                     self.pipeline.fireChannelWritabilityChanged0()
                 }
             }
-
-            do {
-                assert(!self.inFlushNow)
-                self.inFlushNow = true
-                defer {
-                    self.inFlushNow = false
-                }
-
-                assert(self.lifecycleManager.isActive)
-                writeResult = try self.writeToSocket()
-                switch writeResult!.writeResult {
-                case .couldNotWriteEverything:
-                    return .register
-                case .writtenCompletely:
-                    return .unregister
-                }
-            }
-
-
         } catch let err {
             // If there is a write error we should try drain the inbound before closing the socket as there may be some data pending.
             // We ignore any error that is thrown as we will use the original err to close the channel and notify the user.
@@ -529,8 +535,12 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
             // we handled all writes
             return .unregister
         }
-    }
 
+        assert((newWriteRegistrationState == .register && self.hasFlushedPendingWrites()) ||
+               (newWriteRegistrationState == .unregister && !self.hasFlushedPendingWrites()),
+               "illegal flushNow decision: \(newWriteRegistrationState) and \(self.hasFlushedPendingWrites())")
+        return newWriteRegistrationState
+    }
 
     public final func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> EventLoopFuture<Void> {
         if eventLoop.inEventLoop {
@@ -905,9 +915,14 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         assert(self.isOpen)
 
         self.finishConnect()  // If we were connecting, that has finished.
-        if self.flushNow() == .unregister {
-            // Everything was written or connect was complete
+
+        switch self.flushNow() {
+        case .unregister:
+            // Everything was written or connect was complete, let's unregister from writable.
             self.finishWritable()
+        case .register:
+            assert(!self.isOpen || self.interestedEvent.contains(.write))
+            () // nothing to do because given that we just received `writable`, we're still registered for writable.
         }
     }
 
@@ -941,6 +956,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
 
         if self.isOpen {
             assert(self.lifecycleManager.isPreRegistered)
+            assert(!self.hasFlushedPendingWrites())
             self.unregisterForWritable()
         }
     }

--- a/Sources/NIO/BaseStreamSocketChannel.swift
+++ b/Sources/NIO/BaseStreamSocketChannel.swift
@@ -200,6 +200,10 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         }
     }
 
+    final override func hasFlushedPendingWrites() -> Bool {
+        return self.pendingWrites.isFlushPending
+    }
+
     final override func markFlushPoint() {
         // Even if writable() will be called later by the EventLoop we still need to mark the flush checkpoint so we are sure all the flushed messages
         // are actually written once writable() is called.

--- a/Sources/NIO/PendingWritesManager.swift
+++ b/Sources/NIO/PendingWritesManager.swift
@@ -501,3 +501,10 @@ extension PendingWritesManager {
         return result
     }
 }
+
+extension PendingStreamWritesManager: CustomStringConvertible {
+    var description: String {
+        return "PendingStreamWritesManager { isFlushPending: \(self.isFlushPending), " +
+        /*  */ "writabilityFlag: \(self.channelWritabilityFlag.load())), state: \(self.state) }"
+    }
+}

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -291,6 +291,10 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         }
     }
 
+    override func hasFlushedPendingWrites() -> Bool {
+        return false
+    }
+
     override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
         promise?.fail(ChannelError.operationUnsupported)
     }
@@ -561,6 +565,10 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             assert(self.isActive)
             pipeline.fireChannelWritabilityChanged0()
         }
+    }
+
+    override final func hasFlushedPendingWrites() -> Bool {
+        return self.pendingWrites.isFlushPending
     }
 
     /// Mark a flush point. This is called when flush is received, and instructs

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -82,6 +82,7 @@ extension ChannelTests {
                 ("testTCP_NODELAYisOnByDefault", testTCP_NODELAYisOnByDefault),
                 ("testDescriptionCanBeCalledFromNonEventLoopThreads", testDescriptionCanBeCalledFromNonEventLoopThreads),
                 ("testFixedSizeRecvByteBufferAllocatorSizeIsConstant", testFixedSizeRecvByteBufferAllocatorSizeIsConstant),
+                ("testCloseInConnectPromise", testCloseInConnectPromise),
            ]
    }
 }

--- a/Tests/NIOTests/StreamChannelsTest+XCTest.swift
+++ b/Tests/NIOTests/StreamChannelsTest+XCTest.swift
@@ -39,6 +39,8 @@ extension StreamChannelTest {
                 ("testFlushInWritePromise", testFlushInWritePromise),
                 ("testWriteAndFlushInChannelWritabilityChangedToTrue", testWriteAndFlushInChannelWritabilityChangedToTrue),
                 ("testWritabilityChangedDoesNotGetCalledOnSimpleWrite", testWritabilityChangedDoesNotGetCalledOnSimpleWrite),
+                ("testWriteAndFlushFromReentrantFlushNowTriggeredOutOfWritabilityWhereOuterSaysAllWrittenAndInnerDoesNot", testWriteAndFlushFromReentrantFlushNowTriggeredOutOfWritabilityWhereOuterSaysAllWrittenAndInnerDoesNot),
+                ("testCloseInReEntrantFlushNowCall", testCloseInReEntrantFlushNowCall),
            ]
    }
 }


### PR DESCRIPTION
## Motivation

The fix in #1344 wasn't complete, there is another, quite complicated scenario where we would still forget to send flushed bytes until we see another `flush` call. The scenario is

         1: writable()
         2: --> flushNow (result: .writtenCompletely)
         3:     --> writabilityChanged callout
         4:         --> flushNow because user calls writeAndFlush (result: .couldNotWriteEverything)
         5:         --> registerForWritable (because line 4 could not write everything and flushNow returned .register)
         6: --> unregisterForWritable (because line 2 wrote everything and flushNow returned .unregister)

Line 6 undoes the registeration in line 5.

## Modification

This fix makes sure that flushNow never re-enters and therefore the problem described above cannot happen anymore.

## Result

Hopefully actually fixes rdar://58571521
