### PR TITLE
CNIOWindows: preprocess away WinSock support code

### DIFF
--- a/Sources/CNIOWindows/WSAStartup.c
+++ b/Sources/CNIOWindows/WSAStartup.c
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if defined(_WIN32)
+
 #include <Winsock2.h>
 
 #include <stdlib.h>
@@ -29,3 +31,5 @@ NIOWSAStartup(void) {
 
 __declspec(allocate(".CRT$XCU"))
 static void (*pNIOWSAStartup)(void) = &NIOWSAStartup;
+
+#endif


### PR DESCRIPTION
This preprocesses away the WinSock2 support code when on non-Windows
targets.
