### PR TITLE
Use sendmsg rather than sendto to send UDP data.

### DIFF
--- a/Sources/NIO/BSDSocketAPI.swift
+++ b/Sources/NIO/BSDSocketAPI.swift
@@ -377,6 +377,10 @@ protocol _BSDSocketProtocol {
                      length len: size_t) throws -> IOResult<size_t>
 
     static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>, flags: CInt) throws -> IOResult<ssize_t>
+    
+    static func sendmsg(descriptor: CInt,
+                        msgHdr: UnsafePointer<msghdr>,
+                        flags: CInt) throws -> IOResult<ssize_t>
 
     static func send(socket s: NIOBSDSocket.Handle,
                      buffer buf: UnsafeRawPointer,
@@ -387,15 +391,6 @@ protocol _BSDSocketProtocol {
                            option_name optname: NIOBSDSocket.Option,
                            option_value optval: UnsafeRawPointer,
                            option_len optlen: socklen_t) throws
-
-    // NOTE: this should return a `ssize_t`, however, that is not a standard
-    // type, and defining that type is difficult.  Opt to return a `size_t`
-    // which is the same size, but is unsigned.
-    static func sendto(socket s: NIOBSDSocket.Handle,
-                       buffer buf: UnsafeRawPointer,
-                       length len: size_t,
-                       dest_addr to: UnsafePointer<sockaddr>,
-                       dest_len tolen: socklen_t) throws -> IOResult<size_t>
 
     static func shutdown(socket: NIOBSDSocket.Handle, how: Shutdown) throws
 

--- a/Sources/NIO/BSDSocketAPIPosix.swift
+++ b/Sources/NIO/BSDSocketAPIPosix.swift
@@ -87,6 +87,12 @@ extension NIOBSDSocket {
     static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>, flags: CInt) throws -> IOResult<ssize_t> {
         return try Posix.recvmsg(descriptor: descriptor, msgHdr: msgHdr, flags: flags)
     }
+    
+    static func sendmsg(descriptor: CInt,
+                        msgHdr: UnsafePointer<msghdr>,
+                        flags: CInt) throws -> IOResult<ssize_t> {
+        return try Posix.sendmsg(descriptor: descriptor, msgHdr: msgHdr, flags: flags)
+    }
 
     static func send(socket s: NIOBSDSocket.Handle,
                      buffer buf: UnsafeRawPointer,
@@ -104,21 +110,6 @@ extension NIOBSDSocket {
                                     optionName: optname.rawValue,
                                     optionValue: optval,
                                     optionLen: optlen)
-    }
-
-    // NOTE: this should return a `ssize_t`, however, that is not a standard
-    // type, and defining that type is difficult.  Opt to return a `size_t`
-    // which is the same size, but is unsigned.
-    static func sendto(socket s: NIOBSDSocket.Handle,
-                       buffer buf: UnsafeRawPointer,
-                       length len: size_t,
-                       dest_addr to: UnsafePointer<sockaddr>,
-                       dest_len tolen: socklen_t) throws -> IOResult<size_t> {
-        return try Posix.sendto(descriptor: s,
-                                pointer: buf,
-                                size: len,
-                                destinationPtr: to,
-                                destinationSize: tolen)
     }
 
     static func shutdown(socket: NIOBSDSocket.Handle, how: Shutdown) throws {

--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -195,22 +195,6 @@ extension NIOBSDSocket {
         }
     }
 
-    // NOTE: this should return a `ssize_t`, however, that is not a standard
-    // type, and defining that type is difficult.  Opt to return a `size_t`
-    // which is the same size, but is unsigned.
-    @inline(never)
-    static func sendto(socket s: NIOBSDSocket.Handle,
-                       buffer buf: UnsafeRawPointer,
-                       length len: size_t,
-                       dest_addr to: UnsafePointer<sockaddr>,
-                       dest_len tolen: socklen_t) throws -> IOResult<size_t> {
-        let iResult: CInt = CNIOWindows_sendto(s, buf, CInt(len), 0, to, tolen)
-        if iResult == SOCKET_ERROR {
-            throw IOError(winsock: WSAGetLastError(), reason: "sendto")
-        }
-        return .processed(size_t(iResult))
-    }
-
     @inline(never)
     static func shutdown(socket: NIOBSDSocket.Handle, how: Shutdown) throws {
         if WinSDK.shutdown(socket, how.cValue) == SOCKET_ERROR {

--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -164,6 +164,13 @@ extension NIOBSDSocket {
     static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>, flags: CInt) throws -> IOResult<ssize_t> {
         fatalError("recvmsg not yet implemented on Windows")
     }
+    
+    @inline(never)
+    static func sendmsg(descriptor: CInt,
+                        msgHdr: UnsafePointer<msghdr>,
+                        flags: CInt) throws -> IOResult<ssize_t> {
+        fatalError("recvmsg not yet implemented on Windows")
+    }
 
     @inline(never)
     static func send(socket s: NIOBSDSocket.Handle,

--- a/Sources/NIO/PipePair.swift
+++ b/Sources/NIO/PipePair.swift
@@ -83,10 +83,6 @@ final class PipePair: SocketProtocol {
         }
     }
 
-    func sendto(pointer: UnsafeRawBufferPointer, destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int> {
-        throw ChannelError.operationUnsupported
-    }
-
     func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
         return try self.inputFD.withUnsafeHandle {
             try Posix.read(descriptor: $0, pointer: pointer.baseAddress!, size: pointer.count)
@@ -97,6 +93,13 @@ final class PipePair: SocketProtocol {
                  storage: inout sockaddr_storage,
                  storageLen: inout socklen_t,
                  controlBytes: inout Slice<UnsafeMutableRawBufferPointer>) throws -> IOResult<Int> {
+        throw ChannelError.operationUnsupported
+    }
+    
+    func sendmsg(pointer: UnsafeRawBufferPointer,
+                 destinationPtr: UnsafePointer<sockaddr>,
+                 destinationSize: socklen_t,
+                 controlBytes: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
         throw ChannelError.operationUnsupported
     }
 

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -152,14 +152,14 @@ typealias IOVector = iovec
             try Posix.writev(descriptor: $0, iovecs: iovecs)
         }
     }
-    
+
     /// Send data to a destination.
     ///
     /// - parameters:
     ///     - pointer: Pointer (and size) to the data to send.
-    ///     - controlBytes: Extra `cmsghdr` information.
     ///     - destinationPtr: The destination to which the data should be sent.
     ///     - destinationSize: The size of the destination address given.
+    ///     - controlBytes: Extra `cmsghdr` information.
     /// - returns: The `IOResult` which indicates how much data could be written and if the operation returned before all could be written
     /// (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
@@ -167,14 +167,12 @@ typealias IOVector = iovec
                  destinationPtr: UnsafePointer<sockaddr>,
                  destinationSize: socklen_t,
                  controlBytes: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
-        var vec = iovec(iov_base: UnsafeMutableRawPointer(mutating: pointer.baseAddress!), iov_len: pointer.count)
-        
-        // Dubious const cast - it should be OK as there is no reason why this should get mutated
+        // Dubious const casts - it should be OK as there is no reason why this should get mutated
         // just bad const declaration below us.
+        var vec = iovec(iov_base: UnsafeMutableRawPointer(mutating: pointer.baseAddress!), iov_len: pointer.count)
         let notConstCorrectDestinationPtr = UnsafeMutableRawPointer(mutating: destinationPtr)
 
-        return try withUnsafeHandle {
-            let handle = $0
+        return try withUnsafeHandle { handle in
             return try withUnsafeMutablePointer(to: &vec) { vecPtr in
                 var messageHeader = msghdr(msg_name: notConstCorrectDestinationPtr,
                                            msg_namelen: destinationSize,

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -614,7 +614,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     override func cancelWritesOnClose(error: Error) {
         self.pendingWrites.failAll(error: error, close: true)
     }
-    
+
     override func writeToSocket() throws -> OverallWriteResult {
         let result = try self.pendingWrites.triggerAppropriateWriteOperations(
             scalarWriteOperation: { (ptr, destinationPtr, destinationSize) in
@@ -636,7 +636,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         return result
     }
 
-    
+
     // MARK: Datagram Channel overrides not required by BaseSocketChannel
 
     override func bind0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {

--- a/Sources/NIO/SocketProtocols.swift
+++ b/Sources/NIO/SocketProtocols.swift
@@ -45,14 +45,17 @@ protocol SocketProtocol: BaseSocketProtocol {
 
     func writev(iovecs: UnsafeBufferPointer<IOVector>) throws -> IOResult<Int>
 
-    func sendto(pointer: UnsafeRawBufferPointer, destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int>
-
     func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int>
 
     func recvmsg(pointer: UnsafeMutableRawBufferPointer,
                  storage: inout sockaddr_storage,
                  storageLen: inout socklen_t,
                  controlBytes: inout Slice<UnsafeMutableRawBufferPointer>) throws -> IOResult<Int>
+    
+    func sendmsg(pointer: UnsafeRawBufferPointer,
+                 destinationPtr: UnsafePointer<sockaddr>,
+                 destinationSize: socklen_t,
+                 controlBytes: UnsafeMutableRawBufferPointer) throws -> IOResult<Int>
 
     func sendFile(fd: Int32, offset: Int, count: Int) throws -> IOResult<Int>
 

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -81,8 +81,8 @@ private let sysWritev = sysWritev_wrapper
 private let sysRecvFrom: @convention(c) (CInt, UnsafeMutableRawPointer?, CLong, CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CLong = recvfrom
 private let sysWritev: @convention(c) (Int32, UnsafePointer<iovec>?, CInt) -> CLong = writev
 #endif
-private let sysSendTo: @convention(c) (CInt, UnsafeRawPointer?, CLong, CInt, UnsafePointer<sockaddr>?, socklen_t) -> CLong = sendto
 private let sysRecvMsg: @convention(c) (CInt, UnsafeMutablePointer<msghdr>?, CInt) -> ssize_t = recvmsg
+private let sysSendMsg: @convention(c) (CInt, UnsafePointer<msghdr>?, CInt) -> ssize_t = sendmsg
 private let sysDup: @convention(c) (CInt) -> CInt = dup
 private let sysGetpeername: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = getpeername
 private let sysGetsockname: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = getsockname
@@ -352,14 +352,6 @@ internal enum Posix {
     }
 
     @inline(never)
-    public static func sendto(descriptor: CInt, pointer: UnsafeRawPointer, size: size_t,
-                              destinationPtr: UnsafePointer<sockaddr>, destinationSize: socklen_t) throws -> IOResult<Int> {
-        return try syscall(blocking: true) {
-            sysSendTo(descriptor, pointer, size, 0, destinationPtr, destinationSize)
-        }
-    }
-
-    @inline(never)
     public static func read(descriptor: CInt, pointer: UnsafeMutableRawPointer, size: size_t) throws -> IOResult<ssize_t> {
         return try syscall(blocking: true) {
             sysRead(descriptor, pointer, size)
@@ -377,6 +369,13 @@ internal enum Posix {
     public static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>, flags: CInt) throws -> IOResult<ssize_t> {
         return try syscall(blocking: true) {
             sysRecvMsg(descriptor, msgHdr, flags)
+        }
+    }
+    
+    @inline(never)
+    public static func sendmsg(descriptor: CInt, msgHdr: UnsafePointer<msghdr>, flags: CInt) throws -> IOResult<ssize_t> {
+        return try syscall(blocking: true) {
+            sysSendMsg(descriptor, msgHdr, flags)
         }
     }
 


### PR DESCRIPTION
Motivation:

sendmsg is more powerful - this is paving the way for
Explicit Congestion Notifications to be sent.

Modifications:

Replace the sendto system call with sendmsg up to DatagramChannel.

Result:

Sendmsg will be used to send UDP data.