### PR TITLE
fix macOS build & cleanup Thread

### DIFF
--- a/Sources/NIO/LinuxCPUSet.swift
+++ b/Sources/NIO/LinuxCPUSet.swift
@@ -54,7 +54,7 @@ import CNIOLinux
                 // Ensure the cpuset is empty (and so nothing is selected yet).
                 CNIOLinux_CPU_ZERO(&cpuset)
 
-                let res = withUnsafePthread { p in
+                let res = self.withUnsafeThreadHandle { p in
                     CNIOLinux_pthread_getaffinity_np(p, MemoryLayout.size(ofValue: cpuset), &cpuset)
                 }
 
@@ -71,7 +71,7 @@ import CNIOLinux
 
                 // Mark the CPU we want to run on.
                 cpuSet.cpuIds.forEach { CNIOLinux_CPU_SET(CInt($0), &cpuset) }
-                let res = withUnsafePthread { p in
+                let res = self.withUnsafeThreadHandle { p in
                     CNIOLinux_pthread_setaffinity_np(p, MemoryLayout.size(ofValue: cpuset), &cpuset)
                 }
                 precondition(res == 0, "pthread_setaffinity_np failed: \(res)")

--- a/Sources/NIO/ThreadPosix.swift
+++ b/Sources/NIO/ThreadPosix.swift
@@ -1,0 +1,149 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Linux) || os(Android) || os(FreeBSD) || os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+
+#if os(Linux)
+import CNIOLinux
+
+private let sys_pthread_getname_np = CNIOLinux_pthread_getname_np
+private let sys_pthread_setname_np = CNIOLinux_pthread_setname_np
+private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer?
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+private let sys_pthread_getname_np = pthread_getname_np
+// Emulate the same method signature as pthread_setname_np on Linux.
+private func sys_pthread_setname_np(_ p: pthread_t, _ pointer: UnsafePointer<Int8>) -> Int32 {
+    assert(pthread_equal(pthread_self(), p) != 0)
+    pthread_setname_np(pointer)
+    // Will never fail on macOS so just return 0 which will be used on linux to signal it not failed.
+    return 0
+}
+private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer) -> UnsafeMutableRawPointer?
+
+#endif
+
+private func sysPthread_create(handle: UnsafeMutablePointer<pthread_t?>,
+                               destructor: @escaping ThreadDestructor,
+                               args: UnsafeMutableRawPointer?) -> CInt {
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    return pthread_create(handle, nil, destructor, args)
+    #else
+    var handleLinux = pthread_t()
+    let result = pthread_create(&handleLinux,
+                                nil,
+                                destructor,
+                                args)
+    handle.pointee = handleLinux
+    return result
+    #endif
+}
+
+
+typealias ThreadOpsSystem = ThreadOpsPosix
+
+enum ThreadOpsPosix: ThreadOps {
+    typealias ThreadHandle = pthread_t
+    typealias ThreadSpecificKey = pthread_key_t
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    typealias ThreadSpecificKeyDestructor = @convention(c) (UnsafeMutableRawPointer) -> Void
+    #else
+    typealias ThreadSpecificKeyDestructor = @convention(c) (UnsafeMutableRawPointer?) -> Void
+    #endif
+
+    static func threadName(_ thread: ThreadOpsSystem.ThreadHandle) -> String? {
+        // 64 bytes should be good enough as on Linux the limit is usually 16
+        // and it's very unlikely a user will ever set something longer
+        // anyway.
+        var chars: [CChar] = Array(repeating: 0, count: 64)
+        return chars.withUnsafeMutableBufferPointer { ptr in
+            guard sys_pthread_getname_np(thread, ptr.baseAddress!, ptr.count) == 0 else {
+                return nil
+            }
+
+            let buffer: UnsafeRawBufferPointer =
+                UnsafeRawBufferPointer(UnsafeBufferPointer<CChar>(rebasing: ptr.prefix { $0 != 0 }))
+            return String(decoding: buffer, as: Unicode.UTF8.self)
+        }
+    }
+
+    static func run(handle: inout ThreadOpsSystem.ThreadHandle?, args: Box<NIOThread.ThreadBoxValue>, detachThread: Bool) {
+        let argv0 = Unmanaged.passRetained(args).toOpaque()
+        let res = sysPthread_create(handle: &handle, destructor: {
+            // Cast to UnsafeMutableRawPointer? and force unwrap to make the
+            // same code work on macOS and Linux.
+            let boxed = Unmanaged<NIOThread.ThreadBox>
+                          .fromOpaque(($0 as UnsafeMutableRawPointer?)!)
+                          .takeRetainedValue()
+            let (body, name) = (boxed.value.body, boxed.value.name)
+            let hThread: ThreadOpsSystem.ThreadHandle = pthread_self()
+
+            if let name = name {
+                // this is non-critical so we ignore the result here, we've seen
+                // EPERM in containers.
+                _ = sys_pthread_setname_np(hThread, name)
+            }
+
+            body(NIOThread(handle: hThread, desiredName: name))
+
+            return nil
+        }, args: argv0)
+        precondition(res == 0, "Unable to create thread: \(res)")
+
+        if detachThread {
+            let detachError = pthread_detach(handle!)
+            precondition(detachError == 0, "pthread_detach failed with error \(detachError)")
+        }
+
+    }
+
+    static func isCurrentThread(_ thread: ThreadOpsSystem.ThreadHandle) -> Bool {
+        return pthread_equal(thread, pthread_self()) != 0
+    }
+
+    static var currentThread: ThreadOpsSystem.ThreadHandle {
+        return pthread_self()
+    }
+
+    static func joinThread(_ thread: ThreadOpsSystem.ThreadHandle) {
+        let err = pthread_join(thread, nil)
+        assert(err == 0, "pthread_join failed with \(err)")
+    }
+
+    static func allocateThreadSpecificValue(destructor: @escaping ThreadSpecificKeyDestructor) -> ThreadSpecificKey {
+        var value = pthread_key_t()
+        let result = pthread_key_create(&value, Optional(destructor))
+        precondition(result == 0, "pthread_key_create failed: \(result)")
+        return value
+    }
+
+    static func deallocateThreadSpecificValue(_ key: ThreadSpecificKey) {
+        let result = pthread_key_delete(key)
+        precondition(result == 0, "pthread_key_delete failed: \(result)")
+    }
+
+    static func getThreadSpecificValue(_ key: pthread_key_t) -> UnsafeMutableRawPointer? {
+        return pthread_getspecific(key)
+    }
+
+    static func setThreadSpecificValue(key: pthread_key_t, value: UnsafeMutableRawPointer?) {
+        let result = pthread_setspecific(key, value)
+        precondition(result == 0, "pthread_setspecific failed: \(result)")
+    }
+
+    static func compareThreads(_ lhs: ThreadOpsSystem.ThreadHandle, _ rhs: ThreadOpsSystem.ThreadHandle) -> Bool {
+        return pthread_equal(lhs, rhs) != 0
+    }
+}
+
+#endif

