### PR TITLE
fix linker check test

### DIFF
--- a/IntegrationTests/tests_03_linker_things/defines.sh
+++ b/IntegrationTests/tests_03_linker_things/defines.sh
@@ -13,5 +13,8 @@
 ##
 ##===----------------------------------------------------------------------===##
 
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$here/../.."
 swift build
 bin_path=$(swift build --show-bin-path)
+popd


### PR DESCRIPTION
Motivation:

The linker test script that checks what libraries we link was totally
broken.

Modifications:

Fix the linker test script.

Result:

We can correctly determine what we link and what not.