### PR TITLE
Correct typo in `_ChannelOutboundHandler` docs

### DIFF
--- a/Sources/NIO/ChannelHandler.swift
+++ b/Sources/NIO/ChannelHandler.swift
@@ -98,7 +98,7 @@ public protocol _ChannelOutboundHandler: ChannelHandler {
     /// Called to request that the `Channel` perform a read when data is ready. The read operation will signal that we are ready to read more data.
     ///
     /// This should call `context.read` to forward the operation to the next `_ChannelOutboundHandler` in the `ChannelPipeline` or just
-    /// discard it if the flush should be suppressed.
+    /// discard it if the read should be suppressed.
     ///
     /// - parameters:
     ///     - context: The `ChannelHandlerContext` which this `ChannelHandler` belongs to.


### PR DESCRIPTION
Correct typo in `_ChannelOutboundHandler` docs

### Motivation

The doc block for `_ChannelOutboundHandler.read(context:)` mentions suppressing
a *flush*, it appears this is a copy-paste error from the docs for `flush(context:)`
above and should in fact refer to suppressing the *read*.

### Modifications

Substituted `read` for `flush` in the doc block for `_ChannelOutboundHandler.read(context:)`

### Result

Correct documentation for `_ChannelOutboundHandler.read(context:)`