### PR TITLE
NIO: fix `close(socket:)`

### DIFF
--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -99,7 +99,9 @@ extension NIOBSDSocket {
 
     @inline(never)
     static func close(socket s: NIOBSDSocket.Handle) throws {
-        try Posix.close(descriptor: s)
+        if WinSDK.closesocket(s) == SOCKET_ERROR {
+            throw IOError(winsock: WSAGetLastError(), reason: "close")
+        }
     }
 
     @inline(never)


### PR DESCRIPTION
`Posix.*` cannot be used on Windows.  Sockets and (file) descriptors are
in entirely different namespaces, and will result in an invalid
operation.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
