### PR TITLE
Add synchronous option to Trunk push

### DIFF
--- a/scripts/build_podspecs.sh
+++ b/scripts/build_podspecs.sh
@@ -114,7 +114,7 @@ EOF
   pod repo update # last chance of getting the latest versions of previous pushed pods
   if $upload; then
     echo "Uploading ${tmpfile}/${target}.podspec"
-    pod trunk push "${tmpfile}/${target}.podspec"
+    pod trunk push "${tmpfile}/${target}.podspec" --synchronous
   fi
 
 done


### PR DESCRIPTION
Add synchronous option to trunk push in podspec script

### Motivation:

Currently the `build_podspec.sh` script needs to be ran multiple times due to Podspecs not immediately becoming available for sequential Podspecs. This has been an ongoing issue where I have to run the script multiple times manually in order to get all of them through.

### Modifications:

Add https://github.com/CocoaPods/cocoapods-trunk/pull/147 to the script

### Result:

Now, the script will only need to be ran once! 🎉 
