### PR TITLE
Wait for flush before close in UDP allocation test

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
@@ -15,8 +15,8 @@
 import NIO
 
 fileprivate final class WaitForReadHandler: ChannelInboundHandler {
-    public typealias InboundIn = ByteBuffer
-    public typealias OutboundOut = ByteBuffer
+    public typealias InboundIn = AddressedEnvelope<ByteBuffer>
+    public typealias OutboundOut = AddressedEnvelope<ByteBuffer>
     
     private var completed: EventLoopPromise<Void>
     

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=123050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -38,7 +38,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=113050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=123050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread
 

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=189050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=120050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=128050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
 
 

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=123050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
 
 


### PR DESCRIPTION
Wait for flush before close in UDP allocation test

### Motivation:

The UDP allocation test for connections has been seen to hang. 

### Modifications:

Remove one potential source of problems - wait for the data to flush before closing the channel.
Remove use of shared.swift which has caused issues elsewhere.

### Result:

Data will flush before close.
