### PR TITLE
Correct doc comment on writeEOF

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -165,7 +165,7 @@ internal protocol SelectableChannel: Channel {
     /// Called when the read side of the `SelectableChannel` hit EOF.
     func readEOF()
 
-    /// Called when the read side of the `SelectableChannel` hit EOF.
+    /// Called when the write side of the `SelectableChannel` hit EOF.
     func writeEOF()
 
     /// Called when the `SelectableChannel` was reset (ie. is now unusable)


### PR DESCRIPTION
Motivation:

Make the documentation correct.

Modifications:

Changed the word read to write in comments.

Result:

Doc comment will be correct.