### PR TITLE
Thread: port to Windows

### DIFF
--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -13,15 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 import CNIOLinux
-
-private typealias ThreadBoxValue = (body: (NIOThread) -> Void, name: String?)
-private typealias ThreadBox = Box<ThreadBoxValue>
+#if os(Windows)
+import WinSDK
+#endif
 
 
 #if os(Linux)
 private let sys_pthread_getname_np = CNIOLinux_pthread_getname_np
 private let sys_pthread_setname_np = CNIOLinux_pthread_setname_np
-#else
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 private let sys_pthread_getname_np = pthread_getname_np
 // Emulate the same method signature as pthread_setname_np on Linux.
 private func sys_pthread_setname_np(_ p: pthread_t, _ pointer: UnsafePointer<Int8>) -> Int32 {
@@ -32,21 +32,44 @@ private func sys_pthread_setname_np(_ p: pthread_t, _ pointer: UnsafePointer<Int
 }
 #endif
 
+fileprivate extension NIOThread.NIOThreadHandle {
+  static var invalid: NIOThread.NIOThreadHandle {
+#if os(Windows)
+      return INVALID_HANDLE_VALUE
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+      return nil
+#else
+      return pthread_t()
+#endif
+  }
+}
+
 /// A Thread that executes some runnable block.
 ///
 /// All methods exposed are thread-safe.
 final class NIOThread {
+#if os(Windows)
+    internal typealias NIOThreadHandle = HANDLE
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    internal typealias NIOThreadHandle = pthread_t?
+#else
+    internal typealias NIOThreadHandle = pthread_t
+#endif
+
+    private typealias ThreadBoxValue = (body: (NIOThread) -> Void, name: String?)
+    private typealias ThreadBox = Box<ThreadBoxValue>
+
     private let desiredName: String?
 
-    /// The pthread_t used by this instance.
-    private let pthread: pthread_t
+    /// The thread handle used by this instance.
+    private let handle: NIOThreadHandle
 
     /// Create a new instance
     ///
     /// - arguments:
-    ///     - pthread: The `pthread_t` that is wrapped and used by the `NIOThread`.
-    private init(pthread: pthread_t, desiredName: String?) {
-        self.pthread = pthread
+    ///     - handle: The `NIOThreadHandle` that is wrapped and used by the `NIOThread`.
+    private init(handle: NIOThreadHandle, desiredName: String?) {
+        self.handle = handle
         self.desiredName = desiredName
     }
 
@@ -57,31 +80,46 @@ final class NIOThread {
     /// - parameters:
     ///     - body: The closure that will accept the `pthread_t`.
     /// - returns: The value returned by `body`.
-    func withUnsafePthread<T>(_ body: (pthread_t) throws -> T) rethrows -> T {
-        return try body(self.pthread)
+#if !os(Windows)
+    internal func withUnsafePthread<T>(_ body: (pthread_t) throws -> T) rethrows -> T {
+        return try body(self.handle)
     }
+#endif
 
     /// Get current name of the `NIOThread` or `nil` if not set.
     var currentName: String? {
-        get {
-            // 64 bytes should be good enough as on Linux the limit is usually 16 and it's very unlikely a user will ever set something longer anyway.
-            var chars: [CChar] = Array(repeating: 0, count: 64)
-            return chars.withUnsafeMutableBufferPointer { ptr in
-                guard sys_pthread_getname_np(self.pthread, ptr.baseAddress!, ptr.count) == 0 else {
-                    return nil
-                }
-
-                return String(decoding: UnsafeRawBufferPointer(UnsafeBufferPointer<CChar>(rebasing: ptr.prefix { char in
-                                  char != 0
-                              })),
-                              as: Unicode.UTF8.self)
+#if os(Windows)
+        var pszBuffer: PWSTR?
+        GetThreadDescription(self.handle, &pszBuffer)
+        guard let buffer = pszBuffer else { return nil }
+        let string: String = String(decodingCString: buffer, as: UTF16.self)
+        LocalFree(buffer)
+        return string
+#else
+        // 64 bytes should be good enough as on Linux the limit is usually 16
+        // and it's very unlikely a user will ever set something longer
+        // anyway.
+        var chars: [CChar] = Array(repeating: 0, count: 64)
+        return chars.withUnsafeMutableBufferPointer { ptr in
+            guard sys_pthread_getname_np(self.handle, ptr.baseAddress!, ptr.count) == 0 else {
+                return nil
             }
+
+            let buffer: UnsafeRawBufferPointer =
+                UnsafeRawBufferPointer(UnsafeBufferPointer<CChar>(rebasing: ptr.prefix { $0 != 0 }))
+            return String(decoding: buffer, as: Unicode.UTF8.self)
         }
+#endif
     }
 
     func join() {
-        let err = pthread_join(self.pthread, nil)
+#if os(Windows)
+        let dwResult: DWORD = WaitForSingleObject(self.handle, INFINITE)
+        assert(dwResult == WAIT_OBJECT_0, "WaitForSingleObject: \(GetLastError())")
+#else
+        let err = pthread_join(self.handle, nil)
         assert(err == 0, "pthread_join failed with \(err)")
+#endif
     }
 
     /// Spawns and runs some task in a `NIOThread`.
@@ -90,51 +128,86 @@ final class NIOThread {
     ///     - name: The name of the `NIOThread` or `nil` if no specific name should be set.
     ///     - body: The function to execute within the spawned `NIOThread`.
     ///     - detach: Whether to detach the thread. If the thread is not detached it must be `join`ed.
-    static func spawnAndRun(name: String? = nil, detachThread: Bool = true, body: @escaping (NIOThread) -> Void) {
-        // Unfortunately the pthread_create method take a different first argument depending on if it's on Linux or macOS, so ensure we use the correct one.
-        #if os(Linux)
-            var pt: pthread_t = pthread_t()
-        #else
-            var pt: pthread_t? = nil
-        #endif
+    static func spawnAndRun(name: String? = nil, detachThread: Bool = true,
+                            body: @escaping (NIOThread) -> Void) {
+        var handle: NIOThreadHandle = .invalid
 
-        // Store everything we want to pass into the c function in a Box so we can hand-over the reference.
+        // Store everything we want to pass into the c function in a Box so we
+        // can hand-over the reference.
         let tuple: ThreadBoxValue = (body: body, name: name)
         let box = ThreadBox(tuple)
-        let res = pthread_create(&pt, nil, { p in
-            // Cast to UnsafeMutableRawPointer? and force unwrap to make the same code work on macOS and Linux.
-            let b = Unmanaged<ThreadBox>.fromOpaque((p as UnsafeMutableRawPointer?)!).takeRetainedValue()
 
-            let body = b.value.body
-            let name = b.value.name
+        let argv0 = Unmanaged.passRetained(box).toOpaque()
 
-            let pt = pthread_self()
+#if os(Windows)
+        // FIXME(compnerd) this should use the `stdcall` calling convention
+        let routine: @convention(c) (UnsafeMutableRawPointer?) -> CUnsignedInt = {
+            let boxed = Unmanaged<ThreadBox>.fromOpaque($0!).takeRetainedValue()
+            let (body, name) = (boxed.value.body, boxed.value.name)
+            let hThread: NIOThreadHandle = GetCurrentThread()
 
-            if let threadName = name {
-                _ = sys_pthread_setname_np(pt, threadName)
-                // this is non-critical so we ignore the result here, we've seen EPERM in containers.
+            if let name = name {
+                _ = name.withCString(encodedAs: UTF16.self) {
+                    SetThreadDescription(hThread, $0)
+                }
             }
 
-            body(NIOThread(pthread: pt, desiredName: name))
-            return nil
-        }, Unmanaged.passRetained(box).toOpaque())
+            body(NIOThread(handle: hThread, desiredName: name))
 
+            return 0
+        }
+        let hThread: HANDLE =
+            HANDLE(bitPattern: _beginthreadex(nil, 0, routine, argv0, 0, nil))!
+
+        if detachThread {
+            CloseHandle(hThread)
+        }
+#else
+        let res = pthread_create(&handle, nil, {
+            // Cast to UnsafeMutableRawPointer? and force unwrap to make the
+            // same code work on macOS and Linux.
+            let boxed = Unmanaged<ThreadBox>
+                          .fromOpaque(($0 as UnsafeMutableRawPointer?)!)
+                          .takeRetainedValue()
+            let (body, name) = (boxed.value.body, boxed.value.name)
+            let hThread: NIOThreadHandle = pthread_self()
+
+            if let name = name {
+                // this is non-critical so we ignore the result here, we've seen
+                // EPERM in containers.
+                _ = sys_pthread_setname_np(hThread, name)
+            }
+
+            body(NIOThread(handle: hThread, desiredName: name))
+
+            return nil
+        }, argv0)
         precondition(res == 0, "Unable to create thread: \(res)")
 
         if detachThread {
-            let detachError = pthread_detach((pt as pthread_t?)!)
+            let detachError = pthread_detach(handle)
             precondition(detachError == 0, "pthread_detach failed with error \(detachError)")
         }
+#endif
     }
 
     /// Returns `true` if the calling thread is the same as this one.
     var isCurrent: Bool {
-        return pthread_equal(pthread, pthread_self()) != 0
+#if os(Windows)
+        return CompareObjectHandles(self.handle, GetCurrentThread())
+#else
+        return pthread_equal(self.handle, pthread_self()) != 0
+#endif
     }
 
     /// Returns the current running `NIOThread`.
     static var current: NIOThread {
-        return NIOThread(pthread: pthread_self(), desiredName: nil)
+#if os(Windows)
+        let hThread: NIOThreadHandle = GetCurrentThread()
+#else
+        let hThread: NIOThreadHandle = pthread_self()
+#endif
+        return NIOThread(handle: hThread, desiredName: nil)
     }
 }
 
@@ -176,21 +249,66 @@ public final class ThreadSpecificVariable<Value: AnyObject> {
     /* the actual type in there is `Box<(ThreadSpecificVariable<T>, T)>` but we can't use that as C functions can't capture (even types) */
     private typealias BoxedType = Box<(AnyObject, AnyObject)>
 
-    private let key: pthread_key_t
+    private class Key {
+#if os(Windows)
+        private var value: DWORD
+#else
+        private var value: pthread_key_t
+#endif
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        public typealias KeyDestructor =
+            @convention(c) (UnsafeMutableRawPointer) -> Void
+#else
+        public typealias KeyDestructor =
+            @convention(c) (UnsafeMutableRawPointer?) -> Void
+#endif
+
+        public init(destructor: KeyDestructor?) {
+#if os(Windows)
+            self.value = FlsAlloc(destructor)
+#else
+            self.value = pthread_key_t()
+            let result = pthread_key_create(&self.value, destructor)
+            precondition(result == 0, "pthread_key_create failed: \(result)")
+#endif
+        }
+
+        deinit {
+#if os(Windows)
+            let dwResult: Bool = FlsFree(self.value)
+            precondition(dwResult, "FlsFree: \(GetLastError())")
+#else
+            let result = pthread_key_delete(self.value)
+            precondition(result == 0, "pthread_key_delete failed: \(result)")
+#endif
+        }
+
+        public static func get(for key: Key) -> UnsafeMutableRawPointer? {
+#if os(Windows)
+            return FlsGetValue(key.value)
+#else
+            return pthread_getspecific(key.value)
+#endif
+        }
+
+        public static func set(value: UnsafeMutableRawPointer?, for key: Key) {
+#if os(Windows)
+            FlsSetValue(key.value, value)
+#else
+            let result = pthread_setspecific(key.value, value)
+            precondition(result == 0, "pthread_setspecific failed: \(result)")
+#endif
+        }
+    }
+
+    private let key: Key
 
     /// Initialize a new `ThreadSpecificVariable` without a current value (`currentValue == nil`).
     public init() {
-        var key = pthread_key_t()
-        let pthreadErr = pthread_key_create(&key) { ptr in
-            Unmanaged<BoxedType>.fromOpaque((ptr as UnsafeMutableRawPointer?)!).release()
-        }
-        precondition(pthreadErr == 0, "pthread_key_create failed, error \(pthreadErr)")
-        self.key = key
-    }
-
-    deinit {
-        let pthreadErr = pthread_key_delete(self.key)
-        precondition(pthreadErr == 0, "pthread_key_delete failed, error \(pthreadErr)")
+        self.key = Key(destructor: {
+          Unmanaged<BoxedType>.fromOpaque(($0 as UnsafeMutableRawPointer?)!).release()
+        })
     }
 
     /// Initialize a new `ThreadSpecificVariable` with `value` for the calling thread. After calling this, the calling
@@ -207,27 +325,31 @@ public final class ThreadSpecificVariable<Value: AnyObject> {
     public var currentValue: Value? {
         /// Get the current value for the calling thread.
         get {
-            guard let raw = pthread_getspecific(self.key) else {
-                return nil
-            }
-            return (Unmanaged<BoxedType>.fromOpaque(raw).takeUnretainedValue().value.1 as! Value)
+          guard let raw = Key.get(for: self.key) else { return nil }
+          // parenthesize the return value to silence the cast warning
+          return (Unmanaged<BoxedType>
+                   .fromOpaque(raw)
+                   .takeUnretainedValue()
+                   .value.1 as! Value)
         }
 
         /// Set the current value for the calling threads. The `currentValue` for all other threads remains unchanged.
         set {
-            if let raw = pthread_getspecific(self.key) {
+            if let raw = Key.get(for: self.key) {
                 Unmanaged<BoxedType>.fromOpaque(raw).release()
             }
-            let pthreadErr = pthread_setspecific(self.key, newValue.map { v -> UnsafeMutableRawPointer in
-                return Unmanaged.passRetained(Box((self, v))).toOpaque()
-            })
-            precondition(pthreadErr == 0, "pthread_setspecific failed, error \(pthreadErr)")
+            Key.set(value: newValue.map { Unmanaged.passRetained(Box((self, $0))).toOpaque() },
+                    for: self.key)
         }
     }
 }
 
 extension NIOThread: Equatable {
     static func ==(lhs: NIOThread, rhs: NIOThread) -> Bool {
-        return pthread_equal(lhs.pthread, rhs.pthread) != 0
+#if os(Windows)
+        return CompareObjectHandles(lhs.handle, rhs.handle)
+#else
+        return pthread_equal(lhs.handle, rhs.handle) != 0
+#endif
     }
 }


### PR DESCRIPTION
This restructures `Thread` to have a more generic representation of a
thread handle.  Using that it is possible to have an implementation of
the threading APIs for Windows.

Similarly, introduce an abstraction over the Thread Specific Key.  This
allows us to abstract away the key type and the usage.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
