### PR TITLE
fix incorrect case when removing an element from a circular buffer

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -656,9 +656,8 @@ extension CircularBuffer: RangeReplaceableCollection {
         case self.headBackingIndex:
             self.advanceHeadIdx(by: 1)
             self._buffer[bufferIndex] = nil
-        case self.indexBeforeHeadIdx():
+        case self.indexBeforeTailIdx():
             self.advanceTailIdx(by: -1)
-            self.tailBackingIndex = self.indexBeforeTailIdx()
             self._buffer[bufferIndex] = nil
         default:
             self._buffer[bufferIndex] = nil


### PR DESCRIPTION
### Motivation:

```swift
// CircularBuffer.swift
public mutating func remove(at position: Index) -> Element {
  // ...
  switch bufferIndex {
  // ...
  case self.indexBeforeHeadIdx():  // incorrect case, will never be executed.
    self.advanceTailIdx(by: -1)
    self.tailBackingIndex = self.indexBeforeTailIdx()
    self._buffer[bufferIndex] = nil
  }
}
```

### Modifications:

Should be:

```swift
  case self.indexBeforeTailIdx():
    self.advanceTailIdx(by: -1)
    self._buffer[bufferIndex] = nil
```

### Result:

more efficient to remove the last element.
