### PR TITLE
Add custom index methods to ByteBufferView

### DIFF
--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -86,23 +86,15 @@ public struct ByteBufferView: RandomAccessCollection {
     }
 
     public func _customIndexOfEquatableElement(_ element : Element) -> Index?? {
-        let indexInRange = self.withUnsafeBytes { (ptr) -> Index? in
-            return ptr.firstIndex(of: element)
-        }
-        if let indexFoundInRange = indexInRange {
-            return Optional(Optional(indexFoundInRange + self._range.lowerBound))
-        }
-        return Optional(Optional(nil))
+        return .some(self.withUnsafeBytes { ptr -> Index? in
+            return ptr.firstIndex(of: element).map { $0 + self._range.lowerBound }
+        })
     }
 
     public func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
-        let indexInRange = self.withUnsafeBytes { (ptr) -> Index? in
-            return ptr.lastIndex(of: element)
-        }
-        if let indexFoundInRange = indexInRange {
-            return Optional(Optional(indexFoundInRange + self._range.lowerBound))
-        }
-        return Optional(Optional(nil))
+        return .some(self.withUnsafeBytes { ptr -> Index? in
+            return ptr.lastIndex(of: element).map { $0 + self._range.lowerBound }
+        })
     }
 }
 

--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -84,6 +84,26 @@ public struct ByteBufferView: RandomAccessCollection {
             return try body(bytes.bindMemory(to: UInt8.self))
         }
     }
