### PR TITLE
NIO: ignore `SIGPIPE` on Windows

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -351,7 +351,11 @@ class BaseSocket: BaseSocketProtocol {
         do {
             try self.ignoreSIGPIPE()
         } catch {
+#if os(Windows)
+            self.descriptor = INVALID_SOCKET // We have to unset the fd here, otherwise we'll crash with "leaking open BaseSocket"
+#else
             self.descriptor = -1 // We have to unset the fd here, otherwise we'll crash with "leaking open BaseSocket"
+#endif
             throw error
         }
     }

--- a/Sources/NIO/SocketProtocols.swift
+++ b/Sources/NIO/SocketProtocols.swift
@@ -85,6 +85,7 @@ extension BaseSocketProtocol {
         guard haveWeIgnoredSIGPIEThisIsHereToTriggerIgnoringIt else {
             fatalError("BUG in NIO. We did not ignore SIGPIPE, this code path should definitely not be reachable.")
         }
+        #elseif os(Windows)
         #else
         assert(fd >= 0, "illegal file descriptor \(fd)")
         do {


### PR DESCRIPTION
Windows does not support Unix-style signals.  Simply exclude the SIGPIPE
path on Windows.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
