### PR TITLE
Make array ByteBuffer initialiser public

### DIFF
--- a/Sources/NIO/ByteBuffer-conversions.swift
+++ b/Sources/NIO/ByteBuffer-conversions.swift
@@ -18,7 +18,7 @@ extension Array where Element == UInt8 {
     
     /// Creates a `[UInt8]` from the given buffer. The entire readable portion of the buffer will be read.
     /// - parameter buffer: The buffer to read.
-    init(buffer: ByteBuffer) {
+    public init(buffer: ByteBuffer) {
         var buffer = buffer
         self = buffer.readBytes(length: buffer.readableBytes)!
     }


### PR DESCRIPTION
Make array ByteBuffer initialiser public.

### Motivation:
This was meant to be public, but accidentally was left as internal.

### Modifications:
Add `public` to the initialiser.

### Result:
The initialiser is now public.
