### PR TITLE
NIO: implement `cleanupSocket(unixDomainSocketPath:)` for Windows

### DIFF
--- a/Sources/CNIOWindows/include/CNIOWindows.h
+++ b/Sources/CNIOWindows/include/CNIOWindows.h
@@ -20,6 +20,36 @@
 #include <WinSock2.h>
 #include <time.h>
 
+// This is a DDK type which is not available in the WinSDK as it is not part of
+// the shared, usermode (um), or ucrt portions of the code.  We must replicate
+// this datastructure manually from the MSDN references or the DDK.
+// https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_reparse_data_buffer
+typedef struct _REPARSE_DATA_BUFFER {
+  ULONG   ReparseTag;
+  USHORT  ReparseDataLength;
+  USHORT  Reserved;
+  union {
+    struct {
+      USHORT  SubstituteNameOffset;
+      USHORT  SubstituteNameLength;
+      USHORT  PrintNameOffset;
+      USHORT  PrintNameLength;
+      ULONG   Flags;
+      WCHAR   PathBuffer[1];
+    } SymbolicLinkReparseBuffer;
+    struct {
+      USHORT  SubstituteNameOffset;
+      USHORT  SubstituteNameLength;
+      USHORT  PrintNameOffset;
+      USHORT  PrintNameLength;
+      WCHAR   PathBuffer[1];
+    } MountPointReparseBuffer;
+    struct {
+      UCHAR   DataBuffer[1];
+    } GenericReparsaeBuffer;
+  } DUMMYUNIONNAME;
+} REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
+
 #define NIO(name) CNIOWindows_ ## name
 
 typedef struct {

--- a/Sources/CNIOWindows/include/CNIOWindows.h
+++ b/Sources/CNIOWindows/include/CNIOWindows.h
@@ -20,11 +20,13 @@
 #include <WinSock2.h>
 #include <time.h>
 
+#define NIO(name) CNIOWindows_ ## name
+
 // This is a DDK type which is not available in the WinSDK as it is not part of
 // the shared, usermode (um), or ucrt portions of the code.  We must replicate
 // this datastructure manually from the MSDN references or the DDK.
 // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_reparse_data_buffer
-typedef struct _REPARSE_DATA_BUFFER {
+typedef struct NIO(_REPARSE_DATA_BUFFER) {
   ULONG   ReparseTag;
   USHORT  ReparseDataLength;
   USHORT  Reserved;
@@ -48,9 +50,7 @@ typedef struct _REPARSE_DATA_BUFFER {
       UCHAR   DataBuffer[1];
     } GenericReparsaeBuffer;
   } DUMMYUNIONNAME;
-} REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
-
-#define NIO(name) CNIOWindows_ ## name
+} NIO(REPARSE_DATA_BUFFER), *NIO(PREPARSE_DATA_BUFFER);
 
 typedef struct {
   WSAMSG msg_hdr;

--- a/Sources/NIO/BSDSocketAPI.swift
+++ b/Sources/NIO/BSDSocketAPI.swift
@@ -393,6 +393,8 @@ extension NIOBSDSocket.Option {
 }
 #endif
 
+/// The requested UDS path exists and has wrong type (not a socket).
+public struct UnixDomainSocketPathWrongType: Error {}
 
 /// This protocol defines the methods that are expected to be found on `NIOBSDSocket`. While defined as a protocol
 /// there is no expectation that any object other than `NIOBSDSocket` will implement this protocol: instead, this protocol

--- a/Sources/NIO/BSDSocketAPI.swift
+++ b/Sources/NIO/BSDSocketAPI.swift
@@ -511,7 +511,11 @@ protocol _BSDSocketProtocol {
                          offset: off_t,
                          len: off_t) throws -> IOResult<Int>
 
+    // MARK: non-BSD APIs added by NIO
+
     static func setNonBlocking(socket: NIOBSDSocket.Handle) throws
+
+    static func cleanupUnixDomainSocket(atPath path: String) throws
 }
 
 /// If this extension is hitting a compile error, your platform is missing one of the functions defined above!

--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -403,7 +403,8 @@ extension NIOBSDSocket {
         }
 
         var nBytesWritten: DWORD = 0
