### PR TITLE
NIO: repair the build after e3508b0d0

### DIFF
--- a/Sources/NIO/BSDSocketAPI.swift
+++ b/Sources/NIO/BSDSocketAPI.swift
@@ -376,11 +376,17 @@ protocol _BSDSocketProtocol {
                      buffer buf: UnsafeMutableRawPointer,
                      length len: size_t) throws -> IOResult<size_t>
 
-    static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>, flags: CInt) throws -> IOResult<ssize_t>
-    
-    static func sendmsg(descriptor: CInt,
-                        msgHdr: UnsafePointer<msghdr>,
-                        flags: CInt) throws -> IOResult<ssize_t>
+    // NOTE: this should return a `ssize_t`, however, that is not a standard
+    // type, and defining that type is difficult.  Opt to return a `size_t`
+    // which is the same size, but is unsigned.
+    static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>,
+                        flags: CInt) throws -> IOResult<size_t>
+
+    // NOTE: this should return a `ssize_t`, however, that is not a standard
+    // type, and defining that type is difficult.  Opt to return a `size_t`
+    // which is the same size, but is unsigned.
+    static func sendmsg(descriptor: CInt, msgHdr: UnsafePointer<msghdr>,
+                        flags: CInt) throws -> IOResult<size_t>
 
     static func send(socket s: NIOBSDSocket.Handle,
                      buffer buf: UnsafeRawPointer,

--- a/Sources/NIO/BSDSocketAPIPosix.swift
+++ b/Sources/NIO/BSDSocketAPIPosix.swift
@@ -84,13 +84,13 @@ extension NIOBSDSocket {
         return try Posix.read(descriptor: s, pointer: buf, size: len)
     }
 
-    static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>, flags: CInt) throws -> IOResult<ssize_t> {
+    static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>, flags: CInt) throws -> IOResult<size_t> {
         return try Posix.recvmsg(descriptor: descriptor, msgHdr: msgHdr, flags: flags)
     }
-    
+
     static func sendmsg(descriptor: CInt,
                         msgHdr: UnsafePointer<msghdr>,
-                        flags: CInt) throws -> IOResult<ssize_t> {
+                        flags: CInt) throws -> IOResult<size_t> {
         return try Posix.sendmsg(descriptor: descriptor, msgHdr: msgHdr, flags: flags)
     }
 

--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -161,14 +161,14 @@ extension NIOBSDSocket {
     }
 
     @inline(never)
-    static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>, flags: CInt) throws -> IOResult<ssize_t> {
+    static func recvmsg(descriptor: CInt, msgHdr: UnsafeMutablePointer<msghdr>,
+                        flags: CInt) throws -> IOResult<size_t> {
         fatalError("recvmsg not yet implemented on Windows")
     }
-    
+
     @inline(never)
-    static func sendmsg(descriptor: CInt,
-                        msgHdr: UnsafePointer<msghdr>,
-                        flags: CInt) throws -> IOResult<ssize_t> {
+    static func sendmsg(descriptor: CInt, msgHdr: UnsafePointer<msghdr>,
+                        flags: CInt) throws -> IOResult<size_t> {
         fatalError("recvmsg not yet implemented on Windows")
     }
 


### PR DESCRIPTION
`ssize_t` is not a standard type and does not have a portable Swift
spelling.  Use `size_t` which is compatible in size, but is signed
instead.  This is needed in order to be compatible to more standard
conforming environments like Windows.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
