### PR TITLE
Allow bootstraps to override TCP shorthand options from universal.

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
@@ -98,7 +98,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
 
 func doRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
     let serverChannel = try ServerBootstrap(group: group)
-        .serverOptions([.allowImmediateEndpointAddressReuse])
+        .serverChannelOptions([.allowImmediateEndpointAddressReuse])
         .childChannelInitializer { channel in
             channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true,
                                                          withErrorHandling: false).flatMap {

--- a/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
@@ -98,7 +98,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
 
 func doRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
     let serverChannel = try ServerBootstrap(group: group)
-        .serverOptions([.reuseAddr])
+        .serverOptions([.allowImmediateEndpointAddressReuse])
         .childChannelInitializer { channel in
             channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true,
                                                          withErrorHandling: false).flatMap {

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_ping_pong_1000_reqs_1_conn.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_ping_pong_1000_reqs_1_conn.swift
@@ -111,7 +111,7 @@ private final class PongHandler: ChannelInboundHandler {
 
 func doPingPongRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
     let serverChannel = try ServerBootstrap(group: group)
-        .serverOptions([.allowImmediateEndpointAddressReuse])
+        .serverChannelOptions([.allowImmediateEndpointAddressReuse])
         .childChannelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))
         .childChannelInitializer { channel in
             channel.pipeline.addHandler(ByteToMessageHandler(PongDecoder())).flatMap {

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_ping_pong_1000_reqs_1_conn.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_ping_pong_1000_reqs_1_conn.swift
@@ -111,7 +111,7 @@ private final class PongHandler: ChannelInboundHandler {
 
 func doPingPongRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
     let serverChannel = try ServerBootstrap(group: group)
-        .serverOptions([.reuseAddr])
+        .serverOptions([.allowImmediateEndpointAddressReuse])
         .childChannelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))
         .childChannelInitializer { channel in
             channel.pipeline.addHandler(ByteToMessageHandler(PongDecoder())).flatMap {

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -1050,7 +1050,7 @@ extension ShorthandServerBootstrapOption {
     
     /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`. This is only useful for `ServerSocketChannel`s.
     /// - See: ChannelOptions.backlog
-    public static func backlog(_ value : ChannelOptions.Types.BacklogOption.Value) -> ShorthandServerBootstrapOption {
+    public static func backlog(_ value: ChannelOptions.Types.BacklogOption.Value) -> ShorthandServerBootstrapOption {
         return ShorthandServerBootstrapOption(.backlog(value))
     }
 }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -494,7 +494,7 @@ extension ServerBootstrap.ShorthandChildBootstrapOption {
     /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) ->
         ServerBootstrap.ShorthandChildBootstrapOption {
-        ServerBootstrap.ShorthandChildBootstrapOption(.allowRemoteHalfClosure(value))
+        return ServerBootstrap.ShorthandChildBootstrapOption(.allowRemoteHalfClosure(value))
     }
 }
 
@@ -843,7 +843,7 @@ extension ClientBootstrap.ShorthandClientBootstrapOption {
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) -> ClientBootstrap.ShorthandClientBootstrapOption {
-        ClientBootstrap.ShorthandClientBootstrapOption(.allowRemoteHalfClosure(value))
+        return ClientBootstrap.ShorthandClientBootstrapOption(.allowRemoteHalfClosure(value))
     }
 }
 
@@ -1281,6 +1281,6 @@ extension NIOPipeBootstrap.ShorthandChannelBootstrapOption {
     /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) ->
         NIOPipeBootstrap.ShorthandChannelBootstrapOption {
-        NIOPipeBootstrap.ShorthandChannelBootstrapOption(.allowRemoteHalfClosure(value))
+        return NIOPipeBootstrap.ShorthandChannelBootstrapOption(.allowRemoteHalfClosure(value))
     }
 }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -179,6 +179,7 @@ public final class ServerBootstrap {
     /// - See: serverChannelOption
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated server bootstrap (`self` being mutated)
+    @inlinable
     public func serverOptions(_ options: [ShorthandServerBootstrapOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
@@ -201,6 +202,7 @@ public final class ServerBootstrap {
     /// - See: childChannelOption
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The update server bootstrap (`self` being mutated)
+    @inlinable
     public func childChannelOptions(_ options: [ShorthandChildBootstrapOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
@@ -398,6 +400,7 @@ public final class ServerBootstrap {
         /// Apply the contained option to the supplied ServerBootstrap
         /// - Parameter serverBootstrap: bootstrap to apply this option to.
         /// - Returns: the modified bootstrap (currently the same one mutated)
+        @usableFromInline
         func applyOption(to serverBootstrap: ServerBootstrap) {
             data.applyOption(to: serverBootstrap)
         }
@@ -433,6 +436,7 @@ public final class ServerBootstrap {
         /// Apply the contained option to the supplied ServerBootstrap
         /// - Parameter serverBootstrap: bootstrap to apply this option to.
         /// - Returns: the modified bootstrap (currently the same one mutated)
+        @usableFromInline
         func applyOption(to serverBootstrap: ServerBootstrap) {
             data.applyOption(to: serverBootstrap)
         }
@@ -642,6 +646,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     /// - See: channelOption
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The update server bootstrap (`self` being mutated)
+    @inlinable
     public func channelOptions(_ options: [ShorthandClientBootstrapOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
@@ -807,6 +812,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         /// Apply the contained option to the supplied ClientBootstrap
         /// - Parameter to: bootstrap to apply this option to.
         /// - Returns: the modified bootstrap (currently the same one mutated)
+        @usableFromInline
         func applyOption(to clientBootstrap: ClientBootstrap) {
             data.applyOption(to: clientBootstrap)
         }
@@ -932,6 +938,7 @@ public final class DatagramBootstrap {
     /// - See: channelOption
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated server bootstrap (`self` being mutated)
+    @inlinable
     public func channelOptions(_ options: [ShorthandChannelBootstrapOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
@@ -1048,6 +1055,7 @@ public final class DatagramBootstrap {
         /// Apply the contained option to the supplied DatagramBootstrap
         /// - Parameter to: bootstrap to apply this option to.
         /// - Returns: the modified bootstrap (currently the same one mutated)
+        @usableFromInline
         func applyOption(to bootstrap: DatagramBootstrap) {
             data.applyOption(to: bootstrap)
         }
@@ -1161,6 +1169,7 @@ public final class NIOPipeBootstrap {
     /// - See: channelOption
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated server bootstrap (`self` being mutated)
+    @inlinable
     public func channelOptions(_ options: [ShorthandChannelBootstrapOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
@@ -1245,6 +1254,7 @@ public final class NIOPipeBootstrap {
         /// Apply the contained option to the supplied NIOPipeBootstrap
         /// - Parameter to: bootstrap to apply this option to.
         /// - Returns: the modified bootstrap (currently the same one mutated)
+        @usableFromInline
         func applyOption(to bootstrap: NIOPipeBootstrap) {
             data.applyOption(to: bootstrap)
         }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -1034,9 +1034,9 @@ public struct ShorthandServerBootstrapOption {
     }
 }
 
-// Equatable and Hashable for the convenience of users.
-extension ShorthandServerBootstrapOption : Equatable, Hashable {}
-extension ShorthandServerBootstrapOption.ShorthandServerOption : Equatable, Hashable {}
+// Hashable for the convenience of users.
+extension ShorthandServerBootstrapOption : Hashable {}
+extension ShorthandServerBootstrapOption.ShorthandServerOption : Hashable {}
 
 /// Approved shorthand server options.
 extension ShorthandServerBootstrapOption {
@@ -1086,9 +1086,9 @@ public struct ShorthandChildBootstrapOption {
     }
 }
 
-// Equatable and Hashable for the convenience of users.
-extension ShorthandChildBootstrapOption : Equatable, Hashable {}
-extension ShorthandChildBootstrapOption.ShorthandChildOption : Equatable, Hashable {}
+// Hashable for the convenience of users.
+extension ShorthandChildBootstrapOption : Hashable {}
+extension ShorthandChildBootstrapOption.ShorthandChildOption : Hashable {}
 
 /// Approved shorthand child options.
 extension ShorthandChildBootstrapOption {
@@ -1136,9 +1136,9 @@ public struct ShorthandClientBootstrapOption {
     }
 }
 
-// Equatable and Hashable for the convenience of users.
-extension ShorthandClientBootstrapOption : Equatable, Hashable {}
-extension ShorthandClientBootstrapOption.ShorthandClientOption : Equatable, Hashable {}
+// Hashable for the convenience of users.
+extension ShorthandClientBootstrapOption : Hashable {}
+extension ShorthandClientBootstrapOption.ShorthandClientOption : Hashable {}
 
 /// Approved shorthand client options.
 extension ShorthandClientBootstrapOption {

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -443,6 +443,7 @@ public final class ServerBootstrap {
         
         fileprivate enum ShorthandChildOption {
             case reuseAddr
+            case disableAutoRead
             case allowRemoteHalfClosure(Bool)
             
             func applyOption(to serverBootstrap: ServerBootstrap) {
@@ -452,6 +453,8 @@ public final class ServerBootstrap {
                                                            value: 1)
                 case .allowRemoteHalfClosure(let value):
                     _ = serverBootstrap.childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+                case .disableAutoRead:
+                    _ = serverBootstrap.childChannelOption(ChannelOptions.autoRead, value: false)
                 }
             }
         }
@@ -490,6 +493,10 @@ extension ServerBootstrap.ChildOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
     public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ChildOption(.reuseAddr)
+    
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = ServerBootstrap.ChildOption(.disableAutoRead)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =
@@ -819,6 +826,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         
         fileprivate enum ShorthandClientOption {
             case reuseAddr
+            case disableAutoRead
             case allowRemoteHalfClosure(Bool)
             
             func applyOption(to clientBootstrap: ClientBootstrap) {
@@ -827,6 +835,8 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
                     _ = clientBootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
                 case .allowRemoteHalfClosure(let value):
                     _ = clientBootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+                case .disableAutoRead:
+                    _ = clientBootstrap.channelOption(ChannelOptions.autoRead, value: false)
                 }
             }
         }
@@ -842,6 +852,10 @@ extension ClientBootstrap.Option {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
     public static let allowImmediateEndpointAddressReuse = ClientBootstrap.Option(.reuseAddr)
+    
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = ClientBootstrap.Option(.disableAutoRead)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -46,7 +46,7 @@ internal enum NIOOnSocketsBootstraps {
 ///         }
 ///
 ///         // Enable SO_REUSEADDR for the accepted Channels
-///         .childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+///         .childChannelOptions([.allowImmediateEndpointAddressReuse])
 ///         .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
 ///         .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 ///     let channel = try! bootstrap.bind(host: host, port: port).wait()
@@ -393,7 +393,7 @@ private extension Channel {
 ///     }
 ///     let bootstrap = ClientBootstrap(group: group)
 ///         // Enable SO_REUSEADDR.
-///         .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+///         .channelOptions([.allowImmediateEndpointAddressReuse])
 ///         .channelInitializer { channel in
 ///             // always instantiate the handler _within_ the closure as
 ///             // it may be called multiple times (for example if the hostname
@@ -662,7 +662,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
 ///     }
 ///     let bootstrap = DatagramBootstrap(group: group)
 ///         // Enable SO_REUSEADDR.
-///         .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+///         .channelOption([.allowImmediateEndpointAddressReuse])
 ///         .channelInitializer { channel in
 ///             channel.pipeline.addHandler(MyChannelHandler())
 ///         }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -197,7 +197,7 @@ public final class ServerBootstrap {
         return self
     }
     
-    /// Specifies some `ChannelOption`s to be applied to the  accepted `SocketChannel`s.
+    /// Specifies some `ChannelOption`s to be applied to the accepted `SocketChannel`s.
     /// - See: childChannelOption
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The update server bootstrap (`self` being mutated)

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -180,7 +180,7 @@ public final class ServerBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated server bootstrap (`self` being mutated)
     @inlinable
-    public func serverOptions(_ options: [ServerOption]) -> Self {
+    public func serverChannelOptions(_ options: [ServerOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
         }
@@ -390,7 +390,7 @@ public final class ServerBootstrap {
     }
     
     /// A channel option which can be applied to bootstrap using shorthand notation.
-    /// - See: ServerBootstrap.serverOptions(_ options: [ServerOption])
+    /// - See: ServerBootstrap.serverChannelOptions(_ options: [ServerOption])
     public struct ServerOption {
         private let data: ShorthandServerOption
         

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -1023,12 +1023,12 @@ public struct ShorthandServerBootstrapOption {
         
         func applyOption(to serverBootstrap: ServerBootstrap) {
             switch self {
-                case .autoRead(let value):
-                    let _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: value)
-                case .reuseAddr(let value):
-                    let _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
-                case .backlog(let value):
-                    let _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
+            case .autoRead(let value):
+                let _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: value)
+            case .reuseAddr(let value):
+                let _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
+            case .backlog(let value):
+                let _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
             }
         }
     }
@@ -1073,10 +1073,10 @@ public struct ShorthandChildBootstrapOption {
         
         func applyOption(to serverBootstrap: ServerBootstrap) {
             switch self {
-                case .reuseAddr(let value):
-                    let _ = serverBootstrap.childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
-                case .allowRemoteHalfClosure(let value):
-                    let _ = serverBootstrap.childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+            case .reuseAddr(let value):
+                let _ = serverBootstrap.childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
+            case .allowRemoteHalfClosure(let value):
+                let _ = serverBootstrap.childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
             }
         }
     }
@@ -1119,10 +1119,10 @@ public struct ShorthandClientBootstrapOption {
         
         func applyOption(to clientBootstrap: ClientBootstrap) {
             switch self {
-                case .reuseAddr(let value):
-                    let _ = clientBootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
-                case .allowRemoteHalfClosure(let value):
-                    let _ = clientBootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+            case .reuseAddr(let value):
+                let _ = clientBootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
+            case .allowRemoteHalfClosure(let value):
+                let _ = clientBootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
             }
         }
     }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -1088,8 +1088,10 @@ extension ShorthandChildBootstrapOption {
     /// - See:  NIOBSDSocket.Option.reuseaddr
     public static let reuseAddr = ShorthandChildBootstrapOption(.ReuseAddr(true))
     
+    /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure = ShorthandChildBootstrapOption(.AllowRemoteHalfClosure(true))
     
+    /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) -> ShorthandChildBootstrapOption {
         ShorthandChildBootstrapOption(.AllowRemoteHalfClosure(value))
     }
@@ -1132,8 +1134,10 @@ extension ShorthandClientBootstrapOption {
     /// - See:  NIOBSDSocket.Option.reuseaddr
     public static let reuseAddr = ShorthandClientBootstrapOption(.ReuseAddr(true))
     
+    /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure = ShorthandClientBootstrapOption(.AllowRemoteHalfClosure(true))
     
+    /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) -> ShorthandClientBootstrapOption {
         ShorthandClientBootstrapOption(.AllowRemoteHalfClosure(value))
     }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -528,7 +528,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     /// Specifies some `ChannelOption`s to be applied to the `SocketChannel`.
     /// - See: channelOption
     /// - Parameter options: List of shorthand options to apply.
-    /// - Returns: The update server bootstrap (this mutated)
+    /// - Returns: The update server bootstrap (`self` being mutated)
     public func channelOptions(_ options: [ShorthandClientBootstrapOption]) -> Self {
         for option in options {
             option.applyOption(to: self)

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -412,7 +412,8 @@ public final class ServerBootstrap {
                 case .autoRead(let value):
                     _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: value)
                 case .reuseAddr(let value):
-                    _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
+                    _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr),
+                                                            value: value ? 1 : 0)
                 case .backlog(let value):
                     _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
                 }
@@ -443,7 +444,8 @@ public final class ServerBootstrap {
             func applyOption(to serverBootstrap: ServerBootstrap) {
                 switch self {
                 case .reuseAddr(let value):
-                    _ = serverBootstrap.childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
+                    _ = serverBootstrap.childChannelOption(ChannelOptions.socketOption(.reuseaddr),
+                                                           value: value ? 1 : 0)
                 case .allowRemoteHalfClosure(let value):
                     _ = serverBootstrap.childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
                 }
@@ -466,9 +468,11 @@ extension ServerBootstrap.ShorthandServerBootstrapOption {
     /// - See: ChannelOptions.autoRead
     public static let disableAutoRead = ServerBootstrap.ShorthandServerBootstrapOption(.autoRead(false))
     
-    /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`. This is only useful for `ServerSocketChannel`s.
+    /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`.
+    /// This is only useful for `ServerSocketChannel`s.
     /// - See: ChannelOptions.backlog
-    public static func backlog(_ value: ChannelOptions.Types.BacklogOption.Value) -> ServerBootstrap.ShorthandServerBootstrapOption {
+    public static func backlog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
+        ServerBootstrap.ShorthandServerBootstrapOption {
         return ServerBootstrap.ShorthandServerBootstrapOption(.backlog(value))
     }
 }
@@ -484,10 +488,12 @@ extension ServerBootstrap.ShorthandChildBootstrapOption {
     public static let reuseAddr = ServerBootstrap.ShorthandChildBootstrapOption(.reuseAddr(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
-    public static let allowRemoteHalfClosure = ServerBootstrap.ShorthandChildBootstrapOption(.allowRemoteHalfClosure(true))
+    public static let allowRemoteHalfClosure =
+        ServerBootstrap.ShorthandChildBootstrapOption(.allowRemoteHalfClosure(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
-    public static func allowRemoteHalfClosure(_ value: Bool) -> ServerBootstrap.ShorthandChildBootstrapOption {
+    public static func allowRemoteHalfClosure(_ value: Bool) ->
+        ServerBootstrap.ShorthandChildBootstrapOption {
         ServerBootstrap.ShorthandChildBootstrapOption(.allowRemoteHalfClosure(value))
     }
 }
@@ -832,7 +838,8 @@ extension ClientBootstrap.ShorthandClientBootstrapOption {
     public static let reuseAddr = ClientBootstrap.ShorthandClientBootstrapOption(.reuseAddr(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
-    public static let allowRemoteHalfClosure = ClientBootstrap.ShorthandClientBootstrapOption(.allowRemoteHalfClosure(true))
+    public static let allowRemoteHalfClosure =
+        ClientBootstrap.ShorthandClientBootstrapOption(.allowRemoteHalfClosure(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) -> ClientBootstrap.ShorthandClientBootstrapOption {

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -174,18 +174,6 @@ public final class ServerBootstrap {
         self._serverChannelOptions.append(key: option, value: value)
         return self
     }
-    
-    /// Specifies some `ChannelOption`s to be applied to the `ServerSocketChannel`.
-    /// - See: serverChannelOption
-    /// - Parameter options: List of shorthand options to apply.
-    /// - Returns: The updated server bootstrap (`self` being mutated)
-    @inlinable
-    public func serverChannelOptions(_ options: [ServerOption]) -> Self {
-        for option in options {
-            option.applyOption(to: self)
-        }
-        return self
-    }
 
     /// Specifies a `ChannelOption` to be applied to the accepted `SocketChannel`s.
     ///
@@ -196,19 +184,6 @@ public final class ServerBootstrap {
     public func childChannelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
         self._childChannelOptions.append(key: option, value: value)
         return self
-    }
-    
-    /// Specifies some `ChannelOption`s to be applied to the accepted `SocketChannel`s.
-    /// - See: childChannelOption
-    /// - Parameter options: List of shorthand options to apply.
-    /// - Returns: The update server bootstrap (`self` being mutated)
-    @inlinable
-    public func childChannelOptions(_ options: [NIOTCPShorthandOption]) -> Self {
-        var toReturn = self
-        for option in options {
-            toReturn = option.applyOption(with: toReturn)
-        }
-        return toReturn
     }
 
     /// Specifies a timeout to apply to a bind attempt. Currently unsupported.
@@ -388,64 +363,6 @@ public final class ServerBootstrap {
             }
         }
     }
-    
-    /// A channel option which can be applied to bootstrap using shorthand notation.
-    /// - See: ServerBootstrap.serverChannelOptions(_ options: [ServerOption])
-    public struct ServerOption {
-        private let data: ShorthandServerOption
-        
-        private init(_ data: ShorthandServerOption) {
-            self.data = data
-        }
-        
-        /// Apply the contained option to the supplied ServerBootstrap
-        /// - Parameter serverBootstrap: bootstrap to apply this option to.
-        @usableFromInline
-        func applyOption(to serverBootstrap: ServerBootstrap) {
-            data.applyOption(to: serverBootstrap)
-        }
-        
-        fileprivate enum ShorthandServerOption {
-            case reuseAddr
-            case disableAutoRead
-            case backlog(Int32)
-            
-            func applyOption(to serverBootstrap: ServerBootstrap) {
-                switch self {
-                case .disableAutoRead:
-                    _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: false)
-                case .reuseAddr:
-                    _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr),
-                                                            value: 1)
-                case .backlog(let value):
-                    _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
-                }
-            }
-        }
-    }
-}
-
-// Hashable for the convenience of users.
-extension ServerBootstrap.ServerOption: Hashable {}
-extension ServerBootstrap.ServerOption.ShorthandServerOption: Hashable {}
-
-/// Approved shorthand server options.
-extension ServerBootstrap.ServerOption {
-    /// Option to reuse address.
-    /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ServerOption(.reuseAddr)
-    
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = ServerBootstrap.ServerOption(.disableAutoRead)
-    
-    /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`.
-    /// This is only useful for `ServerSocketChannel`s.
-    /// - See: ChannelOptions.backlog
-    public static func maximumUnacceptedConnectionBacklog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
-        ServerBootstrap.ServerOption {
-        return ServerBootstrap.ServerOption(.backlog(value))
-    }
 }
 
 private extension Channel {
@@ -586,19 +503,6 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         return self
     }
     
-    /// Specifies some `ChannelOption`s to be applied to the `SocketChannel`.
-    /// - See: channelOption
-    /// - Parameter options: List of shorthand options to apply.
-    /// - Returns: The updated client bootstrap (`self` being mutated)
-    @inlinable
-    public func channelOptions(_ options: [NIOTCPShorthandOption]) -> Self {
-        var toReturn = self
-        for option in options {
-            toReturn = option.applyOption(with: toReturn)
-        }
-        return toReturn
-    }
-
     /// Specifies a timeout to apply to a connection attempt.
     //
     /// - parameters:
@@ -826,18 +730,6 @@ public final class DatagramBootstrap {
         self._channelOptions.append(key: option, value: value)
         return self
     }
-    
-    /// Specifies some `ChannelOption`s to be applied to the `DatagramChannel`.
-    /// - See: channelOption
-    /// - Parameter options: List of shorthand options to apply.
-    /// - Returns: The updated datagram bootstrap (`self` being mutated)
-    @inlinable
-    public func channelOptions(_ options: [Option]) -> Self {
-        for option in options {
-            option.applyOption(to: self)
-        }
-        return self
-    }
 
     /// Use the existing bound socket file descriptor.
     ///
@@ -935,54 +827,6 @@ public final class DatagramBootstrap {
             }
         }
     }
-    
-    /// A channel option which can be applied to datagram bootstrap using shorthand notation.
-    /// - See: DatagramBootstrap.channelOptions(_ options: [Option])
-    public struct Option {
-        private let data: ShorthandChannelOption
-        
-        private init(_ data: ShorthandChannelOption) {
-            self.data = data
-        }
-        
-        /// Apply the contained option to the supplied DatagramBootstrap
-        /// - Parameter to: bootstrap to apply this option to.
-        @usableFromInline
-        func applyOption(to bootstrap: DatagramBootstrap) {
-            data.applyOption(to: bootstrap)
-        }
-        
-        fileprivate enum ShorthandChannelOption {
-            case reuseAddr
-            case disableAutoRead
-            
-            func applyOption(to bootstrap: DatagramBootstrap) {
-                switch self {
-                case .reuseAddr:
-                    _ = bootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
-                case .disableAutoRead:
-                    _ = bootstrap.channelOption(ChannelOptions.autoRead, value: false)
-                
-                }
-            }
-        }
-    }
-}
-
-// Hashable for the convenience of users.
-extension DatagramBootstrap.Option: Hashable {}
-extension DatagramBootstrap.Option.ShorthandChannelOption: Hashable {}
-
-/// Approved shorthand datagram channel options.
-extension DatagramBootstrap.Option {
-    /// Option to reuse address.
-    /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let allowImmediateEndpointAddressReuse =
-        	DatagramBootstrap.Option(.reuseAddr)
-    
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = DatagramBootstrap.Option(.disableAutoRead)
 }
 
 /// A `NIOPipeBootstrap` is an easy way to bootstrap a `PipeChannel` which uses two (uni-directional) UNIX pipes
@@ -1056,18 +900,6 @@ public final class NIOPipeBootstrap {
         self._channelOptions.append(key: option, value: value)
         return self
     }
-    
-    /// Specifies some `ChannelOption`s to be applied to the `PipeChannel`.
-    /// - See: channelOption
-    /// - Parameter options: List of shorthand options to apply.
-    /// - Returns: The updated pipe bootstrap (`self` being mutated)
-    @inlinable
-    public func channelOptions(_ options: [Option]) -> Self {
-        for option in options {
-            option.applyOption(to: self)
-        }
-        return self
-    }
 
     private func validateFileDescriptorIsNotAFile(_ descriptor: CInt) throws {
         precondition(MultiThreadedEventLoopGroup.currentEventLoop == nil,
@@ -1132,135 +964,5 @@ public final class NIOPipeBootstrap {
                 setupChannel()
             }
         }
-    }
-    
-    /// A channel option which can be applied to pipe bootstrap using shorthand notation.
-    /// - See: NIOPipeBootstrap.channelOptions(_ options: [Option])
-    public struct Option {
-        private let data: ShorthandChannelOption
-        
-        private init(_ data: ShorthandChannelOption) {
-            self.data = data
-        }
-        
-        /// Apply the contained option to the supplied NIOPipeBootstrap
-        /// - Parameter to: bootstrap to apply this option to.
-        @usableFromInline
-        func applyOption(to bootstrap: NIOPipeBootstrap) {
-            data.applyOption(to: bootstrap)
-        }
-        
-        fileprivate enum ShorthandChannelOption {
-            case disableAutoRead
-            case allowRemoteHalfClosure(Bool)
-            
-            func applyOption(to bootstrap: NIOPipeBootstrap) {
-                switch self {
-                case .disableAutoRead:
-                    _ = bootstrap.channelOption(ChannelOptions.autoRead, value: false)
-                case .allowRemoteHalfClosure(let value):
-                    _ = bootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
-                }
-            }
-        }
-    }
-}
-
-// Hashable for the convenience of users.
-extension NIOPipeBootstrap.Option: Hashable {}
-extension NIOPipeBootstrap.Option.ShorthandChannelOption: Hashable {}
-
-/// Approved shorthand datagram channel options.
-extension NIOPipeBootstrap.Option {
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = NIOPipeBootstrap.Option(.disableAutoRead)
-    
-    /// - See: `AllowRemoteHalfClosureOption`.
-    public static let allowRemoteHalfClosure =
-        NIOPipeBootstrap.Option(.allowRemoteHalfClosure(true))
-    
-    /// - See: `AllowRemoteHalfClosureOption`.
-    public static func allowRemoteHalfClosure(_ value: Bool) ->
-        NIOPipeBootstrap.Option {
-        return NIOPipeBootstrap.Option(.allowRemoteHalfClosure(value))
-    }
-}
-
-
-
-// ------------------------
-
-public protocol NIOTCPOptionAppliable {
-    func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
-}
-
-extension ServerBootstrap : NIOTCPOptionAppliable {
-    public func applyOption<Option>(_ option: Option, value: Option.Value) -> Self where Option : ChannelOption {
-        return self.childChannelOption(option, value: value)
-    }
-}
-
-extension ClientBootstrap : NIOTCPOptionAppliable {
-    public func applyOption<Option>(_ option: Option, value: Option.Value) -> Self where Option : ChannelOption {
-        return self.channelOption(option, value: value)
-    }
-}
-
-/// A channel option which can be applied to a bootstrap or similar using shorthand notation.
-/// - See: ClientBootstrap.channelOptions(_ options: [Option])
-public struct NIOTCPShorthandOption  {
-    private let data: ShorthandOption
-    
-    private init(_ data: ShorthandOption) {
-        self.data = data
-    }
-    
-    /// Apply the contained option to the supplied object (almost certainly bootstrap) using the default mapping.
-    /// - Parameter to: object to apply this option to.
-    /// - Returns: the modified object
-    public func applyOption<T : NIOTCPOptionAppliable>(with: T) -> T {
-        return data.applyOption(with: with)
-    }
-    
-    fileprivate enum ShorthandOption {
-        case reuseAddr
-        case disableAutoRead
-        case allowRemoteHalfClosure(Bool)
-        
-        func applyOption<T : NIOTCPOptionAppliable>(with: T) -> T {
-            switch self {
-            case .reuseAddr:
-                return with.applyOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
-            case .allowRemoteHalfClosure(let value):
-                return with.applyOption(ChannelOptions.allowRemoteHalfClosure, value: value)
-            case .disableAutoRead:
-                return with.applyOption(ChannelOptions.autoRead, value: false)
-            }
-        }
-    }
-}
-
-// Hashable for the convenience of users.
-extension NIOTCPShorthandOption: Hashable {}
-extension NIOTCPShorthandOption.ShorthandOption: Hashable {}
-
-/// Approved shorthand client options.
-extension NIOTCPShorthandOption {
-    /// Option to reuse address.
-    /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let allowImmediateEndpointAddressReuse = NIOTCPShorthandOption(.reuseAddr)
-    
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = NIOTCPShorthandOption(.disableAutoRead)
-    
-    /// - See: `AllowRemoteHalfClosureOption`.
-    public static let allowRemoteHalfClosure =
-        NIOTCPShorthandOption(.allowRemoteHalfClosure(true))
-    
-    /// - See: `AllowRemoteHalfClosureOption`.
-    public static func allowRemoteHalfClosure(_ value: Bool) -> NIOTCPShorthandOption {
-        return NIOTCPShorthandOption(.allowRemoteHalfClosure(value))
     }
 }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -455,8 +455,8 @@ public final class ServerBootstrap {
 }
 
 // Hashable for the convenience of users.
