### PR TITLE
Draft - Shorthand way of setting options in server bootstrap.

### DIFF
--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -527,7 +527,7 @@ let fileIO = NonBlockingFileIO(threadPool: threadPool)
 let socketBootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)
-    .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .serverOptions([.reuseAddr])
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer(childChannelInitializer(channel:))

--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -48,6 +48,7 @@ extension BootstrapTest {
                 ("testDatagramBootstrapRejectsNotWorkingELGsCorrectly", testDatagramBootstrapRejectsNotWorkingELGsCorrectly),
                 ("testNIOPipeBootstrapValidatesWorkingELGsCorrectly", testNIOPipeBootstrapValidatesWorkingELGsCorrectly),
                 ("testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly", testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly),
+                ("testShorthandOptionsAreEquivalent", testShorthandOptionsAreEquivalent),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Less typing is good.

Modifications:

Add a new collection of types to provide shorthand channel options.
A new method on ServerBootstrap to set an array of these shorthand options.
A test case that long hand does the same as short hand.
Change to HTTPServer to demonstrate the change.

Result:

There will be an new way of setting options involving less typing.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
