### PR TITLE
NIOConcurrencyHelpers: port to Windows

### DIFF
--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -19,6 +19,12 @@ import Darwin
 fileprivate func sys_sched_yield() {
     pthread_yield_np()
 }
+#elseif os(Windows)
+import ucrt
+import WinSDK
+fileprivate func sys_sched_yield() {
+  Sleep(0)
+}
 #else
 import Glibc
 fileprivate func sys_sched_yield() {


### PR DESCRIPTION
Add support for Windows to the `NIOConcurrencyHelpers`, replacing the
`pthreads` usage for Windows threading primitives.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
