### PR TITLE
Don't use deadbeef for dead pointers.

### DIFF
--- a/Sources/NIO/ControlMessage.swift
+++ b/Sources/NIO/ControlMessage.swift
@@ -46,7 +46,7 @@ struct UnsafeControlMessageStorage: Collection {
 
     mutating func deallocate() {
         self.buffer.deallocate()
-        self.buffer = UnsafeMutableRawBufferPointer(start: UnsafeMutableRawPointer(bitPattern: 0xdeadbeef), count: 0)
+        self.buffer = UnsafeMutableRawBufferPointer(start: UnsafeMutableRawPointer(bitPattern: 0x7eadbeef), count: 0)
     }
 
     /// Get the part of the buffer for use with a message.


### PR DESCRIPTION
Motivation:

It turns out using this overflows Int on "Any iOS Device"

Modifications:

Switch the first d to a 7.

Result:

Code will compile on "Any iOS Device".