### PR TITLE
Make UDP connection allocation test more like best practice code.

### DIFF
--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=105050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -38,7 +38,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - SANITIZER_ARG=--sanitize=thread
 

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=189050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=110050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=108050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
 
 

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=105050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
 
 


### PR DESCRIPTION
Motivation:

There is at least a theoretical race to flush before close in prior version.
Having terrible code in the NIO repo is asking for someone to copy it.

Modifications:

flatMap the various parts of the client together which also ensures the
flush is complete before close is called.

Result:

Slightly nicer code, slightly fewer allocations.
