### PR TITLE
UDPEchoClient to close channel after response received.

### DIFF
--- a/Sources/NIOUDPEchoClient/main.swift
+++ b/Sources/NIOUDPEchoClient/main.swift
@@ -59,6 +59,7 @@ private final class EchoHandler: ChannelInboundHandler {
         if self.numBytes <= 0 {
             let string = String(buffer: byteBuffer)
             print("Received: '\(string)' back from the server, closing channel.")
+            context.close(promise: nil)
         }
     }
     


### PR DESCRIPTION
Close channel after UCPEchoClient received a response.

### Motivation:

The application does not shutdown without doing this.

### Modifications:

Close channel after receiving data.

### Result:

Application exits after receiving data.
