### PR TITLE
Update http-parser for CVE.

### DIFF
--- a/Sources/CNIOHTTPParser/include/c_nio_http_parser.h
+++ b/Sources/CNIOHTTPParser/include/c_nio_http_parser.h
@@ -29,8 +29,8 @@ extern "C" {
 
 /* Also update SONAME in the Makefile whenever you change these. */
 #define HTTP_PARSER_VERSION_MAJOR 2
-#define HTTP_PARSER_VERSION_MINOR 8
-#define HTTP_PARSER_VERSION_PATCH 1
+#define HTTP_PARSER_VERSION_MINOR 9
+#define HTTP_PARSER_VERSION_PATCH 3
 
 #include <stddef.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && \
@@ -228,6 +228,7 @@ enum flags
   , F_UPGRADE               = 1 << 5
   , F_SKIPBODY              = 1 << 6
   , F_CONTENTLENGTH         = 1 << 7
+  , F_TRANSFER_ENCODING     = 1 << 8
   };
 
 
@@ -274,6 +275,8 @@ enum flags
      "unexpected content-length header")                             \
   XX(INVALID_CHUNK_SIZE,                                             \
      "invalid character in chunk size header")                       \
+  XX(INVALID_TRANSFER_ENCODING,                                      \
+     "request has invalid transfer-encoding")                        \
   XX(INVALID_CONSTANT, "invalid constant string")                    \
   XX(INVALID_INTERNAL_STATE, "encountered unexpected internal state")\
   XX(STRICT, "strict mode assertion failed")                         \
