### PR TITLE
silence the #file used instead of #filepath warning

### DIFF
--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
@@ -1025,7 +1025,7 @@ func spawnAndJoinRacingThreads(count: Int, _ body: @escaping (Int) -> Void) {
     group.wait()
 }
 
-func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testInterval: TimeAmount? = nil, _ message: String = "condition not satisfied in time", file: StaticString = #file, line: UInt = #line) {
+func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testInterval: TimeAmount? = nil, _ message: String = "condition not satisfied in time", file: StaticString = fullFilePath(), line: UInt = #line) {
     let testInterval = testInterval ?? TimeAmount.nanoseconds(time.nanoseconds / 5)
     let endTime = NIODeadline.now() + time
 
@@ -1053,3 +1053,13 @@ fileprivate class IntHolderWithDeallocationTracking {
         _ = self.allDeallocations.add(1)
     }
 }
+
+#if compiler(>=5.3)
+internal func fullFilePath(_ filePath: StaticString = #filePath) -> StaticString {
+    return filePath
+}
+#else
+internal func fullFilePath(_ filePath: StaticString = #file) -> StaticString {
+    return filePath
+}
+#endif

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -23,7 +23,7 @@ extension ChannelPipeline {
     }
 
     func assertDoesNotContain<Handler: ChannelHandler>(handlerType: Handler.Type,
-                                                       file: StaticString = #file,
+                                                       file: StaticString = fullFilePath(),
                                                        line: UInt = #line) throws {
         do {
             let context = try self.context(handlerType: handlerType).wait()

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -281,7 +281,7 @@ private final class TestHTTPHandler: ChannelInboundHandler {
 }
 
 extension HTTPServerRequestPart {
-    func assertHead(expectedURI: String, file: StaticString = #file, line: UInt = #line) {
+    func assertHead(expectedURI: String, file: StaticString = fullFilePath(), line: UInt = #line) {
         switch self {
         case .head(let head):
             XCTAssertEqual(.GET, head.method)
@@ -292,7 +292,7 @@ extension HTTPServerRequestPart {
         }
     }
 
-    func assertBody(expectedMessage: String, file: StaticString = #file, line: UInt = #line) {
+    func assertBody(expectedMessage: String, file: StaticString = fullFilePath(), line: UInt = #line) {
         switch self {
         case .body(let buffer):
             // Note that the test server coalesces the body parts for us.
@@ -303,7 +303,7 @@ extension HTTPServerRequestPart {
         }
     }
 
-    func assertEnd(file: StaticString = #file, line: UInt = #line) {
+    func assertEnd(file: StaticString = fullFilePath(), line: UInt = #line) {
         switch self {
         case .end(_):
             ()
@@ -343,7 +343,11 @@ private enum ResponseError: Error {
     case missingResponse
 }
 
-func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testInterval: TimeAmount? = nil, _ message: String = "condition not satisfied in time", file: StaticString = #file, line: UInt = #line) {
+func assert(_ condition: @autoclosure () -> Bool,
+            within time: TimeAmount,
+            testInterval: TimeAmount? = nil,
+            _ message: String = "condition not satisfied in time",
+            file: StaticString = fullFilePath(), line: UInt = #line) {
     let testInterval = testInterval ?? TimeAmount.nanoseconds(time.nanoseconds / 5)
     let endTime = NIODeadline.now() + time
 
@@ -356,3 +360,13 @@ func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testI
         XCTFail(message, file: file, line: line)
     }
 }
+
+#if compiler(>=5.3)
+internal func fullFilePath(_ filePath: StaticString = #filePath) -> StaticString {
+    return filePath
+}
+#else
+internal func fullFilePath(_ filePath: StaticString = #file) -> StaticString {
+    return filePath
+}
+#endif

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1120,7 +1120,7 @@ class ByteBufferTest: XCTestCase {
         buf.reserveCapacity(1024)
         buf.writeStaticString("hello world, just some trap bytes here")
 
-        func testIndexAndLengthFunc<T>(_ body: (Int, Int) -> T?, file: StaticString = #file, line: UInt = #line) {
+        func testIndexAndLengthFunc<T>(_ body: (Int, Int) -> T?, file: StaticString = fullFilePath(), line: UInt = #line) {
             XCTAssertNil(body(Int.max, 1), file: file, line: line)
             XCTAssertNil(body(Int.max - 1, 2), file: file, line: line)
             XCTAssertNil(body(1, Int.max), file: file, line: line)
@@ -1131,7 +1131,7 @@ class ByteBufferTest: XCTestCase {
             XCTAssertNil(body(Int.min, Int.max), file: file, line: line)
         }
 
-        func testIndexOrLengthFunc<T>(_ body: (Int) -> T?, file: StaticString = #file, line: UInt = #line) {
+        func testIndexOrLengthFunc<T>(_ body: (Int) -> T?, file: StaticString = fullFilePath(), line: UInt = #line) {
             XCTAssertNil(body(Int.max))
             XCTAssertNil(body(Int.max - 1))
             XCTAssertNil(body(Int.min))

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -17,7 +17,7 @@ import XCTest
 
 class ChannelNotificationTest: XCTestCase {
 
-    private static func assertFulfilled(promise: EventLoopPromise<Void>?, promiseName: String, trigger: String, setter: String, file: StaticString = #file, line: UInt = #line) {
+    private static func assertFulfilled(promise: EventLoopPromise<Void>?, promiseName: String, trigger: String, setter: String, file: StaticString = fullFilePath(), line: UInt = #line) {
         if let promise = promise {
             XCTAssertTrue(promise.futureResult.isFulfilled, "\(promiseName) not fulfilled before \(trigger) was called", file: file, line: line)
         } else {

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -255,7 +255,7 @@ public final class ChannelTests: XCTestCase {
                                    expectedFileWritabilities: [(Int, Int)]?,
                                    returns: [IOResult<Int>],
                                    promiseStates: [[Bool]],
-                                   file: StaticString = #file,
+                                   file: StaticString = fullFilePath(),
                                    line: UInt = #line) throws -> OverallWriteResult {
         var everythingState = 0
         var singleState = 0
@@ -1959,7 +1959,7 @@ public final class ChannelTests: XCTestCase {
     }
 
     func testAppropriateAndInappropriateOperationsForUnregisteredSockets() throws {
-        func checkThatItThrowsInappropriateOperationForState(file: StaticString = #file, line: UInt = #line, _ body: () throws -> Void) {
+        func checkThatItThrowsInappropriateOperationForState(file: StaticString = fullFilePath(), line: UInt = #line, _ body: () throws -> Void) {
             XCTAssertThrowsError(try body(), file: file, line: line) { error in
                 XCTAssertEqual(.inappropriateOperationForState, error as? ChannelError)
             }
@@ -1969,7 +1969,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try elg.syncShutdownGracefully())
         }
 
-        func withChannel(skipDatagram: Bool = false, skipStream: Bool = false, skipServerSocket: Bool = false, file: StaticString = #file, line: UInt = #line,  _ body: (Channel) throws -> Void) {
+        func withChannel(skipDatagram: Bool = false, skipStream: Bool = false, skipServerSocket: Bool = false, file: StaticString = fullFilePath(), line: UInt = #line,  _ body: (Channel) throws -> Void) {
             XCTAssertNoThrow(try {
                 let el = elg.next() as! SelectableEventLoop
                 let channels: [Channel] = (skipDatagram ? [] : [try DatagramChannel(eventLoop: el, protocolFamily: .inet)]) +

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -1541,7 +1541,7 @@ public final class MessageToByteEncoderTest: XCTestCase {
         try testEncoder(MessageToByteHandler(Int32ToByteEncoderWithDefaultImpl()))
     }
 
-    private func testEncoder(_ handler: ChannelHandler, file: StaticString = #file, line: UInt = #line) throws {
+    private func testEncoder(_ handler: ChannelHandler, file: StaticString = fullFilePath(), line: UInt = #line) throws {
         let channel = EmbeddedChannel()
 
         XCTAssertNoThrow(try channel.pipeline.addHandler(MessageToByteHandler(Int32ToByteEncoder())).wait(),

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -165,7 +165,7 @@ class EmbeddedChannelTest: XCTestCase {
 
         func check<Expected, Actual>(expected: Expected.Type,
                                      actual: Actual.Type,
-                                     file: StaticString = #file,
+                                     file: StaticString = fullFilePath(),
                                      line: UInt = #line) {
             do {
                 _ = try channel.readOutbound(as: Expected.self)

--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -118,7 +118,7 @@ final class MulticastTest: XCTestCase {
         }
     }
 
-    private func assertDatagramReaches(multicastChannel: Channel, sender: Channel, multicastAddress: SocketAddress, file: StaticString = #file, line: UInt = #line) throws {
+    private func assertDatagramReaches(multicastChannel: Channel, sender: Channel, multicastAddress: SocketAddress, file: StaticString = fullFilePath(), line: UInt = #line) throws {
         let receivedMulticastDatagram = multicastChannel.eventLoop.makePromise(of: AddressedEnvelope<ByteBuffer>.self)
         XCTAssertNoThrow(try multicastChannel.pipeline.addHandler(PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
 
@@ -140,7 +140,7 @@ final class MulticastTest: XCTestCase {
                                             after timeout: TimeAmount,
                                             sender: Channel,
                                             multicastAddress: SocketAddress,
-                                            file: StaticString = #file, line: UInt = #line) throws {
+                                            file: StaticString = fullFilePath(), line: UInt = #line) throws {
         let timeoutPromise = multicastChannel.eventLoop.makePromise(of: Void.self)
         let receivedMulticastDatagram = multicastChannel.eventLoop.makePromise(of: AddressedEnvelope<ByteBuffer>.self)
         XCTAssertNoThrow(try multicastChannel.pipeline.addHandler(PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
@@ -102,7 +102,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                            expectedVectorWritabilities: [[(Int, SocketAddress)]]?,
                                            returns: [Result<IOResult<Int>, Error>],
                                            promiseStates: [[Bool]],
-                                           file: StaticString = #file,
+                                           file: StaticString = fullFilePath(),
                                            line: UInt = #line) throws -> OverallWriteResult {
         var everythingState = 0
         var singleState = 0

--- a/Tests/NIOTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOTests/SocketOptionProviderTest.swift
@@ -24,7 +24,7 @@ final class SocketOptionProviderTest: XCTestCase {
 
     struct CastError: Error { }
 
-    private func convertedChannel(file: StaticString = #file, line: UInt = #line) throws -> SocketOptionProvider {
+    private func convertedChannel(file: StaticString = fullFilePath(), line: UInt = #line) throws -> SocketOptionProvider {
         guard let provider = self.clientChannel as? SocketOptionProvider else {
             XCTFail("Unable to cast \(String(describing: self.clientChannel)) to SocketOptionProvider", file: file, line: line)
             throw CastError()
@@ -32,7 +32,7 @@ final class SocketOptionProviderTest: XCTestCase {
         return provider
     }
 
-    private func ipv4MulticastProvider(file: StaticString = #file, line: UInt = #line) throws -> SocketOptionProvider {
+    private func ipv4MulticastProvider(file: StaticString = fullFilePath(), line: UInt = #line) throws -> SocketOptionProvider {
         guard let provider = self.ipv4DatagramChannel as? SocketOptionProvider else {
             XCTFail("Unable to cast \(String(describing: self.ipv4DatagramChannel)) to SocketOptionProvider", file: file, line: line)
             throw CastError()
@@ -40,7 +40,7 @@ final class SocketOptionProviderTest: XCTestCase {
         return provider
     }
 
-    private func ipv6MulticastProvider(file: StaticString = #file, line: UInt = #line) throws -> SocketOptionProvider? {
+    private func ipv6MulticastProvider(file: StaticString = fullFilePath(), line: UInt = #line) throws -> SocketOptionProvider? {
         guard let ipv6Channel = self.ipv6DatagramChannel else {
             return nil
         }

--- a/Tests/NIOTests/StreamChannelsTest.swift
+++ b/Tests/NIOTests/StreamChannelsTest.swift
@@ -836,7 +836,7 @@ final class AccumulateAllReads: ChannelInboundHandler {
     }
 }
 
-private func assertNoSelectorChanges(fd: CInt, file: StaticString = #file, line: UInt = #line) throws {
+private func assertNoSelectorChanges(fd: CInt, file: StaticString = fullFilePath(), line: UInt = #line) throws {
     struct UnexpectedSelectorChanges: Error, CustomStringConvertible {
         let description: String
     }

--- a/Tests/NIOTests/SyscallAbstractionLayer.swift
+++ b/Tests/NIOTests/SyscallAbstractionLayer.swift
@@ -47,7 +47,11 @@ final class LockedBox<T> {
         }
     }
 
-    init(_ value: T? = nil, description: String? = nil, file: String = #file, line: UInt = #line, didSet: @escaping (T?) -> Void = { _ in }) {
+    init(_ value: T? = nil,
+         description: String? = nil,
+         file: StaticString = fullFilePath(),
+         line: UInt = #line,
+         didSet: @escaping (T?) -> Void = { _ in }) {
         self._value = value
         self.didSet = didSet
         self.description = description ?? "\(file):\(line)"
@@ -342,7 +346,7 @@ class HookedSocket: Socket, UserKernelInterface {
 
 extension HookedSelector {
     func assertSyscallAndReturn(_ result: KernelToUser,
-                                file: StaticString = #file,
+                                file: StaticString = fullFilePath(),
                                 line: UInt = #line,
                                 matcher: (UserToKernel) throws -> Bool) throws {
         let syscall = try self.userToKernel.takeValue()
@@ -354,7 +358,7 @@ extension HookedSelector {
         }
     }
 
-    func assertWakeup(file: StaticString = #file, line: UInt = #line) throws {
+    func assertWakeup(file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.assertSyscallAndReturn(.returnSelectorEvent(nil), file: file, line: line) { syscall in
             if case .whenReady(.block) = syscall {
@@ -370,7 +374,7 @@ extension HookedSelector {
 
 extension EventLoop {
     internal func runSAL<T>(syscallAssertions: () throws -> Void = {},
-                            file: StaticString = #file,
+                            file: StaticString = fullFilePath(),
                             line: UInt = #line,
                             _ body: @escaping () throws -> T) throws -> T {
         let hookedSelector = ((self as! SelectableEventLoop)._selector as! HookedSelector)
@@ -454,7 +458,7 @@ extension SALTest {
     }
 
     private func makeSocketChannel(eventLoop: SelectableEventLoop,
-                                   file: StaticString = #file, line: UInt = #line) throws -> SocketChannel {
+                                   file: StaticString = fullFilePath(), line: UInt = #line) throws -> SocketChannel {
         let channel = try eventLoop.runSAL(syscallAssertions: {
             try self.assertdisableSIGPIPE(expectedFD: .max, result: .success(()))
             try self.assertLocalAddress(address: nil)
@@ -493,7 +497,7 @@ extension SALTest {
 
     func makeConnectedSocketChannel(localAddress: SocketAddress?,
                                     remoteAddress: SocketAddress,
-                                    file: StaticString = #file,
+                                    file: StaticString = fullFilePath(),
                                     line: UInt = #line) throws -> SocketChannel {
         let channel = try self.makeSocketChannel(eventLoop: self.loop)
         let connectFuture = try channel.eventLoop.runSAL(syscallAssertions: {
@@ -554,7 +558,7 @@ extension SALTest {
         self.wakeups = nil
     }
 
-    func assertParkedRightNow(file: StaticString = #file, line: UInt = #line) throws {
+    func assertParkedRightNow(file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         let syscall = try self.userToKernelBox.waitForValue()
         if case .whenReady = syscall {
@@ -565,7 +569,7 @@ extension SALTest {
     }
 
     func assertWaitingForNotification(result: SelectorEvent<NIORegistration>?,
-                                      file: StaticString = #file, line: UInt = #line) throws {
+                                      file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)(result: \(result.debugDescription))")
         try self.selector.assertSyscallAndReturn(.returnSelectorEvent(result),
                                                  file: file, line: line) { syscall in
@@ -577,13 +581,13 @@ extension SALTest {
         }
     }
 
-    func assertWakeup(file: StaticString = #file, line: UInt = #line) throws {
+    func assertWakeup(file: StaticString = fullFilePath(), line: UInt = #line) throws {
         try self.selector.assertWakeup(file: file, line: line)
     }
 
     func assertdisableSIGPIPE(expectedFD: CInt,
                              result: Result<Void, IOError>,
-                             file: StaticString = #file, line: UInt = #line) throws {
+                             file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         let ret: KernelToUser
         switch result {
@@ -602,7 +606,7 @@ extension SALTest {
     }
 
 
-    func assertLocalAddress(address: SocketAddress?, file: StaticString = #file, line: UInt = #line) throws {
+    func assertLocalAddress(address: SocketAddress?, file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(address.map { .returnSocketAddress($0) } ??
             /*                                */ .error(.init(errnoCode: EOPNOTSUPP, reason: "nil passed")),
@@ -615,7 +619,7 @@ extension SALTest {
         }
     }
 
-    func assertRemoteAddress(address: SocketAddress?, file: StaticString = #file, line: UInt = #line) throws {
+    func assertRemoteAddress(address: SocketAddress?, file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(address.map { .returnSocketAddress($0) } ??
             /*                                */ .error(.init(errnoCode: EOPNOTSUPP, reason: "nil passed")),
@@ -628,7 +632,7 @@ extension SALTest {
         }
     }
 
-    func assertConnect(result: Bool, file: StaticString = #file, line: UInt = #line, _ matcher: (SocketAddress) -> Bool = { _ in true }) throws {
+    func assertConnect(result: Bool, file: StaticString = fullFilePath(), line: UInt = #line, _ matcher: (SocketAddress) -> Bool = { _ in true }) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(.returnBool(result), file: file, line: line) { syscall in
             if case .connect(let address) = syscall {
@@ -639,7 +643,7 @@ extension SALTest {
         }
     }
 
-    func assertClose(expectedFD: CInt, file: StaticString = #file, line: UInt = #line) throws {
+    func assertClose(expectedFD: CInt, file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
             if case .close(let fd) = syscall {
@@ -652,7 +656,7 @@ extension SALTest {
     }
 
 
-    func assertRegister(file: StaticString = #file, line: UInt = #line, _ matcher: (Selectable, SelectorEventSet, NIORegistration) throws -> Bool) throws {
+    func assertRegister(file: StaticString = fullFilePath(), line: UInt = #line, _ matcher: (Selectable, SelectorEventSet, NIORegistration) throws -> Bool) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
             if case .register(let selectable, let eventSet, let registration) = syscall {
@@ -663,7 +667,7 @@ extension SALTest {
         }
     }
 
-    func assertReregister(file: StaticString = #file, line: UInt = #line, _ matcher: (Selectable, SelectorEventSet) throws -> Bool) throws {
+    func assertReregister(file: StaticString = fullFilePath(), line: UInt = #line, _ matcher: (Selectable, SelectorEventSet) throws -> Bool) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
             if case .reregister(let selectable, let eventSet) = syscall {
@@ -674,7 +678,7 @@ extension SALTest {
         }
     }
 
-    func assertDeregister(file: StaticString = #file, line: UInt = #line, _ matcher: (Selectable) throws -> Bool) throws {
+    func assertDeregister(file: StaticString = fullFilePath(), line: UInt = #line, _ matcher: (Selectable) throws -> Bool) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
             if case .deregister(let selectable) = syscall {
@@ -685,7 +689,7 @@ extension SALTest {
         }
     }
 
-    func assertWrite(expectedFD: CInt, expectedBytes: ByteBuffer, return: IOResult<Int>, file: StaticString = #file, line: UInt = #line) throws {
+    func assertWrite(expectedFD: CInt, expectedBytes: ByteBuffer, return: IOResult<Int>, file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(.returnIOResultInt(`return`), file: file, line: line) { syscall in
             if case .write(let actualFD, let actualBytes) = syscall {
@@ -696,7 +700,7 @@ extension SALTest {
         }
     }
 
-    func assertWritev(expectedFD: CInt, expectedBytes: [ByteBuffer], return: IOResult<Int>, file: StaticString = #file, line: UInt = #line) throws {
+    func assertWritev(expectedFD: CInt, expectedBytes: [ByteBuffer], return: IOResult<Int>, file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(.returnIOResultInt(`return`), file: file, line: line) { syscall in
             if case .writev(let actualFD, let actualBytes) = syscall {
@@ -708,7 +712,7 @@ extension SALTest {
     }
 
     func assertRead(expectedFD: CInt, expectedBufferSpace: Int, return: ByteBuffer,
-                    file: StaticString = #file, line: UInt = #line) throws {
+                    file: StaticString = fullFilePath(), line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(.returnBytes(`return`),
                                                  file: file, line: line) { syscall in

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -32,7 +32,7 @@ extension EmbeddedChannel {
 extension ChannelPipeline {
     
     fileprivate func assertDoesNotContain<Handler: ChannelHandler>(handlerType: Handler.Type,
-                                                                   file: StaticString = #file,
+                                                                   file: StaticString = fullFilePath(),
                                                                    line: UInt = #line) throws {
         XCTAssertThrowsError(try self.context(handlerType: handlerType).wait(), file: file, line: line) { error in
             XCTAssertEqual(.notFound, error as? ChannelPipelineError)
@@ -411,3 +411,13 @@ class WebSocketClientEndToEndTests: XCTestCase {
         XCTAssertNoThrow(try clientChannel.close().wait())
     }
 }
+
+#if compiler(>=5.3)
+internal func fullFilePath(_ filePath: StaticString = #filePath) -> StaticString {
+    return filePath
+}
+#else
+internal func fullFilePath(_ filePath: StaticString = #file) -> StaticString {
+    return filePath
+}
+#endif


### PR DESCRIPTION
Motivation:

Very recent versions of the Swift compiler complain if you pass `#file`
to a parameter that is defaulted to `#filePath`. You can silence the
warning by using `(#file)`. We cannot migrate to `#filepath` because we
support Swift 5.0 and 5.1 which don't have `#filepath` yet.

Modifications:

- replace all occurances of `#file` by a special (test `internal`)
function `fullFilePath()` which gives you the full path and is defined
differently depending on the compiler version.

Result:

No warnings even on the latest compiler versions.