### PR TITLE
switch swift-tools-version to 5.0 for integration tests

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
+++ b/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
@@ -103,7 +103,7 @@ function dir_basename() {
 
 function fake_package_swift() {
     cat > Package.swift <<EOF
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(name: "$1")

--- a/IntegrationTests/tests_02_syscall_wrappers/defines.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/defines.sh
@@ -17,7 +17,7 @@ set -eu
 
 function make_package() {
     cat > "$tmpdir/syscallwrapper/Package.swift" <<"EOF"
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Motivation:

Some integration tests still used swift-tools-version:4.0.

Modifications:

Make it 5.0

Result:

Run the compiler in a sensible mode.