### PR TITLE
CNIOWindows: add stubs for `sendmmsg` and `recvmmsg`

### DIFF
--- a/Sources/CNIOWindows/include/CNIOWindows.h
+++ b/Sources/CNIOWindows/include/CNIOWindows.h
@@ -18,6 +18,7 @@
 #if defined(_WIN32)
 
 #include <WinSock2.h>
+#include <time.h>
 
 #define NIO(name) CNIOWindows_ ## name
 
@@ -58,6 +59,11 @@ NIO(sendto)(SOCKET s, const void *buf, int len, int flags, const SOCKADDR *to,
             int tolen) {
   return sendto(s, buf, len, flags, to, tolen);
 }
+
+int NIO(sendmmsg)(SOCKET s, NIO(mmsghdr) *msgvec, unsigned int vlen, int flags);
+
+int NIO(recvmmsg)(SOCKET s, NIO(mmsghdr) *msgvec, unsigned int vlen, int flags,
+                  struct timespec *timeout);
 
 #undef NIO
 

--- a/Sources/CNIOWindows/shim.c
+++ b/Sources/CNIOWindows/shim.c
@@ -16,4 +16,15 @@
 
 #include "CNIOWindows.h"
 
+int NIO(sendmmsg)(SOCKET s, NIO(mmsghdr) *msgvec, unsigned int vlen, int flags) {
+  assert(!"sendmmsg not implemented");
+  abort();
+}
+
+int NIO(recvmmsg)(SOCKET s, NIO(mmsghdr) *msgvec, unsigned int vlen, int flags,
+                  struct timespec *timeout) {
+  assert(!"recvmmsg not implemented");
+  abort();
+}
+
 #endif


### PR DESCRIPTION
These need to be filled out, but lets stub them out for the time being
to get the symbol resolution sorted out.  These are possible to
implement using the WinSDK.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
