### PR TITLE
Properly allow ThreadPool to be started multiple times.

### DIFF
--- a/Sources/NIO/NIOThreadPool.swift
+++ b/Sources/NIO/NIOThreadPool.swift
@@ -153,16 +153,21 @@ public final class NIOThreadPool {
 
     /// Start the `NIOThreadPool` if not already started.
     public func start() {
-        self.lock.withLock {
+        let alreadyRunning: Bool = self.lock.withLock {
             switch self.state {
             case .running(_):
-                return
+                return true
             case .shuttingDown(_):
                 // This should never happen
                 fatalError("start() called while in shuttingDown")
             case .stopped:
                 self.state = .running(CircularBuffer(initialCapacity: 16))
+                return false
             }
+        }
+
+        if alreadyRunning {
+            return
         }
 
         let group = DispatchGroup()

--- a/Tests/NIOTests/NIOThreadPoolTest+XCTest.swift
+++ b/Tests/NIOTests/NIOThreadPoolTest+XCTest.swift
@@ -28,6 +28,7 @@ extension NIOThreadPoolTest {
    static var allTests : [(String, (NIOThreadPoolTest) -> () throws -> Void)] {
       return [
                 ("testThreadNamesAreSetUp", testThreadNamesAreSetUp),
+                ("testThreadPoolStartsMultipleTimes", testThreadPoolStartsMultipleTimes),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Our API documentation claims that NIOThreadPool.start() will tolerate
being called multiple times. However, this wasn't actually true: in
debug mode it'd hit an assertion, and in release mode it would quietly
orphan all its threads and replace them with new ones, leaving there
with twice as many threads and some that wouldn't be closed down.

We should support the functionality we claim we do.

Modifications:

- Fixed the incorrect check for running thread pool state.
- Added a test to validate we actually allow multiple starts.

Result:

Thread pools really can be started multiple times.