### PR TITLE
Add `BSDSocket.AddressFamily`

### DIFF
--- a/Sources/NIO/BSDSocketAPI.swift
+++ b/Sources/NIO/BSDSocketAPI.swift
@@ -13,10 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Windows)
+import let WinSDK.AF_INET
+import let WinSDK.AF_INET6
+import let WinSDK.AF_UNIX
+
 import let WinSDK.IPPROTO_IP
 import let WinSDK.IPPROTO_IPV6
 import let WinSDK.IPPROTO_TCP
-import let WinSDK.SOL_SOCKET
 
 import let WinSDK.IP_ADD_MEMBERSHIP
 import let WinSDK.IP_DROP_MEMBERSHIP
@@ -45,6 +48,8 @@ import let WinSDK.SO_RCVTIMEO
 import let WinSDK.SO_REUSEADDR
 import let WinSDK.SO_REUSE_UNICASTPORT
 
+import let WinSDK.SOL_SOCKET
+
 import let WinSDK.SOCK_DGRAM
 import let WinSDK.SOCK_STREAM
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
@@ -71,6 +76,23 @@ extension NIOBSDSocket.SocketType: Equatable {
 }
 
 extension NIOBSDSocket.SocketType: Hashable {
+}
+
+extension NIOBSDSocket {
+    /// Specifies the addressing scheme that the socket can use.
+    public struct AddressFamily: RawRepresentable {
+        public typealias RawValue = CInt
+        public var rawValue: RawValue
+        public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+        }
+    }
+}
+
+extension NIOBSDSocket.AddressFamily: Equatable {
+}
+
+extension NIOBSDSocket.AddressFamily: Hashable {
 }
 
 extension NIOBSDSocket {
@@ -122,6 +144,21 @@ extension NIOBSDSocket.Option: Equatable {
 }
 
 extension NIOBSDSocket.Option: Hashable {
+}
+
+// Address Family
+extension NIOBSDSocket.AddressFamily {
+    /// Address for IP version 4.
+    public static let inet: NIOBSDSocket.AddressFamily =
+            NIOBSDSocket.AddressFamily(rawValue: AF_INET)
+
+    /// Address for IP version 6.
+    public static let inet6: NIOBSDSocket.AddressFamily =
+            NIOBSDSocket.AddressFamily(rawValue: AF_INET6)
+
+    /// Unix local to host address.
+    public static let unix: NIOBSDSocket.AddressFamily =
+            NIOBSDSocket.AddressFamily(rawValue: AF_UNIX)
 }
 
 // Protocol Family

--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -26,10 +26,10 @@ protocol SockAddrProtocol {
 }
 
 /// Returns a description for the given address.
-internal func descriptionForAddress(family: sa_family_t, bytes: UnsafeRawPointer, length byteCount: Int) throws -> String {
+internal func descriptionForAddress(family: NIOBSDSocket.AddressFamily, bytes: UnsafeRawPointer, length byteCount: Int) throws -> String {
     var addressBytes: [Int8] = Array(repeating: 0, count: byteCount)
     return try addressBytes.withUnsafeMutableBufferPointer { (addressBytesPtr: inout UnsafeMutableBufferPointer<Int8>) -> String in
-        try Posix.inet_ntop(addressFamily: family,
+        try Posix.inet_ntop(addressFamily: sa_family_t(family.rawValue),
                             addressBytes: bytes,
                             addressDescription: addressBytesPtr.baseAddress!,
                             addressDescriptionLength: socklen_t(byteCount))
@@ -43,16 +43,16 @@ internal func descriptionForAddress(family: sa_family_t, bytes: UnsafeRawPointer
 extension UnsafeMutablePointer where Pointee == sockaddr {
     /// Converts the `sockaddr` to a `SocketAddress`.
     func convert() -> SocketAddress? {
-        switch pointee.sa_family {
-        case Posix.AF_INET:
+        switch NIOBSDSocket.AddressFamily(rawValue: CInt(pointee.sa_family)) {
+        case .inet:
             return self.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
                 SocketAddress($0.pointee, host: $0.pointee.addressDescription())
             }
-        case Posix.AF_INET6:
+        case .inet6:
             return self.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
                 SocketAddress($0.pointee, host: $0.pointee.addressDescription())
             }
-        case Posix.AF_UNIX:
+        case .unix:
             return self.withMemoryRebound(to: sockaddr_un.self, capacity: 1) {
                 SocketAddress($0.pointee)
             }
@@ -81,7 +81,7 @@ extension sockaddr_in: SockAddrProtocol {
     mutating func addressDescription() -> String {
         return withUnsafePointer(to: &self.sin_addr) { addrPtr in
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            try! descriptionForAddress(family: Posix.AF_INET, bytes: addrPtr, length: Int(INET_ADDRSTRLEN))
+            try! descriptionForAddress(family: .inet, bytes: addrPtr, length: Int(INET_ADDRSTRLEN))
         }
     }
 }
@@ -105,7 +105,7 @@ extension sockaddr_in6: SockAddrProtocol {
     mutating func addressDescription() -> String {
         return withUnsafePointer(to: &self.sin6_addr) { addrPtr in
             // this uses inet_ntop which is documented to only fail if family is not AF_INET or AF_INET6 (or ENOSPC)
-            try! descriptionForAddress(family: Posix.AF_INET6, bytes: addrPtr, length: Int(INET6_ADDRSTRLEN))
+            try! descriptionForAddress(family: .inet6, bytes: addrPtr, length: Int(INET6_ADDRSTRLEN))
         }
     }
 }
@@ -154,7 +154,7 @@ extension sockaddr_storage {
     ///
     /// This will crash if `ss_family` != AF_INET!
     mutating func convert() -> sockaddr_in {
-        precondition(self.ss_family == Posix.AF_INET)
+        precondition(self.ss_family == NIOBSDSocket.AddressFamily.inet.rawValue)
         return withUnsafePointer(to: &self) {
             $0.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
                 $0.pointee
@@ -166,7 +166,7 @@ extension sockaddr_storage {
     ///
     /// This will crash if `ss_family` != AF_INET6!
     mutating func convert() -> sockaddr_in6 {
-        precondition(self.ss_family == Posix.AF_INET6)
+        precondition(self.ss_family == NIOBSDSocket.AddressFamily.inet6.rawValue)
         return withUnsafePointer(to: &self) {
             $0.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
                 $0.pointee
@@ -178,7 +178,7 @@ extension sockaddr_storage {
     ///
     /// This will crash if `ss_family` != AF_UNIX!
     mutating func convert() -> sockaddr_un {
-        precondition(self.ss_family == Posix.AF_UNIX)
+        precondition(self.ss_family == NIOBSDSocket.AddressFamily.unix.rawValue)
         return withUnsafePointer(to: &self) {
             $0.withMemoryRebound(to: sockaddr_un.self, capacity: 1) {
                 $0.pointee
@@ -188,14 +188,14 @@ extension sockaddr_storage {
 
     /// Converts the `socketaddr_storage` to a `SocketAddress`.
     mutating func convert() -> SocketAddress {
-        switch self.ss_family {
-        case Posix.AF_INET:
+        switch NIOBSDSocket.AddressFamily(rawValue: CInt(self.ss_family)) {
+        case .inet:
             var sockAddr: sockaddr_in = self.convert()
             return SocketAddress(sockAddr, host: sockAddr.addressDescription())
-        case Posix.AF_INET6:
+        case .inet6:
             var sockAddr: sockaddr_in6 = self.convert()
             return SocketAddress(sockAddr, host: sockAddr.addressDescription())
-        case Posix.AF_UNIX:
+        case .unix:
             return SocketAddress(self.convert() as sockaddr_un)
         default:
             fatalError("unknown sockaddr family \(self.ss_family)")

--- a/Sources/NIO/GetaddrinfoResolver.swift
+++ b/Sources/NIO/GetaddrinfoResolver.swift
@@ -115,12 +115,12 @@ internal class GetaddrinfoResolver: Resolver {
         var v6Results = [SocketAddress]()
 
         while true {
-            switch info.pointee.ai_family {
-            case AF_INET:
+            switch NIOBSDSocket.AddressFamily(rawValue: info.pointee.ai_family) {
+            case .inet:
                 info.pointee.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { ptr in
                     v4Results.append(.init(ptr.pointee, host: host))
                 }
-            case AF_INET6:
+            case .inet6:
                 info.pointee.ai_addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { ptr in
                     v6Results.append(.init(ptr.pointee, host: host))
                 }

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -84,9 +84,6 @@ private let sysGetsockname: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>
 private let sysGetifaddrs: @convention(c) (UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>?) -> CInt = getifaddrs
 private let sysFreeifaddrs: @convention(c) (UnsafeMutablePointer<ifaddrs>?) -> Void = freeifaddrs
 private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsignedInt = if_nametoindex
-private let sysAF_INET = AF_INET
-private let sysAF_INET6 = AF_INET6
-private let sysAF_UNIX = AF_UNIX
 private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
 private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>?) -> CInt = socketpair
 
@@ -194,10 +191,6 @@ internal enum Posix {
         fatalError("unsupported OS")
     }
 #endif
-
-    static let AF_INET = sa_family_t(sysAF_INET)
-    static let AF_INET6 = sa_family_t(sysAF_INET6)
-    static let AF_UNIX = sa_family_t(sysAF_UNIX)
 
     @inline(never)
     public static func shutdown(descriptor: CInt, how: Shutdown) throws {

--- a/Tests/NIOTests/HappyEyeballsTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest.swift
@@ -129,15 +129,15 @@ private extension SocketAddress {
         var v4addr = in_addr()
         var v6addr = in6_addr()
 
-        if inet_pton(AF_INET, ipAddress, &v4addr) == 1 {
+        if inet_pton(NIOBSDSocket.AddressFamily.inet.rawValue, ipAddress, &v4addr) == 1 {
             var sockaddr = sockaddr_in()
-            sockaddr.sin_family = sa_family_t(AF_INET)
+            sockaddr.sin_family = sa_family_t(NIOBSDSocket.AddressFamily.inet.rawValue)
             sockaddr.sin_port = in_port_t(port).bigEndian
             sockaddr.sin_addr = v4addr
             self = .init(sockaddr, host: host)
-        } else if inet_pton(AF_INET6, ipAddress, &v6addr) == 1 {
+        } else if inet_pton(NIOBSDSocket.AddressFamily.inet6.rawValue, ipAddress, &v6addr) == 1 {
             var sockaddr = sockaddr_in6()
-            sockaddr.sin6_family = sa_family_t(AF_INET6)
+            sockaddr.sin6_family = sa_family_t(NIOBSDSocket.AddressFamily.inet6.rawValue)
             sockaddr.sin6_port = in_port_t(port).bigEndian
             sockaddr.sin6_flowinfo = 0
             sockaddr.sin6_scope_id = 0
@@ -153,10 +153,10 @@ private extension SocketAddress {
         switch self {
         case .v4(let address):
             var baseAddress = address.address
-            precondition(inet_ntop(AF_INET, &baseAddress.sin_addr, ptr, 256) != nil)
+            precondition(inet_ntop(NIOBSDSocket.AddressFamily.inet.rawValue, &baseAddress.sin_addr, ptr, 256) != nil)
         case .v6(let address):
             var baseAddress = address.address
-            precondition(inet_ntop(AF_INET6, &baseAddress.sin6_addr, ptr, 256) != nil)
+            precondition(inet_ntop(NIOBSDSocket.AddressFamily.inet6.rawValue, &baseAddress.sin6_addr, ptr, 256) != nil)
         case .unixDomainSocket:
             fatalError("No UDS support in happy eyeballs.")
         }

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
@@ -17,18 +17,16 @@ import XCTest
 
 private extension SocketAddress {
     init(_ addr: UnsafePointer<sockaddr>) {
-        let family = addr.pointee.sa_family
-
-        switch family {
-        case sa_family_t(AF_UNIX):
+        switch NIOBSDSocket.AddressFamily(rawValue: CInt(addr.pointee.sa_family)) {
+        case .unix:
             self = addr.withMemoryRebound(to: sockaddr_un.self, capacity: 1) {
                 SocketAddress($0.pointee)
             }
-        case sa_family_t(AF_INET):
+        case .inet:
             self = addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
                 SocketAddress($0.pointee, host: "")
             }
-        case sa_family_t(AF_INET6):
+        case .inet6:
             self = addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
                 SocketAddress($0.pointee, host: "")
             }

--- a/Tests/NIOTests/SocketAddressTest.swift
+++ b/Tests/NIOTests/SocketAddressTest.swift
@@ -20,7 +20,7 @@ class SocketAddressTest: XCTestCase {
     func testDescriptionWorks() throws {
         var ipv4SocketAddress = sockaddr_in()
         let res = "10.0.0.1".withCString { p in
-            inet_pton(AF_INET, p, &ipv4SocketAddress.sin_addr)
+            inet_pton(NIOBSDSocket.AddressFamily.inet.rawValue, p, &ipv4SocketAddress.sin_addr)
         }
         XCTAssertEqual(res, 1)
         ipv4SocketAddress.sin_port = (12345 as in_port_t).bigEndian
@@ -54,7 +54,7 @@ class SocketAddressTest: XCTestCase {
         #else
           address.sin6_len  = UInt8(MemoryLayout<sockaddr_in6>.size)
         #endif
-        address.sin6_family = sa_family_t(AF_INET6)
+        address.sin6_family = sa_family_t(NIOBSDSocket.AddressFamily.inet6.rawValue)
         address.sin6_addr   = sampleIn6Addr.withUnsafeBytes {
             $0.baseAddress!.bindMemory(to: in6_addr.self, capacity: 1).pointee
         }
@@ -82,7 +82,7 @@ class SocketAddressTest: XCTestCase {
             var addr = address.address
             let host = address.host
             XCTAssertEqual(host, "")
-            XCTAssertEqual(addr.sin_family, sa_family_t(AF_INET))
+            XCTAssertEqual(addr.sin_family, sa_family_t(NIOBSDSocket.AddressFamily.inet.rawValue))
             XCTAssertEqual(addr.sin_port, in_port_t(80).bigEndian)
             expectedAddress.withUnsafeBytes { expectedPtr in
                 withUnsafeBytes(of: &addr.sin_addr) { actualPtr in
@@ -102,7 +102,7 @@ class SocketAddressTest: XCTestCase {
             var addr = address.address
             let host = address.host
             XCTAssertEqual(host, "")
-            XCTAssertEqual(addr.sin6_family, sa_family_t(AF_INET6))
+            XCTAssertEqual(addr.sin6_family, sa_family_t(NIOBSDSocket.AddressFamily.inet6.rawValue))
             XCTAssertEqual(addr.sin6_port, in_port_t(443).bigEndian)
             XCTAssertEqual(addr.sin6_scope_id, 0)
             XCTAssertEqual(addr.sin6_flowinfo, 0)
@@ -367,9 +367,9 @@ class SocketAddressTest: XCTestCase {
         var storage = sockaddr_storage()
         XCTAssertEqual(storage.ss_family, 0)
         storage.withMutableSockAddr { (addr, _) in
-            addr.pointee.sa_family = sa_family_t(AF_UNIX)
+            addr.pointee.sa_family = sa_family_t(NIOBSDSocket.AddressFamily.unix.rawValue)
         }
-        XCTAssertEqual(storage.ss_family, sa_family_t(AF_UNIX))
+        XCTAssertEqual(storage.ss_family, sa_family_t(NIOBSDSocket.AddressFamily.unix.rawValue))
     }
 
     func testPortIsMutable() throws {


### PR DESCRIPTION
This finishes up the encapsulation that is required to ensure that we
are not leaking libc interfaces to clients but instead vend an
enumeration that they can use.  The enumeration is open so although we
may not have the full interface enumerated, users will not be prevented
from using alternate values.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
