### PR TITLE
NIOUDPEchoServer use AddressedEnvelope as InboundIn and OutboundOut

### DIFF
--- a/Sources/NIOUDPEchoServer/main.swift
+++ b/Sources/NIOUDPEchoServer/main.swift
@@ -14,8 +14,8 @@
 import NIO
 
 private final class EchoHandler: ChannelInboundHandler {
-    public typealias InboundIn = ByteBuffer
-    public typealias OutboundOut = ByteBuffer
+    public typealias InboundIn = AddressedEnvelope<ByteBuffer>
+    public typealias OutboundOut = AddressedEnvelope<ByteBuffer>
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         // As we are not really interested getting notified on success or failure we just pass nil as promise to


### PR DESCRIPTION
As discussed on Slack

### Motivation:

Currently the Channel types don't match between `NIOUDPEchoServer` and `NIOUDPEchoClient`. The correct type to use is `AddressedEnvelope<ByteBuffer>` in the server. 

So far this has only worked since `unwrapInboundIn(data)` has not been called in the server.

### Modifications:

The `NIOUDPEchoServer` example now uses `AddressedEnvelope<ByteBuffer>` in its `EchoHandler` as `InboundIn` and `OutboundOut` type.

### Result:

Newbies are less confused. 🤩
