### PR TITLE
Include stackdiff-ing in the debugging-allocations doc

### DIFF
--- a/dev/stackdiff-dtrace.py
+++ b/dev/stackdiff-dtrace.py
@@ -46,11 +46,11 @@ def extract_useful_keys(d):
 
 def usage():
     print("Usage: stackdiff-dtrace.py OLD-STACKS NEW-STACKS")
-    print()
+    print("")
     print("stackdiff-dtrace can diff aggregated stack traces as produced")
     print("by a `agg[ustack()] = count();` and printed with `printa(agg)`;")
     print("by a dtrace program.")
-    print()
+    print("")
     print("Full example leveraging the malloc aggregation:")
     print("  # get old stack traces")
     print("  sudo malloc-aggregation.d -c ./old-binary > /tmp/old")
@@ -66,8 +66,8 @@ if len(sys.argv) != 3:
 before_file = sys.argv[1]
 after_file = sys.argv[2]
 
-after_dict = put_in_dict(before_file)
-before_dict = put_in_dict(after_file)
+after_dict = put_in_dict(after_file)
+before_dict = put_in_dict(before_file)
 
 useful_after_keys = extract_useful_keys(after_dict)
 useful_before_keys = extract_useful_keys(before_dict)


### PR DESCRIPTION
Motivation:

We recently grew a script to diff the output of `malloc-aggregation.d`,
we should document how this can be used when debugging allocation
regressions.

Modifications:

- Update the doc to include an example of using the script to debug an
  allocation regression
- Fix a bug in the script where before/after were mixed up
- Fix a bug in the script where usage would print '()\n' instead of '\n'

Result:

- Better info on debugging allocations
