### PR TITLE
Define public EventLoopGroupProvider type

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -771,6 +771,10 @@ extension EventLoopGroup {
 }
 
 /// Specifies how `EventLoopGroup` will be created and establishes lifecycle ownership.
+///
+/// This type is intended to be used by libraries which use NIO, and offer their users either the option
+/// to `.share` an existing event loop group or create (and manage) a new one (`.createNew`) and let it be 
+/// managed by given library and its lifecycle.
 public enum EventLoopGroupProvider {
     /// `EventLoopGroup` will be provided by the user. Owner of this group is responsible for its lifecycle.
     case shared(EventLoopGroup)

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -770,16 +770,16 @@ extension EventLoopGroup {
     }
 }
 
-/// Specifies how `EventLoopGroup` will be created and establishes lifecycle ownership.
-///
 /// This type is intended to be used by libraries which use NIO, and offer their users either the option
-/// to `.share` an existing event loop group or create (and manage) a new one (`.createNew`) and let it be 
+/// to `.share` an existing event loop group or create (and manage) a new one (`.createNew`) and let it be
 /// managed by given library and its lifecycle.
 public enum EventLoopGroupProvider {
-    /// Use an `EventLoopGroup` provided by the user. 
+    /// Use an `EventLoopGroup` provided by the user.
     /// The owner of this group is responsible for its lifecycle.
     case shared(EventLoopGroup)
-    /// `EventLoopGroup` will be created by the client. When `syncShutdown` is called, created `EventLoopGroup` will be shut down as well.
+    /// Create a new `EventLoopGroup` when necessary.
+    /// The library which accepts this provider takes ownership of the created event loop group,
+    /// and must ensure its proper shutdown when the library is being shut down.
     case createNew
 }
 

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -770,6 +770,14 @@ extension EventLoopGroup {
     }
 }
 
