### PR TITLE
fix #1363: fix race between EL exit and wakeup call

### DIFF
--- a/Tests/NIOTests/SyscallAbstractionLayer.swift
+++ b/Tests/NIOTests/SyscallAbstractionLayer.swift
@@ -508,7 +508,10 @@ extension SALTest {
             XCTAssertNil(error, "unexpected error: \(error!)")
             group.leave()
         })
-        XCTAssertNoThrow(try self.assertWakeup())
+        // We're in a slightly tricky situation here. We don't know if the EventLoop thread enters `whenReady` again
+        // or not. If it has, we have to wake it up, so let's just put a return value in the 'kernel to user' box, just
+        // in case :)
+        XCTAssertNoThrow(try self.kernelToUserBox.waitForEmptyAndSet(.returnSelectorEvent(nil)))
         group.wait()
 
         self.group = nil


### PR DESCRIPTION
## Motivation:

The problem that manifested in #1363 was that when we told the EL to exit, it would sometimes exit straight away and sometimes go around its loop one more time and call `whenReady`, waiting for a wakeup. Previously, we assumed that it would always wait for a wakeup which isn't true.

### Modifications:

Offer it a wakeup if it needs to but don't require it.

### Result:

- fixes #1363 