+
+    public func _customIndexOfEquatableElement(_ element : Element) -> Index?? {
+        let indexInRange = self.withUnsafeBytes { (ptr) -> Index? in
+            return ptr.firstIndex(of: element)
+        }
+        if let indexFoundInRange = indexInRange {
+            return Optional(Optional(indexFoundInRange + self._range.lowerBound))
+        }
+        return Optional(Optional(nil))
+    }
+
+    public func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
+        let indexInRange = self.withUnsafeBytes { (ptr) -> Index? in
+            return ptr.lastIndex(of: element)
+        }
+        if let indexFoundInRange = indexInRange {
+            return Optional(Optional(indexFoundInRange + self._range.lowerBound))
+        }
+        return Optional(Optional(nil))
+    }
 }
 
 extension ByteBufferView: MutableCollection {}

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -151,6 +151,8 @@ extension ByteBufferTest {
                 ("testBufferViewReplaceSubrangeWithFewerBytes", testBufferViewReplaceSubrangeWithFewerBytes),
                 ("testBufferViewReplaceSubrangeWithMoreBytes", testBufferViewReplaceSubrangeWithMoreBytes),
                 ("testBufferViewEmpty", testBufferViewEmpty),
+                ("testBufferViewFirstIndex", testBufferViewFirstIndex),
+                ("testBufferViewLastIndex", testBufferViewLastIndex),
                 ("testByteBuffersCanBeInitializedFromByteBufferViews", testByteBuffersCanBeInitializedFromByteBufferViews),
                 ("testReserveCapacityWhenOversize", testReserveCapacityWhenOversize),
                 ("testReserveCapacitySameCapacity", testReserveCapacitySameCapacity),

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1939,6 +1939,34 @@ class ByteBufferTest: XCTestCase {
         XCTAssertEqual([], self.buf.readBytes(length: self.buf.readableBytes))
     }
 
+    func testBufferViewFirstIndex() {
+          self.buf.clear();
+          self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
+          self.buf.setBytes([UInt8(0x59)], at: 1000)
+          self.buf.setBytes([UInt8(0x59)], at: 1001)
+          self.buf.setBytes([UInt8(0x59)], at: 1022)
+          self.buf.setBytes([UInt8(0x59)], at: 3)
+          self.buf.setBytes([UInt8(0x3F)], at: 1023)
+          self.buf.setBytes([UInt8(0x3F)], at: 2)
+          let view = self.buf.viewBytes(at: 5, length: 1010)
+          XCTAssertEqual(1000, view?.firstIndex(of: UInt8(0x59)));
+          XCTAssertNil(view?.firstIndex(of: UInt8(0x3F)));
+      }
+
+      func testBufferViewLastIndex() {
+          self.buf.clear();
+          self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
+          self.buf.setBytes([UInt8(0x59)], at: 1000)
+          self.buf.setBytes([UInt8(0x59)], at: 1001)
+          self.buf.setBytes([UInt8(0x59)], at: 1022)
+          self.buf.setBytes([UInt8(0x59)], at: 3)
+          self.buf.setBytes([UInt8(0x3F)], at: 1023)
+          self.buf.setBytes([UInt8(0x3F)], at: 2)
+          let view = self.buf.viewBytes(at: 5, length: 1010)
+          XCTAssertEqual(1001, view?.lastIndex(of: UInt8(0x59)));
+          XCTAssertNil(view?.lastIndex(of: UInt8(0x3F)));
+      }
+
     func testByteBuffersCanBeInitializedFromByteBufferViews() throws {
         self.buf.writeString("hello")
 

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1940,32 +1940,32 @@ class ByteBufferTest: XCTestCase {
     }
 
     func testBufferViewFirstIndex() {
-          self.buf.clear();
-          self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
-          self.buf.setBytes([UInt8(0x59)], at: 1000)
-          self.buf.setBytes([UInt8(0x59)], at: 1001)
-          self.buf.setBytes([UInt8(0x59)], at: 1022)
-          self.buf.setBytes([UInt8(0x59)], at: 3)
-          self.buf.setBytes([UInt8(0x3F)], at: 1023)
-          self.buf.setBytes([UInt8(0x3F)], at: 2)
-          let view = self.buf.viewBytes(at: 5, length: 1010)
-          XCTAssertEqual(1000, view?.firstIndex(of: UInt8(0x59)));
-          XCTAssertNil(view?.firstIndex(of: UInt8(0x3F)));
-      }
+        self.buf.clear()
+        self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
+        self.buf.setBytes([UInt8(0x59)], at: 1000)
+        self.buf.setBytes([UInt8(0x59)], at: 1001)
+        self.buf.setBytes([UInt8(0x59)], at: 1022)
+        self.buf.setBytes([UInt8(0x59)], at: 3)
+        self.buf.setBytes([UInt8(0x3F)], at: 1023)
+        self.buf.setBytes([UInt8(0x3F)], at: 2)
+        let view = self.buf.viewBytes(at: 5, length: 1010)
+        XCTAssertEqual(1000, view?.firstIndex(of: UInt8(0x59)))
+        XCTAssertNil(view?.firstIndex(of: UInt8(0x3F)))
+    }
 
-      func testBufferViewLastIndex() {
-          self.buf.clear();
-          self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
-          self.buf.setBytes([UInt8(0x59)], at: 1000)
-          self.buf.setBytes([UInt8(0x59)], at: 1001)
-          self.buf.setBytes([UInt8(0x59)], at: 1022)
-          self.buf.setBytes([UInt8(0x59)], at: 3)
-          self.buf.setBytes([UInt8(0x3F)], at: 1023)
-          self.buf.setBytes([UInt8(0x3F)], at: 2)
-          let view = self.buf.viewBytes(at: 5, length: 1010)
-          XCTAssertEqual(1001, view?.lastIndex(of: UInt8(0x59)));
-          XCTAssertNil(view?.lastIndex(of: UInt8(0x3F)));
-      }
+    func testBufferViewLastIndex() {
+        self.buf.clear()
+        self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
+        self.buf.setBytes([UInt8(0x59)], at: 1000)
+        self.buf.setBytes([UInt8(0x59)], at: 1001)
+        self.buf.setBytes([UInt8(0x59)], at: 1022)
+        self.buf.setBytes([UInt8(0x59)], at: 3)
+        self.buf.setBytes([UInt8(0x3F)], at: 1023)
+        self.buf.setBytes([UInt8(0x3F)], at: 2)
+        let view = self.buf.viewBytes(at: 5, length: 1010)
+        XCTAssertEqual(1001, view?.lastIndex(of: UInt8(0x59)))
+        XCTAssertNil(view?.lastIndex(of: UInt8(0x3F)))
+    }
 
     func testByteBuffersCanBeInitializedFromByteBufferViews() throws {
         self.buf.writeString("hello")


### PR DESCRIPTION
Motivation:

The performance of firstIndex and lastIndex is
dramatically improved by addding custom
indexing methods as detailed in issue 1385.

Modifications:

Added methods to ByteBufferView:
   _customIndexOfEquatableElement
       for firstIndex
   _customLastIndexOfEquatableElement
       for lastIndex

Added a unit test for firstIndex and lastIndex
to ensure functional behaviour is unchanged.

Result:

firstIndex and lastIndex behave as before.

Performance is improved by approximately 20% for
the shortest searches.
When tested searching over 1024 byte buffer
with either no match or a match at the end
I observed approximately 15 times performance
improvement.