### PR TITLE
Avoid including non-modular headers.

### DIFF
--- a/Sources/CNIODarwin/include/CNIODarwin.h
+++ b/Sources/CNIODarwin/include/CNIODarwin.h
@@ -18,8 +18,6 @@
 #include <sys/socket.h>
 #include <time.h>
 
-#include <netinet/ip.h>
-
 // Darwin platforms do not have a sendmmsg implementation available to them. This C module
 // provides a shim that implements sendmmsg on top of sendmsg. It also provides a shim for
 // recvmmsg, but does not actually implement that shim, instantly throwing errors if called.
@@ -32,6 +30,12 @@ typedef struct {
     struct msghdr msg_hdr;
     unsigned int msg_len;
 } CNIODarwin_mmsghdr;
+
+extern int CNIODarwin_IPTOS_ECN_NOTECT;
+extern int CNIODarwin_IPTOS_ECN_MASK;
+extern int CNIODarwin_IPTOS_ECN_ECT0;
+extern int CNIODarwin_IPTOS_ECN_ECT1;
+extern int CNIODarwin_IPTOS_ECN_CE;
 
 int CNIODarwin_sendmmsg(int sockfd, CNIODarwin_mmsghdr *msgvec, unsigned int vlen, int flags);
 int CNIODarwin_recvmmsg(int sockfd, CNIODarwin_mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout);

--- a/Sources/CNIODarwin/shim.c
+++ b/Sources/CNIODarwin/shim.c
@@ -19,6 +19,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <assert.h>
+#include <netinet/ip.h>
 
 int CNIODarwin_sendmmsg(int sockfd, CNIODarwin_mmsghdr *msgvec, unsigned int vlen, int flags) {
     // Some quick error checking. If vlen can't fit into int, we bail.
@@ -79,5 +80,11 @@ size_t CNIODarwin_CMSG_LEN(size_t payloadSizeBytes) {
 size_t CNIODarwin_CMSG_SPACE(size_t payloadSizeBytes) {
     return CMSG_SPACE(payloadSizeBytes);
 }
+
+int CNIODarwin_IPTOS_ECN_NOTECT = IPTOS_ECN_NOTECT;
+int CNIODarwin_IPTOS_ECN_MASK = IPTOS_ECN_MASK;
+int CNIODarwin_IPTOS_ECN_ECT0 = IPTOS_ECN_ECT0;
+int CNIODarwin_IPTOS_ECN_ECT1 = IPTOS_ECN_ECT1;
+int CNIODarwin_IPTOS_ECN_CE = IPTOS_ECN_CE;
 
 #endif  // __APPLE__

--- a/Sources/NIO/ControlMessage.swift
+++ b/Sources/NIO/ControlMessage.swift
@@ -191,12 +191,12 @@ struct ControlMessageParser {
 extension NIOExplicitCongestionNotificationState {
     /// Initialise a NIOExplicitCongestionNotificationState from a value received via either TCLASS or TOS cmsg.
     init(receivedValue: CInt) {
-        switch receivedValue & IPTOS_ECN_MASK {
-        case IPTOS_ECN_ECT1:
+        switch receivedValue & Posix.IPTOS_ECN_MASK {
+        case Posix.IPTOS_ECN_ECT1:
             self = .transportCapableFlag1
-        case IPTOS_ECN_ECT0:
+        case Posix.IPTOS_ECN_ECT0:
             self = .transportCapableFlag0
-        case IPTOS_ECN_CE:
+        case Posix.IPTOS_ECN_CE:
             self = .congestionExperienced
         default:
             self = .transportNotCapable
@@ -205,23 +205,17 @@ extension NIOExplicitCongestionNotificationState {
 }
 
 extension CInt {
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-    private static let notCapableValue = IPTOS_ECN_NOTECT
-    #else
-    private static let notCapableValue = IPTOS_ECN_NOT_ECT    // Linux
-    #endif
-
     /// Create a CInt encoding of ExplicitCongestionNotification suitable for sending in TCLASS or TOS cmsg.
     init(ecnValue: NIOExplicitCongestionNotificationState) {
         switch ecnValue {
         case .transportNotCapable:
-            self = CInt.notCapableValue
+            self = Posix.IPTOS_ECN_NOTECT
         case .transportCapableFlag0:
-            self = IPTOS_ECN_ECT0
+            self = Posix.IPTOS_ECN_ECT0
         case .transportCapableFlag1:
-            self = IPTOS_ECN_ECT1
+            self = Posix.IPTOS_ECN_ECT1
         case .congestionExperienced:
-            self = IPTOS_ECN_CE
+            self = Posix.IPTOS_ECN_CE
         }
     }
 }

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -191,12 +191,22 @@ internal enum Posix {
     static let SHUT_RD: CInt = CInt(Darwin.SHUT_RD)
     static let SHUT_WR: CInt = CInt(Darwin.SHUT_WR)
     static let SHUT_RDWR: CInt = CInt(Darwin.SHUT_RDWR)
+    static let IPTOS_ECN_NOTECT: CInt = CNIODarwin_IPTOS_ECN_NOTECT
+    static let IPTOS_ECN_MASK: CInt = CNIODarwin_IPTOS_ECN_MASK
+    static let IPTOS_ECN_ECT0: CInt = CNIODarwin_IPTOS_ECN_ECT0
+    static let IPTOS_ECN_ECT1: CInt = CNIODarwin_IPTOS_ECN_ECT1
+    static let IPTOS_ECN_CE: CInt = CNIODarwin_IPTOS_ECN_CE
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 
     static let UIO_MAXIOV: Int = Int(Glibc.UIO_MAXIOV)
     static let SHUT_RD: CInt = CInt(Glibc.SHUT_RD)
     static let SHUT_WR: CInt = CInt(Glibc.SHUT_WR)
     static let SHUT_RDWR: CInt = CInt(Glibc.SHUT_RDWR)
+    static let IPTOS_ECN_NOTECT: CInt = CInt(CNIOLinux.IPTOS_ECN_NOT_ECT)
+    static let IPTOS_ECN_MASK: CInt = CInt(CNIOLinux.IPTOS_ECN_MASK)
+    static let IPTOS_ECN_ECT0: CInt = CInt(CNIOLinux.IPTOS_ECN_ECT0)
+    static let IPTOS_ECN_ECT1: CInt = CInt(CNIOLinux.IPTOS_ECN_ECT1)
+    static let IPTOS_ECN_CE: CInt = CInt(CNIOLinux.IPTOS_ECN_CE)
 #else
     static var UIO_MAXIOV: Int {
         fatalError("unsupported OS")


### PR DESCRIPTION
Motivation:

We included netinet/ip.h in CNIODarwin, which unfortunately is not
modularised. This causes issues when using SwiftPM to create xcodeproj
files. There's no real reason to do it this way, when we can just as
easily abstract the issue.

Modifications:

- Moved netinet/ip.h to the .c file instead of the .h.
- Defined some exported namespaced integers to correspond to the macros.
- Performed platform abstraction in Posix instead of everywhere.

Result:

- Creating xcodeproj files should be fine.
- Resolves #1601 