### PR TITLE
UDP allocation tests should not use so_reuseaddr

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
@@ -217,7 +217,6 @@ enum UDPShared {
 
     static func doUDPRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
         let serverChannel = try DatagramBootstrap(group: group)
-            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             // Set the handlers that are applied to the bound channel
             .channelInitializer { channel in
                 return channel.pipeline.addHandler(EchoHandler())
@@ -231,8 +230,6 @@ enum UDPShared {
         let remoteAddress = serverChannel.localAddress!
 
         let clientChannel = try DatagramBootstrap(group: group)
-            // Enable SO_REUSEADDR.
-            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
                 channel.pipeline.addHandler(EchoHandlerClient(remoteAddress: remoteAddress,
                                                               numberOfRepetitions: numberOfRequests))

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udp_reqs.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udp_reqs.swift
@@ -90,7 +90,6 @@ fileprivate final class ClientHandler: ChannelInboundHandler {
 
 func run(identifier: String) {
     let serverChannel = try! DatagramBootstrap(group: group)
-        .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         // Set the handlers that are applied to the bound channel
         .channelInitializer { channel in
             return channel.pipeline.addHandler(ServerEchoHandler())
@@ -104,7 +103,6 @@ func run(identifier: String) {
     let clientHandler = ClientHandler(remoteAddress: remoteAddress)
 
     let clientChannel = try! DatagramBootstrap(group: group)
-        .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         .channelInitializer { channel in
             channel.pipeline.addHandler(clientHandler)
         }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpbootstraps.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpbootstraps.swift
@@ -24,7 +24,6 @@ func run(identifier: String) {
         let numberOfIterations = 1000
         for _ in 0 ..< numberOfIterations {
             _ = DatagramBootstrap(group: group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
                 .channelInitializer { channel in
                     channel.pipeline.addHandler(DoNothingHandler())
                 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udpconnections.swift
@@ -56,7 +56,6 @@ func run(identifier: String) {
     let remoteAddress = serverChannel.localAddress!
     
     let clientBootstrap = DatagramBootstrap(group: group)
-            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
     measure(identifier: identifier) {
         let buffer = ByteBuffer(integer: 1, as: UInt8.self)

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -38,7 +38,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181010
-      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
+      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -35,7 +35,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=202050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=105050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -38,7 +38,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=113050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread
 

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010
-      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=4000
+      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=113050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -34,7 +34,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200500 #5.3 improvement 210050
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=226050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=202050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -35,7 +35,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=230050
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=18250
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=235050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=213050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=189050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=189050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=120050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=110050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
 
 

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -38,7 +38,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=235050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=189050
-      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
+      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=120050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
 

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=105050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
 
 

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -35,7 +35,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=224050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=202050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -38,7 +38,7 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=224050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181050
-      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=3000
+      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=115050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
 


### PR DESCRIPTION
Motivation:

so_reuseaddr on linux allows multiple binding to the same port simultaneously - this has not been seen to happen in practice but it is best to be cautious.

Modifications:

Remove address reuse from the UDP allocation tests.

Result:

Reduced danger of binding the same port twice.