-extension ServerBootstrap.ShorthandServerBootstrapOption : Hashable {}
-extension ServerBootstrap.ShorthandServerBootstrapOption.ShorthandServerOption : Hashable {}
+extension ServerBootstrap.ShorthandServerBootstrapOption: Hashable {}
+extension ServerBootstrap.ShorthandServerBootstrapOption.ShorthandServerOption: Hashable {}
 
 /// Approved shorthand server options.
 extension ServerBootstrap.ShorthandServerBootstrapOption {
@@ -478,8 +478,8 @@ extension ServerBootstrap.ShorthandServerBootstrapOption {
 }
 
 // Hashable for the convenience of users.
-extension ServerBootstrap.ShorthandChildBootstrapOption : Hashable {}
-extension ServerBootstrap.ShorthandChildBootstrapOption.ShorthandChildOption : Hashable {}
+extension ServerBootstrap.ShorthandChildBootstrapOption: Hashable {}
+extension ServerBootstrap.ShorthandChildBootstrapOption.ShorthandChildOption: Hashable {}
 
 /// Approved shorthand child options.
 extension ServerBootstrap.ShorthandChildBootstrapOption {
@@ -828,8 +828,8 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
 }
 
 // Hashable for the convenience of users.
-extension ClientBootstrap.ShorthandClientBootstrapOption : Hashable {}
-extension ClientBootstrap.ShorthandClientBootstrapOption.ShorthandClientOption : Hashable {}
+extension ClientBootstrap.ShorthandClientBootstrapOption: Hashable {}
+extension ClientBootstrap.ShorthandClientBootstrapOption.ShorthandClientOption: Hashable {}
 
 /// Approved shorthand client options.
 extension ClientBootstrap.ShorthandClientBootstrapOption {
@@ -1045,23 +1045,23 @@ public final class DatagramBootstrap {
             self.data = data
         }
         
-        /// Apply the contained option to the supplied ServerBootstrap
+        /// Apply the contained option to the supplied DatagramBootstrap
         /// - Parameter to: bootstrap to apply this option to.
         /// - Returns: the modified bootstrap (currently the same one mutated)
-        func applyOption(to clientBootstrap: DatagramBootstrap) {
-            data.applyOption(to: clientBootstrap)
+        func applyOption(to bootstrap: DatagramBootstrap) {
+            data.applyOption(to: bootstrap)
         }
         
         fileprivate enum ShorthandChannelOption {
             case reuseAddr
             case disableAutoRead
             
-            func applyOption(to datagramBootstrap: DatagramBootstrap) {
+            func applyOption(to bootstrap: DatagramBootstrap) {
                 switch self {
                 case .reuseAddr:
-                    _ = datagramBootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+                    _ = bootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
                 case .disableAutoRead:
-                    _ = datagramBootstrap.channelOption(ChannelOptions.autoRead, value: false)
+                    _ = bootstrap.channelOption(ChannelOptions.autoRead, value: false)
                 
                 }
             }
@@ -1070,8 +1070,8 @@ public final class DatagramBootstrap {
 }
 
 // Hashable for the convenience of users.
-extension DatagramBootstrap.ShorthandChannelBootstrapOption : Hashable {}
-extension DatagramBootstrap.ShorthandChannelBootstrapOption.ShorthandChannelOption : Hashable {}
+extension DatagramBootstrap.ShorthandChannelBootstrapOption: Hashable {}
+extension DatagramBootstrap.ShorthandChannelBootstrapOption.ShorthandChannelOption: Hashable {}
 
 /// Approved shorthand datagram channel options.
 extension DatagramBootstrap.ShorthandChannelBootstrapOption {
@@ -1265,8 +1265,8 @@ public final class NIOPipeBootstrap {
 }
 
 // Hashable for the convenience of users.
-extension NIOPipeBootstrap.ShorthandChannelBootstrapOption : Hashable {}
-extension NIOPipeBootstrap.ShorthandChannelBootstrapOption.ShorthandChannelOption : Hashable {}
+extension NIOPipeBootstrap.ShorthandChannelBootstrapOption: Hashable {}
+extension NIOPipeBootstrap.ShorthandChannelBootstrapOption.ShorthandChannelOption: Hashable {}
 
 /// Approved shorthand datagram channel options.
 extension NIOPipeBootstrap.ShorthandChannelBootstrapOption {

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -1012,7 +1012,7 @@ public struct ShorthandServerBootstrapOption {
     /// Apply the contained option to the supplied ServerBootstrap
     /// - Parameter serverBootstrap: bootstrap to apply this option to.
     /// - Returns: the modified bootstrap (currently the same one mutated)
-    func applyOption(to serverBootstrap : ServerBootstrap) {
+    func applyOption(to serverBootstrap: ServerBootstrap) {
         data.applyOption(to: serverBootstrap)
     }
     
@@ -1067,7 +1067,7 @@ public struct ShorthandChildBootstrapOption {
     /// Apply the contained option to the supplied ServerBootstrap
     /// - Parameter serverBootstrap: bootstrap to apply this option to.
     /// - Returns: the modified bootstrap (currently the same one mutated)
-    func applyOption(to serverBootstrap : ServerBootstrap) {
+    func applyOption(to serverBootstrap: ServerBootstrap) {
         data.applyOption(to: serverBootstrap)
     }
     
@@ -1117,7 +1117,7 @@ public struct ShorthandClientBootstrapOption {
     /// Apply the contained option to the supplied ServerBootstrap
     /// - Parameter to: bootstrap to apply this option to.
     /// - Returns: the modified bootstrap (currently the same one mutated)
-    func applyOption(to clientBootstrap : ClientBootstrap) {
+    func applyOption(to clientBootstrap: ClientBootstrap) {
         data.applyOption(to: clientBootstrap)
     }
     

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -387,7 +387,7 @@ public final class ServerBootstrap {
     }
     
     /// A channel option which can be applied to bootstrap using shorthand notation.
-    /// - See: ServerBootstrap.serverOptions(_ options: [ShorthandBootstrapOption])
+    /// - See: ServerBootstrap.serverOptions(_ options: [ShorthandServerBootstrapOption])
     public struct ShorthandServerBootstrapOption {
         private let data: ShorthandServerOption
         
@@ -422,7 +422,7 @@ public final class ServerBootstrap {
     }
     
     /// A channel option which can be applied to bootstrap using shorthand notation.
-    /// - See: ServerBootstrap.serverOptions(_ options: [ShorthandBootstrapOption])
+    /// - See: ServerBootstrap.childChannelOptions(_ options: [ShorthandChildBootstrapOption])
     public struct ShorthandChildBootstrapOption {
         private let data: ShorthandChildOption
         
@@ -796,7 +796,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     }
     
     /// A channel option which can be applied to bootstrap using shorthand notation.
-    /// - See: ServerBootstrap.clientOptions(_ options: [ShorthandClientBootstrapOption])
+    /// - See: ClientBootstrap.clientOptions(_ options: [ShorthandClientBootstrapOption])
     public struct ShorthandClientBootstrapOption {
         private let data: ShorthandClientOption
         
@@ -804,7 +804,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
             self.data = data
         }
         
-        /// Apply the contained option to the supplied ServerBootstrap
+        /// Apply the contained option to the supplied ClientBootstrap
         /// - Parameter to: bootstrap to apply this option to.
         /// - Returns: the modified bootstrap (currently the same one mutated)
         func applyOption(to clientBootstrap: ClientBootstrap) {

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -1017,17 +1017,17 @@ public struct ShorthandServerBootstrapOption {
     }
     
     private enum ShorthandServerOption {
-        case ReuseAddr(Bool)
-        case AutoRead(Bool)
-        case Backlog(Int32)
+        case reuseAddr(Bool)
+        case autoRead(Bool)
+        case backlog(Int32)
         
         func applyOption(to serverBootstrap: ServerBootstrap) {
             switch self {
-                case .AutoRead(let value):
+                case .autoRead(let value):
                     let _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: value)
-                case .ReuseAddr(let value):
+                case .reuseAddr(let value):
                     let _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
-                case .Backlog(let value):
+                case .backlog(let value):
                     let _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
             }
         }
@@ -1038,16 +1038,16 @@ public struct ShorthandServerBootstrapOption {
 extension ShorthandServerBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = ShorthandServerBootstrapOption(.ReuseAddr(true))
+    public static let reuseAddr = ShorthandServerBootstrapOption(.reuseAddr(true))
     
     /// Option to disble autoRead
     /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = ShorthandServerBootstrapOption(.AutoRead(false))
+    public static let disableAutoRead = ShorthandServerBootstrapOption(.autoRead(false))
     
     /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`. This is only useful for `ServerSocketChannel`s.
     /// - See: ChannelOptions.backlog
     public static func backlog(_ value : ChannelOptions.Types.BacklogOption.Value) -> ShorthandServerBootstrapOption {
-        return ShorthandServerBootstrapOption(.Backlog(value))
+        return ShorthandServerBootstrapOption(.backlog(value))
     }
 }
 
@@ -1068,14 +1068,14 @@ public struct ShorthandChildBootstrapOption {
     }
     
     private enum ShorthandChildOption {
-        case ReuseAddr(Bool)
-        case AllowRemoteHalfClosure(Bool)
+        case reuseAddr(Bool)
+        case allowRemoteHalfClosure(Bool)
         
         func applyOption(to serverBootstrap: ServerBootstrap) {
             switch self {
-                case .ReuseAddr(let value):
+                case .reuseAddr(let value):
                     let _ = serverBootstrap.childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
-                case .AllowRemoteHalfClosure(let value):
+                case .allowRemoteHalfClosure(let value):
                     let _ = serverBootstrap.childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
             }
         }
@@ -1086,14 +1086,14 @@ public struct ShorthandChildBootstrapOption {
 extension ShorthandChildBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = ShorthandChildBootstrapOption(.ReuseAddr(true))
+    public static let reuseAddr = ShorthandChildBootstrapOption(.reuseAddr(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
-    public static let allowRemoteHalfClosure = ShorthandChildBootstrapOption(.AllowRemoteHalfClosure(true))
+    public static let allowRemoteHalfClosure = ShorthandChildBootstrapOption(.allowRemoteHalfClosure(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) -> ShorthandChildBootstrapOption {
-        ShorthandChildBootstrapOption(.AllowRemoteHalfClosure(value))
+        ShorthandChildBootstrapOption(.allowRemoteHalfClosure(value))
     }
 }
 
@@ -1114,14 +1114,14 @@ public struct ShorthandClientBootstrapOption {
     }
     
     private enum ShorthandClientOption {
-        case ReuseAddr(Bool)
-        case AllowRemoteHalfClosure(Bool)
+        case reuseAddr(Bool)
+        case allowRemoteHalfClosure(Bool)
         
         func applyOption(to clientBootstrap: ClientBootstrap) {
             switch self {
-                case .ReuseAddr(let value):
+                case .reuseAddr(let value):
                     let _ = clientBootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
-                case .AllowRemoteHalfClosure(let value):
+                case .allowRemoteHalfClosure(let value):
                     let _ = clientBootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
             }
         }
@@ -1132,13 +1132,13 @@ public struct ShorthandClientBootstrapOption {
 extension ShorthandClientBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = ShorthandClientBootstrapOption(.ReuseAddr(true))
+    public static let reuseAddr = ShorthandClientBootstrapOption(.reuseAddr(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
-    public static let allowRemoteHalfClosure = ShorthandClientBootstrapOption(.AllowRemoteHalfClosure(true))
+    public static let allowRemoteHalfClosure = ShorthandClientBootstrapOption(.allowRemoteHalfClosure(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) -> ShorthandClientBootstrapOption {
-        ShorthandClientBootstrapOption(.AllowRemoteHalfClosure(value))
+        ShorthandClientBootstrapOption(.allowRemoteHalfClosure(value))
     }
 }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -33,7 +33,7 @@ internal enum NIOOnSocketsBootstraps {
 ///     }
 ///     let bootstrap = ServerBootstrap(group: group)
 ///         // Specify backlog and enable SO_REUSEADDR for the server itself
-///         .serverOptions([.maximumUnacceptedConnectionBacklog(256), .allowImmediateEndpointAddressReuse])
+///         .serverChannelOptions([.maximumUnacceptedConnectionBacklog(256), .allowImmediateEndpointAddressReuse])
 ///
 ///         // Set the handlers that are applied to the accepted child `Channel`s.
 ///         .childChannelInitializer { channel in

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -1024,11 +1024,11 @@ public struct ShorthandServerBootstrapOption {
         func applyOption(to serverBootstrap: ServerBootstrap) {
             switch self {
             case .autoRead(let value):
-                let _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: value)
+                _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: value)
             case .reuseAddr(let value):
-                let _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
+                _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
             case .backlog(let value):
-                let _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
+                _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
             }
         }
     }
@@ -1074,9 +1074,9 @@ public struct ShorthandChildBootstrapOption {
         func applyOption(to serverBootstrap: ServerBootstrap) {
             switch self {
             case .reuseAddr(let value):
-                let _ = serverBootstrap.childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
+                _ = serverBootstrap.childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
             case .allowRemoteHalfClosure(let value):
-                let _ = serverBootstrap.childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+                _ = serverBootstrap.childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
             }
         }
     }
@@ -1120,9 +1120,9 @@ public struct ShorthandClientBootstrapOption {
         func applyOption(to clientBootstrap: ClientBootstrap) {
             switch self {
             case .reuseAddr(let value):
-                let _ = clientBootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
+                _ = clientBootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
             case .allowRemoteHalfClosure(let value):
-                let _ = clientBootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+                _ = clientBootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
             }
         }
     }

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -200,7 +200,7 @@ public final class ServerBootstrap {
     /// Specifies some `ChannelOption`s to be applied to the  accepted `SocketChannel`s.
     /// - See: childChannelOption
     /// - Parameter options: List of shorthand options to apply.
-    /// - Returns: The update server bootstrap (this mutated)
+    /// - Returns: The update server bootstrap (`self` being mutated)
     public func childChannelOptions(_ options: [ShorthandChildBootstrapOption]) -> Self {
         for option in options {
             option.applyOption(to: self)

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -1077,7 +1077,8 @@ extension DatagramBootstrap.ShorthandChannelBootstrapOption.ShorthandChannelOpti
 extension DatagramBootstrap.ShorthandChannelBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let allowImmediateEndpointAddressReuse = DatagramBootstrap.ShorthandChannelBootstrapOption(.reuseAddr)
+    public static let allowImmediateEndpointAddressReuse =
+        	DatagramBootstrap.ShorthandChannelBootstrapOption(.reuseAddr)
     
     /// Option to disable autoRead
     /// - See: ChannelOptions.autoRead

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -1016,7 +1016,7 @@ public struct ShorthandServerBootstrapOption {
         data.applyOption(to: serverBootstrap)
     }
     
-    private enum ShorthandServerOption {
+    fileprivate enum ShorthandServerOption {
         case reuseAddr(Bool)
         case autoRead(Bool)
         case backlog(Int32)
@@ -1033,6 +1033,10 @@ public struct ShorthandServerBootstrapOption {
         }
     }
 }
+
+// Equatable and Hashable for the convenience of users.
+extension ShorthandServerBootstrapOption : Equatable, Hashable {}
+extension ShorthandServerBootstrapOption.ShorthandServerOption : Equatable, Hashable {}
 
 /// Approved shorthand server options.
 extension ShorthandServerBootstrapOption {
@@ -1067,7 +1071,7 @@ public struct ShorthandChildBootstrapOption {
         data.applyOption(to: serverBootstrap)
     }
     
-    private enum ShorthandChildOption {
+    fileprivate enum ShorthandChildOption {
         case reuseAddr(Bool)
         case allowRemoteHalfClosure(Bool)
         
@@ -1081,6 +1085,10 @@ public struct ShorthandChildBootstrapOption {
         }
     }
 }
+
+// Equatable and Hashable for the convenience of users.
+extension ShorthandChildBootstrapOption : Equatable, Hashable {}
+extension ShorthandChildBootstrapOption.ShorthandChildOption : Equatable, Hashable {}
 
 /// Approved shorthand child options.
 extension ShorthandChildBootstrapOption {
@@ -1113,7 +1121,7 @@ public struct ShorthandClientBootstrapOption {
         data.applyOption(to: clientBootstrap)
     }
     
-    private enum ShorthandClientOption {
+    fileprivate enum ShorthandClientOption {
         case reuseAddr(Bool)
         case allowRemoteHalfClosure(Bool)
         
@@ -1127,6 +1135,10 @@ public struct ShorthandClientBootstrapOption {
         }
     }
 }
+
+// Equatable and Hashable for the convenience of users.
+extension ShorthandClientBootstrapOption : Equatable, Hashable {}
+extension ShorthandClientBootstrapOption.ShorthandClientOption : Equatable, Hashable {}
 
 /// Approved shorthand client options.
 extension ShorthandClientBootstrapOption {

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -462,7 +462,7 @@ extension ServerBootstrap.ShorthandServerBootstrapOption.ShorthandServerOption: 
 extension ServerBootstrap.ShorthandServerBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = ServerBootstrap.ShorthandServerBootstrapOption(.reuseAddr)
+    public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ShorthandServerBootstrapOption(.reuseAddr)
     
     /// Option to disable autoRead
     /// - See: ChannelOptions.autoRead
@@ -471,7 +471,7 @@ extension ServerBootstrap.ShorthandServerBootstrapOption {
     /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`.
     /// This is only useful for `ServerSocketChannel`s.
     /// - See: ChannelOptions.backlog
-    public static func backlog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
+    public static func maximumUnacceptedConnectionBacklog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
         ServerBootstrap.ShorthandServerBootstrapOption {
         return ServerBootstrap.ShorthandServerBootstrapOption(.backlog(value))
     }
@@ -485,7 +485,7 @@ extension ServerBootstrap.ShorthandChildBootstrapOption.ShorthandChildOption: Ha
 extension ServerBootstrap.ShorthandChildBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = ServerBootstrap.ShorthandChildBootstrapOption(.reuseAddr)
+    public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ShorthandChildBootstrapOption(.reuseAddr)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =
@@ -835,7 +835,7 @@ extension ClientBootstrap.ShorthandClientBootstrapOption.ShorthandClientOption: 
 extension ClientBootstrap.ShorthandClientBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = ClientBootstrap.ShorthandClientBootstrapOption(.reuseAddr)
+    public static let allowImmediateEndpointAddressReuse = ClientBootstrap.ShorthandClientBootstrapOption(.reuseAddr)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =
@@ -1077,7 +1077,7 @@ extension DatagramBootstrap.ShorthandChannelBootstrapOption.ShorthandChannelOpti
 extension DatagramBootstrap.ShorthandChannelBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = DatagramBootstrap.ShorthandChannelBootstrapOption(.reuseAddr)
+    public static let allowImmediateEndpointAddressReuse = DatagramBootstrap.ShorthandChannelBootstrapOption(.reuseAddr)
     
     /// Option to disable autoRead
     /// - See: ChannelOptions.autoRead

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -403,17 +403,17 @@ public final class ServerBootstrap {
         }
         
         fileprivate enum ShorthandServerOption {
-            case reuseAddr(Bool)
-            case autoRead(Bool)
+            case reuseAddr
+            case disableAutoRead
             case backlog(Int32)
             
             func applyOption(to serverBootstrap: ServerBootstrap) {
                 switch self {
-                case .autoRead(let value):
-                    _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: value)
-                case .reuseAddr(let value):
+                case .disableAutoRead:
+                    _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: false)
+                case .reuseAddr:
                     _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr),
-                                                            value: value ? 1 : 0)
+                                                            value: 1)
                 case .backlog(let value):
                     _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
                 }
@@ -438,14 +438,14 @@ public final class ServerBootstrap {
         }
         
         fileprivate enum ShorthandChildOption {
-            case reuseAddr(Bool)
+            case reuseAddr
             case allowRemoteHalfClosure(Bool)
             
             func applyOption(to serverBootstrap: ServerBootstrap) {
                 switch self {
-                case .reuseAddr(let value):
+                case .reuseAddr:
                     _ = serverBootstrap.childChannelOption(ChannelOptions.socketOption(.reuseaddr),
-                                                           value: value ? 1 : 0)
+                                                           value: 1)
                 case .allowRemoteHalfClosure(let value):
                     _ = serverBootstrap.childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
                 }
@@ -462,11 +462,11 @@ extension ServerBootstrap.ShorthandServerBootstrapOption.ShorthandServerOption :
 extension ServerBootstrap.ShorthandServerBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = ServerBootstrap.ShorthandServerBootstrapOption(.reuseAddr(true))
+    public static let reuseAddr = ServerBootstrap.ShorthandServerBootstrapOption(.reuseAddr)
     
     /// Option to disable autoRead
     /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = ServerBootstrap.ShorthandServerBootstrapOption(.autoRead(false))
+    public static let disableAutoRead = ServerBootstrap.ShorthandServerBootstrapOption(.disableAutoRead)
     
     /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`.
     /// This is only useful for `ServerSocketChannel`s.
@@ -485,7 +485,7 @@ extension ServerBootstrap.ShorthandChildBootstrapOption.ShorthandChildOption : H
 extension ServerBootstrap.ShorthandChildBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = ServerBootstrap.ShorthandChildBootstrapOption(.reuseAddr(true))
+    public static let reuseAddr = ServerBootstrap.ShorthandChildBootstrapOption(.reuseAddr)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =
@@ -812,13 +812,13 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         }
         
         fileprivate enum ShorthandClientOption {
-            case reuseAddr(Bool)
+            case reuseAddr
             case allowRemoteHalfClosure(Bool)
             
             func applyOption(to clientBootstrap: ClientBootstrap) {
                 switch self {
-                case .reuseAddr(let value):
-                    _ = clientBootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: value ? 1 : 0)
+                case .reuseAddr:
+                    _ = clientBootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
                 case .allowRemoteHalfClosure(let value):
                     _ = clientBootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
                 }
@@ -835,7 +835,7 @@ extension ClientBootstrap.ShorthandClientBootstrapOption.ShorthandClientOption :
 extension ClientBootstrap.ShorthandClientBootstrapOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let reuseAddr = ClientBootstrap.ShorthandClientBootstrapOption(.reuseAddr(true))
+    public static let reuseAddr = ClientBootstrap.ShorthandClientBootstrapOption(.reuseAddr)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -180,7 +180,7 @@ public final class ServerBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated server bootstrap (`self` being mutated)
     @inlinable
-    public func serverOptions(_ options: [ShorthandServerBootstrapOption]) -> Self {
+    public func serverOptions(_ options: [ServerOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
         }
@@ -203,7 +203,7 @@ public final class ServerBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The update server bootstrap (`self` being mutated)
     @inlinable
-    public func childChannelOptions(_ options: [ShorthandChildBootstrapOption]) -> Self {
+    public func childChannelOptions(_ options: [ChildOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
         }
@@ -389,8 +389,8 @@ public final class ServerBootstrap {
     }
     
     /// A channel option which can be applied to bootstrap using shorthand notation.
-    /// - See: ServerBootstrap.serverOptions(_ options: [ShorthandServerBootstrapOption])
-    public struct ShorthandServerBootstrapOption {
+    /// - See: ServerBootstrap.serverOptions(_ options: [ServerOption])
+    public struct ServerOption {
         private let data: ShorthandServerOption
         
         private init(_ data: ShorthandServerOption) {
@@ -425,8 +425,8 @@ public final class ServerBootstrap {
     }
     
     /// A channel option which can be applied to bootstrap using shorthand notation.
-    /// - See: ServerBootstrap.childChannelOptions(_ options: [ShorthandChildBootstrapOption])
-    public struct ShorthandChildBootstrapOption {
+    /// - See: ServerBootstrap.childChannelOptions(_ options: [ChildOption])
+    public struct ChildOption {
         private let data: ShorthandChildOption
         
         private init(_ data: ShorthandChildOption) {
@@ -459,46 +459,46 @@ public final class ServerBootstrap {
 }
 
 // Hashable for the convenience of users.
-extension ServerBootstrap.ShorthandServerBootstrapOption: Hashable {}
-extension ServerBootstrap.ShorthandServerBootstrapOption.ShorthandServerOption: Hashable {}
+extension ServerBootstrap.ServerOption: Hashable {}
+extension ServerBootstrap.ServerOption.ShorthandServerOption: Hashable {}
 
 /// Approved shorthand server options.
-extension ServerBootstrap.ShorthandServerBootstrapOption {
+extension ServerBootstrap.ServerOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ShorthandServerBootstrapOption(.reuseAddr)
+    public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ServerOption(.reuseAddr)
     
     /// Option to disable autoRead
     /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = ServerBootstrap.ShorthandServerBootstrapOption(.disableAutoRead)
+    public static let disableAutoRead = ServerBootstrap.ServerOption(.disableAutoRead)
     
     /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`.
     /// This is only useful for `ServerSocketChannel`s.
     /// - See: ChannelOptions.backlog
     public static func maximumUnacceptedConnectionBacklog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
-        ServerBootstrap.ShorthandServerBootstrapOption {
-        return ServerBootstrap.ShorthandServerBootstrapOption(.backlog(value))
+        ServerBootstrap.ServerOption {
+        return ServerBootstrap.ServerOption(.backlog(value))
     }
 }
 
 // Hashable for the convenience of users.
-extension ServerBootstrap.ShorthandChildBootstrapOption: Hashable {}
-extension ServerBootstrap.ShorthandChildBootstrapOption.ShorthandChildOption: Hashable {}
+extension ServerBootstrap.ChildOption: Hashable {}
+extension ServerBootstrap.ChildOption.ShorthandChildOption: Hashable {}
 
 /// Approved shorthand child options.
-extension ServerBootstrap.ShorthandChildBootstrapOption {
+extension ServerBootstrap.ChildOption {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ShorthandChildBootstrapOption(.reuseAddr)
+    public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ChildOption(.reuseAddr)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =
-        ServerBootstrap.ShorthandChildBootstrapOption(.allowRemoteHalfClosure(true))
+        ServerBootstrap.ChildOption(.allowRemoteHalfClosure(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) ->
-        ServerBootstrap.ShorthandChildBootstrapOption {
-        return ServerBootstrap.ShorthandChildBootstrapOption(.allowRemoteHalfClosure(value))
+        ServerBootstrap.ChildOption {
+        return ServerBootstrap.ChildOption(.allowRemoteHalfClosure(value))
     }
 }
 
@@ -647,7 +647,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The update server bootstrap (`self` being mutated)
     @inlinable
-    public func channelOptions(_ options: [ShorthandClientBootstrapOption]) -> Self {
+    public func channelOptions(_ options: [Option]) -> Self {
         for option in options {
             option.applyOption(to: self)
         }
@@ -801,8 +801,8 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     }
     
     /// A channel option which can be applied to bootstrap using shorthand notation.
-    /// - See: ClientBootstrap.clientOptions(_ options: [ShorthandClientBootstrapOption])
-    public struct ShorthandClientBootstrapOption {
+    /// - See: ClientBootstrap.clientOptions(_ options: [Option])
+    public struct Option {
         private let data: ShorthandClientOption
         
         private init(_ data: ShorthandClientOption) {
@@ -834,22 +834,22 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
 }
 
 // Hashable for the convenience of users.
-extension ClientBootstrap.ShorthandClientBootstrapOption: Hashable {}
-extension ClientBootstrap.ShorthandClientBootstrapOption.ShorthandClientOption: Hashable {}
+extension ClientBootstrap.Option: Hashable {}
+extension ClientBootstrap.Option.ShorthandClientOption: Hashable {}
 
 /// Approved shorthand client options.
-extension ClientBootstrap.ShorthandClientBootstrapOption {
+extension ClientBootstrap.Option {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let allowImmediateEndpointAddressReuse = ClientBootstrap.ShorthandClientBootstrapOption(.reuseAddr)
+    public static let allowImmediateEndpointAddressReuse = ClientBootstrap.Option(.reuseAddr)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =
-        ClientBootstrap.ShorthandClientBootstrapOption(.allowRemoteHalfClosure(true))
+        ClientBootstrap.Option(.allowRemoteHalfClosure(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
-    public static func allowRemoteHalfClosure(_ value: Bool) -> ClientBootstrap.ShorthandClientBootstrapOption {
-        return ClientBootstrap.ShorthandClientBootstrapOption(.allowRemoteHalfClosure(value))
+    public static func allowRemoteHalfClosure(_ value: Bool) -> ClientBootstrap.Option {
+        return ClientBootstrap.Option(.allowRemoteHalfClosure(value))
     }
 }
 
@@ -939,7 +939,7 @@ public final class DatagramBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated server bootstrap (`self` being mutated)
     @inlinable
-    public func channelOptions(_ options: [ShorthandChannelBootstrapOption]) -> Self {
+    public func channelOptions(_ options: [Option]) -> Self {
         for option in options {
             option.applyOption(to: self)
         }
@@ -1044,8 +1044,8 @@ public final class DatagramBootstrap {
     }
     
     /// A channel option which can be applied to datagram bootstrap using shorthand notation.
-    /// - See: DatagramBootstrap.channelOptions(_ options: [ShorthandChannelBootstrapOption])
-    public struct ShorthandChannelBootstrapOption {
+    /// - See: DatagramBootstrap.channelOptions(_ options: [Option])
+    public struct Option {
         private let data: ShorthandChannelOption
         
         private init(_ data: ShorthandChannelOption) {
@@ -1078,19 +1078,19 @@ public final class DatagramBootstrap {
 }
 
 // Hashable for the convenience of users.
-extension DatagramBootstrap.ShorthandChannelBootstrapOption: Hashable {}
-extension DatagramBootstrap.ShorthandChannelBootstrapOption.ShorthandChannelOption: Hashable {}
+extension DatagramBootstrap.Option: Hashable {}
+extension DatagramBootstrap.Option.ShorthandChannelOption: Hashable {}
 
 /// Approved shorthand datagram channel options.
-extension DatagramBootstrap.ShorthandChannelBootstrapOption {
+extension DatagramBootstrap.Option {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
     public static let allowImmediateEndpointAddressReuse =
-        	DatagramBootstrap.ShorthandChannelBootstrapOption(.reuseAddr)
+        	DatagramBootstrap.Option(.reuseAddr)
     
     /// Option to disable autoRead
     /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = DatagramBootstrap.ShorthandChannelBootstrapOption(.disableAutoRead)
+    public static let disableAutoRead = DatagramBootstrap.Option(.disableAutoRead)
 }
 
 /// A `NIOPipeBootstrap` is an easy way to bootstrap a `PipeChannel` which uses two (uni-directional) UNIX pipes
@@ -1170,7 +1170,7 @@ public final class NIOPipeBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated server bootstrap (`self` being mutated)
     @inlinable
-    public func channelOptions(_ options: [ShorthandChannelBootstrapOption]) -> Self {
+    public func channelOptions(_ options: [Option]) -> Self {
         for option in options {
             option.applyOption(to: self)
         }
@@ -1243,8 +1243,8 @@ public final class NIOPipeBootstrap {
     }
     
     /// A channel option which can be applied to datagram bootstrap using shorthand notation.
-    /// - See: DatagramBootstrap.channelOptions(_ options: [ShorthandChannelBootstrapOption])
-    public struct ShorthandChannelBootstrapOption {
+    /// - See: NIOPipeBootstrap.channelOptions(_ options: [Option])
+    public struct Option {
         private let data: ShorthandChannelOption
         
         private init(_ data: ShorthandChannelOption) {
@@ -1276,22 +1276,22 @@ public final class NIOPipeBootstrap {
 }
 
 // Hashable for the convenience of users.
-extension NIOPipeBootstrap.ShorthandChannelBootstrapOption: Hashable {}
-extension NIOPipeBootstrap.ShorthandChannelBootstrapOption.ShorthandChannelOption: Hashable {}
+extension NIOPipeBootstrap.Option: Hashable {}
+extension NIOPipeBootstrap.Option.ShorthandChannelOption: Hashable {}
 
 /// Approved shorthand datagram channel options.
-extension NIOPipeBootstrap.ShorthandChannelBootstrapOption {
+extension NIOPipeBootstrap.Option {
     /// Option to disable autoRead
     /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = NIOPipeBootstrap.ShorthandChannelBootstrapOption(.disableAutoRead)
+    public static let disableAutoRead = NIOPipeBootstrap.Option(.disableAutoRead)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =
-        NIOPipeBootstrap.ShorthandChannelBootstrapOption(.allowRemoteHalfClosure(true))
+        NIOPipeBootstrap.Option(.allowRemoteHalfClosure(true))
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) ->
-        NIOPipeBootstrap.ShorthandChannelBootstrapOption {
-        return NIOPipeBootstrap.ShorthandChannelBootstrapOption(.allowRemoteHalfClosure(value))
+        NIOPipeBootstrap.Option {
+        return NIOPipeBootstrap.Option(.allowRemoteHalfClosure(value))
     }
 }

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -19,12 +19,12 @@ extension ServerBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated server bootstrap (`self` being mutated)
     @inlinable
-    public func serverChannelOptions(_ options: [NIOTCPServerShorthandOption]) -> Self {
+    public func serverChannelOptions(_ options: [NIOTCPServerShorthandOption]) -> ServerBootstrap {
         var applier = ServerBootstrapServer_Applier(contained: self)
         for option in options {
             applier = option.applyOptionDefaultMapping(with: applier)
         }
-        return applier.contained as! Self
+        return applier.contained
     }
     
     @usableFromInline
@@ -38,8 +38,8 @@ extension ServerBootstrap {
         }
         
         @usableFromInline
-        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
-            return Self(contained: contained.serverChannelOption(option, value: value))
+        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> ServerBootstrapServer_Applier {
+            return ServerBootstrapServer_Applier(contained: contained.serverChannelOption(option, value: value))
         }
     }
 }
@@ -51,12 +51,12 @@ extension ServerBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The update server bootstrap (`self` being mutated)
     @inlinable
-    public func childChannelOptions(_ options: [NIOTCPShorthandOption]) -> Self {
+    public func childChannelOptions(_ options: [NIOTCPShorthandOption]) -> ServerBootstrap {
         var applier = ServerBootstrapChild_Applier(contained: self)
         for option in options {
             applier = option.applyOptionDefaultMapping(with: applier)
         }
-        return applier.contained as! Self
+        return applier.contained
     }
     
     @usableFromInline
@@ -70,8 +70,8 @@ extension ServerBootstrap {
         }
         
         @usableFromInline
-        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
-            return Self(contained: contained.childChannelOption(option, value: value))
+        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> ServerBootstrapChild_Applier {
+            return ServerBootstrapChild_Applier(contained: contained.childChannelOption(option, value: value))
         }
     }
 }
@@ -83,12 +83,12 @@ extension ClientBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated client bootstrap (`self` being mutated)
     @inlinable
-    public func channelOptions(_ options: [NIOTCPShorthandOption]) -> Self {
+    public func channelOptions(_ options: [NIOTCPShorthandOption]) -> ClientBootstrap {
         var applier = ClientBootstrap_Applier(contained: self)
         for option in options {
             applier = option.applyOptionDefaultMapping(with: applier)
         }
-        return applier.contained as! Self
+        return applier.contained
     }
     
     @usableFromInline
@@ -102,8 +102,8 @@ extension ClientBootstrap {
         }
         
         @usableFromInline
-        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
-            return Self(contained: contained.channelOption(option, value: value))
+        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> ClientBootstrap_Applier {
+            return ClientBootstrap_Applier(contained: contained.channelOption(option, value: value))
         }
     }
 }
@@ -115,12 +115,12 @@ extension DatagramBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated datagram bootstrap (`self` being mutated)
     @inlinable
-    public func channelOptions(_ options: [NIOUDPShorthandOption]) -> Self {
+    public func channelOptions(_ options: [NIOUDPShorthandOption]) -> DatagramBootstrap {
         var applier = DatagramBootstrap_Applier(contained: self)
         for option in options {
             applier = option.applyOptionDefaultMapping(with: applier)
         }
-        return applier.contained as! Self
+        return applier.contained
     }
     
     @usableFromInline
@@ -134,8 +134,8 @@ extension DatagramBootstrap {
         }
         
         @usableFromInline
-        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
-            return Self(contained: contained.channelOption(option, value: value))
+        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> DatagramBootstrap_Applier {
+            return DatagramBootstrap_Applier(contained: contained.channelOption(option, value: value))
         }
     }
 }
@@ -147,12 +147,12 @@ extension NIOPipeBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated pipe bootstrap (`self` being mutated)
     @inlinable
-    public func channelOptions(_ options: [NIOPipeShorthandOption]) -> Self {
+    public func channelOptions(_ options: [NIOPipeShorthandOption]) -> NIOPipeBootstrap {
         var applier = NIOPipeBootstrap_Applier(contained: self)
         for option in options {
             applier = option.applyOptionDefaultMapping(with: applier)
         }
-        return applier.contained as! Self
+        return applier.contained
     }
     
     @usableFromInline
@@ -166,8 +166,8 @@ extension NIOPipeBootstrap {
         }
         
         @usableFromInline
-        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
-            return Self(contained: contained.channelOption(option, value: value))
+        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> NIOPipeBootstrap_Applier {
+            return NIOPipeBootstrap_Applier(contained: contained.channelOption(option, value: value))
         }
     }
 }
@@ -212,8 +212,8 @@ extension NIOClientTCPBootstrap {
         }
         
         @usableFromInline
-        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self {
-            return Self(contained: contained.channelOption(option, value: value))
+        func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> NIOClientTCPBootstrap_Applier {
+            return NIOClientTCPBootstrap_Applier(contained: contained.channelOption(option, value: value))
         }
     }
 }

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -20,24 +20,22 @@ extension ServerBootstrap {
     /// - Returns: The updated server bootstrap (`self` being mutated)
     @inlinable
     public func serverChannelOptions(_ options: [NIOTCPServerShorthandOption]) -> ServerBootstrap {
-        var applier = ServerBootstrapServer_Applier(contained: self)
+        var toReturn = self
         for option in options {
-            applier = option.applyOptionDefaultMapping(with: applier)
+            toReturn = toReturn.serverChannelOption(option)
         }
-        return applier.contained
+        return toReturn
     }
     
     @usableFromInline
-    struct ServerBootstrapServer_Applier : NIOChannelOptionAppliable {
-        @usableFromInline
+    func serverChannelOption(_ option : NIOTCPServerShorthandOption) -> ServerBootstrap {
+        let applier = ServerBootstrapServer_Applier(contained: self)
+        return option.applyOptionDefaultMapping(with: applier).contained
+    }
+    
+    fileprivate struct ServerBootstrapServer_Applier : NIOChannelOptionAppliable {
         var contained : ServerBootstrap
-        
-        @usableFromInline
-        init(contained: ServerBootstrap) {
-            self.contained = contained
-        }
-        
-        @usableFromInline
+
         func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> ServerBootstrapServer_Applier {
             return ServerBootstrapServer_Applier(contained: contained.serverChannelOption(option, value: value))
         }
@@ -52,24 +50,22 @@ extension ServerBootstrap {
     /// - Returns: The update server bootstrap (`self` being mutated)
     @inlinable
     public func childChannelOptions(_ options: [NIOTCPShorthandOption]) -> ServerBootstrap {
-        var applier = ServerBootstrapChild_Applier(contained: self)
+        var toReturn = self
         for option in options {
-            applier = option.applyOptionDefaultMapping(with: applier)
+            toReturn = toReturn.childChannelOption(option)
         }
-        return applier.contained
+        return toReturn
     }
     
     @usableFromInline
-    struct ServerBootstrapChild_Applier : NIOChannelOptionAppliable {
-        @usableFromInline
+    func childChannelOption(_ option: NIOTCPShorthandOption) -> ServerBootstrap {
+        let applier = ServerBootstrapChild_Applier(contained: self)
+        return option.applyOptionDefaultMapping(with: applier).contained
+    }
+    
+    fileprivate struct ServerBootstrapChild_Applier : NIOChannelOptionAppliable {
         var contained : ServerBootstrap
-        
-        @usableFromInline
-        init(contained: ServerBootstrap) {
-            self.contained = contained
-        }
-        
-        @usableFromInline
+
         func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> ServerBootstrapChild_Applier {
             return ServerBootstrapChild_Applier(contained: contained.childChannelOption(option, value: value))
         }
@@ -84,24 +80,22 @@ extension ClientBootstrap {
     /// - Returns: The updated client bootstrap (`self` being mutated)
     @inlinable
     public func channelOptions(_ options: [NIOTCPShorthandOption]) -> ClientBootstrap {
-        var applier = ClientBootstrap_Applier(contained: self)
+        var toReturn = self
         for option in options {
-            applier = option.applyOptionDefaultMapping(with: applier)
+            toReturn = toReturn.channelOption(option)
         }
-        return applier.contained
+        return toReturn
     }
     
     @usableFromInline
-    struct ClientBootstrap_Applier : NIOChannelOptionAppliable {
-        @usableFromInline
+    func channelOption(_ option: NIOTCPShorthandOption) -> ClientBootstrap {
+        let applier = ClientBootstrap_Applier(contained: self)
+        return option.applyOptionDefaultMapping(with: applier).contained
+    }
+    
+    fileprivate struct ClientBootstrap_Applier : NIOChannelOptionAppliable {
         var contained : ClientBootstrap
         
-        @usableFromInline
-        init(contained: ClientBootstrap) {
-            self.contained = contained
-        }
-        
-        @usableFromInline
         func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> ClientBootstrap_Applier {
             return ClientBootstrap_Applier(contained: contained.channelOption(option, value: value))
         }
@@ -116,24 +110,22 @@ extension DatagramBootstrap {
     /// - Returns: The updated datagram bootstrap (`self` being mutated)
     @inlinable
     public func channelOptions(_ options: [NIOUDPShorthandOption]) -> DatagramBootstrap {
-        var applier = DatagramBootstrap_Applier(contained: self)
+        var toReturn = self
         for option in options {
-            applier = option.applyOptionDefaultMapping(with: applier)
+            toReturn = toReturn.channelOption(option)
         }
-        return applier.contained
+        return toReturn
     }
     
     @usableFromInline
-    struct DatagramBootstrap_Applier : NIOChannelOptionAppliable {
-        @usableFromInline
+    func channelOption(_ option: NIOUDPShorthandOption) -> DatagramBootstrap {
+        let applier = DatagramBootstrap_Applier(contained: self)
+        return option.applyOptionDefaultMapping(with: applier).contained
+    }
+    
+    fileprivate struct DatagramBootstrap_Applier : NIOChannelOptionAppliable {
         var contained : DatagramBootstrap
         
-        @usableFromInline
-        init(contained: DatagramBootstrap) {
-            self.contained = contained
-        }
-        
-        @usableFromInline
         func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> DatagramBootstrap_Applier {
             return DatagramBootstrap_Applier(contained: contained.channelOption(option, value: value))
         }
@@ -148,24 +140,22 @@ extension NIOPipeBootstrap {
     /// - Returns: The updated pipe bootstrap (`self` being mutated)
     @inlinable
     public func channelOptions(_ options: [NIOPipeShorthandOption]) -> NIOPipeBootstrap {
-        var applier = NIOPipeBootstrap_Applier(contained: self)
+        var toReturn = self
         for option in options {
-            applier = option.applyOptionDefaultMapping(with: applier)
+            toReturn = toReturn.channelOption(option)
         }
-        return applier.contained
+        return toReturn
     }
     
     @usableFromInline
-    struct NIOPipeBootstrap_Applier : NIOChannelOptionAppliable {
-        @usableFromInline
+    func channelOption(_ option: NIOPipeShorthandOption) -> NIOPipeBootstrap {
+        let applier = NIOPipeBootstrap_Applier(contained: self)
+        return option.applyOptionDefaultMapping(with: applier).contained
+    }
+    
+    fileprivate struct NIOPipeBootstrap_Applier : NIOChannelOptionAppliable {
         var contained : NIOPipeBootstrap
         
-        @usableFromInline
-        init(contained: NIOPipeBootstrap) {
-            self.contained = contained
-        }
-        
-        @usableFromInline
         func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> NIOPipeBootstrap_Applier {
             return NIOPipeBootstrap_Applier(contained: contained.channelOption(option, value: value))
         }
@@ -201,17 +191,9 @@ extension NIOClientTCPBootstrap {
         return toReturn
     }
     
-    @usableFromInline
     struct NIOClientTCPBootstrap_Applier : NIOChannelOptionAppliable {
-        @usableFromInline
         var contained : NIOClientTCPBootstrap
         
-        @usableFromInline
-        init(contained: NIOClientTCPBootstrap) {
-            self.contained = contained
-        }
-        
-        @usableFromInline
         func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> NIOClientTCPBootstrap_Applier {
             return NIOClientTCPBootstrap_Applier(contained: contained.channelOption(option, value: value))
         }
@@ -238,7 +220,7 @@ public struct NIOTCPShorthandOption  {
     /// - Parameter with: object to use to apply the option.
     /// - Returns: the modified object
     public func applyOptionDefaultMapping<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
-        return data.applyOption(with: optionApplier)
+        return data.applyOptionDefaultMapping(with: optionApplier)
     }
     
     fileprivate enum ShorthandOption {
@@ -246,7 +228,7 @@ public struct NIOTCPShorthandOption  {
         case disableAutoRead
         case allowRemoteHalfClosure(Bool)
         
-        func applyOption<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
+        func applyOptionDefaultMapping<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
             switch self {
             case .reuseAddr:
                 return optionApplier.applyOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
@@ -302,7 +284,7 @@ public struct NIOTCPServerShorthandOption {
     /// - Parameter with: object to use to apply the option.
     /// - Returns: the modified object
     public func applyOptionDefaultMapping<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
-        return data.applyOption(with: optionApplier)
+        return data.applyOptionDefaultMapping(with: optionApplier)
     }
     
     fileprivate enum ShorthandOption {
@@ -310,7 +292,7 @@ public struct NIOTCPServerShorthandOption {
         case disableAutoRead
         case backlog(Int32)
         
-        func applyOption<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
+        func applyOptionDefaultMapping<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
             switch self {
             case .disableAutoRead:
                 return optionApplier.applyOption(ChannelOptions.autoRead, value: false)
@@ -357,14 +339,14 @@ public struct NIOUDPShorthandOption {
     /// - Parameter with: object to use to apply the option.
     /// - Returns: the modified object
     public func applyOptionDefaultMapping<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
-        return data.applyOption(with: optionApplier)
+        return data.applyOptionDefaultMapping(with: optionApplier)
     }
     
     fileprivate enum ShorthandOption {
         case reuseAddr
         case disableAutoRead
         
-        func applyOption<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
+        func applyOptionDefaultMapping<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
             switch self {
             case .reuseAddr:
                 return optionApplier.applyOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
@@ -404,14 +386,14 @@ public struct NIOPipeShorthandOption {
     /// - Parameter with: object to use to apply the option.
     /// - Returns: the modified object
     public func applyOptionDefaultMapping<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
-        return data.applyOption(with: optionApplier)
+        return data.applyOptionDefaultMapping(with: optionApplier)
     }
     
     fileprivate enum ShorthandOption {
         case disableAutoRead
         case allowRemoteHalfClosure(Bool)
         
-        func applyOption<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
+        func applyOptionDefaultMapping<OptionApplier : NIOChannelOptionAppliable>(with optionApplier: OptionApplier) -> OptionApplier {
             switch self {
             case .disableAutoRead:
                 return optionApplier.applyOption(ChannelOptions.autoRead, value: false)

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -319,6 +319,7 @@ extension NIOTCPServerShorthandOption {
     public static let disableAutoRead = NIOTCPServerShorthandOption(.disableAutoRead)
     
     /// Allows users to configure the `backlog` value as specified in `man 2 listen` - the maximum number of connections waiting to be accepted.
+    /// This is possibly advisory and exact resuilts will depend on the underlying implementation.
     public static func maximumUnacceptedConnectionBacklog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
         NIOTCPServerShorthandOption {
         return NIOTCPServerShorthandOption(.backlog(value))

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -19,69 +19,11 @@ extension ServerBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated server bootstrap (`self` being mutated)
     @inlinable
-    public func serverChannelOptions(_ options: [ServerOption]) -> Self {
+    public func serverChannelOptions(_ options: [NIOTCPServerShorthandOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
         }
         return self
-    }
-    
-    /// A channel option which can be applied to bootstrap using shorthand notation.
-    /// - See: ServerBootstrap.serverChannelOptions(_ options: [ServerOption])
-    public struct ServerOption {
-        private let data: ShorthandServerOption
-        
-        private init(_ data: ShorthandServerOption) {
-            self.data = data
-        }
-        
-        /// Apply the contained option to the supplied ServerBootstrap
-        /// - Parameter serverBootstrap: bootstrap to apply this option to.
-        @usableFromInline
-        func applyOption(to serverBootstrap: ServerBootstrap) {
-            data.applyOption(to: serverBootstrap)
-        }
-        
-        fileprivate enum ShorthandServerOption {
-            case reuseAddr
-            case disableAutoRead
-            case backlog(Int32)
-            
-            func applyOption(to serverBootstrap: ServerBootstrap) {
-                switch self {
-                case .disableAutoRead:
-                    _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: false)
-                case .reuseAddr:
-                    _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr),
-                                                            value: 1)
-                case .backlog(let value):
-                    _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
-                }
-            }
-        }
-    }
-}
-
-// Hashable for the convenience of users.
-extension ServerBootstrap.ServerOption: Hashable {}
-extension ServerBootstrap.ServerOption.ShorthandServerOption: Hashable {}
-
-/// Approved shorthand server options.
-extension ServerBootstrap.ServerOption {
-    /// Option to reuse address.
-    /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ServerOption(.reuseAddr)
-    
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = ServerBootstrap.ServerOption(.disableAutoRead)
-    
-    /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`.
-    /// This is only useful for `ServerSocketChannel`s.
-    /// - See: ChannelOptions.backlog
-    public static func maximumUnacceptedConnectionBacklog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
-        ServerBootstrap.ServerOption {
-        return ServerBootstrap.ServerOption(.backlog(value))
     }
 }
 
@@ -124,60 +66,12 @@ extension DatagramBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated datagram bootstrap (`self` being mutated)
     @inlinable
-    public func channelOptions(_ options: [Option]) -> Self {
+    public func channelOptions(_ options: [NIOUDPShorthandOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
         }
         return self
     }
-    
-    /// A channel option which can be applied to datagram bootstrap using shorthand notation.
-    /// - See: DatagramBootstrap.channelOptions(_ options: [Option])
-    public struct Option {
-        private let data: ShorthandChannelOption
-        
-        private init(_ data: ShorthandChannelOption) {
-            self.data = data
-        }
-        
-        /// Apply the contained option to the supplied DatagramBootstrap
-        /// - Parameter to: bootstrap to apply this option to.
-        @usableFromInline
-        func applyOption(to bootstrap: DatagramBootstrap) {
-            data.applyOption(to: bootstrap)
-        }
-        
-        fileprivate enum ShorthandChannelOption {
-            case reuseAddr
-            case disableAutoRead
-            
-            func applyOption(to bootstrap: DatagramBootstrap) {
-                switch self {
-                case .reuseAddr:
-                    _ = bootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
-                case .disableAutoRead:
-                    _ = bootstrap.channelOption(ChannelOptions.autoRead, value: false)
-                
-                }
-            }
-        }
-    }
-}
-
-// Hashable for the convenience of users.
-extension DatagramBootstrap.Option: Hashable {}
-extension DatagramBootstrap.Option.ShorthandChannelOption: Hashable {}
-
-/// Approved shorthand datagram channel options.
-extension DatagramBootstrap.Option {
-    /// Option to reuse address.
-    /// - See:  NIOBSDSocket.Option.reuseaddr
-    public static let allowImmediateEndpointAddressReuse =
-            DatagramBootstrap.Option(.reuseAddr)
-    
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = DatagramBootstrap.Option(.disableAutoRead)
 }
 
 // MARK: NIOPipeBootstrap
@@ -187,63 +81,11 @@ extension NIOPipeBootstrap {
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The updated pipe bootstrap (`self` being mutated)
     @inlinable
-    public func channelOptions(_ options: [Option]) -> Self {
+    public func channelOptions(_ options: [NIOPipeShorthandOption]) -> Self {
         for option in options {
             option.applyOption(to: self)
         }
         return self
-    }
-    
-    /// A channel option which can be applied to pipe bootstrap using shorthand notation.
-    /// - See: NIOPipeBootstrap.channelOptions(_ options: [Option])
-    public struct Option {
-        private let data: ShorthandChannelOption
-        
-        private init(_ data: ShorthandChannelOption) {
-            self.data = data
-        }
-        
-        /// Apply the contained option to the supplied NIOPipeBootstrap
-        /// - Parameter to: bootstrap to apply this option to.
-        @usableFromInline
-        func applyOption(to bootstrap: NIOPipeBootstrap) {
-            data.applyOption(to: bootstrap)
-        }
-        
-        fileprivate enum ShorthandChannelOption {
-            case disableAutoRead
-            case allowRemoteHalfClosure(Bool)
-            
-            func applyOption(to bootstrap: NIOPipeBootstrap) {
-                switch self {
-                case .disableAutoRead:
-                    _ = bootstrap.channelOption(ChannelOptions.autoRead, value: false)
-                case .allowRemoteHalfClosure(let value):
-                    _ = bootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
-                }
-            }
-        }
-    }
-}
-
-// Hashable for the convenience of users.
-extension NIOPipeBootstrap.Option: Hashable {}
-extension NIOPipeBootstrap.Option.ShorthandChannelOption: Hashable {}
-
-/// Approved shorthand datagram channel options.
-extension NIOPipeBootstrap.Option {
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
-    public static let disableAutoRead = NIOPipeBootstrap.Option(.disableAutoRead)
-    
-    /// - See: `AllowRemoteHalfClosureOption`.
-    public static let allowRemoteHalfClosure =
-        NIOPipeBootstrap.Option(.allowRemoteHalfClosure(true))
-    
-    /// - See: `AllowRemoteHalfClosureOption`.
-    public static func allowRemoteHalfClosure(_ value: Bool) ->
-        NIOPipeBootstrap.Option {
-        return NIOPipeBootstrap.Option(.allowRemoteHalfClosure(value))
     }
 }
 
@@ -302,7 +144,7 @@ extension ClientBootstrap : NIOTCPOptionAppliable {
 /// A channel option which can be applied to a bootstrap or similar using shorthand notation.
 /// - See: ClientBootstrap.channelOptions(_ options: [Option])
 public struct NIOTCPShorthandOption  {
-    private let data: ShorthandOption
+    private var data: ShorthandOption
     
     private init(_ data: ShorthandOption) {
         self.data = data
@@ -354,5 +196,166 @@ extension NIOTCPShorthandOption {
     /// - See: `AllowRemoteHalfClosureOption`.
     public static func allowRemoteHalfClosure(_ value: Bool) -> NIOTCPShorthandOption {
         return NIOTCPShorthandOption(.allowRemoteHalfClosure(value))
+    }
+}
+
+// MARK: TCP - server
+/// A channel option which can be applied to bootstrap using shorthand notation.
+/// - See: ServerBootstrap.serverChannelOptions(_ options: [ServerOption])
+public struct NIOTCPServerShorthandOption {
+    private var data: ShorthandOption
+    
+    private init(_ data: ShorthandOption) {
+        self.data = data
+    }
+    
+    /// Apply the contained option to the supplied ServerBootstrap
+    /// - Parameter serverBootstrap: bootstrap to apply this option to.
+    @usableFromInline
+    func applyOption(to serverBootstrap: ServerBootstrap) {
+        data.applyOption(to: serverBootstrap)
+    }
+    
+    fileprivate enum ShorthandOption {
+        case reuseAddr
+        case disableAutoRead
+        case backlog(Int32)
+        
+        func applyOption(to serverBootstrap: ServerBootstrap) {
+            switch self {
+            case .disableAutoRead:
+                _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: false)
+            case .reuseAddr:
+                _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr),
+                                                        value: 1)
+            case .backlog(let value):
+                _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
+            }
+        }
+    }
+}
+
+// Hashable for the convenience of users.
+extension NIOTCPServerShorthandOption: Hashable {}
+extension NIOTCPServerShorthandOption.ShorthandOption: Hashable {}
+
+/// Approved shorthand server options.
+extension NIOTCPServerShorthandOption {
+    /// Option to reuse address.
+    /// - See:  NIOBSDSocket.Option.reuseaddr
+    public static let allowImmediateEndpointAddressReuse = NIOTCPServerShorthandOption(.reuseAddr)
+    
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = NIOTCPServerShorthandOption(.disableAutoRead)
+    
+    /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`.
+    /// This is only useful for `ServerSocketChannel`s.
+    /// - See: ChannelOptions.backlog
+    public static func maximumUnacceptedConnectionBacklog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
+        NIOTCPServerShorthandOption {
+        return NIOTCPServerShorthandOption(.backlog(value))
+    }
+}
+
+// MARK: UDP
+/// A channel option which can be applied to datagram bootstrap using shorthand notation.
+/// - See: DatagramBootstrap.channelOptions(_ options: [Option])
+public struct NIOUDPShorthandOption {
+    private var data: ShorthandOption
+    
+    private init(_ data: ShorthandOption) {
+        self.data = data
+    }
+    
+    /// Apply the contained option to the supplied DatagramBootstrap
+    /// - Parameter to: bootstrap to apply this option to.
+    @usableFromInline
+    func applyOption(to bootstrap: DatagramBootstrap) {
+        data.applyOption(to: bootstrap)
+    }
+    
+    fileprivate enum ShorthandOption {
+        case reuseAddr
+        case disableAutoRead
+        
+        func applyOption(to bootstrap: DatagramBootstrap) {
+            switch self {
+            case .reuseAddr:
+                _ = bootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            case .disableAutoRead:
+                _ = bootstrap.channelOption(ChannelOptions.autoRead, value: false)
+            
+            }
+        }
+    }
+}
+
+// Hashable for the convenience of users.
+extension NIOUDPShorthandOption: Hashable {}
+extension NIOUDPShorthandOption.ShorthandOption: Hashable {}
+
+/// Approved shorthand datagram channel options.
+extension NIOUDPShorthandOption {
+    /// Option to reuse address.
+    /// - See:  NIOBSDSocket.Option.reuseaddr
+    public static let allowImmediateEndpointAddressReuse =
+            NIOUDPShorthandOption(.reuseAddr)
+    
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = NIOUDPShorthandOption(.disableAutoRead)
+}
+
+// MARK: Pipe
+/// A channel option which can be applied to pipe bootstrap using shorthand notation.
+/// - See: NIOPipeBootstrap.channelOptions(_ options: [Option])
+public struct NIOPipeShorthandOption {
+    private let data: ShorthandOption
+    
+    private init(_ data: ShorthandOption) {
+        self.data = data
+    }
+    
+    /// Apply the contained option to the supplied NIOPipeBootstrap
+    /// - Parameter to: bootstrap to apply this option to.
+    @usableFromInline
+    func applyOption(to bootstrap: NIOPipeBootstrap) {
+        data.applyOption(to: bootstrap)
+    }
+    
+    fileprivate enum ShorthandOption {
+        case disableAutoRead
+        case allowRemoteHalfClosure(Bool)
+        
+        func applyOption(to bootstrap: NIOPipeBootstrap) {
+            switch self {
+            case .disableAutoRead:
+                _ = bootstrap.channelOption(ChannelOptions.autoRead, value: false)
+            case .allowRemoteHalfClosure(let value):
+                _ = bootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+            }
+        }
+    }
+}
+
+// Hashable for the convenience of users.
+extension NIOPipeShorthandOption: Hashable {}
+extension NIOPipeShorthandOption.ShorthandOption: Hashable {}
+
+/// Approved shorthand datagram channel options.
+extension NIOPipeShorthandOption {
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = NIOPipeShorthandOption(.disableAutoRead)
+    
+    /// - See: `AllowRemoteHalfClosureOption`.
+    public static let allowRemoteHalfClosure =
+        NIOPipeShorthandOption(.allowRemoteHalfClosure(true))
+    
+    /// - See: `AllowRemoteHalfClosureOption`.
+    public static func allowRemoteHalfClosure(_ value: Bool) ->
+        NIOPipeShorthandOption {
+        return NIOPipeShorthandOption(.allowRemoteHalfClosure(value))
     }
 }

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -181,19 +181,25 @@ extension NIOTCPShorthandOption.ShorthandOption: Hashable {}
 
 /// Approved shorthand client options.
 extension NIOTCPShorthandOption {
-    /// Option to reuse address.
-    /// - See:  NIOBSDSocket.Option.reuseaddr
+    /// Allow immediately reusing a local address.
     public static let allowImmediateEndpointAddressReuse = NIOTCPShorthandOption(.reuseAddr)
     
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
+    /// The user will manually call `Channel.read` once all the data is read from the transport.
     public static let disableAutoRead = NIOTCPShorthandOption(.disableAutoRead)
     
-    /// - See: `AllowRemoteHalfClosureOption`.
+    /// Allows users to configure whether the `Channel` will close itself when its remote
+    /// peer shuts down its send stream, or whether it will remain open. If set to `false` (the default), the `Channel`
+    /// will be closed automatically if the remote peer shuts down its send stream. If set to true, the `Channel` will
+    /// not be closed: instead, a `ChannelEvent.inboundClosed` user event will be sent on the `ChannelPipeline`,
+    /// and no more data will be received.
     public static let allowRemoteHalfClosure =
         NIOTCPShorthandOption(.allowRemoteHalfClosure(true))
     
-    /// - See: `AllowRemoteHalfClosureOption`.
+    /// Allows users to configure whether the `Channel` will close itself when its remote
+    /// peer shuts down its send stream, or whether it will remain open. If set to `false` (the default), the `Channel`
+    /// will be closed automatically if the remote peer shuts down its send stream. If set to true, the `Channel` will
+    /// not be closed: instead, a `ChannelEvent.inboundClosed` user event will be sent on the `ChannelPipeline`,
+    /// and no more data will be received.
     public static func allowRemoteHalfClosure(_ value: Bool) -> NIOTCPShorthandOption {
         return NIOTCPShorthandOption(.allowRemoteHalfClosure(value))
     }
@@ -241,17 +247,13 @@ extension NIOTCPServerShorthandOption.ShorthandOption: Hashable {}
 
 /// Approved shorthand server options.
 extension NIOTCPServerShorthandOption {
-    /// Option to reuse address.
-    /// - See:  NIOBSDSocket.Option.reuseaddr
+    /// Allow immediately reusing a local address.
     public static let allowImmediateEndpointAddressReuse = NIOTCPServerShorthandOption(.reuseAddr)
     
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
+    /// The user will manually call `Channel.read` once all the data is read from the transport.
     public static let disableAutoRead = NIOTCPServerShorthandOption(.disableAutoRead)
     
-    /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`.
-    /// This is only useful for `ServerSocketChannel`s.
-    /// - See: ChannelOptions.backlog
+    /// Allows users to configure the `backlog` value as specified in `man 2 listen` - the maximum number of connections waiting to be accepted.
     public static func maximumUnacceptedConnectionBacklog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
         NIOTCPServerShorthandOption {
         return NIOTCPServerShorthandOption(.backlog(value))
@@ -259,7 +261,7 @@ extension NIOTCPServerShorthandOption {
 }
 
 // MARK: UDP
-/// A channel option which can be applied to datagram bootstrap using shorthand notation.
+/// A channel option which can be applied to a UDP based bootstrap using shorthand notation.
 /// - See: DatagramBootstrap.channelOptions(_ options: [Option])
 public struct NIOUDPShorthandOption {
     private var data: ShorthandOption
@@ -297,13 +299,11 @@ extension NIOUDPShorthandOption.ShorthandOption: Hashable {}
 
 /// Approved shorthand datagram channel options.
 extension NIOUDPShorthandOption {
-    /// Option to reuse address.
-    /// - See:  NIOBSDSocket.Option.reuseaddr
+    /// Allow immediately reusing a local address.
     public static let allowImmediateEndpointAddressReuse =
             NIOUDPShorthandOption(.reuseAddr)
     
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
+    /// The user will manually call `Channel.read` once all the data is read from the transport.
     public static let disableAutoRead = NIOUDPShorthandOption(.disableAutoRead)
 }
 
@@ -345,15 +345,22 @@ extension NIOPipeShorthandOption.ShorthandOption: Hashable {}
 
 /// Approved shorthand datagram channel options.
 extension NIOPipeShorthandOption {
-    /// Option to disable autoRead
-    /// - See: ChannelOptions.autoRead
+    /// The user will manually call `Channel.read` once all the data is read from the transport.
     public static let disableAutoRead = NIOPipeShorthandOption(.disableAutoRead)
     
-    /// - See: `AllowRemoteHalfClosureOption`.
+    /// Allows users to configure whether the `Channel` will close itself when its remote
+    /// peer shuts down its send stream, or whether it will remain open. If set to `false` (the default), the `Channel`
+    /// will be closed automatically if the remote peer shuts down its send stream. If set to true, the `Channel` will
+    /// not be closed: instead, a `ChannelEvent.inboundClosed` user event will be sent on the `ChannelPipeline`,
+    /// and no more data will be received.
     public static let allowRemoteHalfClosure =
         NIOPipeShorthandOption(.allowRemoteHalfClosure(true))
     
-    /// - See: `AllowRemoteHalfClosureOption`.
+    /// Allows users to configure whether the `Channel` will close itself when its remote
+    /// peer shuts down its send stream, or whether it will remain open. If set to `false` (the default), the `Channel`
+    /// will be closed automatically if the remote peer shuts down its send stream. If set to true, the `Channel` will
+    /// not be closed: instead, a `ChannelEvent.inboundClosed` user event will be sent on the `ChannelPipeline`,
+    /// and no more data will be received.
     public static func allowRemoteHalfClosure(_ value: Bool) ->
         NIOPipeShorthandOption {
         return NIOPipeShorthandOption(.allowRemoteHalfClosure(value))

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -1,0 +1,358 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: ServerBootstrap - Server
+extension ServerBootstrap {
+    /// Specifies some `ChannelOption`s to be applied to the `ServerSocketChannel`.
+    /// - See: serverChannelOption
+    /// - Parameter options: List of shorthand options to apply.
+    /// - Returns: The updated server bootstrap (`self` being mutated)
+    @inlinable
+    public func serverChannelOptions(_ options: [ServerOption]) -> Self {
+        for option in options {
+            option.applyOption(to: self)
+        }
+        return self
+    }
+    
+    /// A channel option which can be applied to bootstrap using shorthand notation.
+    /// - See: ServerBootstrap.serverChannelOptions(_ options: [ServerOption])
+    public struct ServerOption {
+        private let data: ShorthandServerOption
+        
+        private init(_ data: ShorthandServerOption) {
+            self.data = data
+        }
+        
+        /// Apply the contained option to the supplied ServerBootstrap
+        /// - Parameter serverBootstrap: bootstrap to apply this option to.
+        @usableFromInline
+        func applyOption(to serverBootstrap: ServerBootstrap) {
+            data.applyOption(to: serverBootstrap)
+        }
+        
+        fileprivate enum ShorthandServerOption {
+            case reuseAddr
+            case disableAutoRead
+            case backlog(Int32)
+            
+            func applyOption(to serverBootstrap: ServerBootstrap) {
+                switch self {
+                case .disableAutoRead:
+                    _ = serverBootstrap.serverChannelOption(ChannelOptions.autoRead, value: false)
+                case .reuseAddr:
+                    _ = serverBootstrap.serverChannelOption(ChannelOptions.socketOption(.reuseaddr),
+                                                            value: 1)
+                case .backlog(let value):
+                    _ = serverBootstrap.serverChannelOption(ChannelOptions.backlog, value: value)
+                }
+            }
+        }
+    }
+}
+
+// Hashable for the convenience of users.
+extension ServerBootstrap.ServerOption: Hashable {}
+extension ServerBootstrap.ServerOption.ShorthandServerOption: Hashable {}
+
+/// Approved shorthand server options.
+extension ServerBootstrap.ServerOption {
+    /// Option to reuse address.
+    /// - See:  NIOBSDSocket.Option.reuseaddr
+    public static let allowImmediateEndpointAddressReuse = ServerBootstrap.ServerOption(.reuseAddr)
+    
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = ServerBootstrap.ServerOption(.disableAutoRead)
+    
+    /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`.
+    /// This is only useful for `ServerSocketChannel`s.
+    /// - See: ChannelOptions.backlog
+    public static func maximumUnacceptedConnectionBacklog(_ value: ChannelOptions.Types.BacklogOption.Value) ->
+        ServerBootstrap.ServerOption {
+        return ServerBootstrap.ServerOption(.backlog(value))
+    }
+}
+
+// MARK: ServerBootstrap - Child
+extension ServerBootstrap {
+    /// Specifies some `ChannelOption`s to be applied to the accepted `SocketChannel`s.
+    /// - See: childChannelOption
+    /// - Parameter options: List of shorthand options to apply.
+    /// - Returns: The update server bootstrap (`self` being mutated)
+    @inlinable
+    public func childChannelOptions(_ options: [NIOTCPShorthandOption]) -> Self {
+        var toReturn = self
+        for option in options {
+            toReturn = option.applyOption(with: toReturn)
+        }
+        return toReturn
+    }
+}
+
+// MARK: ClientBootstrap
+extension ClientBootstrap {
+    /// Specifies some `ChannelOption`s to be applied to the `SocketChannel`.
+    /// - See: channelOption
+    /// - Parameter options: List of shorthand options to apply.
+    /// - Returns: The updated client bootstrap (`self` being mutated)
+    @inlinable
+    public func channelOptions(_ options: [NIOTCPShorthandOption]) -> Self {
+        var toReturn = self
+        for option in options {
+            toReturn = option.applyOption(with: toReturn)
+        }
+        return toReturn
+    }
+}
+
+// MARK: DatagramBootstrap
+extension DatagramBootstrap {
+    /// Specifies some `ChannelOption`s to be applied to the `DatagramChannel`.
+    /// - See: channelOption
+    /// - Parameter options: List of shorthand options to apply.
+    /// - Returns: The updated datagram bootstrap (`self` being mutated)
+    @inlinable
+    public func channelOptions(_ options: [Option]) -> Self {
+        for option in options {
+            option.applyOption(to: self)
+        }
+        return self
+    }
+    
+    /// A channel option which can be applied to datagram bootstrap using shorthand notation.
+    /// - See: DatagramBootstrap.channelOptions(_ options: [Option])
+    public struct Option {
+        private let data: ShorthandChannelOption
+        
+        private init(_ data: ShorthandChannelOption) {
+            self.data = data
+        }
+        
+        /// Apply the contained option to the supplied DatagramBootstrap
+        /// - Parameter to: bootstrap to apply this option to.
+        @usableFromInline
+        func applyOption(to bootstrap: DatagramBootstrap) {
+            data.applyOption(to: bootstrap)
+        }
+        
+        fileprivate enum ShorthandChannelOption {
+            case reuseAddr
+            case disableAutoRead
+            
+            func applyOption(to bootstrap: DatagramBootstrap) {
+                switch self {
+                case .reuseAddr:
+                    _ = bootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+                case .disableAutoRead:
+                    _ = bootstrap.channelOption(ChannelOptions.autoRead, value: false)
+                
+                }
+            }
+        }
+    }
+}
+
+// Hashable for the convenience of users.
+extension DatagramBootstrap.Option: Hashable {}
+extension DatagramBootstrap.Option.ShorthandChannelOption: Hashable {}
+
+/// Approved shorthand datagram channel options.
+extension DatagramBootstrap.Option {
+    /// Option to reuse address.
+    /// - See:  NIOBSDSocket.Option.reuseaddr
+    public static let allowImmediateEndpointAddressReuse =
+            DatagramBootstrap.Option(.reuseAddr)
+    
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = DatagramBootstrap.Option(.disableAutoRead)
+}
+
+// MARK: NIOPipeBootstrap
+extension NIOPipeBootstrap {
+    /// Specifies some `ChannelOption`s to be applied to the `PipeChannel`.
+    /// - See: channelOption
+    /// - Parameter options: List of shorthand options to apply.
+    /// - Returns: The updated pipe bootstrap (`self` being mutated)
+    @inlinable
+    public func channelOptions(_ options: [Option]) -> Self {
+        for option in options {
+            option.applyOption(to: self)
+        }
+        return self
+    }
+    
+    /// A channel option which can be applied to pipe bootstrap using shorthand notation.
+    /// - See: NIOPipeBootstrap.channelOptions(_ options: [Option])
+    public struct Option {
+        private let data: ShorthandChannelOption
+        
+        private init(_ data: ShorthandChannelOption) {
+            self.data = data
+        }
+        
+        /// Apply the contained option to the supplied NIOPipeBootstrap
+        /// - Parameter to: bootstrap to apply this option to.
+        @usableFromInline
+        func applyOption(to bootstrap: NIOPipeBootstrap) {
+            data.applyOption(to: bootstrap)
+        }
+        
+        fileprivate enum ShorthandChannelOption {
+            case disableAutoRead
+            case allowRemoteHalfClosure(Bool)
+            
+            func applyOption(to bootstrap: NIOPipeBootstrap) {
+                switch self {
+                case .disableAutoRead:
+                    _ = bootstrap.channelOption(ChannelOptions.autoRead, value: false)
+                case .allowRemoteHalfClosure(let value):
+                    _ = bootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+                }
+            }
+        }
+    }
+}
+
+// Hashable for the convenience of users.
+extension NIOPipeBootstrap.Option: Hashable {}
+extension NIOPipeBootstrap.Option.ShorthandChannelOption: Hashable {}
+
+/// Approved shorthand datagram channel options.
+extension NIOPipeBootstrap.Option {
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = NIOPipeBootstrap.Option(.disableAutoRead)
+    
+    /// - See: `AllowRemoteHalfClosureOption`.
+    public static let allowRemoteHalfClosure =
+        NIOPipeBootstrap.Option(.allowRemoteHalfClosure(true))
+    
+    /// - See: `AllowRemoteHalfClosureOption`.
+    public static func allowRemoteHalfClosure(_ value: Bool) ->
+        NIOPipeBootstrap.Option {
+        return NIOPipeBootstrap.Option(.allowRemoteHalfClosure(value))
+    }
+}
+
+// MARK:  Universal Client Bootstrap
+extension NIOClientTCPBootstrapProtocol {
+    /// Apply a shorthand option to this bootstrap - default implementation which always fails to apply.
+    /// - parameters:
+    ///     - option:  The option to try applying.
+    /// - returns: The updated bootstrap if option was successfully applied, otherwise nil suggesting the caller try another method.
+    public func applyChannelOption(_ option: NIOTCPShorthandOption) -> Self? {
+        return .none
+    }
+}
+
+extension NIOClientTCPBootstrap {
+    /// Specifies some `ChannelOption`s to be applied to the channel.
+    /// - See: channelOption
+    /// - Parameter options: List of shorthand options to apply.
+    /// - Returns: The updated bootstrap (`self` being mutated)
+    public func channelOptions(_ options: [NIOTCPShorthandOption]) -> NIOClientTCPBootstrap {
+        var toReturn = self
+        for option in options {
+            if let updatedUnderlying = toReturn.underlyingBootstrap.applyChannelOption(option) {
+                toReturn = NIOClientTCPBootstrap(toReturn, withUpdated: updatedUnderlying)
+            } else {
+                toReturn = option.applyOption(with: toReturn)
+            }
+        }
+        return toReturn
+    }
+}
+
+extension NIOClientTCPBootstrap : NIOTCPOptionAppliable {
+    public func applyOption<Option>(_ option: Option, value: Option.Value) -> NIOClientTCPBootstrap where Option : ChannelOption {
+        return self.channelOption(option, value: value)
+    }
+}
+
+// MARK: TCP - data
+public protocol NIOTCPOptionAppliable {
+    func applyOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
+}
+
+extension ServerBootstrap : NIOTCPOptionAppliable {
+    public func applyOption<Option>(_ option: Option, value: Option.Value) -> Self where Option : ChannelOption {
+        return self.childChannelOption(option, value: value)
+    }
+}
+
+extension ClientBootstrap : NIOTCPOptionAppliable {
+    public func applyOption<Option>(_ option: Option, value: Option.Value) -> Self where Option : ChannelOption {
+        return self.channelOption(option, value: value)
+    }
+}
+
+/// A channel option which can be applied to a bootstrap or similar using shorthand notation.
+/// - See: ClientBootstrap.channelOptions(_ options: [Option])
+public struct NIOTCPShorthandOption  {
+    private let data: ShorthandOption
+    
+    private init(_ data: ShorthandOption) {
+        self.data = data
+    }
+    
+    /// Apply the contained option to the supplied object (almost certainly bootstrap) using the default mapping.
+    /// - Parameter to: object to apply this option to.
+    /// - Returns: the modified object
+    public func applyOption<T : NIOTCPOptionAppliable>(with: T) -> T {
+        return data.applyOption(with: with)
+    }
+    
+    fileprivate enum ShorthandOption {
+        case reuseAddr
+        case disableAutoRead
+        case allowRemoteHalfClosure(Bool)
+        
+        func applyOption<T : NIOTCPOptionAppliable>(with: T) -> T {
+            switch self {
+            case .reuseAddr:
+                return with.applyOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            case .allowRemoteHalfClosure(let value):
+                return with.applyOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+            case .disableAutoRead:
+                return with.applyOption(ChannelOptions.autoRead, value: false)
+            }
+        }
+    }
+}
+
+// Hashable for the convenience of users.
+extension NIOTCPShorthandOption: Hashable {}
+extension NIOTCPShorthandOption.ShorthandOption: Hashable {}
+
+/// Approved shorthand client options.
+extension NIOTCPShorthandOption {
+    /// Option to reuse address.
+    /// - See:  NIOBSDSocket.Option.reuseaddr
+    public static let allowImmediateEndpointAddressReuse = NIOTCPShorthandOption(.reuseAddr)
+    
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = NIOTCPShorthandOption(.disableAutoRead)
+    
+    /// - See: `AllowRemoteHalfClosureOption`.
+    public static let allowRemoteHalfClosure =
+        NIOTCPShorthandOption(.allowRemoteHalfClosure(true))
+    
+    /// - See: `AllowRemoteHalfClosureOption`.
+    public static func allowRemoteHalfClosure(_ value: Bool) -> NIOTCPShorthandOption {
+        return NIOTCPShorthandOption(.allowRemoteHalfClosure(value))
+    }
+}

--- a/Sources/NIO/UniversalBootstrapSupport.swift
+++ b/Sources/NIO/UniversalBootstrapSupport.swift
@@ -262,7 +262,7 @@ public struct NIOInsecureNoTLS<Bootstrap: NIOClientTCPBootstrapProtocol>: NIOCli
 
 extension NIOClientTCPBootstrap : TCPOptionAppliable {
     @usableFromInline
-    func applyOption<Option>(_ option: Option, value: Option.Value) -> Self where Option : ChannelOption {
+    func applyOption<Option>(_ option: Option, value: Option.Value) -> NIOClientTCPBootstrap where Option : ChannelOption {
         return self.channelOption(option, value: value)
     }
 }

--- a/Sources/NIO/UniversalBootstrapSupport.swift
+++ b/Sources/NIO/UniversalBootstrapSupport.swift
@@ -130,11 +130,12 @@ public struct NIOClientTCPBootstrap {
     /// - See: channelOption
     /// - Parameter options: List of shorthand options to apply.
     /// - Returns: The update server bootstrap (`self` being mutated)
-    public func channelOptions(_ options: [Option]) -> Self {
+    public func channelOptions(_ options: [Option]) -> NIOClientTCPBootstrap {
+        var toReturn = self
         for option in options {
-            option.applyOption(to: self)
+            toReturn = option.applyOption(to: toReturn)
         }
-        return self
+        return toReturn
     }
 
     /// - parameters:
@@ -192,20 +193,20 @@ public struct NIOClientTCPBootstrap {
         /// - Parameter to: bootstrap to apply this option to.
         /// - Returns: the modified bootstrap (currently the same one mutated)
         @usableFromInline
-        func applyOption(to clientBootstrap: NIOClientTCPBootstrap) {
-            data.applyOption(to: clientBootstrap)
+        func applyOption(to clientBootstrap: NIOClientTCPBootstrap) -> NIOClientTCPBootstrap {
+            return data.applyOption(to: clientBootstrap)
         }
         
         fileprivate enum ShorthandOption {
             case reuseAddr
             case allowRemoteHalfClosure(Bool)
             
-            func applyOption(to bootstrap: NIOClientTCPBootstrap) {
+            func applyOption(to bootstrap: NIOClientTCPBootstrap) -> NIOClientTCPBootstrap {
                 switch self {
                 case .reuseAddr:
-                    _ = bootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+                    return bootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
                 case .allowRemoteHalfClosure(let value):
-                    _ = bootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+                    return bootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
                 }
             }
         }

--- a/Sources/NIO/UniversalBootstrapSupport.swift
+++ b/Sources/NIO/UniversalBootstrapSupport.swift
@@ -265,6 +265,7 @@ public struct NIOClientTCPBootstrap {
         fileprivate enum ShorthandOption {
             case reuseAddr
             case allowRemoteHalfClosure(Bool)
+            case disableAutoRead
             
             func applyOption(to bootstrap: NIOClientTCPBootstrap) -> NIOClientTCPBootstrap {
                 switch self {
@@ -272,6 +273,8 @@ public struct NIOClientTCPBootstrap {
                     return bootstrap.channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
                 case .allowRemoteHalfClosure(let value):
                     return bootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: value)
+                case .disableAutoRead:
+                    return bootstrap.channelOption(ChannelOptions.autoRead, value: false)
                 }
             }
         }
@@ -287,6 +290,10 @@ extension NIOClientTCPBootstrap.Option {
     /// Option to reuse address.
     /// - See:  NIOBSDSocket.Option.reuseaddr
     public static let allowImmediateEndpointAddressReuse = NIOClientTCPBootstrap.Option(.reuseAddr)
+    
+    /// Option to disable autoRead
+    /// - See: ChannelOptions.autoRead
+    public static let disableAutoRead = NIOClientTCPBootstrap.Option(.disableAutoRead)
     
     /// - See: `AllowRemoteHalfClosureOption`.
     public static let allowRemoteHalfClosure =

--- a/Sources/NIOChatClient/main.swift
+++ b/Sources/NIOChatClient/main.swift
@@ -44,7 +44,7 @@ private final class ChatHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOptions([.reuseAddr])
+    .channelOptions([.allowImmediateEndpointAddressReuse])
     .channelInitializer { channel in
         channel.pipeline.addHandler(ChatHandler())
     }

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -116,7 +116,7 @@ let chatHandler = ChatHandler()
 let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverOptions([.maximumUnacceptedConnectionBacklog(256),
+    .serverChannelOptions([.maximumUnacceptedConnectionBacklog(256),
                     .allowImmediateEndpointAddressReuse])
 
     // Set the handlers that are applied to the accepted Channels

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -116,7 +116,8 @@ let chatHandler = ChatHandler()
 let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverOptions([.backlog(256), .reuseAddr])
+    .serverOptions([.maximumUnacceptedConnectionBacklog(256),
+                    .allowImmediateEndpointAddressReuse])
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
@@ -128,7 +129,7 @@ let bootstrap = ServerBootstrap(group: group)
     }
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOptions([.reuseAddr])
+    .childChannelOptions([.allowImmediateEndpointAddressReuse])
     .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
     .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 defer {

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -54,7 +54,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOptions([.reuseAddr])
+    .channelOptions([.allowImmediateEndpointAddressReuse])
     .channelInitializer { channel in
         channel.pipeline.addHandler(EchoHandler())
     }

--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -39,7 +39,8 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverOptions([.backlog(256), .reuseAddr])
+    .serverOptions([.maximumUnacceptedConnectionBacklog(256),
+                    .allowImmediateEndpointAddressReuse])
 
     // Set the handlers that are appled to the accepted Channels
     .childChannelInitializer { channel in
@@ -50,7 +51,7 @@ let bootstrap = ServerBootstrap(group: group)
     }
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOptions([.reuseAddr])
+    .childChannelOptions([.allowImmediateEndpointAddressReuse])
     .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
     .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 defer {

--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -39,7 +39,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverOptions([.maximumUnacceptedConnectionBacklog(256),
+    .serverChannelOptions([.maximumUnacceptedConnectionBacklog(256),
                     .allowImmediateEndpointAddressReuse])
 
     // Set the handlers that are appled to the accepted Channels

--- a/Sources/NIOHTTP1Client/main.swift
+++ b/Sources/NIOHTTP1Client/main.swift
@@ -77,7 +77,7 @@ private final class HTTPEchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOptions([.reuseaddr])
+    .channelOptions([.reuseAddr])
     .channelInitializer { channel in
         channel.pipeline.addHTTPClientHandlers(position: .first,
                                                leftOverBytesStrategy: .fireError).flatMap {

--- a/Sources/NIOHTTP1Client/main.swift
+++ b/Sources/NIOHTTP1Client/main.swift
@@ -77,7 +77,7 @@ private final class HTTPEchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOptions([.reuseAddr])
+    .channelOptions([.allowImmediateEndpointAddressReuse])
     .channelInitializer { channel in
         channel.pipeline.addHTTPClientHandlers(position: .first,
                                                leftOverBytesStrategy: .fireError).flatMap {

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -526,13 +526,14 @@ func childChannelInitializer(channel: Channel) -> EventLoopFuture<Void> {
 let fileIO = NonBlockingFileIO(threadPool: threadPool)
 let socketBootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverOptions([.reuseAddr, .backlog(256)])
+    .serverOptions([.allowImmediateEndpointAddressReuse,
+                    .maximumUnacceptedConnectionBacklog	(256)])
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer(childChannelInitializer(channel:))
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOptions([.reuseAddr, .allowRemoteHalfClosure(allowHalfClosure)])
+    .childChannelOptions([.allowImmediateEndpointAddressReuse, .allowRemoteHalfClosure(allowHalfClosure)])
     .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
 let pipeBootstrap = NIOPipeBootstrap(group: group)
     // Set the handlers that are applied to the accepted Channels

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -539,7 +539,7 @@ let pipeBootstrap = NIOPipeBootstrap(group: group)
     .channelInitializer(childChannelInitializer(channel:))
 
     .channelOption(ChannelOptions.maxMessagesPerRead, value: 1)
-    .channelOption(ChannelOptions.allowRemoteHalfClosure, value: allowHalfClosure)
+    .channelOptions([.allowRemoteHalfClosure(allowHalfClosure)])
 
 defer {
     try! group.syncShutdownGracefully()

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -526,7 +526,7 @@ func childChannelInitializer(channel: Channel) -> EventLoopFuture<Void> {
 let fileIO = NonBlockingFileIO(threadPool: threadPool)
 let socketBootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverOptions([.allowImmediateEndpointAddressReuse,
+    .serverChannelOptions([.allowImmediateEndpointAddressReuse,
                     .maximumUnacceptedConnectionBacklog(256)])
 
     // Set the handlers that are applied to the accepted Channels

--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -70,7 +70,7 @@ let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
 // Begin by setting up the basics of the bootstrap.
 var datagramBootstrap = DatagramBootstrap(group: group)
-    .channelOptions([.reuseAddr])
+    .channelOptions([.allowImmediateEndpointAddressReuse])
     .channelOption(ChannelOptions.socketOption(.reuseport), value: 1)
     .channelInitializer { channel in
         return channel.pipeline.addHandler(ChatMessageEncoder()).flatMap {

--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -70,7 +70,7 @@ let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
 // Begin by setting up the basics of the bootstrap.
 var datagramBootstrap = DatagramBootstrap(group: group)
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .channelOptions([.reuseAddr])
     .channelOption(ChannelOptions.socketOption(.reuseport), value: 1)
     .channelInitializer { channel in
         return channel.pipeline.addHandler(ChatMessageEncoder()).flatMap {

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -122,7 +122,7 @@ defer {
 }
 
 let serverChannel = try ServerBootstrap(group: group)
-    .serverOptions([.allowImmediateEndpointAddressReuse])
+    .serverChannelOptions([.allowImmediateEndpointAddressReuse])
     .childChannelInitializer { channel in
         channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true).flatMap {
             channel.pipeline.addHandler(SimpleHTTPServer())

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -122,7 +122,7 @@ defer {
 }
 
 let serverChannel = try ServerBootstrap(group: group)
-    .serverOptions([.reuseAddr])
+    .serverOptions([.allowImmediateEndpointAddressReuse])
     .childChannelInitializer { channel in
         channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true).flatMap {
             channel.pipeline.addHandler(SimpleHTTPServer())

--- a/Sources/NIOUDPEchoClient/main.swift
+++ b/Sources/NIOUDPEchoClient/main.swift
@@ -117,7 +117,7 @@ let remoteAddress = { () -> SocketAddress in
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = DatagramBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOptions([.reuseaddr])
+    .channelOptions([.reuseAddr])
     .channelInitializer { channel in
         channel.pipeline.addHandler(EchoHandler(remoteAddressInitializer: remoteAddress))
 }

--- a/Sources/NIOUDPEchoClient/main.swift
+++ b/Sources/NIOUDPEchoClient/main.swift
@@ -117,7 +117,7 @@ let remoteAddress = { () -> SocketAddress in
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = DatagramBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .channelOptions([.reuseaddr])
     .channelInitializer { channel in
         channel.pipeline.addHandler(EchoHandler(remoteAddressInitializer: remoteAddress))
 }

--- a/Sources/NIOUDPEchoClient/main.swift
+++ b/Sources/NIOUDPEchoClient/main.swift
@@ -117,7 +117,7 @@ let remoteAddress = { () -> SocketAddress in
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = DatagramBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOptions([.reuseAddr])
+    .channelOptions([.allowImmediateEndpointAddressReuse])
     .channelInitializer { channel in
         channel.pipeline.addHandler(EchoHandler(remoteAddressInitializer: remoteAddress))
 }

--- a/Sources/NIOUDPEchoServer/main.swift
+++ b/Sources/NIOUDPEchoServer/main.swift
@@ -42,7 +42,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 var bootstrap = DatagramBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR
-    .channelOptions([.reuseAddr])
+    .channelOptions([.allowImmediateEndpointAddressReuse])
 
     // Set the handlers that are applied to the bound channel
     .channelInitializer { channel in

--- a/Sources/NIOUDPEchoServer/main.swift
+++ b/Sources/NIOUDPEchoServer/main.swift
@@ -42,7 +42,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 var bootstrap = DatagramBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR
-    .channelOptions(.reuseAddr])
+    .channelOptions([.reuseAddr])
 
     // Set the handlers that are applied to the bound channel
     .channelInitializer { channel in

--- a/Sources/NIOUDPEchoServer/main.swift
+++ b/Sources/NIOUDPEchoServer/main.swift
@@ -42,7 +42,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 var bootstrap = DatagramBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .channelOptions(.reuseAddr])
 
     // Set the handlers that are applied to the bound channel
     .channelInitializer { channel in

--- a/Sources/NIOWebSocketClient/main.swift
+++ b/Sources/NIOWebSocketClient/main.swift
@@ -158,7 +158,7 @@ private final class WebSocketPingPongHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOptions([.reuseAddr])
+    .channelOptions([.allowImmediateEndpointAddressReuse	])
     .channelInitializer { channel in
         
         let httpHandler = HTTPInitialRequestHandler()

--- a/Sources/NIOWebSocketClient/main.swift
+++ b/Sources/NIOWebSocketClient/main.swift
@@ -158,7 +158,7 @@ private final class WebSocketPingPongHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOptions([.reuseaddr])
+    .channelOptions([.reuseAddr])
     .channelInitializer { channel in
         
         let httpHandler = HTTPInitialRequestHandler()

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -226,7 +226,7 @@ let bootstrap = ServerBootstrap(group: group)
     }
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOptions([.reuseaddr])
+    .childChannelOptions([.reuseAddr])
 
 defer {
     try! group.syncShutdownGracefully()

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -209,7 +209,7 @@ let upgrader = NIOWebSocketServerUpgrader(shouldUpgrade: { (channel: Channel, he
 
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverOptions([.backlog(256), .reuseAddr])
+    .serverOptions([.maximumUnacceptedConnectionBacklog(256), .allowImmediateEndpointAddressReuse])
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
@@ -226,7 +226,7 @@ let bootstrap = ServerBootstrap(group: group)
     }
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOptions([.reuseAddr])
+    .childChannelOptions([.allowImmediateEndpointAddressReuse])
 
 defer {
     try! group.syncShutdownGracefully()

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -209,7 +209,7 @@ let upgrader = NIOWebSocketServerUpgrader(shouldUpgrade: { (channel: Channel, he
 
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverOptions([.maximumUnacceptedConnectionBacklog(256), .allowImmediateEndpointAddressReuse])
+    .serverChannelOptions([.maximumUnacceptedConnectionBacklog(256), .allowImmediateEndpointAddressReuse])
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -338,7 +338,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
@@ -395,7 +395,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
@@ -455,7 +455,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                     channel.pipeline.addHandler(httpHandler)
@@ -511,7 +511,7 @@ class HTTPServerClientTest : XCTestCase {
         let numBytes = 16 * 1024
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
@@ -553,7 +553,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                     channel.pipeline.addHandler(httpHandler)
@@ -597,7 +597,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                     channel.pipeline.addHandler(httpHandler)

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -338,7 +338,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
@@ -395,7 +395,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
@@ -455,7 +455,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                     channel.pipeline.addHandler(httpHandler)
@@ -511,7 +511,7 @@ class HTTPServerClientTest : XCTestCase {
         let numBytes = 16 * 1024
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
@@ -553,7 +553,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                     channel.pipeline.addHandler(httpHandler)
@@ -597,7 +597,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                     channel.pipeline.addHandler(httpHandler)

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -88,7 +88,7 @@ private func serverHTTPChannelWithAutoremoval(group: EventLoopGroup,
                                               _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) throws -> (Channel, EventLoopFuture<Channel>) {
     let p = group.next().makePromise(of: Channel.self)
     let c = try ServerBootstrap(group: group)
-        .serverOptions([.allowImmediateEndpointAddressReuse])
+        .serverChannelOptions([.allowImmediateEndpointAddressReuse])
         .childChannelInitializer { channel in
             p.succeed(channel)
             let upgradeConfig = (upgraders: upgraders, completionHandler: upgradeCompletionHandler)

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -88,7 +88,7 @@ private func serverHTTPChannelWithAutoremoval(group: EventLoopGroup,
                                               _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) throws -> (Channel, EventLoopFuture<Channel>) {
     let p = group.next().makePromise(of: Channel.self)
     let c = try ServerBootstrap(group: group)
-        .serverOptions([.reuseAddr])
+        .serverOptions([.allowImmediateEndpointAddressReuse])
         .childChannelInitializer { channel in
             p.succeed(channel)
             let upgradeConfig = (upgraders: upgraders, completionHandler: upgradeCompletionHandler)

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -32,7 +32,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
 
     func connect(serverPort: Int, responsePromise: EventLoopPromise<String>) throws -> EventLoopFuture<Channel> {
         let bootstrap = ClientBootstrap(group: self.group)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers(position: .first,
                                                        leftOverBytesStrategy: .fireError).flatMap {

--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -49,6 +49,11 @@ extension BootstrapTest {
                 ("testNIOPipeBootstrapValidatesWorkingELGsCorrectly", testNIOPipeBootstrapValidatesWorkingELGsCorrectly),
                 ("testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly", testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly),
                 ("testShorthandServerOptionsAreEquivalent", testShorthandServerOptionsAreEquivalent),
+                ("testShorthandOptionsAreEquivalentServerChild", testShorthandOptionsAreEquivalentServerChild),
+                ("testShorthandOptionsAreEquivalentClient", testShorthandOptionsAreEquivalentClient),
+                ("testShorthandOptionsAreEquivalentUniversalClient", testShorthandOptionsAreEquivalentUniversalClient),
+                ("testShorthandOptionsAreEquivalentDatagram", testShorthandOptionsAreEquivalentDatagram),
+                ("testShorthandOptionsAreEquivalentPipe", testShorthandOptionsAreEquivalentPipe),
            ]
    }
 }

--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -48,7 +48,7 @@ extension BootstrapTest {
                 ("testDatagramBootstrapRejectsNotWorkingELGsCorrectly", testDatagramBootstrapRejectsNotWorkingELGsCorrectly),
                 ("testNIOPipeBootstrapValidatesWorkingELGsCorrectly", testNIOPipeBootstrapValidatesWorkingELGsCorrectly),
                 ("testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly", testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly),
-                ("testShorthandOptionsAreEquivalent", testShorthandOptionsAreEquivalent),
+                ("testShorthandServerOptionsAreEquivalent", testShorthandServerOptionsAreEquivalent),
            ]
    }
 }

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -639,10 +639,8 @@ class BootstrapTest: XCTestCase {
             XCTAssertNotEqual(longSetValue, unsetValue)
         }
         
+        // allowImmediateEndpointAddressReuse not checked as problematic to test -
         // At least on Darwin the default for child is to have allow reuse set - probably inherited from listen
-        // try checkOptionEquivalence(longOption: ChannelOptions.socketOption(.reuseaddr),
-        //                           setValue: 1,
-        //                           shortOption: .allowImmediateEndpointAddressReuse)
         try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
                                    setValue: true,
                                    shortOption: .allowRemoteHalfClosure)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -368,7 +368,7 @@ class BootstrapTest: XCTestCase {
             }
             var channel: Channel? = nil
             XCTAssertNoThrow(channel = try NIOPipeBootstrap(group: self.group)
-                .channelOption(ChannelOptions.autoRead, value: false)
+                .channelOptions([.disableAutoRead])
                 .channelInitializer { channel in
                     channel.getOption(ChannelOptions.autoRead).whenComplete { result in
                         func workaround() {

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -612,7 +612,7 @@ class BootstrapTest: XCTestCase {
                 let serverAcceptedChannel = try serverAcceptedChannelPromise.futureResult.wait()
 
                 // Start shutting stuff down.
-                XCTAssertNoThrow(try clientChannel.close().wait())
+                XCTAssertNoThrow(try serverAcceptedChannel.close().wait())
 
                 // Wait for the close promises. These fire last.
                 XCTAssertNoThrow(try EventLoopFuture.andAllSucceed([clientChannel.closeFuture,
@@ -644,9 +644,9 @@ class BootstrapTest: XCTestCase {
         try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
                                    setValue: true,
                                    shortOption: .allowRemoteHalfClosure)
-        // try checkOptionEquivalence(longOption: ChannelOptions.autoRead,
-           //                        setValue: false,
-             //                      shortOption: .disableAutoRead)
+        try checkOptionEquivalence(longOption: ChannelOptions.autoRead,
+                                   setValue: false,
+                                   shortOption: .disableAutoRead)
     }
     
     func testShorthandOptionsAreEquivalentClient() throws {

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -561,6 +561,13 @@ class BootstrapTest: XCTestCase {
         try checkOptionEquivalence(longOption: ChannelOptions.socketOption(.reuseaddr),
                                    setValue: 1,
                                    shortOption: .allowImmediateEndpointAddressReuse)
+        #if !os(Windows)
+            // Check the oldest way of all.
+            // .socket(.init(SOL_SOCKET), .init(SO_REUSEADDR), value: 1)
+            try checkOptionEquivalence(longOption: ChannelOptions.socket(.init(SOL_SOCKET), .init(SO_REUSEADDR)),
+                                       setValue: 1,
+                                       shortOption: .allowImmediateEndpointAddressReuse)
+        #endif
         try checkOptionEquivalence(longOption: ChannelOptions.autoRead,
                                    setValue: false,
                                    shortOption: .disableAutoRead)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -531,7 +531,8 @@ class BootstrapTest: XCTestCase {
     }
     
     func testShorthandOptionsAreEquivalent() throws {
-        func bindAndGetReuseAddrOption(_ applyBootstrapOptions : (ServerBootstrap) -> ServerBootstrap) throws -> ChannelOptions.Types.SocketOption.Value {
+        func bindAndGetReuseAddrOption(_ applyBootstrapOptions : (ServerBootstrap) -> ServerBootstrap) throws ->
+                ChannelOptions.Types.SocketOption.Value {
             let bootstrap = applyBootstrapOptions(ServerBootstrap(group: group))
             let serverChannel = try bootstrap.bind(host: "127.0.0.1", port: 0).wait()
             let reuseValue = try serverChannel.getOption(ChannelOptions.socketOption(.reuseaddr)).wait()
@@ -539,7 +540,8 @@ class BootstrapTest: XCTestCase {
             return reuseValue
         }
         
-        let sbLongReuseValue = try bindAndGetReuseAddrOption { bs in bs.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1) }
+        let sbLongReuseValue = try bindAndGetReuseAddrOption { bs in
+            bs.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1) }
         let sbShortReuseValue = try bindAndGetReuseAddrOption { bs in bs.serverOptions([.reuseAddr])}
         let sbNoReuseValue = try bindAndGetReuseAddrOption { bs in bs }
         

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -542,7 +542,8 @@ class BootstrapTest: XCTestCase {
         
         let sbLongReuseValue = try bindAndGetReuseAddrOption { bs in
             bs.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1) }
-        let sbShortReuseValue = try bindAndGetReuseAddrOption { bs in bs.serverOptions([.allowImmediateEndpointAddressReuse])}
+        let sbShortReuseValue = try bindAndGetReuseAddrOption { bs in
+            	bs.serverOptions([.allowImmediateEndpointAddressReuse])}
         let sbNoReuseValue = try bindAndGetReuseAddrOption { $0 }
         
         XCTAssertEqual(sbLongReuseValue, sbShortReuseValue)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -644,13 +644,16 @@ class BootstrapTest: XCTestCase {
             XCTAssertNotEqual(longSetValue, unsetValue)
         }
         
-        // At least on Darwin the default for clients is to have allow reuse set.
+        // At least on Darwin the default for child is to have allow reuse set - probably inherited from listen
         // try checkOptionEquivalence(longOption: ChannelOptions.socketOption(.reuseaddr),
         //                           setValue: 1,
         //                           shortOption: .allowImmediateEndpointAddressReuse)
         try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
                                    setValue: true,
                                    shortOption: .allowRemoteHalfClosure)
+        // try checkOptionEquivalence(longOption: ChannelOptions.autoRead,
+           //                        setValue: false,
+             //                      shortOption: .disableAutoRead)
     }
     
     func testShorthandOptionsAreEquivalentClient() throws {
@@ -695,6 +698,9 @@ class BootstrapTest: XCTestCase {
         try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
                                    setValue: true,
                                    shortOption: .allowRemoteHalfClosure)
+        try checkOptionEquivalence(longOption: ChannelOptions.autoRead,
+                                   setValue: false,
+                                   shortOption: .disableAutoRead)
     }
     
     func testShorthandOptionsAreEquivalentUniversalClient() throws {
@@ -740,6 +746,9 @@ class BootstrapTest: XCTestCase {
         try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
                                    setValue: true,
                                    shortOption: .allowRemoteHalfClosure)
+        try checkOptionEquivalence(longOption: ChannelOptions.autoRead,
+                                   setValue: false,
+                                   shortOption: .disableAutoRead)
     }
 
     func testShorthandOptionsAreEquivalentDatagram() throws {

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -620,6 +620,51 @@ class BootstrapTest: XCTestCase {
                                    shortOption: .allowRemoteHalfClosure)
     }
     
+    func testShorthandOptionsAreEquivalentUniversalClient() throws {
+        func setAndGetOption<Option>(option: Option, _ applyOptions : (NIOClientTCPBootstrap) -> NIOClientTCPBootstrap) throws
+            -> Option.Value where Option : ChannelOption {
+            var optionRead : EventLoopFuture<Option.Value>?
+            XCTAssertNoThrow(try withTCPServerChannel(group: self.group) { server in
+                var channel: Channel? = nil
+                XCTAssertNoThrow(channel = try applyOptions(NIOClientTCPBootstrap(
+                    ClientBootstrap(group: self.group), tls: NIOInsecureNoTLS()))
+                    .channelInitializer { channel in optionRead = channel.getOption(option)
+                        return channel.eventLoop.makeSucceededFuture(())
+                    }
+                .connect(to: server.localAddress!)
+                .wait())
+                XCTAssertNotNil(optionRead)
+                XCTAssertNotNil(channel)
+                XCTAssertNoThrow(try channel?.close().wait())
+            })
+            return try optionRead!.wait()
+        }
+        
+        func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
+                                            shortOption: NIOClientTCPBootstrap.Option) throws
+            where Option : ChannelOption, Option.Value : Equatable {
+            let longSetValue = try setAndGetOption(
+                option: longOption, { bs in
+                bs.channelOption(longOption, value: setValue) })
+            let shortSetValue = try setAndGetOption(
+                option: longOption, { bs in
+                    bs.channelOptions([shortOption])})
+            let unsetValue = try setAndGetOption(
+                option: longOption,
+                { $0 })
+            
+            XCTAssertEqual(longSetValue, shortSetValue)
+            XCTAssertNotEqual(longSetValue, unsetValue)
+        }
+        
+        try checkOptionEquivalence(longOption: ChannelOptions.socketOption(.reuseaddr),
+                                   setValue: 1,
+                                   shortOption: .allowImmediateEndpointAddressReuse)
+        try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
+                                   setValue: true,
+                                   shortOption: .allowRemoteHalfClosure)
+    }
+    
     func testShorthandOptionsAreEquivalentDatagram() throws {
         func setAndGetOption<Option>(option: Option, _ applyOptions : (DatagramBootstrap) -> DatagramBootstrap) throws
             -> Option.Value where Option : ChannelOption {

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -531,7 +531,7 @@ class BootstrapTest: XCTestCase {
     }
     
     func testShorthandOptionsAreEquivalent() throws {
-        func bindAndGetReuseAddrOption(applyBootstrapOptions : (ServerBootstrap) -> ServerBootstrap) throws -> ChannelOptions.Types.SocketOption.Value {
+        func bindAndGetReuseAddrOption(_ applyBootstrapOptions : (ServerBootstrap) -> ServerBootstrap) throws -> ChannelOptions.Types.SocketOption.Value {
             let bootstrap = applyBootstrapOptions(ServerBootstrap(group: group))
             let serverChannel = try bootstrap.bind(host: "127.0.0.1", port: 0).wait()
             let reuseValue = try serverChannel.getOption(ChannelOptions.socketOption(.reuseaddr)).wait()
@@ -539,9 +539,9 @@ class BootstrapTest: XCTestCase {
             return reuseValue
         }
         
-        let sbLongReuseValue = try bindAndGetReuseAddrOption(applyBootstrapOptions: { bs in bs.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1) })
-        let sbShortReuseValue = try bindAndGetReuseAddrOption(applyBootstrapOptions: { bs in bs.serverOptions([.reuseAddr])})
-        let sbNoReuseValue = try bindAndGetReuseAddrOption(applyBootstrapOptions: { bs in bs })
+        let sbLongReuseValue = try bindAndGetReuseAddrOption { bs in bs.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1) }
+        let sbShortReuseValue = try bindAndGetReuseAddrOption { bs in bs.serverOptions([.reuseAddr])}
+        let sbNoReuseValue = try bindAndGetReuseAddrOption { bs in bs }
         
         XCTAssertEqual(sbLongReuseValue, sbShortReuseValue)
         XCTAssertNotEqual(sbLongReuseValue, sbNoReuseValue)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -542,7 +542,7 @@ class BootstrapTest: XCTestCase {
         }
         
         func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
-                                            shortOption: ServerBootstrap.ServerOption) throws
+                                            shortOption: NIOTCPServerShorthandOption) throws
             where Option : ChannelOption, Option.Value : Equatable {
             let longSetValue = try bindAndGetOption(option: longOption) { bs in
                 bs.serverChannelOption(longOption, value: setValue)
@@ -760,7 +760,7 @@ class BootstrapTest: XCTestCase {
         }
         
         func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
-                                            shortOption: DatagramBootstrap.Option) throws
+                                            shortOption: NIOUDPShorthandOption) throws
             where Option : ChannelOption, Option.Value : Equatable {
             let longSetValue = try setAndGetOption(option: longOption) { bs in
                 bs.channelOption(longOption, value: setValue)
@@ -811,7 +811,7 @@ class BootstrapTest: XCTestCase {
         }
         
         func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
-                                            shortOption: NIOPipeBootstrap.Option) throws
+                                            shortOption: NIOPipeShorthandOption) throws
             where Option : ChannelOption, Option.Value : Equatable {
             let longSetValue = try setAndGetOption(option: longOption) { bs in
                 bs.channelOption(longOption, value: setValue)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -221,7 +221,7 @@ class BootstrapTest: XCTestCase {
         func restrictBootstrapType(clientBootstrap: NIOClientTCPBootstrap) throws {
             let serverAcceptedChannelPromise = group.next().makePromise(of: Channel.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.allowImmediateEndpointAddressReuse])
+                .serverChannelOptions([.allowImmediateEndpointAddressReuse])
                 .childChannelInitializer { channel in
                     serverAcceptedChannelPromise.succeed(channel)
                     return channel.eventLoop.makeSucceededFuture(())
@@ -269,7 +269,7 @@ class BootstrapTest: XCTestCase {
     func testServerBootstrapSetsChannelOptionsBeforeChannelInitializer() {
         var channel: Channel? = nil
         XCTAssertNoThrow(channel = try ServerBootstrap(group: self.group)
-            .serverOptions([.disableAutoRead])
+            .serverChannelOptions([.disableAutoRead])
             .serverChannelInitializer { channel in
                 channel.getOption(ChannelOptions.autoRead).whenComplete { result in
                     func workaround() {
@@ -548,7 +548,7 @@ class BootstrapTest: XCTestCase {
                 bs.serverChannelOption(longOption, value: setValue)
             }
             let shortSetValue = try bindAndGetOption(option: longOption) { bs in
-                bs.serverOptions([shortOption])
+                bs.serverChannelOptions([shortOption])
             }
             let unsetValue = try bindAndGetOption(option: longOption) { $0 }
             
@@ -598,7 +598,7 @@ class BootstrapTest: XCTestCase {
                 let clientBootstrap = ClientBootstrap(group: group)
                 let serverAcceptedChannelPromise = group.next().makePromise(of: Channel.self)
                 let serverChannel = try assertNoThrowWithValue(applyOptions(ServerBootstrap(group: group))
-                    .serverOptions([.allowImmediateEndpointAddressReuse])
+                    .serverChannelOptions([.allowImmediateEndpointAddressReuse])
                     .childChannelInitializer { channel in
                         optionRead = channel.getOption(option)
                         serverAcceptedChannelPromise.succeed(channel)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -627,7 +627,7 @@ class BootstrapTest: XCTestCase {
         }
         
         func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
-                                            shortOption: ServerBootstrap.ChildOption) throws
+                                            shortOption: NIOTCPShorthandOption) throws
             where Option : ChannelOption, Option.Value : Equatable {
             
             let longSetValue = try setAndGetOption(
@@ -676,7 +676,7 @@ class BootstrapTest: XCTestCase {
         }
         
         func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
-                                            shortOption: ClientBootstrap.Option) throws
+                                            shortOption: NIOTCPShorthandOption) throws
             where Option : ChannelOption, Option.Value : Equatable {
             let longSetValue = try setAndGetOption(
                 option: longOption, { bs in
@@ -724,7 +724,7 @@ class BootstrapTest: XCTestCase {
         }
         
         func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
-                                            shortOption: NIOClientTCPBootstrap.Option) throws
+                                            shortOption: NIOTCPShorthandOption) throws
             where Option : ChannelOption, Option.Value : Equatable {
             let longSetValue = try setAndGetOption(
                 option: longOption, { bs in

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -221,7 +221,7 @@ class BootstrapTest: XCTestCase {
         func restrictBootstrapType(clientBootstrap: NIOClientTCPBootstrap) throws {
             let serverAcceptedChannelPromise = group.next().makePromise(of: Channel.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.reuseAddr])
+                .serverOptions([.allowImmediateEndpointAddressReuse])
                 .childChannelInitializer { channel in
                     serverAcceptedChannelPromise.succeed(channel)
                     return channel.eventLoop.makeSucceededFuture(())
@@ -542,7 +542,7 @@ class BootstrapTest: XCTestCase {
         
         let sbLongReuseValue = try bindAndGetReuseAddrOption { bs in
             bs.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1) }
-        let sbShortReuseValue = try bindAndGetReuseAddrOption { bs in bs.serverOptions([.reuseAddr])}
+        let sbShortReuseValue = try bindAndGetReuseAddrOption { bs in bs.serverOptions([.allowImmediateEndpointAddressReuse])}
         let sbNoReuseValue = try bindAndGetReuseAddrOption { $0 }
         
         XCTAssertEqual(sbLongReuseValue, sbShortReuseValue)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -543,7 +543,7 @@ class BootstrapTest: XCTestCase {
         let sbLongReuseValue = try bindAndGetReuseAddrOption { bs in
             bs.serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1) }
         let sbShortReuseValue = try bindAndGetReuseAddrOption { bs in bs.serverOptions([.reuseAddr])}
-        let sbNoReuseValue = try bindAndGetReuseAddrOption { bs in bs }
+        let sbNoReuseValue = try bindAndGetReuseAddrOption { $0 }
         
         XCTAssertEqual(sbLongReuseValue, sbShortReuseValue)
         XCTAssertNotEqual(sbLongReuseValue, sbNoReuseValue)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -340,7 +340,7 @@ class BootstrapTest: XCTestCase {
     func testDatagramBootstrapSetsChannelOptionsBeforeChannelInitializer() {
         var channel: Channel? = nil
         XCTAssertNoThrow(channel = try DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.autoRead, value: false)
+            .channelOptions([.disableAutoRead])
             .channelInitializer { channel in
                 channel.getOption(ChannelOptions.autoRead).whenComplete { result in
                     func workaround() {

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -294,7 +294,7 @@ class ChannelNotificationTest: XCTestCase {
         let acceptedChannelPromise = group.next().makePromise(of: Channel.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .serverChannelInitializer { channel in
                 channel.pipeline.addHandler(ServerSocketChannelLifecycleVerificationHandler())
             }
@@ -376,7 +376,7 @@ class ChannelNotificationTest: XCTestCase {
 
         let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: true)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(OrderVerificationHandler(promise))

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -294,7 +294,7 @@ class ChannelNotificationTest: XCTestCase {
         let acceptedChannelPromise = group.next().makePromise(of: Channel.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .serverChannelInitializer { channel in
                 channel.pipeline.addHandler(ServerSocketChannelLifecycleVerificationHandler())
             }
@@ -376,7 +376,7 @@ class ChannelNotificationTest: XCTestCase {
 
         let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: true)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(OrderVerificationHandler(promise))

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -80,7 +80,7 @@ public final class ChannelTests: XCTestCase {
         let serverAcceptedChannelPromise = group.next().makePromise(of: Channel.self)
         let serverLifecycleHandler = ChannelLifecycleHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 serverAcceptedChannelPromise.succeed(channel)
                 return channel.pipeline.addHandler(serverLifecycleHandler)
@@ -118,7 +118,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -147,7 +147,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -181,7 +181,7 @@ public final class ChannelTests: XCTestCase {
 
         let childChannelPromise = group.next().makePromise(of: Channel.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 childChannelPromise.succeed(channel)
                 return channel.eventLoop.makeSucceededFuture(())
@@ -1350,7 +1350,7 @@ public final class ChannelTests: XCTestCase {
         try {
             let serverChildChannelPromise = group.next().makePromise(of: Channel.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.reuseAddr])
+                .serverOptions([.allowImmediateEndpointAddressReuse])
                 .childChannelInitializer { channel in
                     serverChildChannelPromise.succeed(channel)
                     channel.close(promise: nil)
@@ -1406,7 +1406,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -1445,7 +1445,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(AddressVerificationHandler())
             }
@@ -1509,7 +1509,7 @@ public final class ChannelTests: XCTestCase {
         let readDelayer = ReadDelayer()
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer {
                 $0.pipeline.addHandler(readDelayer)
             }
@@ -1565,7 +1565,7 @@ public final class ChannelTests: XCTestCase {
 
         let handler = VerifyNoReadBeforeEOFHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(handler)
@@ -1621,7 +1621,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(VerifyEOFReadOrderingAndCloseInChannelReadHandler())
@@ -1679,7 +1679,7 @@ public final class ChannelTests: XCTestCase {
 
         let allDone = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(CloseWhenWeGetEOFHandler(allDone: allDone))
@@ -1737,7 +1737,7 @@ public final class ChannelTests: XCTestCase {
 
         let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(ChannelInactiveVerificationHandler(promise))
@@ -2314,7 +2314,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "localhost", port: 0)
             .wait())
 
@@ -2563,7 +2563,7 @@ public final class ChannelTests: XCTestCase {
                                                              singleThreadedELG.next().makePromise(),
                                                              singleThreadedELG.next().makePromise()]
         let server = try assertNoThrowWithValue(ServerBootstrap(group: singleThreadedELG)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .serverChannelOption(ChannelOptions.socketOption(.timestamp), value: 1)
             .childChannelOption(ChannelOptions.socketOption(.keepalive), value: 1)
             .childChannelOption(ChannelOptions.tcpOption(.nodelay), value: 0)
@@ -2581,7 +2581,7 @@ public final class ChannelTests: XCTestCase {
         XCTAssertTrue(try getBoolSocketOption(channel: server, level: .socket, name: .timestamp))
 
         let client1 = try assertNoThrowWithValue(ClientBootstrap(group: singleThreadedELG)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .channelOption(ChannelOptions.tcpOption(.nodelay), value: 0)
             .connect(to: server.localAddress!)
             .wait())
@@ -2590,7 +2590,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try client1.close().wait())
         }
         let client2 = try assertNoThrowWithValue(ClientBootstrap(group: singleThreadedELG)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .connect(to: server.localAddress!)
             .wait())
         let accepted2 = try assertNoThrowWithValue(acceptedChannels[0].futureResult.wait())
@@ -2761,7 +2761,7 @@ public final class ChannelTests: XCTestCase {
 
         var maybeServer: Channel? = nil
         XCTAssertNoThrow(maybeServer = try ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0)
             .wait())
         guard let server = maybeServer else {

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -80,7 +80,7 @@ public final class ChannelTests: XCTestCase {
         let serverAcceptedChannelPromise = group.next().makePromise(of: Channel.self)
         let serverLifecycleHandler = ChannelLifecycleHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 serverAcceptedChannelPromise.succeed(channel)
                 return channel.pipeline.addHandler(serverLifecycleHandler)
@@ -118,7 +118,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -147,7 +147,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -181,7 +181,7 @@ public final class ChannelTests: XCTestCase {
 
         let childChannelPromise = group.next().makePromise(of: Channel.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 childChannelPromise.succeed(channel)
                 return channel.eventLoop.makeSucceededFuture(())
@@ -1350,7 +1350,7 @@ public final class ChannelTests: XCTestCase {
         try {
             let serverChildChannelPromise = group.next().makePromise(of: Channel.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.allowImmediateEndpointAddressReuse])
+                .serverChannelOptions([.allowImmediateEndpointAddressReuse])
                 .childChannelInitializer { channel in
                     serverChildChannelPromise.succeed(channel)
                     channel.close(promise: nil)
@@ -1406,7 +1406,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -1445,7 +1445,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(AddressVerificationHandler())
             }
@@ -1509,7 +1509,7 @@ public final class ChannelTests: XCTestCase {
         let readDelayer = ReadDelayer()
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer {
                 $0.pipeline.addHandler(readDelayer)
             }
@@ -1565,7 +1565,7 @@ public final class ChannelTests: XCTestCase {
 
         let handler = VerifyNoReadBeforeEOFHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(handler)
@@ -1621,7 +1621,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(VerifyEOFReadOrderingAndCloseInChannelReadHandler())
@@ -1679,7 +1679,7 @@ public final class ChannelTests: XCTestCase {
 
         let allDone = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(CloseWhenWeGetEOFHandler(allDone: allDone))
@@ -1737,7 +1737,7 @@ public final class ChannelTests: XCTestCase {
 
         let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(ChannelInactiveVerificationHandler(promise))
@@ -2314,7 +2314,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "localhost", port: 0)
             .wait())
 
@@ -2563,7 +2563,7 @@ public final class ChannelTests: XCTestCase {
                                                              singleThreadedELG.next().makePromise(),
                                                              singleThreadedELG.next().makePromise()]
         let server = try assertNoThrowWithValue(ServerBootstrap(group: singleThreadedELG)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .serverChannelOption(ChannelOptions.socketOption(.timestamp), value: 1)
             .childChannelOption(ChannelOptions.socketOption(.keepalive), value: 1)
             .childChannelOption(ChannelOptions.tcpOption(.nodelay), value: 0)
@@ -2761,7 +2761,7 @@ public final class ChannelTests: XCTestCase {
 
         var maybeServer: Channel? = nil
         XCTAssertNoThrow(maybeServer = try ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0)
             .wait())
         guard let server = maybeServer else {

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -108,7 +108,7 @@ final class DatagramChannelTests: XCTestCase {
 
     private func buildChannel(group: EventLoopGroup) throws -> Channel {
         return try DatagramBootstrap(group: group)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .channelInitializer { channel in
                 channel.pipeline.addHandler(DatagramReadRecorder<ByteBuffer>(), name: "ByteReadRecorder")
             }
@@ -520,7 +520,7 @@ final class DatagramChannelTests: XCTestCase {
 
     func testSettingTwoDistinctChannelOptionsWorksForDatagramChannel() throws {
         let channel = try assertNoThrowWithValue(DatagramBootstrap(group: group)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .channelOption(ChannelOptions.socketOption(.timestamp), value: 1)
             .bind(host: "127.0.0.1", port: 0)
             .wait())

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -108,7 +108,7 @@ final class DatagramChannelTests: XCTestCase {
 
     private func buildChannel(group: EventLoopGroup) throws -> Channel {
         return try DatagramBootstrap(group: group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOptions([.reuseAddr])
             .channelInitializer { channel in
                 channel.pipeline.addHandler(DatagramReadRecorder<ByteBuffer>(), name: "ByteReadRecorder")
             }
@@ -520,7 +520,7 @@ final class DatagramChannelTests: XCTestCase {
 
     func testSettingTwoDistinctChannelOptionsWorksForDatagramChannel() throws {
         let channel = try assertNoThrowWithValue(DatagramBootstrap(group: group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOptions([.reuseAddr])
             .channelOption(ChannelOptions.socketOption(.timestamp), value: 1)
             .bind(host: "127.0.0.1", port: 0)
             .wait())

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -27,7 +27,7 @@ class EchoServerClientTest : XCTestCase {
         let numBytes = 16 * 1024
         let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
 
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(countingHandler)
@@ -63,7 +63,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(WriteALotHandler())
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -99,7 +99,7 @@ class EchoServerClientTest : XCTestCase {
             let numBytes = 16 * 1024
             let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.allowImmediateEndpointAddressReuse])
+                .serverChannelOptions([.allowImmediateEndpointAddressReuse])
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -141,7 +141,7 @@ class EchoServerClientTest : XCTestCase {
             let numBytes = 16 * 1024
             let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.allowImmediateEndpointAddressReuse])
+                .serverChannelOptions([.allowImmediateEndpointAddressReuse])
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -180,7 +180,7 @@ class EchoServerClientTest : XCTestCase {
 
         let handler = ChannelActiveHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -205,7 +205,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(EchoServer())
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -401,7 +401,7 @@ class EchoServerClientTest : XCTestCase {
                                                                    channelInactivePromise: inactivePromise)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
 
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(handler)
@@ -435,7 +435,7 @@ class EchoServerClientTest : XCTestCase {
         let bytesReceivedPromise = group.next().makePromise(of: ByteBuffer.self)
         let byteCountingHandler = ByteCountingHandler(numBytes: writingBytes.utf8.count, promise: bytesReceivedPromise)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 // When we've received all the bytes we know the connection is up. Remove the handler.
                 _ = bytesReceivedPromise.futureResult.flatMap { (_: ByteBuffer) in
@@ -479,7 +479,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(EchoServer())
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -513,7 +513,7 @@ class EchoServerClientTest : XCTestCase {
 
         let stringToWrite = "hello"
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(WriteOnConnectHandler(toWrite: stringToWrite))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -546,7 +546,7 @@ class EchoServerClientTest : XCTestCase {
 
         dpGroup.enter()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(EchoAndEchoAgainAfterSomeTimeServer(time: .seconds(1), secondWriteDoneHandler: {
                     dpGroup.leave()
@@ -638,7 +638,7 @@ class EchoServerClientTest : XCTestCase {
             }
         }
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(WriteWhenActiveHandler(str, dpGroup))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -700,7 +700,7 @@ class EchoServerClientTest : XCTestCase {
         let promise = group.next().makePromise(of: Void.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(ErrorHandler(promise))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -730,7 +730,7 @@ class EchoServerClientTest : XCTestCase {
             let serverChannel: Channel
             do {
                 serverChannel = try ServerBootstrap(group: group)
-                    .serverOptions([.allowImmediateEndpointAddressReuse])
+                    .serverChannelOptions([.allowImmediateEndpointAddressReuse])
                     .childChannelInitializer { channel in
                         acceptedRemotePort.store(channel.remoteAddress?.port ?? -3)
                         acceptedLocalPort.store(channel.localAddress?.port ?? -4)
@@ -781,7 +781,7 @@ class EchoServerClientTest : XCTestCase {
 
         // we're binding to IPv4 only
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(countingHandler)
             }

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -27,7 +27,7 @@ class EchoServerClientTest : XCTestCase {
         let numBytes = 16 * 1024
         let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
 
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(countingHandler)
@@ -63,7 +63,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(WriteALotHandler())
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -99,7 +99,7 @@ class EchoServerClientTest : XCTestCase {
             let numBytes = 16 * 1024
             let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.reuseAddr])
+                .serverOptions([.allowImmediateEndpointAddressReuse])
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -141,7 +141,7 @@ class EchoServerClientTest : XCTestCase {
             let numBytes = 16 * 1024
             let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.reuseAddr])
+                .serverOptions([.allowImmediateEndpointAddressReuse])
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -180,7 +180,7 @@ class EchoServerClientTest : XCTestCase {
 
         let handler = ChannelActiveHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -205,7 +205,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(EchoServer())
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -401,7 +401,7 @@ class EchoServerClientTest : XCTestCase {
                                                                    channelInactivePromise: inactivePromise)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
 
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(handler)
@@ -435,7 +435,7 @@ class EchoServerClientTest : XCTestCase {
         let bytesReceivedPromise = group.next().makePromise(of: ByteBuffer.self)
         let byteCountingHandler = ByteCountingHandler(numBytes: writingBytes.utf8.count, promise: bytesReceivedPromise)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 // When we've received all the bytes we know the connection is up. Remove the handler.
                 _ = bytesReceivedPromise.futureResult.flatMap { (_: ByteBuffer) in
@@ -479,7 +479,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(EchoServer())
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -513,7 +513,7 @@ class EchoServerClientTest : XCTestCase {
 
         let stringToWrite = "hello"
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(WriteOnConnectHandler(toWrite: stringToWrite))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -546,7 +546,7 @@ class EchoServerClientTest : XCTestCase {
 
         dpGroup.enter()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(EchoAndEchoAgainAfterSomeTimeServer(time: .seconds(1), secondWriteDoneHandler: {
                     dpGroup.leave()
@@ -638,7 +638,7 @@ class EchoServerClientTest : XCTestCase {
             }
         }
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(WriteWhenActiveHandler(str, dpGroup))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -700,7 +700,7 @@ class EchoServerClientTest : XCTestCase {
         let promise = group.next().makePromise(of: Void.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(ErrorHandler(promise))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -730,7 +730,7 @@ class EchoServerClientTest : XCTestCase {
             let serverChannel: Channel
             do {
                 serverChannel = try ServerBootstrap(group: group)
-                    .serverOptions([.reuseAddr])
+                    .serverOptions([.allowImmediateEndpointAddressReuse])
                     .childChannelInitializer { channel in
                         acceptedRemotePort.store(channel.remoteAddress?.port ?? -3)
                         acceptedLocalPort.store(channel.localAddress?.port ?? -4)
@@ -781,7 +781,7 @@ class EchoServerClientTest : XCTestCase {
 
         // we're binding to IPv4 only
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(countingHandler)
             }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -43,7 +43,7 @@ public final class EventLoopTest : XCTestCase {
 
         // First, we create a server and client channel, but don't connect them.
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: eventLoopGroup)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
         let clientBootstrap = ClientBootstrap(group: eventLoopGroup)
 
@@ -354,7 +354,7 @@ public final class EventLoopTest : XCTestCase {
 
         // Create a server channel.
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         // We now want to connect to it. To try to slow this stuff down, we're going to use a multiple of the number
@@ -978,7 +978,7 @@ public final class EventLoopTest : XCTestCase {
         g.enter()
         var maybeServer: Channel?
         XCTAssertNoThrow(maybeServer = try ServerBootstrap(group: elg2)
-            .serverOptions([.reuseAddr, .disableAutoRead])
+            .serverOptions([.allowImmediateEndpointAddressReuse, .disableAutoRead])
             .serverChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(ExecuteSomethingOnEventLoop(groupToNotify: g))

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -43,7 +43,7 @@ public final class EventLoopTest : XCTestCase {
 
         // First, we create a server and client channel, but don't connect them.
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: eventLoopGroup)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
         let clientBootstrap = ClientBootstrap(group: eventLoopGroup)
 
@@ -354,7 +354,7 @@ public final class EventLoopTest : XCTestCase {
 
         // Create a server channel.
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         // We now want to connect to it. To try to slow this stuff down, we're going to use a multiple of the number
@@ -978,7 +978,7 @@ public final class EventLoopTest : XCTestCase {
         g.enter()
         var maybeServer: Channel?
         XCTAssertNoThrow(maybeServer = try ServerBootstrap(group: elg2)
-            .serverOptions([.allowImmediateEndpointAddressReuse, .disableAutoRead])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse, .disableAutoRead])
             .serverChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(ExecuteSomethingOnEventLoop(groupToNotify: g))

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -34,7 +34,7 @@ class FileRegionTest : XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
@@ -74,7 +74,7 @@ class FileRegionTest : XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: 0, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
@@ -125,7 +125,7 @@ class FileRegionTest : XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -34,7 +34,7 @@ class FileRegionTest : XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
@@ -74,7 +74,7 @@ class FileRegionTest : XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: 0, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
@@ -125,7 +125,7 @@ class FileRegionTest : XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -75,7 +75,7 @@ class IdleStateHandlerTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse])
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(handler).flatMap { f in
                     channel.pipeline.addHandler(TestWriteHandler(writeToChannel, assertEventFn))

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -75,7 +75,7 @@ class IdleStateHandlerTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr])
+            .serverOptions([.allowImmediateEndpointAddressReuse])
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(handler).flatMap { f in
                     channel.pipeline.addHandler(TestWriteHandler(writeToChannel, assertEventFn))

--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -68,7 +68,7 @@ final class MulticastTest: XCTestCase {
 
     private func bindMulticastChannel(host: String, port: Int, multicastAddress: String, interface: NIONetworkInterface) -> EventLoopFuture<MulticastChannel> {
         return DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOptions([.reuseAddr])
             .bind(host: host, port: port)
             .flatMap { channel in
                 let channel = channel as! MulticastChannel
@@ -207,7 +207,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOptions([.reuseAddr])
             .bind(host: "127.0.0.1", port: 0)
             .wait()
         )
@@ -266,7 +266,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOptions([.reuseAddr])
             .bind(host: "::1", port: 0)
             .wait()
         )
@@ -300,7 +300,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOptions([.reuseAddr])
             .bind(host: "127.0.0.1", port: 0)
             .wait()
         )
@@ -342,7 +342,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOptions([.reuseAddr])
             .bind(host: "::1", port: 0)
             .wait()
         )

--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -68,7 +68,7 @@ final class MulticastTest: XCTestCase {
 
     private func bindMulticastChannel(host: String, port: Int, multicastAddress: String, interface: NIONetworkInterface) -> EventLoopFuture<MulticastChannel> {
         return DatagramBootstrap(group: self.group)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: host, port: port)
             .flatMap { channel in
                 let channel = channel as! MulticastChannel
@@ -207,7 +207,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0)
             .wait()
         )
@@ -266,7 +266,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "::1", port: 0)
             .wait()
         )
@@ -300,7 +300,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "127.0.0.1", port: 0)
             .wait()
         )
@@ -342,7 +342,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOptions([.reuseAddr])
+            .channelOptions([.allowImmediateEndpointAddressReuse])
             .bind(host: "::1", port: 0)
             .wait()
         )

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -71,7 +71,7 @@ public final class SocketChannelTest : XCTestCase {
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.allowImmediateEndpointAddressReuse,
+            .serverChannelOptions([.allowImmediateEndpointAddressReuse,
                             .maximumUnacceptedConnectionBacklog(256)])
             .bind(host: "127.0.0.1", port: 0).wait())
 
@@ -577,7 +577,7 @@ public final class SocketChannelTest : XCTestCase {
             // Build server channel; after this point the server called listen()
             let serverPromise = group.next().makePromise(of: IOError.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.allowImmediateEndpointAddressReuse,
+                .serverChannelOptions([.allowImmediateEndpointAddressReuse,
                                 .maximumUnacceptedConnectionBacklog(256),
                                 .disableAutoRead])
                 .serverChannelInitializer { channel in channel.pipeline.addHandler(ErrorHandler(serverPromise)) }

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -71,7 +71,8 @@ public final class SocketChannelTest : XCTestCase {
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverOptions([.reuseAddr, .backlog(256)])
+            .serverOptions([.allowImmediateEndpointAddressReuse,
+                            .maximumUnacceptedConnectionBacklog(256)])
             .bind(host: "127.0.0.1", port: 0).wait())
 
         // The goal of this test is to try to trigger at least one channel to have connection setup that is not
@@ -576,7 +577,9 @@ public final class SocketChannelTest : XCTestCase {
             // Build server channel; after this point the server called listen()
             let serverPromise = group.next().makePromise(of: IOError.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverOptions([.reuseAddr, .backlog(256), .disableAutoRead])
+                .serverOptions([.allowImmediateEndpointAddressReuse,
+                                .maximumUnacceptedConnectionBacklog(256),
+                                .disableAutoRead])
                 .serverChannelInitializer { channel in channel.pipeline.addHandler(ErrorHandler(serverPromise)) }
                 .bind(host: "127.0.0.1", port: 0)
                 .wait())

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -523,7 +523,7 @@ func withTCPServerChannel<R>(bindTarget: SocketAddress? = nil,
                              line: UInt = #line,
                              _ body: (Channel) throws -> R) throws -> R {
     let server = try ServerBootstrap(group: group)
-        .serverOptions([.reuseAddr])
+        .serverOptions([.allowImmediateEndpointAddressReuse])
         .bind(to: bindTarget ?? .init(ipAddress: "127.0.0.1", port: 0))
         .wait()
     do {

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -523,7 +523,7 @@ func withTCPServerChannel<R>(bindTarget: SocketAddress? = nil,
                              line: UInt = #line,
                              _ body: (Channel) throws -> R) throws -> R {
     let server = try ServerBootstrap(group: group)
-        .serverOptions([.allowImmediateEndpointAddressReuse])
+        .serverChannelOptions([.allowImmediateEndpointAddressReuse])
         .bind(to: bindTarget ?? .init(ipAddress: "127.0.0.1", port: 0))
         .wait()
     do {

--- a/Tests/NIOTests/UniversalBootstrapSupportTest+XCTest.swift
+++ b/Tests/NIOTests/UniversalBootstrapSupportTest+XCTest.swift
@@ -28,6 +28,7 @@ extension UniversalBootstrapSupportTest {
    static var allTests : [(String, (UniversalBootstrapSupportTest) -> () throws -> Void)] {
       return [
                 ("testBootstrappingWorks", testBootstrappingWorks),
+                ("testBootstrapOverrideOfShortcutOptions", testBootstrapOverrideOfShortcutOptions),
            ]
    }
 }

--- a/Tests/NIOTests/UniversalBootstrapSupportTest.swift
+++ b/Tests/NIOTests/UniversalBootstrapSupportTest.swift
@@ -135,4 +135,68 @@ class UniversalBootstrapSupportTest: XCTestCase {
             XCTAssertEqual(0, counter2.channelReadCalls)
         })
     }
+    
+    func testBootstrapOverrideOfShortcutOptions() {
+        final class FakeBootstrap : NIOClientTCPBootstrapProtocol {
+            func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self {
+                fatalError("Not implemented")
+            }
+            
+            func protocolHandlers(_ handlers: @escaping () -> [ChannelHandler]) -> Self {
+                fatalError("Not implemented")
+            }
+            
+            var regularOptionsSeen = false
+            func channelOption<Option>(_ option: Option, value: Option.Value) -> Self where Option : ChannelOption {
+                regularOptionsSeen = true
+                return self
+            }
+            
+            var shorthandOptionConsumed = false
+            func applyChannelOption(_ option: NIOTCPShorthandOption) -> FakeBootstrap? {
+                if option == .allowImmediateEndpointAddressReuse {
+                    shorthandOptionConsumed = true
+                    return self
+                }
+                return .none
+            }
+            
+            func connectTimeout(_ timeout: TimeAmount) -> Self {
+                fatalError("Not implemented")
+            }
+            
+            func connect(host: String, port: Int) -> EventLoopFuture<Channel> {
+                fatalError("Not implemented")
+            }
+            
+            func connect(to address: SocketAddress) -> EventLoopFuture<Channel> {
+                fatalError("Not implemented")
+            }
+            
+            func connect(unixDomainSocketPath: String) -> EventLoopFuture<Channel> {
+                fatalError("Not implemented")
+            }
+        }
+        
+        // Check consumption works.
+        let consumingFake = FakeBootstrap()
+        _ = NIOClientTCPBootstrap(consumingFake, tls: NIOInsecureNoTLS())
+            .channelOptions([.allowImmediateEndpointAddressReuse])
+        XCTAssertTrue(consumingFake.shorthandOptionConsumed)
+        XCTAssertFalse(consumingFake.regularOptionsSeen)
+        
+        // Check default behaviour works.
+        let nonConsumingFake = FakeBootstrap()
+        _ = NIOClientTCPBootstrap(nonConsumingFake, tls: NIOInsecureNoTLS())
+            .channelOptions([.allowRemoteHalfClosure])
+        XCTAssertFalse(nonConsumingFake.shorthandOptionConsumed)
+        XCTAssertTrue(nonConsumingFake.regularOptionsSeen)
+        
+        // Both at once.
+        let bothFake = FakeBootstrap()
+        _ = NIOClientTCPBootstrap(bothFake, tls: NIOInsecureNoTLS())
+            .channelOptions([.allowRemoteHalfClosure, .allowImmediateEndpointAddressReuse])
+        XCTAssertTrue(bothFake.shorthandOptionConsumed)
+        XCTAssertTrue(bothFake.regularOptionsSeen)
+    }
 }


### PR DESCRIPTION
Allow bootstraps to override TCP shorthand options from universal.

### Motivation:

Some underlying bootstraps may know how to interpret the common shorthand options in a better way than translating to the default socket options.

### Modifications:

Add a method and default implementation to NIOClientTCPBootstrapProtocol to optionally interpret options.  Default implementation always reports failure.
Add a test to prove it is possible to consume options in this way and that the default is still to arrive as channel options.

### Result:

It is now possible to override interpretation of shorthand channel options when applied through universal bootstrap.
