### PR TITLE
Linux: make `Epoll` available on Android

### DIFF
--- a/Sources/NIO/Linux.swift
+++ b/Sources/NIO/Linux.swift
@@ -16,7 +16,7 @@
 // only on Linux, or things that have Linux-specific extensions.
 import CNIOLinux
 
-#if os(Linux)
+#if os(Linux) || os(Android)
 internal enum TimerFd {
     public static let TFD_CLOEXEC = CNIOLinux.TFD_CLOEXEC
     public static let TFD_NONBLOCK = CNIOLinux.TFD_NONBLOCK


### PR DESCRIPTION
Android is sufficiently Linux-esque that it should be able to use `Epoll`.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
