### PR TITLE
Remove a warning from the performance test build.

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_read_10000_chunks_from_file.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_read_10000_chunks_from_file.swift
@@ -31,7 +31,6 @@ func run(identifier: String) {
     let fileIO = NonBlockingFileIO(threadPool: threadPool)
 
     let numberOfChunks = 10_000
-    let dg = DispatchGroup()
 
     let allocator = ByteBufferAllocator()
     var fileBuffer = allocator.buffer(capacity: numberOfChunks)


### PR DESCRIPTION
Remove a warning from the performance test build.

### Motivation:

Warnings are just distracting and should be removed where possible.

### Modifications:

Remove an unused variable from the code.

### Result:

One fewer warning when the performance tests are compiled.
