### PR TITLE
Scheduling tasks Int.max ns into future results in an obtuse fatal error (#1056)

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -255,6 +255,7 @@ public protocol EventLoop: EventLoopGroup {
     ///            on the completion of the task.
     ///
     /// - note: You can only cancel a task before it has started executing.
+    /// - note: The `in` value is clamped to a maximum when running on a Darwin-kernel.
     @discardableResult
     func scheduleTask<T>(in: TimeAmount, _ task: @escaping () throws -> T) -> Scheduled<T>
 

--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -78,6 +78,7 @@ extension EventLoopTest {
                 ("testWeFailOutstandingScheduledTasksOnELShutdown", testWeFailOutstandingScheduledTasksOnELShutdown),
                 ("testSchedulingTaskOnFutureFailedByELShutdownDoesNotMakeUsExplode", testSchedulingTaskOnFutureFailedByELShutdownDoesNotMakeUsExplode),
                 ("testEventLoopGroupProvider", testEventLoopGroupProvider),
+                ("testScheduleMaximum", testScheduleMaximum),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When scheduling a task too far into the future a meaningful fatal error
should be produced. As the bounds on a kevent timeout are enforced in
kernel (and are undocumented), the current error only indicates that a
parameter to the kevent syscall was invalid (EINVAL).

Modifications:

Surrounded KQueue.kevent sycall with do{} catch{}. The catch clause matches
EINVAL (one or more paramters are invalid) and then checks if this is
likely to have resulted from specifying  an invalid timeout. The bounds
checks are duplicated from those in Darwin kernel interval timer.

The rethrown IOError is caught in the SelectableEventLoop run method
and the offending task is failed (.fail()). This prevents the failure of
assert conditions in the defer statement when running as debug.

Result:

The fatal error will now output a more meaningful reason indicating the
kevent timeout bounds were exceeded (due to scheduling an event too far
into the future).