### PR TITLE
forward #file to #filePath differently

### DIFF
--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
@@ -1025,7 +1025,7 @@ func spawnAndJoinRacingThreads(count: Int, _ body: @escaping (Int) -> Void) {
     group.wait()
 }
 
-func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testInterval: TimeAmount? = nil, _ message: String = "condition not satisfied in time", file: StaticString = (#file), line: UInt = #line) {
+func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testInterval: TimeAmount? = nil, _ message: String = "condition not satisfied in time", file: StaticString = #file, line: UInt = #line) {
     let testInterval = testInterval ?? TimeAmount.nanoseconds(time.nanoseconds / 5)
     let endTime = NIODeadline.now() + time
 
@@ -1035,7 +1035,7 @@ func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testI
     } while (NIODeadline.now() < endTime)
 
     if !condition() {
-        XCTFail(message, file: file, line: line)
+        XCTFail(message, file: (file), line: line)
     }
 }
 

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -23,11 +23,11 @@ extension ChannelPipeline {
     }
 
     func assertDoesNotContain<Handler: ChannelHandler>(handlerType: Handler.Type,
-                                                       file: StaticString = (#file),
+                                                       file: StaticString = #file,
                                                        line: UInt = #line) throws {
         do {
             let context = try self.context(handlerType: handlerType).wait()
-            XCTFail("Found handler: \(context.handler)", file: file, line: line)
+            XCTFail("Found handler: \(context.handler)", file: (file), line: line)
         } catch ChannelPipelineError.notFound {
             // Nothing to see here
         }

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -277,34 +277,34 @@ private final class TestHTTPHandler: ChannelInboundHandler {
 }
 
 extension HTTPServerRequestPart {
-    func assertHead(expectedURI: String, file: StaticString = (#file), line: UInt = #line) {
+    func assertHead(expectedURI: String, file: StaticString = #file, line: UInt = #line) {
         switch self {
         case .head(let head):
             XCTAssertEqual(.GET, head.method)
             XCTAssertEqual(expectedURI, head.uri)
             XCTAssertEqual("text/plain; charset=utf-8", head.headers["Content-Type"].first)
         default:
-            XCTFail("Expected head, got \(self)", file: file, line: line)
+            XCTFail("Expected head, got \(self)", file: (file), line: line)
         }
     }
 
-    func assertBody(expectedMessage: String, file: StaticString = (#file), line: UInt = #line) {
+    func assertBody(expectedMessage: String, file: StaticString = #file, line: UInt = #line) {
         switch self {
         case .body(let buffer):
             // Note that the test server coalesces the body parts for us.
             XCTAssertEqual(expectedMessage,
                            String(decoding: buffer.readableBytesView, as: Unicode.UTF8.self))
         default:
-            XCTFail("Expected body, got \(self)", file: file, line: line)
+            XCTFail("Expected body, got \(self)", file: (file), line: line)
         }
     }
 
-    func assertEnd(file: StaticString = (#file), line: UInt = #line) {
+    func assertEnd(file: StaticString = #file, line: UInt = #line) {
         switch self {
         case .end(_):
             ()
         default:
-            XCTFail("Expected end, got \(self)", file: file, line: line)
+            XCTFail("Expected end, got \(self)", file: (file), line: line)
         }
     }
 }
@@ -339,7 +339,7 @@ func assert(_ condition: @autoclosure () -> Bool,
             within time: TimeAmount,
             testInterval: TimeAmount? = nil,
             _ message: String = "condition not satisfied in time",
-            file: StaticString = (#file), line: UInt = #line) {
+            file: StaticString = #file, line: UInt = #line) {
     let testInterval = testInterval ?? TimeAmount.nanoseconds(time.nanoseconds / 5)
     let endTime = NIODeadline.now() + time
 
@@ -349,6 +349,6 @@ func assert(_ condition: @autoclosure () -> Bool,
     } while (NIODeadline.now() < endTime)
 
     if !condition() {
-        XCTFail(message, file: file, line: line)
+        XCTFail(message, file: (file), line: line)
     }
 }

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -205,6 +205,7 @@ extension ByteBufferTest {
                 ("testAllocatorGivesStableZeroSizedBuffers", testAllocatorGivesStableZeroSizedBuffers),
                 ("testClearOnZeroCapacityActuallyAllocates", testClearOnZeroCapacityActuallyAllocates),
                 ("testCreateBufferFromSequence", testCreateBufferFromSequence),
+                ("testWeDoNotResizeIfWeHaveExactlyTheRightCapacityAvailable", testWeDoNotResizeIfWeHaveExactlyTheRightCapacityAvailable),
                 ("testCreateArrayFromBuffer", testCreateArrayFromBuffer),
                 ("testCreateStringFromBuffer", testCreateStringFromBuffer),
                 ("testCreateDispatchDataFromBuffer", testCreateDispatchDataFromBuffer),

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1120,18 +1120,18 @@ class ByteBufferTest: XCTestCase {
         buf.reserveCapacity(1024)
         buf.writeStaticString("hello world, just some trap bytes here")
 
-        func testIndexAndLengthFunc<T>(_ body: (Int, Int) -> T?, file: StaticString = (#file), line: UInt = #line) {
-            XCTAssertNil(body(Int.max, 1), file: file, line: line)
-            XCTAssertNil(body(Int.max - 1, 2), file: file, line: line)
-            XCTAssertNil(body(1, Int.max), file: file, line: line)
-            XCTAssertNil(body(2, Int.max - 1), file: file, line: line)
-            XCTAssertNil(body(Int.max, Int.max), file: file, line: line)
-            XCTAssertNil(body(Int.min, Int.min), file: file, line: line)
-            XCTAssertNil(body(Int.max, Int.min), file: file, line: line)
-            XCTAssertNil(body(Int.min, Int.max), file: file, line: line)
+        func testIndexAndLengthFunc<T>(_ body: (Int, Int) -> T?, file: StaticString = #file, line: UInt = #line) {
+            XCTAssertNil(body(Int.max, 1), file: (file), line: line)
+            XCTAssertNil(body(Int.max - 1, 2), file: (file), line: line)
+            XCTAssertNil(body(1, Int.max), file: (file), line: line)
+            XCTAssertNil(body(2, Int.max - 1), file: (file), line: line)
+            XCTAssertNil(body(Int.max, Int.max), file: (file), line: line)
+            XCTAssertNil(body(Int.min, Int.min), file: (file), line: line)
+            XCTAssertNil(body(Int.max, Int.min), file: (file), line: line)
+            XCTAssertNil(body(Int.min, Int.max), file: (file), line: line)
         }
 
-        func testIndexOrLengthFunc<T>(_ body: (Int) -> T?, file: StaticString = (#file), line: UInt = #line) {
+        func testIndexOrLengthFunc<T>(_ body: (Int) -> T?, file: StaticString = #file, line: UInt = #line) {
             XCTAssertNil(body(Int.max))
             XCTAssertNil(body(Int.max - 1))
             XCTAssertNil(body(Int.min))
@@ -2786,6 +2786,18 @@ class ByteBufferTest: XCTestCase {
         let aSequenceThatIsNotACollection = Array(buffer: self.buf).makeIterator()
         XCTAssertEqual(self.buf, self.allocator.buffer(bytes: aSequenceThatIsNotACollection))
         XCTAssertEqual(self.buf, ByteBuffer(bytes: aSequenceThatIsNotACollection))
+    }
+
+    func testWeDoNotResizeIfWeHaveExactlyTheRightCapacityAvailable() {
+        let bufferSize = 32*1024
+        var buffer = self.allocator.buffer(capacity: bufferSize)
+        buffer.moveWriterIndex(forwardBy: bufferSize / 2)
+        XCTAssertEqual(bufferSize, buffer.capacity)
+        let oldBufferStorage = buffer.storagePointerIntegerValue()
+        buffer.writeWithUnsafeMutableBytes(minimumWritableBytes: bufferSize/2, { _ in return 0 })
+        XCTAssertEqual(bufferSize, buffer.capacity)
+        let newBufferStorage = buffer.storagePointerIntegerValue()
+        XCTAssertEqual(oldBufferStorage, newBufferStorage)
     }
 }
 

--- a/Tests/NIOTests/ChannelNotificationTest.swift
+++ b/Tests/NIOTests/ChannelNotificationTest.swift
@@ -17,11 +17,11 @@ import XCTest
 
 class ChannelNotificationTest: XCTestCase {
 
-    private static func assertFulfilled(promise: EventLoopPromise<Void>?, promiseName: String, trigger: String, setter: String, file: StaticString = (#file), line: UInt = #line) {
+    private static func assertFulfilled(promise: EventLoopPromise<Void>?, promiseName: String, trigger: String, setter: String, file: StaticString = #file, line: UInt = #line) {
         if let promise = promise {
-            XCTAssertTrue(promise.futureResult.isFulfilled, "\(promiseName) not fulfilled before \(trigger) was called", file: file, line: line)
+            XCTAssertTrue(promise.futureResult.isFulfilled, "\(promiseName) not fulfilled before \(trigger) was called", file: (file), line: line)
         } else {
-            XCTFail("\(setter) not called before \(trigger)", file: file, line: line)
+            XCTFail("\(setter) not called before \(trigger)", file: (file), line: line)
         }
     }
 

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -255,7 +255,7 @@ public final class ChannelTests: XCTestCase {
                                    expectedFileWritabilities: [(Int, Int)]?,
                                    returns: [IOResult<Int>],
                                    promiseStates: [[Bool]],
-                                   file: StaticString = (#file),
+                                   file: StaticString = #file,
                                    line: UInt = #line) throws -> OverallWriteResult {
         var everythingState = 0
         var singleState = 0
@@ -272,11 +272,11 @@ public final class ChannelTests: XCTestCase {
                     XCTAssertEqual(expected[singleState], buf.count, "in single write \(singleState) (overall \(everythingState)), \(expected[singleState]) bytes expected but \(buf.count) actual")
                     return returns[everythingState]
                 } else {
-                    XCTFail("single write call \(singleState) but less than \(expected.count) expected", file: file, line: line)
+                    XCTFail("single write call \(singleState) but less than \(expected.count) expected", file: (file), line: line)
                     return IOResult.wouldBlock(-1 * (everythingState + 1))
                 }
             } else {
-                XCTFail("single write called on \(buf) but no single writes expected", file: file, line: line)
+                XCTFail("single write called on \(buf) but no single writes expected", file: (file), line: line)
                 return IOResult.wouldBlock(-1 * (everythingState + 1))
             }
         }, vectorBufferWriteOperation: { ptrs in
@@ -289,15 +289,15 @@ public final class ChannelTests: XCTestCase {
                     XCTAssertGreaterThan(returns.count, everythingState)
                     XCTAssertEqual(expected[multiState], ptrs.map { numericCast($0.iov_len) },
                                    "in vector write \(multiState) (overall \(everythingState)), \(expected[multiState]) byte counts expected but \(ptrs.map { $0.iov_len }) actual",
-                        file: file, line: line)
+                        file: (file), line: line)
                     return returns[everythingState]
                 } else {
-                    XCTFail("vector write call \(multiState) but less than \(expected.count) expected", file: file, line: line)
+                    XCTFail("vector write call \(multiState) but less than \(expected.count) expected", file: (file), line: line)
                     return IOResult.wouldBlock(-1 * (everythingState + 1))
                 }
             } else {
                 XCTFail("vector write called on \(ptrs) but no vector writes expected",
-                    file: file, line: line)
+                    file: (file), line: line)
                 return IOResult.wouldBlock(-1 * (everythingState + 1))
             }
         }, scalarFileWriteOperation: { _, start, end in
@@ -307,7 +307,7 @@ public final class ChannelTests: XCTestCase {
             }
             guard let expected = expectedFileWritabilities else {
                 XCTFail("file write (\(start), \(end)) but no file writes expected",
-                    file: file, line: line)
+                    file: (file), line: line)
                 return IOResult.wouldBlock(-1 * (everythingState + 1))
             }
 
@@ -315,50 +315,50 @@ public final class ChannelTests: XCTestCase {
                 XCTAssertGreaterThan(returns.count, everythingState)
                 XCTAssertEqual(expected[fileState].0, start,
                                "in file write \(fileState) (overall \(everythingState)), \(expected[fileState].0) expected as start index but \(start) actual",
-                    file: file, line: line)
+                    file: (file), line: line)
                 XCTAssertEqual(expected[fileState].1, end,
                                "in file write \(fileState) (overall \(everythingState)), \(expected[fileState].1) expected as end index but \(end) actual",
-                    file: file, line: line)
+                    file: (file), line: line)
                 return returns[everythingState]
             } else {
-                XCTFail("file write call \(fileState) but less than \(expected.count) expected", file: file, line: line)
+                XCTFail("file write call \(fileState) but less than \(expected.count) expected", file: (file), line: line)
                 return IOResult.wouldBlock(-1 * (everythingState + 1))
             }
         })
         if everythingState > 0 {
             XCTAssertEqual(promises.count, promiseStates[everythingState - 1].count,
                            "number of promises (\(promises.count)) != number of promise states (\(promiseStates[everythingState - 1].count))",
-                file: file, line: line)
+                file: (file), line: line)
             _ = zip(promises, promiseStates[everythingState - 1]).map { p, pState in
-                XCTAssertEqual(p.futureResult.isFulfilled, pState, "promise states incorrect (\(everythingState) callbacks)", file: file, line: line)
+                XCTAssertEqual(p.futureResult.isFulfilled, pState, "promise states incorrect (\(everythingState) callbacks)", file: (file), line: line)
             }
 
             XCTAssertEqual(everythingState, singleState + multiState + fileState,
-                           "odd, calls the single/vector/file writes: \(singleState)/\(multiState)/\(fileState) but overall \(everythingState+1)", file: file, line: line)
+                           "odd, calls the single/vector/file writes: \(singleState)/\(multiState)/\(fileState) but overall \(everythingState+1)", file: (file), line: line)
 
             if singleState == 0 {
                 XCTAssertNil(expectedSingleWritabilities, "no single writes have been done but we expected some")
             } else {
-                XCTAssertEqual(singleState, (expectedSingleWritabilities?.count ?? Int.min), "different number of single writes than expected", file: file, line: line)
+                XCTAssertEqual(singleState, (expectedSingleWritabilities?.count ?? Int.min), "different number of single writes than expected", file: (file), line: line)
             }
             if multiState == 0 {
                 XCTAssertNil(expectedVectorWritabilities, "no vector writes have been done but we expected some")
             } else {
-                XCTAssertEqual(multiState, (expectedVectorWritabilities?.count ?? Int.min), "different number of vector writes than expected", file: file, line: line)
+                XCTAssertEqual(multiState, (expectedVectorWritabilities?.count ?? Int.min), "different number of vector writes than expected", file: (file), line: line)
             }
             if fileState == 0 {
                 XCTAssertNil(expectedFileWritabilities, "no file writes have been done but we expected some")
             } else {
-                XCTAssertEqual(fileState, (expectedFileWritabilities?.count ?? Int.min), "different number of file writes than expected", file: file, line: line)
+                XCTAssertEqual(fileState, (expectedFileWritabilities?.count ?? Int.min), "different number of file writes than expected", file: (file), line: line)
             }
         } else {
-            XCTAssertEqual(0, returns.count, "no callbacks called but apparently \(returns.count) expected", file: file, line: line)
-            XCTAssertNil(expectedSingleWritabilities, "no callbacks called but apparently some single writes expected", file: file, line: line)
-            XCTAssertNil(expectedVectorWritabilities, "no callbacks calles but apparently some vector writes expected", file: file, line: line)
-            XCTAssertNil(expectedFileWritabilities, "no callbacks calles but apparently some file writes expected", file: file, line: line)
+            XCTAssertEqual(0, returns.count, "no callbacks called but apparently \(returns.count) expected", file: (file), line: line)
+            XCTAssertNil(expectedSingleWritabilities, "no callbacks called but apparently some single writes expected", file: (file), line: line)
+            XCTAssertNil(expectedVectorWritabilities, "no callbacks calles but apparently some vector writes expected", file: (file), line: line)
+            XCTAssertNil(expectedFileWritabilities, "no callbacks calles but apparently some file writes expected", file: (file), line: line)
 
             _ = zip(promises, promiseStates[0]).map { p, pState in
-                XCTAssertEqual(p.futureResult.isFulfilled, pState, "promise states incorrect (no callbacks)", file: file, line: line)
+                XCTAssertEqual(p.futureResult.isFulfilled, pState, "promise states incorrect (no callbacks)", file: (file), line: line)
             }
         }
         return result
@@ -1959,8 +1959,8 @@ public final class ChannelTests: XCTestCase {
     }
 
     func testAppropriateAndInappropriateOperationsForUnregisteredSockets() throws {
-        func checkThatItThrowsInappropriateOperationForState(file: StaticString = (#file), line: UInt = #line, _ body: () throws -> Void) {
-            XCTAssertThrowsError(try body(), file: file, line: line) { error in
+        func checkThatItThrowsInappropriateOperationForState(file: StaticString = #file, line: UInt = #line, _ body: () throws -> Void) {
+            XCTAssertThrowsError(try body(), file: (file), line: line) { error in
                 XCTAssertEqual(.inappropriateOperationForState, error as? ChannelError)
             }
         }
@@ -1969,7 +1969,7 @@ public final class ChannelTests: XCTestCase {
             XCTAssertNoThrow(try elg.syncShutdownGracefully())
         }
 
-        func withChannel(skipDatagram: Bool = false, skipStream: Bool = false, skipServerSocket: Bool = false, file: StaticString = (#file), line: UInt = #line,  _ body: (Channel) throws -> Void) {
+        func withChannel(skipDatagram: Bool = false, skipStream: Bool = false, skipServerSocket: Bool = false, file: StaticString = #file, line: UInt = #line,  _ body: (Channel) throws -> Void) {
             XCTAssertNoThrow(try {
                 let el = elg.next() as! SelectableEventLoop
                 let channels: [Channel] = (skipDatagram ? [] : [try DatagramChannel(eventLoop: el, protocolFamily: .inet)]) +
@@ -1977,9 +1977,9 @@ public final class ChannelTests: XCTestCase {
                     /* Xcode need help */ (skipServerSocket ? []: [try ServerSocketChannel(eventLoop: el, group: elg, protocolFamily: .inet)])
                 for channel in channels {
                     try body(channel)
-                    XCTAssertNoThrow(try channel.close().wait(), file: file, line: line)
+                    XCTAssertNoThrow(try channel.close().wait(), file: (file), line: line)
                 }
-            }(), file: file, line: line)
+            }(), file: (file), line: line)
         }
         withChannel { channel in
             checkThatItThrowsInappropriateOperationForState {

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -1541,13 +1541,13 @@ public final class MessageToByteEncoderTest: XCTestCase {
         try testEncoder(MessageToByteHandler(Int32ToByteEncoderWithDefaultImpl()))
     }
 
-    private func testEncoder(_ handler: ChannelHandler, file: StaticString = (#file), line: UInt = #line) throws {
+    private func testEncoder(_ handler: ChannelHandler, file: StaticString = #file, line: UInt = #line) throws {
         let channel = EmbeddedChannel()
 
         XCTAssertNoThrow(try channel.pipeline.addHandler(MessageToByteHandler(Int32ToByteEncoder())).wait(),
-                         file: file, line: line)
+                         file: (file), line: line)
 
-        XCTAssertNoThrow(try channel.writeAndFlush(NIOAny(Int32(5))).wait(), file: file, line: line)
+        XCTAssertNoThrow(try channel.writeAndFlush(NIOAny(Int32(5))).wait(), file: (file), line: line)
 
         if var buffer = try channel.readOutbound(as: ByteBuffer.self) {
             XCTAssertEqual(Int32(5), buffer.readInteger())

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -165,26 +165,26 @@ class EmbeddedChannelTest: XCTestCase {
 
         func check<Expected, Actual>(expected: Expected.Type,
                                      actual: Actual.Type,
-                                     file: StaticString = (#file),
+                                     file: StaticString = #file,
                                      line: UInt = #line) {
             do {
                 _ = try channel.readOutbound(as: Expected.self)
-                XCTFail("this should have failed", file: file, line: line)
+                XCTFail("this should have failed", file: (file), line: line)
             } catch let error as EmbeddedChannel.WrongTypeError {
                 let expectedError = EmbeddedChannel.WrongTypeError(expected: Expected.self, actual: Actual.self)
-                XCTAssertEqual(error, expectedError, file: file, line: line)
+                XCTAssertEqual(error, expectedError, file: (file), line: line)
             } catch {
-                XCTFail("unexpected error: \(error)", file: file, line: line)
+                XCTFail("unexpected error: \(error)", file: (file), line: line)
             }
 
             do {
                 _ = try channel.readInbound(as: Expected.self)
-                XCTFail("this should have failed", file: file, line: line)
+                XCTFail("this should have failed", file: (file), line: line)
             } catch let error as EmbeddedChannel.WrongTypeError {
                 let expectedError = EmbeddedChannel.WrongTypeError(expected: Expected.self, actual: Actual.self)
-                XCTAssertEqual(error, expectedError, file: file, line: line)
+                XCTAssertEqual(error, expectedError, file: (file), line: line)
             } catch {
-                XCTFail("unexpected error: \(error)", file: file, line: line)
+                XCTFail("unexpected error: \(error)", file: (file), line: line)
             }
         }
 

--- a/Tests/NIOTests/MulticastTest.swift
+++ b/Tests/NIOTests/MulticastTest.swift
@@ -109,7 +109,7 @@ final class MulticastTest: XCTestCase {
         }
     }
 
-    private func assertDatagramReaches(multicastChannel: Channel, sender: Channel, multicastAddress: SocketAddress, file: StaticString = (#file), line: UInt = #line) throws {
+    private func assertDatagramReaches(multicastChannel: Channel, sender: Channel, multicastAddress: SocketAddress, file: StaticString = #file, line: UInt = #line) throws {
         let receivedMulticastDatagram = multicastChannel.eventLoop.makePromise(of: AddressedEnvelope<ByteBuffer>.self)
         XCTAssertNoThrow(try multicastChannel.pipeline.addHandler(PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
 
@@ -118,11 +118,11 @@ final class MulticastTest: XCTestCase {
 
         XCTAssertNoThrow(
             try sender.writeAndFlush(AddressedEnvelope(remoteAddress: multicastAddress, data: messageBuffer)).wait(),
-            file: file,
+            file: (file),
             line: line
         )
 
-        let receivedDatagram = try assertNoThrowWithValue(receivedMulticastDatagram.futureResult.wait(), file: file, line: line)
+        let receivedDatagram = try assertNoThrowWithValue(receivedMulticastDatagram.futureResult.wait(), file: (file), line: line)
         XCTAssertEqual(receivedDatagram.remoteAddress, sender.localAddress!)
         XCTAssertEqual(receivedDatagram.data, messageBuffer)
     }
@@ -131,7 +131,7 @@ final class MulticastTest: XCTestCase {
                                             after timeout: TimeAmount,
                                             sender: Channel,
                                             multicastAddress: SocketAddress,
-                                            file: StaticString = (#file), line: UInt = #line) throws {
+                                            file: StaticString = #file, line: UInt = #line) throws {
         let timeoutPromise = multicastChannel.eventLoop.makePromise(of: Void.self)
         let receivedMulticastDatagram = multicastChannel.eventLoop.makePromise(of: AddressedEnvelope<ByteBuffer>.self)
         XCTAssertNoThrow(try multicastChannel.pipeline.addHandler(PromiseOnReadHandler(promise: receivedMulticastDatagram)).wait())
@@ -146,12 +146,12 @@ final class MulticastTest: XCTestCase {
 
         XCTAssertNoThrow(
             try sender.writeAndFlush(AddressedEnvelope(remoteAddress: multicastAddress, data: messageBuffer)).wait(),
-            file: file,
+            file: (file),
             line: line
         )
 
         _ = multicastChannel.eventLoop.scheduleTask(in: timeout) { timeoutPromise.succeed(()) }
-        XCTAssertNoThrow(try timeoutPromise.futureResult.wait(), file: file, line: line)
+        XCTAssertNoThrow(try timeoutPromise.futureResult.wait(), file: (file), line: line)
     }
 
     func testCanJoinBasicMulticastGroupIPv4() throws {

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
@@ -102,7 +102,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                                            expectedVectorWritabilities: [[(Int, SocketAddress)]]?,
                                            returns: [Result<IOResult<Int>, Error>],
                                            promiseStates: [[Bool]],
-                                           file: StaticString = (#file),
+                                           file: StaticString = #file,
                                            line: UInt = #line) throws -> OverallWriteResult {
         var everythingState = 0
         var singleState = 0
@@ -119,9 +119,9 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 if let expected = expectedSingleWritabilities {
                     if expected.count > singleState {
                         XCTAssertGreaterThan(returns.count, everythingState)
-                        XCTAssertEqual(expected[singleState].0, buf.count, "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].0) bytes expected but \(buf.count) actual", file: file, line: line)
-                        XCTAssertEqual(expected[singleState].1, SocketAddress(addr), "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].1) address expected but \(SocketAddress(addr)) received", file: file, line: line)
-                        XCTAssertEqual(expected[singleState].1.expectedSize, len, "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].1.expectedSize) socklen expected but \(len) received", file: file, line: line)
+                        XCTAssertEqual(expected[singleState].0, buf.count, "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].0) bytes expected but \(buf.count) actual", file: (file), line: line)
+                        XCTAssertEqual(expected[singleState].1, SocketAddress(addr), "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].1) address expected but \(SocketAddress(addr)) received", file: (file), line: line)
+                        XCTAssertEqual(expected[singleState].1.expectedSize, len, "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].1.expectedSize) socklen expected but \(len) received", file: (file), line: line)
 
                         switch returns[everythingState] {
                         case .success(let r):
@@ -130,11 +130,11 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                             throw e
                         }
                     } else {
-                        XCTFail("single write call \(singleState) but less than \(expected.count) expected", file: file, line: line)
+                        XCTFail("single write call \(singleState) but less than \(expected.count) expected", file: (file), line: line)
                         return IOResult.wouldBlock(-1 * (everythingState + 1))
                     }
                 } else {
-                    XCTFail("single write called on \(buf) but no single writes expected", file: file, line: line)
+                    XCTFail("single write called on \(buf) but no single writes expected", file: (file), line: line)
                     return IOResult.wouldBlock(-1 * (everythingState + 1))
                 }
             }, vectorWriteOperation: { ptrs in
@@ -145,17 +145,17 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 if let expected = expectedVectorWritabilities {
                     if expected.count > multiState {
                         XCTAssertGreaterThan(returns.count, everythingState)
-                        XCTAssertEqual(ptrs.map { $0.msg_hdr.msg_iovlen }, Array(repeating: 1, count: ptrs.count), "mustn't write more than one iovec element per datagram", file: file, line: line)
+                        XCTAssertEqual(ptrs.map { $0.msg_hdr.msg_iovlen }, Array(repeating: 1, count: ptrs.count), "mustn't write more than one iovec element per datagram", file: (file), line: line)
                         XCTAssertEqual(expected[multiState].map { numericCast($0.0) }, ptrs.map { $0.msg_hdr.msg_iov.pointee.iov_len },
                                        "in vector write \(multiState) (overall \(everythingState)), \(expected[multiState]) byte counts expected but \(ptrs.map { $0.msg_hdr.msg_iov.pointee.iov_len }) actual",
-                                       file: file, line: line)
+                                       file: (file), line: line)
                         XCTAssertEqual(expected[multiState].map { $0.0 }, ptrs.map { Int($0.msg_len) },
                                        "in vector write \(multiState) (overall \(everythingState)), \(expected[multiState]) byte counts expected but \(ptrs.map { $0.msg_len }) actual",
-                            file: file, line: line)
+                            file: (file), line: line)
                         XCTAssertEqual(expected[multiState].map { $0.1 }, ptrs.map { SocketAddress($0.msg_hdr.msg_name.assumingMemoryBound(to: sockaddr.self)) }, "in vector write \(multiState) (overall \(everythingState)), \(expected[multiState].map { $0.1 }) addresses expected but \(ptrs.map { SocketAddress($0.msg_hdr.msg_name.assumingMemoryBound(to: sockaddr.self)) }) actual",
-                            file: file, line: line)
+                            file: (file), line: line)
                         XCTAssertEqual(expected[multiState].map { $0.1.expectedSize }, ptrs.map { $0.msg_hdr.msg_namelen }, "in vector write \(multiState) (overall \(everythingState)), \(expected[multiState].map { $0.1.expectedSize }) address lengths expected but \(ptrs.map { $0.msg_hdr.msg_namelen }) actual",
-                            file:file, line: line)
+                            file: (file), line: line)
 
                         switch returns[everythingState] {
                         case .success(let r):
@@ -164,12 +164,12 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                             throw e
                         }
                     } else {
-                        XCTFail("vector write call \(multiState) but less than \(expected.count) expected", file: file, line: line)
+                        XCTFail("vector write call \(multiState) but less than \(expected.count) expected", file: (file), line: line)
                         return IOResult.wouldBlock(-1 * (everythingState + 1))
                     }
                 } else {
                     XCTFail("vector write called on \(ptrs) but no vector writes expected",
-                        file: file, line: line)
+                        file: (file), line: line)
                     return IOResult.wouldBlock(-1 * (everythingState + 1))
                 }
             })
@@ -181,31 +181,31 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         if everythingState > 0 {
             XCTAssertEqual(promises.count, promiseStates[everythingState - 1].count,
                            "number of promises (\(promises.count)) != number of promise states (\(promiseStates[everythingState - 1].count))",
-                file: file, line: line)
+                file: (file), line: line)
             _ = zip(promises, promiseStates[everythingState - 1]).map { p, pState in
-                XCTAssertEqual(p.futureResult.isFulfilled, pState, "promise states incorrect (\(everythingState) callbacks)", file: file, line: line)
+                XCTAssertEqual(p.futureResult.isFulfilled, pState, "promise states incorrect (\(everythingState) callbacks)", file: (file), line: line)
             }
 
             XCTAssertEqual(everythingState, singleState + multiState,
-                           "odd, calls the single/vector writes: \(singleState)/\(multiState)/ but overall \(everythingState+1)", file: file, line: line)
+                           "odd, calls the single/vector writes: \(singleState)/\(multiState)/ but overall \(everythingState+1)", file: (file), line: line)
 
             if singleState == 0 {
-                XCTAssertNil(expectedSingleWritabilities, "no single writes have been done but we expected some", file: file, line: line)
+                XCTAssertNil(expectedSingleWritabilities, "no single writes have been done but we expected some", file: (file), line: line)
             } else {
-                XCTAssertEqual(singleState, (expectedSingleWritabilities?.count ?? Int.min), "different number of single writes than expected", file: file, line: line)
+                XCTAssertEqual(singleState, (expectedSingleWritabilities?.count ?? Int.min), "different number of single writes than expected", file: (file), line: line)
             }
             if multiState == 0 {
                 XCTAssertNil(expectedVectorWritabilities, "no vector writes have been done but we expected some")
             } else {
-                XCTAssertEqual(multiState, (expectedVectorWritabilities?.count ?? Int.min), "different number of vector writes than expected", file: file, line: line)
+                XCTAssertEqual(multiState, (expectedVectorWritabilities?.count ?? Int.min), "different number of vector writes than expected", file: (file), line: line)
             }
         } else {
-            XCTAssertEqual(0, returns.count, "no callbacks called but apparently \(returns.count) expected", file: file, line: line)
-            XCTAssertNil(expectedSingleWritabilities, "no callbacks called but apparently some single writes expected", file: file, line: line)
-            XCTAssertNil(expectedVectorWritabilities, "no callbacks calles but apparently some vector writes expected", file: file, line: line)
+            XCTAssertEqual(0, returns.count, "no callbacks called but apparently \(returns.count) expected", file: (file), line: line)
+            XCTAssertNil(expectedSingleWritabilities, "no callbacks called but apparently some single writes expected", file: (file), line: line)
+            XCTAssertNil(expectedVectorWritabilities, "no callbacks calles but apparently some vector writes expected", file: (file), line: line)
 
             _ = zip(promises, promiseStates[0]).map { p, pState in
-                XCTAssertEqual(p.futureResult.isFulfilled, pState, "promise states incorrect (no callbacks)", file: file, line: line)
+                XCTAssertEqual(p.futureResult.isFulfilled, pState, "promise states incorrect (no callbacks)", file: (file), line: line)
             }
         }
 

--- a/Tests/NIOTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOTests/SocketOptionProviderTest.swift
@@ -24,29 +24,29 @@ final class SocketOptionProviderTest: XCTestCase {
 
     struct CastError: Error { }
 
-    private func convertedChannel(file: StaticString = (#file), line: UInt = #line) throws -> SocketOptionProvider {
+    private func convertedChannel(file: StaticString = #file, line: UInt = #line) throws -> SocketOptionProvider {
         guard let provider = self.clientChannel as? SocketOptionProvider else {
-            XCTFail("Unable to cast \(String(describing: self.clientChannel)) to SocketOptionProvider", file: file, line: line)
+            XCTFail("Unable to cast \(String(describing: self.clientChannel)) to SocketOptionProvider", file: (file), line: line)
             throw CastError()
         }
         return provider
     }
 
-    private func ipv4MulticastProvider(file: StaticString = (#file), line: UInt = #line) throws -> SocketOptionProvider {
+    private func ipv4MulticastProvider(file: StaticString = #file, line: UInt = #line) throws -> SocketOptionProvider {
         guard let provider = self.ipv4DatagramChannel as? SocketOptionProvider else {
-            XCTFail("Unable to cast \(String(describing: self.ipv4DatagramChannel)) to SocketOptionProvider", file: file, line: line)
+            XCTFail("Unable to cast \(String(describing: self.ipv4DatagramChannel)) to SocketOptionProvider", file: (file), line: line)
             throw CastError()
         }
         return provider
     }
 
-    private func ipv6MulticastProvider(file: StaticString = (#file), line: UInt = #line) throws -> SocketOptionProvider? {
+    private func ipv6MulticastProvider(file: StaticString = #file, line: UInt = #line) throws -> SocketOptionProvider? {
         guard let ipv6Channel = self.ipv6DatagramChannel else {
             return nil
         }
 
         guard let provider = ipv6Channel as? SocketOptionProvider else {
-            XCTFail("Unable to cast \(ipv6Channel)) to SocketOptionChannel", file: file, line: line)
+            XCTFail("Unable to cast \(ipv6Channel)) to SocketOptionChannel", file: (file), line: line)
             throw CastError()
         }
 

--- a/Tests/NIOTests/StreamChannelsTest.swift
+++ b/Tests/NIOTests/StreamChannelsTest.swift
@@ -836,7 +836,7 @@ final class AccumulateAllReads: ChannelInboundHandler {
     }
 }
 
-private func assertNoSelectorChanges(fd: CInt, file: StaticString = (#file), line: UInt = #line) throws {
+private func assertNoSelectorChanges(fd: CInt, file: StaticString = #file, line: UInt = #line) throws {
     struct UnexpectedSelectorChanges: Error, CustomStringConvertible {
         let description: String
     }

--- a/Tests/NIOTests/SyscallAbstractionLayer.swift
+++ b/Tests/NIOTests/SyscallAbstractionLayer.swift
@@ -49,7 +49,7 @@ final class LockedBox<T> {
 
     init(_ value: T? = nil,
          description: String? = nil,
-         file: StaticString = (#file),
+         file: StaticString = #file,
          line: UInt = #line,
          didSet: @escaping (T?) -> Void = { _ in }) {
         self._value = value
@@ -368,21 +368,21 @@ class HookedSocket: Socket, UserKernelInterface {
 
 extension HookedSelector {
     func assertSyscallAndReturn(_ result: KernelToUser,
-                                file: StaticString = (#file),
+                                file: StaticString = #file,
                                 line: UInt = #line,
                                 matcher: (UserToKernel) throws -> Bool) throws {
         let syscall = try self.userToKernel.takeValue()
         if try matcher(syscall) {
             try self.kernelToUser.waitForEmptyAndSet(result)
         } else {
-            XCTFail("unexpected syscall \(syscall)", file: file, line: line)
+            XCTFail("unexpected syscall \(syscall)", file: (file), line: line)
             throw UnexpectedSyscall(syscall)
         }
     }
 
-    func assertWakeup(file: StaticString = (#file), line: UInt = #line) throws {
+    func assertWakeup(file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
-        try self.assertSyscallAndReturn(.returnSelectorEvent(nil), file: file, line: line) { syscall in
+        try self.assertSyscallAndReturn(.returnSelectorEvent(nil), file: (file), line: line) { syscall in
             if case .whenReady(.block) = syscall {
                 return true
             } else {
@@ -396,7 +396,7 @@ extension HookedSelector {
 
 extension EventLoop {
     internal func runSAL<T>(syscallAssertions: () throws -> Void = {},
-                            file: StaticString = (#file),
+                            file: StaticString = #file,
                             line: UInt = #line,
                             _ body: @escaping () throws -> T) throws -> T {
         let hookedSelector = ((self as! SelectableEventLoop)._selector as! HookedSelector)
@@ -408,7 +408,7 @@ extension EventLoop {
                 box.value = .failure(error)
             }
         }
-        try hookedSelector.assertWakeup(file: file, line: line)
+        try hookedSelector.assertWakeup(file: (file), line: line)
         try syscallAssertions()
         return try box.takeValue().get()
     }
@@ -480,7 +480,7 @@ extension SALTest {
     }
 
     private func makeSocketChannel(eventLoop: SelectableEventLoop,
-                                   file: StaticString = (#file), line: UInt = #line) throws -> SocketChannel {
+                                   file: StaticString = #file, line: UInt = #line) throws -> SocketChannel {
         let channel = try eventLoop.runSAL(syscallAssertions: {
             try self.assertdisableSIGPIPE(expectedFD: .max, result: .success(()))
             try self.assertLocalAddress(address: nil)
@@ -518,12 +518,12 @@ extension SALTest {
     }
 
     func makeSocketChannel(file: StaticString = #file, line: UInt = #line) throws -> SocketChannel {
-        return try self.makeSocketChannel(eventLoop: self.loop, file: file, line: line)
+        return try self.makeSocketChannel(eventLoop: self.loop, file: (file), line: line)
     }
 
     func makeConnectedSocketChannel(localAddress: SocketAddress?,
                                     remoteAddress: SocketAddress,
-                                    file: StaticString = (#file),
+                                    file: StaticString = #file,
                                     line: UInt = #line) throws -> SocketChannel {
         let channel = try self.makeSocketChannel(eventLoop: self.loop)
         let connectFuture = try channel.eventLoop.runSAL(syscallAssertions: {
@@ -584,21 +584,21 @@ extension SALTest {
         self.wakeups = nil
     }
 
-    func assertParkedRightNow(file: StaticString = (#file), line: UInt = #line) throws {
+    func assertParkedRightNow(file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         let syscall = try self.userToKernelBox.waitForValue()
         if case .whenReady = syscall {
             return
         } else {
-            XCTFail("unexpected syscall \(syscall)", file: file, line: line)
+            XCTFail("unexpected syscall \(syscall)", file: (file), line: line)
         }
     }
 
     func assertWaitingForNotification(result: SelectorEvent<NIORegistration>?,
-                                      file: StaticString = (#file), line: UInt = #line) throws {
+                                      file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)(result: \(result.debugDescription))")
         try self.selector.assertSyscallAndReturn(.returnSelectorEvent(result),
-                                                 file: file, line: line) { syscall in
+                                                 file: (file), line: line) { syscall in
             if case .whenReady = syscall {
                 return true
             } else {
@@ -607,13 +607,13 @@ extension SALTest {
         }
     }
 
-    func assertWakeup(file: StaticString = (#file), line: UInt = #line) throws {
-        try self.selector.assertWakeup(file: file, line: line)
+    func assertWakeup(file: StaticString = #file, line: UInt = #line) throws {
+        try self.selector.assertWakeup(file: (file), line: line)
     }
 
     func assertdisableSIGPIPE(expectedFD: CInt,
                              result: Result<Void, IOError>,
-                             file: StaticString = (#file), line: UInt = #line) throws {
+                             file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         let ret: KernelToUser
         switch result {
@@ -622,7 +622,7 @@ extension SALTest {
         case .failure(let error):
             ret = .error(error)
         }
-        try self.selector.assertSyscallAndReturn(ret, file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(ret, file: (file), line: line) { syscall in
             if case .disableSIGPIPE(expectedFD) = syscall {
                 return true
             } else {
@@ -632,12 +632,12 @@ extension SALTest {
     }
 
 
-    func assertLocalAddress(address: SocketAddress?, file: StaticString = (#file), line: UInt = #line) throws {
+    func assertLocalAddress(address: SocketAddress?, file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(address.map {
                                                     .returnSocketAddress($0)
             /*                                */ } ?? .error(.init(errnoCode: EOPNOTSUPP, reason: "nil passed")),
-                                                 file: file, line: line) { syscall in
+                                                 file: (file), line: line) { syscall in
             if case .localAddress = syscall {
                 return true
             } else {
@@ -646,11 +646,11 @@ extension SALTest {
         }
     }
 
-    func assertRemoteAddress(address: SocketAddress?, file: StaticString = (#file), line: UInt = #line) throws {
+    func assertRemoteAddress(address: SocketAddress?, file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(address.map { .returnSocketAddress($0) } ??
             /*                                */ .error(.init(errnoCode: EOPNOTSUPP, reason: "nil passed")),
-                                                 file: file, line: line) { syscall in
+                                                 file: (file), line: line) { syscall in
             if case .remoteAddress = syscall {
                 return true
             } else {
@@ -659,9 +659,9 @@ extension SALTest {
         }
     }
 
-    func assertConnect(expectedAddress: SocketAddress, result: Bool, file: StaticString = (#file), line: UInt = #line, _ matcher: (SocketAddress) -> Bool = { _ in true }) throws {
+    func assertConnect(expectedAddress: SocketAddress, result: Bool, file: StaticString = #file, line: UInt = #line, _ matcher: (SocketAddress) -> Bool = { _ in true }) throws {
         SAL.printIfDebug("\(#function)")
-        try self.selector.assertSyscallAndReturn(.returnBool(result), file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(.returnBool(result), file: (file), line: line) { syscall in
             if case .connect(let address) = syscall {
                 return address == expectedAddress
             } else {
@@ -672,7 +672,7 @@ extension SALTest {
 
     func assertBind(expectedAddress: SocketAddress, file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
-        try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(.returnVoid, file: (file), line: line) { syscall in
             if case .bind(let address) = syscall {
                 return address == expectedAddress
             } else {
@@ -681,11 +681,11 @@ extension SALTest {
         }
     }
 
-    func assertClose(expectedFD: CInt, file: StaticString = (#file), line: UInt = #line) throws {
+    func assertClose(expectedFD: CInt, file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
-        try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(.returnVoid, file: (file), line: line) { syscall in
             if case .close(let fd) = syscall {
-                XCTAssertEqual(expectedFD, fd, file: file, line: line)
+                XCTAssertEqual(expectedFD, fd, file: (file), line: line)
                 return true
             } else {
                 return false
@@ -698,7 +698,7 @@ extension SALTest {
                          file: StaticString = #file, line: UInt = #line,
                          _ valueMatcher: (Any) -> Bool = { _ in true }) throws {
         SAL.printIfDebug("\(#function)")
-        try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(.returnVoid, file: (file), line: line) { syscall in
             if case .setOption(expectedLevel, expectedOption, let value) = syscall {
                 return valueMatcher(value)
             } else {
@@ -707,9 +707,9 @@ extension SALTest {
         }
     }
 
-    func assertRegister(file: StaticString = (#file), line: UInt = #line, _ matcher: (Selectable, SelectorEventSet, NIORegistration) throws -> Bool) throws {
+    func assertRegister(file: StaticString = #file, line: UInt = #line, _ matcher: (Selectable, SelectorEventSet, NIORegistration) throws -> Bool) throws {
         SAL.printIfDebug("\(#function)")
-        try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(.returnVoid, file: (file), line: line) { syscall in
             if case .register(let selectable, let eventSet, let registration) = syscall {
                 return try matcher(selectable, eventSet, registration)
             } else {
@@ -718,9 +718,9 @@ extension SALTest {
         }
     }
 
-    func assertReregister(file: StaticString = (#file), line: UInt = #line, _ matcher: (Selectable, SelectorEventSet) throws -> Bool) throws {
+    func assertReregister(file: StaticString = #file, line: UInt = #line, _ matcher: (Selectable, SelectorEventSet) throws -> Bool) throws {
         SAL.printIfDebug("\(#function)")
-        try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(.returnVoid, file: (file), line: line) { syscall in
             if case .reregister(let selectable, let eventSet) = syscall {
                 return try matcher(selectable, eventSet)
             } else {
@@ -729,9 +729,9 @@ extension SALTest {
         }
     }
 
-    func assertDeregister(file: StaticString = (#file), line: UInt = #line, _ matcher: (Selectable) throws -> Bool) throws {
+    func assertDeregister(file: StaticString = #file, line: UInt = #line, _ matcher: (Selectable) throws -> Bool) throws {
         SAL.printIfDebug("\(#function)")
-        try self.selector.assertSyscallAndReturn(.returnVoid, file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(.returnVoid, file: (file), line: line) { syscall in
             if case .deregister(let selectable) = syscall {
                 return try matcher(selectable)
             } else {
@@ -740,9 +740,9 @@ extension SALTest {
         }
     }
 
-    func assertWrite(expectedFD: CInt, expectedBytes: ByteBuffer, return: IOResult<Int>, file: StaticString = (#file), line: UInt = #line) throws {
+    func assertWrite(expectedFD: CInt, expectedBytes: ByteBuffer, return: IOResult<Int>, file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
-        try self.selector.assertSyscallAndReturn(.returnIOResultInt(`return`), file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(.returnIOResultInt(`return`), file: (file), line: line) { syscall in
             if case .write(let actualFD, let actualBytes) = syscall {
                 return expectedFD == actualFD && expectedBytes == actualBytes
             } else {
@@ -751,9 +751,9 @@ extension SALTest {
         }
     }
 
-    func assertWritev(expectedFD: CInt, expectedBytes: [ByteBuffer], return: IOResult<Int>, file: StaticString = (#file), line: UInt = #line) throws {
+    func assertWritev(expectedFD: CInt, expectedBytes: [ByteBuffer], return: IOResult<Int>, file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
-        try self.selector.assertSyscallAndReturn(.returnIOResultInt(`return`), file: file, line: line) { syscall in
+        try self.selector.assertSyscallAndReturn(.returnIOResultInt(`return`), file: (file), line: line) { syscall in
             if case .writev(let actualFD, let actualBytes) = syscall {
                 return expectedFD == actualFD && expectedBytes == actualBytes
             } else {
@@ -763,12 +763,12 @@ extension SALTest {
     }
 
     func assertRead(expectedFD: CInt, expectedBufferSpace: Int, return: ByteBuffer,
-                    file: StaticString = (#file), line: UInt = #line) throws {
+                    file: StaticString = #file, line: UInt = #line) throws {
         SAL.printIfDebug("\(#function)")
         try self.selector.assertSyscallAndReturn(.returnBytes(`return`),
-                                                 file: file, line: line) { syscall in
+                                                 file: (file), line: line) { syscall in
             if case .read(let amount) = syscall {
-                XCTAssertEqual(expectedBufferSpace, amount, file: file, line: line)
+                XCTAssertEqual(expectedBufferSpace, amount, file: (file), line: line)
                 return true
             } else {
                 return false

--- a/Tests/NIOTests/SystemCallWrapperHelpers.swift
+++ b/Tests/NIOTests/SystemCallWrapperHelpers.swift
@@ -48,7 +48,7 @@ enum TestError: Error {
 func runStandalone() {
     func assertFun(condition: @autoclosure () -> Bool, string: @autoclosure () -> String, file: StaticString, line: UInt) -> Void {
         if !condition() {
-            fatalError(string(), file: file, line: line)
+            fatalError(string(), file: (file), line: line)
         }
     }
     do {

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -255,11 +255,11 @@ func assertSetGetOptionOnOpenAndClosed<Option: ChannelOption>(channel: Channel, 
     }
 }
 
-func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil, file: StaticString = (#file), line: UInt = #line) throws -> T {
+func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil, file: StaticString = #file, line: UInt = #line) throws -> T {
     do {
         return try body()
     } catch {
-        XCTFail("\(message.map { $0 + ": " } ?? "")unexpected error \(error) thrown", file: file, line: line)
+        XCTFail("\(message.map { $0 + ": " } ?? "")unexpected error \(error) thrown", file: (file), line: line)
         if let defaultValue = defaultValue {
             return defaultValue
         } else {
@@ -294,7 +294,7 @@ func resolverDebugInformation(eventLoop: EventLoop, host: String, previouslyRece
     """
 }
 
-func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testInterval: TimeAmount? = nil, _ message: String = "condition not satisfied in time", file: StaticString = (#file), line: UInt = #line) {
+func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testInterval: TimeAmount? = nil, _ message: String = "condition not satisfied in time", file: StaticString = #file, line: UInt = #line) {
     let testInterval = testInterval ?? TimeAmount.nanoseconds(time.nanoseconds / 5)
     let endTime = NIODeadline.now() + time
 
@@ -304,21 +304,21 @@ func assert(_ condition: @autoclosure () -> Bool, within time: TimeAmount, testI
     } while (NIODeadline.now() < endTime)
 
     if !condition() {
-        XCTFail(message, file: file, line: line)
+        XCTFail(message, file: (file), line: line)
     }
 }
 
 func getBoolSocketOption(channel: Channel, level: NIOBSDSocket.OptionLevel, name: NIOBSDSocket.Option,
-                         file: StaticString = (#file), line: UInt = #line) throws -> Bool {
-    return try assertNoThrowWithValue(channel.getOption(ChannelOptions.Types.SocketOption(level: level, name: name)), file: file, line: line).wait() != 0
+                         file: StaticString = #file, line: UInt = #line) throws -> Bool {
+    return try assertNoThrowWithValue(channel.getOption(ChannelOptions.Types.SocketOption(level: level, name: name)), file: (file), line: line).wait() != 0
 }
 
-func assertSuccess<Value>(_ result: Result<Value, Error>, file: StaticString = (#file), line: UInt = #line) {
-    guard case .success = result else { return XCTFail("Expected result to be successful", file: file, line: line) }
+func assertSuccess<Value>(_ result: Result<Value, Error>, file: StaticString = #file, line: UInt = #line) {
+    guard case .success = result else { return XCTFail("Expected result to be successful", file: (file), line: line) }
 }
 
-func assertFailure<Value>(_ result: Result<Value, Error>, file: StaticString = (#file), line: UInt = #line) {
-    guard case .failure = result else { return XCTFail("Expected result to be a failure", file: file, line: line) }
+func assertFailure<Value>(_ result: Result<Value, Error>, file: StaticString = #file, line: UInt = #line) {
+    guard case .failure = result else { return XCTFail("Expected result to be a failure", file: (file), line: line) }
 }
 
 /// Fulfills the promise when the respective event is first received.
@@ -490,7 +490,7 @@ final class FulfillOnFirstEventHandler: ChannelDuplexHandler {
     }
 }
 
-func forEachActiveChannelType<T>(file: StaticString = (#file),
+func forEachActiveChannelType<T>(file: StaticString = #file,
                                  line: UInt = #line,
                                  _ body: @escaping (Channel) throws -> T) throws -> [T] {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -501,7 +501,7 @@ func forEachActiveChannelType<T>(file: StaticString = (#file),
 
     let lock = Lock()
     var ret: [T] = []
-    _ = try forEachCrossConnectedStreamChannelPair(file: file, line: line) { (chan1: Channel, chan2: Channel) throws -> Void in
+    _ = try forEachCrossConnectedStreamChannelPair(file: (file), line: line) { (chan1: Channel, chan2: Channel) throws -> Void in
         var innerRet: [T] = [try body(chan1)]
         if let parent = chan1.parent {
             innerRet.append(try body(parent))
@@ -530,7 +530,7 @@ func forEachActiveChannelType<T>(file: StaticString = (#file),
 
 func withTCPServerChannel<R>(bindTarget: SocketAddress? = nil,
                              group: EventLoopGroup,
-                             file: StaticString = (#file),
+                             file: StaticString = #file,
                              line: UInt = #line,
                              _ body: (Channel) throws -> R) throws -> R {
     let server = try ServerBootstrap(group: group)
@@ -549,7 +549,7 @@ func withTCPServerChannel<R>(bindTarget: SocketAddress? = nil,
 
 func withCrossConnectedSockAddrChannels<R>(bindTarget: SocketAddress,
                                            forceSeparateEventLoops: Bool = false,
-                                           file: StaticString = (#file),
+                                           file: StaticString = #file,
                                            line: UInt = #line,
                                            _ body: (Channel, Channel) throws -> R) throws -> R {
     let serverGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -579,7 +579,7 @@ func withCrossConnectedSockAddrChannels<R>(bindTarget: SocketAddress,
             return channel.pipeline.addHandler(FulfillOnFirstEventHandler(channelActivePromise: accepted))
         }
         .bind(to: bindTarget)
-        .wait(), file: file, line: line)
+        .wait(), file: (file), line: line)
     defer {
         XCTAssertNoThrow(try tcpServerChannel.syncCloseAcceptingAlreadyClosed())
     }
@@ -599,7 +599,7 @@ func withCrossConnectedSockAddrChannels<R>(bindTarget: SocketAddress,
 }
 
 func withCrossConnectedTCPChannels<R>(forceSeparateEventLoops: Bool = false,
-                                      file: StaticString = (#file),
+                                      file: StaticString = #file,
                                       line: UInt = #line,
                                       _ body: (Channel, Channel) throws -> R) throws -> R {
     return try withCrossConnectedSockAddrChannels(bindTarget: .init(ipAddress: "127.0.0.1", port: 0),
@@ -608,7 +608,7 @@ func withCrossConnectedTCPChannels<R>(forceSeparateEventLoops: Bool = false,
 }
 
 func withCrossConnectedUnixDomainSocketChannels<R>(forceSeparateEventLoops: Bool = false,
-                                                   file: StaticString = (#file),
+                                                   file: StaticString = #file,
                                                    line: UInt = #line,
                                                    _ body: (Channel, Channel) throws -> R) throws -> R {
     return try withTemporaryDirectory { tempDir in
@@ -620,12 +620,12 @@ func withCrossConnectedUnixDomainSocketChannels<R>(forceSeparateEventLoops: Bool
 }
 
 func withCrossConnectedPipeChannels<R>(forceSeparateEventLoops: Bool = false,
-                                       file: StaticString = (#file),
+                                       file: StaticString = #file,
                                        line: UInt = #line,
                                        _ body: (Channel, Channel) throws -> R) throws -> R {
     let channel1Group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer {
-        XCTAssertNoThrow(try channel1Group.syncShutdownGracefully(), file: file, line: line)
+        XCTAssertNoThrow(try channel1Group.syncShutdownGracefully(), file: (file), line: line)
     }
     let channel2Group: MultiThreadedEventLoopGroup
     if forceSeparateEventLoops {
@@ -663,19 +663,19 @@ func withCrossConnectedPipeChannels<R>(forceSeparateEventLoops: Bool = false,
                     }
                 }
             }
-            XCTAssertNoThrow(try pipe1Read.takeDescriptorOwnership(), file: file, line: line)
-            XCTAssertNoThrow(try pipe1Write.takeDescriptorOwnership(), file: file, line: line)
-            XCTAssertNoThrow(try pipe2Read.takeDescriptorOwnership(), file: file, line: line)
-            XCTAssertNoThrow(try pipe2Write.takeDescriptorOwnership(), file: file, line: line)
+            XCTAssertNoThrow(try pipe1Read.takeDescriptorOwnership(), file: (file), line: line)
+            XCTAssertNoThrow(try pipe1Write.takeDescriptorOwnership(), file: (file), line: line)
+            XCTAssertNoThrow(try pipe2Read.takeDescriptorOwnership(), file: (file), line: line)
+            XCTAssertNoThrow(try pipe2Write.takeDescriptorOwnership(), file: (file), line: line)
             return []
         }
         return [] // the channels are closing the pipes
-    }, file: file, line: line)
+    }, file: (file), line: line)
     return result!
 }
 
 func forEachCrossConnectedStreamChannelPair<R>(forceSeparateEventLoops: Bool = false,
-                                               file: StaticString = (#file),
+                                               file: StaticString = #file,
                                                line: UInt = #line,
                                                _ body: (Channel, Channel) throws -> R) throws -> [R] {
     let r1 = try withCrossConnectedTCPChannels(forceSeparateEventLoops: forceSeparateEventLoops, body)

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -32,9 +32,9 @@ extension EmbeddedChannel {
 extension ChannelPipeline {
     
     fileprivate func assertDoesNotContain<Handler: ChannelHandler>(handlerType: Handler.Type,
-                                                                   file: StaticString = (#file),
+                                                                   file: StaticString = #file,
                                                                    line: UInt = #line) throws {
-        XCTAssertThrowsError(try self.context(handlerType: handlerType).wait(), file: file, line: line) { error in
+        XCTAssertThrowsError(try self.context(handlerType: handlerType).wait(), file: (file), line: line) { error in
             XCTAssertEqual(.notFound, error as? ChannelPipelineError)
         }
     }


### PR DESCRIPTION
Motivation:

only works if done when _calling_ a function, not when defining one :|.

- https://github.com/apple/swift/pull/32445
- https://bugs.swift.org/browse/SR-12936
- https://bugs.swift.org/browse/SR-12934
- https://bugs.swift.org/browse/SR-13041

Modifications:

Silence #file to #filePath differently.

Result:

Hopefully at some point we get this working.