### PR TITLE
Allow mutating in ByteToMessageDecoder encode

### DIFF
--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -704,7 +704,7 @@ public protocol MessageToByteEncoder {
     /// - parameters:
     ///     - data: The data to encode into a `ByteBuffer`.
     ///     - out: The `ByteBuffer` into which we want to encode.
-    func encode(data: OutboundIn, out: inout ByteBuffer) throws
+    mutating func encode(data: OutboundIn, out: inout ByteBuffer) throws
 }
 
 extension ByteToMessageHandler: RemovableChannelHandler {


### PR DESCRIPTION
Resolves #1579 

Structs are now able to conform and track a state where `mutating` is required.