### PR TITLE
HTTPEncoder: fix 0 length chunks

### DIFF
--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -143,13 +143,18 @@ public final class HTTPRequestEncoder: ChannelOutboundHandler, RemovableChannelH
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         switch self.unwrapOutboundIn(data) {
         case .head(var request):
-
             self.isChunked = sanitizeTransportHeaders(hasBody: request.method.hasRequestBody, headers: &request.headers, version: request.version) == .chunked
 
             writeHead(wrapOutboundOut: self.wrapOutboundOut, writeStartLine: { buffer in
                 buffer.write(request: request)
             }, context: context, headers: request.headers, promise: promise)
         case .body(let bodyPart):
+            guard bodyPart.readableBytes > 0 else {
+                // Empty writes shouldn't send any bytes in chunked or identity encoding.
+                context.write(self.wrapOutboundOut(bodyPart), promise: promise)
+                return
+            }
+
             writeChunk(wrapOutboundOut: self.wrapOutboundOut, context: context, isChunked: self.isChunked, chunk: bodyPart, promise: promise)
         case .end(let trailers):
             writeTrailers(wrapOutboundOut: self.wrapOutboundOut, context: context, isChunked: self.isChunked, trailers: trailers, promise: promise)

--- a/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest+XCTest.swift
@@ -37,6 +37,10 @@ extension HTTPRequestEncoderTests {
                 ("testNoChunkedEncodingForHTTP10", testNoChunkedEncodingForHTTP10),
                 ("testBody", testBody),
                 ("testCONNECT", testCONNECT),
+                ("testChunkedEncodingIsTheDefault", testChunkedEncodingIsTheDefault),
+                ("testChunkedEncodingCanBetEnabled", testChunkedEncodingCanBetEnabled),
+                ("testChunkedEncodingDealsWithZeroLengthChunks", testChunkedEncodingDealsWithZeroLengthChunks),
+                ("testChunkedEncodingWorksIfNoPromisesAreAttachedToTheWrites", testChunkedEncodingWorksIfNoPromisesAreAttachedToTheWrites),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously, if the user sent us a 0 length chunk, we would encode it as
`0\r\n\r\n` which means the _end_ of the body in chunked encoding. But
the end in NIO is send by sending `.end(...)`.

Modifications:

Don't write anything for 0 length writes.

Result:

More correct behaviour with 0 length body chunks.