### PR TITLE
IO: extend `IOError` for Windows

### DIFF
--- a/Sources/NIO/IO.swift
+++ b/Sources/NIO/IO.swift
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Windows)
+import typealias WinSDK.DWORD
+#endif
+
 /// An `Error` for an IO operation.
 public struct IOError: Swift.Error {
     @available(*, deprecated, message: "NIO no longer uses FailureDescription.")
@@ -28,16 +32,47 @@ public struct IOError: Swift.Error {
         return .reason(self.failureDescription)
     }
 
+    private enum Error {
+        #if os(Windows)
+            case windows(DWORD)
+            case winsock(CInt)
+        #endif
+        case errno(CInt)
+    }
+
+    private let error: Error
+
     /// The `errno` that was set for the operation.
-    public let errnoCode: CInt
+    public var errnoCode: CInt {
+        switch self.error {
+        case .errno(let code):
+            return code
+        #if os(Windows)
+            default:
+                fatalError("IOError domain is not `errno`")
+        #endif
+        }
+    }
+
+#if os(Windows)
+    public init(windows code: DWORD, reason: String) {
+        self.error = .windows(code)
+        self.failureDescription = reason
+    }
+
+    public init(winsock code: CInt, reason: String) {
+        self.error = .winsock(code)
+        self.failureDescription = reason
+    }
+#endif
 
     /// Creates a new `IOError``
     ///
     /// - parameters:
     ///     - errorCode: the `errno` that was set for the operation.
     ///     - reason: the actual reason (in an human-readable form).
-    public init(errnoCode: CInt, reason: String) {
-        self.errnoCode = errnoCode
+    public init(errnoCode code: CInt, reason: String) {
+        self.error = .errno(code)
         self.failureDescription = reason
     }
 
@@ -47,8 +82,8 @@ public struct IOError: Swift.Error {
     ///     - errorCode: the `errno` that was set for the operation.
     ///     - function: The function the error happened in, the human readable description will be generated automatically when needed.
     @available(*, deprecated, renamed: "init(errnoCode:reason:)")
-    public init(errnoCode: CInt, function: StaticString) {
-        self.errnoCode = errnoCode
+    public init(errnoCode code: CInt, function: StaticString) {
+        self.error = .errno(code)
         self.failureDescription = "\(function)"
     }
 }
@@ -64,6 +99,17 @@ private func reasonForError(errnoCode: CInt, reason: String) -> String {
         return "\(reason): \(String(cString: errorDescC)) (errno: \(errnoCode))"
     } else {
         return "\(reason): Broken strerror, unknown error: \(errnoCode)"
+    }
+}
+
+internal extension IOResult where T: FixedWidthInteger {
+    var result: T {
+        switch self {
+        case .processed(let value):
+            return value
+        case .wouldBlock(_):
+            fatalError("cannot unwrap IOResult")
+        }
     }
 }
 

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -115,17 +115,6 @@ private func preconditionIsNotBlacklistedErrno(err: CInt, where function: String
     precondition(!isBlacklistedErrno(err), "blacklisted errno \(err) \(String(cString: strerror(err)!)) in \(function))")
 }
 
-internal extension IOResult where T: FixedWidthInteger {
-  var result: T {
-    switch self {
-    case .processed(let value):
-      return value
-    case .wouldBlock(_):
-      fatalError("cannot unwrap IOError")
-    }
-  }
-}
-
 /*
  * Sorry, we really try hard to not use underscored attributes. In this case
  * however we seem to break the inlining threshold which makes a system call


### PR DESCRIPTION
There are three different error domains that we deal with in NIO, which
need to be differentiated.  Store the error with the domain to ensure
that we can identify the error domain.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
