### PR TITLE
Make some vars lets.

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -365,7 +365,7 @@ class BaseSocket: BaseSocketProtocol {
                                                                  alignment: MemoryLayout<T>.alignment)
             // write zeroes into the memory as Linux's getsockopt doesn't zero them out
             storage.initializeMemory(as: UInt8.self, repeating: 0)
-            var val = storage.bindMemory(to: T.self).baseAddress!
+            let val = storage.bindMemory(to: T.self).baseAddress!
             // initialisation will be done by getsockopt
             defer {
                 val.deinitialize(count: 1)

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -2270,7 +2270,7 @@ class ByteBufferTest: XCTestCase {
     }
 
     func testGetDispatchDataReadWrite() {
-        var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: 0)
+        let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: 0)
         buffer.copyBytes(from: "1234".utf8)
         defer {
             buffer.deallocate()


### PR DESCRIPTION
Motivation:

Newer Swift 5.3 snapshots have spotted more vars that could be lets.

Modifications:

Made two vars lets.

Result:

The word `let` appears more frequently; the word `var`, less so.

Fixes #1492 