@@ -296,11 +299,11 @@ enum http_errno {
 struct http_parser {
   /** PRIVATE **/
   unsigned int type : 2;         /* enum http_parser_type */
-  unsigned int flags : 8;        /* F_* values from 'flags' enum; semi-public */
   unsigned int state : 7;        /* enum state from http_parser.c */
   unsigned int header_state : 7; /* enum header_state from http_parser.c */
   unsigned int index : 7;        /* index into current matcher */
   unsigned int lenient_http_headers : 1;
+  unsigned int flags : 16;       /* F_* values from 'flags' enum; semi-public */
 
   uint32_t nread;          /* # bytes read in various scenarios */
   uint64_t content_length; /* # bytes in body (0 if no Content-Length header) */
@@ -432,6 +435,9 @@ void c_nio_http_parser_pause(http_parser *parser, int paused);
 
 /* Checks if this is the final chunk of the body. */
 int c_nio_http_body_is_final(const http_parser *parser);
+
+/* Change the maximum header size provided at compile time. */
+void c_nio_http_parser_set_max_header_size(uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/Sources/CNIOHTTPParser/update_and_patch_http_parser.sh
+++ b/Sources/CNIOHTTPParser/update_and_patch_http_parser.sh
@@ -59,6 +59,7 @@ for f in http_parser.c http_parser.h; do
         -e 's/\b\(http_parser_settings_init\)/c_nio_\1/g' \
         -e 's/\b\(http_parser_url_init\)/c_nio_\1/g' \
         -e 's/\b\(http_parser_version\)/c_nio_\1/g' \
+        -e 's/\b\(http_parser_set_max_header_size\)/c_nio_\1/g' \
         -e 's/\b\(http_should_keep_alive\)/c_nio_\1/g' \
         -e 's/\b\(http_status_str\)/c_nio_\1/g' \
         "$here/c_nio_$f"

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -758,6 +758,9 @@ extension HTTPParserError {
             return .paused
         case HPE_UNKNOWN:
             return .unknown
+        case HPE_INVALID_TRANSFER_ENCODING:
+            // The downside of enums here, we don't have a case for this. Map it to .unknown for now.
+            return .unknown
         default:
             return nil
         }

--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest+XCTest.swift
@@ -45,7 +45,7 @@ extension HTTPDecoderLengthTest {
                 ("testIgnoresTransferEncodingFieldOn304Responses", testIgnoresTransferEncodingFieldOn304Responses),
                 ("testIgnoresContentLengthFieldOn304Responses", testIgnoresContentLengthFieldOn304Responses),
                 ("testEarlyFinishWithoutLengthAtAllOn304Responses", testEarlyFinishWithoutLengthAtAllOn304Responses),
-                ("testMultipleTEWithChunkedLastHasNoBodyOnRequest", testMultipleTEWithChunkedLastHasNoBodyOnRequest),
+                ("testMultipleTEWithChunkedLastWorksFine", testMultipleTEWithChunkedLastWorksFine),
                 ("testMultipleTEWithChunkedFirstHasNoBodyOnRequest", testMultipleTEWithChunkedFirstHasNoBodyOnRequest),
                 ("testMultipleTEWithChunkedInTheMiddleHasNoBodyOnRequest", testMultipleTEWithChunkedInTheMiddleHasNoBodyOnRequest),
                 ("testMultipleTEWithChunkedLastHasEOFBodyOnResponseWithChannelInactive", testMultipleTEWithChunkedLastHasEOFBodyOnResponseWithChannelInactive),

--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -292,14 +292,26 @@ class HTTPDecoderLengthTest: XCTestCase {
         try assertIgnoresLengthFields(requestMethod: .GET, responseStatus: .notModified, responseFramingField: .neither)
     }
 
-    private func assertRequestTransferEncodingHasNoBody(transferEncodingHeader: String) throws {
+    private func assertRequestTransferEncodingInError(transferEncodingHeader: String) throws {
         XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
 
         let handler = MessageEndHandler<HTTPRequestHead, ByteBuffer>()
         XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
 
         // Send a GET with the appropriate Transfer Encoding header.
-        XCTAssertNoThrow(try channel.writeInbound(ByteBuffer(string: "POST / HTTP/1.1\r\nTransfer-Encoding: \(transferEncodingHeader)\r\n\r\n")))
+        XCTAssertThrowsError(try channel.writeInbound(ByteBuffer(string: "POST / HTTP/1.1\r\nTransfer-Encoding: \(transferEncodingHeader)\r\n\r\n"))) { error in
+            XCTAssertEqual(error as? HTTPParserError, .unknown)
+        }
+    }
+
+    func testMultipleTEWithChunkedLastWorksFine() throws {
+        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestDecoder()).wait())
+
+        let handler = MessageEndHandler<HTTPRequestHead, ByteBuffer>()
+        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+
+        // Send a GET with the appropriate Transfer Encoding header.
+        XCTAssertNoThrow(try channel.writeInbound(ByteBuffer(string: "POST / HTTP/1.1\r\nTransfer-Encoding: gzip, chunked\r\n\r\n0\r\n\r\n")))
 
         // We should have a request, no body, and immediately see end of request.
         XCTAssert(handler.seenHead)
@@ -309,22 +321,12 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertFalse(try channel.finish())
     }
 
-    func testMultipleTEWithChunkedLastHasNoBodyOnRequest() throws {
-        // This is not quite right: RFC 7230 should allow this as chunked. However, http_parser
-        // does not, so we don't either.
-        try assertRequestTransferEncodingHasNoBody(transferEncodingHeader: "gzip, chunked")
-    }
-
     func testMultipleTEWithChunkedFirstHasNoBodyOnRequest() throws {
-        // Here http_parser is again wrong: strictly this should 400. Again, though,
-        // if http_parser doesn't support this neither do we.
-        try assertRequestTransferEncodingHasNoBody(transferEncodingHeader: "chunked, gzip")
+        try assertRequestTransferEncodingInError(transferEncodingHeader: "chunked, gzip")
     }
 
     func testMultipleTEWithChunkedInTheMiddleHasNoBodyOnRequest() throws {
-        // Here http_parser is again wrong: strictly this should 400. Again, though,
-        // if http_parser doesn't support this neither do we.
-        try assertRequestTransferEncodingHasNoBody(transferEncodingHeader: "gzip, chunked, deflate")
+        try assertRequestTransferEncodingInError(transferEncodingHeader: "gzip, chunked, deflate")
     }
 
     private func assertResponseTransferEncodingHasBodyTerminatedByEOF(transferEncodingHeader: String, eofMechanism: EOFMechanism) throws {
@@ -366,10 +368,51 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertFalse(try channel.finish())
     }
 
+    private func assertResponseTransferEncodingHasBodyTerminatedByEndOfChunk(transferEncodingHeader: String, eofMechanism: EOFMechanism) throws {
+        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.add(handler: HTTPResponseDecoder()).wait())
+
+        let handler = MessageEndHandler<HTTPResponseHead, ByteBuffer>()
+        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+
+        // Prime the decoder with a request and consume it.
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
+                                                                                           method: .GET,
+                                                                                           uri: "/"))))
+        XCTAssertNotNil(channel.readOutbound())
+
+        // Send a 200 with the appropriate Transfer Encoding header. We should see the request.
+        XCTAssertNoThrow(try channel.writeInbound(ByteBuffer(string: "HTTP/1.1 200 OK\r\nTransfer-Encoding: \(transferEncodingHeader)\r\n\r\n")))
+        XCTAssert(handler.seenHead)
+        XCTAssertFalse(handler.seenBody)
+        XCTAssertFalse(handler.seenEnd)
+
+        // Now send body. Note that this *is* chunk encoded. We should also see a body.
+        XCTAssertNoThrow(try channel.writeInbound(ByteBuffer(string: "9\r\ncaribbean\r\n")))
+        XCTAssert(handler.seenHead)
+        XCTAssert(handler.seenBody)
+        XCTAssertFalse(handler.seenEnd)
+
+        // Now send EOF. This should error, as we're expecting the end chunk.
+        if case .halfClosure = eofMechanism {
+            channel.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
+        } else {
+            channel.pipeline.fireChannelInactive()
+        }
+
+        XCTAssert(handler.seenHead)
+        XCTAssert(handler.seenBody)
+        XCTAssertFalse(handler.seenEnd)
+
+        XCTAssertThrowsError(try channel.throwIfErrorCaught()) { error in
+            XCTAssertEqual(error as? HTTPParserError, .invalidEOFState)
+        }
+
+        XCTAssertNoThrow(try channel.finish())
+    }
+
     func testMultipleTEWithChunkedLastHasEOFBodyOnResponseWithChannelInactive() throws {
-        // This is not right: RFC 7230 should allow this as chunked, but http_parser instead parses it as
-        // EOF-terminated. We can't easily override that, so we don't.
-        try assertResponseTransferEncodingHasBodyTerminatedByEOF(transferEncodingHeader: "gzip, chunked", eofMechanism: .channelInactive)
+        try assertResponseTransferEncodingHasBodyTerminatedByEndOfChunk(transferEncodingHeader: "gzip, chunked", eofMechanism: .channelInactive)
     }
 
     func testMultipleTEWithChunkedFirstHasEOFBodyOnResponseWithChannelInactive() throws {
@@ -383,9 +426,7 @@ class HTTPDecoderLengthTest: XCTestCase {
     }
 
     func testMultipleTEWithChunkedLastHasEOFBodyOnResponseWithHalfClosure() throws {
-        // This is not right: RFC 7230 should allow this as chunked, but http_parser instead parses it as
-        // EOF-terminated. We can't easily override that, so we don't.
-        try assertResponseTransferEncodingHasBodyTerminatedByEOF(transferEncodingHeader: "gzip, chunked", eofMechanism: .halfClosure)
+        try assertResponseTransferEncodingHasBodyTerminatedByEndOfChunk(transferEncodingHeader: "gzip, chunked", eofMechanism: .halfClosure)
     }
 
     func testMultipleTEWithChunkedFirstHasEOFBodyOnResponseWithHalfClosure() throws {

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -41,6 +41,8 @@ extension HTTPDecoderTest {
                 ("testExtraCRLF", testExtraCRLF),
                 ("testSOURCEDoesntExplodeUs", testSOURCEDoesntExplodeUs),
                 ("testExtraCarriageReturnBetweenSubsequentRequests", testExtraCarriageReturnBetweenSubsequentRequests),
+                ("testRefusesRequestSmugglingAttempt", testRefusesRequestSmugglingAttempt),
+                ("testTrimsTrailingOWS", testTrimsTrailingOWS),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

http-parser shipped a patche for node.js CVE-2019-15605, which allowed
HTTP request smuggling. This affected SwiftNIO as well, and so we need
to immediately ship an update to help protect affected users.

A CVE for SwiftNIO will follow, but as this patch is in the wild and
SwiftNIO is known to be affected we should not delay shipping this fix.

Modifications:

- Update http-parser.
- Add regression tests to validate this behaviour.

Result:

Close request smugging vector.

(cherry picked from commit f94b22b506e3557cb1b325534fa9bbcd39c90246)
