### PR TITLE
Supply allocation limits for UDP allocation tests

### DIFF
--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -33,6 +33,8 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010 
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200500 #5.3 improvement 210050
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -34,7 +34,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050
-      - MAX_ALLOCS_udp_1000_reqs_1_conn=16250
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=224050
 
   performance-test:


### PR DESCRIPTION
Motivation:

Values were previously missing (5.3) or incorrectly specified (5.1)
meaning that allocations were not checked in for these swift versions.

Modifications:

Correct variable name in 5.1, add missing variables in 5.3 docker files.

Result:

UDP allocations will be checked.