+/// Specifies how `EventLoopGroup` will be created and establishes lifecycle ownership.
+public enum EventLoopGroupProvider {
+    /// `EventLoopGroup` will be provided by the user. Owner of this group is responsible for its lifecycle.
+    case shared(EventLoopGroup)
+    /// `EventLoopGroup` will be created by the client. When `syncShutdown` is called, created `EventLoopGroup` will be shut down as well.
+    case createNew
+}
+
 private let nextEventLoopGroupID = NIOAtomic.makeAtomic(value: 0)
 
 /// Called per `NIOThread` that is created for an EventLoop to do custom initialization of the `NIOThread` before the actual `EventLoop` is run on it.

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -773,7 +773,7 @@ extension EventLoopGroup {
 /// This type is intended to be used by libraries which use NIO, and offer their users either the option
 /// to `.share` an existing event loop group or create (and manage) a new one (`.createNew`) and let it be
 /// managed by given library and its lifecycle.
-public enum EventLoopGroupProvider {
+public enum NIOEventLoopGroupProvider {
     /// Use an `EventLoopGroup` provided by the user.
     /// The owner of this group is responsible for its lifecycle.
     case shared(EventLoopGroup)

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -776,7 +776,8 @@ extension EventLoopGroup {
 /// to `.share` an existing event loop group or create (and manage) a new one (`.createNew`) and let it be 
 /// managed by given library and its lifecycle.
 public enum EventLoopGroupProvider {
-    /// `EventLoopGroup` will be provided by the user. Owner of this group is responsible for its lifecycle.
+    /// Use an `EventLoopGroup` provided by the user. 
+    /// The owner of this group is responsible for its lifecycle.
     case shared(EventLoopGroup)
     /// `EventLoopGroup` will be created by the client. When `syncShutdown` is called, created `EventLoopGroup` will be shut down as well.
     case createNew

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -77,6 +77,7 @@ extension EventLoopTest {
                 ("testWeCanDoTrulySingleThreadedNetworking", testWeCanDoTrulySingleThreadedNetworking),
                 ("testWeFailOutstandingScheduledTasksOnELShutdown", testWeFailOutstandingScheduledTasksOnELShutdown),
                 ("testSchedulingTaskOnFutureFailedByELShutdownDoesNotMakeUsExplode", testSchedulingTaskOnFutureFailedByELShutdownDoesNotMakeUsExplode),
+                ("testEventLoopGroupProvider", testEventLoopGroupProvider),
            ]
    }
 }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -1286,7 +1286,7 @@ public final class EventLoopTest : XCTestCase {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
 
-        let provider = EventLoopGroupProvider.shared(eventLoopGroup)
+        let provider = NIOEventLoopGroupProvider.shared(eventLoopGroup)
 
         if case .shared(let sharedEventLoopGroup) = provider {
             XCTAssertTrue(sharedEventLoopGroup is MultiThreadedEventLoopGroup)

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -1282,20 +1282,15 @@ public final class EventLoopTest : XCTestCase {
 
     func testEventLoopGroupProvider() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let eventLoopGroup2 = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-            XCTAssertNoThrow(try eventLoopGroup2.syncShutdownGracefully())
         }
 
         let provider = EventLoopGroupProvider.shared(eventLoopGroup)
 
-        if case EventLoopGroupProvider.shared(let sharedEventLoopGroup) = provider {
+        if case .shared(let sharedEventLoopGroup) = provider {
             XCTAssertTrue(sharedEventLoopGroup is MultiThreadedEventLoopGroup)
-            // this is sketchy but I dont think we can do better without changing MultiThreadedEventLoopGroup
-            // note that the description contains `myGroupID`
-            XCTAssertEqual(sharedEventLoopGroup.description, eventLoopGroup.description)
-            XCTAssertNotEqual(sharedEventLoopGroup.description, eventLoopGroup2.description)
+            XCTAssertTrue(sharedEventLoopGroup === eventLoopGroup)
         } else {
             XCTFail("Not the same")
         }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -1279,4 +1279,25 @@ public final class EventLoopTest : XCTestCase {
         XCTAssertNoThrow(try group.syncShutdownGracefully())
         waiter.wait()
     }
+
+    func testEventLoopGroupProvider() {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let eventLoopGroup2 = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+            XCTAssertNoThrow(try eventLoopGroup2.syncShutdownGracefully())
+        }
+
+        let provider = EventLoopGroupProvider.shared(eventLoopGroup)
+
+        if case EventLoopGroupProvider.shared(let sharedEventLoopGroup) = provider {
+            XCTAssertTrue(sharedEventLoopGroup is MultiThreadedEventLoopGroup)
+            // this is sketchy but I dont think we can do better without changing MultiThreadedEventLoopGroup
+            // note that the description contains `myGroupID`
+            XCTAssertEqual(sharedEventLoopGroup.description, eventLoopGroup.description)
+            XCTAssertNotEqual(sharedEventLoopGroup.description, eventLoopGroup2.description)
+        } else {
+            XCTFail("Not the same")
+        }
+    }
 }


### PR DESCRIPTION
Closes #1608

Defines public `EventLoopGroupProvider` type.

### Motivation:

`EventLoopGroupProvider` type is used in a number of swift-server libraries, example from [AsyncHTTPClient](https://github.com/swift-server/async-http-client/blob/c9a9bf061d713c91ee9974fa8a6afe413acfd0e9/Sources/AsyncHTTPClient/HTTPClient.swift#L737-L743):

```swift
    /// Specifies how `EventLoopGroup` will be created and establishes lifecycle ownership.
    public enum EventLoopGroupProvider {
        /// `EventLoopGroup` will be provided by the user. Owner of this group is responsible for its lifecycle.
        case shared(EventLoopGroup)
        /// `EventLoopGroup` will be created by the client. When `syncShutdown` is called, created `EventLoopGroup` will be shut down as well.
        case createNew
    }
```

Currently different libraries (have to) implement (copy and paste) the same type in different namespaces.

This is a bit of a hassle as it requires mapping of "the same" type in different namespaces, example: https://github.com/pokryfka/aws-xray-sdk-swift/pull/49#discussion_r464148735

I think it would be very convenient if `SwiftNIO` defined it  and in such way promoted the pattern.

### Modifications:

Created public `EventLoopGroupProvider` type.

### Result:

Nothing in `SwiftNIO` itself ;-)
