### PR TITLE
Add Optional ECN MetaData to Addressed Envelope

### DIFF
--- a/Sources/NIO/AddressedEnvelope.swift
+++ b/Sources/NIO/AddressedEnvelope.swift
@@ -20,7 +20,7 @@
 public struct AddressedEnvelope<DataType> {
     public var remoteAddress: SocketAddress
     public var data: DataType
-    public var metaData : MetaData? = .none
+    public var metaData : MetaData? = nil
 
     public init(remoteAddress: SocketAddress, data: DataType) {
         self.remoteAddress = remoteAddress
@@ -28,7 +28,7 @@ public struct AddressedEnvelope<DataType> {
     }
     
     public struct MetaData {
-        public var ecnEventInProgress : Bool
+        public var ecnEventInProgress : NIOEcnState
     }
 }
 
@@ -36,4 +36,16 @@ extension AddressedEnvelope: CustomStringConvertible {
     public var description: String {
         return "AddressedEnvelope { remoteAddress: \(self.remoteAddress), data: \(self.data) }"
     }
+}
+
+/// Possible ECN States
+public enum NIOEcnState {
+    /// Non-ECN Capable Transport.
+    case nonECT
+    /// ECN Capable Transport (flag 0).
+    case ect0
+    /// ECN Capable Transport (flag 1).
+    case ect1
+    /// Congestion Experienced.
+    case ce
 }

--- a/Sources/NIO/AddressedEnvelope.swift
+++ b/Sources/NIO/AddressedEnvelope.swift
@@ -20,14 +20,16 @@
 public struct AddressedEnvelope<DataType> {
     public var remoteAddress: SocketAddress
     public var data: DataType
-    internal var metaData : MetaData? = nil
+    /// Any MetaData associated with this `AddressedEnvelope`
+    public var metaData : MetaData? = nil
 
     public init(remoteAddress: SocketAddress, data: DataType) {
         self.remoteAddress = remoteAddress
         self.data = data
     }
     
-    internal struct MetaData {
+    /// Any MetaData associated with an AddressedEnvelope
+    public struct MetaData {
         /// Details of any congestion state.
         public var ecnState : NIOEcnState
     }
@@ -40,7 +42,7 @@ extension AddressedEnvelope: CustomStringConvertible {
 }
 
 /// Possible ECN States
-internal enum NIOEcnState {
+public enum NIOEcnState {
     /// Non-ECN Capable Transport.
     case nonECT
     /// ECN Capable Transport (flag 0).

--- a/Sources/NIO/AddressedEnvelope.swift
+++ b/Sources/NIO/AddressedEnvelope.swift
@@ -31,7 +31,7 @@ public struct AddressedEnvelope<DataType> {
     /// Any metadata associated with an `AddressedEnvelope`
     public struct Metadata {
         /// Details of any congestion state.
-        public var ecnState: NIOECNState
+        public var ecnState: NIOExplicitCongestionNotificationState
     }
 }
 
@@ -41,14 +41,14 @@ extension AddressedEnvelope: CustomStringConvertible {
     }
 }
 
-/// Possible ECN States
-public enum NIOECNState: Hashable {
+/// Possible Explicit Congestion Notification States
+public enum NIOExplicitCongestionNotificationState: Hashable {
     /// Non-ECN Capable Transport.
-    case nonECT
+    case transportNotCapable
     /// ECN Capable Transport (flag 0).
-    case ect0
+    case transportCapableFlag0
     /// ECN Capable Transport (flag 1).
-    case ect1
+    case transportCapableFlag1
     /// Congestion Experienced.
-    case ce
+    case congestionExperienced
 }

--- a/Sources/NIO/AddressedEnvelope.swift
+++ b/Sources/NIO/AddressedEnvelope.swift
@@ -20,15 +20,16 @@
 public struct AddressedEnvelope<DataType> {
     public var remoteAddress: SocketAddress
     public var data: DataType
-    public var metaData : MetaData? = nil
+    internal var metaData : MetaData? = nil
 
     public init(remoteAddress: SocketAddress, data: DataType) {
         self.remoteAddress = remoteAddress
         self.data = data
     }
     
-    public struct MetaData {
-        public var ecnEventInProgress : NIOEcnState
+    internal struct MetaData {
+        /// Details of any congestion state.
+        public var ecnState : NIOEcnState
     }
 }
 
@@ -39,7 +40,7 @@ extension AddressedEnvelope: CustomStringConvertible {
 }
 
 /// Possible ECN States
-public enum NIOEcnState {
+internal enum NIOEcnState {
     /// Non-ECN Capable Transport.
     case nonECT
     /// ECN Capable Transport (flag 0).

--- a/Sources/NIO/AddressedEnvelope.swift
+++ b/Sources/NIO/AddressedEnvelope.swift
@@ -20,10 +20,15 @@
 public struct AddressedEnvelope<DataType> {
     public var remoteAddress: SocketAddress
     public var data: DataType
+    public var metaData : MetaData? = .none
 
     public init(remoteAddress: SocketAddress, data: DataType) {
         self.remoteAddress = remoteAddress
         self.data = data
+    }
+    
+    public struct MetaData {
+        public var ecnEventInProgress : Bool
     }
 }
 

--- a/Sources/NIO/AddressedEnvelope.swift
+++ b/Sources/NIO/AddressedEnvelope.swift
@@ -20,18 +20,18 @@
 public struct AddressedEnvelope<DataType> {
     public var remoteAddress: SocketAddress
     public var data: DataType
-    /// Any MetaData associated with this `AddressedEnvelope`
-    public var metaData : MetaData? = nil
+    /// Any metadata associated with this `AddressedEnvelope`
+    public var metadata : Metadata? = nil
 
     public init(remoteAddress: SocketAddress, data: DataType) {
         self.remoteAddress = remoteAddress
         self.data = data
     }
     
-    /// Any MetaData associated with an AddressedEnvelope
-    public struct MetaData {
+    /// Any metadata associated with an `AddressedEnvelope`
+    public struct Metadata {
         /// Details of any congestion state.
-        public var ecnState : NIOEcnState
+        public var ecnState : NIOECNState
     }
 }
 
@@ -42,7 +42,7 @@ extension AddressedEnvelope: CustomStringConvertible {
 }
 
 /// Possible ECN States
-public enum NIOEcnState {
+public enum NIOECNState: Hashable {
     /// Non-ECN Capable Transport.
     case nonECT
     /// ECN Capable Transport (flag 0).

--- a/Sources/NIO/AddressedEnvelope.swift
+++ b/Sources/NIO/AddressedEnvelope.swift
@@ -21,7 +21,7 @@ public struct AddressedEnvelope<DataType> {
     public var remoteAddress: SocketAddress
     public var data: DataType
     /// Any metadata associated with this `AddressedEnvelope`
-    public var metadata : Metadata? = nil
+    public var metadata: Metadata? = nil
 
     public init(remoteAddress: SocketAddress, data: DataType) {
         self.remoteAddress = remoteAddress
@@ -31,7 +31,7 @@ public struct AddressedEnvelope<DataType> {
     /// Any metadata associated with an `AddressedEnvelope`
     public struct Metadata {
         /// Details of any congestion state.
-        public var ecnState : NIOECNState
+        public var ecnState: NIOECNState
     }
 }
 

--- a/Sources/NIO/AddressedEnvelope.swift
+++ b/Sources/NIO/AddressedEnvelope.swift
@@ -29,7 +29,7 @@ public struct AddressedEnvelope<DataType> {
     }
     
     /// Any metadata associated with an `AddressedEnvelope`
-    public struct Metadata {
+    public struct Metadata: Hashable {
         /// Details of any congestion state.
         public var ecnState: NIOExplicitCongestionNotificationState
     }


### PR DESCRIPTION
Add Optional ECN MetaData to Addressed Envelope

### Motivation:

This is a very small step along the path to https://github.com/apple/swift-nio/issues/1472

### Modifications:

Add an optional metadata field to addressed envelope.  Currently the only possible data is ECN information.  This is not currently populated anywhere.

### Result:

Metadata in place for future work.
