### PR TITLE
CNIOWindows: correct declaration

### DIFF
--- a/Sources/CNIOWindows/shim.c
+++ b/Sources/CNIOWindows/shim.c
@@ -16,13 +16,17 @@
 
 #include "CNIOWindows.h"
 
-int NIO(sendmmsg)(SOCKET s, NIO(mmsghdr) *msgvec, unsigned int vlen, int flags) {
+#include <assert.h>
+
+int CNIOWindows_sendmmsg(SOCKET s, CNIOWindows_mmsghdr *msgvec, unsigned int vlen,
+                         int flags) {
   assert(!"sendmmsg not implemented");
   abort();
 }
 
-int NIO(recvmmsg)(SOCKET s, NIO(mmsghdr) *msgvec, unsigned int vlen, int flags,
-                  struct timespec *timeout) {
+int CNIOWindows_recvmmsg(SOCKET s, CNIOWindows_mmsghdr *msgvec,
+                         unsigned int vlen, int flags,
+                         struct timespec *timeout) {
   assert(!"recvmmsg not implemented");
   abort();
 }


### PR DESCRIPTION
This repairs the build on the CNIOWindows module on Windows.  The `NIO`
macro is unavailable in the definition (intentionally) and was being
used accidentally.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
