### PR TITLE
DNM: delete NIO

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -1012,6 +1012,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
     // other words: Failing to unregister the whole selector will cause NIO to spin at 100% CPU constantly delivering
     // the `reset` event.
     final func reset() {
+#if false
         self.readEOF0()
 
         if self.socket.isOpen {
@@ -1040,6 +1041,8 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
             }
         }
         assert(!self.lifecycleManager.isPreRegistered)
+#endif
+      fatalError()
     }
 
     public final func readable() {

--- a/Sources/NIO/BaseStreamSocketChannel.swift
+++ b/Sources/NIO/BaseStreamSocketChannel.swift
@@ -17,24 +17,32 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
     private var allowRemoteHalfClosure: Bool = false
     private var inputShutdown: Bool = false
     private var outputShutdown: Bool = false
+#if false
     private let pendingWrites: PendingStreamWritesManager
+#endif
 
     override init(socket: Socket,
                   parent: Channel?,
                   eventLoop: SelectableEventLoop,
                   recvAllocator: RecvByteBufferAllocator) throws {
+#if false
         self.pendingWrites = PendingStreamWritesManager(iovecs: eventLoop.iovecs, storageRefs: eventLoop.storageRefs)
         self.connectTimeoutScheduled = nil
         try super.init(socket: socket, parent: parent, eventLoop: eventLoop, recvAllocator: recvAllocator)
+#endif
+      fatalError()
     }
 
     deinit {
         // We should never have any pending writes left as otherwise we may leak callbacks
+#if false
         assert(self.pendingWrites.isEmpty)
+#endif
     }
 
     // MARK: BaseSocketChannel's must override API that might be further refined by subclasses
     override func setOption0<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
+#if false
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
@@ -51,9 +59,11 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         default:
             try super.setOption0(option, value: value)
         }
+#endif
     }
 
     override func getOption0<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
+#if false
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
@@ -70,18 +80,26 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         default:
             return try super.getOption0(option)
         }
