### PR TITLE
undo @convention(c) hacks in System.swift

### DIFF
--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -45,23 +45,23 @@ extension ipv6_mreq { // http://lkml.iu.edu/hypermail/linux/kernel/0106.1/0080.h
 #endif
 
 // Declare aliases to share more code and not need to repeat #if #else blocks
-private let sysClose: @convention(c) (CInt) -> CInt = close
-private let sysShutdown: @convention(c) (CInt, CInt) -> CInt = shutdown
-private let sysBind: @convention(c) (CInt, UnsafePointer<sockaddr>?, socklen_t) -> CInt = bind
-private let sysFcntl: @convention(c) (CInt, CInt, CInt) -> CInt = fcntl
-private let sysSocket: @convention(c) (CInt, CInt, CInt) -> CInt = socket
-private let sysSetsockopt: @convention(c) (CInt, CInt, CInt, UnsafeRawPointer?, socklen_t) -> CInt = setsockopt
-private let sysGetsockopt: @convention(c) (CInt, CInt, CInt, UnsafeMutableRawPointer?, UnsafeMutablePointer<socklen_t>?) -> CInt = getsockopt
-private let sysListen: @convention(c) (CInt, CInt) -> CInt = listen
-private let sysAccept: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = accept
-private let sysConnect: @convention(c) (CInt, UnsafePointer<sockaddr>?, socklen_t) -> CInt = connect
-private let sysOpen: @convention(c) (UnsafePointer<CChar>, CInt) -> CInt = open
-private let sysOpenWithMode: @convention(c) (UnsafePointer<CChar>, CInt, mode_t) -> CInt = open
-private let sysWrite: @convention(c) (CInt, UnsafeRawPointer?, size_t) -> ssize_t = write
-private let sysRead: @convention(c) (CInt, UnsafeMutableRawPointer?, size_t) -> ssize_t = read
-private let sysPread: @convention(c) (CInt, UnsafeMutableRawPointer?, size_t, off_t) -> ssize_t = pread
-private let sysLseek: @convention(c) (CInt, off_t, CInt) -> off_t = lseek
-private let sysPoll: @convention(c) (UnsafeMutablePointer<pollfd>?, nfds_t, Int32) -> CInt = poll
+private let sysClose = close
+private let sysShutdown = shutdown
+private let sysBind = bind
+private let sysFcntl: (CInt, CInt, CInt) -> CInt = fcntl
+private let sysSocket = socket
+private let sysSetsockopt = setsockopt
+private let sysGetsockopt = getsockopt
+private let sysListen = listen
+private let sysAccept = accept
+private let sysConnect = connect
+private let sysOpen: (UnsafePointer<CChar>, CInt) -> CInt = open
+private let sysOpenWithMode: (UnsafePointer<CChar>, CInt, mode_t) -> CInt = open
+private let sysWrite = write
+private let sysRead = read
+private let sysPread = pread
+private let sysLseek = lseek
+private let sysPoll = poll
 #if os(Android)
 func sysRecvFrom_wrapper(sockfd: CInt, buf: UnsafeMutableRawPointer, len: CLong, flags: CInt, src_addr: UnsafeMutablePointer<sockaddr>, addrlen: UnsafeMutablePointer<socklen_t>) -> CLong {
     return recvfrom(sockfd, buf, len, flags, src_addr, addrlen) // src_addr is 'UnsafeMutablePointer', but it need to be 'UnsafePointer'


### PR DESCRIPTION

### Motivation:

Undo @convention(c) in System.swift file

### Modifications:

Removed the `@convention` annotation from global constants.

### Result:

Fixes: https://github.com/apple/swift-nio/issues/1397