### PR TITLE
test that massive chunked encoding chunks behave sensibly

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -56,6 +56,7 @@ extension HTTPDecoderTest {
                 ("testOneRequestTwoResponses", testOneRequestTwoResponses),
                 ("testRefusesRequestSmugglingAttempt", testRefusesRequestSmugglingAttempt),
                 ("testTrimsTrailingOWS", testTrimsTrailingOWS),
+                ("testMassiveChunkDoesNotBufferAndGivesUsHoweverMuchIsAvailable", testMassiveChunkDoesNotBufferAndGivesUsHoweverMuchIsAvailable),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Was talking about chunked encoding with @adtrevor, so I thought let's
actually capture it in a test.

Modifications:

- add a test

Result:

- more tests