### PR TITLE
Plumb metadata through PendingDatagramWritesManager.

### DIFF
--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -617,7 +617,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
     override func writeToSocket() throws -> OverallWriteResult {
         let result = try self.pendingWrites.triggerAppropriateWriteOperations(
-            scalarWriteOperation: { (ptr, destinationPtr, destinationSize) in
+            scalarWriteOperation: { (ptr, destinationPtr, destinationSize, metadata) in
                 guard ptr.count > 0 else {
                     // No need to call write if the buffer is empty.
                     return .processed(0)

--- a/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOTests/PendingDatagramWritesManagerTests.swift
@@ -111,7 +111,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
         var result: OverallWriteResult? = nil
 
         do {
-            let r = try pwm.triggerAppropriateWriteOperations(scalarWriteOperation: { (buf, addr, len) in
+            let r = try pwm.triggerAppropriateWriteOperations(scalarWriteOperation: { (buf, addr, len, metadata) in
                 defer {
                     singleState += 1
                     everythingState += 1


### PR DESCRIPTION
### Motivation:

ECN information is held in metadata.
As part of the path to writing ECN to the network the
required state needs to pass through PendingDatagramWritesManager.

### Modifications:

Add an extra metadata field to PendingDatagramWrite and ensure
this data is passed to the correct write method.

### Result:

Nothing visible - just preparation for actual ECN send.
