### PR TITLE
first Swift 5.2 (on 18.04) allocation limits

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Sources/HookedFunctions/src/hooked-functions.c
+++ b/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Sources/HookedFunctions/src/hooked-functions.c
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #define _GNU_SOURCE
+#define __USE_GNU
 #include <atomic-counter.h>
 #include <dlfcn.h>
 #include <fcntl.h>

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -17,14 +17,22 @@ services:
   test:
     image: swift-nio:18.04-5.2
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30600
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=592100
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4600
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=493050 # 5.2 regression 3000
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=99100
-      - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
+      - MAX_ALLOCS_ALLOWED_creating_10000_headers=100 # 5.2 improvement 10000
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=4010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
+      - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010 # 5.2 improvement 4000
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:


### PR DESCRIPTION
## Motivation

We need good allocation count levels for all platforms.

## Modification

This PR seeds 5.2 with a full set that is bootstrapped from the existing 5.1 set and modified where necessary (alongside comments)

## Result

Got a baseline