### PR TITLE
NIO: remove `poll` from the `_BSDSocketProtocol` protocol

### DIFF
--- a/Sources/NIO/BSDSocketAPI.swift
+++ b/Sources/NIO/BSDSocketAPI.swift
@@ -425,9 +425,15 @@ protocol _BSDSocketProtocol {
                        size: size_t,
                        offset: off_t) throws -> IOResult<size_t>
 
-    static func poll(fds: UnsafeMutablePointer<pollfd>,
-                     nfds: nfds_t,
+#if !os(Windows)
+    // NOTE: We do not support this on Windows as WSAPoll behaves differently
+    // from poll with reporting of failed connections (Connect Report 309411),
+    // which recommended that you use NetAPI instead.
+    //
+    // This is safe to exclude as this is a testing-only API.
+    static func poll(fds: UnsafeMutablePointer<pollfd>, nfds: nfds_t,
                      timeout: CInt) throws -> CInt
+#endif
 
     static func inet_ntop(af family: NIOBSDSocket.AddressFamily,
                           src addr: UnsafeRawPointer,

--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -275,13 +275,6 @@ extension NIOBSDSocket {
         return .processed(CInt(nNumberOfBytesWritten))
     }
 
-    @inline(never)
-    static func poll(fds: UnsafeMutablePointer<pollfd>,
-                     nfds: nfds_t,
-                     timeout: CInt) throws -> CInt {
-        fatalError("Poll unsupported on Windows")
-    }
-
     @discardableResult
     @inline(never)
     static func inet_ntop(af family: NIOBSDSocket.AddressFamily,


### PR DESCRIPTION
This removes the testing-only API of `poll` on Windows which does not
have a semantic compatible poll.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
