### PR TITLE
ByteToMessageDecoder: Default implementation for decodeLast should be provided 

### DIFF
--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -234,6 +234,11 @@ extension ByteToMessageDecoder {
     public func wrapInboundOut(_ value: InboundOut) -> NIOAny {
         return NIOAny(value)
     }
+    
+    public mutating func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws  -> DecodingState {
+        while try self.decode(context: context, buffer: &buffer) == .continue {}
+        return .needMoreData
+    }
 }
 
 private struct B2MDBuffer {

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -31,10 +31,6 @@ final class LineDelimiterCodec: ByteToMessageDecoder {
         }
         return .needMoreData
     }
-
-    public func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
-        return try self.decode(context: context, buffer: &buffer)
-    }
 }
 
 /// This `ChannelInboundHandler` demonstrates a few things:

--- a/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
@@ -270,6 +270,7 @@ public final class WebSocketFrameDecoder: ByteToMessageDecoder {
     }
 
     public func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
+        while try self.decode(context: context, buffer: &buffer) == .continue {}
         // EOF is not semantic in WebSocket, so ignore this.
         return .needMoreData
     }

--- a/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameDecoder.swift
@@ -268,10 +268,4 @@ public final class WebSocketFrameDecoder: ByteToMessageDecoder {
             }
         }
     }
-
-    public func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
-        while try self.decode(context: context, buffer: &buffer) == .continue {}
-        // EOF is not semantic in WebSocket, so ignore this.
-        return .needMoreData
-    }
 }


### PR DESCRIPTION

### Motivation:

Corrected the `decodeLast` function  in EOF framed protocols.

### Modifications:

- Removed the `decodeLast` function from `NIOChatServer/main.swift`
- Updated the `decodeLast` function  in `NIOWebSocket/WebSocketFrameDecoder.swift`

### Result:

Fixes: https://github.com/apple/swift-nio/issues/1416