-        var dbReparseDataBuffer: REPARSE_DATA_BUFFER = REPARSE_DATA_BUFFER()
+        var dbReparseDataBuffer: CNIOWindows_REPARSE_DATA_BUFFER =
+            CNIOWindows_REPARSE_DATA_BUFFER()
         try withUnsafeMutablePointer(to: &dbReparseDataBuffer) {
             if !DeviceIoControl(hFile, FSCTL_GET_REPARSE_POINT, nil, 0, $0,
                                 DWORD(MemoryLayout<REPARSE_DATA_BUFFER>.stride),

--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -359,16 +359,69 @@ extension NIOBSDSocket {
 
         return .processed(Int(nNumberOfBytesToWrite))
     }
+}
 
+extension NIOBSDSocket {
     @inline(never)
     static func setNonBlocking(socket: NIOBSDSocket.Handle) throws {
         var ulMode: u_long = 1
         if WinSDK.ioctlsocket(socket, FIONBIO, &ulMode) == SOCKET_ERROR {
             let iResult = WSAGetLastError()
             if iResult == WSAEINVAL {
-                throw NIOFailedToSetSocketNonBlockingError()
+                throw NIOFcntlFailedError()
             }
             throw IOError(winsock: WSAGetLastError(), reason: "ioctlsocket")
+        }
+    }
+
+    static func cleanupUnixDomainSocket(atPath path: String) throws {
+        guard let hFile = (path.withCString(encodedAs: UTF16.self) {
+            CreateFileW($0, GENERIC_READ,
+                        DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE),
+                        nil, DWORD(OPEN_EXISTING),
+                        DWORD(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS),
+                        nil)
+        }) else {
+            throw IOError(windows: DWORD(EBADF), reason: "CreateFileW")
+        }
+        defer { CloseHandle(hFile) }
+
+        let ftFileType =  GetFileType(hFile)
+        let dwError = GetLastError()
+        guard dwError == NO_ERROR, ftFileType != FILE_TYPE_DISK else {
+            throw IOError(windows: dwError, reason: "GetFileType")
+        }
+
+        var fiInformation: BY_HANDLE_FILE_INFORMATION =
+                BY_HANDLE_FILE_INFORMATION()
+        guard GetFileInformationByHandle(hFile, &fiInformation) else {
+            throw IOError(windows: GetLastError(), reason: "GetFileInformationByHandle")
+        }
+
+        guard fiInformation.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) == FILE_ATTRIBUTE_REPARSE_POINT else {
+            throw UnixDomainSocketPathWrongType()
+        }
+
+        var nBytesWritten: DWORD = 0
+        var dbReparseDataBuffer: REPARSE_DATA_BUFFER = REPARSE_DATA_BUFFER()
+        try withUnsafeMutablePointer(to: &dbReparseDataBuffer) {
+            if !DeviceIoControl(hFile, FSCTL_GET_REPARSE_POINT, nil, 0, $0,
+                                DWORD(MemoryLayout<REPARSE_DATA_BUFFER>.stride),
+                                &nBytesWritten, nil) {
+                throw IOError(windows: GetLastError(), reason: "DeviceIoControl")
+            }
+        }
+
+        guard dbReparseDataBuffer.ReparseTag == IO_REPARSE_TAG_AF_UNIX else {
+            throw UnixDomainSocketPathWrongType()
+        }
+
+        var fdi: FILE_DISPOSITION_INFO_EX = FILE_DISPOSITION_INFO_EX()
+        fdi.Flags = DWORD(FILE_DISPOSITION_FLAG_DELETE | FILE_DISPOSITION_FLAG_POSIX_SEMANTICS)
+
+        if !SetFileInformationByHandle(hFile, FileDispositionInfoEx, &fdi,
+                                       DWORD(MemoryLayout<FILE_DISPOSITION_INFO_EX>.stride)) {
+            throw IOError(windows: GetLastError(), reason: "GetFileInformationByHandle")
         }
     }
 }

--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -57,9 +57,6 @@ import struct WinSDK.socklen_t
 import CNIOWindows
 #endif
 
-/// The requested UDS path exists and has wrong type (not a socket).
-public struct UnixDomainSocketPathWrongType: Error {}
-
 /// A Registration on a `Selector`, which is interested in an `SelectorEventSet`.
 protocol Registration {
     /// The `SelectorEventSet` in which the `Registration` is interested.


### PR DESCRIPTION
This adds an initial implementation for the UDS clean up path on
Windows.  Unlike Unix, you cannot simply `stat` the destination to
determine if it is a UDS endpoint.

One must first create a file handle from the path.  Assuming that we are
able to create that, we should verify that the file that we are dealing
with is a not a disk type as the subsequent checks will fail.  Now, we
can use the file handle to query the information of the file.  This will
allow us to determine if it is a reparse point.  If not, it is
impossible for it to be a UDS as a UDS endpoint is a reparse point with
the tag IO_REPARSE_TAG_AF_UNIX.  Once we know that we have a reparse
point, we must query the kernel for information about it via the
`DeviceIoControl` system call (perform an ioctl in Unix speak).  The
returned buffer's tag will identify if we have a UDS.

For the next dance, we must now _close_ the handle as the handle being
left open will cause the subsequent `DeleteFileW` to fail due to there
being an open handle.  Once we have cleaned up the file handle that we
created, we can safely attempt to remove the file via `DeleteFileW`.

This should hopefully be sufficiently robust from possible error
scenarios for the removal of a UDS endpoint.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
