### PR TITLE
HTTP: assert that user doesn't set CL & TE:chunked

### DIFF
--- a/Sources/NIOCrashTester/CrashTestSuites.swift
+++ b/Sources/NIOCrashTester/CrashTestSuites.swift
@@ -16,4 +16,5 @@ let crashTestSuites: [String: Any] = [
     "EventLoopCrashTests": EventLoopCrashTests(),
     "ByteBufferCrashTests": ByteBufferCrashTests(),
     "SystemCrashTests": SystemCrashTests(),
+    "HTTPCrashTests": HTTPCrashTests(),
 ]

--- a/Sources/NIOCrashTester/OutputGrepper.swift
+++ b/Sources/NIOCrashTester/OutputGrepper.swift
@@ -65,7 +65,9 @@ private final class GrepHandler: ChannelInboundHandler {
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let line = self.unwrapInboundIn(data)
-        if line.lowercased().starts(with: "fatal error: ") || line.lowercased().starts(with: "precondition failed: ") {
+        if line.lowercased().starts(with: "fatal error: ") ||
+            line.lowercased().starts(with: "precondition failed: ") ||
+            line.lowercased().starts(with: "assertion failed: ") {
             self.promise.succeed(line)
             context.close(promise: nil)
         }


### PR DESCRIPTION
Motivation:

NIO users need to understand the semantic of the underlying protocol.
Therefore NIO does not (and in many case cannot) check all the
invariants. Generally however, we try to be helpful and assert a bunch
of things that a user has (hopefully) checked. That doesn't affect
performance and simplifies development for users.

Modifications:

- assert that request/response heads don't set content-length +
  transfer-encoding: chunked

Result:

Developers of libraries like AHC will have an easier time.