### PR TITLE
Add Collection customisation points to ByteBufferView

### DIFF
--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -56,22 +56,22 @@ public struct ByteBufferView: RandomAccessCollection {
 
     public subscript(position: Index) -> UInt8 {
         get {
-            _failEarlyRangeCheck(position, bounds: self._range)
+            self._failEarlyRangeCheck(position, bounds: self._range)
             return self._buffer.getInteger(at: position)! // range check above
         }
         set {
-            _failEarlyRangeCheck(position, bounds: self._range)
+            self._failEarlyRangeCheck(position, bounds: self._range)
             self._buffer.setInteger(newValue, at: position)
         }
     }
 
     public subscript(range: Range<Index>) -> ByteBufferView {
         get {
-            _failEarlyRangeCheck(range, bounds: self._range)
+            self._failEarlyRangeCheck(range, bounds: self._range)
             return ByteBufferView(buffer: self._buffer, range: range)
         }
         set {
-            _failEarlyRangeCheck(range, bounds: self._range)
+            self._failEarlyRangeCheck(range, bounds: self._range)
             self.replaceSubrange(range, with: newValue)
         }
     }
@@ -152,7 +152,7 @@ extension ByteBufferView: RangeReplaceableCollection {
 
     @inlinable
     public mutating func replaceSubrange<C: Collection>(_ subrange: Range<Index>, with newElements: C) where ByteBufferView.Element == C.Element {
-        _failEarlyRangeCheck(subrange, bounds: self._range);
+        self._failEarlyRangeCheck(subrange, bounds: self._range);
 
         if newElements.count == subrange.count {
             self._buffer.setBytes(newElements, at: subrange.startIndex)

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1967,6 +1967,20 @@ class ByteBufferTest: XCTestCase {
         XCTAssertNil(view?.lastIndex(of: UInt8(0x3F)))
     }
 
+    func testBufferViewContains() {
+        self.buf.clear()
+
+        let view = ByteBufferView(self.buf)
+        XCTAssertFalse(view.contains(0x0))
+
+        self.buf.writeBytes([0x0, 0x1, 0x2])
+        let anotherView = ByteBufferView(self.buf)
+        XCTAssertTrue(anotherView.contains(0x0))
+        XCTAssertTrue(anotherView.contains(0x1))
+        XCTAssertTrue(anotherView.contains(0x2))
+        XCTAssertFalse(anotherView.contains(0x3))
+    }
+
     func testByteBuffersCanBeInitializedFromByteBufferViews() throws {
         self.buf.writeString("hello")
 


### PR DESCRIPTION
### Motivation:

Resolve #1385

### Modifications:

Added methods
- all three variants of `_failEarlyRangeCheck`
- `_customContainsEquatableElement`
- `_copyToContiguousArray`
- `_copyContents`
- `testBufferViewContains`

### Result:

Better performance
