### PR TITLE
workaround SR-12939

### DIFF
--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -11,6 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+// Xcode's Archive builds with Xcode's Package support struggle with empty .c files
+// (https://bugs.swift.org/browse/SR-12939).
+void CNIOLinux_i_do_nothing_just_working_around_a_darwin_toolchain_bug(void) {}
+
 #ifdef __linux__
 
 #define _GNU_SOURCE


### PR DESCRIPTION
Motivation:

Xcode's Archive builds hit https://bugs.swift.org/browse/SR-12939 when encountering completely empty `.o` files.

Modification:

Add a useless symbol.

Result:

Fewer build failures.