+#endif
+      fatalError()
     }
 
     // MARK: BaseSocketChannel's must override API that cannot be further refined by subclasses
     // This is `Channel` API so must be thread-safe.
     final override public var isWritable: Bool {
+#if false
         return self.pendingWrites.isWritable
+#endif
+      fatalError()
     }
 
     final override var isOpen: Bool {
+#if false
         self.eventLoop.assertInEventLoop()
         assert(super.isOpen == self.pendingWrites.isOpen)
         return super.isOpen
+#endif
+      fatalError()
     }
 
     final override func readFromSocket() throws -> ReadResult {
@@ -137,6 +155,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
     }
 
     final override func writeToSocket() throws -> OverallWriteResult {
+#if false
         let result = try self.pendingWrites.triggerAppropriateWriteOperations(scalarBufferWriteOperation: { ptr in
             guard ptr.count > 0 else {
                 // No need to call write if the buffer is empty.
@@ -151,9 +170,12 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
             try self.socket.sendFile(fd: descriptor, offset: index, count: endIndex - index)
         })
         return result
+#endif
+      fatalError()
     }
 
     final override func close0(error: Error, mode: CloseMode, promise: EventLoopPromise<Void>?) {
+#if false
         do {
             switch mode {
             case .output:
@@ -198,20 +220,30 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         } catch let err {
             promise?.fail(err)
         }
+#endif
     }
 
     final override func hasFlushedPendingWrites() -> Bool {
+#if false
         return self.pendingWrites.isFlushPending
+#endif
+      fatalError()
     }
 
     final override func markFlushPoint() {
         // Even if writable() will be called later by the EventLoop we still need to mark the flush checkpoint so we are sure all the flushed messages
         // are actually written once writable() is called.
+#if false
         self.pendingWrites.markFlushCheckpoint()
+#endif
+      fatalError()
     }
 
     final override func cancelWritesOnClose(error: Error) {
+#if false
         self.pendingWrites.failAll(error: error, close: true)
+#endif
+      fatalError()
     }
 
     @discardableResult
@@ -230,6 +262,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
     }
 
     final override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
+#if false
         if self.outputShutdown {
             promise?.fail(ChannelError.outputClosed)
             return
@@ -240,5 +273,6 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         if !self.pendingWrites.add(data: data, promise: promise) {
             self.pipeline.fireChannelWritabilityChanged0()
         }
+#endif
     }
 }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -80,13 +80,16 @@ public final class ServerBootstrap {
     ///     - group: The `EventLoopGroup` to use for the `bind` of the `ServerSocketChannel` and to accept new `SocketChannel`s with.
     ///     - childGroup: The `EventLoopGroup` to run the accepted `SocketChannel`s on.
     public init(group: EventLoopGroup, childGroup: EventLoopGroup) {
+#if false
         self.group = group
         self.childGroup = childGroup
         self._serverChannelOptions = ChannelOptions.Storage()
         self._childChannelOptions = ChannelOptions.Storage()
         self.serverChannelInit = nil
         self.childChannelInit = nil
-        self._serverChannelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+        self._serverChannelOptions.append(key: ChannelOptions.socket(Posix.IPPROTO_TCP, TCP_NODELAY), value: 1)
+#endif
+      fatalError()
     }
 
     /// Initialize the `ServerSocketChannel` with `initializer`. The most common task in initializer is to add
@@ -414,11 +417,14 @@ public final class ClientBootstrap: NIOTCPClientBootstrap {
     /// - parameters:
     ///     - group: The `EventLoopGroup` to use.
     public init(group: EventLoopGroup) {
+#if false
         self.group = group
         self._channelOptions = ChannelOptions.Storage()
-        self._channelOptions.append(key: ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+        self._channelOptions.append(key: ChannelOptions.socket(Posix.IPPROTO_TCP, TCP_NODELAY), value: 1)
         self.channelInitializer = nil
         self.resolver = nil
+#endif
+      fatalError()
     }
 
     /// Initialize the connected `SocketChannel` with `initializer`. The most common task in initializer is to add
@@ -816,6 +822,7 @@ public final class NIOPipeBootstrap {
     }
 
     private func validateFileDescriptorIsNotAFile(_ descriptor: CInt) throws {
+#if false
         precondition(MultiThreadedEventLoopGroup.currentEventLoop == nil,
                      "limitation in SwiftNIO: cannot bootstrap PipeChannel on EventLoop")
         var s: stat = .init()
@@ -825,6 +832,8 @@ public final class NIOPipeBootstrap {
         if (s.st_mode & S_IFREG) != 0 || (s.st_mode & S_IFDIR) != 0 {
             throw ChannelError.operationUnsupported
         }
+#endif
+      fatalError()
     }
 
     /// Create the `PipeChannel` with the provided input and output file descriptors.

--- a/Sources/NIO/DatagramVectorReadManager.swift
+++ b/Sources/NIO/DatagramVectorReadManager.swift
@@ -31,6 +31,7 @@ struct DatagramVectorReadManager {
             return self.messageVector.count
         }
         set {
+#if false
             precondition(newValue >= 0)
             self.messageVector.deinitializeAndDeallocate()
             self.ioVector.deinitializeAndDeallocate()
@@ -39,6 +40,8 @@ struct DatagramVectorReadManager {
             self.messageVector = .allocateAndInitialize(repeating: MMsgHdr(msg_hdr: msghdr(), msg_len: 0), count: newValue)
             self.ioVector = .allocateAndInitialize(repeating: IOVector(), count: newValue)
             self.sockaddrVector = .allocateAndInitialize(repeating: sockaddr_storage(), count: newValue)
+#endif
+          fatalError()
         }
     }
 
@@ -46,7 +49,9 @@ struct DatagramVectorReadManager {
     private var messageVector: UnsafeMutableBufferPointer<MMsgHdr>
 
     /// The vector of iovec structures needed by msghdr structures.
+#if false
     private var ioVector: UnsafeMutableBufferPointer<IOVector>
+#endif
 
     /// The vector of sockaddr structures used for saving addresses.
     private var sockaddrVector: UnsafeMutableBufferPointer<sockaddr_storage>
@@ -54,11 +59,13 @@ struct DatagramVectorReadManager {
     // FIXME(cory): Right now there's no good API for specifying the various parameters of multi-read, especially how
     // it should interact with RecvByteBufferAllocator. For now I'm punting on this to see if I can get it working,
     // but we should design it back.
+#if false
     fileprivate init(messageVector: UnsafeMutableBufferPointer<MMsgHdr>, ioVector: UnsafeMutableBufferPointer<IOVector>, sockaddrVector: UnsafeMutableBufferPointer<sockaddr_storage>) {
         self.messageVector = messageVector
         self.ioVector = ioVector
         self.sockaddrVector = sockaddrVector
     }
+#endif
 
     /// Performs a socket vector read.
     ///
@@ -79,6 +86,7 @@ struct DatagramVectorReadManager {
     ///     - socket: The underlying socket from which to read.
     ///     - buffer: The single large buffer into which reads will be written.
     func readFromSocket(socket: Socket, buffer: inout ByteBuffer) throws -> ReadResult {
+#if false
         assert(buffer.readerIndex == 0, "Buffer was not cleared between calls to readFromSocket!")
 
         let messageSize = buffer.capacity / self.messageCount
@@ -118,16 +126,22 @@ struct DatagramVectorReadManager {
                                       sliceSize: messageSize,
                                       buffer: &buffer)
         }
+#endif
+      fatalError()
     }
 
     /// Destroys this vector read manager, rendering it impossible to re-use. Use of the vector read manager after this is called is not possible.
     mutating func deallocate() {
+#if false
         self.messageVector.deinitializeAndDeallocate()
         self.ioVector.deinitializeAndDeallocate()
         self.sockaddrVector.deinitializeAndDeallocate()
+#endif
+      fatalError()
     }
 
     private func buildMessages(messageCount: Int, sliceSize: Int, buffer: inout ByteBuffer) -> ReadResult {
+#if false
         var sliceOffset = buffer.readerIndex
         var totalReadSize = 0
 
@@ -155,6 +169,8 @@ struct DatagramVectorReadManager {
 
         // Ok, all built. Now we can return these values to the caller.
         return .some(reads: results, totalSize: totalReadSize)
+#endif
+      fatalError()
     }
 }
 
@@ -164,11 +180,14 @@ extension DatagramVectorReadManager {
     /// - parameters:
     ///     - messageCount: The number of vector reads to support initially.
     static func allocate(messageCount: Int) -> DatagramVectorReadManager {
+#if false
         let messageVector = UnsafeMutableBufferPointer.allocateAndInitialize(repeating: MMsgHdr(msg_hdr: msghdr(), msg_len: 0), count: messageCount)
         let ioVector = UnsafeMutableBufferPointer.allocateAndInitialize(repeating: IOVector(), count: messageCount)
         let sockaddrVector = UnsafeMutableBufferPointer.allocateAndInitialize(repeating: sockaddr_storage(), count: messageCount)
 
         return DatagramVectorReadManager(messageVector: messageVector, ioVector: ioVector, sockaddrVector: sockaddrVector)
+#endif
+      fatalError()
     }
 }
 

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -769,6 +769,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     private static func setupThreadAndEventLoop(name: String,
                                                 selectorFactory: @escaping () throws -> NIO.Selector<NIORegistration>,
                                                 initializer: @escaping ThreadInitializer)  -> SelectableEventLoop {
+#if false
         let lock = Lock()
         /* the `loopUpAndRunningGroup` is done by the calling thread when the EventLoop has been created and was written to `_loop` */
         let loopUpAndRunningGroup = DispatchGroup()
@@ -798,6 +799,8 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
         }
         loopUpAndRunningGroup.wait()
         return lock.withLock { _loop }
+#endif
+      fatalError()
     }
 
     /// Creates a `MultiThreadedEventLoopGroup` instance which uses `numberOfThreads`.

--- a/Sources/NIO/FileDescriptor.swift
+++ b/Sources/NIO/FileDescriptor.swift
@@ -34,6 +34,7 @@ public protocol FileDescriptor {
 
 extension FileDescriptor {
     internal static func setNonBlocking(fileDescriptor: CInt) throws {
+#if false
         let flags = try Posix.fcntl(descriptor: fileDescriptor, command: F_GETFL, value: 0)
         do {
             let ret = try Posix.fcntl(descriptor: fileDescriptor, command: F_SETFL, value: flags | O_NONBLOCK)
@@ -45,5 +46,7 @@ extension FileDescriptor {
             }
             throw error
         }
+#endif
+      fatalError()
     }
 }

--- a/Sources/NIO/FileHandle.swift
+++ b/Sources/NIO/FileHandle.swift
@@ -110,6 +110,7 @@ extension NIOFileHandle {
 
     /// `Flags` allows to specify additional flags to `Mode`, such as permission for file creation.
     public struct Flags {
+#if false
         internal var posixMode: mode_t
         internal var posixFlags: CInt
 
@@ -132,6 +133,7 @@ extension NIOFileHandle {
         public static func posix(flags: CInt, mode: mode_t) -> Flags {
             return Flags(posixMode: mode, posixFlags: flags)
         }
+#endif
     }
 
     /// Open a new `NIOFileHandle`.
@@ -140,10 +142,12 @@ extension NIOFileHandle {
     ///     - path: The path of the file to open. The ownership of the file descriptor is transferred to this `NIOFileHandle` and so it will be closed once `close` is called.
     ///     - mode: Access mode. Default mode is `.read`.
     ///     - flags: Additional POSIX flags.
+#if false
     public convenience init(path: String, mode: Mode = .read, flags: Flags = .default) throws {
         let fd = try Posix.open(file: path, oFlag: mode.posixFlags | O_CLOEXEC | flags.posixFlags, mode: flags.posixMode)
         self.init(descriptor: fd)
     }
+#endif
 
     /// Open a new `NIOFileHandle`.
     ///
@@ -152,7 +156,10 @@ extension NIOFileHandle {
     public convenience init(path: String) throws {
         // This function is here because we had a function like this in NIO 2.0, and the one above doesn't quite match. Sadly we can't
         // really deprecate this either, because it'll be preferred to the one above in many cases.
+#if false
         try self.init(path: path, mode: .read, flags: .default)
+#endif
+      fatalError()
     }
 }
 

--- a/Sources/NIO/GetaddrinfoResolver.swift
+++ b/Sources/NIO/GetaddrinfoResolver.swift
@@ -85,6 +85,7 @@ internal class GetaddrinfoResolver: Resolver {
     ///     - host: The hostname to do the DNS queries on.
     ///     - port: The port we'll be connecting to.
     private func resolve(host: String, port: Int) {
+#if false
         var info: UnsafeMutablePointer<addrinfo>?
 
         var hint = addrinfo()
@@ -102,6 +103,8 @@ internal class GetaddrinfoResolver: Resolver {
             /* this is odd, getaddrinfo returned NULL */
             self.fail(SocketAddressError.unsupported)
         }
+#endif
+      fatalError()
     }
 
     /// Parses the DNS results from the `addrinfo` linked list.
@@ -109,6 +112,7 @@ internal class GetaddrinfoResolver: Resolver {
     /// - parameters:
     ///     - info: The pointer to the first of the `addrinfo` structures in the list.
     ///     - host: The hostname we resolved.
+#if false
     private func parseResults(_ info: UnsafeMutablePointer<addrinfo>, host: String) {
         var info = info
         var v4Results = [SocketAddress]()
@@ -139,6 +143,7 @@ internal class GetaddrinfoResolver: Resolver {
         v6Future.succeed(v6Results)
         v4Future.succeed(v4Results)
     }
+#endif
 
     /// Record an error and fail the lookup process.
     ///

--- a/Sources/NIO/Interfaces.swift
+++ b/Sources/NIO/Interfaces.swift
@@ -20,6 +20,7 @@
 
 import CNIOLinux
 
+#if false
 private extension ifaddrs {
     var dstaddr: UnsafeMutablePointer<sockaddr>? {
         #if os(Linux)
@@ -37,6 +38,7 @@ private extension ifaddrs {
         #endif
     }
 }
+#endif
 
 /// A representation of a single network interface on a system.
 public final class NIONetworkInterface {
@@ -73,6 +75,7 @@ public final class NIONetworkInterface {
     /// This constructor will fail if NIO does not understand the format of the underlying
     /// socket address family. This is quite common: for example, Linux will return AF_PACKET
     /// addressed interfaces on most platforms, which NIO does not currently understand.
+#if false
     internal init?(_ caddr: ifaddrs) {
         self.name = String(cString: caddr.ifa_name)
         guard let address = caddr.ifa_addr!.convert() else {
@@ -108,6 +111,11 @@ public final class NIONetworkInterface {
         } catch {
             return nil
         }
+    }
+#endif
+
+    internal init?(_: AnyObject) {
+      fatalError()
     }
 }
 

--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -309,6 +309,7 @@ public struct NonBlockingFileIO {
                        byteCount: Int,
                        allocator: ByteBufferAllocator,
                        eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
+#if false
         guard byteCount > 0 else {
             return eventLoop.makeSucceededFuture(allocator.buffer(capacity: 0))
         }
@@ -347,6 +348,8 @@ public struct NonBlockingFileIO {
             }
             return buf
         }
+#endif
+      fatalError()
     }
 
     /// Write `buffer` to `fileHandle` in `NonBlockingFileIO`'s private thread pool which is separate from any `EventLoop` thread.
@@ -359,6 +362,7 @@ public struct NonBlockingFileIO {
     public func write(fileHandle: NIOFileHandle,
                       buffer: ByteBuffer,
                       eventLoop: EventLoop) -> EventLoopFuture<()> {
+#if false
         var byteCount = buffer.readableBytes
 
         guard byteCount > 0 else {
@@ -387,6 +391,8 @@ public struct NonBlockingFileIO {
                 byteCount -= n
             }
         }
+#endif
+      fatalError()
     }
 
     /// Open the file at `path` for reading on a private thread pool which is separate from any `EventLoop` thread.
@@ -424,10 +430,12 @@ public struct NonBlockingFileIO {
     ///     - flags: Additional POSIX flags.
     ///     - eventLoop: The `EventLoop` on which the returned `EventLoopFuture` will fire.
     /// - returns: An `EventLoopFuture` containing the `NIOFileHandle` and the `FileRegion` comprising the whole file.
+#if false
     public func openFile(path: String, mode: NIOFileHandle.Mode, flags: NIOFileHandle.Flags = .default, eventLoop: EventLoop) -> EventLoopFuture<NIOFileHandle> {
         return self.threadPool.runIfActive(eventLoop: eventLoop) {
             return try NIOFileHandle(path: path, mode: mode, flags: flags)
         }
     }
+#endif
 
 }

--- a/Sources/NIO/PendingWritesManager.swift
+++ b/Sources/NIO/PendingWritesManager.swift
@@ -26,6 +26,7 @@ private struct PendingStreamWrite {
 ///    - storageRefs: Pre-allocated storage references (per `EventLoop`) to manage the lifetime of the buffers to be passed to `writev`.
 ///    - body: The function that actually does the vector write (usually `writev`).
 /// - returns: A tuple of the number of items attempted to write and the result of the write operation.
+#if false
 private func doPendingWriteVectorOperation(pending: PendingStreamWritesState,
                                            iovecs: UnsafeMutableBufferPointer<IOVector>,
                                            storageRefs: UnsafeMutableBufferPointer<Unmanaged<AnyObject>>,
@@ -70,6 +71,7 @@ private func doPendingWriteVectorOperation(pending: PendingStreamWritesState,
     /* if we hit a limit, we really wanted to write more than we have so the caller should retry us */
     return (numberOfUsedStorageSlots, result)
 }
+#endif
 
 /// The result of a single write operation, usually `write`, `sendfile` or `writev`.
 internal enum OneWriteOperationResult {
@@ -276,9 +278,12 @@ private struct PendingStreamWritesState {
 /// This class manages the writing of pending writes to stream sockets. The state is held in a `PendingWritesState`
 /// value. The most important purpose of this object is to call `write`, `writev` or `sendfile` depending on the
 /// currently pending writes.
+#if false
 final class PendingStreamWritesManager: PendingWritesManager {
     private var state = PendingStreamWritesState()
+#if false
     private var iovecs: UnsafeMutableBufferPointer<IOVector>
+#endif
     private var storageRefs: UnsafeMutableBufferPointer<Unmanaged<AnyObject>>
 
     internal var waterMark: ChannelOptions.Types.WriteBufferWaterMark = ChannelOptions.Types.WriteBufferWaterMark(low: 32 * 1024, high: 64 * 1024)
@@ -333,6 +338,7 @@ final class PendingStreamWritesManager: PendingWritesManager {
     ///     - vectorBufferWriteOperation: An operation that writes multiple contiguous arrays of bytes (usually `writev`).
     ///     - scalarFileWriteOperation: An operation that writes a region of a file descriptor (usually `sendfile`).
     /// - returns: The `OneWriteOperationResult` and whether the `Channel` is now writable.
+#if false
     func triggerAppropriateWriteOperations(scalarBufferWriteOperation: (UnsafeRawBufferPointer) throws -> IOResult<Int>,
                                            vectorBufferWriteOperation: (UnsafeBufferPointer<IOVector>) throws -> IOResult<Int>,
                                            scalarFileWriteOperation: (CInt, Int, Int) throws -> IOResult<Int>) throws -> OverallWriteResult {
@@ -350,6 +356,7 @@ final class PendingStreamWritesManager: PendingWritesManager {
             }
         }
     }
+#endif
 
     /// To be called after a write operation (usually selected and run by `triggerAppropriateWriteOperation`) has
     /// completed.
@@ -443,6 +450,7 @@ final class PendingStreamWritesManager: PendingWritesManager {
         self.storageRefs = storageRefs
     }
 }
+#endif
 
 internal enum WriteMechanism {
     case scalarBufferWrite
@@ -502,9 +510,11 @@ extension PendingWritesManager {
     }
 }
 
+#if false
 extension PendingStreamWritesManager: CustomStringConvertible {
     var description: String {
         return "PendingStreamWritesManager { isFlushPending: \(self.isFlushPending), " +
         /*  */ "writabilityFlag: \(self.channelWritabilityFlag.load())), state: \(self.state) }"
     }
 }
+#endif

--- a/Sources/NIO/PipePair.swift
+++ b/Sources/NIO/PipePair.swift
@@ -53,30 +53,42 @@ final class PipePair: SocketProtocol {
     }
 
     func write(pointer: UnsafeRawBufferPointer) throws -> IOResult<Int> {
+#if false
         return try self.outputFD.withUnsafeFileDescriptor { fd in
             try Posix.write(descriptor: fd, pointer: pointer.baseAddress!, size: pointer.count)
         }
+#endif
+      fatalError()
     }
 
+#if false
     func writev(iovecs: UnsafeBufferPointer<IOVector>) throws -> IOResult<Int> {
         return try self.outputFD.withUnsafeFileDescriptor { fd in
             try Posix.writev(descriptor: fd, iovecs: iovecs)
         }
     }
+#endif
 
+#if false
     func sendto(pointer: UnsafeRawBufferPointer, destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int> {
         throw ChannelError.operationUnsupported
     }
+#endif
 
     func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
+#if false
         return try self.inputFD.withUnsafeFileDescriptor { fd in
             try Posix.read(descriptor: fd, pointer: pointer.baseAddress!, size: pointer.count)
         }
+#endif
+      fatalError()
     }
 
+#if false
     func recvfrom(pointer: UnsafeMutableRawBufferPointer, storage: inout sockaddr_storage, storageLen: inout socklen_t) throws -> IOResult<Int> {
         throw ChannelError.operationUnsupported
     }
+#endif
 
     func sendFile(fd: Int32, offset: Int, count: Int) throws -> IOResult<Int> {
         throw ChannelError.operationUnsupported

--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -18,12 +18,12 @@ import NIOConcurrencyHelpers
 /// Execute the given closure and ensure we release all auto pools if needed.
 @inlinable
 internal func withAutoReleasePool<T>(_ execute: () throws -> T) rethrows -> T {
-    #if os(Linux)
-    return try execute()
-    #else
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     return try autoreleasepool {
         try execute()
     }
+    #else
+    return try execute()
     #endif
 }
 
@@ -72,10 +72,14 @@ internal final class SelectableEventLoop: EventLoop {
     private var internalState: InternalState = .runningAndAcceptingNewRegistrations // protected by the EventLoop thread
     private var externalState: ExternalState = .open // protected by externalStateLock
 
+#if false
     private let _iovecs: UnsafeMutablePointer<IOVector>
+#endif
     private let _storageRefs: UnsafeMutablePointer<Unmanaged<AnyObject>>
 
+#if false
     let iovecs: UnsafeMutableBufferPointer<IOVector>
+#endif
     let storageRefs: UnsafeMutableBufferPointer<Unmanaged<AnyObject>>
 
     // Used for gathering UDP writes.
@@ -105,6 +109,7 @@ internal final class SelectableEventLoop: EventLoop {
     }
 
     internal init(thread: NIOThread, selector: NIO.Selector<NIORegistration>) {
+#if false
         self._selector = selector
         self.thread = thread
         self._iovecs = UnsafeMutablePointer.allocate(capacity: Socket.writevLimitIOVectors)
@@ -117,9 +122,12 @@ internal final class SelectableEventLoop: EventLoop {
         self.addresses = UnsafeMutableBufferPointer(start: _addresses, count: Socket.writevLimitIOVectors)
         // We will process 4096 tasks per while loop.
         self.tasksCopy.reserveCapacity(4096)
+#endif
+      fatalError()
     }
 
     deinit {
+#if false
         assert(self.internalState == .noLongerRunning,
                "illegal internal state on deinit: \(self.internalState)")
         assert(self.externalState == .resourcesReclaimed,
@@ -128,6 +136,7 @@ internal final class SelectableEventLoop: EventLoop {
         _storageRefs.deallocate()
         _msgs.deallocate()
         _addresses.deallocate()
+#endif
     }
 
     /// Provide a valid `ClientBootstrap` to setup this `SelectableEventLoop` with a `SocketChannel`.

--- a/Sources/NIO/ServerSocket.swift
+++ b/Sources/NIO/ServerSocket.swift
@@ -53,9 +53,11 @@
     ///     - backlog: The backlog to use.
     /// - throws: An `IOError` if creation of the socket failed.
     func listen(backlog: Int32 = 128) throws {
+#if false
         try withUnsafeFileDescriptor { fd in
             _ = try Posix.listen(descriptor: fd, backlog: backlog)
         }
+#endif
     }
 
     /// Accept a new connection
@@ -65,6 +67,7 @@
     /// - returns: A `Socket` once a new connection was established or `nil` if this `ServerSocket` is in non-blocking mode and there is no new connection that can be accepted when this method is called.
     /// - throws: An `IOError` if the operation failed.
     func accept(setNonBlocking: Bool = false) throws -> Socket? {
+#if false
         return try withUnsafeFileDescriptor { fd in
             #if os(Linux)
             let flags: Int32
@@ -95,5 +98,7 @@
             #endif
             return sock
         }
+#endif
+      fatalError()
     }
 }

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -13,7 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 /// The container used for writing multiple buffers via `writev`.
+#if os(Windows)
+#else
 typealias IOVector = iovec
+#endif
 
 // TODO: scattering support
 /* final but tests */ class Socket: BaseSocket, SocketProtocol {
@@ -23,7 +26,9 @@ typealias IOVector = iovec
     static var writevLimitBytes = Int(Int32.max)
 
     /// The maximum number of `IOVector`s to write per `writev` call.
+#if false
     static let writevLimitIOVectors: Int = Posix.UIO_MAXIOV
+#endif
 
     /// Create a new instance.
     ///
@@ -68,18 +73,24 @@ typealias IOVector = iovec
     /// - returns: `true` if the connection attempt completes, `false` if `finishConnect` must be called later to complete the connection attempt.
     /// - throws: An `IOError` if the operation failed.
     func connect(to address: SocketAddress) throws -> Bool {
+#if false
         switch address {
         case .v4(let addr):
             return try self.connectSocket(addr: addr.address)
         case .v6(let addr):
             return try self.connectSocket(addr: addr.address)
+#if !os(Windows)
         case .unixDomainSocket(let addr):
             return try self.connectSocket(addr: addr.address)
+#endif
         }
+#endif
+      fatalError()
     }
 
     /// Private helper function to handle connection attempts.
     private func connectSocket<T>(addr: T) throws -> Bool {
+#if false
         return try withUnsafeFileDescriptor { fd in
             var addr = addr
             return try withUnsafePointer(to: &addr) { ptr in
@@ -88,16 +99,20 @@ typealias IOVector = iovec
                 }
             }
         }
+#endif
+      fatalError()
     }
 
     /// Finish a previous non-blocking `connect` operation.
     ///
     /// - throws: An `IOError` if the operation failed.
     func finishConnect() throws {
+#if false
         let result: Int32 = try getOption(level: SOL_SOCKET, name: SO_ERROR)
         if result != 0 {
             throw IOError(errnoCode: result, reason: "finishing a non-blocking connect failed")
         }
+#endif
     }
 
     /// Write data to the remote peer.
@@ -107,9 +122,12 @@ typealias IOVector = iovec
     /// - returns: The `IOResult` which indicates how much data could be written and if the operation returned before all could be written (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
     func write(pointer: UnsafeRawBufferPointer) throws -> IOResult<Int> {
+#if false
         return try withUnsafeFileDescriptor { fd in
             try Posix.write(descriptor: fd, pointer: pointer.baseAddress!, size: pointer.count)
         }
+#endif
+      fatalError()
     }
 
     /// Write data to the remote peer (gathering writes).
@@ -118,11 +136,13 @@ typealias IOVector = iovec
     ///     - iovecs: The `IOVector`s to write.
     /// - returns: The `IOResult` which indicates how much data could be written and if the operation returned before all could be written (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
+#if false
     func writev(iovecs: UnsafeBufferPointer<IOVector>) throws -> IOResult<Int> {
         return try withUnsafeFileDescriptor { fd in
             try Posix.writev(descriptor: fd, iovecs: iovecs)
         }
     }
+#endif
 
     /// Send data to a destination.
     ///
@@ -131,6 +151,7 @@ typealias IOVector = iovec
     ///     - destinationPtr: The destination to which the data should be sent.
     /// - returns: The `IOResult` which indicates how much data could be written and if the operation returned before all could be written (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
+#if false
     func sendto(pointer: UnsafeRawBufferPointer, destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int> {
         return try withUnsafeFileDescriptor { fd in
             try Posix.sendto(descriptor: fd, pointer: UnsafeMutableRawPointer(mutating: pointer.baseAddress!),
@@ -138,6 +159,7 @@ typealias IOVector = iovec
                              destinationSize: destinationSize)
         }
     }
+#endif
 
     /// Read data from the socket.
     ///
@@ -146,9 +168,12 @@ typealias IOVector = iovec
     /// - returns: The `IOResult` which indicates how much data could be read and if the operation returned before all could be read (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
     func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
+#if false
         return try withUnsafeFileDescriptor { fd in
             try Posix.read(descriptor: fd, pointer: pointer.baseAddress!, size: pointer.count)
         }
+#endif
+      fatalError()
     }
 
     /// Receive data from the socket.
@@ -159,6 +184,7 @@ typealias IOVector = iovec
     ///     - storageLen: The size of the storage itself.
     /// - returns: The `IOResult` which indicates how much data could be received and if the operation returned before all could be received (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
+#if false
     func recvfrom(pointer: UnsafeMutableRawBufferPointer, storage: inout sockaddr_storage, storageLen: inout socklen_t) throws -> IOResult<(Int)> {
         return try withUnsafeFileDescriptor { fd in
             try storage.withMutableSockAddr { (storagePtr, _) in
@@ -169,6 +195,7 @@ typealias IOVector = iovec
             }
         }
     }
+#endif
 
     /// Send the content of a file descriptor to the remote peer (if possible a zero-copy strategy is applied).
     ///
@@ -179,9 +206,12 @@ typealias IOVector = iovec
     /// - returns: The `IOResult` which indicates how much data could be send and if the operation returned before all could be send (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
     func sendFile(fd: Int32, offset: Int, count: Int) throws -> IOResult<Int> {
+#if false
         return try withUnsafeFileDescriptor { desc in
             try Posix.sendfile(descriptor: desc, fd: fd, offset: off_t(offset), count: count)
         }
+#endif
+      fatalError()
     }
 
     /// Receive `MMsgHdr`s.
@@ -191,9 +221,12 @@ typealias IOVector = iovec
     /// - returns: The `IOResult` which indicates how many messages could be received and if the operation returned before all messages could be received (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
     func recvmmsg(msgs: UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int> {
+#if false
         return try withUnsafeFileDescriptor { fd in
             try Posix.recvmmsg(sockfd: fd, msgvec: msgs.baseAddress!, vlen: CUnsignedInt(msgs.count), flags: 0, timeout: nil)
         }
+#endif
+      fatalError()
     }
 
     /// Send `MMsgHdr`s.
@@ -203,9 +236,12 @@ typealias IOVector = iovec
     /// - returns: The `IOResult` which indicates how many messages could be send and if the operation returned before all messages could be send (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
     func sendmmsg(msgs: UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int> {
+#if false
         return try withUnsafeFileDescriptor { fd in
             try Posix.sendmmsg(sockfd: fd, msgvec: msgs.baseAddress!, vlen: CUnsignedInt(msgs.count), flags: 0)
         }
+#endif
+      fatalError()
     }
 
     /// Shutdown the socket.
@@ -214,8 +250,11 @@ typealias IOVector = iovec
     ///     - how: the mode of `Shutdown`.
     /// - throws: An `IOError` if the operation failed.
     func shutdown(how: Shutdown) throws {
+#if false
         return try withUnsafeFileDescriptor { fd in
             try Posix.shutdown(descriptor: fd, how: how)
         }
+#endif
+      fatalError()
     }
 }

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -36,7 +36,9 @@ public enum SocketAddress: CustomStringConvertible {
         private let _storage: Box<(address: sockaddr_in, host: String)>
 
         /// The libc socket address for an IPv4 address.
+#if false
         public var address: sockaddr_in { return _storage.value.address }
+#endif
 
         /// The host this address is for, if known.
         public var host: String { return _storage.value.host }
@@ -51,7 +53,9 @@ public enum SocketAddress: CustomStringConvertible {
         private let _storage: Box<(address: sockaddr_in6, host: String)>
 
         /// The libc socket address for an IPv6 address.
+#if false
         public var address: sockaddr_in6 { return _storage.value.address }
+#endif
 
         /// The host this address is for, if known.
         public var host: String { return _storage.value.host }
@@ -88,6 +92,7 @@ public enum SocketAddress: CustomStringConvertible {
 
     /// A human-readable description of this `SocketAddress`. Mostly useful for logging.
     public var description: String {
+#if false
         let addressString: String
         let port: String
         let host: String?
@@ -98,7 +103,7 @@ public enum SocketAddress: CustomStringConvertible {
             type = "IPv4"
             var mutAddr = addr.address.sin_addr
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            addressString = try! descriptionForAddress(family: AF_INET, bytes: &mutAddr, length: Int(INET_ADDRSTRLEN))
+            addressString = try! descriptionForAddress(family: Posix.AF_INET, bytes: &mutAddr, length: Int(INET_ADDRSTRLEN))
 
             port = "\(self.port!)"
         case .v6(let addr):
@@ -106,7 +111,7 @@ public enum SocketAddress: CustomStringConvertible {
             type = "IPv6"
             var mutAddr = addr.address.sin6_addr
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            addressString = try! descriptionForAddress(family: AF_INET6, bytes: &mutAddr, length: Int(INET6_ADDRSTRLEN))
+            addressString = try! descriptionForAddress(family: Posix.AF_INET6, bytes: &mutAddr, length: Int(INET6_ADDRSTRLEN))
     
             port = "\(self.port!)"
         case .unixDomainSocket(let addr):
@@ -122,10 +127,13 @@ public enum SocketAddress: CustomStringConvertible {
         }
         
         return "[\(type)]\(host.map { "\($0)/\(addressString):" } ?? "\(addressString):")\(port)"
+#endif
+      fatalError()
     }
 
     /// Returns the protocol family as defined in `man 2 socket` of this `SocketAddress`.
     public var protocolFamily: Int32 {
+#if false
         switch self {
         case .v4:
             return PF_INET
@@ -134,22 +142,27 @@ public enum SocketAddress: CustomStringConvertible {
         case .unixDomainSocket:
             return PF_UNIX
         }
+#endif
+      fatalError()
     }
 	
     /// Get the IP address as a string
     public var ipAddress: String? {
+#if false
         switch self {
         case .v4(let addr):
             var mutAddr = addr.address.sin_addr
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            return try! descriptionForAddress(family: AF_INET, bytes: &mutAddr, length: Int(INET_ADDRSTRLEN))
+            return try! descriptionForAddress(family: Posix.AF_INET, bytes: &mutAddr, length: Int(INET_ADDRSTRLEN))
         case .v6(let addr):
             var mutAddr = addr.address.sin6_addr
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            return try! descriptionForAddress(family: AF_INET6, bytes: &mutAddr, length: Int(INET6_ADDRSTRLEN))
+            return try! descriptionForAddress(family: Posix.AF_INET6, bytes: &mutAddr, length: Int(INET6_ADDRSTRLEN))
         case .unixDomainSocket(_):
             return nil
         }
+#endif
+      fatalError()
     }
 
     /// Get and set the port associated with the address, if defined.
@@ -157,6 +170,7 @@ public enum SocketAddress: CustomStringConvertible {
     /// be interpreted as "no preference".
     /// Setting a non-nil value for a unix domain socket is invalid and will result in a fatal error.
     public var port: Int? {
+#if false
         get {
             switch self {
             case .v4(let addr):
@@ -183,10 +197,13 @@ public enum SocketAddress: CustomStringConvertible {
                 precondition(newValue == nil, "attempting to set a non-nil value to a unix socket is not valid")
             }
         }
+#endif
+      fatalError()
     }
 
     /// Calls the given function with a pointer to a `sockaddr` structure and the associated size
     /// of that structure.
+#if false
     public func withSockAddr<T>(_ body: (UnsafePointer<sockaddr>, Int) throws -> T) rethrows -> T {
         switch self {
         case .v4(let addr):
@@ -200,24 +217,29 @@ public enum SocketAddress: CustomStringConvertible {
             return try address.withSockAddr({ try body($0, $1) })
         }
     }
+#endif
 
     /// Creates a new IPv4 `SocketAddress`.
     ///
     /// - parameters:
     ///     - addr: the `sockaddr_in` that holds the ipaddress and port.
     ///     - host: the hostname that resolved to the ipaddress.
+#if false
     public init(_ addr: sockaddr_in, host: String) {
         self = .v4(.init(address: addr, host: host))
     }
+#endif
 
     /// Creates a new IPv6 `SocketAddress`.
     ///
     /// - parameters:
     ///     - addr: the `sockaddr_in` that holds the ipaddress and port.
     ///     - host: the hostname that resolved to the ipaddress.
+#if false
     public init(_ addr: sockaddr_in6, host: String) {
         self = .v6(.init(address: addr, host: host))
     }
+#endif
 
 #if !os(Windows)
     /// Creates a new Unix Domain Socket `SocketAddress`.
@@ -267,19 +289,20 @@ public enum SocketAddress: CustomStringConvertible {
     /// - returns: the `SocketAddress` corresponding to this string and port combination.
     /// - throws: may throw `SocketAddressError.failedToParseIPString` if the IP address cannot be parsed.
     public init(ipAddress: String, port: Int) throws {
+#if false
         var ipv4Addr = in_addr()
         var ipv6Addr = in6_addr()
 
         self = try ipAddress.withCString {
-            if inet_pton(AF_INET, $0, &ipv4Addr) == 1 {
+            if inet_pton(Posix.AF_INET, $0, &ipv4Addr) == 1 {
                 var addr = sockaddr_in()
-                addr.sin_family = sa_family_t(AF_INET)
+                addr.sin_family = sa_family_t(Posix.AF_INET)
                 addr.sin_port = in_port_t(port).bigEndian
                 addr.sin_addr = ipv4Addr
                 return .v4(.init(address: addr, host: ""))
-            } else if inet_pton(AF_INET6, $0, &ipv6Addr) == 1 {
+            } else if inet_pton(Posix.AF_INET6, $0, &ipv6Addr) == 1 {
                 var addr = sockaddr_in6()
-                addr.sin6_family = sa_family_t(AF_INET6)
+                addr.sin6_family = sa_family_t(Posix.AF_INET6)
                 addr.sin6_port = in_port_t(port).bigEndian
                 addr.sin6_flowinfo = 0
                 addr.sin6_addr = ipv6Addr
@@ -289,6 +312,8 @@ public enum SocketAddress: CustomStringConvertible {
                 throw SocketAddressError.failedToParseIPString(ipAddress)
             }
         }
+#endif
+      fatalError()
     }
 
     /// Creates a new `SocketAddress` for the given host (which will be resolved) and port.
@@ -299,6 +324,7 @@ public enum SocketAddress: CustomStringConvertible {
     /// - returns: the `SocketAddress` for the host / port pair.
     /// - throws: a `SocketAddressError.unknown` if we could not resolve the `host`, or `SocketAddressError.unsupported` if the address itself is not supported (yet).
     public static func makeAddressResolvingHost(_ host: String, port: Int) throws -> SocketAddress {
+#if false
         var info: UnsafeMutablePointer<addrinfo>?
 
         /* FIXME: this is blocking! */
@@ -329,6 +355,8 @@ public enum SocketAddress: CustomStringConvertible {
             /* this is odd, getaddrinfo returned NULL */
             throw SocketAddressError.unsupported
         }
+#endif
+      fatalError()
     }
 }
 
@@ -336,6 +364,7 @@ public enum SocketAddress: CustomStringConvertible {
 /// only the elements defined on the structure in their man pages (excluding lengths).
 extension SocketAddress: Equatable {
     public static func ==(lhs: SocketAddress, rhs: SocketAddress) -> Bool {
+#if false
         switch (lhs, rhs) {
         case (.v4(let addr1), .v4(let addr2)):
             return addr1.address.sin_family == addr2.address.sin_family &&
@@ -363,6 +392,8 @@ extension SocketAddress: Equatable {
         case (.v4, _), (.v6, _), (.unixDomainSocket, _):
             return false
         }
+#endif
+      fatalError()
     }
 }
 
@@ -370,10 +401,13 @@ extension SocketAddress: Equatable {
 extension SocketAddress {
     /// Whether this `SocketAddress` corresponds to a multicast address.
     public var isMulticast: Bool {
+#if false
         switch self {
+#if !os(Windows)
         case .unixDomainSocket:
             // No multicast on unix sockets.
             return false
+#endif
         case .v4(let v4Addr):
             // For IPv4 a multicast address is in the range 224.0.0.0/4.
             // The easy way to check if this is the case is to just mask off
@@ -389,6 +423,8 @@ extension SocketAddress {
             var v6WireAddress = v6Addr.address.sin6_addr
             return withUnsafeBytes(of: &v6WireAddress) { $0[0] == 0xff }
         }
+#endif
+      fatalError()
     }
 }
 

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -84,6 +84,7 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {
+#if false
         if try self.socket.connect(to: address) {
             return true
         }
@@ -97,6 +98,8 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
         }
 
         return false
+#endif
+      fatalError()
     }
 
     override func finishConnectSocket() throws {
@@ -327,20 +330,28 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
 final class DatagramChannel: BaseSocketChannel<Socket> {
 
     // Guard against re-entrance of flushNow() method.
+#if false
     private let pendingWrites: PendingDatagramWritesManager
+#endif
 
     /// Support for vector reads, if enabled.
     private var vectorReadManager: Optional<DatagramVectorReadManager>
 
     // This is `Channel` API so must be thread-safe.
     override public var isWritable: Bool {
+#if false
         return pendingWrites.isWritable
+#endif
+      fatalError()
     }
 
     override var isOpen: Bool {
+#if false
         self.eventLoop.assertInEventLoop()
         assert(super.isOpen == self.pendingWrites.isOpen)
         return super.isOpen
+#endif
+      fatalError()
     }
 
     convenience init(eventLoop: SelectableEventLoop, descriptor: CInt) throws {
@@ -361,6 +372,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     }
 
     init(eventLoop: SelectableEventLoop, protocolFamily: Int32) throws {
+#if false
         self.vectorReadManager = nil
         let socket = try Socket(protocolFamily: protocolFamily, type: Posix.SOCK_DGRAM)
         do {
@@ -379,9 +391,12 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                        parent: nil,
                        eventLoop: eventLoop,
                        recvAllocator: FixedSizeRecvByteBufferAllocator(capacity: 2048))
+#endif
+      fatalError()
     }
 
     init(socket: Socket, parent: Channel? = nil, eventLoop: SelectableEventLoop) throws {
+#if false
         self.vectorReadManager = nil
         try socket.setNonBlocking()
         self.pendingWrites = PendingDatagramWritesManager(msgs: eventLoop.msgs,
@@ -389,11 +404,14 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                                                           addresses: eventLoop.addresses,
                                                           storageRefs: eventLoop.storageRefs)
         try super.init(socket: socket, parent: parent, eventLoop: eventLoop, recvAllocator: FixedSizeRecvByteBufferAllocator(capacity: 2048))
+#endif
+      fatalError()
     }
 
     // MARK: Datagram Channel overrides required by BaseSocketChannel
 
     override func setOption0<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
+#if false
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
@@ -415,9 +433,11 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         default:
             try super.setOption0(option, value: value)
         }
+#endif
     }
 
     override func getOption0<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
+#if false
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
@@ -434,6 +454,8 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         default:
             return try super.getOption0(option)
         }
+#endif
+      fatalError()
     }
 
     func registrationFor(interested: SelectorEventSet) -> NIORegistration {
@@ -459,6 +481,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     }
 
     private func singleReadFromSocket() throws -> ReadResult {
+#if false
         var rawAddress = sockaddr_storage()
         var rawAddressLength = socklen_t(MemoryLayout<sockaddr_storage>.size)
         var buffer = self.recvAllocator.buffer(allocator: self.allocator)
@@ -493,6 +516,8 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             }
         }
         return readResult
+#endif
+      fatalError()
     }
 
     private func vectorReadFromSocket() throws -> ReadResult {
@@ -559,33 +584,46 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     }
     /// Buffer a write in preparation for a flush.
     override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
+#if false
         let data = data.forceAsByteEnvelope()
 
         if !self.pendingWrites.add(envelope: data, promise: promise) {
             assert(self.isActive)
             pipeline.fireChannelWritabilityChanged0()
         }
+#endif
+      fatalError()
     }
 
     override final func hasFlushedPendingWrites() -> Bool {
+#if false
         return self.pendingWrites.isFlushPending
+#endif
+      fatalError()
     }
 
     /// Mark a flush point. This is called when flush is received, and instructs
     /// the implementation to record the flush.
     override func markFlushPoint() {
+#if false
         // Even if writable() will be called later by the EventLoop we still need to mark the flush checkpoint so we are sure all the flushed messages
         // are actually written once writable() is called.
         self.pendingWrites.markFlushCheckpoint()
+#endif
+      fatalError()
     }
 
     /// Called when closing, to instruct the specific implementation to discard all pending
     /// writes.
     override func cancelWritesOnClose(error: Error) {
+#if false
         self.pendingWrites.failAll(error: error, close: true)
+#endif
+      fatalError()
     }
 
     override func writeToSocket() throws -> OverallWriteResult {
+#if false
         let result = try self.pendingWrites.triggerAppropriateWriteOperations(scalarWriteOperation: { (ptr, destinationPtr, destinationSize) in
             guard ptr.count > 0 else {
                 // No need to call write if the buffer is empty.
@@ -599,6 +637,8 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             try self.socket.sendmmsg(msgs: msgs)
         })
         return result
+#endif
+      fatalError()
     }
 
     // MARK: Datagram Channel overrides not required by BaseSocketChannel
@@ -669,6 +709,7 @@ extension DatagramChannel: MulticastChannel {
         ///         `IPPROTO_IPV6`. Will trap if an invalid value is provided.
         /// - returns: The socket option name to use for this group operation.
         func optionName(level: CInt) -> CInt {
+#if false
             switch (self, level) {
             case (.join, CInt(IPPROTO_IP)):
                 return CInt(IP_ADD_MEMBERSHIP)
@@ -681,6 +722,8 @@ extension DatagramChannel: MulticastChannel {
             default:
                 preconditionFailure("Unexpected socket option level: \(level)")
             }
+#endif
+          fatalError()
         }
     }
 
@@ -711,6 +754,7 @@ extension DatagramChannel: MulticastChannel {
                                         interface: NIONetworkInterface?,
                                         promise: EventLoopPromise<Void>?,
                                         operation: GroupOperation) {
+#if false
         self.eventLoop.assertInEventLoop()
 
         guard self.isActive else {
@@ -752,22 +796,24 @@ extension DatagramChannel: MulticastChannel {
             case (.v4(let groupAddress), .some(.v4(let interfaceAddress))):
                 // IPv4Binding with specific target interface.
                 let multicastRequest = ip_mreq(imr_multiaddr: groupAddress.address.sin_addr, imr_interface: interfaceAddress.address.sin_addr)
-                try self.socket.setOption(level: CInt(IPPROTO_IP), name: operation.optionName(level: CInt(IPPROTO_IP)), value: multicastRequest)
+                try self.socket.setOption(level: CInt(Posix.IPPROTO_IP), name: operation.optionName(level: CInt(Posix.IPPROTO_IP)), value: multicastRequest)
             case (.v4(let groupAddress), .none):
                 // IPv4 binding without target interface.
                 let multicastRequest = ip_mreq(imr_multiaddr: groupAddress.address.sin_addr, imr_interface: in_addr(s_addr: INADDR_ANY))
-                try self.socket.setOption(level: CInt(IPPROTO_IP), name: operation.optionName(level: CInt(IPPROTO_IP)), value: multicastRequest)
+                try self.socket.setOption(level: CInt(Posix.IPPROTO_IP), name: operation.optionName(level: CInt(Posix.IPPROTO_IP)), value: multicastRequest)
             case (.v6(let groupAddress), .some(.v6)):
                 // IPv6 binding with specific target interface.
                 let multicastRequest = ipv6_mreq(ipv6mr_multiaddr: groupAddress.address.sin6_addr, ipv6mr_interface: UInt32(interface!.interfaceIndex))
-                try self.socket.setOption(level: CInt(IPPROTO_IPV6), name: operation.optionName(level: CInt(IPPROTO_IPV6)), value: multicastRequest)
+                try self.socket.setOption(level: CInt(Posix.IPPROTO_IPV6), name: operation.optionName(level: CInt(Posix.IPPROTO_IPV6)), value: multicastRequest)
             case (.v6(let groupAddress), .none):
                 // IPv6 binding with no specific interface requested.
                 let multicastRequest = ipv6_mreq(ipv6mr_multiaddr: groupAddress.address.sin6_addr, ipv6mr_interface: 0)
-                try self.socket.setOption(level: CInt(IPPROTO_IPV6), name: operation.optionName(level: CInt(IPPROTO_IPV6)), value: multicastRequest)
+                try self.socket.setOption(level: CInt(Posix.IPPROTO_IPV6), name: operation.optionName(level: CInt(Posix.IPPROTO_IPV6)), value: multicastRequest)
+#if !os(Windows)
             case (.v4, .some(.v6)), (.v6, .some(.v4)), (.v4, .some(.unixDomainSocket)), (.v6, .some(.unixDomainSocket)):
                 // Mismatched group and interface address: this is an error.
                 throw ChannelError.badInterfaceAddressFamily
+#endif
             }
 
             promise?.succeed(())
@@ -775,5 +821,6 @@ extension DatagramChannel: MulticastChannel {
             promise?.fail(error)
             return
         }
+#endif
     }
 }

--- a/Sources/NIO/SocketOptionProvider.swift
+++ b/Sources/NIO/SocketOptionProvider.swift
@@ -88,17 +88,21 @@ extension SocketOptionProvider {
     ///     - value: The value to set SO_LINGER to.
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
+#if false
     public func setSoLinger(_ value: linger) -> EventLoopFuture<Void> {
         return self.unsafeSetSocketOption(level: SocketOptionLevel(SOL_SOCKET), name: SO_LINGER, value: value)
     }
+#endif
 
     /// Gets the value of the socket option SO_LINGER.
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
+#if false
     public func getSoLinger() -> EventLoopFuture<linger> {
         return self.unsafeGetSocketOption(level: SocketOptionLevel(SOL_SOCKET), name: SO_LINGER)
     }
+#endif
 
     /// Sets the socket option IP_MULTICAST_IF to `value`.
     ///
@@ -106,17 +110,21 @@ extension SocketOptionProvider {
     ///     - value: The value to set IP_MULTICAST_IF to.
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
+#if false
     public func setIPMulticastIF(_ value: in_addr) -> EventLoopFuture<Void> {
-        return self.unsafeSetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_IF, value: value)
+        return self.unsafeSetSocketOption(level: Posix.IPPROTO_IP, name: IP_MULTICAST_IF, value: value)
     }
+#endif
 
     /// Gets the value of the socket option IP_MULTICAST_IF.
     ///
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
+#if false
     public func getIPMulticastIF() -> EventLoopFuture<in_addr> {
-        return self.unsafeGetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_IF)
+        return self.unsafeGetSocketOption(level: Posix.IPPROTO_IP, name: IP_MULTICAST_IF)
     }
+#endif
 
     /// Sets the socket option IP_MULTICAST_TTL to `value`.
     ///
@@ -125,7 +133,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
     public func setIPMulticastTTL(_ value: CUnsignedChar) -> EventLoopFuture<Void> {
-        return self.unsafeSetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_TTL, value: value)
+#if false
+        return self.unsafeSetSocketOption(level: Posix.IPPROTO_IP, name: IP_MULTICAST_TTL, value: value)
+#endif
+      fatalError()
     }
 
     /// Gets the value of the socket option IP_MULTICAST_TTL.
@@ -133,7 +144,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
     public func getIPMulticastTTL() -> EventLoopFuture<CUnsignedChar> {
-        return self.unsafeGetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_TTL)
+#if false
+        return self.unsafeGetSocketOption(level: Posix.IPPROTO_IP, name: IP_MULTICAST_TTL)
+#endif
+      fatalError()
     }
 
     /// Sets the socket option IP_MULTICAST_LOOP to `value`.
@@ -143,7 +157,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
     public func setIPMulticastLoop(_ value: CUnsignedChar) -> EventLoopFuture<Void> {
-        return self.unsafeSetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_LOOP, value: value)
+#if false
+        return self.unsafeSetSocketOption(level: Posix.IPPROTO_IP, name: IP_MULTICAST_LOOP, value: value)
+#endif
+      fatalError()
     }
 
     /// Gets the value of the socket option IP_MULTICAST_LOOP.
@@ -151,7 +168,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
     public func getIPMulticastLoop() -> EventLoopFuture<CUnsignedChar> {
-        return self.unsafeGetSocketOption(level: IPPROTO_IP, name: IP_MULTICAST_LOOP)
+#if false
+        return self.unsafeGetSocketOption(level: Posix.IPPROTO_IP, name: IP_MULTICAST_LOOP)
+#endif
+      fatalError()
     }
 
     /// Sets the socket option IPV6_MULTICAST_IF to `value`.
@@ -161,7 +181,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
     public func setIPv6MulticastIF(_ value: CUnsignedInt) -> EventLoopFuture<Void> {
+#if false
         return self.unsafeSetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_IF, value: value)
+#endif
+      fatalError()
     }
 
     /// Gets the value of the socket option IPV6_MULTICAST_IF.
@@ -169,7 +192,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
     public func getIPv6MulticastIF() -> EventLoopFuture<CUnsignedInt> {
+#if false
         return self.unsafeGetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_IF)
+#endif
+      fatalError()
     }
 
     /// Sets the socket option IPV6_MULTICAST_HOPS to `value`.
@@ -179,7 +205,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
     public func setIPv6MulticastHops(_ value: CInt) -> EventLoopFuture<Void> {
+#if false
         return self.unsafeSetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_HOPS, value: value)
+#endif
+      fatalError()
     }
 
     /// Gets the value of the socket option IPV6_MULTICAST_HOPS.
@@ -187,7 +216,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
     public func getIPv6MulticastHops() -> EventLoopFuture<CInt> {
+#if false
         return self.unsafeGetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_HOPS)
+#endif
+      fatalError()
     }
 
     /// Sets the socket option IPV6_MULTICAST_LOOP to `value`.
@@ -197,7 +229,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
     public func setIPv6MulticastLoop(_ value: CUnsignedInt) -> EventLoopFuture<Void> {
+#if false
         return self.unsafeSetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_LOOP, value: value)
+#endif
+      fatalError()
     }
 
     /// Gets the value of the socket option IPV6_MULTICAST_LOOP.
@@ -205,7 +240,10 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
     public func getIPv6MulticastLoop() -> EventLoopFuture<CUnsignedInt> {
+#if false
         return self.unsafeGetSocketOption(level: IPPROTO_IPV6, name: IPV6_MULTICAST_LOOP)
+#endif
+      fatalError()
     }
 
     #if os(Linux) || os(FreeBSD)

--- a/Sources/NIO/SocketProtocols.swift
+++ b/Sources/NIO/SocketProtocols.swift
@@ -43,13 +43,19 @@ protocol SocketProtocol: BaseSocketProtocol {
 
     func write(pointer: UnsafeRawBufferPointer) throws -> IOResult<Int>
 
+#if false
     func writev(iovecs: UnsafeBufferPointer<IOVector>) throws -> IOResult<Int>
+#endif
 
+#if false
     func sendto(pointer: UnsafeRawBufferPointer, destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int>
+#endif
 
     func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int>
 
+#if false
     func recvfrom(pointer: UnsafeMutableRawBufferPointer, storage: inout sockaddr_storage, storageLen: inout socklen_t) throws -> IOResult<Int>
+#endif
 
     func sendFile(fd: Int32, offset: Int, count: Int) throws -> IOResult<Int>
 
@@ -74,6 +80,7 @@ private let globallyIgnoredSIGPIPE: Bool = {
 extension BaseSocketProtocol {
     // used by `BaseSocket` and `PipePair`.
     internal static func ignoreSIGPIPE(descriptor fd: CInt) throws {
+#if false
         #if os(Linux)
         let haveWeIgnoredSIGPIEThisIsHereToTriggerIgnoringIt = globallyIgnoredSIGPIPE
         guard haveWeIgnoredSIGPIEThisIsHereToTriggerIgnoringIt else {
@@ -88,5 +95,7 @@ extension BaseSocketProtocol {
             throw error
         }
         #endif
+#endif
+      fatalError()
     }
 }

--- a/Sources/NIO/Utilities.swift
+++ b/Sources/NIO/Utilities.swift
@@ -41,7 +41,10 @@ public enum System {
     ///
     /// - returns: The logical core count on the system.
     public static var coreCount: Int {
+#if false
         return sysconf(CInt(_SC_NPROCESSORS_ONLN))
+#endif
+      fatalError()
     }
 
     /// A utility function that enumerates the available network interfaces on this machine.
@@ -53,6 +56,7 @@ public enum System {
     /// - returns: An array of network interfaces available on this machine.
     /// - throws: If an error is encountered while enumerating interfaces.
     public static func enumerateInterfaces() throws -> [NIONetworkInterface] {
+#if false
         var interface: UnsafeMutablePointer<ifaddrs>? = nil
         try Posix.getifaddrs(&interface)
         let originalInterface = interface
@@ -70,5 +74,7 @@ public enum System {
         }
 
         return results
+#endif
+      fatalError()
     }
 }


### PR DESCRIPTION
Largely delete NIO - this is meant to allow others to help with porting to Windows, it identifies the locations that need to be adjusted in order to enable Windows support