### PR TITLE
stablise 1000 TCP connections alloc test

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_tcpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_tcpconnections.swift
@@ -17,38 +17,50 @@ import NIO
 fileprivate final class ReceiveAndCloseHandler: ChannelInboundHandler {
     public typealias InboundIn = ByteBuffer
     public typealias OutboundOut = ByteBuffer
-    
+
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let byteBuffer = self.unwrapInboundIn(data)
         precondition(byteBuffer.readableBytes == 1)
         context.channel.close(promise: nil)
     }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        fatalError("unexpected \(error)")
+    }
 }
 
 func run(identifier: String) {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer {
+        try! group.syncShutdownGracefully()
+    }
+
     let serverChannel = try! ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(ReceiveAndCloseHandler())
-            }.bind(to: localhostPickPort).wait()
+            }.bind(host: "127.0.0.1", port: 0).wait()
     defer {
         try! serverChannel.close().wait()
     }
-    
+
     let clientBootstrap = ClientBootstrap(group: group)
-    
+
     measure(identifier: identifier) {
         let numberOfIterations = 1000
-        
+        let serverAddress = serverChannel.localAddress!
+        let buffer = ByteBuffer(integer: 1, as: UInt8.self)
+        let el = group.next()
+
         for _ in 0 ..< numberOfIterations {
-            let clientChannel = try! clientBootstrap.connect(to: serverChannel.localAddress!)
-                    .wait()
-            // Send a byte to make sure everything is really open.
-            var buffer = clientChannel.allocator.buffer(capacity: 1)
-            buffer.writeInteger(1, as: UInt8.self)
-            clientChannel.writeAndFlush(NIOAny(buffer), promise: nil)
-            // Wait for the close to come from the server side.
-            try! clientChannel.closeFuture.wait()
+            try! el.flatSubmit {
+                clientBootstrap.connect(to: serverAddress).flatMap { clientChannel in
+                    // Send a byte to make sure everything is really open.
+                    clientChannel.writeAndFlush(buffer).flatMap {
+                        clientChannel.closeFuture
+                    }
+                }
+            }.wait()
         }
         return numberOfIterations
     }

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=196800
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=178010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -30,13 +30,13 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=4010
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
-      - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010 
+      - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200500 #5.3 improvement 210050
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=194050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=177010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=113050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=18250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=235050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=205800
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=186050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=120050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=224050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=196800
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=178050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050


### PR DESCRIPTION
Motivation:

The 1000 TCP connections allocation counter test did way too many thread
crosses and other things that allocated for unrelated reasons.

Modifications:

Remove those.

Result:

Much more stable