### PR TITLE
fix inappropriate lanugage in NIO

### DIFF
--- a/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
@@ -69,10 +69,10 @@ for mode in debug release; do
             fail "exited successfully but was supposed to fail"
         else
             exit_code=$?
-            # expecting illegal instruction as it should fail with a blacklisted errno
+            # expecting illegal instruction as it should fail with an unacceptable errno
             assert_equal $(( 128 + 4 )) $exit_code  # 4 == SIGILL
             if [[ "$mode" == "debug" ]]; then
-                grep -q blacklisted\ errno "$temp_file"
+                grep -q unacceptable\ errno "$temp_file"
             fi
         fi
     done

--- a/Sources/NIO/Selector.swift
+++ b/Sources/NIO/Selector.swift
@@ -641,7 +641,7 @@ internal class Selector<R: Registration> {
             // We try! all of the closes because close can only fail in the following ways:
             // - EINTR, which we eat in Posix.close
             // - EIO, which can only happen for on-disk files
-            // - EBADF, which can't happen here because we would crash in the errno blacklisting
+            // - EBADF, which can't happen here because we would crash as EBADF is marked unacceptable
             // Therefore, we assert here that close will always succeed and if not, that's a NIO bug we need to know
             // about.
 

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -98,7 +98,7 @@ private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_m
 private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_mmsghdr>?, CUnsignedInt, CInt, UnsafeMutablePointer<timespec>?) -> CInt = CNIODarwin_recvmmsg
 #endif
 
-private func isBlacklistedErrno(_ code: Int32) -> Bool {
+private func isUnacceptableErrno(_ code: Int32) -> Bool {
     switch code {
     case EFAULT, EBADF:
         return true
@@ -107,9 +107,9 @@ private func isBlacklistedErrno(_ code: Int32) -> Bool {
     }
 }
 
-private func preconditionIsNotBlacklistedErrno(err: CInt, where function: String) -> Void {
+private func preconditionIsNotUnacceptableErrno(err: CInt, where function: String) -> Void {
     // strerror is documented to return "Unknown error: ..." for illegal value so it won't ever fail
-    precondition(!isBlacklistedErrno(err), "blacklisted errno \(err) \(String(cString: strerror(err)!)) in \(function))")
+    precondition(!isUnacceptableErrno(err), "unacceptable errno \(err) \(String(cString: strerror(err)!)) in \(function))")
 }
 
 /*
@@ -133,7 +133,7 @@ internal func syscall<T: FixedWidthInteger>(blocking: Bool,
             case (EWOULDBLOCK, true):
                 return .wouldBlock(0)
             default:
-                preconditionIsNotBlacklistedErrno(err: err, where: function)
+                preconditionIsNotUnacceptableErrno(err: err, where: function)
                 throw IOError(errnoCode: err, reason: function)
             }
         }
@@ -150,7 +150,7 @@ internal func wrapErrorIsNullReturnCall<T>(where function: String = #function, _
             if err == EINTR {
                 continue
             }
-            preconditionIsNotBlacklistedErrno(err: err, where: function)
+            preconditionIsNotUnacceptableErrno(err: err, where: function)
             throw IOError(errnoCode: err, reason: function)
         }
         return res
@@ -212,7 +212,7 @@ internal enum Posix {
             //     - https://bugs.chromium.org/p/chromium/issues/detail?id=269623
             //     - https://lwn.net/Articles/576478/
             if err != EINTR {
-                preconditionIsNotBlacklistedErrno(err: err, where: #function)
+                preconditionIsNotUnacceptableErrno(err: err, where: #function)
                 throw IOError(errnoCode: err, reason: "close")
             }
         }

--- a/Sources/NIOCrashTester/CrashTests+System.swift
+++ b/Sources/NIOCrashTester/CrashTests+System.swift
@@ -12,8 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-let crashTestSuites: [String: Any] = [
-    "EventLoopCrashTests": EventLoopCrashTests(),
-    "ByteBufferCrashTests": ByteBufferCrashTests(),
-    "SystemCrashTests": SystemCrashTests(),
-]
+import NIO
+import Foundation
+
+fileprivate let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+struct SystemCrashTests {
+    let testEBADFIsUnacceptable = CrashTest(
+        regex: "^Precondition failed: unacceptable errno \(EBADF) Bad file descriptor in", {
+            _ = try? NIOPipeBootstrap(group: group).withPipes(inputDescriptor: .max, outputDescriptor: .max - 1).wait()
+        })
+}

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -33,6 +33,21 @@ else
   printf "\033[0;32mokay.\033[0m\n"
 fi
 
+printf "=> Checking for unacceptable language... "
+# This greps for unacceptable terminology. The square bracket[s] are so that
+# "git grep" doesn't find the lines that greps :).
+unacceptable_terms=(
+    -e blacklis[t]
+    -e whitelis[t]
+    -e slav[e]
+)
+if git grep --color=never -i "${unacceptable_terms[@]}" > /dev/null; then
+    printf "\033[0;31mUnacceptable language found.\033[0m\n"
+    git grep -i "${unacceptable_terms[@]}"
+    exit 1
+fi
+printf "\033[0;32mokay.\033[0m\n"
+
 printf "=> Checking license headers... "
 tmp=$(mktemp /tmp/.swift-nio-sanity_XXXXXX)
 


### PR DESCRIPTION
Motivation:

It's 2020, we shouldn't use unnecessary offensive, insulting, or
outdated language.

Modifications:

Fix a few examples.

Result:

More inclusive.