### PR TITLE
Add BaggageContext property to ChannelHandlerContext

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ var targets: [PackageDescription.Target] = [
                            "CNIODarwin",
                            "NIOConcurrencyHelpers",
                            "CNIOAtomics",
-                           "CNIOSHA1"]),
+                           "CNIOSHA1",
+                           "Baggage"]),
     .target(name: "NIOFoundationCompat", dependencies: ["NIO"]),
     .target(name: "CNIOAtomics", dependencies: []),
     .target(name: "CNIOSHA1", dependencies: []),
@@ -94,6 +95,7 @@ let package = Package(
         .library(name: "NIOTestUtils", targets: ["NIOTestUtils"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/slashmo/gsoc-swift-baggage-context", .branch("main"))
     ],
     targets: targets
 )


### PR DESCRIPTION
⚠️ This PR is not intended to ever be merged, but rather meant as a playground to inspire a "real" PR once the `BaggageContext` has matured and was accepted by the SSWG.

Publicly expose a `BaggageContext` through the `ChannelHandlerContext`.

### Motivation:

As already discussed in slashmo/gsoc-swift-tracing#48, in order to share a `BaggageContext` between multiple handlers on the same channel, we want to store a `BaggageContext` on a `Channel`, which it publicly accessible through the `ChannelHandlerContext`.

### Modifications:

- NIO depends on [slashmo/gsoc-swift-baggage-context](https://github.com/slashmo/gsoc-swift-baggage-context)

### Result:

Users of `BaggageContext` and [related APIs](https://github.com/slashmo/gsoc-swift-tracing) will be able to access a `BaggageContext` through the `ChannelHandlerContext`. This has the side-effect of NIO now depending on [slashmo/gsoc-swift-baggage-context](slashmo/gsoc-swift-baggage-context).