### PR TITLE
Better handle writability changes in triggerWriteOperations

### DIFF
--- a/Sources/NIO/PendingDatagramWritesManager.swift
+++ b/Sources/NIO/PendingDatagramWritesManager.swift
@@ -375,7 +375,6 @@ final class PendingDatagramWritesManager: PendingWritesManager {
     internal var writeSpinCount: UInt = 16
     private(set) var isOpen = true
 
-
     /// Initialize with a pre-allocated array of message headers and storage references. We pass in these pre-allocated
     /// objects to save allocations. They can be safely be re-used for all `Channel`s on a given `EventLoop` as an
     /// `EventLoop` always runs on one and the same thread. That means that there can't be any writes of more than

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -83,6 +83,7 @@ extension ChannelTests {
                 ("testDescriptionCanBeCalledFromNonEventLoopThreads", testDescriptionCanBeCalledFromNonEventLoopThreads),
                 ("testFixedSizeRecvByteBufferAllocatorSizeIsConstant", testFixedSizeRecvByteBufferAllocatorSizeIsConstant),
                 ("testCloseInConnectPromise", testCloseInConnectPromise),
+                ("testWritabilityChangeDuringReentrantFlushNow", testWritabilityChangeDuringReentrantFlushNow),
            ]
    }
 }

--- a/Tests/NIOTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOTests/DatagramChannelTests+XCTest.swift
@@ -57,6 +57,7 @@ extension DatagramChannelTests {
                 ("testEcnSendReceiveIPV6VectorRead", testEcnSendReceiveIPV6VectorRead),
                 ("testEcnSendReceiveIPV4VectorReadVectorWrite", testEcnSendReceiveIPV4VectorReadVectorWrite),
                 ("testEcnSendReceiveIPV6VectorReadVectorWrite", testEcnSendReceiveIPV6VectorReadVectorWrite),
+                ("testWritabilityChangeDuringReentrantFlushNow", testWritabilityChangeDuringReentrantFlushNow),
            ]
    }
 }

--- a/Tests/NIOTests/DatagramChannelTests.swift
+++ b/Tests/NIOTests/DatagramChannelTests.swift
@@ -753,4 +753,42 @@ final class DatagramChannelTests: XCTestCase {
         }
         testEcnReceive(address: "::1", vectorRead: true, vectorSend: true)
     }
+
+    func testWritabilityChangeDuringReentrantFlushNow() throws {
+        class EnvelopingHandler: ChannelOutboundHandler {
+            typealias OutboundIn = ByteBuffer
+            typealias OutboundOut = AddressedEnvelope<ByteBuffer>
+
+            func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+                let buffer = self.unwrapOutboundIn(data)
+                context.write(self.wrapOutboundOut(AddressedEnvelope(remoteAddress: context.channel.localAddress!, data: buffer)), promise: promise)
+            }
+        }
+
+        let loop = self.group.next()
+        let handler = ReentrantWritabilityChangingHandler(becameUnwritable: loop.makePromise(),
+                                                          becameWritable: loop.makePromise())
+
+        let channel1Future = DatagramBootstrap(group: self.group)
+            .bind(host: "localhost", port: 0)
+        let channel1 = try assertNoThrowWithValue(try channel1Future.wait())
+        defer {
+            XCTAssertNoThrow(try channel1.close().wait())
+        }
+
+        let channel2Future = DatagramBootstrap(group: self.group)
+            .channelOption(ChannelOptions.writeBufferWaterMark, value: handler.watermark)
+            .channelInitializer { channel in
+                channel.pipeline.addHandlers([EnvelopingHandler(), handler])
+            }
+            .bind(host: "localhost", port: 0)
+        let channel2 = try assertNoThrowWithValue(try channel2Future.wait())
+        defer {
+            XCTAssertNoThrow(try channel2.close().wait())
+        }
+
+        // Now wait.
+        XCTAssertNoThrow(try handler.becameUnwritable.futureResult.wait())
+        XCTAssertNoThrow(try handler.becameWritable.futureResult.wait())
+    }
 }


### PR DESCRIPTION
Motivation:

If a write is buffered in the `PendingWritesManager` and the high
watermark is breached then a writability change will be fired as a
result. The corresponding event when the channel becomes writable again
comes when enough pending bytes have been written to the socket (i.e. as
a result of a `flush()`) and we fall below the low watermark.

However, if a promise associated with a write has a callback
registered on its future which writes enough data to breach the high
watermark (and also flushes) then we will re-entrantly enter
`flushNow()`. This is okay, `flushNow()` protects against re-entrancy
and any re-entrantly enqueud flushed writes will be picked up in the
write-spin-loop.

The issue here is that the `writeSpinLoop` does not monitor for changes
in writability. Instead if checks the writability before it begins and
after it completes, only signalling if there was a change. This is
problematic: the re-entrant write-and-flush could have caused the
channel to become unwritable yet no event will be fired to make it
writable again!

Modifications:

- Check whether the channel became unwritable after each write
  operation, and emit a writability change if the channel became
  unwritable and writable again during the spin loop.

Result:

- Better protection against re-entrant writability changes.