### PR TITLE
Add `BSDSocket.ProtocolFamily`

### DIFF
--- a/Sources/NIO/BSDSocketAPI.swift
+++ b/Sources/NIO/BSDSocketAPI.swift
@@ -31,6 +31,10 @@ import let WinSDK.IPV6_MULTICAST_IF
 import let WinSDK.IPV6_MULTICAST_LOOP
 import let WinSDK.IPV6_V6ONLY
 
+import let WinSDK.PF_INET
+import let WinSDK.PF_INET6
+import let WinSDK.PF_UNIX
+
 import let WinSDK.TCP_NODELAY
 
 import let WinSDK.SO_ERROR
@@ -70,6 +74,23 @@ extension NIOBSDSocket.SocketType: Hashable {
 }
 
 extension NIOBSDSocket {
+    /// Specifies the type of protocol that the socket can use.
+    public struct ProtocolFamily: RawRepresentable {
+        public typealias RawValue = CInt
+        public var rawValue: RawValue
+        public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+        }
+    }
+}
+
+extension NIOBSDSocket.ProtocolFamily: Equatable {
+}
+
+extension NIOBSDSocket.ProtocolFamily: Hashable {
+}
+
+extension NIOBSDSocket {
     /// Defines socket option levels.
     public struct OptionLevel: RawRepresentable {
         public typealias RawValue = CInt
@@ -102,6 +123,29 @@ extension NIOBSDSocket.Option: Equatable {
 
 extension NIOBSDSocket.Option: Hashable {
 }
+
+// Protocol Family
+extension NIOBSDSocket.ProtocolFamily {
+    /// IP network 4 protocol.
+    public static let inet: NIOBSDSocket.ProtocolFamily =
+            NIOBSDSocket.ProtocolFamily(rawValue: PF_INET)
+
+    /// IP network 6 protocol.
+    public static let inet6: NIOBSDSocket.ProtocolFamily =
+            NIOBSDSocket.ProtocolFamily(rawValue: PF_INET6)
+
+    /// UNIX local to the host.
+    public static let unix: NIOBSDSocket.ProtocolFamily =
+            NIOBSDSocket.ProtocolFamily(rawValue: PF_UNIX)
+}
+
+#if !os(Windows)
+    extension NIOBSDSocket.ProtocolFamily {
+        /// UNIX local to the host, alias for `PF_UNIX` (`.unix`)
+        public static let local: NIOBSDSocket.ProtocolFamily =
+                NIOBSDSocket.ProtocolFamily(rawValue: PF_LOCAL)
+    }
+#endif
 
 // Socket Types
 extension NIOBSDSocket.SocketType {

--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -252,7 +252,7 @@ class BaseSocket: BaseSocketProtocol {
     ///     - setNonBlocking: Set non-blocking mode on the socket.
     /// - returns: the file descriptor of the socket that was created.
     /// - throws: An `IOError` if creation of the socket failed.
-    static func makeSocket(protocolFamily: Int32, type: NIOBSDSocket.SocketType, setNonBlocking: Bool = false) throws -> CInt {
+    static func makeSocket(protocolFamily: NIOBSDSocket.ProtocolFamily, type: NIOBSDSocket.SocketType, setNonBlocking: Bool = false) throws -> CInt {
         var sockType: CInt = type.rawValue
         #if os(Linux)
         if setNonBlocking {
@@ -273,7 +273,7 @@ class BaseSocket: BaseSocketProtocol {
             }
         }
         #endif
-        if protocolFamily == Posix.AF_INET6 {
+        if protocolFamily == .inet6 {
             var zero: Int32 = 0
             do {
                 try Posix.setsockopt(socket: sock, level: NIOBSDSocket.OptionLevel.ipv6.rawValue, optionName: NIOBSDSocket.Option.ipv6_v6only.rawValue, optionValue: &zero, optionLen: socklen_t(MemoryLayout.size(ofValue: zero)))
@@ -333,7 +333,7 @@ class BaseSocket: BaseSocketProtocol {
     ///     - value: The value for the option.
     /// - throws: An `IOError` if the operation failed.
     final func setOption<T>(level: NIOBSDSocket.OptionLevel, name: NIOBSDSocket.Option, value: T) throws {
-        if level == .tcp && name == .nodelay && (try? self.localAddress().protocolFamily) == Optional<Int32>.some(Int32(Posix.AF_UNIX)) {
+        if level == .tcp && name == .nodelay && (try? self.localAddress().protocol) == Optional<NIOBSDSocket.ProtocolFamily>.some(.unix) {
             // setting TCP_NODELAY on UNIX domain sockets will fail. Previously we had a bug where we would ignore
             // most socket options settings so for the time being we'll just ignore this. Let's revisit for NIO 2.0.
             return

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -249,7 +249,7 @@ public final class ServerBootstrap {
         func makeChannel(_ eventLoop: SelectableEventLoop, _ childEventLoopGroup: EventLoopGroup) throws -> ServerSocketChannel {
             return try ServerSocketChannel(eventLoop: eventLoop,
                                            group: childEventLoopGroup,
-                                           protocolFamily: address.protocolFamily)
+                                           protocolFamily: address.protocol)
         }
 
         return bind0(makeServerChannel: makeChannel) { (eventLoop, serverChannel) in
@@ -546,7 +546,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     ///     - address: The address to connect to.
     /// - returns: An `EventLoopFuture<Channel>` to deliver the `Channel` when connected.
     public func connect(to address: SocketAddress) -> EventLoopFuture<Channel> {
-        return execute(eventLoop: group.next(), protocolFamily: address.protocolFamily) { channel in
+        return execute(eventLoop: group.next(), protocolFamily: address.protocol) { channel in
             let connectPromise = channel.eventLoop.makePromise(of: Void.self)
             channel.connect(to: address, promise: connectPromise)
             let cancelTask = channel.eventLoop.scheduleTask(in: self.connectTimeout) {
@@ -615,7 +615,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     }
 
     private func execute(eventLoop: EventLoop,
-                         protocolFamily: Int32,
+                         protocolFamily: NIOBSDSocket.ProtocolFamily,
                          _ body: @escaping (Channel) -> EventLoopFuture<Void>) -> EventLoopFuture<Channel> {
         let channelInitializer = self.channelInitializer
         let channelOptions = self._channelOptions
@@ -785,7 +785,7 @@ public final class DatagramBootstrap {
         }
         func makeChannel(_ eventLoop: SelectableEventLoop) throws -> DatagramChannel {
             return try DatagramChannel(eventLoop: eventLoop,
-                                       protocolFamily: address.protocolFamily)
+                                       protocolFamily: address.protocol)
         }
         return bind0(makeChannel: makeChannel) { (eventLoop, channel) in
             channel.register().flatMap {

--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -221,7 +221,7 @@ internal class HappyEyeballsConnector {
     /// than intended.
     ///
     /// The channel builder callback takes an event loop and a protocol family as arguments.
-    private let channelBuilderCallback: (EventLoop, Int32) -> EventLoopFuture<Channel>
+    private let channelBuilderCallback: (EventLoop, NIOBSDSocket.ProtocolFamily) -> EventLoopFuture<Channel>
 
     /// The amount of time to wait for an AAAA response to come in after a A response is
     /// received. By default this is 50ms.
@@ -279,7 +279,7 @@ internal class HappyEyeballsConnector {
          connectTimeout: TimeAmount,
          resolutionDelay: TimeAmount = .milliseconds(50),
          connectionDelay: TimeAmount = .milliseconds(250),
-         channelBuilderCallback: @escaping (EventLoop, Int32) -> EventLoopFuture<Channel>) {
+         channelBuilderCallback: @escaping (EventLoop, NIOBSDSocket.ProtocolFamily) -> EventLoopFuture<Channel>) {
         self.resolver = resolver
         self.loop = loop
         self.host = host
@@ -529,7 +529,7 @@ internal class HappyEyeballsConnector {
     /// - parameters:
     ///     - target: The address to connect to.
     private func connectToTarget(_ target: SocketAddress) {
-        let channelFuture = channelBuilderCallback(self.loop, target.protocolFamily)
+        let channelFuture = channelBuilderCallback(self.loop, target.protocol)
         pendingConnections.append(channelFuture)
 
         channelFuture.whenSuccess { channel in

--- a/Sources/NIO/ServerSocket.swift
+++ b/Sources/NIO/ServerSocket.swift
@@ -16,7 +16,7 @@
 /* final but tests */ class ServerSocket: BaseSocket, ServerSocketProtocol {
     typealias SocketType = ServerSocket
 
-    public final class func bootstrap(protocolFamily: Int32, host: String, port: Int) throws -> ServerSocket {
+    public final class func bootstrap(protocolFamily: NIOBSDSocket.ProtocolFamily, host: String, port: Int) throws -> ServerSocket {
         let socket = try ServerSocket(protocolFamily: protocolFamily)
         try socket.bind(to: SocketAddress.makeAddressResolvingHost(host, port: port))
         try socket.listen()
@@ -29,7 +29,7 @@
     ///     - protocolFamily: The protocol family to use (usually `AF_INET6` or `AF_INET`).
     ///     - setNonBlocking: Set non-blocking mode on the socket.
     /// - throws: An `IOError` if creation of the socket failed.
-    init(protocolFamily: Int32, setNonBlocking: Bool = false) throws {
+    init(protocolFamily: NIOBSDSocket.ProtocolFamily, setNonBlocking: Bool = false) throws {
         let sock = try BaseSocket.makeSocket(protocolFamily: protocolFamily, type: .stream, setNonBlocking: setNonBlocking)
         try super.init(descriptor: sock)
     }

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -32,7 +32,7 @@ typealias IOVector = iovec
     ///     - type: The type of the socket to create.
     ///     - setNonBlocking: Set non-blocking mode on the socket.
     /// - throws: An `IOError` if creation of the socket failed.
-    init(protocolFamily: CInt, type: NIOBSDSocket.SocketType, setNonBlocking: Bool = false) throws {
+    init(protocolFamily: NIOBSDSocket.ProtocolFamily, type: NIOBSDSocket.SocketType, setNonBlocking: Bool = false) throws {
         let sock = try BaseSocket.makeSocket(protocolFamily: protocolFamily, type: type, setNonBlocking: setNonBlocking)
         try super.init(descriptor: sock)
     }

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -118,15 +118,20 @@ public enum SocketAddress: CustomStringConvertible {
         return "[\(type)]\(host.map { "\($0)/\(addressString):" } ?? "\(addressString):")\(port)"
     }
 
-    /// Returns the protocol family as defined in `man 2 socket` of this `SocketAddress`.
+    @available(*, deprecated, renamed: "SocketAddress.protocol")
     public var protocolFamily: Int32 {
+      return Int32(self.protocol.rawValue)
+    }
+
+    /// Returns the protocol family as defined in `man 2 socket` of this `SocketAddress`.
+    public var `protocol`: NIOBSDSocket.ProtocolFamily {
         switch self {
         case .v4:
-            return PF_INET
+            return .inet
         case .v6:
-            return PF_INET6
+            return .inet6
         case .unixDomainSocket:
-            return PF_UNIX
+            return .unix
         }
     }
 

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -35,7 +35,7 @@ extension ByteBuffer {
 final class SocketChannel: BaseStreamSocketChannel<Socket> {
     private var connectTimeout: TimeAmount? = nil
 
-    init(eventLoop: SelectableEventLoop, protocolFamily: Int32) throws {
+    init(eventLoop: SelectableEventLoop, protocolFamily: NIOBSDSocket.ProtocolFamily) throws {
         let socket = try Socket(protocolFamily: protocolFamily, type: .stream, setNonBlocking: true)
         try super.init(socket: socket, parent: nil, eventLoop: eventLoop, recvAllocator: AdaptiveRecvByteBufferAllocator())
     }
@@ -135,7 +135,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     // This is `Channel` API so must be thread-safe.
     override public var isWritable: Bool { return false }
 
-    convenience init(eventLoop: SelectableEventLoop, group: EventLoopGroup, protocolFamily: Int32) throws {
+    convenience init(eventLoop: SelectableEventLoop, group: EventLoopGroup, protocolFamily: NIOBSDSocket.ProtocolFamily) throws {
         try self.init(serverSocket: try ServerSocket(protocolFamily: protocolFamily, setNonBlocking: true), eventLoop: eventLoop, group: group)
     }
 
@@ -360,7 +360,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         }
     }
 
-    init(eventLoop: SelectableEventLoop, protocolFamily: Int32) throws {
+    init(eventLoop: SelectableEventLoop, protocolFamily: NIOBSDSocket.ProtocolFamily) throws {
         self.vectorReadManager = nil
         let socket = try Socket(protocolFamily: protocolFamily, type: .dgram)
         do {
@@ -733,7 +733,7 @@ extension DatagramChannel: MulticastChannel {
             return
         }
 
-        guard localAddress.protocolFamily == group.protocolFamily else {
+        guard localAddress.protocol == group.protocol else {
             promise?.fail(ChannelError.badMulticastGroupAddressFamily)
             return
         }

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -242,9 +242,9 @@ internal enum Posix {
     }
 
     @inline(never)
-    public static func socket(domain: CInt, type: NIOBSDSocket.SocketType, `protocol`: CInt) throws -> CInt {
+    public static func socket(domain: NIOBSDSocket.ProtocolFamily, type: NIOBSDSocket.SocketType, `protocol`: CInt) throws -> CInt {
         return try syscall(blocking: false) {
-            return sysSocket(domain, type.rawValue, `protocol`)
+            return sysSocket(domain.rawValue, type.rawValue, `protocol`)
         }.result
     }
 
@@ -500,12 +500,12 @@ internal enum Posix {
     }
 
     @inline(never)
-    public static func socketpair(domain: CInt,
+    public static func socketpair(domain: NIOBSDSocket.ProtocolFamily,
                                   type: NIOBSDSocket.SocketType,
                                   protocol: CInt,
                                   socketVector: UnsafeMutablePointer<CInt>?) throws {
         _ = try syscall(blocking: false) {
-            sysSocketpair(domain, type.rawValue, `protocol`, socketVector)
+            sysSocketpair(domain.rawValue, type.rawValue, `protocol`, socketVector)
         }
     }
 }

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -149,7 +149,7 @@ class BootstrapTest: XCTestCase {
 
     func testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
         var socketFDs: [CInt] = [-1, -1]
-        XCTAssertNoThrow(try Posix.socketpair(domain: PF_LOCAL,
+        XCTAssertNoThrow(try Posix.socketpair(domain: .local,
                                               type: .stream,
                                               protocol: 0,
                                               socketVector: &socketFDs))
@@ -170,7 +170,7 @@ class BootstrapTest: XCTestCase {
     }
 
     func testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
-        let socket = try Posix.socket(domain: AF_INET, type: .stream, protocol: 0)
+        let socket = try Posix.socket(domain: .inet, type: .stream, protocol: 0)
 
         let serverAddress = try assertNoThrowWithValue(SocketAddress.makeAddressResolvingHost("127.0.0.1", port: 0))
         try serverAddress.withSockAddr { serverAddressPtr, size in
@@ -309,7 +309,7 @@ class BootstrapTest: XCTestCase {
     func testPreConnectedSocketSetsChannelOptionsBeforeChannelInitializer() {
         XCTAssertNoThrow(try withTCPServerChannel(group: self.group) { server in
             var maybeSocket: Socket? = nil
-            XCTAssertNoThrow(maybeSocket = try Socket(protocolFamily: AF_INET, type: .stream))
+            XCTAssertNoThrow(maybeSocket = try Socket(protocolFamily: .inet, type: .stream))
             XCTAssertNoThrow(XCTAssertEqual(true, try maybeSocket?.connect(to: server.localAddress!)))
             var maybeFD: CInt? = nil
             XCTAssertNoThrow(maybeFD = try maybeSocket?.takeDescriptorOwnership())

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -1108,7 +1108,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let server = try assertNoThrowWithValue(ServerSocket(protocolFamily: PF_INET))
+        let server = try assertNoThrowWithValue(ServerSocket(protocolFamily: .inet))
         defer {
             XCTAssertNoThrow(try server.close())
         }
@@ -1161,7 +1161,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let server = try assertNoThrowWithValue(ServerSocket(protocolFamily: PF_INET))
+        let server = try assertNoThrowWithValue(ServerSocket(protocolFamily: .inet))
         defer {
             XCTAssertNoThrow(try server.close())
         }
@@ -1224,7 +1224,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let server = try assertNoThrowWithValue(ServerSocket(protocolFamily: PF_INET))
+        let server = try assertNoThrowWithValue(ServerSocket(protocolFamily: .inet))
         defer {
             XCTAssertNoThrow(try server.close())
         }
@@ -1851,7 +1851,7 @@ public final class ChannelTests: XCTestCase {
 
     func testChannelReadsDoesNotHappenAfterRegistration() throws {
         class SocketThatSucceedsOnSecondConnectForPort123: Socket {
-            init(protocolFamily: CInt) throws {
+            init(protocolFamily: NIOBSDSocket.ProtocolFamily) throws {
                 try super.init(protocolFamily: protocolFamily, type: .stream, setNonBlocking: true)
             }
             override func connect(to address: SocketAddress) throws -> Bool {
@@ -1905,7 +1905,7 @@ public final class ChannelTests: XCTestCase {
         let serverEL = group.next()
         let clientEL = group.next()
         precondition(serverEL !== clientEL)
-        let sc = try SocketChannel(socket: SocketThatSucceedsOnSecondConnectForPort123(protocolFamily: PF_INET), eventLoop: clientEL as! SelectableEventLoop)
+        let sc = try SocketChannel(socket: SocketThatSucceedsOnSecondConnectForPort123(protocolFamily: .inet), eventLoop: clientEL as! SelectableEventLoop)
 
         class WriteImmediatelyHandler: ChannelInboundHandler {
             typealias InboundIn = Any
@@ -1972,9 +1972,9 @@ public final class ChannelTests: XCTestCase {
         func withChannel(skipDatagram: Bool = false, skipStream: Bool = false, skipServerSocket: Bool = false, file: StaticString = #file, line: UInt = #line,  _ body: (Channel) throws -> Void) {
             XCTAssertNoThrow(try {
                 let el = elg.next() as! SelectableEventLoop
-                let channels: [Channel] = (skipDatagram ? [] : [try DatagramChannel(eventLoop: el, protocolFamily: PF_INET)]) +
-                    /* Xcode need help */ (skipStream ? []: [try SocketChannel(eventLoop: el, protocolFamily: PF_INET)]) +
-                    /* Xcode need help */ (skipServerSocket ? []: [try ServerSocketChannel(eventLoop: el, group: elg, protocolFamily: PF_INET)])
+                let channels: [Channel] = (skipDatagram ? [] : [try DatagramChannel(eventLoop: el, protocolFamily: .inet)]) +
+                    /* Xcode need help */ (skipStream ? []: [try SocketChannel(eventLoop: el, protocolFamily: .inet)]) +
+                    /* Xcode need help */ (skipServerSocket ? []: [try ServerSocketChannel(eventLoop: el, group: elg, protocolFamily: .inet)])
                 for channel in channels {
                     try body(channel)
                     XCTAssertNoThrow(try channel.close().wait(), file: file, line: line)
@@ -2024,7 +2024,7 @@ public final class ChannelTests: XCTestCase {
     func testCloseSocketWhenReadErrorWasReceivedAndMakeSureNoReadCompleteArrives() throws {
         class SocketThatHasTheFirstReadSucceedButFailsTheNextWithECONNRESET: Socket {
             private var firstReadHappened = false
-            init(protocolFamily: CInt) throws {
+            init(protocolFamily: NIOBSDSocket.ProtocolFamily) throws {
                 try super.init(protocolFamily: protocolFamily, type: .stream, setNonBlocking: true)
             }
             override func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
@@ -2094,7 +2094,7 @@ public final class ChannelTests: XCTestCase {
         let serverEL = group.next()
         let clientEL = group.next()
         precondition(serverEL !== clientEL)
-        let sc = try SocketChannel(socket: SocketThatHasTheFirstReadSucceedButFailsTheNextWithECONNRESET(protocolFamily: PF_INET), eventLoop: clientEL as! SelectableEventLoop)
+        let sc = try SocketChannel(socket: SocketThatHasTheFirstReadSucceedButFailsTheNextWithECONNRESET(protocolFamily: .inet), eventLoop: clientEL as! SelectableEventLoop)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: serverEL)
             .childChannelInitializer { channel in
@@ -2131,7 +2131,7 @@ public final class ChannelTests: XCTestCase {
         enum DummyError: Error { case dummy }
         class SocketFailingAsyncConnect: Socket {
             init() throws {
-                try super.init(protocolFamily: PF_INET, type: .stream, setNonBlocking: true)
+                try super.init(protocolFamily: .inet, type: .stream, setNonBlocking: true)
             }
 
             override func connect(to address: SocketAddress) throws -> Bool {
@@ -2177,7 +2177,7 @@ public final class ChannelTests: XCTestCase {
         enum DummyError: Error { case dummy }
         class SocketFailingConnect: Socket {
             init() throws {
-                try super.init(protocolFamily: PF_INET, type: .stream, setNonBlocking: true)
+                try super.init(protocolFamily: .inet, type: .stream, setNonBlocking: true)
             }
 
             override func connect(to address: SocketAddress) throws -> Bool {
@@ -2225,7 +2225,7 @@ public final class ChannelTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
-        let serverSock = try Socket(protocolFamily: PF_INET, type: .stream)
+        let serverSock = try Socket(protocolFamily: .inet, type: .stream)
         // we deliberately don't set SO_REUSEADDR
         XCTAssertNoThrow(try serverSock.bind(to: SocketAddress(ipAddress: "127.0.0.1", port: 0)))
         let serverSockAddress = try! serverSock.localAddress()
@@ -2244,7 +2244,7 @@ public final class ChannelTests: XCTestCase {
         enum DummyError: Error { case dummy }
         class SocketFailingClose: Socket {
             init() throws {
-                try super.init(protocolFamily: PF_INET, type: .stream, setNonBlocking: true)
+                try super.init(protocolFamily: .inet, type: .stream, setNonBlocking: true)
             }
 
             override func close() throws {
@@ -2295,7 +2295,7 @@ public final class ChannelTests: XCTestCase {
         }
         let server = try assertNoThrowWithValue(ServerSocketChannel(eventLoop: group.next() as! SelectableEventLoop,
                                                                     group: group,
-                                                                    protocolFamily: PF_INET))
+                                                                    protocolFamily: .inet))
         defer {
             XCTAssertNoThrow(try server.close().wait())
         }
@@ -2319,7 +2319,7 @@ public final class ChannelTests: XCTestCase {
             .wait())
 
         let client = try SocketChannel(eventLoop: group.next() as! SelectableEventLoop,
-                                       protocolFamily: serverChannel.localAddress!.protocolFamily)
+                                       protocolFamily: serverChannel.localAddress!.protocol)
         defer {
             XCTAssertNoThrow(try client.close().wait())
         }
@@ -2439,7 +2439,7 @@ public final class ChannelTests: XCTestCase {
 
         final class WriteAlwaysFailingSocket: Socket {
             init() throws {
-                try super.init(protocolFamily: AF_INET, type: .stream, setNonBlocking: true)
+                try super.init(protocolFamily: .inet, type: .stream, setNonBlocking: true)
             }
 
             override func write(pointer: UnsafeRawBufferPointer) throws -> IOResult<Int> {
@@ -2636,8 +2636,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         let channel = try ServerSocketChannel(eventLoop: group.next() as! SelectableEventLoop,
-                                              group: group,
-                                              protocolFamily: AF_INET)
+                                              group: group, protocolFamily: .inet)
         XCTAssertThrowsError(try channel.triggerUserOutboundEvent("event").wait()) { (error: Error) in
             if let error = error as? ChannelError {
                 XCTAssertEqual(ChannelError.operationUnsupported, error)

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -386,7 +386,7 @@ final class DatagramChannelTests: XCTestCase {
 
             init(error: Int32) throws {
                 self.error = error
-                try super.init(protocolFamily: AF_INET, type: .dgram)
+                try super.init(protocolFamily: .inet, type: .dgram)
             }
 
             override func recvfrom(pointer: UnsafeMutableRawBufferPointer, storage: inout sockaddr_storage, storageLen: inout socklen_t) throws -> IOResult<(Int)> {
@@ -462,7 +462,7 @@ final class DatagramChannelTests: XCTestCase {
 
             init(error: Int32) throws {
                 self.error = error
-                try super.init(protocolFamily: AF_INET, type: .dgram)
+                try super.init(protocolFamily: .inet, type: .dgram)
             }
 
             override func recvmmsg(msgs: UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int> {
@@ -538,7 +538,7 @@ final class DatagramChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         let channel = try DatagramChannel(eventLoop: group.next() as! SelectableEventLoop,
-                                          protocolFamily: AF_INET)
+                                          protocolFamily: .inet)
         XCTAssertThrowsError(try channel.triggerUserOutboundEvent("event").wait()) { (error: Error) in
             if let error = error as? ChannelError {
                 XCTAssertEqual(ChannelError.operationUnsupported, error)

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -443,7 +443,7 @@ public final class EventLoopTest : XCTestCase {
         let wedgeHandler = WedgeOpenHandler { promise in
             promiseQueue.sync { promises.append(promise) }
         }
-        let channel = try SocketChannel(eventLoop: loop, protocolFamily: AF_INET)
+        let channel = try SocketChannel(eventLoop: loop, protocolFamily: .inet)
         try channel.eventLoop.submit {
             channel.pipeline.addHandler(wedgeHandler).flatMap {
                 channel.register()
@@ -471,7 +471,7 @@ public final class EventLoopTest : XCTestCase {
         }
 
         // Now we're going to attempt to register a new channel. This should immediately fail.
-        let newChannel = try SocketChannel(eventLoop: loop, protocolFamily: AF_INET)
+        let newChannel = try SocketChannel(eventLoop: loop, protocolFamily: .inet)
 
         XCTAssertThrowsError(try newChannel.register().wait()) { error in
             XCTAssertEqual(.shutdown, error as? EventLoopError)
@@ -598,7 +598,7 @@ public final class EventLoopTest : XCTestCase {
         let serverSocket = try assertNoThrowWithValue(ServerBootstrap(group: group)
             .bind(host: "localhost", port: 0).wait())
         let channel = try assertNoThrowWithValue(SocketChannel(eventLoop: eventLoop as! SelectableEventLoop,
-                                                               protocolFamily: serverSocket.localAddress!.protocolFamily))
+                                                               protocolFamily: serverSocket.localAddress!.protocol))
         XCTAssertNoThrow(try channel.pipeline.addHandler(assertHandler).wait() as Void)
         XCTAssertNoThrow(try channel.eventLoop.flatSubmit {
             channel.register().flatMap {

--- a/Tests/NIOTests/HappyEyeballsTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest.swift
@@ -213,7 +213,7 @@ private class DummyResolver: Resolver {
 extension DummyResolver.Event: Equatable {
 }
 
-private func defaultChannelBuilder(loop: EventLoop, family: Int32) -> EventLoopFuture<Channel> {
+private func defaultChannelBuilder(loop: EventLoop, family: NIOBSDSocket.ProtocolFamily) -> EventLoopFuture<Channel> {
     let channel = EmbeddedChannel(loop: loop as! EmbeddedEventLoop)
     XCTAssertNoThrow(try channel.pipeline.addHandler(ConnectRecorder(), name: CONNECT_RECORDER).wait())
     return loop.makeSucceededFuture(channel)
@@ -222,7 +222,7 @@ private func defaultChannelBuilder(loop: EventLoop, family: Int32) -> EventLoopF
 private func buildEyeballer(host: String,
                             port: Int,
                             connectTimeout: TimeAmount = .seconds(10),
-                            channelBuilderCallback: @escaping (EventLoop, Int32) -> EventLoopFuture<Channel> = defaultChannelBuilder) -> (eyeballer: HappyEyeballsConnector, resolver: DummyResolver, loop: EmbeddedEventLoop) {
+                            channelBuilderCallback: @escaping (EventLoop, NIOBSDSocket.ProtocolFamily) -> EventLoopFuture<Channel> = defaultChannelBuilder) -> (eyeballer: HappyEyeballsConnector, resolver: DummyResolver, loop: EmbeddedEventLoop) {
     let loop = EmbeddedEventLoop()
     let resolver = DummyResolver(loop: loop)
     let eyeballer = HappyEyeballsConnector(resolver: resolver,
@@ -1087,14 +1087,14 @@ public final class HappyEyeballsTest : XCTestCase {
 
         // Succeed the first channel future, which will connect because the default
         // channel builder always does.
-        defaultChannelBuilder(loop: loop, family: AF_INET6).whenSuccess {
+        defaultChannelBuilder(loop: loop, family: .inet6).whenSuccess {
             ourChannelFutures.first!.succeed($0)
             XCTAssertEqual($0.state(), .connected)
         }
         XCTAssertTrue(channelFuture.isFulfilled)
 
         // Ok, now succeed the second channel future. This should cause the channel to immediately be closed.
-        defaultChannelBuilder(loop: loop, family: AF_INET6).whenSuccess {
+        defaultChannelBuilder(loop: loop, family: .inet6).whenSuccess {
             ourChannelFutures[1].succeed($0)
             XCTAssertEqual($0.state(), .closed)
         }

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -191,7 +191,7 @@ class NonBlockingFileIOTest: XCTestCase {
 
     func testFailedIO() throws {
         enum DummyError: Error { case dummy }
-        let unconnectedSockFH = NIOFileHandle(descriptor: try! Posix.socket(domain: AF_UNIX, type: .stream, protocol: 0))
+        let unconnectedSockFH = NIOFileHandle(descriptor: try! Posix.socket(domain: .unix, type: .stream, protocol: 0))
         defer {
             XCTAssertNoThrow(try unconnectedSockFH.close())
         }

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -37,7 +37,7 @@ class SelectorTest: XCTestCase {
             XCTAssertNoThrow(try selector.close())
         }
 
-        let socket1 = try Socket(protocolFamily: PF_INET, type: .stream)
+        let socket1 = try Socket(protocolFamily: .inet, type: .stream)
         defer {
             if socket1.isOpen {
                 XCTAssertNoThrow(try socket1.close())
@@ -45,7 +45,7 @@ class SelectorTest: XCTestCase {
         }
         try socket1.setNonBlocking()
 
-        let socket2 = try Socket(protocolFamily: PF_INET, type: .stream)
+        let socket2 = try Socket(protocolFamily: .inet, type: .stream)
         defer {
             if socket2.isOpen {
                 XCTAssertNoThrow(try socket2.close())
@@ -53,7 +53,7 @@ class SelectorTest: XCTestCase {
         }
         try socket2.setNonBlocking()
 
-        let serverSocket = try assertNoThrowWithValue(ServerSocket.bootstrap(protocolFamily: PF_INET,
+        let serverSocket = try assertNoThrowWithValue(ServerSocket.bootstrap(protocolFamily: .inet,
                                                                              host: "127.0.0.1",
                                                                              port: 0))
         defer {
@@ -386,7 +386,7 @@ class SelectorTest: XCTestCase {
             }
         }
         var socketFDs: [CInt] = [-1, -1]
-        XCTAssertNoThrow(try Posix.socketpair(domain: PF_LOCAL,
+        XCTAssertNoThrow(try Posix.socketpair(domain: .local,
                                               type: .stream,
                                               protocol: 0,
                                               socketVector: &socketFDs))

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -211,7 +211,7 @@ final class NonAcceptingServerSocket: ServerSocket {
     init(errors: [Int32]) throws {
         // Reverse so it's cheaper to remove errors.
         self.errors = errors.reversed()
-        try super.init(protocolFamily: AF_INET, setNonBlocking: true)
+        try super.init(protocolFamily: .inet, setNonBlocking: true)
     }
 
     override func accept(setNonBlocking: Bool) throws -> Socket? {


### PR DESCRIPTION
This encapsulates the enumeration of protocol families rather than
relying on the underlying C library to provide the value.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
