### PR TITLE
Unify wrapper paths

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -26,7 +26,7 @@ protocol SockAddrProtocol {
 }
 
 /// Returns a description for the given address.
-internal func descriptionForAddress(family: CInt, bytes: UnsafeRawPointer, length byteCount: Int) throws -> String {
+internal func descriptionForAddress(family: sa_family_t, bytes: UnsafeRawPointer, length byteCount: Int) throws -> String {
     var addressBytes: [Int8] = Array(repeating: 0, count: byteCount)
     return try addressBytes.withUnsafeMutableBufferPointer { (addressBytesPtr: inout UnsafeMutableBufferPointer<Int8>) -> String in
         try Posix.inet_ntop(addressFamily: family,
@@ -81,7 +81,7 @@ extension sockaddr_in: SockAddrProtocol {
     mutating func addressDescription() -> String {
         return withUnsafePointer(to: &self.sin_addr) { addrPtr in
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            try! descriptionForAddress(family: AF_INET, bytes: addrPtr, length: Int(INET_ADDRSTRLEN))
+            try! descriptionForAddress(family: Posix.AF_INET, bytes: addrPtr, length: Int(INET_ADDRSTRLEN))
         }
     }
 }
@@ -105,7 +105,7 @@ extension sockaddr_in6: SockAddrProtocol {
     mutating func addressDescription() -> String {
         return withUnsafePointer(to: &self.sin6_addr) { addrPtr in
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            try! descriptionForAddress(family: AF_INET6, bytes: addrPtr, length: Int(INET6_ADDRSTRLEN))
+            try! descriptionForAddress(family: Posix.AF_INET6, bytes: addrPtr, length: Int(INET6_ADDRSTRLEN))
         }
     }
 }

--- a/Sources/NIO/Linux.swift
+++ b/Sources/NIO/Linux.swift
@@ -23,16 +23,16 @@ internal enum TimerFd {
 
     @inline(never)
     public static func timerfd_settime(fd: Int32, flags: Int32, newValue: UnsafePointer<itimerspec>, oldValue: UnsafeMutablePointer<itimerspec>?) throws  {
-        try wrapSyscall {
+        _ = try syscall(blocking: false) {
             CNIOLinux.timerfd_settime(fd, flags, newValue, oldValue)
         }
     }
 
     @inline(never)
     public static func timerfd_create(clockId: Int32, flags: Int32) throws -> Int32 {
-        return try wrapSyscall {
+        return try syscall(blocking: false) {
             CNIOLinux.timerfd_create(clockId, flags)
-        }
+        }.result
     }
 }
 
@@ -43,23 +43,23 @@ internal enum EventFd {
 
     @inline(never)
     public static func eventfd_write(fd: Int32, value: UInt64) throws -> Int32 {
-        return try wrapSyscall {
+        return try syscall(blocking: false) {
             CNIOLinux.eventfd_write(fd, value)
-        }
+        }.result
     }
 
     @inline(never)
     public static func eventfd_read(fd: Int32, value: UnsafeMutablePointer<UInt64>) throws -> Int32 {
-        return try wrapSyscall {
+        return try syscall(blocking: false) {
             CNIOLinux.eventfd_read(fd, value)
-        }
+        }.result
     }
 
     @inline(never)
     public static func eventfd(initval: Int32, flags: Int32) throws -> Int32 {
-        return try wrapSyscall {
+        return try syscall(blocking: false) {
             CNIOLinux.eventfd(0, Int32(EFD_CLOEXEC | EFD_NONBLOCK))
-        }
+        }.result
     }
 }
 
@@ -91,24 +91,24 @@ internal enum Epoll {
 
     @inline(never)
     public static func epoll_create(size: Int32) throws -> Int32 {
-        return try wrapSyscall {
+        return try syscall(blocking: false) {
             CNIOLinux.epoll_create(size)
-        }
+        }.result
     }
 
     @inline(never)
     @discardableResult
     public static func epoll_ctl(epfd: Int32, op: Int32, fd: Int32, event: UnsafeMutablePointer<epoll_event>) throws -> Int32 {
-        return try wrapSyscall {
+        return try syscall(blocking: false) {
             CNIOLinux.epoll_ctl(epfd, op, fd, event)
-        }
+        }.result
     }
 
     @inline(never)
     public static func epoll_wait(epfd: Int32, events: UnsafeMutablePointer<epoll_event>, maxevents: Int32, timeout: Int32) throws -> Int32 {
-        return try wrapSyscall {
+        return try syscall(blocking: false) {
             CNIOLinux.epoll_wait(epfd, events, maxevents, timeout)
-        }
+        }.result
     }
 }
 
@@ -125,15 +125,12 @@ internal enum Linux {
                                addr: UnsafeMutablePointer<sockaddr>?,
                                len: UnsafeMutablePointer<socklen_t>?,
                                flags: CInt) throws -> CInt? {
-        let result: IOResult<CInt> = try wrapSyscallMayBlock {
+        guard case let .processed(fd) = try syscall(blocking: true, {
             CNIOLinux.CNIOLinux_accept4(descriptor, addr, len, flags)
+        }) else {
+          return nil
         }
-        switch result {
-        case .processed(let fd):
-            return fd
-        default:
-            return nil
-        }
+        return fd
     }
 }
 #endif

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -92,7 +92,7 @@ public enum SocketAddress: CustomStringConvertible {
             type = "IPv4"
             var mutAddr = addr.address.sin_addr
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            addressString = try! descriptionForAddress(family: AF_INET, bytes: &mutAddr, length: Int(INET_ADDRSTRLEN))
+            addressString = try! descriptionForAddress(family: Posix.AF_INET, bytes: &mutAddr, length: Int(INET_ADDRSTRLEN))
 
             port = "\(self.port!)"
         case .v6(let addr):
@@ -100,8 +100,8 @@ public enum SocketAddress: CustomStringConvertible {
             type = "IPv6"
             var mutAddr = addr.address.sin6_addr
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            addressString = try! descriptionForAddress(family: AF_INET6, bytes: &mutAddr, length: Int(INET6_ADDRSTRLEN))
-    
+            addressString = try! descriptionForAddress(family: Posix.AF_INET6, bytes: &mutAddr, length: Int(INET6_ADDRSTRLEN))
+
             port = "\(self.port!)"
         case .unixDomainSocket(let addr):
             var address = addr.address
@@ -114,7 +114,7 @@ public enum SocketAddress: CustomStringConvertible {
             }
             return "[\(type)]\(port)"
         }
-        
+
         return "[\(type)]\(host.map { "\($0)/\(addressString):" } ?? "\(addressString):")\(port)"
     }
 
@@ -129,18 +129,18 @@ public enum SocketAddress: CustomStringConvertible {
             return PF_UNIX
         }
     }
-	
+
     /// Get the IP address as a string
     public var ipAddress: String? {
         switch self {
         case .v4(let addr):
             var mutAddr = addr.address.sin_addr
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            return try! descriptionForAddress(family: AF_INET, bytes: &mutAddr, length: Int(INET_ADDRSTRLEN))
+            return try! descriptionForAddress(family: Posix.AF_INET, bytes: &mutAddr, length: Int(INET_ADDRSTRLEN))
         case .v6(let addr):
             var mutAddr = addr.address.sin6_addr
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            return try! descriptionForAddress(family: AF_INET6, bytes: &mutAddr, length: Int(INET6_ADDRSTRLEN))
+            return try! descriptionForAddress(family: Posix.AF_INET6, bytes: &mutAddr, length: Int(INET6_ADDRSTRLEN))
         case .unixDomainSocket(_):
             return nil
         }


### PR DESCRIPTION
Merge the block and non-blocking sys call wrappers

### Motivation:

The two paths are nearly identical with the core difference being that blocking calls ignore `EWOULDBLOCK`.  This simplifies the handling for the different types by adding a parameter to the `wrapSyscall` method.

### Modifications:

Added a new parameter `nonblocking` to the `wrapSyscall` and `wrapSyscallWouldBlock`.  Those paths are then merged into a single `call` method.

### Result:

No external changes.