### PR TITLE
Stop copying Strings into Arrays for SHA1

### DIFF
--- a/Sources/NIOWebSocket/SHA1.swift
+++ b/Sources/NIOWebSocket/SHA1.swift
@@ -46,6 +46,12 @@ internal struct SHA1 {
     ///     - string: The string that will be UTF-8 encoded and fed into the
     ///         hash context.
     mutating func update(string: String) {
+        let isAvailable: ()? = string.utf8.withContiguousStorageIfAvailable {
+            self.update($0)
+        }
+        if isAvailable != nil {
+            return
+        }
         let buffer = Array(string.utf8)
         buffer.withUnsafeBufferPointer {
             self.update($0)


### PR DESCRIPTION
### Motivation:

Resolve #1409

### Modifications:

Using `withContiguousStorageIfAvailable` if `string.utf8` supports an internal representation in a form. Otherwise, fall back to use `withUnsafeBufferPointer`.

### Result:

Save an allocation for each hash function update
