### PR TITLE
fix docker setup for development snapshots

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 ARG swift_version=5.0
 ARG ubuntu_version=bionic
-FROM swift:$swift_version-$ubuntu_version
+ARG base_image=swift:$swift_version-$ubuntu_version
+FROM $base_image
 # needed to do again after FROM due to docker limitation
 ARG swift_version
 ARG ubuntu_version

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -6,10 +6,7 @@ services:
     image: swift-nio:18.04-5.2
     build:
       args:
-        ubuntu_version: "bionic"
-        swift_version: "5.2"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2020-01-14-a"
-        swift_builds_suffix: "branch"
+        base_image: "swiftlang/swift:nightly-5.2-bionic"
 
   unit-tests:
     image: swift-nio:18.04-5.2


### PR DESCRIPTION
motivation: test against 5.2 development snapshots

changes:
* update Dockerfile so that a custom base image can be selected
* update 5.2 docker-compose file to use the nighly docker images for 5.2
