### PR TITLE
Note that certain NIOFileHandle.init overloads are blocking

### DIFF
--- a/Sources/NIO/FileHandle.swift
+++ b/Sources/NIO/FileHandle.swift
@@ -134,7 +134,7 @@ extension NIOFileHandle {
         }
     }
 
-    /// Open a new `NIOFileHandle`.
+    /// Open a new `NIOFileHandle`. This operation is blocking.
     ///
     /// - parameters:
     ///     - path: The path of the file to open. The ownership of the file descriptor is transferred to this `NIOFileHandle` and so it will be closed once `close` is called.
@@ -145,7 +145,7 @@ extension NIOFileHandle {
         self.init(descriptor: fd)
     }
 
-    /// Open a new `NIOFileHandle`.
+    /// Open a new `NIOFileHandle`. This operation is blocking.
     ///
     /// - parameters:
     ///     - path: The path of the file to open. The ownership of the file descriptor is transferred to this `NIOFileHandle` and so it will be closed once `close` is called.


### PR DESCRIPTION
This was noted in review  of swift-server/async-http-client#275, but I don't think that this was clearly stated in the documentation.

_[One line description of your change]_

### Motivation:

Making documentation more explicit about the blocking behavior of the calls.

### Modifications:

Modified the doc comments.

### Result:

No functional change.
