### PR TITLE
Allow multiple 1xx before the regular response head

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -290,7 +290,7 @@ private class BetterHTTPParser {
             // https://github.com/nodejs/http-parser/issues/251. As a result, we check for these status
             // codes and override http_parser's handling as well.
             
-            if statusCode / 100 == 1 && statusCode != 101 {
+            if statusCode / 100 == 1 && statusCode != 101 /* Switching Protocols */ {
                 skipBody = true
             } else {
                 guard let method = self.requestHeads.popFirst()?.method else {
@@ -300,7 +300,7 @@ private class BetterHTTPParser {
                 
                 if method == .HEAD || method == .CONNECT {
                     skipBody = true
-                } else if statusCode == 204 || statusCode == 304 {
+                } else if statusCode == 204 /* No Content */ || statusCode == 304 /* Not Modified */ {
                     skipBody = true
                 }
             }

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -289,16 +289,20 @@ private class BetterHTTPParser {
             // does not meet the requirement of RFC 7230. This is an outstanding http_parser issue:
             // https://github.com/nodejs/http-parser/issues/251. As a result, we check for these status
             // codes and override http_parser's handling as well.
-            guard let method = self.requestHeads.popFirst()?.method else {
-                self.richerError = NIOHTTPDecoderError.unsolicitedResponse
-                return .error(HPE_UNKNOWN)
-            }
-
-            if method == .HEAD || method == .CONNECT {
+            
+            if statusCode / 100 == 1 && statusCode != 101 {
                 skipBody = true
-            } else if statusCode / 100 == 1 ||  // 1XX codes
-                statusCode == 204 || statusCode == 304 {
-                skipBody = true
+            } else {
+                guard let method = self.requestHeads.popFirst()?.method else {
+                    self.richerError = NIOHTTPDecoderError.unsolicitedResponse
+                    return .error(HPE_UNKNOWN)
+                }
+                
+                if method == .HEAD || method == .CONNECT {
+                    skipBody = true
+                } else if statusCode == 204 || statusCode == 304 {
+                    skipBody = true
+                }
             }
         }
 

--- a/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
@@ -301,7 +301,7 @@ public final class HTTPServerPipelineHandler: ChannelDuplexHandler, RemovableCha
             switch res {
             case .head(let head):
                 assert(self.nextExpectedOutboundMessage == .head)
-                if head.status != .`continue` {
+                if !head.status.isInformational || head.status == .switchingProtocols {
                     self.nextExpectedOutboundMessage = .bodyOrEnd
                 }
             case .body:

--- a/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
@@ -299,9 +299,11 @@ public final class HTTPServerPipelineHandler: ChannelDuplexHandler, RemovableCha
         debugOnly {
             let res = self.unwrapOutboundIn(data)
             switch res {
-            case .head:
+            case .head(let head):
                 assert(self.nextExpectedOutboundMessage == .head)
-                self.nextExpectedOutboundMessage = .bodyOrEnd
+                if head.status != .`continue` {
+                    self.nextExpectedOutboundMessage = .bodyOrEnd
+                }
             case .body:
                 assert(self.nextExpectedOutboundMessage == .bodyOrEnd)
             case .end:

--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -60,7 +60,7 @@ public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler, Removab
         switch res {
         case .head(let head):
             precondition(!self.hasUnterminatedResponse)
-            if head.status != .`continue` {
+            if !head.status.isInformational || head.status == .switchingProtocols {
                 self.hasUnterminatedResponse = true
             }
         case .body:

--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -58,9 +58,11 @@ public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler, Removab
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let res = self.unwrapOutboundIn(data)
         switch res {
-        case .head:
-            precondition(!self.hasUnterminatedResponse)
-            self.hasUnterminatedResponse = true
+        case .head(let head):
+            if head.status != .`continue` || self.hasUnterminatedResponse {
+                precondition(!self.hasUnterminatedResponse)
+                self.hasUnterminatedResponse = true
+            }
         case .body:
             precondition(self.hasUnterminatedResponse)
         case .end:

--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -59,8 +59,8 @@ public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler, Removab
         let res = self.unwrapOutboundIn(data)
         switch res {
         case .head(let head):
-            if head.status != .`continue` || self.hasUnterminatedResponse {
-                precondition(!self.hasUnterminatedResponse)
+            precondition(!self.hasUnterminatedResponse)
+            if head.status != .`continue` {
                 self.hasUnterminatedResponse = true
             }
         case .body:

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -1119,6 +1119,11 @@ public enum HTTPResponseStatus {
             return true
         }
     }
+    
+    /// Whether responses with this status code are of the informational type (1xx).
+    public var isInformational: Bool {
+        return self.code / 100 == 1
+    }
 
     /// Initialize a `HTTPResponseStatus` from a given status and reason.
     ///

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest+XCTest.swift
@@ -38,6 +38,7 @@ extension HTTPServerClientTest {
                 ("testHead", testHead),
                 ("test204", test204),
                 ("testNoResponseHeaders", testNoResponseHeaders),
+                ("testProcessingResponse", testProcessingResponse),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest+XCTest.swift
@@ -31,6 +31,8 @@ extension HTTPServerPipelineHandlerTest {
                 ("testReadCallsAreSuppressedWhenPipelining", testReadCallsAreSuppressedWhenPipelining),
                 ("testReadCallsAreSuppressedWhenUnbufferingIfThereIsStillBufferedData", testReadCallsAreSuppressedWhenUnbufferingIfThereIsStillBufferedData),
                 ("testServerCanRespondEarly", testServerCanRespondEarly),
+                ("testServerCanRepondContinueMultipleTimes", testServerCanRepondContinueMultipleTimes),
+                ("testServerCanRepondProcessingMultipleTimes", testServerCanRepondProcessingMultipleTimes),
                 ("testPipelineHandlerWillBufferHalfClose", testPipelineHandlerWillBufferHalfClose),
                 ("testPipelineHandlerWillDeliverHalfCloseEarly", testPipelineHandlerWillDeliverHalfCloseEarly),
                 ("testAReadIsNotIssuedWhenUnbufferingAHalfCloseAfterRequestComplete", testAReadIsNotIssuedWhenUnbufferingAHalfCloseAfterRequestComplete),


### PR DESCRIPTION
This PR adds on #1330 to support multiple informational HTTP response heads (1xx) emitted from the server before the regular response head.

### Motivation:

HTTP channel handlers should allow multiple 1xx response heads to travel through the pipeline before the regular HTTP response.

### Modifications:

- Added a **public** `isInformational` property in `HTTPStatus`
- Special case `isInformational` response heads in `HTTPServerPipelineHandler` and `HTTPServerProtocolErrorHandler`
- Allow `HTTPDecoder` to accept multiple `isInformational` response heads

### Result:

Channel handlers can write one or multiple 1xx heads to the NIOHTTP1 pipeline.