### PR TITLE
Make allocation tests produce more stable results

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_tcpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_tcpconnections.swift
@@ -21,7 +21,7 @@ fileprivate final class ReceiveAndCloseHandler: ChannelInboundHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let byteBuffer = self.unwrapInboundIn(data)
         precondition(byteBuffer.readableBytes == 1)
-        _ = context.channel.close()
+        context.channel.close(promise: nil)
     }
 }
 
@@ -46,7 +46,7 @@ func run(identifier: String) {
             // Send a byte to make sure everything is really open.
             var buffer = clientChannel.allocator.buffer(capacity: 1)
             buffer.writeInteger(1, as: UInt8.self)
-            _ = clientChannel.writeAndFlush(NIOAny(buffer))
+            clientChannel.writeAndFlush(NIOAny(buffer), promise: nil)
             // Wait for the close to come from the server side.
             try! clientChannel.closeFuture.wait()
         }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
@@ -29,8 +29,8 @@ fileprivate final class CountReadsHandler: ChannelInboundHandler {
     }
     
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        readsRemaining -= 1
-        if readsRemaining <= 0 {
+        self.readsRemaining -= 1
+        if self.readsRemaining <= 0 {
             self.completed.succeed(())
         }
     }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
@@ -14,17 +14,37 @@
 
 import NIO
 
-fileprivate final class DoNothingHandler: ChannelInboundHandler {
+fileprivate final class CountReadsHandler: ChannelInboundHandler {
     public typealias InboundIn = ByteBuffer
     public typealias OutboundOut = ByteBuffer
+    
+    private var readsRemaining: Int
+    private let completed: EventLoopPromise<Void>
+    
+    var completionFuture: EventLoopFuture<Void> { return self.completed.futureResult }
+    
+    init(numberOfReadsExpected: Int, eventLoop: EventLoop) {
+        self.readsRemaining = numberOfReadsExpected
+        self.completed = eventLoop.makePromise()
+    }
+    
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        readsRemaining -= 1
+        if readsRemaining <= 0 {
+            self.completed.succeed(())
+        }
+    }
 }
 
 func run(identifier: String) {
+    let numberOfIterations = 1000
+    
+    let serverHandler = CountReadsHandler(numberOfReadsExpected: numberOfIterations, eventLoop: group.next())
     let serverChannel = try! DatagramBootstrap(group: group)
         .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         // Set the handlers that are applied to the bound channel
         .channelInitializer { channel in
-            return channel.pipeline.addHandler(DoNothingHandler())
+            return channel.pipeline.addHandler(serverHandler)
         }
         .bind(to: localhostPickPort).wait()
     defer {
@@ -37,7 +57,6 @@ func run(identifier: String) {
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
     measure(identifier: identifier) {
-        let numberOfIterations = 1000
         let buffer = ByteBuffer(integer: 1, as: UInt8.self)
         for _ in 0 ..< numberOfIterations {
             let clientChannel = try! clientBootstrap.bind(to: localhostPickPort).wait()
@@ -49,6 +68,7 @@ func run(identifier: String) {
             let envelope = AddressedEnvelope<ByteBuffer>(remoteAddress: remoteAddress, data: buffer)
             clientChannel.writeAndFlush(envelope, promise: nil)
         }
+        try! serverHandler.completionFuture.wait()
         return numberOfIterations
     }
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
@@ -21,11 +21,13 @@ fileprivate final class CountReadsHandler: ChannelInboundHandler {
     private var readsRemaining: Int
     private let completed: EventLoopPromise<Void>
     
-    var completionFuture: EventLoopFuture<Void> { return self.completed.futureResult }
+    var completionFuture: EventLoopFuture<Void> {
+        return self.completed.futureResult
+    }
     
-    init(numberOfReadsExpected: Int, eventLoop: EventLoop) {
+    init(numberOfReadsExpected: Int, completionPromise: EventLoopPromise<Void>) {
         self.readsRemaining = numberOfReadsExpected
-        self.completed = eventLoop.makePromise()
+        self.completed = completionPromise
     }
     
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -39,7 +41,8 @@ fileprivate final class CountReadsHandler: ChannelInboundHandler {
 func run(identifier: String) {
     let numberOfIterations = 1000
     
-    let serverHandler = CountReadsHandler(numberOfReadsExpected: numberOfIterations, eventLoop: group.next())
+    let serverHandler = CountReadsHandler(numberOfReadsExpected: numberOfIterations,
+                                          completionPromise: group.next().makePromise())
     let serverChannel = try! DatagramBootstrap(group: group)
         .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         // Set the handlers that are applied to the bound channel

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -37,9 +37,9 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=211000
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=198800
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=111050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=198800
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=196800
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -36,9 +36,9 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=208100
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=196050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=110050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=113050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread
 

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=196050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=194050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=113050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=18250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=235050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=207800
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=205800
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=120050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -37,9 +37,9 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=18250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=235050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=220000
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=207800
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=116050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=120050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
 
 

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=224050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=198800
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=196800
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -37,9 +37,9 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=224050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=211000
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=198800
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=111050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
 
 


### PR DESCRIPTION
Make allocation tests produce more stable results

### Motivation:

Allocation tests are very hard to use productively if they don't produce stable results.

### Modifications:

Change TCP and UDP connection tests to monitor on the server side as well as the client side to make sure all data is completely send and received before stopping counting allocations.

### Result:

Allocation tests are more stable than before.
