### PR TITLE
Fix NIOThreadPool type name in NonBlockingFileIO.init

### DIFF
--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -44,10 +44,10 @@ public struct NonBlockingFileIO {
 
     private let threadPool: NIOThreadPool
 
-    /// Initialize a `NonBlockingFileIO` which uses the `BlockingIOThreadPool`.
+    /// Initialize a `NonBlockingFileIO` which uses the `NIOThreadPool`.
     ///
     /// - parameters:
-    ///   - threadPool: The `BlockingIOThreadPool` that will be used for all the IO.
+    ///   - threadPool: The `NIOThreadPool` that will be used for all the IO.
     public init(threadPool: NIOThreadPool) {
         self.threadPool = threadPool
     }


### PR DESCRIPTION
Updates `NonBlockingFileIO.init` docs to use the new type name.