### PR TITLE
NIO: remove unnecessary `@discardableResult`

### DIFF
--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -296,7 +296,6 @@ extension NIOBSDSocket {
         return result
     }
 
-    @discardableResult
     @inline(never)
     static func inet_pton(af family: NIOBSDSocket.AddressFamily,
                           src description: UnsafePointer<CChar>,


### PR DESCRIPTION
The function returns `Void`, the attribute does not apply.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
