### PR TITLE
Print the usage if no args are provided to the build_podspecs script

### DIFF
--- a/scripts/build_podspecs.sh
+++ b/scripts/build_podspecs.sh
@@ -44,7 +44,7 @@ done
 shift "$((OPTIND-1))"
 
 if [[ $# -eq 0 ]]; then
-  echo "Must provide target version"
+  usage
   exit 1
 fi
 


### PR DESCRIPTION
Motivation:

The information printed when invoking `build_podspecs.sh` without
arguments is outdated.

Modifications:

- Print usage information when invoking without arguments.

Result:

- 'build_podspecs.sh' is more helpful when you can't remember how it
  should be invoked