### PR TITLE
PipeChannel: don't explode if user passes us weird fd

### DIFF
--- a/Tests/NIOTests/PipeChannelTest+XCTest.swift
+++ b/Tests/NIOTests/PipeChannelTest+XCTest.swift
@@ -30,6 +30,7 @@ extension PipeChannelTest {
                 ("testBasicIO", testBasicIO),
                 ("testWriteErrorsCloseChannel", testWriteErrorsCloseChannel),
                 ("testWeDontAcceptRegularFiles", testWeDontAcceptRegularFiles),
+                ("testWeDontExplodeIfWeGetPassedAKqueueOrEpoll", testWeDontExplodeIfWeGetPassedAKqueueOrEpoll),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

If the user passes us a totally wrong fd, we can't do much, we may hit
EBADF or so. We should however try to not explode if at least the fd
number is correct. Most fd types we actually handle file but for kqueue
we exploded because we can't make it non-blocking :)

Modifications:

Return the appropriate error instead of failing an assertion if kqueue
passed.

Result:

Better message for users.