### PR TITLE
make-single-file-spm: better directory name

### DIFF
--- a/dev/make-single-file-spm
+++ b/dev/make-single-file-spm
@@ -137,7 +137,7 @@ if [[ $# -lt 2 ]]; then
     exit 1
 fi
 
-destination=$(mktemp -d /tmp/.gen-swift-perf-test_XXXXXX)
+destination=$(mktemp -d /tmp/test_package_XXXXXX)
 file="$1"
 command="$2"
 shift; shift


### PR DESCRIPTION
Motivation:

The make-single-file-spm script used to use a hidden folder in /tmp
which isn't very helpful when tar'ing up the result for a bug report.

Modifications:

Switch to a non-hidden folder.

Result:

Easier bugs.swift.org reports.