### PR TITLE
Adjust names of BSDSocket option values.

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
@@ -98,7 +98,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
 
 func doRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
     let serverChannel = try ServerBootstrap(group: group)
-        .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         .childChannelInitializer { channel in
             channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true,
                                                          withErrorHandling: false).flatMap {
@@ -213,7 +213,7 @@ enum UDPShared {
 
     static func doUDPRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
         let serverChannel = try DatagramBootstrap(group: group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             // Set the handlers that are applied to the bound channel
             .channelInitializer { channel in
                 return channel.pipeline.addHandler(EchoHandler())
@@ -228,7 +228,7 @@ enum UDPShared {
 
         let clientChannel = try DatagramBootstrap(group: group)
             // Enable SO_REUSEADDR.
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
                 channel.pipeline.addHandler(EchoHandlerClient(remoteAddress: remoteAddress,
                                                               numberOfRepetitions: numberOfRequests))

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_ping_pong_1000_reqs_1_conn.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_ping_pong_1000_reqs_1_conn.swift
@@ -111,7 +111,7 @@ private final class PongHandler: ChannelInboundHandler {
 
 func doPingPongRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
     let serverChannel = try ServerBootstrap(group: group)
-        .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         .childChannelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))
         .childChannelInitializer { channel in
             channel.pipeline.addHandler(ByteToMessageHandler(PongDecoder())).flatMap {

--- a/Sources/NIO/BSDSocketAPI.swift
+++ b/Sources/NIO/BSDSocketAPI.swift
@@ -189,10 +189,10 @@ extension NIOBSDSocket.SocketType {
     /// Supports datagrams, which are connectionless, unreliable messages of a
     /// fixed (typically small) maximum length.
     #if os(Linux)
-        internal static let dgram: NIOBSDSocket.SocketType =
+        internal static let datagram: NIOBSDSocket.SocketType =
                 NIOBSDSocket.SocketType(rawValue: CInt(SOCK_DGRAM.rawValue))
     #else
-        internal static let dgram: NIOBSDSocket.SocketType =
+        internal static let datagram: NIOBSDSocket.SocketType =
                 NIOBSDSocket.SocketType(rawValue: SOCK_DGRAM)
     #endif
 
@@ -301,14 +301,14 @@ extension NIOBSDSocket.Option {
 // TCP Options
 extension NIOBSDSocket.Option {
     /// Disables the Nagle algorithm for send coalescing.
-    public static let nodelay: NIOBSDSocket.Option =
+    public static let tcp_nodelay: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: TCP_NODELAY)
 }
 
 #if os(Linux) || os(FreeBSD)
 extension NIOBSDSocket.Option {
     /// Get information about the TCP connection.
-    public static let info: NIOBSDSocket.Option =
+    public static let tcp_info: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: TCP_INFO)
 }
 #endif
@@ -316,7 +316,7 @@ extension NIOBSDSocket.Option {
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 extension NIOBSDSocket.Option {
     /// Get information about the TCP connection.
-    public static let connection_info: NIOBSDSocket.Option =
+    public static let tcp_connection_info: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: TCP_CONNECTION_INFO)
 }
 #endif
@@ -324,44 +324,34 @@ extension NIOBSDSocket.Option {
 // Socket Options
 extension NIOBSDSocket.Option {
     /// Get the error status and clear.
-    public static let error: NIOBSDSocket.Option =
+    public static let so_error: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: SO_ERROR)
 
     /// Use keep-alives.
-    public static let keepalive: NIOBSDSocket.Option =
+    public static let so_keepalive: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: SO_KEEPALIVE)
 
     /// Linger on close if unsent data is present.
-    public static let linger: NIOBSDSocket.Option =
+    public static let so_linger: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: SO_LINGER)
 
     /// Specifies the total per-socket buffer space reserved for receives.
-    public static let rcvbuf: NIOBSDSocket.Option =
+    public static let so_rcvbuf: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: SO_RCVBUF)
 
     /// Specifies the receive timeout.
-    public static let rcvtimeo: NIOBSDSocket.Option =
+    public static let so_rcvtimeo: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: SO_RCVTIMEO)
 
-    /// Indicates that the system should defer ephemeral port allocation for
-    /// outbound connections.
-    #if os(Windows)
-        public static let reuseport: NIOBSDSocket.Option =
-                NIOBSDSocket.Option(rawValue: SO_REUSE_UNICASTPORT)
-    #else
-        public static let reuseport: NIOBSDSocket.Option =
-                NIOBSDSocket.Option(rawValue: SO_REUSEPORT)
-    #endif
-
     /// Allows the socket to be bound to an address that is already in use.
-    public static let reuseaddr: NIOBSDSocket.Option =
+    public static let so_reuseaddr: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: SO_REUSEADDR)
 }
 
 #if !os(Windows)
 extension NIOBSDSocket.Option {
     /// Indicate when to generate timestamps.
-    public static let timestamp: NIOBSDSocket.Option =
+    public static let so_timestamp: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: SO_TIMESTAMP)
 }
 #endif

