### PR TITLE
Stop udp connection allocation test hanging on linux.

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
@@ -44,7 +44,6 @@ func run(identifier: String) {
     let serverHandler = CountReadsHandler(numberOfReadsExpected: numberOfIterations,
                                           completionPromise: group.next().makePromise())
     let serverChannel = try! DatagramBootstrap(group: group)
-        .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         // Set the handlers that are applied to the bound channel
         .channelInitializer { channel in
             return channel.pipeline.addHandler(serverHandler)


### PR DESCRIPTION
Motivation:

Hanging tests make doing work and asserting correctness very difficult.

Modifications:

Remove address reuse from the server side of the udp channel.

Result:

The tests no longer hang.

(The reason things we hanging was that the client side was occasionally getting assigned the same port number as the server side (extremely agressive port reuse)