### PR TITLE
NIO: move comment to right location (NFC)

### DIFF
--- a/Sources/NIO/Utilities.swift
+++ b/Sources/NIO/Utilities.swift
@@ -12,11 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A utility function that runs the body code only in debug builds, without
-/// emitting compiler warnings.
-///
-/// This is currently the only way to do this in Swift: see
-/// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
 import CNIOLinux
 
 #if os(Windows)
@@ -30,6 +25,11 @@ import struct WinSDK.SYSTEM_LOGICAL_PROCESSOR_INFORMATION
 import typealias WinSDK.DWORD
 #endif
 
+/// A utility function that runs the body code only in debug builds, without
+/// emitting compiler warnings.
+///
+/// This is currently the only way to do this in Swift: see
+/// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
 @inlinable
 internal func debugOnly(_ body: () -> Void) {
     assert({ body(); return true }())


### PR DESCRIPTION
Move the block comment to the right location before the function it
describes.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
