### PR TITLE
fix accidental deprecation [MUST go into next release]

### DIFF
--- a/Sources/NIO/ChannelOption.swift
+++ b/Sources/NIO/ChannelOption.swift
@@ -98,7 +98,6 @@ extension ChannelOptions {
                 /// - parameters:
                 ///     - level: The level for the option as defined in `man setsockopt`, e.g. SO_SOCKET.
                 ///     - name: The name of the option as defined in `man setsockopt`, e.g. `SO_REUSEADDR`.
-                @available(*, deprecated)
                 public init(level: SocketOptionLevel, name: SocketOptionName) {
                     self.optionLevel = NIOBSDSocket.OptionLevel(rawValue: CInt(level))
                     self.optionName = NIOBSDSocket.Option(rawValue: CInt(name))


### PR DESCRIPTION
Motivation:

In one of the previous patches, we accidentally merged the deprecation
of `ChannelOptions.Types.SocketOption.init` which will break a lot of
NIO programs.

Modifications:

Undo the deprecation.

Result:

NIOTS builds without warnings.