### PR TITLE
thread takeover: test it unsets current EL

### DIFF
--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -73,6 +73,7 @@ extension EventLoopTest {
                 ("testSafeToExecuteTrue", testSafeToExecuteTrue),
                 ("testSafeToExecuteFalse", testSafeToExecuteFalse),
                 ("testTakeOverThreadAndAlsoTakeItBack", testTakeOverThreadAndAlsoTakeItBack),
+                ("testThreadTakeoverUnsetsCurrentEventLoop", testThreadTakeoverUnsetsCurrentEventLoop),
                 ("testWeCanDoTrulySingleThreadedNetworking", testWeCanDoTrulySingleThreadedNetworking),
            ]
    }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -1159,6 +1159,19 @@ public final class EventLoopTest : XCTestCase {
         XCTAssertTrue(lock.withLock { hasBeenShutdown })
     }
 
+    func testThreadTakeoverUnsetsCurrentEventLoop() {
+        XCTAssertNil(MultiThreadedEventLoopGroup.currentEventLoop)
+
+        MultiThreadedEventLoopGroup.withCurrentThreadAsEventLoop { el in
+            XCTAssert(el === MultiThreadedEventLoopGroup.currentEventLoop)
+            el.shutdownGracefully { error in
+                XCTAssertNil(error)
+            }
+        }
+
+        XCTAssertNil(MultiThreadedEventLoopGroup.currentEventLoop)
+    }
+
     func testWeCanDoTrulySingleThreadedNetworking() {
         final class SaveReceivedByte: ChannelInboundHandler {
             typealias InboundIn = ByteBuffer


### PR DESCRIPTION
Motivation:

I thought I forgot to implement unsetting the current EventLoop in the
thread takeover (withCurrentThreadAsEventLoop). Turns out I didn't.

Modifications:

Add a test to prove it's okay.

Result:

More test coverage.