### PR TITLE
Allow EmbeddedEventLoop to advanceTime(to:) a deadline

### DIFF
--- a/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedEventLoopTest+XCTest.swift
@@ -44,6 +44,8 @@ extension EmbeddedEventLoopTest {
                 ("testCancelledScheduledTasksDoNotHoldOnToRunClosure", testCancelledScheduledTasksDoNotHoldOnToRunClosure),
                 ("testDrainScheduledTasks", testDrainScheduledTasks),
                 ("testDrainScheduledTasksDoesNotRunNewlyScheduledTasks", testDrainScheduledTasksDoesNotRunNewlyScheduledTasks),
+                ("testAdvanceTimeToDeadline", testAdvanceTimeToDeadline),
+                ("testWeCantTimeTravelByAdvancingTimeToThePast", testWeCantTimeTravelByAdvancingTimeToThePast),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

You can schedule tasks for a deadline on `EmbeddedEventLoop` but have no
way of knowing the current time on the `EventLoop` and how much to
advance the time by in order to meet that deadline. In most cases this
is okay because you know that time starts at zero and you can keep track
of time, however, it's generally useful to not have to keep track of
this yourself.

Modifications:

- Add `advanceTime(to:)` on `EmbeddedEventLoop`
- Document that time may be controlled on `EmbeddedEventLoop` and how to
  advance it
- Tests

Result:

- `EmbeddedEventLoop` is more usable with deadlines
- Better documentation