### PR TITLE
adding docset to files copied into gh-pages dir

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -108,6 +108,7 @@ if [[ $PUSH == true ]]; then
   rm -rf "docs/$version"
   rm -rf "docs/current"
   cp -r "$jazzy_dir/docs/$version" docs/
+  cp -r "$jazzy_dir/docset/$version" docset/
   cp -r "docs/$version" docs/current
   git add --all docs
   echo '<html><head><meta http-equiv="refresh" content="0; url=docs/current/NIO/index.html" /></head></html>' > index.html

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -90,7 +90,7 @@ For the API documentation of the other repositories in the SwiftNIO family check
 EOF
 
 for module in "${modules[@]}"; do
-  args=("${jazzy_args[@]}" --output "$jazzy_dir/docs/$version/$module" --docset-path "$jazzy_dir/docset/$version/$module"
+  args=("${jazzy_args[@]}" --output "$jazzy_dir/docs/$version/$module"
         --module "$module" --module-version $version
         --root-url "https://apple.github.io/swift-nio/docs/$version/$module/")
   if [[ -f "$root_path/.build/sourcekitten/$module.json" ]]; then
@@ -108,7 +108,6 @@ if [[ $PUSH == true ]]; then
   rm -rf "docs/$version"
   rm -rf "docs/current"
   cp -r "$jazzy_dir/docs/$version" docs/
-  cp -r "$jazzy_dir/docset/$version" docset/
   cp -r "docs/$version" docs/current
   git add --all docs
   echo '<html><head><meta http-equiv="refresh" content="0; url=docs/current/NIO/index.html" /></head></html>' > index.html


### PR DESCRIPTION
adding docset to files copied into gh-pages dir

### Motivation:

I noticed the missing link when perusing swift-metrics, and after having submitted a fix there, I was told the same script was used here, so I thought it might be convenient to have the same fix (https://github.com/apple/swift-metrics/pull/69) propagated here.

### Modifications:

added a line to copy the docset files in addition to the docs

### Result:

Future updates should also include docset files for swift-metrics on
additional publications to gh-pages by authors.
