### PR TITLE
Allow discardable results on NIOAtomic for mutating functions

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
@@ -223,6 +223,7 @@ public final class NIOAtomic<T: NIOAtomicPrimitive> {
     /// - Returns: `True` if the exchange occurred, or `False` if `expected` did not
     ///     match the current value and so no exchange occurred.
     @inlinable
+    @discardableResult
     public func compareAndExchange(expected: T, desired: T) -> Bool {
         return Manager(unsafeBufferObject: self).withUnsafeMutablePointerToElements {
             return T.nio_atomic_compare_and_exchange($0, expected, desired)
@@ -238,6 +239,7 @@ public final class NIOAtomic<T: NIOAtomicPrimitive> {
     /// - Parameter rhs: The value to add to this object.
     /// - Returns: The previous value of this object, before the addition occurred.
     @inlinable
+    @discardableResult
     public func add(_ rhs: T) -> T {
         return Manager(unsafeBufferObject: self).withUnsafeMutablePointerToElements {
             return T.nio_atomic_add($0, rhs)
@@ -253,6 +255,7 @@ public final class NIOAtomic<T: NIOAtomicPrimitive> {
     /// - Parameter rhs: The value to subtract from this object.
     /// - Returns: The previous value of this object, before the subtraction occurred.
     @inlinable
+    @discardableResult
     public func sub(_ rhs: T) -> T {
         return Manager(unsafeBufferObject: self).withUnsafeMutablePointerToElements {
             return T.nio_atomic_sub($0, rhs)
@@ -268,6 +271,7 @@ public final class NIOAtomic<T: NIOAtomicPrimitive> {
     /// - Parameter value: The new value to set this object to.
     /// - Returns: The value previously held by this object.
     @inlinable
+    @discardableResult
     public func exchange(with value: T) -> T {
         return Manager(unsafeBufferObject: self).withUnsafeMutablePointerToElements {
             return T.nio_atomic_exchange($0, value)

--- a/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
@@ -223,7 +223,6 @@ public final class NIOAtomic<T: NIOAtomicPrimitive> {
     /// - Returns: `True` if the exchange occurred, or `False` if `expected` did not
     ///     match the current value and so no exchange occurred.
     @inlinable
-    @discardableResult
     public func compareAndExchange(expected: T, desired: T) -> Bool {
         return Manager(unsafeBufferObject: self).withUnsafeMutablePointerToElements {
             return T.nio_atomic_compare_and_exchange($0, expected, desired)
@@ -271,7 +270,6 @@ public final class NIOAtomic<T: NIOAtomicPrimitive> {
     /// - Parameter value: The new value to set this object to.
     /// - Returns: The value previously held by this object.
     @inlinable
-    @discardableResult
     public func exchange(with value: T) -> T {
         return Manager(unsafeBufferObject: self).withUnsafeMutablePointerToElements {
             return T.nio_atomic_exchange($0, value)

--- a/Sources/NIOTestUtils/EventCounterHandler.swift
+++ b/Sources/NIOTestUtils/EventCounterHandler.swift
@@ -264,103 +264,103 @@ extension EventCounterHandler: ChannelDuplexHandler {
 
     /// @see: `_ChannelInboundHandler.channelRegistered`
     public func channelRegistered(context: ChannelHandlerContext) {
-        _ = self._channelRegisteredCalls.add(1)
+        self._channelRegisteredCalls.add(1)
         context.fireChannelRegistered()
     }
 
     /// @see: `_ChannelInboundHandler.channelUnregistered`
     public func channelUnregistered(context: ChannelHandlerContext) {
-        _ = self._channelUnregisteredCalls.add(1)
+        self._channelUnregisteredCalls.add(1)
         context.fireChannelUnregistered()
     }
 
     /// @see: `_ChannelInboundHandler.channelActive`
     public func channelActive(context: ChannelHandlerContext) {
-        _ = self._channelActiveCalls.add(1)
+        self._channelActiveCalls.add(1)
         context.fireChannelActive()
     }
 
     /// @see: `_ChannelInboundHandler.channelInactive`
     public func channelInactive(context: ChannelHandlerContext) {
-        _ = self._channelInactiveCalls.add(1)
+        self._channelInactiveCalls.add(1)
         context.fireChannelInactive()
     }
 
     /// @see: `_ChannelInboundHandler.channelRead`
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        _ = self._channelReadCalls.add(1)
+        self._channelReadCalls.add(1)
         context.fireChannelRead(data)
     }
     
     /// @see: `_ChannelInboundHandler.channelReadComplete`
     public func channelReadComplete(context: ChannelHandlerContext) {
-        _ = self._channelReadCompleteCalls.add(1)
+        self._channelReadCompleteCalls.add(1)
         context.fireChannelReadComplete()
     }
 
     /// @see: `_ChannelInboundHandler.channelWritabilityChanged`
     public func channelWritabilityChanged(context: ChannelHandlerContext) {
-        _ = self._channelWritabilityChangedCalls.add(1)
+        self._channelWritabilityChangedCalls.add(1)
         context.fireChannelWritabilityChanged()
     }
 
     /// @see: `_ChannelInboundHandler.userInboundEventTriggered`
     public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
-        _ = self._userInboundEventTriggeredCalls.add(1)
+        self._userInboundEventTriggeredCalls.add(1)
         context.fireUserInboundEventTriggered(event)
     }
     
     /// @see: `_ChannelInboundHandler.errorCaught`
     public func errorCaught(context: ChannelHandlerContext, error: Error) {
-        _ = self._errorCaughtCalls.add(1)
+        self._errorCaughtCalls.add(1)
         context.fireErrorCaught(error)
     }
 
     /// @see: `_ChannelOutboundHandler.register`
     public func register(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
-        _ = self._registerCalls.add(1)
+        self._registerCalls.add(1)
         context.register(promise: promise)
     }
 
     /// @see: `_ChannelOutboundHandler.bind`
     public func bind(context: ChannelHandlerContext, to: SocketAddress, promise: EventLoopPromise<Void>?) {
-        _ = self._bindCalls.add(1)
+        self._bindCalls.add(1)
         context.bind(to: to, promise: promise)
     }
 
     /// @see: `_ChannelOutboundHandler.connect`
     public func connect(context: ChannelHandlerContext, to: SocketAddress, promise: EventLoopPromise<Void>?) {
-        _ = self._connectCalls.add(1)
+        self._connectCalls.add(1)
         context.connect(to: to, promise: promise)
     }
 
     /// @see: `_ChannelOutboundHandler.write`
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        _ = self._writeCalls.add(1)
+        self._writeCalls.add(1)
         context.write(data, promise: promise)
     }
 
     /// @see: `_ChannelOutboundHandler.flush`
     public func flush(context: ChannelHandlerContext) {
-        _ = self._flushCalls.add(1)
+        self._flushCalls.add(1)
         context.flush()
     }
 
     /// @see: `_ChannelOutboundHandler.read`
     public func read(context: ChannelHandlerContext) {
-        _ = self._readCalls.add(1)
+        self._readCalls.add(1)
         context.read()
     }
 
     /// @see: `_ChannelOutboundHandler.close`
     public func close(context: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
-        _ = self._closeCalls.add(1)
+        self._closeCalls.add(1)
         context.close(mode: mode, promise: promise)
     }
 
     /// @see: `_ChannelOutboundHandler.triggerUserOutboundEvent`
     public func triggerUserOutboundEvent(context: ChannelHandlerContext, event: Any, promise: EventLoopPromise<Void>?) {
-        _ = self._triggerUserOutboundEventCalls.add(1)
+        self._triggerUserOutboundEventCalls.add(1)
         context.triggerUserOutboundEvent(event, promise: promise)
     }
 }

--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
@@ -374,6 +374,13 @@ class NIOConcurrencyHelpersTests: XCTestCase {
             XCTAssertEqual(1, ab.sub(1))
 
             XCTAssertEqual(0, ab.load())
+
+            let atomic = NIOAtomic<T>.makeAtomic(value: zero)
+            atomic.store(100)
+            atomic.add(1)
+            XCTAssertEqual(101, atomic.load())
+            atomic.sub(1)
+            XCTAssertEqual(100, atomic.load())
         }
 
         testFor(Int8.self)


### PR DESCRIPTION
### Motivation:
Make the NIOAtomic API look a little cleaner
Currently when using add or sub, we have code the tlooks like this,
```swift
_ = self.activeConns.add(1)
channel.closeFuture.whenComplete { _ in
    _ = self.activeConns.sub(1)
}
```
### Modifications:
Adding @disrcardableResult to the to following function signatures.
- `public func add(_ rhs: T) -> T {`
- `public func sub(_ rhs: T) -> T {`

### Result:
If the API consumer wishes to discard results, the above looks much cleaner.
```swift
self.activeConns.add(1)
channel.closeFuture.whenComplete { _ in
    self.activeConns.sub(1)
}
```
