### PR TITLE
adding an extra test for reading many chunks

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_read_10000_chunks_from_file.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_read_10000_chunks_from_file.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Dispatch
+import NIO
+import NIOConcurrencyHelpers
+
+func run(identifier: String) {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer {
+        try! group.syncShutdownGracefully()
+    }
+    let loop = group.next()
+    let threadPool = NIOThreadPool(numberOfThreads: 1)
+    threadPool.start()
+    defer {
+        try! threadPool.syncShutdownGracefully()
+    }
+    let fileIO = NonBlockingFileIO(threadPool: threadPool)
+
+    let numberOfChunks = 10_000
+    let dg = DispatchGroup()
+
+    let allocator = ByteBufferAllocator()
+    var fileBuffer = allocator.buffer(capacity: numberOfChunks)
+    fileBuffer.writeString(String(repeating: "X", count: numberOfChunks))
+    let path = NSTemporaryDirectory() + "/\(UUID())"
+    let fileHandle = try! NIOFileHandle(path: path,
+                                        mode: [.write, .read],
+                                        flags: .allowFileCreation(posixMode: 0o600))
+    defer {
+        unlink(path)
+    }
+    try! fileIO.write(fileHandle: fileHandle,
+                      buffer: fileBuffer,
+                      eventLoop: loop).wait()
+
+    let numberOfBytes = NIOAtomic<Int>.makeAtomic(value: 0)
+    measure(identifier: identifier) {
+        numberOfBytes.store(0)
+        try! fileIO.readChunked(fileHandle: fileHandle,
+                                fromOffset: 0,
+                                byteCount: numberOfChunks,
+                                chunkSize: 1,
+                                allocator: allocator,
+                                eventLoop: loop) { buffer in
+                _ = numberOfBytes.add(buffer.readableBytes)
+                return loop.makeSucceededFuture(())
+        }.wait()
+        precondition(numberOfBytes.load() == numberOfChunks, "\(numberOfBytes.load()), \(numberOfChunks)")
+        return numberOfBytes.load()
+    }
+}

--- a/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
@@ -65,6 +65,7 @@ extension NonBlockingFileIOTest {
                 ("testReadFromOffsetAfterEOFDeliversExactlyOneChunk", testReadFromOffsetAfterEOFDeliversExactlyOneChunk),
                 ("testReadFromEOFDeliversExactlyOneChunk", testReadFromEOFDeliversExactlyOneChunk),
                 ("testReadChunkedFromOffsetFileRegion", testReadChunkedFromOffsetFileRegion),
+                ("testReadManyChunks", testReadManyChunks),
            ]
    }
 }

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -33,6 +33,7 @@ services:
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=250050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -33,7 +33,7 @@ services:
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=250050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=270050
 
   performance-test:
     image: swift-nio:18.04-5.0

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -33,6 +33,7 @@ services:
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=250050
 
   performance-test:
     image: swift-nio:18.04-5.0

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/2017-201[89]/YEARS/' -e 's/2019/YEARS/'
+    sed -e 's/20[12][78901]-20[12][8901]/YEARS/' -e 's/20[12][8901]/YEARS/'
 }
 
 printf "=> Checking linux tests... "


### PR DESCRIPTION
### Motivation:

We got a great PR #1353 and I thought it'd be great to add a test that specifically tests the 'many chunks' case.

### Modifications:

- add a case that reads a file in 3000 chunks.
- add an allocation counter test reading 10000 chunks.

### Result:

more tests.