### PR TITLE
SelectableEventLoop: make Darwin the special case

### DIFF
--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -18,13 +18,13 @@ import NIOConcurrencyHelpers
 /// Execute the given closure and ensure we release all auto pools if needed.
 @inlinable
 internal func withAutoReleasePool<T>(_ execute: () throws -> T) rethrows -> T {
-    #if os(Linux)
-    return try execute()
-    #else
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     return try autoreleasepool {
         try execute()
     }
-    #endif
+#else
+    return try execute()
+#endif
 }
 
 /// `EventLoop` implementation that uses a `Selector` to get notified once there is more I/O or tasks to process.


### PR DESCRIPTION
Treat the `autoreleasepool` case for Darwin as the special case rather
than Linux as the special case.  This is following the case throughout
the rest of the code base.  This is also needed for the Windows port.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