--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -333,7 +333,7 @@ class BaseSocket: BaseSocketProtocol {
     ///     - value: The value for the option.
     /// - throws: An `IOError` if the operation failed.
     final func setOption<T>(level: NIOBSDSocket.OptionLevel, name: NIOBSDSocket.Option, value: T) throws {
-        if level == .tcp && name == .nodelay && (try? self.localAddress().protocol) == Optional<NIOBSDSocket.ProtocolFamily>.some(.unix) {
+        if level == .tcp && name == .tcp_nodelay && (try? self.localAddress().protocol) == Optional<NIOBSDSocket.ProtocolFamily>.some(.unix) {
             // setting TCP_NODELAY on UNIX domain sockets will fail. Previously we had a bug where we would ignore
             // most socket options settings so for the time being we'll just ignore this. Let's revisit for NIO 2.0.
             return

--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -1019,7 +1019,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
             let error: IOError
             // if the socket is still registered (and therefore open), let's try to get the actual socket error from the socket
             do {
-                let result: Int32 = try self.socket.getOption(level: .socket, name: .error)
+                let result: Int32 = try self.socket.getOption(level: .socket, name: .so_error)
                 if result != 0 {
                     // we have a socket error, let's forward
                     // this path will be executed on Linux (EPOLLERR) & Darwin (ev.fflags != 0)

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -34,7 +34,7 @@ internal enum NIOOnSocketsBootstraps {
 ///     let bootstrap = ServerBootstrap(group: group)
 ///         // Specify backlog and enable SO_REUSEADDR for the server itself
 ///         .serverChannelOption(ChannelOptions.backlog, value: 256)
-///         .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+///         .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 ///
 ///         // Set the handlers that are applied to the accepted child `Channel`s.
 ///         .childChannelInitializer { channel in
@@ -47,7 +47,7 @@ internal enum NIOOnSocketsBootstraps {
 ///         }
 ///
 ///         // Enable SO_REUSEADDR for the accepted Channels
-///         .childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+///         .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 ///         .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
 ///         .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 ///     let channel = try! bootstrap.bind(host: host, port: port).wait()
@@ -128,7 +128,7 @@ public final class ServerBootstrap {
         self._childChannelOptions = ChannelOptions.Storage()
         self.serverChannelInit = nil
         self.childChannelInit = nil
-        self._serverChannelOptions.append(key: ChannelOptions.tcpOption(.nodelay), value: 1)
+        self._serverChannelOptions.append(key: ChannelOptions.tcpOption(.tcp_nodelay), value: 1)
     }
 
     /// Initialize the `ServerSocketChannel` with `initializer`. The most common task in initializer is to add
@@ -394,7 +394,7 @@ private extension Channel {
 ///     }
 ///     let bootstrap = ClientBootstrap(group: group)
 ///         // Enable SO_REUSEADDR.
-///         .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+///         .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 ///         .channelInitializer { channel in
 ///             // always instantiate the handler _within_ the closure as
 ///             // it may be called multiple times (for example if the hostname
@@ -453,7 +453,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         }
         self.group = group
         self._channelOptions = ChannelOptions.Storage()
-        self._channelOptions.append(key: ChannelOptions.tcpOption(.nodelay), value: 1)
+        self._channelOptions.append(key: ChannelOptions.tcpOption(.tcp_nodelay), value: 1)
         self._channelInitializer = { channel in channel.eventLoop.makeSucceededFuture(()) }
         self.protocolHandlers = nil
         self.resolver = nil
@@ -663,7 +663,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
 ///     }
 ///     let bootstrap = DatagramBootstrap(group: group)
 ///         // Enable SO_REUSEADDR.
-///         .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+///         .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 ///         .channelInitializer { channel in
 ///             channel.pipeline.addHandler(MyChannelHandler())
 ///         }

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -94,7 +94,7 @@ typealias IOVector = iovec
     ///
     /// - throws: An `IOError` if the operation failed.
     func finishConnect() throws {
-        let result: Int32 = try getOption(level: .socket, name: .error)
+        let result: Int32 = try getOption(level: .socket, name: .so_error)
         if result != 0 {
             throw IOError(errnoCode: result, reason: "finishing a non-blocking connect failed")
         }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -362,7 +362,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
     init(eventLoop: SelectableEventLoop, protocolFamily: NIOBSDSocket.ProtocolFamily) throws {
         self.vectorReadManager = nil
-        let socket = try Socket(protocolFamily: protocolFamily, type: .dgram)
+        let socket = try Socket(protocolFamily: protocolFamily, type: .datagram)
         do {
             try socket.setNonBlocking()
         } catch let err {

--- a/Sources/NIO/SocketOptionProvider.swift
+++ b/Sources/NIO/SocketOptionProvider.swift
@@ -133,7 +133,7 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` that fires when the option has been set,
     ///     or if an error has occurred.
     public func setSoLinger(_ value: linger) -> EventLoopFuture<Void> {
-        return self.unsafeSetSocketOption(level: .socket, name: .linger, value: value)
+        return self.unsafeSetSocketOption(level: .socket, name: .so_linger, value: value)
     }
 
     /// Gets the value of the socket option SO_LINGER.
@@ -141,7 +141,7 @@ extension SocketOptionProvider {
     /// - returns: An `EventLoopFuture` containing the value of the socket option, or
     ///     any error that occurred while retrieving the socket option.
     public func getSoLinger() -> EventLoopFuture<linger> {
-        return self.unsafeGetSocketOption(level: .socket, name: .linger)
+        return self.unsafeGetSocketOption(level: .socket, name: .so_linger)
     }
 
     /// Sets the socket option IP_MULTICAST_IF to `value`.
@@ -260,7 +260,7 @@ extension SocketOptionProvider {
         /// - returns: An `EventLoopFuture` containing the value of the socket option, or
         ///     any error that occurred while retrieving the socket option.
         public func getTCPInfo() -> EventLoopFuture<tcp_info> {
-            return self.unsafeGetSocketOption(level: .tcp, name: .info)
+            return self.unsafeGetSocketOption(level: .tcp, name: .tcp_info)
         }
     #endif
 
@@ -272,7 +272,7 @@ extension SocketOptionProvider {
         /// - returns: An `EventLoopFuture` containing the value of the socket option, or
         ///     any error that occurred while retrieving the socket option.
         public func getTCPConnectionInfo() -> EventLoopFuture<tcp_connection_info> {
-            return self.unsafeGetSocketOption(level: .tcp, name: .connection_info)
+            return self.unsafeGetSocketOption(level: .tcp, name: .tcp_connection_info)
         }
     #endif
 }

--- a/Sources/NIOChatClient/main.swift
+++ b/Sources/NIOChatClient/main.swift
@@ -44,7 +44,7 @@ private final class ChatHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         channel.pipeline.addHandler(ChatHandler())
     }

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -117,7 +117,7 @@ let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)
-    .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
@@ -129,7 +129,7 @@ let bootstrap = ServerBootstrap(group: group)
     }
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
     .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 defer {

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -54,7 +54,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         channel.pipeline.addHandler(EchoHandler())
     }

--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -40,7 +40,7 @@ let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)
-    .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
     // Set the handlers that are appled to the accepted Channels
     .childChannelInitializer { channel in
@@ -51,7 +51,7 @@ let bootstrap = ServerBootstrap(group: group)
     }
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
     .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 defer {

--- a/Sources/NIOHTTP1Client/main.swift
+++ b/Sources/NIOHTTP1Client/main.swift
@@ -77,7 +77,7 @@ private final class HTTPEchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         channel.pipeline.addHTTPClientHandlers(position: .first,
                                                leftOverBytesStrategy: .fireError).flatMap {

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -527,13 +527,13 @@ let fileIO = NonBlockingFileIO(threadPool: threadPool)
 let socketBootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)
-    .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer(childChannelInitializer(channel:))
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
     .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: allowHalfClosure)
 let pipeBootstrap = NIOPipeBootstrap(group: group)

--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -70,8 +70,7 @@ let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
 // Begin by setting up the basics of the bootstrap.
 var datagramBootstrap = DatagramBootstrap(group: group)
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
-    .channelOption(ChannelOptions.socketOption(.reuseport), value: 1)
+    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         return channel.pipeline.addHandler(ChatMessageEncoder()).flatMap {
             channel.pipeline.addHandler(ChatMessageDecoder())

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -122,7 +122,7 @@ defer {
 }
 
 let serverChannel = try ServerBootstrap(group: group)
-    .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .childChannelInitializer { channel in
         channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true).flatMap {
             channel.pipeline.addHandler(SimpleHTTPServer())

--- a/Sources/NIOUDPEchoClient/main.swift
+++ b/Sources/NIOUDPEchoClient/main.swift
@@ -118,7 +118,7 @@ let remoteAddress = { () -> SocketAddress in
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = DatagramBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         channel.pipeline.addHandler(EchoHandler(remoteAddressInitializer: remoteAddress))
 }

--- a/Sources/NIOUDPEchoServer/main.swift
+++ b/Sources/NIOUDPEchoServer/main.swift
@@ -42,7 +42,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 var bootstrap = DatagramBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
     // Set the handlers that are applied to the bound channel
     .channelInitializer { channel in

--- a/Sources/NIOWebSocketClient/main.swift
+++ b/Sources/NIOWebSocketClient/main.swift
@@ -158,7 +158,7 @@ private final class WebSocketPingPongHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         
         let httpHandler = HTTPInitialRequestHandler()

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -210,7 +210,7 @@ let upgrader = NIOWebSocketServerUpgrader(shouldUpgrade: { (channel: Channel, he
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)
-    .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
@@ -227,7 +227,7 @@ let bootstrap = ServerBootstrap(group: group)
     }
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+    .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
 defer {
     try! group.syncShutdownGracefully()

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -338,7 +338,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
@@ -395,7 +395,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
@@ -455,7 +455,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                     channel.pipeline.addHandler(httpHandler)
@@ -511,7 +511,7 @@ class HTTPServerClientTest : XCTestCase {
         let numBytes = 16 * 1024
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
             // Set the handlers that are appled to the accepted Channels
             .childChannelInitializer { channel in
@@ -553,7 +553,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                     channel.pipeline.addHandler(httpHandler)
@@ -597,7 +597,7 @@ class HTTPServerClientTest : XCTestCase {
 
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                     channel.pipeline.addHandler(httpHandler)

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -88,7 +88,7 @@ private func serverHTTPChannelWithAutoremoval(group: EventLoopGroup,
                                               _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) throws -> (Channel, EventLoopFuture<Channel>) {
     let p = group.next().makePromise(of: Channel.self)
     let c = try ServerBootstrap(group: group)
-        .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         .childChannelInitializer { channel in
             p.succeed(channel)
             let upgradeConfig = (upgraders: upgraders, completionHandler: upgradeCompletionHandler)

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -32,7 +32,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
 
     func connect(serverPort: Int, responsePromise: EventLoopPromise<String>) throws -> EventLoopFuture<Channel> {
         let bootstrap = ClientBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers(position: .first,
                                                        leftOverBytesStrategy: .fireError).flatMap {

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -221,7 +221,7 @@ class BootstrapTest: XCTestCase {
         func restrictBootstrapType(clientBootstrap: NIOClientTCPBootstrap) throws {
             let serverAcceptedChannelPromise = group.next().makePromise(of: Channel.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     serverAcceptedChannelPromise.succeed(channel)
                     return channel.eventLoop.makeSucceededFuture(())

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -294,7 +294,7 @@ class ChannelNotificationTest: XCTestCase {
         let acceptedChannelPromise = group.next().makePromise(of: Channel.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .serverChannelInitializer { channel in
                 channel.pipeline.addHandler(ServerSocketChannelLifecycleVerificationHandler())
             }
@@ -376,7 +376,7 @@ class ChannelNotificationTest: XCTestCase {
 
         let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: true)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(OrderVerificationHandler(promise))

--- a/Tests/NIOTests/ChannelOptionStorageTest.swift
+++ b/Tests/NIOTests/ChannelOptionStorageTest.swift
@@ -27,15 +27,15 @@ class ChannelOptionStorageTest: XCTestCase {
     func testSetTwoOptionsOfDifferentType() throws {
         var cos = ChannelOptions.Storage()
         let optionsCollector = OptionsCollectingChannel()
-        cos.append(key: ChannelOptions.socketOption(.reuseaddr), value: 1)
+        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         cos.append(key: ChannelOptions.backlog, value: 2)
         XCTAssertNoThrow(try cos.applyAllChannelOptions(to: optionsCollector).wait())
         XCTAssertEqual(2, optionsCollector.allOptions.count)
     }
 
     func testSetTwoOptionsOfSameType() throws {
-        let options: [(ChannelOptions.Types.SocketOption, SocketOptionValue)] = [(ChannelOptions.socketOption(.reuseaddr), 1),
-                                                            (ChannelOptions.socketOption(.reuseport), 2)]
+        let options: [(ChannelOptions.Types.SocketOption, SocketOptionValue)] = [(ChannelOptions.socketOption(.so_reuseaddr), 1),
+                                                            (ChannelOptions.socketOption(.so_rcvtimeo), 2)]
         var cos = ChannelOptions.Storage()
         let optionsCollector = OptionsCollectingChannel()
         for kv in options {
@@ -56,11 +56,11 @@ class ChannelOptionStorageTest: XCTestCase {
     func testSetOneOptionTwice() throws {
         var cos = ChannelOptions.Storage()
         let optionsCollector = OptionsCollectingChannel()
-        cos.append(key: ChannelOptions.socketOption(.reuseaddr), value: 1)
-        cos.append(key: ChannelOptions.socketOption(.reuseaddr), value: 2)
+        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 2)
         XCTAssertNoThrow(try cos.applyAllChannelOptions(to: optionsCollector).wait())
         XCTAssertEqual(1, optionsCollector.allOptions.count)
-        XCTAssertEqual([ChannelOptions.socketOption(.reuseaddr)],
+        XCTAssertEqual([ChannelOptions.socketOption(.so_reuseaddr)],
                        optionsCollector.allOptions.map { option in
                            return option.0 as! ChannelOptions.Types.SocketOption
                        })

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -80,7 +80,7 @@ public final class ChannelTests: XCTestCase {
         let serverAcceptedChannelPromise = group.next().makePromise(of: Channel.self)
         let serverLifecycleHandler = ChannelLifecycleHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 serverAcceptedChannelPromise.succeed(channel)
                 return channel.pipeline.addHandler(serverLifecycleHandler)
@@ -118,7 +118,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -147,7 +147,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -181,7 +181,7 @@ public final class ChannelTests: XCTestCase {
 
         let childChannelPromise = group.next().makePromise(of: Channel.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 childChannelPromise.succeed(channel)
                 return channel.eventLoop.makeSucceededFuture(())
@@ -1350,7 +1350,7 @@ public final class ChannelTests: XCTestCase {
         try {
             let serverChildChannelPromise = group.next().makePromise(of: Channel.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     serverChildChannelPromise.succeed(channel)
                     channel.close(promise: nil)
@@ -1406,7 +1406,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "127.0.0.1", port: 0).wait())
 
         let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group)
@@ -1445,7 +1445,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(AddressVerificationHandler())
             }
@@ -1509,7 +1509,7 @@ public final class ChannelTests: XCTestCase {
         let readDelayer = ReadDelayer()
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer {
                 $0.pipeline.addHandler(readDelayer)
             }
@@ -1565,7 +1565,7 @@ public final class ChannelTests: XCTestCase {
 
         let handler = VerifyNoReadBeforeEOFHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(handler)
@@ -1621,7 +1621,7 @@ public final class ChannelTests: XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(VerifyEOFReadOrderingAndCloseInChannelReadHandler())
@@ -1679,7 +1679,7 @@ public final class ChannelTests: XCTestCase {
 
         let allDone = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(CloseWhenWeGetEOFHandler(allDone: allDone))
@@ -1737,7 +1737,7 @@ public final class ChannelTests: XCTestCase {
 
         let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelOption(ChannelOptions.autoRead, value: false)
             .childChannelInitializer { ch in
                 ch.pipeline.addHandler(ChannelInactiveVerificationHandler(promise))
@@ -2314,7 +2314,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "localhost", port: 0)
             .wait())
 
@@ -2563,10 +2563,10 @@ public final class ChannelTests: XCTestCase {
                                                              singleThreadedELG.next().makePromise(),
                                                              singleThreadedELG.next().makePromise()]
         let server = try assertNoThrowWithValue(ServerBootstrap(group: singleThreadedELG)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
-            .serverChannelOption(ChannelOptions.socketOption(.timestamp), value: 1)
-            .childChannelOption(ChannelOptions.socketOption(.keepalive), value: 1)
-            .childChannelOption(ChannelOptions.tcpOption(.nodelay), value: 0)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_timestamp), value: 1)
+            .childChannelOption(ChannelOptions.socketOption(.so_keepalive), value: 1)
+            .childChannelOption(ChannelOptions.tcpOption(.tcp_nodelay), value: 0)
             .childChannelInitializer { channel in
                 acceptedChannels[numberOfAcceptedChannel].succeed(channel)
                 numberOfAcceptedChannel += 1
@@ -2577,12 +2577,12 @@ public final class ChannelTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try server.close().wait())
         }
-        XCTAssertTrue(try getBoolSocketOption(channel: server, level: .socket, name: .reuseaddr))
-        XCTAssertTrue(try getBoolSocketOption(channel: server, level: .socket, name: .timestamp))
+        XCTAssertTrue(try getBoolSocketOption(channel: server, level: .socket, name: .so_reuseaddr))
+        XCTAssertTrue(try getBoolSocketOption(channel: server, level: .socket, name: .so_timestamp))
 
         let client1 = try assertNoThrowWithValue(ClientBootstrap(group: singleThreadedELG)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
-            .channelOption(ChannelOptions.tcpOption(.nodelay), value: 0)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(ChannelOptions.tcpOption(.tcp_nodelay), value: 0)
             .connect(to: server.localAddress!)
             .wait())
         let accepted1 = try assertNoThrowWithValue(acceptedChannels[0].futureResult.wait())
@@ -2590,7 +2590,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try client1.close().wait())
         }
         let client2 = try assertNoThrowWithValue(ClientBootstrap(group: singleThreadedELG)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .connect(to: server.localAddress!)
             .wait())
         let accepted2 = try assertNoThrowWithValue(acceptedChannels[0].futureResult.wait())
@@ -2605,29 +2605,29 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try client3.close().wait())
         }
 
-        XCTAssertTrue(try getBoolSocketOption(channel: client1, level: .socket, name: .reuseaddr))
+        XCTAssertTrue(try getBoolSocketOption(channel: client1, level: .socket, name: .so_reuseaddr))
 
-        XCTAssertFalse(try getBoolSocketOption(channel: client1, level: .tcp, name: .nodelay))
+        XCTAssertFalse(try getBoolSocketOption(channel: client1, level: .tcp, name: .tcp_nodelay))
 
-        XCTAssertTrue(try getBoolSocketOption(channel: accepted1, level: .socket, name: .keepalive))
+        XCTAssertTrue(try getBoolSocketOption(channel: accepted1, level: .socket, name: .so_keepalive))
 
-        XCTAssertFalse(try getBoolSocketOption(channel: accepted1, level: .tcp, name: .nodelay))
+        XCTAssertFalse(try getBoolSocketOption(channel: accepted1, level: .tcp, name: .tcp_nodelay))
 
-        XCTAssertTrue(try getBoolSocketOption(channel: client2, level: .socket, name: .reuseaddr))
+        XCTAssertTrue(try getBoolSocketOption(channel: client2, level: .socket, name: .so_reuseaddr))
 
-        XCTAssertTrue(try getBoolSocketOption(channel: client2, level: .tcp, name: .nodelay))
+        XCTAssertTrue(try getBoolSocketOption(channel: client2, level: .tcp, name: .tcp_nodelay))
 
-        XCTAssertTrue(try getBoolSocketOption(channel: accepted2, level: .socket, name: .keepalive))
+        XCTAssertTrue(try getBoolSocketOption(channel: accepted2, level: .socket, name: .so_keepalive))
 
-        XCTAssertFalse(try getBoolSocketOption(channel: accepted2, level: .tcp, name: .nodelay))
+        XCTAssertFalse(try getBoolSocketOption(channel: accepted2, level: .tcp, name: .tcp_nodelay))
 
-        XCTAssertFalse(try getBoolSocketOption(channel: client3, level: .socket, name: .reuseaddr))
+        XCTAssertFalse(try getBoolSocketOption(channel: client3, level: .socket, name: .so_reuseaddr))
 
-        XCTAssertTrue(try getBoolSocketOption(channel: client3, level: .tcp, name: .nodelay))
+        XCTAssertTrue(try getBoolSocketOption(channel: client3, level: .tcp, name: .tcp_nodelay))
 
-        XCTAssertTrue(try getBoolSocketOption(channel: accepted3, level: .socket, name: .keepalive))
+        XCTAssertTrue(try getBoolSocketOption(channel: accepted3, level: .socket, name: .so_keepalive))
 
-        XCTAssertFalse(try getBoolSocketOption(channel: accepted3, level: .tcp, name: .nodelay))
+        XCTAssertFalse(try getBoolSocketOption(channel: accepted3, level: .tcp, name: .tcp_nodelay))
     }
 
     func testUnprocessedOutboundUserEventFailsOnServerSocketChannel() throws {
@@ -2706,7 +2706,7 @@ public final class ChannelTests: XCTestCase {
         }
         XCTAssertNoThrow(XCTAssertTrue(try getBoolSocketOption(channel: server,
                                                                level: .tcp,
-                                                               name: .nodelay)))
+                                                               name: .tcp_nodelay)))
 
         let client = try assertNoThrowWithValue(ClientBootstrap(group: singleThreadedELG)
             .connect(to: server.localAddress!)
@@ -2717,10 +2717,10 @@ public final class ChannelTests: XCTestCase {
         }
         XCTAssertNoThrow(XCTAssertTrue(try getBoolSocketOption(channel: accepted,
                                                                level: .tcp,
-                                                               name: .nodelay)))
+                                                               name: .tcp_nodelay)))
         XCTAssertNoThrow(XCTAssertTrue(try getBoolSocketOption(channel: client,
                                                                level: .tcp,
-                                                               name: .nodelay)))
+                                                               name: .tcp_nodelay)))
     }
 
     func testDescriptionCanBeCalledFromNonEventLoopThreads() {
@@ -2761,7 +2761,7 @@ public final class ChannelTests: XCTestCase {
 
         var maybeServer: Channel? = nil
         XCTAssertNoThrow(maybeServer = try ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "127.0.0.1", port: 0)
             .wait())
         guard let server = maybeServer else {

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -108,7 +108,7 @@ final class DatagramChannelTests: XCTestCase {
 
     private func buildChannel(group: EventLoopGroup) throws -> Channel {
         return try DatagramBootstrap(group: group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
                 channel.pipeline.addHandler(DatagramReadRecorder<ByteBuffer>(), name: "ByteReadRecorder")
             }
@@ -374,7 +374,7 @@ final class DatagramChannelTests: XCTestCase {
 
             init(error: Int32) throws {
                 self.error = error
-                try super.init(protocolFamily: .inet, type: .dgram)
+                try super.init(protocolFamily: .inet, type: .datagram)
             }
 
             override func recvfrom(pointer: UnsafeMutableRawBufferPointer, storage: inout sockaddr_storage, storageLen: inout socklen_t) throws -> IOResult<(Int)> {
@@ -450,7 +450,7 @@ final class DatagramChannelTests: XCTestCase {
 
             init(error: Int32) throws {
                 self.error = error
-                try super.init(protocolFamily: .inet, type: .dgram)
+                try super.init(protocolFamily: .inet, type: .datagram)
             }
 
             override func recvmmsg(msgs: UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int> {
@@ -508,16 +508,16 @@ final class DatagramChannelTests: XCTestCase {
 
     func testSettingTwoDistinctChannelOptionsWorksForDatagramChannel() throws {
         let channel = try assertNoThrowWithValue(DatagramBootstrap(group: group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
-            .channelOption(ChannelOptions.socketOption(.timestamp), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_timestamp), value: 1)
             .bind(host: "127.0.0.1", port: 0)
             .wait())
         defer {
             XCTAssertNoThrow(try channel.close().wait())
         }
-        XCTAssertTrue(try getBoolSocketOption(channel: channel, level: .socket, name: .reuseaddr))
-        XCTAssertTrue(try getBoolSocketOption(channel: channel, level: .socket, name: .timestamp))
-        XCTAssertFalse(try getBoolSocketOption(channel: channel, level: .socket, name: .keepalive))
+        XCTAssertTrue(try getBoolSocketOption(channel: channel, level: .socket, name: .so_reuseaddr))
+        XCTAssertTrue(try getBoolSocketOption(channel: channel, level: .socket, name: .so_timestamp))
+        XCTAssertFalse(try getBoolSocketOption(channel: channel, level: .socket, name: .so_keepalive))
     }
 
     func testUnprocessedOutboundUserEventFailsOnDatagramChannel() throws {

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -27,7 +27,7 @@ class EchoServerClientTest : XCTestCase {
         let numBytes = 16 * 1024
         let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(countingHandler)
@@ -63,7 +63,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(WriteALotHandler())
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -99,7 +99,7 @@ class EchoServerClientTest : XCTestCase {
             let numBytes = 16 * 1024
             let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -141,7 +141,7 @@ class EchoServerClientTest : XCTestCase {
             let numBytes = 16 * 1024
             let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -180,7 +180,7 @@ class EchoServerClientTest : XCTestCase {
 
         let handler = ChannelActiveHandler()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "127.0.0.1", port: 0).wait())
 
         defer {
@@ -205,7 +205,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(EchoServer())
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -401,7 +401,7 @@ class EchoServerClientTest : XCTestCase {
                                                                    channelInactivePromise: inactivePromise)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(handler)
@@ -435,7 +435,7 @@ class EchoServerClientTest : XCTestCase {
         let bytesReceivedPromise = group.next().makePromise(of: ByteBuffer.self)
         let byteCountingHandler = ByteCountingHandler(numBytes: writingBytes.utf8.count, promise: bytesReceivedPromise)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 // When we've received all the bytes we know the connection is up. Remove the handler.
                 _ = bytesReceivedPromise.futureResult.flatMap { (_: ByteBuffer) in
@@ -479,7 +479,7 @@ class EchoServerClientTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(EchoServer())
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -513,7 +513,7 @@ class EchoServerClientTest : XCTestCase {
 
         let stringToWrite = "hello"
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(WriteOnConnectHandler(toWrite: stringToWrite))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -546,7 +546,7 @@ class EchoServerClientTest : XCTestCase {
 
         dpGroup.enter()
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(EchoAndEchoAgainAfterSomeTimeServer(time: .seconds(1), secondWriteDoneHandler: {
                     dpGroup.leave()
@@ -638,7 +638,7 @@ class EchoServerClientTest : XCTestCase {
             }
         }
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(WriteWhenActiveHandler(str, dpGroup))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -700,7 +700,7 @@ class EchoServerClientTest : XCTestCase {
         let promise = group.next().makePromise(of: Void.self)
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(ErrorHandler(promise))
             }.bind(host: "127.0.0.1", port: 0).wait())
@@ -730,7 +730,7 @@ class EchoServerClientTest : XCTestCase {
             let serverChannel: Channel
             do {
                 serverChannel = try ServerBootstrap(group: group)
-                    .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+                    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
                     .childChannelInitializer { channel in
                         acceptedRemotePort.store(channel.remoteAddress?.port ?? -3)
                         acceptedLocalPort.store(channel.localAddress?.port ?? -4)
@@ -781,7 +781,7 @@ class EchoServerClientTest : XCTestCase {
 
         // we're binding to IPv4 only
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(countingHandler)
             }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -43,7 +43,7 @@ public final class EventLoopTest : XCTestCase {
 
         // First, we create a server and client channel, but don't connect them.
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: eventLoopGroup)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "127.0.0.1", port: 0).wait())
         let clientBootstrap = ClientBootstrap(group: eventLoopGroup)
 
@@ -354,7 +354,7 @@ public final class EventLoopTest : XCTestCase {
 
         // Create a server channel.
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "127.0.0.1", port: 0).wait())
 
         // We now want to connect to it. To try to slow this stuff down, we're going to use a multiple of the number
@@ -978,7 +978,7 @@ public final class EventLoopTest : XCTestCase {
         g.enter()
         var maybeServer: Channel?
         XCTAssertNoThrow(maybeServer = try ServerBootstrap(group: elg2)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .serverChannelOption(ChannelOptions.autoRead, value: false)
             .serverChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
             .childChannelInitializer { channel in

--- a/Tests/NIOTests/FileRegionTest.swift
+++ b/Tests/NIOTests/FileRegionTest.swift
@@ -34,7 +34,7 @@ class FileRegionTest : XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
@@ -74,7 +74,7 @@ class FileRegionTest : XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: 0, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())
@@ -125,7 +125,7 @@ class FileRegionTest : XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: bytes.count, promise: group.next().makePromise())
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
             .bind(host: "127.0.0.1", port: 0)
             .wait())

--- a/Tests/NIOTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOTests/IdleStateHandlerTest.swift
@@ -75,7 +75,7 @@ class IdleStateHandlerTest : XCTestCase {
         }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(handler).flatMap { f in
                     channel.pipeline.addHandler(TestWriteHandler(writeToChannel, assertEventFn))

--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -68,7 +68,7 @@ final class MulticastTest: XCTestCase {
 
     private func bindMulticastChannel(host: String, port: Int, multicastAddress: String, interface: NIONetworkInterface) -> EventLoopFuture<MulticastChannel> {
         return DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: host, port: port)
             .flatMap { channel in
                 let channel = channel as! MulticastChannel
@@ -207,7 +207,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "127.0.0.1", port: 0)
             .wait()
         )
@@ -266,7 +266,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "::1", port: 0)
             .wait()
         )
@@ -300,7 +300,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "127.0.0.1", port: 0)
             .wait()
         )
@@ -342,7 +342,7 @@ final class MulticastTest: XCTestCase {
 
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .bind(host: "::1", port: 0)
             .wait()
         )

--- a/Tests/NIOTests/SocketChannelTest.swift
+++ b/Tests/NIOTests/SocketChannelTest.swift
@@ -71,7 +71,7 @@ public final class SocketChannelTest : XCTestCase {
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .bind(host: "127.0.0.1", port: 0).wait())
 
@@ -354,7 +354,7 @@ public final class SocketChannelTest : XCTestCase {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
 
-        let serverSock = try Socket(protocolFamily: .inet, type: .dgram)
+        let serverSock = try Socket(protocolFamily: .inet, type: .datagram)
         try serverSock.bind(to: SocketAddress(ipAddress: "127.0.0.1", port: 0))
         let serverChannelFuture = try serverSock.withUnsafeHandle {
             DatagramBootstrap(group: group).withBoundSocket(descriptor: dup($0))
@@ -577,7 +577,7 @@ public final class SocketChannelTest : XCTestCase {
             // Build server channel; after this point the server called listen()
             let serverPromise = group.next().makePromise(of: IOError.self)
             let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
                 .serverChannelOption(ChannelOptions.backlog, value: 256)
                 .serverChannelOption(ChannelOptions.autoRead, value: false)
                 .serverChannelInitializer { channel in channel.pipeline.addHandler(ErrorHandler(serverPromise)) }
@@ -586,7 +586,7 @@ public final class SocketChannelTest : XCTestCase {
 
             // Make a client socket to mess with the server. Setting SO_LINGER forces RST instead of FIN.
             let clientSocket = try assertNoThrowWithValue(Socket(protocolFamily: .inet, type: .stream))
-            XCTAssertNoThrow(try clientSocket.setOption(level: .socket, name: .linger, value: linger(l_onoff: 1, l_linger: 0)))
+            XCTAssertNoThrow(try clientSocket.setOption(level: .socket, name: .so_linger, value: linger(l_onoff: 1, l_linger: 0)))
             XCTAssertNoThrow(try clientSocket.connect(to: serverChannel.localAddress!))
             XCTAssertNoThrow(try clientSocket.close())
         

--- a/Tests/NIOTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOTests/SocketOptionProviderTest.swift
@@ -100,8 +100,8 @@ final class SocketOptionProviderTest: XCTestCase {
         let provider = try assertNoThrowWithValue(self.convertedChannel())
 
         let newTimeout = timeval(tv_sec: 5, tv_usec: 0)
-        let retrievedTimeout = try assertNoThrowWithValue(provider.unsafeSetSocketOption(level: .socket, name: .rcvtimeo, value: newTimeout).flatMap {
-            provider.unsafeGetSocketOption(level: .socket, name: .rcvtimeo) as EventLoopFuture<timeval>
+        let retrievedTimeout = try assertNoThrowWithValue(provider.unsafeSetSocketOption(level: .socket, name: .so_rcvtimeo, value: newTimeout).flatMap {
+            provider.unsafeGetSocketOption(level: .socket, name: .so_rcvtimeo) as EventLoopFuture<timeval>
         }.wait())
 
         XCTAssertEqual(retrievedTimeout.tv_sec, newTimeout.tv_sec)
@@ -111,7 +111,7 @@ final class SocketOptionProviderTest: XCTestCase {
     func testObtainingDefaultValueOfComplexSocketOption() throws {
         let provider = try assertNoThrowWithValue(self.convertedChannel())
 
-        let retrievedTimeout: timeval = try assertNoThrowWithValue(provider.unsafeGetSocketOption(level: .socket, name: .rcvtimeo).wait())
+        let retrievedTimeout: timeval = try assertNoThrowWithValue(provider.unsafeGetSocketOption(level: .socket, name: .so_rcvtimeo).wait())
         XCTAssertEqual(retrievedTimeout.tv_sec, 0)
         XCTAssertEqual(retrievedTimeout.tv_usec, 0)
     }
@@ -120,8 +120,8 @@ final class SocketOptionProviderTest: XCTestCase {
         let provider = try assertNoThrowWithValue(self.convertedChannel())
 
         let newReuseAddr = 1 as CInt
-        let retrievedReuseAddr = try assertNoThrowWithValue(provider.unsafeSetSocketOption(level: .socket, name: .reuseaddr, value: newReuseAddr).flatMap {
-            provider.unsafeGetSocketOption(level: .socket, name: .reuseaddr) as EventLoopFuture<CInt>
+        let retrievedReuseAddr = try assertNoThrowWithValue(provider.unsafeSetSocketOption(level: .socket, name: .so_reuseaddr, value: newReuseAddr).flatMap {
+            provider.unsafeGetSocketOption(level: .socket, name: .so_reuseaddr) as EventLoopFuture<CInt>
         }.wait())
 
         XCTAssertNotEqual(retrievedReuseAddr, 0)
@@ -130,7 +130,7 @@ final class SocketOptionProviderTest: XCTestCase {
     func testObtainingDefaultValueOfSimpleSocketOption() throws {
         let provider = try assertNoThrowWithValue(self.convertedChannel())
 
-        let reuseAddr: CInt = try assertNoThrowWithValue(provider.unsafeGetSocketOption(level: .socket, name: .reuseaddr).wait())
+        let reuseAddr: CInt = try assertNoThrowWithValue(provider.unsafeGetSocketOption(level: .socket, name: .so_reuseaddr).wait())
         XCTAssertEqual(reuseAddr, 0)
     }
 
@@ -142,7 +142,7 @@ final class SocketOptionProviderTest: XCTestCase {
         // we just abandon the other tests: this is sufficient to prove that the error path works.
         let provider = try assertNoThrowWithValue(self.convertedChannel())
 
-        XCTAssertThrowsError(try provider.unsafeSetSocketOption(level: .socket, name: .rcvtimeo, value: 1).wait()) { error in
+        XCTAssertThrowsError(try provider.unsafeSetSocketOption(level: .socket, name: .so_rcvtimeo, value: 1).wait()) { error in
             XCTAssertEqual(EINVAL, (error as? IOError)?.errnoCode)
         }
     }

--- a/Tests/NIOTests/StreamChannelsTest.swift
+++ b/Tests/NIOTests/StreamChannelsTest.swift
@@ -285,7 +285,7 @@ class StreamChannelTest: XCTestCase {
             XCTAssertNoThrow(try receiver.pipeline.addHandler(FailOnReadHandler(areReadOkayNow: areReadsOkayNow)).wait())
 
             // We will immediately send exactly the amount of data that fits in the receiver's receive buffer.
-            let receiveBufferSize = Int((try? receiver.getOption(ChannelOptions.socketOption(.rcvbuf)).wait()) ?? 8192)
+            let receiveBufferSize = Int((try? receiver.getOption(ChannelOptions.socketOption(.so_rcvbuf)).wait()) ?? 8192)
             var buffer = sender.allocator.buffer(capacity: receiveBufferSize)
             buffer.writeBytes(Array(repeating: UInt8(ascii: "X"), count: receiveBufferSize))
 

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -523,7 +523,7 @@ func withTCPServerChannel<R>(bindTarget: SocketAddress? = nil,
                              line: UInt = #line,
                              _ body: (Channel) throws -> R) throws -> R {
     let server = try ServerBootstrap(group: group)
-        .serverChannelOption(ChannelOptions.socketOption(.reuseaddr), value: 1)
+        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         .bind(to: bindTarget ?? .init(ipAddress: "127.0.0.1", port: 0))
         .wait()
     do {


### PR DESCRIPTION
Motivation:

The names of most of the BSD socket option values were brought over into
their NIO helper properties, with their namespace removed. This vastly
increases the risk of collision, particularly for things like TCP_INFO,
which just became .info.

Modifications:

- Added the prefixes back, e.g. `.info` is now `.tcp_info`.
- Renamed socket type `.dgram` to `.datagram`, as this is the nice clean
  API and we should use nice clean names.

Result:

Better APIs
