### PR TITLE
ByteBuffer: make getInteger for UInt8 faster

### DIFF
--- a/Sources/NIO/ByteBuffer-int.swift
+++ b/Sources/NIO/ByteBuffer-int.swift
@@ -51,6 +51,14 @@ extension ByteBuffer {
         guard let range = self.rangeWithinReadableBytes(index: index, length: MemoryLayout<T>.size) else {
             return nil
         }
+
+        if T.self == UInt8.self {
+            assert(range.count == 1)
+            return self.withUnsafeReadableBytes { ptr in
+                ptr[range.startIndex] as! T
+            }
+        }
+
         return self.withUnsafeReadableBytes { ptr in
             var value: T = 0
             withUnsafeMutableBytes(of: &value) { valuePtr in

--- a/Sources/NIOPerformanceTester/ByteBufferViewIteratorBenchmark.swift
+++ b/Sources/NIOPerformanceTester/ByteBufferViewIteratorBenchmark.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIO
+
+final class ByteBufferViewIteratorBenchmark: Benchmark {
+    private let iterations: Int
+    private let bufferSize: Int
+    private var buffer: ByteBuffer
+
+    init(iterations: Int, bufferSize: Int) {
+        self.iterations = iterations
+        self.bufferSize = bufferSize
+        self.buffer = ByteBufferAllocator().buffer(capacity: self.bufferSize)
+    }
+
+    func setUp() throws {
+        self.buffer.writeBytes(Array(repeating: UInt8(ascii: "A"), count: self.bufferSize - 1))
+        self.buffer.writeInteger(UInt8(ascii: "B"))
+    }
+
+    func tearDown() {
+    }
+
+    func run() -> Int {
+        var which: UInt8 = 0
+        for _ in 1...self.iterations {
+            for byte in self.buffer.readableBytesView {
+                if byte != UInt8(ascii: "A") {
+                    which = byte
+                }
+            }
+        }
+        return Int(which)
+    }
+
+}

--- a/Sources/NIOPerformanceTester/CircularBufferIntoByteBufferBenchmark.swift
+++ b/Sources/NIOPerformanceTester/CircularBufferIntoByteBufferBenchmark.swift
@@ -15,7 +15,7 @@
 import Foundation
 import NIO
 
-final class ByteBufferBenchmark: Benchmark {
+final class CircularBufferIntoByteBufferBenchmark: Benchmark {
     private let iterations: Int
     private let bufferSize: Int
     private var circularBuffer: CircularBuffer<UInt8>

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -762,6 +762,8 @@ try measureAndPrint(desc: "websocket_decode_64kb_+1_100k_frames",
 try measureAndPrint(desc: "websocket_decode_64kb_+1_with_а_masking_key_100k_frames",
                     benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max) + 1, runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
 
-try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1kb", benchmark: ByteBufferBenchmark(iterations: 10000, bufferSize: 1024))
+try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1kb", benchmark: CircularBufferIntoByteBufferBenchmark(iterations: 10000, bufferSize: 1024))
 
-try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1mb", benchmark: ByteBufferBenchmark(iterations: 20, bufferSize: 1024*1024))
+try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1mb", benchmark: CircularBufferIntoByteBufferBenchmark(iterations: 20, bufferSize: 1024*1024))
+
+try measureAndPrint(desc: "byte_buffer_view_iterator_1mb", benchmark: ByteBufferViewIteratorBenchmark(iterations: 20, bufferSize: 1024*1024))


### PR DESCRIPTION
Motivation:

getInteger used the normal, generic implementation for UInt8s, however
they can be made considerably faster by using a specialised method.
ByteBufferIterator was also affected by this.

Modifications:

Use a specialised version for UInt8s for getInteger.

Result:

- ByteBufferView can be iterated about 20% faster.
