### PR TITLE
Provide descriptions for EventLoopError

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -1027,3 +1027,18 @@ public enum EventLoopError: Error {
     /// Shutting down the `EventLoop` failed.
     case shutdownFailed
 }
+
+extension EventLoopError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .unsupportedOperation:
+            return "EventLoopError: the executed operation is not supported by the event loop"
+        case .cancelled:
+            return "EventLoopError: the scheduled task was cancelled"
+        case .shutdown:
+            return "EventLoopError: the event loop is shutdown"
+        case .shutdownFailed:
+            return "EventLoopError: failed to shutdown the event loop"
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

EventLoopError does not conform to CustomStringConvertible. When these
errors appear in programs depending on NIO the source of the error is
non-obvious to the user.

EventLoopError.shutdown, for example, would appear in logs as
"shutdown" with no indication that it was the event loop being referred
to.

Modifications:

- Conform EventLoopError to CustomStringConvertible

Result:

- More helpful error descriptions for EventLoopError