### PR TITLE
survive having disableSIGPIPE fail

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -301,7 +301,12 @@ class BaseSocket: BaseSocketProtocol {
     init(descriptor: CInt) throws {
         precondition(descriptor >= 0, "invalid file descriptor")
         self.descriptor = descriptor
-        try self.ignoreSIGPIPE()
+        do {
+            try self.ignoreSIGPIPE()
+        } catch {
+            self.descriptor = -1 // We have to unset the fd here, otherwise we'll crash with "leaking open BaseSocket"
+            throw error
+        }
     }
 
     deinit {

--- a/Tests/NIOTests/SALChannelTests+XCTest.swift
+++ b/Tests/NIOTests/SALChannelTests+XCTest.swift
@@ -29,6 +29,7 @@ extension SALChannelTest {
       return [
                 ("testBasicConnectedChannel", testBasicConnectedChannel),
                 ("testWritesFromWritabilityNotificationsDoNotGetLostIfWePreviouslyWroteEverything", testWritesFromWritabilityNotificationsDoNotGetLostIfWePreviouslyWroteEverything),
+                ("testWeSurviveIfIgnoringSIGPIPEFails", testWeSurviveIfIgnoringSIGPIPEFails),
                 ("testBasicRead", testBasicRead),
            ]
    }

--- a/Tests/NIOTests/SALChannelTests.swift
+++ b/Tests/NIOTests/SALChannelTests.swift
@@ -182,6 +182,14 @@ final class SALChannelTest: XCTestCase, SALTest {
         }.salWait())
     }
 
+    func testWeSurviveIfIgnoringSIGPIPEFails() {
+        // We know this sometimes happens on Darwin, so let's test it.
+        let expectedError = IOError(errnoCode: EINVAL, reason: "bad")
+        XCTAssertThrowsError(try self.makeSocketChannelInjectingFailures(disableSIGPIPEFailure: expectedError)) { error in
+            XCTAssertEqual(expectedError.errnoCode, (error as? IOError)?.errnoCode)
+        }
+    }
+
     func testBasicRead() {
         let localAddress = try! SocketAddress(ipAddress: "0.1.2.3", port: 4)
         let serverAddress = try! SocketAddress(ipAddress: "9.8.7.6", port: 5)


### PR DESCRIPTION
Motivation:

We know that on Darwin (eg. when the other end of a TCP connection reset
_really_ early on) F_SETNOSIGPIPE sometimes fails. We thought we could
handle it but we weren't able to handle everywhere.

Modifications:

- make us survive it everywhere
- tests

Result:

- Fewer crashes with ClientBootstrap.withConnectedSocket
