### PR TITLE
Add `EventLoop.makeResultantFuture(Result<T, Error>...)`

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -566,11 +566,24 @@ extension EventLoop {
     /// Creates and returns a new `EventLoopFuture` that is already marked as success. Notifications will be done using this `EventLoop` as execution `NIOThread`.
     ///
     /// - parameters:
-    ///     - result: the value that is used by the `EventLoopFuture`.
+    ///     - value: the value that is used by the `EventLoopFuture`.
     /// - returns: a succeeded `EventLoopFuture`.
     @inlinable
     public func makeSucceededFuture<Success>(_ value: Success, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Success> {
         return EventLoopFuture<Success>(eventLoop: self, value: value, file: file, line: line)
+    }
+    
+    /// Creates and returns a new `EventLoopFuture` with state arbitrated from a provided `Result`. Notifications will be done using this `EventLoop` as execution `NIOThread`.
+    ///
+    /// - parameters:
+    ///     - value: the `Result` whose state will arbitrate the resultant `EventLoopFuture`.
+    /// - returns: a succeeded or failed `EventLoopFuture`.
+    @inlinable
+    public func makeResultantFuture<T>(_ value: Result<T, Error>, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<T> {
+        switch value {
+            case .success(let success): return makeSucceededFuture(success, file: file, line: line)
+            case .failure(let failure): return makeFailedFuture(failure, file: file, line: line)
+        }
     }
 
     /// An `EventLoop` forms a singular `EventLoopGroup`, returning itself as the 'next' `EventLoop`.

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -580,10 +580,7 @@ extension EventLoop {
     /// - returns: a succeeded or failed `EventLoopFuture`.
     @inlinable
     public func makeResultantFuture<T>(_ value: Result<T, Error>, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<T> {
-        switch value {
-            case .success(let success): return makeSucceededFuture(success, file: file, line: line)
-            case .failure(let failure): return makeFailedFuture(failure, file: file, line: line)
-        }
+        return EventLoopFuture<T>(_eventLoop: self, value: value, file: file, line: line)
     }
 
     /// An `EventLoop` forms a singular `EventLoopGroup`, returning itself as the 'next' `EventLoop`.


### PR DESCRIPTION
Adds a method to`EventLoop` to allow creating a succeeded or failed `EventLoopFuture` directly from a `Result`.

```swift
public func makeResultantFuture<T>(_ value: Result<T, Error>, ...)
```

### Motivation:
In API functions that return an `EventLoopFuture`, underlying synchronous functions may themselves be already able to provide useful `Result`s that can immediately be passed to a completed promise, and it would be easier to pass that directly onwards before moving to potentially blocking branches; example:

Before:
```swift
if let result = blockingCache.insert(ast, replace: true) {
  switch result {
    case .success(let ast): return eventLoop.makeSucceededFuture(ast)
    case .failure(let err): return eventLoop.makeFailedFuture(err)
  }
}
// .... move on to handle async operations
```
After:
```swift
if let result = blockingCache.insert(ast, replace: true) {
  return eventLoop.makeResultantFuture(result) 
}
//  ... move on to handle async operations
```
### Modifications:

Add above method

### Result:

Less boilerplate switches needed in mixed sync/async code when returning ELFs
