### PR TITLE
apply ChannelOptions before channel initializer runs

### DIFF
--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -34,6 +34,11 @@ extension BootstrapTest {
                 ("testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers", testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers),
                 ("testTCPClientBootstrapAllowsConformanceCorrectly", testTCPClientBootstrapAllowsConformanceCorrectly),
                 ("testServerBootstrapBindTimeout", testServerBootstrapBindTimeout),
+                ("testServerBootstrapSetsChannelOptionsBeforeChannelInitializer", testServerBootstrapSetsChannelOptionsBeforeChannelInitializer),
+                ("testClientBootstrapSetsChannelOptionsBeforeChannelInitializer", testClientBootstrapSetsChannelOptionsBeforeChannelInitializer),
+                ("testPreConnectedSocketSetsChannelOptionsBeforeChannelInitializer", testPreConnectedSocketSetsChannelOptionsBeforeChannelInitializer),
+                ("testDatagramBootstrapSetsChannelOptionsBeforeChannelInitializer", testDatagramBootstrapSetsChannelOptionsBeforeChannelInitializer),
+                ("testPipeBootstrapSetsChannelOptionsBeforeChannelInitializer", testPipeBootstrapSetsChannelOptionsBeforeChannelInitializer),
            ]
    }
 }

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -518,6 +518,25 @@ func forEachActiveChannelType<T>(file: StaticString = #file,
     }
 }
 
+func withTCPServerChannel<R>(bindTarget: SocketAddress? = nil,
+                             group: EventLoopGroup,
+                             file: StaticString = #file,
+                             line: UInt = #line,
+                             _ body: (Channel) throws -> R) throws -> R {
+    let server = try ServerBootstrap(group: group)
+        .serverChannelOption(ChannelOptions.socket(.init(SOL_SOCKET), .init(SO_REUSEADDR)), value: 1)
+        .bind(to: bindTarget ?? .init(ipAddress: "127.0.0.1", port: 0))
+        .wait()
+    do {
+        let result = try body(server)
+        try server.close().wait()
+        return result
+    } catch {
+        try? server.close().wait()
+        throw error
+    }
+}
+
 func withCrossConnectedSockAddrChannels<R>(bindTarget: SocketAddress,
                                            forceSeparateEventLoops: Bool = false,
                                            file: StaticString = #file,


### PR DESCRIPTION
Motivation:

The channel initializers should see the the Channel after the options
have been applied so they can potentially override the options.

Modifications:

Set the options before the channel initialiser rather than after.

Result:

- More sense, more compatibility with Netty
- fixes #1114