### PR TITLE
use Posix.read instead of Glibc.read for timerfd 

### DIFF
--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -549,7 +549,7 @@ internal class Selector<R: Registration> {
                 // Consume event
                 var val: UInt64 = 0
                 // We are not interested in the result
-                _ = try! Posix.read(self.timerFD, &val, MemoryLayout.size(ofValue: val))
+                _ = try! Posix.read(descriptor: self.timerFD, pointer: &val, size: MemoryLayout.size(ofValue: val))
 
                 // Processed the earliest set timer so reset it.
                 self.earliestTimer = .distantFuture

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -549,7 +549,7 @@ internal class Selector<R: Registration> {
                 // Consume event
                 var val: UInt64 = 0
                 // We are not interested in the result
-                _ = Glibc.read(self.timerFD, &val, MemoryLayout.size(ofValue: val))
+                _ = try! Posix.read(self.timerFD, &val, MemoryLayout.size(ofValue: val))
 
                 // Processed the earliest set timer so reset it.
                 self.earliestTimer = .distantFuture


### PR DESCRIPTION


### Motivation:

To read the bytes from `timerfd`, we use Glibc.read directly but we should use `try! Posix.read`

### Modifications:

Using `Posix` instead of `Glibc` for read operation with `try!` to check for any error.

### Result:

Fixes https://github.com/apple/swift-nio/issues/1341

