### PR TITLE
tests: improve tests that are supposed to throw

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -34,23 +34,18 @@ class HTTPDecoderTest: XCTestCase {
 
     func testDoesNotDecodeRealHTTP09Request() throws {
         XCTAssertNoThrow(try channel.pipeline.addHandler(ByteToMessageHandler(HTTPRequestDecoder())).wait())
-
+        
         // This is an invalid HTTP/0.9 simple request (too many CRLFs), but we need to
         // trigger https://github.com/nodejs/http-parser/issues/386 or http_parser won't
         // actually parse this at all.
         var buffer = channel.allocator.buffer(capacity: 64)
         buffer.writeStaticString("GET /a-file\r\n\r\n")
-
-        do {
-            try channel.writeInbound(buffer)
-            XCTFail("Did not error")
-        } catch HTTPParserError.invalidVersion {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        
+        XCTAssertThrowsError(try channel.writeInbound(buffer)) { error in
+            XCTAssertEqual(.invalidVersion, error as? HTTPParserError)
         }
-
-       loop.run()
+        
+        self.loop.run()
     }
 
     func testDoesNotDecodeFakeHTTP09Request() throws {
@@ -60,16 +55,11 @@ class HTTPDecoderTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 64)
         buffer.writeStaticString("GET / HTTP/0.9\r\nHost: whatever\r\n\r\n")
 
-        do {
-            try channel.writeInbound(buffer)
-            XCTFail("Did not error")
-        } catch HTTPParserError.invalidVersion {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channel.writeInbound(buffer)) { error in
+            XCTAssertEqual(.invalidVersion, error as? HTTPParserError)
         }
 
-        loop.run()
+        self.loop.run()
     }
 
     func testDoesNotDecodeHTTP2XRequest() throws {
@@ -80,16 +70,11 @@ class HTTPDecoderTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 64)
         buffer.writeStaticString("GET / HTTP/2.0\r\nHost: whatever\r\n\r\n")
 
-        do {
-            try channel.writeInbound(buffer)
-            XCTFail("Did not error")
-        } catch HTTPParserError.invalidVersion {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channel.writeInbound(buffer)) { error in
+            XCTAssertEqual(.invalidVersion, error as? HTTPParserError)
         }
 
-        loop.run()
+        self.loop.run()
     }
 
     func testToleratesHTTP13Request() throws {
@@ -116,16 +101,11 @@ class HTTPDecoderTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 64)
         buffer.writeStaticString("This is file data\n")
 
-        do {
-            try channel.writeInbound(buffer)
-            XCTFail("Did not error")
-        } catch HTTPParserError.invalidConstant {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channel.writeInbound(buffer)) { error in
+            XCTAssertEqual(.invalidConstant, error as? HTTPParserError)
         }
 
-        loop.run()
+        self.loop.run()
     }
 
     func testDoesNotDecodeFakeHTTP09Response() throws {
@@ -139,16 +119,11 @@ class HTTPDecoderTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 64)
         buffer.writeStaticString("HTTP/0.9 200 OK\r\nServer: whatever\r\n\r\n")
 
-        do {
-            try channel.writeInbound(buffer)
-            XCTFail("Did not error")
-        } catch HTTPParserError.invalidVersion {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channel.writeInbound(buffer)) { error in
+            XCTAssertEqual(.invalidVersion, error as? HTTPParserError)
         }
 
-        loop.run()
+        self.loop.run()
     }
 
     func testDoesNotDecodeHTTP2XResponse() throws {
@@ -163,16 +138,11 @@ class HTTPDecoderTest: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 64)
         buffer.writeStaticString("HTTP/2.0 200 OK\r\nServer: whatever\r\n\r\n")
 
-        do {
-            try channel.writeInbound(buffer)
-            XCTFail("Did not error")
-        } catch HTTPParserError.invalidVersion {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channel.writeInbound(buffer)) { error in
+            XCTAssertEqual(.invalidVersion, error as? HTTPParserError)
         }
 
