### PR TITLE
NIO: implement network interface enumeration for Windows

### DIFF
--- a/Sources/NIO/MulticastChannel.swift
+++ b/Sources/NIO/MulticastChannel.swift
@@ -25,6 +25,7 @@ public protocol MulticastChannel: Channel {
     ///         `nil` if you are not interested in the result of the operation.
     func joinGroup(_ group: SocketAddress, promise: EventLoopPromise<Void>?)
 
+#if !os(Windows)
     /// Request that the `MulticastChannel` join the multicast group given by `group` on the interface
     /// given by `interface`.
     ///
@@ -35,6 +36,7 @@ public protocol MulticastChannel: Channel {
     ///         `nil` if you are not interested in the result of the operation.
     @available(*, deprecated, renamed: "joinGroup(_:device:promise:)")
     func joinGroup(_ group: SocketAddress, interface: NIONetworkInterface?, promise: EventLoopPromise<Void>?)
+#endif
 
     /// Request that the `MulticastChannel` join the multicast group given by `group` on the device
     /// given by `device`.
@@ -54,6 +56,7 @@ public protocol MulticastChannel: Channel {
     ///         `nil` if you are not interested in the result of the operation.
     func leaveGroup(_ group: SocketAddress, promise: EventLoopPromise<Void>?)
 
+#if !os(Windows)
     /// Request that the `MulticastChannel` leave the multicast group given by `group` on the interface
     /// given by `interface`.
     ///
@@ -64,6 +67,7 @@ public protocol MulticastChannel: Channel {
     ///         `nil` if you are not interested in the result of the operation.
     @available(*, deprecated, renamed: "leaveGroup(_:device:promise:)")
     func leaveGroup(_ group: SocketAddress, interface: NIONetworkInterface?, promise: EventLoopPromise<Void>?)
+#endif
 
     /// Request that the `MulticastChannel` leave the multicast group given by `group` on the device
     /// given by `device`.
@@ -89,12 +93,14 @@ extension MulticastChannel {
         return promise.futureResult
     }
 
+#if !os(Windows)
     @available(*, deprecated, renamed: "joinGroup(_:device:)")
     public func joinGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         self.joinGroup(group, interface: interface, promise: promise)
         return promise.futureResult
     }
+#endif
 
     public func joinGroup(_ group: SocketAddress, device: NIONetworkDevice?) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
@@ -112,12 +118,14 @@ extension MulticastChannel {
         return promise.futureResult
     }
 
+#if !os(Windows)
     @available(*, deprecated, renamed: "leaveGroup(_:device:)")
     public func leaveGroup(_ group: SocketAddress, interface: NIONetworkInterface?) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         self.leaveGroup(group, interface: interface, promise: promise)
         return promise.futureResult
     }
+#endif
 
     public func leaveGroup(_ group: SocketAddress, device: NIONetworkDevice?) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -12,6 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Windows)
+import let WinSDK.ECONNABORTED
+import let WinSDK.ECONNREFUSED
+import let WinSDK.EMFILE
+import let WinSDK.ENFILE
+import let WinSDK.ENOBUFS
+import let WinSDK.ENOMEM
+#endif
+
 extension ByteBuffer {
     mutating func withMutableWritePointer(body: (UnsafeMutableRawBufferPointer) throws -> IOResult<Int>) rethrows -> IOResult<Int> {
         var singleResult: IOResult<Int>!
@@ -755,6 +764,7 @@ extension DatagramChannel: MulticastChannel {
         }
     }
 
+#if !os(Windows)
     @available(*, deprecated, renamed: "joinGroup(_:device:promise:)")
     func joinGroup(_ group: SocketAddress, interface: NIONetworkInterface?, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
@@ -776,6 +786,7 @@ extension DatagramChannel: MulticastChannel {
             }
         }
     }
+#endif
 
     func joinGroup(_ group: SocketAddress, device: NIONetworkDevice?, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {


### PR DESCRIPTION
Partially implement network interface enumeration.  This is sufficient
to build up the structures for basic operations.  Although the interface
information is incomplete, this provides enough structure to continue
porting the rest of the NIO interfaces.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
