### PR TITLE
Distinguish capacity and no. of addressable bytes. (#1485)

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -441,6 +441,13 @@ public struct ByteBuffer {
         return self._slice.count
     }
 
+    /// The current capacity of the underlying storage of this `ByteBuffer`.
+    /// A COW slice of the buffer (e.g. readSlice(length: x)) will posses the same storageCapacity as the original
+    /// buffer until new data is written.
+    public var storageCapacity: Int {
+        return self._storage.fullSlice.count
+    }
+
     /// Reserves enough space to store the specified number of bytes.
     ///
     /// This method will ensure that the buffer has space for at least as many bytes as requested.
@@ -742,7 +749,7 @@ public struct ByteBuffer {
 extension ByteBuffer: CustomStringConvertible {
     /// A `String` describing this `ByteBuffer`. Example:
     ///
-    ///     ByteBuffer { readerIndex: 0, writerIndex: 4, readableBytes: 4, capacity: 512, slice: 256..<768, storage: 0x0000000103001000 (1024 bytes)}
+    ///     ByteBuffer { readerIndex: 0, writerIndex: 4, readableBytes: 4, capacity: 512, storageCapacity: 1024, slice: 256..<768, storage: 0x0000000103001000 (1024 bytes)}
     ///
     /// The format of the description is not API.
     ///
@@ -754,6 +761,7 @@ extension ByteBuffer: CustomStringConvertible {
         writerIndex: \(self.writerIndex), \
         readableBytes: \(self.readableBytes), \
         capacity: \(self.capacity), \
+        storageCapacity: \(self.storageCapacity), \
         slice: \(self._slice), \
         storage: \(self._storage.bytes) (\(self._storage.capacity) bytes) \
         }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -133,6 +133,7 @@ class ByteBufferTest: XCTestCase {
     func testMakeSureUniquelyOwnedSliceDoesNotGetReallocatedOnWrite() {
         var slice = self.makeSliceToBufferWhichIsDeallocated()
         XCTAssertEqual(1, slice.capacity)
+        XCTAssertEqual(16, slice.storageCapacity)
         let oldStorageBegin = slice.withUnsafeReadableBytes { ptr in
             return UInt(bitPattern: ptr.baseAddress!)
         }
@@ -146,6 +147,7 @@ class ByteBufferTest: XCTestCase {
     func testWriteToUniquelyOwnedSliceWhichTriggersAReallocation() {
         var slice = self.makeSliceToBufferWhichIsDeallocated()
         XCTAssertEqual(1, slice.capacity)
+        XCTAssertEqual(16, slice.storageCapacity)
         // this will cause a re-allocation, the whole buffer should be 32 bytes then, the slice having 17 of that.
         // this fills 16 bytes so will still fit
         slice.writeBytes(Array(16..<32))

--- a/Tests/NIOTests/NIOAnyDebugTest.swift
+++ b/Tests/NIOTests/NIOAnyDebugTest.swift
@@ -22,7 +22,7 @@ class NIOAnyDebugTest: XCTestCase {
         XCTAssertEqual(wrappedInNIOAnyBlock(123), wrappedInNIOAnyBlock("123"))
         
         let bb = ByteBuffer(string: "byte buffer string")
-        XCTAssertTrue(wrappedInNIOAnyBlock(bb).contains("NIOAny { ByteBuffer { readerIndex: 0, writerIndex: 18, readableBytes: 18, capacity: 32, slice: _ByteBufferSlice { 0..<32 }, storage: "))
+        XCTAssertTrue(wrappedInNIOAnyBlock(bb).contains("NIOAny { ByteBuffer { readerIndex: 0, writerIndex: 18, readableBytes: 18, capacity: 32, storageCapacity: 32, slice: _ByteBufferSlice { 0..<32 }, storage: "))
         XCTAssertTrue(wrappedInNIOAnyBlock(bb).hasSuffix(" }"))
         
         let fileHandle = NIOFileHandle(descriptor: 1)


### PR DESCRIPTION
## Motivation:

Whilst the semantics of the capacity property are well defined, a
distinction between the number of addressable bytes in the buffer and
the total number of bytes allocated to the buffer would be clearer (note
that these values are not necessarily the same for example, when
constructing of COW slice from the original buffer:
buf.readSlice(length: 1)).

## Modifications:

- Repurposed the capacity property to always report the capacity of the
allocation underlying the storage.
- Added new length property to show the number of addressable bytes of
the buffer (or derived COW slice).

## Result:

The capacity of the original buffer and a COW slice with remain the same
as the original buffer until data is written to the slice. The length
property reports the number of addressable bytes e.g. the length of the
buffer obtained by buf.readSlice(length: 1) is 1.