-        loop.run()
+        self.loop.run()
     }
 
     func testToleratesHTTP13Response() throws {
@@ -844,16 +814,11 @@ class HTTPDecoderTest: XCTestCase {
                            "Transfer-Encoding: gzip, chunked\r\n\r\n" +
                            "3\r\na=1\r\n0\r\n\r\n")
 
-        do {
-            try channel.writeInbound(buffer)
-            XCTFail("Did not error")
-        } catch HTTPParserError.unexpectedContentLength {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channel.writeInbound(buffer)) { error in
+            XCTAssertEqual(.unexpectedContentLength, error as? HTTPParserError)
         }
 
-        loop.run()
+        self.loop.run()
     }
 
     func testTrimsTrailingOWS() throws {

--- a/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
@@ -141,15 +141,9 @@ class HTTPRequestEncoderTests: XCTestCase {
     }
 
     private func assertOutboundContainsOnly(_ channel: EmbeddedChannel, _ expected: String) {
-        do {
-            if let buffer = try channel.readOutbound(as: ByteBuffer.self) {
-                buffer.assertContainsOnly(expected)
-            } else {
-                fatalError("Could not read ByteBuffer from channel")
-            }
-        } catch {
-            XCTFail("unexpected error: \(error)")
-        }
+        XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self).map { buffer in
+            buffer.assertContainsOnly(expected)
+        }, "couldn't read ByteBuffer"))
     }
 }
 

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -66,13 +66,8 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).wait())
 
         channel.pipeline.fireErrorCaught(DummyError.error)
-        do {
-            try channel.throwIfErrorCaught()
-            XCTFail("No error caught")
-        } catch DummyError.error {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channel.throwIfErrorCaught()) { error in
+            XCTAssertEqual(DummyError.error, error as? DummyError)
         }
 
         XCTAssertNoThrow(try channel.finish())

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -38,11 +38,7 @@ extension ChannelPipeline {
     }
 
     func assertContains<Handler: ChannelHandler>(handlerType: Handler.Type) throws {
-        do {
-            _ = try self.context(handlerType: handlerType).wait()
-        } catch ChannelPipelineError.notFound {
-            XCTFail("Did not find handler")
-        }
+        XCTAssertNoThrow(try self.context(handlerType: handlerType).wait(), "did not find handler")
     }
 
     fileprivate func removeUpgrader() throws {
@@ -425,11 +421,8 @@ class HTTPServerUpgradeTestCase: XCTestCase {
 
         XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
-        do {
-            try channel.writeInbound(data)
-            XCTFail("Writing of bad data did not error")
-        } catch HTTPServerUpgradeErrors.invalidHTTPOrdering {
-            // Nothing to see here.
+        XCTAssertThrowsError(try channel.writeInbound(data)) { error in
+            XCTAssertEqual(.invalidHTTPOrdering, error as? HTTPServerUpgradeErrors)
         }
 
         // The handler removed itself from the pipeline and passed the unexpected
@@ -924,13 +917,9 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         XCTAssertEqual(upgradingProtocol, "myproto")
         XCTAssertNoThrow(try channel.pipeline.assertContainsUpgrader())
         XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self)))
-        do {
-            try channel.throwIfErrorCaught()
-            XCTFail("Did not throw")
-        } catch No.no {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        
+        XCTAssertThrowsError(try channel.throwIfErrorCaught()) { error in
+            XCTAssertEqual(.no, error as? No)
         }
 
         // Ok, now we can upgrade. Upgrader should be out of the pipeline, and we should have seen the 101 response.
@@ -985,13 +974,8 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.assertDoesNotContainUpgrader())
         XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self)))
 
-        do {
-            try channel.throwIfErrorCaught()
-            XCTFail("Did not throw")
-        } catch No.no {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channel.throwIfErrorCaught()) { error in
+            XCTAssertEqual(.no, error as? No)
         }
 
         switch try channel.readInbound(as: HTTPServerRequestPart.self) {
@@ -1065,13 +1049,8 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.assertDoesNotContainUpgrader())
         XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self)))
 
