### PR TITLE
NIO: implement core counting on Windows

### DIFF
--- a/Sources/NIO/Utilities.swift
+++ b/Sources/NIO/Utilities.swift
@@ -72,7 +72,7 @@ public enum System {
                                capacity: dwSLPICount)
 
         let bResult: Bool = GetLogicalProcessorInformation(pSLPI, &dwLength)
-        assert(bResult, "GetLogicalProcessorInformation: \(GetLastError())")
+        precondition(bResult, "GetLogicalProcessorInformation: \(GetLastError())")
 
         return UnsafeBufferPointer<SYSTEM_LOGICAL_PROCESSOR_INFORMATION>(start: pSLPI,
                                                                          count: dwSLPICount)


### PR DESCRIPTION
Implement the core counting logic for Windows, which does not support
`sysconf`.  It uses the Windows SDK to get the processor topology and
computes the core count from the topology.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
