### PR TITLE
NIO: invalid sockets are not `-1` but `INVALID_SOCKET`

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -471,7 +471,11 @@ class BaseSocket: BaseSocketProtocol {
     /// - throws: An `IOError` if the operation failed.
     final func takeDescriptorOwnership() throws -> NIOBSDSocket.Handle {
         return try self.withUnsafeHandle {
+#if os(Windows)
+            self.descriptor = INVALID_SOCKET
+#else
             self.descriptor = -1
+#endif
             return $0
         }
     }


### PR DESCRIPTION
Adjust the sentinel indicating an invalid socket.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
