### PR TITLE
Allow Metadata to be constructed and set on AddressedEnvelope

### DIFF
--- a/Sources/NIO/AddressedEnvelope.swift
+++ b/Sources/NIO/AddressedEnvelope.swift
@@ -28,10 +28,20 @@ public struct AddressedEnvelope<DataType> {
         self.data = data
     }
     
+    public init(remoteAddress: SocketAddress, data: DataType, metadata: Metadata?) {
+        self.remoteAddress = remoteAddress
+        self.data = data
+        self.metadata = metadata
+    }
+    
     /// Any metadata associated with an `AddressedEnvelope`
     public struct Metadata: Hashable {
         /// Details of any congestion state.
         public var ecnState: NIOExplicitCongestionNotificationState
+        
+        public init(ecnState: NIOExplicitCongestionNotificationState) {
+            self.ecnState = ecnState
+        }
     }
 }
 


### PR DESCRIPTION
Motivation:

This needs to be possible so users can specify what
ECN status they wish to send.  The auto-generated
initialiser is internal.

Modifications:

Add public initialiser to AddressedEnvelope.Metadata
Add public initialiser to AddressedEnvelope taking Metadata

Result:

Users will be able to construct AddressedEnvelopes with Metadata set.