### PR TITLE
NIOConcurrencyHelpers: make LLP64 friendly

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
@@ -129,6 +129,29 @@ extension UInt64: NIOAtomicPrimitive {
     public static let nio_atomic_store                        = catmc_nio_atomic_unsigned_long_long_store
 }
 
+#if os(Windows)
+extension Int: NIOAtomicPrimitive {
+    public typealias AtomicWrapper = catmc_nio_atomic_intptr_t
+    public static let nio_atomic_create_with_existing_storage = catmc_nio_atomic_intptr_t_create_with_existing_storage
+    public static let nio_atomic_compare_and_exchange         = catmc_nio_atomic_intptr_t_compare_and_exchange
+    public static let nio_atomic_add                          = catmc_nio_atomic_intptr_t_add
+    public static let nio_atomic_sub                          = catmc_nio_atomic_intptr_t_sub
+    public static let nio_atomic_exchange                     = catmc_nio_atomic_intptr_t_exchange
+    public static let nio_atomic_load                         = catmc_nio_atomic_intptr_t_load
+    public static let nio_atomic_store                        = catmc_nio_atomic_intptr_t_store
+}
+
+extension UInt: NIOAtomicPrimitive {
+    public typealias AtomicWrapper = catmc_nio_atomic_uintptr_t
+    public static let nio_atomic_create_with_existing_storage = catmc_nio_atomic_uintptr_t_create_with_existing_storage
+    public static let nio_atomic_compare_and_exchange         = catmc_nio_atomic_uintptr_t_compare_and_exchange
+    public static let nio_atomic_add                          = catmc_nio_atomic_uintptr_t_add
+    public static let nio_atomic_sub                          = catmc_nio_atomic_uintptr_t_sub
+    public static let nio_atomic_exchange                     = catmc_nio_atomic_uintptr_t_exchange
+    public static let nio_atomic_load                         = catmc_nio_atomic_uintptr_t_load
+    public static let nio_atomic_store                        = catmc_nio_atomic_uintptr_t_store
+}
+#else
 extension Int: NIOAtomicPrimitive {
     public typealias AtomicWrapper = catmc_nio_atomic_long
     public static let nio_atomic_create_with_existing_storage = catmc_nio_atomic_long_create_with_existing_storage
@@ -150,6 +173,7 @@ extension UInt: NIOAtomicPrimitive {
     public static let nio_atomic_load                         = catmc_nio_atomic_unsigned_long_load
     public static let nio_atomic_store                        = catmc_nio_atomic_unsigned_long_store
 }
+#endif
 
 /// An encapsulation of an atomic primitive object.
 ///

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -379,6 +379,29 @@ extension UInt64: AtomicPrimitive {
     public static let atomic_store                = catmc_atomic_unsigned_long_long_store
 }
 
+#if os(Windows)
+extension Int: AtomicPrimitive {
+    public static let atomic_create               = catmc_atomic_intptr_t_create
+    public static let atomic_destroy              = catmc_atomic_intptr_t_destroy
+    public static let atomic_compare_and_exchange = catmc_atomic_intptr_t_compare_and_exchange
+    public static let atomic_add                  = catmc_atomic_intptr_t_add
+    public static let atomic_sub                  = catmc_atomic_intptr_t_sub
+    public static let atomic_exchange             = catmc_atomic_intptr_t_exchange
+    public static let atomic_load                 = catmc_atomic_intptr_t_load
+    public static let atomic_store                = catmc_atomic_intptr_t_store
+}
+
+extension UInt: AtomicPrimitive {
+    public static let atomic_create               = catmc_atomic_uintptr_t_create
+    public static let atomic_destroy              = catmc_atomic_uintptr_t_destroy
+    public static let atomic_compare_and_exchange = catmc_atomic_uintptr_t_compare_and_exchange
+    public static let atomic_add                  = catmc_atomic_uintptr_t_add
+    public static let atomic_sub                  = catmc_atomic_uintptr_t_sub
+    public static let atomic_exchange             = catmc_atomic_uintptr_t_exchange
+    public static let atomic_load                 = catmc_atomic_uintptr_t_load
+    public static let atomic_store                = catmc_atomic_uintptr_t_store
+}
+#else
 extension Int: AtomicPrimitive {
     public static let atomic_create               = catmc_atomic_long_create
     public static let atomic_destroy              = catmc_atomic_long_destroy
@@ -400,6 +423,7 @@ extension UInt: AtomicPrimitive {
     public static let atomic_load                 = catmc_atomic_unsigned_long_load
     public static let atomic_store                = catmc_atomic_unsigned_long_store
 }
+#endif
 
 /// `AtomicBox` is a heap-allocated box which allows lock-free access to an instance of a Swift class.
 ///


### PR DESCRIPTION
On LLP64 platforms, `Int` is mapped to `intptr_t` and `UInt` is mapped
to `uintptr_t`.  Use the newly minted `CNIOAtomics` operations to
support these semantics.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
