### PR TITLE
NIO: excise UDS support for Windows

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -52,10 +52,12 @@ extension UnsafeMutablePointer where Pointee == sockaddr {
             return self.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
                 SocketAddress($0.pointee, host: $0.pointee.addressDescription())
             }
+#if !os(Windows)
         case Posix.AF_UNIX:
             return self.withMemoryRebound(to: sockaddr_un.self, capacity: 1) {
                 SocketAddress($0.pointee)
             }
+#endif
         default:
             return nil
         }
@@ -110,6 +112,7 @@ extension sockaddr_in6: SockAddrProtocol {
     }
 }
 
+#if !os(Windows)
 extension sockaddr_un: SockAddrProtocol {
     mutating func withSockAddr<R>(_ body: (UnsafePointer<sockaddr>, Int) throws -> R) rethrows -> R {
         var me = self
@@ -125,6 +128,7 @@ extension sockaddr_un: SockAddrProtocol {
         }
     }
 }
+#endif
 
 extension sockaddr_storage: SockAddrProtocol {
     mutating func withSockAddr<R>(_ body: (UnsafePointer<sockaddr>, Int) throws -> R) rethrows -> R {
@@ -174,6 +178,7 @@ extension sockaddr_storage {
         }
     }
 
+#if !os(Windows)
     /// Converts the `socketaddr_storage` to a `sockaddr_un`.
     ///
     /// This will crash if `ss_family` != AF_UNIX!
@@ -185,6 +190,7 @@ extension sockaddr_storage {
             }
         }
     }
+#endif
 
     /// Converts the `socketaddr_storage` to a `SocketAddress`.
     mutating func convert() -> SocketAddress {
@@ -402,9 +408,11 @@ class BaseSocket: Selectable, BaseSocketProtocol {
             case .v6(let address):
                 var addr = address.address
                 try addr.withSockAddr({ try doBind(ptr: $0, bytes: $1) })
+#if !os(Windows)
             case .unixDomainSocket(let address):
                 var addr = address.address
                 try addr.withSockAddr({ try doBind(ptr: $0, bytes: $1) })
+#endif
             }
         }
     }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -172,6 +172,7 @@ public final class ServerBootstrap {
         return bind0 { address }
     }
 
+#if !os(Windows)
     /// Bind the `ServerSocketChannel` to a UNIX Domain Socket.
     ///
     /// - parameters:
@@ -181,6 +182,7 @@ public final class ServerBootstrap {
             try SocketAddress(unixDomainSocketPath: unixDomainSocketPath)
         }
     }
+#endif
 
     /// Use the existing bound socket file descriptor.
     ///
@@ -509,6 +511,7 @@ public final class ClientBootstrap: NIOTCPClientBootstrap {
         }
     }
 
+#if !os(Windows)
     /// Specify the `unixDomainSocket` path to connect to for the UDS `Channel` that will be established.
     ///
     /// - parameters:
@@ -522,6 +525,7 @@ public final class ClientBootstrap: NIOTCPClientBootstrap {
             return group.next().makeFailedFuture(error)
         }
     }
+#endif
 
     /// Use the existing connected socket file descriptor.
     ///
@@ -694,6 +698,7 @@ public final class DatagramBootstrap {
         return bind0 { address }
     }
 
+#if !os(Windows)
     /// Bind the `DatagramChannel` to a UNIX Domain Socket.
     ///
     /// - parameters:
@@ -703,6 +708,7 @@ public final class DatagramBootstrap {
             return try SocketAddress(unixDomainSocketPath: unixDomainSocketPath)
         }
     }
+#endif
 
     private func bind0(_ makeSocketAddress: () throws -> SocketAddress) -> EventLoopFuture<Channel> {
         let address: SocketAddress

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -20,8 +20,10 @@ public enum SocketAddressError: Error {
     case unknown(host: String, port: Int)
     /// The requested `SocketAddress` is not supported.
     case unsupported
+#if !os(Windows)
     /// The requested UDS path is too long.
     case unixDomainSocketPathTooLong
+#endif
     /// Unable to parse a given IP string
     case failedToParseIPString(String)
 }
@@ -59,6 +61,7 @@ public enum SocketAddress: CustomStringConvertible {
         }
     }
 
+#if !os(Windows)
     /// A single Unix socket address for `SocketAddress`.
     public struct UnixSocketAddress {
         private let _storage: Box<sockaddr_un>
@@ -70,6 +73,7 @@ public enum SocketAddress: CustomStringConvertible {
             self._storage = Box(address)
         }
     }
+#endif
 
     /// An IPv4 `SocketAddress`.
     case v4(IPv4Address)
@@ -77,8 +81,10 @@ public enum SocketAddress: CustomStringConvertible {
     /// An IPv6 `SocketAddress`.
     case v6(IPv6Address)
 
+#if !os(Windows)
     /// An UNIX Domain `SocketAddress`.
     case unixDomainSocket(UnixSocketAddress)
+#endif
 
     /// A human-readable description of this `SocketAddress`. Mostly useful for logging.
     public var description: String {
@@ -213,6 +219,7 @@ public enum SocketAddress: CustomStringConvertible {
         self = .v6(.init(address: addr, host: host))
     }
 
+#if !os(Windows)
     /// Creates a new Unix Domain Socket `SocketAddress`.
     ///
     /// - parameters:
@@ -250,6 +257,7 @@ public enum SocketAddress: CustomStringConvertible {
 
         self = .unixDomainSocket(.init(address: addr))
     }
+#endif
 
     /// Create a new `SocketAddress` for an IP address in string form.
     ///


### PR DESCRIPTION
This removes support for Unix Domain Sockets from NIO on Windows.
Although Windows 10.17063 introduced basic support for UDS, the support
is incomplete and has differences from the tradtional UDS sockets in
terms of behaviour.  Excise the support initially to get NIO to build on
Windows.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
