### PR TITLE
Add bindTimeout function to ServerBootstrap

### DIFF
--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -145,6 +145,14 @@ public final class ServerBootstrap {
         return self
     }
 
+    /// Specifies a timeout to apply to a bind attempt. Currently unsupported.
+    ///
+    /// - parameters:
+    ///     - timeout: The timeout that will apply to the bind attempt.
+    public func bindTimeout(_ timeout: TimeAmount) -> Self {
+        return self
+    }
+
     /// Bind the `ServerSocketChannel` to `host` and `port`.
     ///
     /// - parameters:

--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -33,6 +33,7 @@ extension BootstrapTest {
                 ("testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
                 ("testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
                 ("testTCPClientBootstrapAllowsConformanceCorrectly", testTCPClientBootstrapAllowsConformanceCorrectly),
+                ("testServerBootstrapBindTimeout", testServerBootstrapBindTimeout),
            ]
    }
 }

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -246,4 +246,20 @@ class BootstrapTest: XCTestCase {
             XCTFail("Did not generate a valid Bootstrap")
         }
     }
+    
+    func testServerBootstrapBindTimeout() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        // Set a bindTimeout and call bind. Setting a bind timeout is currently unsupported
+        // by ServerBootstrap. We therefore expect the bind timeout to be ignored and bind to
+        // succeed, even with a minimal bind timeout.
+        let bootstrap = ServerBootstrap(group: group)
+            .bindTimeout(.nanoseconds(0))
+
+        let channel = try assertNoThrowWithValue(bootstrap.bind(host: "127.0.0.1", port: 0).wait())
+        XCTAssertNoThrow(try channel.close().wait())
+    }
 }


### PR DESCRIPTION
### Motivation:

We add an empty `bindTimeout` function to `ServerBootstrap`. While
ServerBootstrap itself is based on a blocking socket bind operation, this
enables the possibility of having bind be asynchronous in other use cases and
it unifies the API with other Bootstrap classes, e.g. `NIOTSListenerBootstrap`.
See also #1135.

### Modifications:

Add `bindTimeout` function to `ServerBootstrap`.
Add `Bootstrap.testServerBootstrapBindTimeout` test.

### Result:

`ServerBootstrap` has a `bindTimeout` function/API compatibility with other
Bootstrap classes.