### PR TITLE
Provide a means to control the underlying header storage capacity.

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -476,6 +476,21 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
     }
 }
 
+extension HTTPHeaders {
+
+    /// The total number of headers that can be contained without allocating new storage.
+    public var capacity: Int {
+        return self.headers.capacity
+    }
+
+    /// Reserves enough space to store the specified number of headers.
+    ///
+    /// - Parameter minimumCapacity: The requested number of headers to store.
+    public mutating func reserveCapacity(_ minimumCapacity: Int) {
+        self.headers.reserveCapacity(minimumCapacity)
+    }
+}
+
 extension ByteBuffer {
 
     /// Serializes this HTTP header block to bytes suitable for writing to the wire.

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest+XCTest.swift
@@ -51,6 +51,7 @@ extension HTTPHeadersTest {
                 ("testWeDefaultToCloseIfDoesNotMakeSense", testWeDefaultToCloseIfDoesNotMakeSense),
                 ("testAddingSequenceOfPairs", testAddingSequenceOfPairs),
                 ("testAddingOtherHTTPHeader", testAddingOtherHTTPHeader),
+                ("testCapacity", testCapacity),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -357,4 +357,20 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertEqual(["bazzy"], fooBarHeaders["baz"])
         XCTAssertEqual(.unknown, fooBarHeaders.keepAliveState)
     }
+
+    func testCapacity() {
+        // no headers
+        var headers = HTTPHeaders()
+        XCTAssertEqual(headers.capacity, 0)
+        // reserve capacity
+        headers.reserveCapacity(5)
+        XCTAssertEqual(headers.capacity, 5)
+
+        // initialize with some headers
+        headers = HTTPHeaders([("foo", "bar")])
+        XCTAssertEqual(headers.capacity, 1)
+        // reserve more capacity
+        headers.reserveCapacity(4)
+        XCTAssertEqual(headers.capacity, 4)
+    }
 }


### PR DESCRIPTION
### Motivation:

It's not always possible to initialize `HTTPHeaders` with all the headers one needs to set. In such case, the underlying array will be expanded as and when needed upon headers being appended. `Array` provides the means to reserve capacity to optimize such use case. This PR exposes this functionality in `HTTPHeaders`.

### Modifications:

Exposed method `reserveCapacity(_ minimumCapacity: Int)` and computed variable `capacity: Int` in `HTTPHeaders` and added some tests.

### Result:

Developers will be able to control the capacity of the underlying headers array as such:

```swift
var headers = HTTPHeaders()
headers.reserveCapacity(5)
```