### PR TITLE
Recursive file reading not building up EventLoopFuture chain

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -33,7 +33,7 @@ services:
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=250050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -33,7 +33,7 @@ services:
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=270050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=230050
 
   performance-test:
     image: swift-nio:18.04-5.0


### PR DESCRIPTION
### Motivation:

After a long discussion with @adam-fowler today in aws-sdk-swift about how to recursively build a streaming interface (see https://github.com/swift-aws/aws-sdk-swift-core/pull/181), we came to the conclusion that it’s probably for the best not to build up an EventLoopFuture chain, since all EventLoopFutures are kept in memory while iterating. It would be better to create a promise that is captured by the recursive function, because in this case the internal EventLoopFutures can be released.

The memory footprint should be O(1) instead O(n) with a EventLoopFuture chain.

Later today, @adam-fowler made me aware of this code in NIO and that it uses a chain.

### Modifications:

```swift
_read(remainingReads: Int, bytesReadSoFar: Int64)
```

The internal read function no longer returns an EventLoopFuture. All Futures end with an `whenSuccess` or `whenFailure` case.

### Result:

From my understanding the memory footprint should be reduced when reading large files. The interface stays completely the same.