### PR TITLE
support quoted strings in HTTPHeaders[canonicalForm:]

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -485,7 +485,7 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
 
 private struct HTTPHeaderValueParser {
     var current: Substring
-    
+
     init(_ string: String) {
         self.current = .init(string)
     }
@@ -527,6 +527,7 @@ private struct HTTPHeaderValueParser {
             return nil
         }
         if self.current[self.current.index(before: nextQuote)] == "\\" {
+            // Skip escaped quotes.
             return self.nextDoubleQuote(from: self.current.index(after: nextQuote))
         }
         return nextQuote
@@ -561,6 +562,7 @@ private struct HTTPHeaderValueParser {
 }
 
 private extension Substring {
+    /// Converts all `\"` to `"`. 
     func unescapingQuotes() -> Substring {
         return self.split(separator: "\\").reduce("") { (result, part) -> SubSequence in
             guard !result.isEmpty else {

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -472,7 +472,6 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
             return result.map { $0[...] }
         }
 
-
         var values: [Substring] = []
         for result in result {
             var parser = HTTPHeaderValueParser(result)

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -561,11 +561,11 @@ private struct HTTPHeaderValueParser {
 private extension Substring {
     /// Converts all `\"` to `"`.
     func unescapingDoubleQuotes() -> Substring {
-        return self.split(separator: "\\").lazy.reduce(into: "") { (result, part) in
+        return self.lazy.split(separator: "\\").reduce(into: "") { (result, part) in
             if result.isEmpty || part.first == "\"" {
                 result += part
             } else {
-                result += "\\\(part)"
+                result += "\\" + part
             }
         }
     }

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -519,7 +519,7 @@ private struct HTTPHeaderValueParser {
     }
 
     private func nextDoubleQuote() -> Substring.Index? {
-        self.nextDoubleQuote(from: self.current.startIndex)
+        return self.nextDoubleQuote(from: self.current.startIndex)
     }
 
     private func nextDoubleQuote(from startIndex: Substring.Index) -> Substring.Index? {

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -546,7 +546,7 @@ private struct HTTPHeaderValueParser {
     }
 
     private func nextComma() -> Substring.Index? {
-        self.current.firstIndex(of: ",")
+        return self.current.firstIndex(of: ",")
     }
 
     private mutating func nextWhitespace() -> Substring.Index? {
@@ -562,9 +562,7 @@ private struct HTTPHeaderValueParser {
     }
 
     private mutating func pop() {
-        if self.current.startIndex == self.current.endIndex {
-            return
-        } else {
+        if self.current.startIndex != self.current.endIndex {
             self.current = self.current[self.current.index(after: self.current.startIndex)...]
         }
     }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -51,6 +51,7 @@ extension HTTPHeadersTest {
                 ("testWeDefaultToCloseIfDoesNotMakeSense", testWeDefaultToCloseIfDoesNotMakeSense),
                 ("testAddingSequenceOfPairs", testAddingSequenceOfPairs),
                 ("testAddingOtherHTTPHeader", testAddingOtherHTTPHeader),
+                ("testCanonicalFormRespectsQuotedStrings", testCanonicalFormRespectsQuotedStrings),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -357,4 +357,15 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertEqual(["bazzy"], fooBarHeaders["baz"])
         XCTAssertEqual(.unknown, fooBarHeaders.keepAliveState)
     }
+
+    func testCanonicalFormRespectsQuotedStrings() {
+        let headers = HTTPHeaders([
+            ("foo", #""bar, baz""#),
+            ("bar", #""bar, baz", qux"#),
+            ("baz", #""bar, baz", "qux"#),
+        ])
+        XCTAssertEqual(["bar, baz"], headers[canonicalForm: "foo"])
+        XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "bar"])
+        XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "baz"])
+    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -366,6 +366,7 @@ class HTTPHeadersTest : XCTestCase {
             ("qux", #""bar""#),
             ("quuz", #" "bar" "#),
             ("corge", #""bar\"baz""#),
+            ("grault", #""foo\'bar""#)
         ])
         XCTAssertEqual(["bar, baz"], headers[canonicalForm: "foo"])
         XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "bar"])
@@ -373,5 +374,6 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertEqual(["bar"], headers[canonicalForm: "qux"])
         XCTAssertEqual(["bar"], headers[canonicalForm: "quuz"])
         XCTAssertEqual([#"bar"baz"#], headers[canonicalForm: "corge"])
+        XCTAssertEqual([#"foo\'bar"#], headers[canonicalForm: "grault"])
     }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -360,20 +360,24 @@ class HTTPHeadersTest : XCTestCase {
 
     func testCanonicalFormRespectsQuotedStrings() {
         let headers = HTTPHeaders([
-            ("foo", #""bar, baz""#),
-            ("bar", #""bar, baz", qux"#),
-            ("baz", #""bar, baz", "qux""#),
-            ("qux", #""bar""#),
-            ("quuz", #" "bar" "#),
-            ("corge", #""bar\"baz""#),
-            ("grault", #""foo\'bar""#)
+            ("a", #""bar, baz""#),
+            ("b", #""bar, baz", qux"#),
+            ("c", #""bar, baz", "qux""#),
+            ("d", #""bar""#),
+            ("e", #" "bar" "#),
+            ("f", #""bar\"baz""#),
+            ("g", #""foo\'bar""#),
+            ("h", "\"\""),
+            ("i", "foo, bar baz"),
         ])
-        XCTAssertEqual(["bar, baz"], headers[canonicalForm: "foo"])
-        XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "bar"])
-        XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "baz"])
-        XCTAssertEqual(["bar"], headers[canonicalForm: "qux"])
-        XCTAssertEqual(["bar"], headers[canonicalForm: "quuz"])
-        XCTAssertEqual([#"bar"baz"#], headers[canonicalForm: "corge"])
-        XCTAssertEqual([#"foo\'bar"#], headers[canonicalForm: "grault"])
+        XCTAssertEqual(["bar, baz"], headers[canonicalForm: "a"])
+        XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "b"])
+        XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "c"])
+        XCTAssertEqual(["bar"], headers[canonicalForm: "d"])
+        XCTAssertEqual(["bar"], headers[canonicalForm: "e"])
+        XCTAssertEqual([#"bar"baz"#], headers[canonicalForm: "f"])
+        XCTAssertEqual([#"foo\'bar"#], headers[canonicalForm: "g"])
+        XCTAssertEqual([""], headers[canonicalForm: "h"])
+        XCTAssertEqual(["foo", "bar baz"], headers[canonicalForm: "i"])
     }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -369,6 +369,7 @@ class HTTPHeadersTest : XCTestCase {
             ("g", #""foo\'bar""#),
             ("h", "\"\""),
             ("i", "foo, bar baz"),
+            ("j", #""a;b"; c="d;e", f"#),
         ])
         XCTAssertEqual(["bar, baz"], headers[canonicalForm: "a"])
         XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "b"])
@@ -379,5 +380,6 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertEqual([#"foo\'bar"#], headers[canonicalForm: "g"])
         XCTAssertEqual([""], headers[canonicalForm: "h"])
         XCTAssertEqual(["foo", "bar baz"], headers[canonicalForm: "i"])
+        XCTAssertEqual([#""a;b"; c="d;e""#, "f"], headers[canonicalForm: "j"])
     }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -362,10 +362,16 @@ class HTTPHeadersTest : XCTestCase {
         let headers = HTTPHeaders([
             ("foo", #""bar, baz""#),
             ("bar", #""bar, baz", qux"#),
-            ("baz", #""bar, baz", "qux"#),
+            ("baz", #""bar, baz", "qux""#),
+            ("qux", #""bar""#),
+            ("quuz", #" "bar" "#),
+            ("corge", #""bar\"baz""#),
         ])
         XCTAssertEqual(["bar, baz"], headers[canonicalForm: "foo"])
         XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "bar"])
         XCTAssertEqual(["bar, baz", "qux"], headers[canonicalForm: "baz"])
+        XCTAssertEqual(["bar"], headers[canonicalForm: "qux"])
+        XCTAssertEqual(["bar"], headers[canonicalForm: "quuz"])
+        XCTAssertEqual([#"bar"baz"#], headers[canonicalForm: "corge"])
     }
 }


### PR DESCRIPTION
Adds support for quoted strings in HTTPHeaders[canonicalForm:]

### Motivation:

Fixes https://github.com/apple/swift-nio/issues/1441

### Modifications:

Improves HTTP header value parsing.

### Result:

HTTP headers now respects quoted strings. 