-        do {
-            try channel.throwIfErrorCaught()
-            XCTFail("Did not throw")
-        } catch No.no {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channel.throwIfErrorCaught()) { error in
+            XCTAssertEqual(.no, error as? No)
         }
 
         switch try channel.readInbound(as: HTTPServerRequestPart.self) {

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -164,12 +164,8 @@ final class DatagramChannelTests: XCTestCase {
     }
 
     func testConnectionFails() throws {
-        do {
-            try self.firstChannel.connect(to: self.secondChannel.localAddress!).wait()
-        } catch ChannelError.operationUnsupported {
-            // All is well
-        } catch {
-            XCTFail("Encountered error: \(error)")
+        XCTAssertThrowsError(try self.firstChannel.connect(to: self.secondChannel.localAddress!).wait()) { error in
+            XCTAssertEqual(.operationUnsupported, error as? ChannelError)
         }
     }
 
@@ -216,16 +212,11 @@ final class DatagramChannelTests: XCTestCase {
         }.wait()
         XCTAssertTrue(fulfilled)
 
-        promises.forEach {
-            do {
-                try $0.wait()
-                XCTFail("Did not error")
-            } catch ChannelError.ioOnClosedChannel {
-                // All good
-            } catch {
-                XCTFail("Unexpected error: \(error)")
+        XCTAssertNoThrow(try promises.forEach {
+            XCTAssertThrowsError(try $0.wait()) { error in
+                XCTAssertEqual(.ioOnClosedChannel, error as? ChannelError)
             }
-        }
+        })
     }
 
     func testManyManyDatagramWrites() throws {
@@ -291,13 +282,8 @@ final class DatagramChannelTests: XCTestCase {
         let writeFut = self.firstChannel.write(NIOAny(envelope))
         self.firstChannel.flush()
 
-        do {
-            try writeFut.wait()
-            XCTFail("Did not throw")
-        } catch ChannelError.writeMessageTooLarge {
-            // All good
-        } catch {
-            XCTFail("Got unexpected error \(error)")
+        XCTAssertThrowsError(try writeFut.wait()) { error in
+            XCTAssertEqual(.writeMessageTooLarge, error as? ChannelError)
         }
     }
 
@@ -324,13 +310,8 @@ final class DatagramChannelTests: XCTestCase {
         XCTAssertNoThrow(try thirdWrite.wait())
 
         // The second should have failed.
-        do {
-            try secondWrite.wait()
-            XCTFail("Did not throw")
-        } catch ChannelError.writeMessageTooLarge {
-            // All good
-        } catch {
-            XCTFail("Got unexpected error \(error)")
+        XCTAssertThrowsError(try secondWrite.wait()) { error in
+            XCTAssertEqual(.writeMessageTooLarge, error as? ChannelError)
         }
     }
 
@@ -357,13 +338,8 @@ final class DatagramChannelTests: XCTestCase {
         XCTAssertNoThrow(try thirdWrite.wait())
 
         // The second should have failed.
-        do {
-            try secondWrite.wait()
-            XCTFail("Did not throw")
-        } catch ChannelError.writeMessageTooLarge {
-            // All good
-        } catch {
-            XCTFail("Got unexpected error \(error)")
+        XCTAssertThrowsError(try secondWrite.wait()) { error in
+            XCTAssertEqual(.writeMessageTooLarge, error as? ChannelError)
         }
     }
 

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -104,13 +104,8 @@ class EventLoopFutureTest : XCTestCase {
 
         _ = promises.map { $0.succeed(0) }
         XCTAssert(fN.isFulfilled)
-        do {
-            _ = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -143,13 +138,8 @@ class EventLoopFutureTest : XCTestCase {
         }
 
         XCTAssert(fN.isFulfilled)
-        do {
-            _ = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -169,13 +159,8 @@ class EventLoopFutureTest : XCTestCase {
 
         _ = promises.map { $0.succeed(1) }
         XCTAssert(fN.isFulfilled)
-        do {
-            _ = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -194,13 +179,8 @@ class EventLoopFutureTest : XCTestCase {
         }
 
         XCTAssert(fN.isFulfilled)
-        do {
-            _ = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -218,13 +198,8 @@ class EventLoopFutureTest : XCTestCase {
         }
 
         XCTAssert(fN.isFulfilled)
-        do {
-            _ = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -255,13 +230,8 @@ class EventLoopFutureTest : XCTestCase {
 
         let fN = EventLoopFuture.andAllSucceed(futures, on: eventLoop)
         _ = promises.map { $0.fail(E()) }
-        do {
-            () = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -277,13 +247,8 @@ class EventLoopFutureTest : XCTestCase {
         let futures = promises.map { $0.futureResult }
 
         let fN = EventLoopFuture.andAllSucceed(futures, on: eventLoop)
-        do {
-            () = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -325,13 +290,8 @@ class EventLoopFutureTest : XCTestCase {
         let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, on: eventLoop, +)
         _ = promises.map { $0.fail(E()) }
         XCTAssert(fN.eventLoop === eventLoop)
-        do {
-            _ = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -348,13 +308,8 @@ class EventLoopFutureTest : XCTestCase {
 
         let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, on: eventLoop, +)
         XCTAssert(fN.eventLoop === eventLoop)
-        do {
-            _ = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -373,13 +328,8 @@ class EventLoopFutureTest : XCTestCase {
 
         XCTAssertTrue(fN.isFulfilled)
         XCTAssert(fN.eventLoop === eventLoop)
-        do {
-            _ = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -432,13 +382,8 @@ class EventLoopFutureTest : XCTestCase {
 
         XCTAssert(fN.isFulfilled)
         XCTAssert(fN.eventLoop === eventLoop)
-        do {
-            _ = try fN.wait()
-            XCTFail("should've thrown an error")
-        } catch _ as E {
-            /* good */
-        } catch let e {
-            XCTFail("error of wrong type \(e)")
+        XCTAssertThrowsError(try fN.wait()) { error in
+            XCTAssertNotNil(error as? E)
         }
     }
 
@@ -625,13 +570,8 @@ class EventLoopFutureTest : XCTestCase {
             }
             prev = p.futureResult
         }
-        do {
-            _ = try prev.wait()
-            XCTFail("should have failed")
-        } catch _ as DummyError {
-            // OK
-        } catch {
-            XCTFail("wrong error \(error)")
+        XCTAssertThrowsError(try prev.wait()) { error in
+            XCTAssertNotNil(error as? DummyError)
         }
         XCTAssertNoThrow(try elg.syncShutdownGracefully())
     }
@@ -670,13 +610,8 @@ class EventLoopFutureTest : XCTestCase {
                 }
             }
         }
-        do {
-            try allOfEm.wait()
-            XCTFail("unexpected failure")
-        } catch _ as DummyError {
-            // ok
-        } catch {
-            XCTFail("unexpected error: \(error)")
+        XCTAssertThrowsError(try allOfEm.wait()) { error in
+            XCTAssertNotNil(error as? DummyError)
         }
         XCTAssertNoThrow(try elg.syncShutdownGracefully())
         XCTAssertNoThrow(try fireBackEl.syncShutdownGracefully())

--- a/Tests/NIOTests/HappyEyeballsTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest.swift
@@ -32,8 +32,9 @@ private extension Array where Element == Channel {
         self.forEach {
             do {
                 _ = try($0 as! EmbeddedChannel).finish()
+                // We're happy with no error
             } catch ChannelError.alreadyClosed {
-                return
+                return // as well as already closed.
             } catch {
                 XCTFail("Finishing got error \(error)")
             }
@@ -1168,13 +1169,8 @@ public final class HappyEyeballsTest : XCTestCase {
 
         // At this time the connection attempt should have failed, as the connect timeout
         // fired.
-        do {
-            _ = try channelFuture.wait()
-            XCTFail("connection succeeded")
-        } catch ChannelError.connectTimeout(.milliseconds(250)) {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channelFuture.wait()) { error in
+            XCTAssertEqual(.connectTimeout(.milliseconds(250)), error as? ChannelError)
         }
 
         // There may be one or two channels, depending on ordering, but both
@@ -1217,13 +1213,8 @@ public final class HappyEyeballsTest : XCTestCase {
 
         // At this time the connection attempt should have failed, as the connect timeout
         // fired.
-        do {
-            _ = try channelFuture.wait()
-            XCTFail("connection succeeded")
-        } catch ChannelError.connectTimeout(.milliseconds(50)) {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try channelFuture.wait()) { error in
+            XCTAssertEqual(.connectTimeout(.milliseconds(50)), error as? ChannelError)
         }
 
         // There may be zero or one channels, depending on ordering, but if there is one it

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -134,16 +134,11 @@ class NonBlockingFileIOTest: XCTestCase {
         }
 
         try withPipe { readFH, writeFH in
-            do {
-                _ = try self.fileIO.read(fileHandle: readFH,
+            XCTAssertThrowsError(try self.fileIO.read(fileHandle: readFH,
                                          byteCount: 1,
                                          allocator: self.allocator,
-                                         eventLoop: self.eventLoop).wait()
-                XCTFail("should've thrown")
-            } catch let e as ChannelError {
-                XCTAssertEqual(ChannelError.ioOnClosedChannel, e)
-            } catch {
-                XCTFail("unexpected error \(error)")
+                                         eventLoop: self.eventLoop).wait()) { error in
+                XCTAssertEqual(.ioOnClosedChannel, error as? ChannelError)
             }
             return [readFH, writeFH]
         }
@@ -175,25 +170,20 @@ class NonBlockingFileIOTest: XCTestCase {
         let content = "hello"
         let contentBytes = Array(content.utf8)
         var numCalls = 0
-        withTemporaryFile(content: content) { (fileHandle, path) -> Void in
+        try withTemporaryFile(content: content) { (fileHandle, path) -> Void in
             let fr = FileRegion(fileHandle: fileHandle, readerIndex: 0, endIndex: 5)
-            do {
-                try self.fileIO.readChunked(fileRegion: fr,
-                                            chunkSize: 1,
-                                            allocator: self.allocator,
-                                            eventLoop: self.eventLoop) { buf in
-                                                var buf = buf
-                                        XCTAssertTrue(self.eventLoop.inEventLoop)
-                                        XCTAssertEqual(1, buf.readableBytes)
-                                        XCTAssertEqual(contentBytes[numCalls], buf.readBytes(length: 1)?.first!)
-                                        numCalls += 1
-                                        return self.eventLoop.makeFailedFuture(DummyError.dummy)
-                    }.wait()
-                XCTFail("call successful but should've failed")
-            } catch let e as DummyError where e == .dummy {
-                // ok
-            } catch {
-                XCTFail("wrong error \(error) caught")
+            XCTAssertThrowsError(try self.fileIO.readChunked(fileRegion: fr,
+                                                             chunkSize: 1,
+                                                             allocator: self.allocator,
+                                                             eventLoop: self.eventLoop) { buf in
+                var buf = buf
+                XCTAssertTrue(self.eventLoop.inEventLoop)
+                XCTAssertEqual(1, buf.readableBytes)
+                XCTAssertEqual(contentBytes[numCalls], buf.readBytes(length: 1)?.first!)
+                numCalls += 1
+                return self.eventLoop.makeFailedFuture(DummyError.dummy)
+            }.wait()) { error in
+                XCTAssertEqual(.dummy, error as? DummyError)
             }
         }
         XCTAssertEqual(1, numCalls)
@@ -205,24 +195,19 @@ class NonBlockingFileIOTest: XCTestCase {
         defer {
             XCTAssertNoThrow(try unconnectedSockFH.close())
         }
-        do {
-            try self.fileIO.readChunked(fileHandle: unconnectedSockFH,
+        XCTAssertThrowsError(try self.fileIO.readChunked(fileHandle: unconnectedSockFH,
                                         byteCount: 5,
                                         chunkSize: 1,
                                         allocator: self.allocator,
                                         eventLoop: self.eventLoop) { buf in
                                             XCTFail("shouldn't have been called")
                                             return self.eventLoop.makeSucceededFuture(())
-                }.wait()
-            XCTFail("call successful but should've failed")
-        } catch let e as IOError {
+        }.wait()) { error in
             #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-                XCTAssertEqual(ENOTCONN, e.errnoCode)
+                XCTAssertEqual(ENOTCONN, (error as? IOError)?.errnoCode)
             #else
-                XCTAssertEqual(EINVAL, e.errnoCode)
+                XCTAssertEqual(EINVAL, (error as? IOError)?.errnoCode)
             #endif
-        } catch {
-            XCTFail("wrong error \(error) caught")
         }
     }
 
@@ -384,19 +369,14 @@ class NonBlockingFileIOTest: XCTestCase {
                 _ = try! Posix.write(descriptor: writeFD, pointer: "ABC", size: 3)
             }
             let fr = FileRegion(fileHandle: readFH, readerIndex: 1, endIndex: 2)
-            do {
-                try self.fileIO.readChunked(fileRegion: fr,
+            XCTAssertThrowsError(try self.fileIO.readChunked(fileRegion: fr,
                                             chunkSize: 10,
                                             allocator: self.allocator,
                                             eventLoop: self.eventLoop) { buf in
                                                 XCTFail("this shouldn't have been called")
                                                 return self.eventLoop.makeSucceededFuture(())
-                    }.wait()
-                XCTFail("succeeded and shouldn't have")
-            } catch let e as IOError where e.errnoCode == ESPIPE {
-                // OK
-            } catch {
-                XCTFail("wrong error \(error) caught")
+            }.wait()) { error in
+                XCTAssertEqual(ESPIPE, (error as? IOError)?.errnoCode)
             }
             return [readFH, writeFH]
         }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -261,11 +261,8 @@ public final class SocketChannelTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .bind(host: "127.0.0.1", port: 0)
             .wait())
-        do {
-            try serverChannel.writeAndFlush("test").wait()
-            XCTFail("did not throw")
-        } catch let err as ChannelError where err == .operationUnsupported {
-            // expected
+        XCTAssertThrowsError(try serverChannel.writeAndFlush("test").wait()) { error in
+            XCTAssertEqual(.operationUnsupported, error as? ChannelError)
         }
         try serverChannel.close().wait()
     }
@@ -278,10 +275,8 @@ public final class SocketChannelTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .bind(host: "127.0.0.1", port: 0)
             .wait())
-        do {
-            try serverChannel.writeAndFlush("test").wait()
-        } catch let err as ChannelError where err == .operationUnsupported {
-            // expected
+        XCTAssertThrowsError(try serverChannel.writeAndFlush("test").wait()) { error in
+            XCTAssertEqual(.operationUnsupported, error as? ChannelError)
         }
         try serverChannel.close().wait()
     }
@@ -294,15 +289,8 @@ public final class SocketChannelTest : XCTestCase {
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .bind(host: "127.0.0.1", port: 0)
             .wait())
-        do {
-            try serverChannel.connect(to: serverChannel.localAddress!).wait()
-            XCTFail("Did not throw")
-            XCTAssertNoThrow(try serverChannel.close().wait())
-        } catch let err as ChannelError where err == .operationUnsupported {
-            // expected, no close here as the channel is already closed.
-        } catch {
-            XCTFail("Unexpected error \(error)")
-            XCTAssertNoThrow(try serverChannel.close().wait())
+        XCTAssertThrowsError(try serverChannel.writeAndFlush("test").wait()) { error in
+            XCTAssertEqual(.operationUnsupported, error as? ChannelError)
         }
     }
 
@@ -330,13 +318,8 @@ public final class SocketChannelTest : XCTestCase {
         }
         XCTAssertNoThrow(try clientChannel.close().wait())
 
-        do {
-            try writeFut.wait()
-            XCTFail("Did not throw")
-        } catch ChannelError.alreadyClosed {
-            // ok
-        } catch {
-            XCTFail("Unexpected error \(error)")
+        XCTAssertThrowsError(try writeFut.wait()) { error in
+            XCTAssertEqual(.alreadyClosed, error as? ChannelError)
         }
     }
 
@@ -471,11 +454,8 @@ public final class SocketChannelTest : XCTestCase {
             }
         }.wait() as Void)
 
-        do {
-            try connectPromise.futureResult.wait()
-            XCTFail("Did not throw")
-        } catch let err as ChannelError where err == .ioOnClosedChannel {
-            // expected
+        XCTAssertThrowsError(try connectPromise.futureResult.wait()) { error in
+            XCTAssertEqual(.ioOnClosedChannel, error as? ChannelError)
         }
         XCTAssertNoThrow(try closePromise.futureResult.wait())
         XCTAssertNoThrow(try channel.closeFuture.wait())

--- a/Tests/NIOTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOTests/SocketOptionProviderTest.swift
@@ -142,13 +142,9 @@ final class SocketOptionProviderTest: XCTestCase {
         // we just abandon the other tests: this is sufficient to prove that the error path works.
         let provider = try assertNoThrowWithValue(self.convertedChannel())
 
-        do {
-            try provider.unsafeSetSocketOption(level: SocketOptionLevel(SOL_SOCKET), name: SO_RCVTIMEO, value: CInt(1)).wait()
-            XCTFail("Did not throw")
-        } catch let err as IOError where err.errnoCode == EINVAL {
-            // Acceptable error
-        } catch {
-            XCTFail("Invalid error: \(error)")
+        XCTAssertThrowsError(try provider.unsafeSetSocketOption(level: SocketOptionLevel(SOL_SOCKET),
+                                                                name: SO_RCVTIMEO, value: CInt(1)).wait()) { error in
+            XCTAssertEqual(EINVAL, (error as? IOError)?.errnoCode)
         }
     }
 

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -231,14 +231,16 @@ func assertSetGetOptionOnOpenAndClosed<Option: ChannelOption>(channel: Channel, 
 
     do {
         _ = try channel.setOption(option, value: value).wait()
+        // We're okay with no error
     } catch let err as ChannelError where err == .ioOnClosedChannel {
-        // expected
+        // as well as already closed channels.
     }
 
     do {
         _ = try channel.getOption(option).wait()
+        // We're okay with no error
     } catch let err as ChannelError where err == .ioOnClosedChannel {
-        // expected
+        // as well as already closed channels.
     }
 }
 

--- a/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
+++ b/Tests/NIOWebSocketTests/WebSocketFrameDecoderTest.swift
@@ -247,13 +247,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // larger than the frame max.
         self.buffer.writeBytes([0x81, 0xFE, 0x40, 0x01])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.invalidFrameLength {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.invalidFrameLength, error as? NIOWebSocketError)
         }
 
         // We expect that an error frame will have been written out.
@@ -267,13 +262,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // A fake frame header that claims this is a fragmented ping frame.
         self.buffer.writeBytes([0x09, 0x00])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.fragmentedControlFrame {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.fragmentedControlFrame, error as? NIOWebSocketError)
         }
 
         // We expect that an error frame will have been written out.
@@ -287,13 +277,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // A fake frame header that claims this is a ping frame with 126 bytes of data.
         self.buffer.writeBytes([0x89, 0x7E, 0x00, 0x7E])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.multiByteControlFrameLength {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.multiByteControlFrameLength, error as? NIOWebSocketError)
         }
 
         // We expect that an error frame will have been written out.
@@ -309,13 +294,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // A fake frame header that claims this is a fragmented ping frame.
         self.buffer.writeBytes([0x09, 0x00])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.fragmentedControlFrame {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.fragmentedControlFrame, error as? NIOWebSocketError)
         }
 
         // We expect that an error frame will have been written out.
@@ -377,13 +357,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // larger than the frame max.
         self.buffer.writeBytes([0x81, 0xFE, 0x40, 0x01])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.invalidFrameLength {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.invalidFrameLength, error as? NIOWebSocketError)
         }
 
         // No error frame should be written.
@@ -399,13 +374,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // A fake frame header that claims this is a fragmented ping frame.
         self.buffer.writeBytes([0x09, 0x00])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.fragmentedControlFrame {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.fragmentedControlFrame, error as? NIOWebSocketError)
         }
 
         // No error frame should be written.
@@ -421,13 +391,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // A fake frame header that claims this is a ping frame with 126 bytes of data.
         self.buffer.writeBytes([0x89, 0x7E, 0x00, 0x7E])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.multiByteControlFrameLength {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.multiByteControlFrameLength, error as? NIOWebSocketError)
         }
 
         // No error frame should be written.
@@ -443,13 +408,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // A fake frame header that claims this is a fragmented ping frame.
         self.buffer.writeBytes([0x09, 0x00])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.fragmentedControlFrame {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.fragmentedControlFrame, error as? NIOWebSocketError)
         }
 
         // No error frame should be written.
@@ -484,13 +444,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // larger than the frame max.
         self.buffer.writeBytes([0x81, 0xFE, 0x40, 0x01])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.invalidFrameLength {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.invalidFrameLength, error as? NIOWebSocketError)
         }
 
         // We expect that an error frame will have been written out.
@@ -507,13 +462,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // A fake frame header that claims this is a fragmented ping frame.
         self.buffer.writeBytes([0x09, 0x00])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.fragmentedControlFrame {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.fragmentedControlFrame, error as? NIOWebSocketError)
         }
 
         // We expect that an error frame will have been written out.
@@ -530,13 +480,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // A fake frame header that claims this is a ping frame with 126 bytes of data.
         self.buffer.writeBytes([0x89, 0x7E, 0x00, 0x7E])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.multiByteControlFrameLength {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.multiByteControlFrameLength, error as? NIOWebSocketError)
         }
 
         // We expect that an error frame will have been written out.
@@ -555,13 +500,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
         // A fake frame header that claims this is a fragmented ping frame.
         self.buffer.writeBytes([0x09, 0x00])
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.fragmentedControlFrame {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.fragmentedControlFrame, error as? NIOWebSocketError)
         }
 
         // We expect that an error frame will have been written out.
@@ -606,13 +546,8 @@ public final class WebSocketFrameDecoderTest: XCTestCase {
             XCTAssertNotNil(error as? Dummy, "unexpected error: \(error)")
         }
 
-        do {
-            try self.decoderChannel.writeInbound(self.buffer)
-            XCTFail("did not throw")
-        } catch NIOWebSocketError.invalidFrameLength {
-            // OK
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try self.decoderChannel.writeInbound(self.buffer)) { error in
+            XCTAssertEqual(.invalidFrameLength, error as? NIOWebSocketError)
         }
 
         // We expect that an error frame will have been written out.

--- a/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
@@ -188,13 +188,8 @@ class WebSocketServerEndToEndTests: XCTestCase {
         buffer.writeString(upgradeRequest)
 
         // Write this directly to the server.
-        do {
-            try server.writeInbound(buffer)
-            XCTFail("Did not throw")
-        } catch let error as NIOWebSocketUpgradeError where error == .unsupportedWebSocketTarget {
-            // ok
-        } catch {
-            XCTFail("Unexpected error hit: \(error)")
+        XCTAssertThrowsError(try server.writeInbound(buffer)) { error in
+            XCTAssertEqual(.unsupportedWebSocketTarget, error as? NIOWebSocketUpgradeError)
         }
 
         // Nothing gets written.
@@ -260,13 +255,8 @@ class WebSocketServerEndToEndTests: XCTestCase {
         buffer.writeString(upgradeRequest)
 
         // Write this directly to the server.
-        do {
-            try server.writeInbound(buffer)
-            XCTFail("Did not throw")
-        } catch let error as NIOWebSocketUpgradeError where error == .invalidUpgradeHeader {
-            // ok
-        } catch {
-            XCTFail("Unexpected error hit: \(error)")
+        XCTAssertThrowsError(try server.writeInbound(buffer)) { error in
+            XCTAssertEqual(.invalidUpgradeHeader, error as? NIOWebSocketUpgradeError)
         }
 
         // Nothing gets written.
@@ -288,13 +278,8 @@ class WebSocketServerEndToEndTests: XCTestCase {
         buffer.writeString(upgradeRequest)
 
         // Write this directly to the server.
-        do {
-            try server.writeInbound(buffer)
-            XCTFail("Did not throw")
-        } catch let error as NIOWebSocketUpgradeError where error == .invalidUpgradeHeader {
-            // ok
-        } catch {
-            XCTFail("Unexpected error hit: \(error)")
+        XCTAssertThrowsError(try server.writeInbound(buffer)) { error in
+            XCTAssertEqual(.invalidUpgradeHeader, error as? NIOWebSocketUpgradeError)
         }
 
         // Nothing gets written.
@@ -316,13 +301,8 @@ class WebSocketServerEndToEndTests: XCTestCase {
         buffer.writeString(upgradeRequest)
 
         // Write this directly to the server.
-        do {
-            try server.writeInbound(buffer)
-            XCTFail("Did not throw")
-        } catch let error as NIOWebSocketUpgradeError where error == .invalidUpgradeHeader {
-            // ok
-        } catch {
-            XCTFail("Unexpected error hit: \(error)")
+        XCTAssertThrowsError(try server.writeInbound(buffer)) { error in
+            XCTAssertEqual(.invalidUpgradeHeader, error as? NIOWebSocketUpgradeError)
         }
 
         // Nothing gets written.
@@ -472,13 +452,8 @@ class WebSocketServerEndToEndTests: XCTestCase {
         data.writeBytes([0x89, 0x7E, 0x00, 0x7E])
         XCTAssertNoThrow(try client.writeAndFlush(data).wait())
 
-        do {
-            try interactInMemory(client, server, eventLoop: loop)
-            XCTFail("Did not throw")
-        } catch NIOWebSocketError.multiByteControlFrameLength {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try interactInMemory(client, server, eventLoop: loop)) { error in
+            XCTAssertEqual(NIOWebSocketError.multiByteControlFrameLength, error as? NIOWebSocketError)
         }
 
         XCTAssertEqual(recorder.errors.count, 1)
@@ -516,13 +491,8 @@ class WebSocketServerEndToEndTests: XCTestCase {
         data.writeBytes([0x89, 0x7E, 0x00, 0x7E])
         XCTAssertNoThrow(try client.writeAndFlush(data).wait())
 
-        do {
-            try interactInMemory(client, server, eventLoop: loop)
-            XCTFail("Did not throw")
-        } catch NIOWebSocketError.multiByteControlFrameLength {
-            // ok
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try interactInMemory(client, server, eventLoop: loop)) { error in
+            XCTAssertEqual(NIOWebSocketError.multiByteControlFrameLength, error as? NIOWebSocketError)
         }
 
         XCTAssertEqual(recorder.errors.count, 1)


### PR DESCRIPTION
Motivation:

The

    do {
        try someOperation()
	XCTFail("should throw") // easy to forget
    } catch error as SomethingError {
        XCTAssertEqual(.something, error as? SomethingError)
    } catch {
        XCTFail("wrong error")
    }

pattern is not only very long, it's also very error prone. If you forget
any of the XCTFails, you might not tests what it looks like

    XCTAssertThrowsError(try someOperation) { error in
        XCTAssertEqual(.something, error as? SomethingError)
    }

is much safer and shorter.

Modifcations:

Do many of the above replaces.

Result:

Cleaner, shorter, and safer tests.