### PR TITLE
Minor cleanups of Windows compatability code.

### DIFF
--- a/Sources/NIO/BSDSocketAPI.swift
+++ b/Sources/NIO/BSDSocketAPI.swift
@@ -15,6 +15,8 @@
 #if os(Windows)
 import ucrt
 
+import let WinSDK.INVALID_SOCKET
+
 import let WinSDK.IPPROTO_IP
 import let WinSDK.IPPROTO_IPV6
 import let WinSDK.IPPROTO_TCP
@@ -75,6 +77,12 @@ public enum NIOBSDSocket {
     public typealias Handle = SOCKET
 #else
     public typealias Handle = CInt
+#endif
+
+#if os(Windows)
+    internal static let invalidHandle: Handle = INVALID_SOCKET
+#else
+    internal static let invalidHandle: Handle = -1
 #endif
 }
 

--- a/Sources/NIO/SocketProtocols.swift
+++ b/Sources/NIO/SocketProtocols.swift
@@ -86,6 +86,7 @@ extension BaseSocketProtocol {
             fatalError("BUG in NIO. We did not ignore SIGPIPE, this code path should definitely not be reachable.")
         }
         #elseif os(Windows)
+        // Deliberately empty: SIGPIPE just ain't a thing on Windows
         #else
         assert(fd >= 0, "illegal file descriptor \(fd)")
         do {


### PR DESCRIPTION
Motivation:

Cleanup some noise that came in with some previous Windows compat
patches.

Modifications:

- Move INVALID_SOCKET to NIOBSDSocket, and refer to it by a better name
  there.
- Comment in an empty block to indicate that it's supposed to be empty.

Result:

Bit cleaner code.
