### PR TITLE
Adds NonBlockingFileIO method returning FileRegion for read/write method

### DIFF
--- a/Sources/NIO/NonBlockingFileIO.swift
+++ b/Sources/NIO/NonBlockingFileIO.swift
@@ -469,15 +469,23 @@ public struct NonBlockingFileIO {
     ///     - eventLoop: The `EventLoop` on which the returned `EventLoopFuture` will fire.
     /// - returns: An `EventLoopFuture` containing the `NIOFileHandle` and the `FileRegion` comprising the whole file.
     public func openFile(path: String, eventLoop: EventLoop) -> EventLoopFuture<(NIOFileHandle, FileRegion)> {
+        return self.openFileWithRegion(path: path, mode: .read, flags: .default, eventLoop: eventLoop)
+    }
+
+    /// Open the file at `path` with specified access mode and POSIX flags on a private thread pool which is separate from any `EventLoop` thread.
+    ///
+    /// This function will return (a future) of the `NIOFileHandle` associated with the file opened.
+    /// The caller must close the returned `NIOFileHandle` when it's no longer needed.
+    ///
+    /// - parameters:
+    ///     - path: The path of the file to be opened for writing.
+    ///     - mode: File access mode.
+    ///     - flags: Additional POSIX flags.
+    ///     - eventLoop: The `EventLoop` on which the returned `EventLoopFuture` will fire.
+    /// - returns: An `EventLoopFuture` containing the `NIOFileHandle`.
+    public func openFile(path: String, mode: NIOFileHandle.Mode, flags: NIOFileHandle.Flags = .default, eventLoop: EventLoop) -> EventLoopFuture<NIOFileHandle> {
         return self.threadPool.runIfActive(eventLoop: eventLoop) {
-            let fh = try NIOFileHandle(path: path)
-            do {
-                let fr = try FileRegion(fileHandle: fh)
-                return (fh, fr)
-            } catch {
-                _ = try? fh.close()
-                throw error
-            }
+            return try NIOFileHandle(path: path, mode: mode, flags: flags)
         }
     }
 
@@ -492,9 +500,16 @@ public struct NonBlockingFileIO {
     ///     - flags: Additional POSIX flags.
     ///     - eventLoop: The `EventLoop` on which the returned `EventLoopFuture` will fire.
     /// - returns: An `EventLoopFuture` containing the `NIOFileHandle` and the `FileRegion` comprising the whole file.
-    public func openFile(path: String, mode: NIOFileHandle.Mode, flags: NIOFileHandle.Flags = .default, eventLoop: EventLoop) -> EventLoopFuture<NIOFileHandle> {
+    public func openFileWithRegion(path: String, mode: NIOFileHandle.Mode, flags: NIOFileHandle.Flags = .default, eventLoop: EventLoop) -> EventLoopFuture<(NIOFileHandle, FileRegion)> {
         return self.threadPool.runIfActive(eventLoop: eventLoop) {
-            return try NIOFileHandle(path: path, mode: mode, flags: flags)
+            let fh = try NIOFileHandle(path: path, mode: mode, flags: flags)
+            do {
+                let fr = try FileRegion(fileHandle: fh)
+                return (fh, fr)
+            } catch {
+                _ = try? fh.close()
+                throw error
+            }
         }
     }
 


### PR DESCRIPTION

### Motivation:

For consistent behaviour when opening file with/without explicit flags, want a version that returns FileRegion

Resolves https://github.com/apple/swift-nio/issues/1620

### Modifications:

Additional method in NonBlockingFileIO that uses the same code as earlier `openFile` but includes file mode and flags

### Result:

Method returning both `NIOFileHandle` and `FileRegion`

*Issue: if `mode` does not include reading, attempting to read from `FileRegion` will crash the program*
