### PR TITLE
Deprecate and replace `ByteBuffer.clear(minimumCapacity: _Capacity)`

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -709,16 +709,8 @@ public struct ByteBuffer {
     /// - parameters:
     ///     - minimumCapacity: The minimum capacity that will be (re)allocated for this buffer
     @available(*, deprecated, message: "Use an `Int` as the argument")
-    public mutating func clear(minimumCapacity: _Capacity) {
-        if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = self._storage.allocateStorage(capacity: minimumCapacity)
-        } else if minimumCapacity > self._storage.capacity {
-            self._storage.reallocStorage(capacity: minimumCapacity)
-        }
-        self._slice = self._storage.fullSlice
-
-        self._moveWriterIndex(to: 0)
-        self._moveReaderIndex(to: 0)
+    public mutating func clear(minimumCapacity: UInt32) {
+        self.clear(minimumCapacity: Int(minimumCapacity))
     }
     
     /// Set both reader index and writer index to `0`. This will reset the state of this `ByteBuffer` to the state

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -708,7 +708,33 @@ public struct ByteBuffer {
     ///
     /// - parameters:
     ///     - minimumCapacity: The minimum capacity that will be (re)allocated for this buffer
+    @available(*, deprecated, message: "Use an `Int` as the argument")
     public mutating func clear(minimumCapacity: _Capacity) {
+        if !isKnownUniquelyReferenced(&self._storage) {
+            self._storage = self._storage.allocateStorage(capacity: minimumCapacity)
+        } else if minimumCapacity > self._storage.capacity {
+            self._storage.reallocStorage(capacity: minimumCapacity)
+        }
+        self._slice = self._storage.fullSlice
+
+        self._moveWriterIndex(to: 0)
+        self._moveReaderIndex(to: 0)
+    }
+    
+    /// Set both reader index and writer index to `0`. This will reset the state of this `ByteBuffer` to the state
+    /// of a freshly allocated one, if possible without allocations. This is the cheapest way to recycle a `ByteBuffer`
+    /// for a new use-case.
+    ///
+    /// - note: This method will allocate if the underlying storage is referenced by another `ByteBuffer`. Even if an
+    ///         allocation is necessary this will be cheaper as the copy of the storage is elided.
+    ///
+    /// - parameters:
+    ///     - minimumCapacity: The minimum capacity that will be (re)allocated for this buffer
+    public mutating func clear(minimumCapacity: Int) {
+        precondition(minimumCapacity >= 0, "Cannot have a minimum capacity")
+        precondition(minimumCapacity <= _Capacity.max, "Minimum capacity must be <= \(_Capacity.max)")
+        
+        let minimumCapacity = _Capacity(minimumCapacity)
         if !isKnownUniquelyReferenced(&self._storage) {
             self._storage = self._storage.allocateStorage(capacity: minimumCapacity)
         } else if minimumCapacity > self._storage.capacity {

--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -731,7 +731,7 @@ public struct ByteBuffer {
     /// - parameters:
     ///     - minimumCapacity: The minimum capacity that will be (re)allocated for this buffer
     public mutating func clear(minimumCapacity: Int) {
-        precondition(minimumCapacity >= 0, "Cannot have a minimum capacity")
+        precondition(minimumCapacity >= 0, "Cannot have a minimum capacity < 0")
         precondition(minimumCapacity <= _Capacity.max, "Minimum capacity must be <= \(_Capacity.max)")
         
         let minimumCapacity = _Capacity(minimumCapacity)


### PR DESCRIPTION
Resolves #1589 

Deprecate `ByteBuffer.clear(minimumCapacity: _Capacity)` and introduce `Bytebuffer.clear(minimumCapacity: Int)`.

Note - all of the tests for `clear` will automatically use the new `Int` method. I considered making new tests to explicitly cover the existing `_Capacity` method, but thought that this is probably not necessary. Open to being told otherwise.

### Motivation:

`_Capacity` is underscored and so should be used publicly.

### Modifications:

Add a deprecation warning to the `_Capacity` method, and introduce a new `Int`-based method.

### Result:

Deprecation warning if the `_Capacity` version of `clear` was used.
