### PR TITLE
don't blow up if schedule happens during EL shutdown

### DIFF
--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -75,6 +75,8 @@ extension EventLoopTest {
                 ("testTakeOverThreadAndAlsoTakeItBack", testTakeOverThreadAndAlsoTakeItBack),
                 ("testThreadTakeoverUnsetsCurrentEventLoop", testThreadTakeoverUnsetsCurrentEventLoop),
                 ("testWeCanDoTrulySingleThreadedNetworking", testWeCanDoTrulySingleThreadedNetworking),
+                ("testWeFailOutstandingScheduledTasksOnELShutdown", testWeFailOutstandingScheduledTasksOnELShutdown),
+                ("testSchedulingTaskOnFutureFailedByELShutdownDoesNotMakeUsExplode", testSchedulingTaskOnFutureFailedByELShutdownDoesNotMakeUsExplode),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously, if we scheduled EventLoop executions from the promises we
failed during EventLoop shutdown, we'd blow up. Thanks to @fabianfett
for the bug report.

Modifications:

Set the EL state to 'exiting thread' only after we failed all
outstanding tasks.

Result:

Fewer crashes.
