### PR TITLE
include clang modularised headers last

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Sources/HookedFunctions/src/hooked-functions.c
+++ b/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Sources/HookedFunctions/src/hooked-functions.c
@@ -13,11 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 #define _GNU_SOURCE
-#define __USE_GNU
-#include <atomic-counter.h>
 #include <dlfcn.h>
 #include <fcntl.h>
-#include <hooked-functions.h>
 #include <inttypes.h>
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -27,6 +24,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include <atomic-counter.h>
+#include <hooked-functions.h>
 
 /* a big block of memory that we'll use for recursive mallocs */
 static char g_recursive_malloc_mem[10 * 1024 * 1024] = {0};


### PR DESCRIPTION
Motivation:

Clang modules seem to mess with stuff like _GNU_SOURCE as soon as
they're included. We do need _GNU_SOURCE (but don't like the
`#define __USE_GNU` hack).

Modifications:

Include the modularised headers last.

Result:

Alloc counter tests work without `#define __USE_GNU`.