### PR TITLE
Shorthand way of setting options in universal bootstrap

### DIFF
--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -97,7 +97,7 @@ extension ChannelOptions {
 /// Approved shorthand options.
 extension ChannelOptions.NIOTCPShorthandOption {
     /// Allow immediately reusing a local address.
-    public static let allowImmediateLocalAddressReuse = ChannelOptions.NIOTCPShorthandOption(.reuseAddr)
+    public static let allowLocalEndpointReuse = ChannelOptions.NIOTCPShorthandOption(.reuseAddr)
     
     /// The user will manually call `Channel.read` once all the data is read from the transport.
     public static let disableAutoRead = ChannelOptions.NIOTCPShorthandOption(.disableAutoRead)
@@ -114,7 +114,7 @@ extension ChannelOptions.NIOTCPShorthandOption {
 extension ChannelOptions {
     /// A set of `NIOTCPShorthandOption`s
     public struct NIOTCPShorthandOptions: ExpressibleByArrayLiteral, Hashable {
-        var allowImmediateLocalAddressReuse = false
+        var allowLocalEndpointReuse = false
         var disableAutoRead = false
         var allowRemoteHalfClosure = false
         
@@ -130,7 +130,7 @@ extension ChannelOptions {
         mutating func add(_ element: NIOTCPShorthandOption) {
             switch element.data {
             case .reuseAddr:
-                self.allowImmediateLocalAddressReuse = true
+                self.allowLocalEndpointReuse = true
             case .allowRemoteHalfClosure:
                 self.allowRemoteHalfClosure = true
             case .disableAutoRead:
@@ -138,14 +138,14 @@ extension ChannelOptions {
             }
         }
         
-        /// Caller is consuming the knowledge that allowImmediateLocalAddressReuse was set or not.
+        /// Caller is consuming the knowledge that `allowLocalEndpointReuse` was set or not.
         /// The setting will nolonger be set after this call.
-        /// - Returns: If allowImmediateLocalAddressReuse was set.
-        public mutating func consumeAllowImmediateLocalAddressReuse() -> Types.NIOOptionValue<Void> {
+        /// - Returns: If `allowLocalEndpointReuse` was set.
+        public mutating func consumeAllowLocalEndpointReuse() -> Types.NIOOptionValue<Void> {
             defer {
-                self.allowImmediateLocalAddressReuse = false
+                self.allowLocalEndpointReuse = false
             }
-            return Types.NIOOptionValue<Void>(flag: self.allowImmediateLocalAddressReuse)
+            return Types.NIOOptionValue<Void>(flag: self.allowLocalEndpointReuse)
         }
         
         /// Caller is consuming the knowledge that disableAutoRead was set or not.
@@ -170,7 +170,7 @@ extension ChannelOptions {
         
         func applyFallbackMapping(_ universalBootstrap: NIOClientTCPBootstrap) -> NIOClientTCPBootstrap {
             var result = universalBootstrap
-            if self.allowImmediateLocalAddressReuse {
+            if self.allowLocalEndpointReuse {
                 result = result.channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             }
             if self.allowRemoteHalfClosure {

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -168,15 +168,15 @@ extension ChannelOptions {
             return Types.NIOOptionValue<Void>(flag: self.allowRemoteHalfClosure)
         }
         
-        func applyFallbackMapping(_ universalBootstrap: NIOClientTCPBootstrap) -> NIOClientTCPBootstrap {
+        mutating func applyFallbackMapping(_ universalBootstrap: NIOClientTCPBootstrap) -> NIOClientTCPBootstrap {
             var result = universalBootstrap
-            if self.allowLocalEndpointReuse {
+            if self.consumeAllowLocalEndpointReuse().isSet {
                 result = result.channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             }
-            if self.allowRemoteHalfClosure {
+            if self.consumeAllowRemoteHalfClosure().isSet {
                 result = result.channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
             }
-            if self.disableAutoRead {
+            if self.consumeDisableAutoRead().isSet {
                 result = result.channelOption(ChannelOptions.autoRead, value: false)
             }
             return result

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -34,8 +34,8 @@ extension NIOClientTCPBootstrap {
         var optionsRemaining = options
         // First give the underlying a chance to consume options.
         let withUnderlyingOverrides =
-            NIOClientTCPBootstrap(self, withUpdated:
-                                    underlyingBootstrap._applyChannelConvenienceOptions(&optionsRemaining))
+            NIOClientTCPBootstrap(self,
+                                  updating: underlyingBootstrap._applyChannelConvenienceOptions(&optionsRemaining))
         // Default apply any remaining options.
         return optionsRemaining.applyFallbackMapping(withUnderlyingOverrides)
     }
@@ -123,7 +123,7 @@ extension ChannelOptions {
         @inlinable
         public init(arrayLiteral elements: TCPConvenienceOption...) {
             for element in elements {
-                add(element)
+                self.add(element)
             }
         }
         

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -1,0 +1,178 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// MARK:  Universal Client Bootstrap
+extension NIOClientTCPBootstrapProtocol {
+    /// Apply any understood shorthand options to the bootstrap, removing them from the set of options if they are consumed.
+    /// - parameters:
+    ///     - options:  The options to try applying - the options applied should be consumed from here.
+    /// - returns: The updated bootstrap with and options applied.
+    public func _applyOptions(_ options: inout NIOTCPShorthandOptions) -> Self {
+        // Default is to consume no options and not update self.
+        return self
+    }
+}
+
+extension NIOClientTCPBootstrap {
+    /// Specifies some `ChannelOption`s to be applied to the channel.
+    /// - See: channelOption
+    /// - Parameter options: Set of shorthand options to apply.
+    /// - Returns: The updated bootstrap (`self` being mutated)
+    public func options(_ options: NIOTCPShorthandOptions) -> NIOClientTCPBootstrap {
+        var optionsRemaining = options
+        // First give the underlying a chance to consume options.
+        let withUnderlyingOverrides =
+            NIOClientTCPBootstrap(self, withUpdated: underlyingBootstrap._applyOptions(&optionsRemaining))
+        // Default apply any remaining options.
+        return optionsRemaining.applyFallbackMapping(withUnderlyingOverrides)
+    }
+}
+
+// MARK: Utility
+/// Has an option been set?
+/// Option has a value of generic type T.
+public enum NIOOptionValue<T> {
+    /// The option was not set.
+    case notSet
+    /// The option was set with a value of type T.
+    case set(T)
+}
+
+public extension NIOOptionValue where T == () {
+    /// Convenience method working with bool options as bool values for set.
+    var isSet: Bool {
+        get {
+            switch self {
+            case .notSet:
+                return false
+            case .set(()):
+                return true
+            }
+        }
+    }
+}
+
+private extension NIOOptionValue where T == () {
+    init(flag: Bool) {
+        if flag {
+            self = .set(())
+        } else {
+            self = .notSet
+        }
+    }
+}
+
+// MARK: TCP - data
+/// A TCP channel option which can be applied to a bootstrap using shorthand notation.
+public struct NIOTCPShorthandOption: Hashable {
+    fileprivate var data: ShorthandOption
+    
+    private init(_ data: ShorthandOption) {
+        self.data = data
+    }
+    
+    fileprivate enum ShorthandOption: Hashable {
+        case reuseAddr
+        case disableAutoRead
+        case allowRemoteHalfClosure
+    }
+}
+
+/// Approved shorthand options.
+extension NIOTCPShorthandOption {
+    /// Allow immediately reusing a local address.
+    public static let allowImmediateLocalEndpointAddressReuse = NIOTCPShorthandOption(.reuseAddr)
+    
+    /// The user will manually call `Channel.read` once all the data is read from the transport.
+    public static let disableAutoRead = NIOTCPShorthandOption(.disableAutoRead)
+    
+    /// Allows users to configure whether the `Channel` will close itself when its remote
+    /// peer shuts down its send stream, or whether it will remain open. If set to `false` (the default), the `Channel`
+    /// will be closed automatically if the remote peer shuts down its send stream. If set to true, the `Channel` will
+    /// not be closed: instead, a `ChannelEvent.inboundClosed` user event will be sent on the `ChannelPipeline`,
+    /// and no more data will be received.
+    public static let allowRemoteHalfClosure =
+        NIOTCPShorthandOption(.allowRemoteHalfClosure)
+}
+
+/// A set of `NIOTCPShorthandOption`s
+public struct NIOTCPShorthandOptions : ExpressibleByArrayLiteral, Hashable {
+    var allowImmediateLocalEndpointAddressReuse = false
+    var disableAutoRead = false
+    var allowRemoteHalfClosure = false
+    
+    /// Construct from an array literal.
+    @inlinable
+    public init(arrayLiteral elements: NIOTCPShorthandOption...) {
+        for element in elements {
+            add(element)
+        }
+    }
+    
+    @usableFromInline
+    mutating func add(_ element: NIOTCPShorthandOption) {
+        switch element.data {
+        case .reuseAddr:
+            self.allowImmediateLocalEndpointAddressReuse = true
+        case .allowRemoteHalfClosure:
+            self.allowRemoteHalfClosure = true
+        case .disableAutoRead:
+            self.disableAutoRead = true
+        }
+    }
+    
+    /// Caller is consuming the knowledge that allowImmediateLocalEndpointAddressReuse was set or not.
+    /// The setting will nolonger be set after this call.
+    /// - Returns: If allowImmediateLocalEndpointAddressReuse was set.
+    public mutating func consumeAllowImmediateLocalEndpointAddressReuse() -> NIOOptionValue<Void> {
+        defer {
+            self.allowImmediateLocalEndpointAddressReuse = false
+        }
+        return NIOOptionValue<Void>(flag: self.allowImmediateLocalEndpointAddressReuse)
+    }
+    
+    /// Caller is consuming the knowledge that disableAutoRead was set or not.
+    /// The setting will nolonger be set after this call.
+    /// - Returns: If disableAutoRead was set.
+    public mutating func consumeDisableAutoRead() -> NIOOptionValue<Void> {
+        defer {
+            self.disableAutoRead = false
+        }
+        return NIOOptionValue<Void>(flag: self.disableAutoRead)
+    }
+    
+    /// Caller is consuming the knowledge that allowRemoteHalfClosure was set or not.
+    /// The setting will nolonger be set after this call.
+    /// - Returns: If allowRemoteHalfClosure was set.
+    public mutating func consumeAllowRemoteHalfClosure() -> NIOOptionValue<Void> {
+        defer {
+            self.allowRemoteHalfClosure = false
+        }
+        return NIOOptionValue<Void>(flag: self.allowRemoteHalfClosure)
+    }
+    
+    func applyFallbackMapping(_ universalBootstrap: NIOClientTCPBootstrap) -> NIOClientTCPBootstrap {
+        var result = universalBootstrap
+        if self.allowImmediateLocalEndpointAddressReuse {
+            result = result.channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+        }
+        if self.allowRemoteHalfClosure {
+            result = result.channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+        }
+        if self.disableAutoRead {
+            result = result.channelOption(ChannelOptions.autoRead, value: false)
+        }
+        return result
+    }
+}

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -120,14 +120,14 @@ extension ChannelOptions {
         
         /// Construct from an array literal.
         @inlinable
-        public init(arrayLiteral elements: ChannelOptions.NIOTCPShorthandOption...) {
+        public init(arrayLiteral elements: NIOTCPShorthandOption...) {
             for element in elements {
                 add(element)
             }
         }
         
         @usableFromInline
-        mutating func add(_ element: ChannelOptions.NIOTCPShorthandOption) {
+        mutating func add(_ element: NIOTCPShorthandOption) {
             switch element.data {
             case .reuseAddr:
                 self.allowImmediateLocalAddressReuse = true
@@ -141,32 +141,31 @@ extension ChannelOptions {
         /// Caller is consuming the knowledge that allowImmediateLocalAddressReuse was set or not.
         /// The setting will nolonger be set after this call.
         /// - Returns: If allowImmediateLocalAddressReuse was set.
-        public mutating func consumeAllowImmediateLocalAddressReuse() ->
-                                ChannelOptions.Types.NIOOptionValue<Void> {
+        public mutating func consumeAllowImmediateLocalAddressReuse() -> Types.NIOOptionValue<Void> {
             defer {
                 self.allowImmediateLocalAddressReuse = false
             }
-            return ChannelOptions.Types.NIOOptionValue<Void>(flag: self.allowImmediateLocalAddressReuse)
+            return Types.NIOOptionValue<Void>(flag: self.allowImmediateLocalAddressReuse)
         }
         
         /// Caller is consuming the knowledge that disableAutoRead was set or not.
         /// The setting will nolonger be set after this call.
         /// - Returns: If disableAutoRead was set.
-        public mutating func consumeDisableAutoRead() -> ChannelOptions.Types.NIOOptionValue<Void> {
+        public mutating func consumeDisableAutoRead() -> Types.NIOOptionValue<Void> {
             defer {
                 self.disableAutoRead = false
             }
-            return ChannelOptions.Types.NIOOptionValue<Void>(flag: self.disableAutoRead)
+            return Types.NIOOptionValue<Void>(flag: self.disableAutoRead)
         }
         
         /// Caller is consuming the knowledge that allowRemoteHalfClosure was set or not.
         /// The setting will nolonger be set after this call.
         /// - Returns: If allowRemoteHalfClosure was set.
-        public mutating func consumeAllowRemoteHalfClosure() -> ChannelOptions.Types.NIOOptionValue<Void> {
+        public mutating func consumeAllowRemoteHalfClosure() -> Types.NIOOptionValue<Void> {
             defer {
                 self.allowRemoteHalfClosure = false
             }
-            return ChannelOptions.Types.NIOOptionValue<Void>(flag: self.allowRemoteHalfClosure)
+            return Types.NIOOptionValue<Void>(flag: self.allowRemoteHalfClosure)
         }
         
         func applyFallbackMapping(_ universalBootstrap: NIOClientTCPBootstrap) -> NIOClientTCPBootstrap {

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -27,7 +27,7 @@ extension NIOClientTCPBootstrapProtocol {
 extension NIOClientTCPBootstrap {
     /// Specifies some `TCPConvenienceOption`s to be applied to the channel.
     /// These are preferred over regular channel options as they are easier to use and restrict
-    /// options to those with a normal user would consider.
+    /// options to those which a normal user would consider.
     /// - Parameter options: Set of convenience options to apply.
     /// - Returns: The updated bootstrap (`self` being mutated)
     public func channelConvenienceOptions(_ options: ChannelOptions.TCPConvenienceOptions) -> NIOClientTCPBootstrap {

--- a/Sources/NIO/ConvenienceOptionSupport.swift
+++ b/Sources/NIO/ConvenienceOptionSupport.swift
@@ -49,9 +49,9 @@ public enum NIOOptionValue<T> {
     case set(T)
 }
 
-public extension NIOOptionValue where T == () {
+extension NIOOptionValue where T == () {
     /// Convenience method working with bool options as bool values for set.
-    var isSet: Bool {
+    public var isSet: Bool {
         get {
             switch self {
             case .notSet:
@@ -63,8 +63,8 @@ public extension NIOOptionValue where T == () {
     }
 }
 
-private extension NIOOptionValue where T == () {
-    init(flag: Bool) {
+extension NIOOptionValue where T == () {
+    fileprivate init(flag: Bool) {
         if flag {
             self = .set(())
         } else {
@@ -107,7 +107,7 @@ extension NIOTCPShorthandOption {
 }
 
 /// A set of `NIOTCPShorthandOption`s
-public struct NIOTCPShorthandOptions : ExpressibleByArrayLiteral, Hashable {
+public struct NIOTCPShorthandOptions: ExpressibleByArrayLiteral, Hashable {
     var allowImmediateLocalEndpointAddressReuse = false
     var disableAutoRead = false
     var allowRemoteHalfClosure = false

--- a/Sources/NIO/UniversalBootstrapSupport.swift
+++ b/Sources/NIO/UniversalBootstrapSupport.swift
@@ -49,12 +49,12 @@ public protocol NIOClientTCPBootstrapProtocol {
     ///     - value: The value for the option.
     func channelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
     
-    /// Apply any understood shorthand options to the bootstrap, removing them from the set of options if they are consumed.
+    /// Apply any understood convenience options to the bootstrap, removing them from the set of options if they are consumed.
     /// Method is optional to implement and should never be directly called by users.
     /// - parameters:
     ///     - options:  The options to try applying - the options applied should be consumed from here.
     /// - returns: The updated bootstrap with and options applied.
-    func _applyChannelConvenienceOptions(_ options: inout ChannelOptions.NIOTCPShorthandOptions) -> Self
+    func _applyChannelConvenienceOptions(_ options: inout ChannelOptions.TCPConvenienceOptions) -> Self
 
     /// - parameters:
     ///     - timeout: The timeout that will apply to the connection attempt.

--- a/Sources/NIO/UniversalBootstrapSupport.swift
+++ b/Sources/NIO/UniversalBootstrapSupport.swift
@@ -166,7 +166,7 @@ public struct NIOClientTCPBootstrap {
         self.tlsEnablerTypeErased = tlsEnabler
     }
     
-    internal init(_ original : NIOClientTCPBootstrap, withUpdated underlying : NIOClientTCPBootstrapProtocol) {
+    internal init(_ original : NIOClientTCPBootstrap, updating underlying : NIOClientTCPBootstrapProtocol) {
         self.underlyingBootstrap = underlying
         self.tlsEnablerTypeErased = original.tlsEnablerTypeErased
     }

--- a/Sources/NIO/UniversalBootstrapSupport.swift
+++ b/Sources/NIO/UniversalBootstrapSupport.swift
@@ -48,6 +48,13 @@ public protocol NIOClientTCPBootstrapProtocol {
     ///     - option: The option to be applied.
     ///     - value: The value for the option.
     func channelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
+    
+    /// Apply any understood shorthand options to the bootstrap, removing them from the set of options if they are consumed.
+    /// Method is optional to implement and should never be directly called by users.
+    /// - parameters:
+    ///     - options:  The options to try applying - the options applied should be consumed from here.
+    /// - returns: The updated bootstrap with and options applied.
+    func _applyOptions(_ options: inout NIOTCPShorthandOptions) -> Self
 
     /// - parameters:
     ///     - timeout: The timeout that will apply to the connection attempt.
@@ -157,6 +164,11 @@ public struct NIOClientTCPBootstrap {
                  tlsEnabler: @escaping (NIOClientTCPBootstrapProtocol) -> NIOClientTCPBootstrapProtocol) {
         self.underlyingBootstrap = bootstrap
         self.tlsEnablerTypeErased = tlsEnabler
+    }
+    
+    internal init(_ original : NIOClientTCPBootstrap, withUpdated underlying : NIOClientTCPBootstrapProtocol) {
+        self.underlyingBootstrap = underlying
+        self.tlsEnablerTypeErased = original.tlsEnablerTypeErased
     }
 
     /// Initialize the connected `SocketChannel` with `initializer`. The most common task in initializer is to add

--- a/Sources/NIO/UniversalBootstrapSupport.swift
+++ b/Sources/NIO/UniversalBootstrapSupport.swift
@@ -54,7 +54,7 @@ public protocol NIOClientTCPBootstrapProtocol {
     /// - parameters:
     ///     - options:  The options to try applying - the options applied should be consumed from here.
     /// - returns: The updated bootstrap with and options applied.
-    func _applyOptions(_ options: inout NIOTCPShorthandOptions) -> Self
+    func _applyChannelConvenienceOptions(_ options: inout ChannelOptions.NIOTCPShorthandOptions) -> Self
 
     /// - parameters:
     ///     - timeout: The timeout that will apply to the connection attempt.

--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -48,6 +48,7 @@ extension BootstrapTest {
                 ("testDatagramBootstrapRejectsNotWorkingELGsCorrectly", testDatagramBootstrapRejectsNotWorkingELGsCorrectly),
                 ("testNIOPipeBootstrapValidatesWorkingELGsCorrectly", testNIOPipeBootstrapValidatesWorkingELGsCorrectly),
                 ("testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly", testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly),
+                ("testShorthandOptionsAreEquivalentUniversalClient", testShorthandOptionsAreEquivalentUniversalClient),
            ]
    }
 }

--- a/Tests/NIOTests/BootstrapTest+XCTest.swift
+++ b/Tests/NIOTests/BootstrapTest+XCTest.swift
@@ -48,7 +48,7 @@ extension BootstrapTest {
                 ("testDatagramBootstrapRejectsNotWorkingELGsCorrectly", testDatagramBootstrapRejectsNotWorkingELGsCorrectly),
                 ("testNIOPipeBootstrapValidatesWorkingELGsCorrectly", testNIOPipeBootstrapValidatesWorkingELGsCorrectly),
                 ("testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly", testNIOPipeBootstrapRejectsNotWorkingELGsCorrectly),
-                ("testShorthandOptionsAreEquivalentUniversalClient", testShorthandOptionsAreEquivalentUniversalClient),
+                ("testConvenienceOptionsAreEquivalentUniversalClient", testConvenienceOptionsAreEquivalentUniversalClient),
            ]
    }
 }

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -529,6 +529,53 @@ class BootstrapTest: XCTestCase {
         XCTAssertNil(NIOPipeBootstrap(validatingGroup: elg))
         XCTAssertNil(NIOPipeBootstrap(validatingGroup: el))
     }
+    
+    func testShorthandOptionsAreEquivalentUniversalClient() throws {
+        func setAndGetOption<Option>(option: Option, _ applyOptions : (NIOClientTCPBootstrap) -> NIOClientTCPBootstrap) throws
+            -> Option.Value where Option : ChannelOption {
+            var optionRead : EventLoopFuture<Option.Value>?
+            XCTAssertNoThrow(try withTCPServerChannel(group: self.group) { server in
+                var channel: Channel? = nil
+                XCTAssertNoThrow(channel = try applyOptions(NIOClientTCPBootstrap(
+                    ClientBootstrap(group: self.group), tls: NIOInsecureNoTLS()))
+                    .channelInitializer { channel in optionRead = channel.getOption(option)
+                        return channel.eventLoop.makeSucceededFuture(())
+                    }
+                .connect(to: server.localAddress!)
+                .wait())
+                XCTAssertNotNil(optionRead)
+                XCTAssertNotNil(channel)
+                XCTAssertNoThrow(try channel?.close().wait())
+            })
+            return try optionRead!.wait()
+        }
+        
+        func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
+                                            shortOption: NIOTCPShorthandOption) throws
+            where Option : ChannelOption, Option.Value : Equatable {
+            let longSetValue = try setAndGetOption(option: longOption) { bs in
+                bs.channelOption(longOption, value: setValue)
+            }
+            let shortSetValue = try setAndGetOption(option: longOption) { bs in
+                bs.options([shortOption])
+            }
+            let unsetValue = try setAndGetOption(option: longOption) { $0 }
+            
+            XCTAssertEqual(longSetValue, shortSetValue)
+            XCTAssertNotEqual(longSetValue, unsetValue)
+        }
+        
+        try checkOptionEquivalence(longOption: ChannelOptions.socketOption(.so_reuseaddr),
+                                   setValue: 1,
+                                   shortOption: .allowImmediateLocalEndpointAddressReuse)
+        try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
+                                   setValue: true,
+                                   shortOption: .allowRemoteHalfClosure)
+        try checkOptionEquivalence(longOption: ChannelOptions.autoRead,
+                                   setValue: false,
+                                   shortOption: .disableAutoRead)
+    }
+
 }
 
 private final class MakeSureAutoReadIsOffInChannelInitializer:  ChannelInboundHandler {

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -530,7 +530,7 @@ class BootstrapTest: XCTestCase {
         XCTAssertNil(NIOPipeBootstrap(validatingGroup: el))
     }
     
-    func testShorthandOptionsAreEquivalentUniversalClient() throws {
+    func testConvenienceOptionsAreEquivalentUniversalClient() throws {
         func setAndGetOption<Option>(option: Option, _ applyOptions : (NIOClientTCPBootstrap) -> NIOClientTCPBootstrap) throws
             -> Option.Value where Option : ChannelOption {
             var optionRead : EventLoopFuture<Option.Value>?
@@ -551,7 +551,7 @@ class BootstrapTest: XCTestCase {
         }
         
         func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
-                                            shortOption: ChannelOptions.NIOTCPShorthandOption) throws
+                                            shortOption: ChannelOptions.TCPConvenienceOption) throws
             where Option : ChannelOption, Option.Value : Equatable {
             let longSetValue = try setAndGetOption(option: longOption) { bs in
                 bs.channelOption(longOption, value: setValue)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -551,13 +551,13 @@ class BootstrapTest: XCTestCase {
         }
         
         func checkOptionEquivalence<Option>(longOption: Option, setValue: Option.Value,
-                                            shortOption: NIOTCPShorthandOption) throws
+                                            shortOption: ChannelOptions.NIOTCPShorthandOption) throws
             where Option : ChannelOption, Option.Value : Equatable {
             let longSetValue = try setAndGetOption(option: longOption) { bs in
                 bs.channelOption(longOption, value: setValue)
             }
             let shortSetValue = try setAndGetOption(option: longOption) { bs in
-                bs.options([shortOption])
+                bs.channelConvenienceOptions([shortOption])
             }
             let unsetValue = try setAndGetOption(option: longOption) { $0 }
             
@@ -567,7 +567,7 @@ class BootstrapTest: XCTestCase {
         
         try checkOptionEquivalence(longOption: ChannelOptions.socketOption(.so_reuseaddr),
                                    setValue: 1,
-                                   shortOption: .allowImmediateLocalEndpointAddressReuse)
+                                   shortOption: .allowImmediateLocalAddressReuse)
         try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
                                    setValue: true,
                                    shortOption: .allowRemoteHalfClosure)

--- a/Tests/NIOTests/BootstrapTest.swift
+++ b/Tests/NIOTests/BootstrapTest.swift
@@ -567,7 +567,7 @@ class BootstrapTest: XCTestCase {
         
         try checkOptionEquivalence(longOption: ChannelOptions.socketOption(.so_reuseaddr),
                                    setValue: 1,
-                                   shortOption: .allowImmediateLocalAddressReuse)
+                                   shortOption: .allowLocalEndpointReuse)
         try checkOptionEquivalence(longOption: ChannelOptions.allowRemoteHalfClosure,
                                    setValue: true,
                                    shortOption: .allowRemoteHalfClosure)

--- a/Tests/NIOTests/UniversalBootstrapSupportTest+XCTest.swift
+++ b/Tests/NIOTests/UniversalBootstrapSupportTest+XCTest.swift
@@ -28,6 +28,7 @@ extension UniversalBootstrapSupportTest {
    static var allTests : [(String, (UniversalBootstrapSupportTest) -> () throws -> Void)] {
       return [
                 ("testBootstrappingWorks", testBootstrappingWorks),
+                ("testBootstrapOverrideOfShortcutOptions", testBootstrapOverrideOfShortcutOptions),
            ]
    }
 }

--- a/Tests/NIOTests/UniversalBootstrapSupportTest.swift
+++ b/Tests/NIOTests/UniversalBootstrapSupportTest.swift
@@ -154,7 +154,7 @@ class UniversalBootstrapSupportTest: XCTestCase {
             
             var shorthandOptionConsumed = false
             func _applyOptions(_ options: inout ChannelOptions.NIOTCPShorthandOptions) -> FakeBootstrap {
-                if options.consumeAllowImmediateLocalAddressReuse().isSet {
+                if options.consumeAllowLocalEndpointReuse().isSet {
                     shorthandOptionConsumed = true
                 }
                 return self
@@ -180,7 +180,7 @@ class UniversalBootstrapSupportTest: XCTestCase {
         // Check consumption works.
         let consumingFake = FakeBootstrap()
         _ = NIOClientTCPBootstrap(consumingFake, tls: NIOInsecureNoTLS())
-            .channelConvenienceOptions([.allowImmediateLocalAddressReuse])
+            .channelConvenienceOptions([.allowLocalEndpointReuse])
         XCTAssertTrue(consumingFake.shorthandOptionConsumed)
         XCTAssertFalse(consumingFake.regularOptionsSeen)
         
@@ -194,7 +194,7 @@ class UniversalBootstrapSupportTest: XCTestCase {
         // Both at once.
         let bothFake = FakeBootstrap()
         _ = NIOClientTCPBootstrap(bothFake, tls: NIOInsecureNoTLS())
-            .channelConvenienceOptions([.allowRemoteHalfClosure, .allowImmediateLocalAddressReuse])
+            .channelConvenienceOptions([.allowRemoteHalfClosure, .allowLocalEndpointReuse])
         XCTAssertTrue(bothFake.shorthandOptionConsumed)
         XCTAssertTrue(bothFake.regularOptionsSeen)
     }

--- a/Tests/NIOTests/UniversalBootstrapSupportTest.swift
+++ b/Tests/NIOTests/UniversalBootstrapSupportTest.swift
@@ -199,3 +199,34 @@ class UniversalBootstrapSupportTest: XCTestCase {
         XCTAssertTrue(bothFake.regularOptionsSeen)
     }
 }
+
+// Prove we've not broken implementors of NIOClientTCPBootstrapProtocol by adding a new method.
+private class UniversalWithoutNewMethods : NIOClientTCPBootstrapProtocol {
+    func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self {
+        return self
+    }
+    
+    func protocolHandlers(_ handlers: @escaping () -> [ChannelHandler]) -> Self {
+        return self
+    }
+    
+    func channelOption<Option>(_ option: Option, value: Option.Value) -> Self where Option : ChannelOption {
+        return self
+    }
+    
+    func connectTimeout(_ timeout: TimeAmount) -> Self {
+        return self
+    }
+    
+    func connect(host: String, port: Int) -> EventLoopFuture<Channel> {
+        return EmbeddedEventLoop().makePromise(of: Channel.self).futureResult
+    }
+    
+    func connect(to address: SocketAddress) -> EventLoopFuture<Channel> {
+        return EmbeddedEventLoop().makePromise(of: Channel.self).futureResult
+    }
+    
+    func connect(unixDomainSocketPath: String) -> EventLoopFuture<Channel> {
+        return EmbeddedEventLoop().makePromise(of: Channel.self).futureResult
+    }
+}

--- a/Tests/NIOTests/UniversalBootstrapSupportTest.swift
+++ b/Tests/NIOTests/UniversalBootstrapSupportTest.swift
@@ -152,10 +152,10 @@ class UniversalBootstrapSupportTest: XCTestCase {
                 return self
             }
             
-            var shorthandOptionConsumed = false
-            func _applyOptions(_ options: inout ChannelOptions.NIOTCPShorthandOptions) -> FakeBootstrap {
+            var convenienceOptionConsumed = false
+            func _applyOptions(_ options: inout ChannelOptions.TCPConvenienceOptions) -> FakeBootstrap {
                 if options.consumeAllowLocalEndpointReuse().isSet {
-                    shorthandOptionConsumed = true
+                    convenienceOptionConsumed = true
                 }
                 return self
             }
@@ -181,21 +181,21 @@ class UniversalBootstrapSupportTest: XCTestCase {
         let consumingFake = FakeBootstrap()
         _ = NIOClientTCPBootstrap(consumingFake, tls: NIOInsecureNoTLS())
             .channelConvenienceOptions([.allowLocalEndpointReuse])
-        XCTAssertTrue(consumingFake.shorthandOptionConsumed)
+        XCTAssertTrue(consumingFake.convenienceOptionConsumed)
         XCTAssertFalse(consumingFake.regularOptionsSeen)
         
         // Check default behaviour works.
         let nonConsumingFake = FakeBootstrap()
         _ = NIOClientTCPBootstrap(nonConsumingFake, tls: NIOInsecureNoTLS())
             .channelConvenienceOptions([.allowRemoteHalfClosure])
-        XCTAssertFalse(nonConsumingFake.shorthandOptionConsumed)
+        XCTAssertFalse(nonConsumingFake.convenienceOptionConsumed)
         XCTAssertTrue(nonConsumingFake.regularOptionsSeen)
         
         // Both at once.
         let bothFake = FakeBootstrap()
         _ = NIOClientTCPBootstrap(bothFake, tls: NIOInsecureNoTLS())
             .channelConvenienceOptions([.allowRemoteHalfClosure, .allowLocalEndpointReuse])
-        XCTAssertTrue(bothFake.shorthandOptionConsumed)
+        XCTAssertTrue(bothFake.convenienceOptionConsumed)
         XCTAssertTrue(bothFake.regularOptionsSeen)
     }
 }

--- a/Tests/NIOTests/UniversalBootstrapSupportTest.swift
+++ b/Tests/NIOTests/UniversalBootstrapSupportTest.swift
@@ -153,8 +153,8 @@ class UniversalBootstrapSupportTest: XCTestCase {
             }
             
             var shorthandOptionConsumed = false
-            func _applyOptions(_ options: inout NIOTCPShorthandOptions) -> FakeBootstrap {
-                if options.consumeAllowImmediateLocalEndpointAddressReuse().isSet {
+            func _applyOptions(_ options: inout ChannelOptions.NIOTCPShorthandOptions) -> FakeBootstrap {
+                if options.consumeAllowImmediateLocalAddressReuse().isSet {
                     shorthandOptionConsumed = true
                 }
                 return self
@@ -180,21 +180,21 @@ class UniversalBootstrapSupportTest: XCTestCase {
         // Check consumption works.
         let consumingFake = FakeBootstrap()
         _ = NIOClientTCPBootstrap(consumingFake, tls: NIOInsecureNoTLS())
-            .options([.allowImmediateLocalEndpointAddressReuse])
+            .channelConvenienceOptions([.allowImmediateLocalAddressReuse])
         XCTAssertTrue(consumingFake.shorthandOptionConsumed)
         XCTAssertFalse(consumingFake.regularOptionsSeen)
         
         // Check default behaviour works.
         let nonConsumingFake = FakeBootstrap()
         _ = NIOClientTCPBootstrap(nonConsumingFake, tls: NIOInsecureNoTLS())
-            .options([.allowRemoteHalfClosure])
+            .channelConvenienceOptions([.allowRemoteHalfClosure])
         XCTAssertFalse(nonConsumingFake.shorthandOptionConsumed)
         XCTAssertTrue(nonConsumingFake.regularOptionsSeen)
         
         // Both at once.
         let bothFake = FakeBootstrap()
         _ = NIOClientTCPBootstrap(bothFake, tls: NIOInsecureNoTLS())
-            .options([.allowRemoteHalfClosure, .allowImmediateLocalEndpointAddressReuse])
+            .channelConvenienceOptions([.allowRemoteHalfClosure, .allowImmediateLocalAddressReuse])
         XCTAssertTrue(bothFake.shorthandOptionConsumed)
         XCTAssertTrue(bothFake.regularOptionsSeen)
     }

--- a/Tests/NIOTests/UniversalBootstrapSupportTest.swift
+++ b/Tests/NIOTests/UniversalBootstrapSupportTest.swift
@@ -153,7 +153,7 @@ class UniversalBootstrapSupportTest: XCTestCase {
             }
             
             var convenienceOptionConsumed = false
-            func _applyOptions(_ options: inout ChannelOptions.TCPConvenienceOptions) -> FakeBootstrap {
+            func _applyChannelConvenienceOptions(_ options: inout ChannelOptions.TCPConvenienceOptions) -> FakeBootstrap {
                 if options.consumeAllowLocalEndpointReuse().isSet {
                     convenienceOptionConsumed = true
                 }


### PR DESCRIPTION
Motivation:

Guide novice users towards the options they are most likely to want to use.

Modifications:

New type to represent shorthand TCP client options containing only the options
which are sensible for novice users.
New type to represent a collection of these options.
A method to allow underlying bootstraps to override universal behaviour - default
implementation is to do nothing.

A test case to demonstrate that shorthand options match old style options.
A test case to demonstrate that overriding option behaviour is possible.

Result:

For universal botostrap there will be an new way of setting options involving
less typing which guides the user towards the common options.
