### PR TITLE
Increases default initial size for `AdaptiveRecvByteBufferAllocator`

### DIFF
--- a/Sources/NIO/RecvByteBufferAllocator.swift
+++ b/Sources/NIO/RecvByteBufferAllocator.swift
@@ -81,7 +81,7 @@ public struct AdaptiveRecvByteBufferAllocator: RecvByteBufferAllocator {
     private var decreaseNow: Bool
 
     public init() {
-        self.init(minimum: 64, initial: 1024, maximum: 65536)
+        self.init(minimum: 64, initial: 2048, maximum: 65536)
     }
 
     public init(minimum: Int, initial: Int, maximum: Int) {

--- a/Tests/NIOTests/SALChannelTests.swift
+++ b/Tests/NIOTests/SALChannelTests.swift
@@ -228,7 +228,7 @@ final class SALChannelTest: XCTestCase, SALTest {
         XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
             try self.assertWaitingForNotification(result: .some(.init(io: [.read],
                                                                       registration: .socketChannel(channel, [.read]))))
-            try self.assertRead(expectedFD: .max, expectedBufferSpace: 1024, return: buffer)
+            try self.assertRead(expectedFD: .max, expectedBufferSpace: 2048, return: buffer)
         }) {
             channel.pipeline.addHandler(SignalGroupOnRead(group: g))
         })


### PR DESCRIPTION
### Motivation:

Resolves https://github.com/apple/swift-nio/issues/1558
A common MTU on the internet is 1500 bytes, and it should fit in the initial size buffer

### Modifications:

Only the default initial size is increased

### Result:

Little is changed, but should result in fewer reallocations e.g. during TLS connection handshake
