### PR TITLE
Execute tasks scheduled at the same time in order on EmbeddedEventLoop

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -434,7 +434,7 @@ extension NIODeadline: CustomStringConvertible {
 
 extension NIODeadline {
     public static func - (lhs: NIODeadline, rhs: NIODeadline) -> TimeAmount {
-        // This won't ever crash, NIODeadlines are guanteed to be within 0 ..< 2^63-1 nanoseconds so the result can
+        // This won't ever crash, NIODeadlines are guaranteed to be within 0 ..< 2^63-1 nanoseconds so the result can
         // definitely be stored in a TimeAmount (which is an Int64).
         return .nanoseconds(Int64(lhs.uptimeNanoseconds) - Int64(rhs.uptimeNanoseconds))
     }

--- a/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
@@ -46,6 +46,8 @@ extension EmbeddedEventLoopTest {
                 ("testDrainScheduledTasksDoesNotRunNewlyScheduledTasks", testDrainScheduledTasksDoesNotRunNewlyScheduledTasks),
                 ("testAdvanceTimeToDeadline", testAdvanceTimeToDeadline),
                 ("testWeCantTimeTravelByAdvancingTimeToThePast", testWeCantTimeTravelByAdvancingTimeToThePast),
+                ("testExecuteInOrder", testExecuteInOrder),
+                ("testScheduledTasksInOrder", testScheduledTasksInOrder),
            ]
    }
 }

--- a/Tests/NIOTests/EmbeddedEventLoopTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest.swift
@@ -406,4 +406,50 @@ public final class EmbeddedEventLoopTest: XCTestCase {
         eventLoop.advanceTime(by: .seconds(2))
         XCTAssertEqual(tasksRun, 1)
     }
+
+    func testExecuteInOrder() {
+        let eventLoop = EmbeddedEventLoop()
+        var counter = 0
+
+        eventLoop.execute {
+            XCTAssertEqual(counter, 0)
+            counter += 1
+        }
+
+        eventLoop.execute {
+            XCTAssertEqual(counter, 1)
+            counter += 1
+        }
+
+        eventLoop.execute {
+            XCTAssertEqual(counter, 2)
+            counter += 1
+        }
+
+        eventLoop.run()
+        XCTAssertEqual(counter, 3)
+    }
+
+    func testScheduledTasksInOrder() {
+        let eventLoop = EmbeddedEventLoop()
+        var counter = 0
+
+        eventLoop.scheduleTask(in: .seconds(1)) {
+            XCTAssertEqual(counter, 1)
+            counter += 1
+        }
+
+        eventLoop.scheduleTask(in: .milliseconds(1)) {
+            XCTAssertEqual(counter, 0)
+            counter += 1
+        }
+
+        eventLoop.scheduleTask(in: .seconds(1)) {
+            XCTAssertEqual(counter, 2)
+            counter += 1
+        }
+
+        eventLoop.advanceTime(by: .seconds(1))
+        XCTAssertEqual(counter, 3)
+    }
 }


### PR DESCRIPTION
Motivation:

`EmbeddedEventLoop` executes scheduled tasks in their run-time order.
If multiple tasks are scheduled for the same time then the order in
which they are eventually executed is undefined.

Since `execute` defers to scheduling a task for "now" it is possible for
tasks to be executed out of order if `run()` is not called between each
execute.

In "real" event loops this isn't an issue because the system time must
advance between each call to `execute`.

Modifications:

- Add a 'insertionOrder' to `EmbeddedScheduledTask`; use it to break
  ties when comparing two tasks with the same run time
- Add a task counter to `EmbeddedEventLoop` which is used to provide an
  insertion order when scheduling tasks.

Result:

- EmbeddedEventLoop will `execute` tasks in order