### PR TITLE
Cleanup unix socket pathname on server socket close or bind

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -18,10 +18,8 @@ import NIOConcurrencyHelpers
 import let WinSDK.INVALID_SOCKET
 #endif
 
-public enum SocketSetupError: Error {
-    /// The requested UDS path exists and has wrong type (not a socket).
-    case unixDomainSocketPathWrongType
-}
+/// The requested UDS path exists and has wrong type (not a socket).
+public struct UnixDomainSocketPathWrongType: Error {}
 
 /// A Registration on a `Selector`, which is interested in an `SelectorEventSet`.
 protocol Registration {
@@ -313,7 +311,7 @@ class BaseSocket: BaseSocketProtocol {
     ///
     /// - parameters:
     ///     - unixDomainSocketPath: The pathname of the UDS.
-    /// - throws: An `SocketSetupError.unixDomainSocketPathWrongType` if the pathname exists and is not a socket.
+    /// - throws: An `UnixDomainSocketPathWrongType` if the pathname exists and is not a socket.
     static func cleanupSocket(unixDomainSocketPath: String) throws {
         do {
             var sb: stat = stat()
@@ -325,12 +323,12 @@ class BaseSocket: BaseSocketProtocol {
             if sb.st_mode & S_IFSOCK == S_IFSOCK {
                 try Posix.unlink(pathname: unixDomainSocketPath)
             } else {
-                throw SocketSetupError.unixDomainSocketPathWrongType
+                throw UnixDomainSocketPathWrongType()
             }
         } catch let err as IOError {
             // If the filepath did not exist, we consider it cleaned up
             if err.errnoCode == ENOENT {
-                return ();
+                return
             }
             throw err
         }

--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -18,6 +18,11 @@ import NIOConcurrencyHelpers
 import let WinSDK.INVALID_SOCKET
 #endif
 
+public enum SocketSetupError: Error {
+    /// The requested UDS path exists and has wrong type (not a socket).
+    case unixDomainSocketPathWrongType
+}
+
 /// A Registration on a `Selector`, which is interested in an `SelectorEventSet`.
 protocol Registration {
     /// The `SelectorEventSet` in which the `Registration` is interested.
@@ -308,7 +313,7 @@ class BaseSocket: BaseSocketProtocol {
     ///
     /// - parameters:
     ///     - unixDomainSocketPath: The pathname of the UDS.
-    /// - throws: An `SocketAddressError.unixDomainSocketPathWrongType` if the pathname exists and is not a socket.
+    /// - throws: An `SocketSetupError.unixDomainSocketPathWrongType` if the pathname exists and is not a socket.
     static func cleanupSocket(unixDomainSocketPath: String) throws {
         do {
             var sb: stat = stat()
@@ -320,7 +325,7 @@ class BaseSocket: BaseSocketProtocol {
             if sb.st_mode & S_IFSOCK == S_IFSOCK {
                 try Posix.unlink(pathname: unixDomainSocketPath)
             } else {
-                throw SocketAddressError.unixDomainSocketPathWrongType
+                throw SocketSetupError.unixDomainSocketPathWrongType
             }
         } catch let err as IOError {
             // If the filepath did not exist, we consider it cleaned up

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -219,8 +219,18 @@ public final class ServerBootstrap {
     ///
     /// - parameters:
     ///     - unixDomainSocketPath: The _Unix domain socket_ path to bind to. `unixDomainSocketPath` must not exist, it will be created by the system.
+    public func bind(unixDomainSocketPath: String) -> EventLoopFuture<Channel> {
+        return bind0 {
+            try SocketAddress(unixDomainSocketPath: unixDomainSocketPath)
+        }
+    }
+    
+    /// Bind the `ServerSocketChannel` to a UNIX Domain Socket.
+    ///
+    /// - parameters:
+    ///     - unixDomainSocketPath: The _Unix domain socket_ path to bind to. `unixDomainSocketPath` must not exist, it will be created by the system.
     ///     - cleanupExistingSocketFile: Whether to cleanup an existing socket file at `path`.
-    public func bind(unixDomainSocketPath: String, cleanupExistingSocketFile: Bool = true) -> EventLoopFuture<Channel> {
+    public func bind(unixDomainSocketPath: String, cleanupExistingSocketFile: Bool) -> EventLoopFuture<Channel> {
         if cleanupExistingSocketFile {
             do {
                 try BaseSocket.cleanupSocket(unixDomainSocketPath: unixDomainSocketPath)
@@ -229,9 +239,7 @@ public final class ServerBootstrap {
             }
         }
 
-        return bind0 {
-            try SocketAddress(unixDomainSocketPath: unixDomainSocketPath)
-        }
+        return self.bind(unixDomainSocketPath: unixDomainSocketPath)
     }
 
     #if !os(Windows)
@@ -864,8 +872,18 @@ public final class DatagramBootstrap {
     ///
     /// - parameters:
     ///     - unixDomainSocketPath: The path of the UNIX Domain Socket to bind on. `path` must not exist, it will be created by the system.
+    public func bind(unixDomainSocketPath: String) -> EventLoopFuture<Channel> {
+        return bind0 {
+            return try SocketAddress(unixDomainSocketPath: unixDomainSocketPath)
+        }
+    }
+    
+    /// Bind the `DatagramChannel` to a UNIX Domain Socket.
+    ///
+    /// - parameters:
+    ///     - unixDomainSocketPath: The path of the UNIX Domain Socket to bind on. `path` must not exist, it will be created by the system.
     ///     - cleanupExistingSocketFile: Whether to cleanup an existing socket file at `path`.
-    public func bind(unixDomainSocketPath: String, cleanupExistingSocketFile: Bool = true) -> EventLoopFuture<Channel> {
+    public func bind(unixDomainSocketPath: String, cleanupExistingSocketFile: Bool) -> EventLoopFuture<Channel> {
         if cleanupExistingSocketFile {
             do {
                 try BaseSocket.cleanupSocket(unixDomainSocketPath: unixDomainSocketPath)
@@ -874,9 +892,7 @@ public final class DatagramBootstrap {
             }
         }
 
-        return bind0 {
-            return try SocketAddress(unixDomainSocketPath: unixDomainSocketPath)
-        }
+        return self.bind(unixDomainSocketPath: unixDomainSocketPath)
     }
 
     private func bind0(_ makeSocketAddress: () throws -> SocketAddress) -> EventLoopFuture<Channel> {

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -219,7 +219,16 @@ public final class ServerBootstrap {
     ///
     /// - parameters:
     ///     - unixDomainSocketPath: The _Unix domain socket_ path to bind to. `unixDomainSocketPath` must not exist, it will be created by the system.
-    public func bind(unixDomainSocketPath: String) -> EventLoopFuture<Channel> {
+    ///     - cleanupExistingSocketFile: Whether to cleanup an existing socket file at `path`.
+    public func bind(unixDomainSocketPath: String, cleanupExistingSocketFile: Bool = true) -> EventLoopFuture<Channel> {
+        if cleanupExistingSocketFile {
+            do {
+                try BaseSocket.cleanupSocket(unixDomainSocketPath: unixDomainSocketPath)
+            } catch {
+                return group.next().makeFailedFuture(error)
+            }
+        }
+
         return bind0 {
             try SocketAddress(unixDomainSocketPath: unixDomainSocketPath)
         }
@@ -855,7 +864,16 @@ public final class DatagramBootstrap {
     ///
     /// - parameters:
     ///     - unixDomainSocketPath: The path of the UNIX Domain Socket to bind on. `path` must not exist, it will be created by the system.
-    public func bind(unixDomainSocketPath: String) -> EventLoopFuture<Channel> {
+    ///     - cleanupExistingSocketFile: Whether to cleanup an existing socket file at `path`.
+    public func bind(unixDomainSocketPath: String, cleanupExistingSocketFile: Bool = true) -> EventLoopFuture<Channel> {
+        if cleanupExistingSocketFile {
+            do {
+                try BaseSocket.cleanupSocket(unixDomainSocketPath: unixDomainSocketPath)
+            } catch {
+                return group.next().makeFailedFuture(error)
+            }
+        }
+
         return bind0 {
             return try SocketAddress(unixDomainSocketPath: unixDomainSocketPath)
         }

--- a/Sources/NIO/ServerSocket.swift
+++ b/Sources/NIO/ServerSocket.swift
@@ -15,6 +15,7 @@
 /// A server socket that can accept new connections.
 /* final but tests */ class ServerSocket: BaseSocket, ServerSocketProtocol {
     typealias SocketType = ServerSocket
+    private let cleanupOnClose: Bool
 
     public final class func bootstrap(protocolFamily: NIOBSDSocket.ProtocolFamily, host: String, port: Int) throws -> ServerSocket {
         let socket = try ServerSocket(protocolFamily: protocolFamily)
@@ -31,6 +32,12 @@
     /// - throws: An `IOError` if creation of the socket failed.
     init(protocolFamily: NIOBSDSocket.ProtocolFamily, setNonBlocking: Bool = false) throws {
         let sock = try BaseSocket.makeSocket(protocolFamily: protocolFamily, type: .stream, setNonBlocking: setNonBlocking)
+        switch protocolFamily {
+        case .unix:
+            cleanupOnClose = true
+        default:
+            cleanupOnClose = false
+        }
         try super.init(socket: sock)
     }
 
@@ -54,6 +61,7 @@
     ///     - setNonBlocking: Set non-blocking mode on the socket.
     /// - throws: An `IOError` if socket is invalid.
     init(socket: NIOBSDSocket.Handle, setNonBlocking: Bool = false) throws {
+        cleanupOnClose = false  // socket already bound, owner must clean up
         try super.init(socket: socket)
         if setNonBlocking {
             try self.setNonBlocking()
@@ -116,7 +124,7 @@
     ///
     /// - throws: An `IOError` if the operation failed.
     override func close() throws {
-        let maybePathname = try? self.localAddress().pathname
+        let maybePathname = self.cleanupOnClose ? (try? self.localAddress().pathname) : nil
         try super.close()
         if let socketPath = maybePathname {
             try BaseSocket.cleanupSocket(unixDomainSocketPath: socketPath)

--- a/Sources/NIO/ServerSocket.swift
+++ b/Sources/NIO/ServerSocket.swift
@@ -109,4 +109,17 @@
             return sock
         }
     }
+    
+    /// Close the socket.
+    ///
+    /// After the socket was closed all other methods will throw an `IOError` when called.
+    ///
+    /// - throws: An `IOError` if the operation failed.
+    override func close() throws {
+        let maybePathname = try? self.localAddress().pathname
+        try super.close()
+        if let socketPath = maybePathname {
+            try BaseSocket.cleanupSocket(unixDomainSocketPath: socketPath)
+        }
+    }
 }

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -181,9 +181,9 @@ public enum SocketAddress: CustomStringConvertible {
     /// Get the pathname of a UNIX domain socket as a string
     public var pathname: String? {
         switch self {
-        case .v4(_):
+        case .v4:
             return nil
-        case .v6(_):
+        case .v6:
             return nil
         case .unixDomainSocket(let addr):
             // This is a static assert that exists just to verify the safety of the assumption below.

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -22,6 +22,8 @@ public enum SocketAddressError: Error {
     case unsupported
     /// The requested UDS path is too long.
     case unixDomainSocketPathTooLong
+    /// The requested UDS path exists and has wrong type (not a socket).
+    case unixDomainSocketPathWrongType
     /// Unable to parse a given IP string
     case failedToParseIPString(String)
 }

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -22,8 +22,6 @@ public enum SocketAddressError: Error {
     case unsupported
     /// The requested UDS path is too long.
     case unixDomainSocketPathTooLong
-    /// The requested UDS path exists and has wrong type (not a socket).
-    case unixDomainSocketPathWrongType
     /// Unable to parse a given IP string
     case failedToParseIPString(String)
 }

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -95,6 +95,8 @@ private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointe
 
 #if os(Linux)
 private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>) -> CInt = fstat
+private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat
+private let sysUnlink: @convention(c) (UnsafePointer<CChar>) -> CInt = unlink
 private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIOLinux_mmsghdr>?, CUnsignedInt, CInt) -> CInt = CNIOLinux_sendmmsg
 private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIOLinux_mmsghdr>?, CUnsignedInt, CInt, UnsafeMutablePointer<timespec>?) -> CInt  = CNIOLinux_recvmmsg
 private let sysCmsgFirstHdr: @convention(c) (UnsafePointer<msghdr>?) -> UnsafeMutablePointer<cmsghdr>? =
@@ -108,6 +110,8 @@ private let sysCmsgSpace: @convention(c) (size_t) -> size_t = CNIOLinux_CMSG_SPA
 private let sysCmsgLen: @convention(c) (size_t) -> size_t = CNIOLinux_CMSG_LEN
 #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>?) -> CInt = fstat
+private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat
+private let sysUnlink: @convention(c) (UnsafePointer<CChar>?) -> CInt = unlink
 private let sysKevent = kevent
 private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_mmsghdr>?, CUnsignedInt, CInt) -> CInt = CNIODarwin_sendmmsg
 private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_mmsghdr>?, CUnsignedInt, CInt, UnsafeMutablePointer<timespec>?) -> CInt = CNIODarwin_recvmmsg
@@ -515,6 +519,20 @@ internal enum Posix {
     public static func fstat(descriptor: CInt, outStat: UnsafeMutablePointer<stat>) throws {
         _ = try syscall(blocking: false) {
             sysFstat(descriptor, outStat)
+        }
+    }
+
+    @inline(never)
+    public static func stat(pathname: String, outStat: UnsafeMutablePointer<stat>) throws {
+        _ = try syscall(blocking: false) {
+            sysStat(pathname, outStat)
+        }
+    }
+
+    @inline(never)
+    public static func unlink(pathname: String) throws {
+        _ = try syscall(blocking: false) {
+            sysUnlink(pathname)
         }
     }
 

--- a/Tests/NIOTests/EchoServerClientTest+XCTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest+XCTest.swift
@@ -31,6 +31,8 @@ extension EchoServerClientTest {
                 ("testLotsOfUnflushedWrites", testLotsOfUnflushedWrites),
                 ("testEchoUnixDomainSocket", testEchoUnixDomainSocket),
                 ("testConnectUnixDomainSocket", testConnectUnixDomainSocket),
+                ("testCleanupUnixDomainSocket", testCleanupUnixDomainSocket),
+                ("testBootstrapUnixDomainSocketNameClash", testBootstrapUnixDomainSocketNameClash),
                 ("testChannelActiveOnConnect", testChannelActiveOnConnect),
                 ("testWriteThenRead", testWriteThenRead),
                 ("testCloseInInactive", testCloseInInactive),

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -172,6 +172,45 @@ class EchoServerClientTest : XCTestCase {
         }
     }
 
+    func testCleanupUnixDomainSocket() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        try withTemporaryUnixDomainSocketPathName { udsPath in
+            let bootstrap = ServerBootstrap(group: group)
+                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            
+            let serverChannel = try assertNoThrowWithValue(
+                bootstrap.bind(unixDomainSocketPath: udsPath).wait())
+
+            XCTAssertNoThrow(try serverChannel.close().wait())
+
+            let reusedPathServerChannel = try assertNoThrowWithValue(
+                bootstrap.bind(unixDomainSocketPath: udsPath).wait())
+
+            XCTAssertNoThrow(try reusedPathServerChannel.close().wait())
+        }
+    }
+
+    func testBootstrapUnixDomainSocketNameClash() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        try withTemporaryUnixDomainSocketPathName { udsPath in
+            // Bootstrap should not overwrite an existing file unless it is a socket
+            FileManager.default.createFile(atPath: udsPath, contents: nil, attributes: nil)
+            let bootstrap = ServerBootstrap(group: group)
+                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+
+            XCTAssertThrowsError(
+                try bootstrap.bind(unixDomainSocketPath: udsPath).wait())
+        }
+    }
+
     func testChannelActiveOnConnect() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {

--- a/Tests/NIOTests/EchoServerClientTest.swift
+++ b/Tests/NIOTests/EchoServerClientTest.swift
@@ -180,7 +180,6 @@ class EchoServerClientTest : XCTestCase {
 
         try withTemporaryUnixDomainSocketPathName { udsPath in
             let bootstrap = ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             
             let serverChannel = try assertNoThrowWithValue(
                 bootstrap.bind(unixDomainSocketPath: udsPath).wait())
@@ -188,7 +187,8 @@ class EchoServerClientTest : XCTestCase {
             XCTAssertNoThrow(try serverChannel.close().wait())
 
             let reusedPathServerChannel = try assertNoThrowWithValue(
-                bootstrap.bind(unixDomainSocketPath: udsPath).wait())
+                bootstrap.bind(unixDomainSocketPath: udsPath,
+                               cleanupExistingSocketFile: true).wait())
 
             XCTAssertNoThrow(try reusedPathServerChannel.close().wait())
         }
@@ -204,7 +204,6 @@ class EchoServerClientTest : XCTestCase {
             // Bootstrap should not overwrite an existing file unless it is a socket
             FileManager.default.createFile(atPath: udsPath, contents: nil, attributes: nil)
             let bootstrap = ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
             XCTAssertThrowsError(
                 try bootstrap.bind(unixDomainSocketPath: udsPath).wait())


### PR DESCRIPTION
Resolves https://github.com/apple/swift-nio/issues/1619

### Motivation:

Server bootstrap should clean up its socket file on clean close, and additionally, we should by default try and remove an existing socket file before binding to it.

### Modifications:

- Adds `cleanupExistingSocketFile` to server bootstrap `bind` that signals whether preexisting socket file should be cleaned up before binding
- Cleans up existing socket file on server socket close

To avoid accidental loss of data, the path is only cleaned up if it points to a socket file.

### Result:

Server socket successfully binds to a UNIX Domain Socket Path if the path already exists and is a socket file. On clean close, the socket file also gets removed.