--- a/Sources/NIO/ThreadWindows.swift
+++ b/Sources/NIO/ThreadWindows.swift
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+
+import WinSDK
+
+
+typealias ThreadOpsSystem = ThreadOpsWindows
+enum ThreadOpsWindows: ThreadOps {
+    typealias ThreadHandle = HANDLE
+    typealias ThreadSpecificKey = DWORD
+    typealias ThreadSpecificKeyDestructor = @convention(c) (UnsafeMutableRawPointer?) -> Void
+
+    static func threadName(_ thread: ThreadOpsSystem.ThreadHandle) -> String? {
+        var pszBuffer: PWSTR?
+        GetThreadDescription(thread, &pszBuffer)
+        guard let buffer = pszBuffer else { return nil }
+        let string: String = String(decodingCString: buffer, as: UTF16.self)
+        LocalFree(buffer)
+        return string
+    }
+
+    static func run(handle: inout ThreadOpsSystem.ThreadHandle?, args: Box<NIOThread.ThreadBoxValue>, detachThread: Bool) {
+        let argv0 = Unmanaged.passRetained(args).toOpaque()
+
+        // FIXME(compnerd) this should use the `stdcall` calling convention
+        let routine: @convention(c) (UnsafeMutableRawPointer?) -> CUnsignedInt = {
+            let boxed = Unmanaged<ThreadBox>.fromOpaque($0!).takeRetainedValue()
+            let (body, name) = (boxed.value.body, boxed.value.name)
+            let hThread: ThreadOpsSystem.ThreadHandle = GetCurrentThread()
+
+            if let name = name {
+                _ = name.withCString(encodedAs: UTF16.self) {
+                    SetThreadDescription(hThread, $0)
+                }
+            }
+
+            body(NIOThread(handle: hThread, desiredName: name))
+
+            return 0
+        }
+        let hThread: HANDLE =
+            HANDLE(bitPattern: _beginthreadex(nil, 0, routine, argv0, 0, nil))!
+
+        if detachThread {
+            CloseHandle(hThread)
+        }
+    }
+
+    static func isCurrentThread(_ thread: ThreadOpsSystem.ThreadHandle) -> Bool {
+        return CompareObjectHandles(thread, GetCurrentThread())
+    }
+
+    static var currentThread: ThreadOpsSystem.ThreadHandle {
+        return GetCurrentThread()
+    }
+
+    static func joinThread(_ thread: ThreadOpsSystem.ThreadHandle) {
+        let dwResult: DWORD = WaitForSingleObject(thread, INFINITE)
+        assert(dwResult == WAIT_OBJECT_0, "WaitForSingleObject: \(GetLastError())")
+    }
+
+    static func allocateThreadSpecificValue(destructor: ThreadSpecificKeyDestructor) -> ThreadSpecificKey {
+        return FlsAlloc(destructor)
+    }
+
+    static func deallocateThreadSpecificValue(_ key: ThreadSpecificKey) {
+        let dwResult: Bool = FlsFree(key)
+        precondition(dwResult, "FlsFree: \(GetLastError())")
+    }
+
+    static func getThreadSpecificValue(_ key: pthread_key_t) -> UnsafeMutableRawPointer? {
+        return FlsGetValue(key.value)
+    }
+
+    static func setThreadSpecificValue(key: pthread_key_t, value: UnsafeMutableRawPointer?) {
+        FlsSetValue(key, value)
+    }
+
+    static func compareThreads(_ lhs: ThreadOpsSystem.ThreadHandle, _ rhs: ThreadOpsSystem.ThreadHandle) -> Bool {
+        return CompareObjectHandles(lhs, rhs)
+    }
+}
+
+#endif


### PR DESCRIPTION
Motivation:

The macOS build was broken by #1424, also the Thread.swift file became
a bit of a mess with `#if os(...)/#else` everywhere.

Modifications:

- fix macOS build
- cleanup Thread by splitting it into ThreadPosix & ThreadWindows

Result:

- build working again
- cleaner code