### PR TITLE
NIO: correct return value for messaging on Windows

### DIFF
--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -268,7 +268,7 @@ extension NIOBSDSocket {
                          vlen: CUnsignedInt, flags: CInt,
                          timeout: UnsafeMutablePointer<timespec>?)
             throws -> IOResult<Int> {
-        return CNIOWindows_recvmmsg(socket, msgvec, vlen, flags, timeout)
+        return .processed(Int(CNIOWindows_recvmmsg(socket, msgvec, vlen, flags, timeout)))
     }
 
     @inline(never)
@@ -276,7 +276,7 @@ extension NIOBSDSocket {
                          msgvec: UnsafeMutablePointer<MMsgHdr>,
                          vlen: CUnsignedInt, flags: CInt)
             throws -> IOResult<Int> {
-        return CNIOWindows_sendmmsg(socket, msgvec, vlen, flags)
+        return .processed(Int(CNIOWindows_sendmmsg(socket, msgvec, vlen, flags)))
     }
 
     // NOTE: this should return a `ssize_t`, however, that is not a standard


### PR DESCRIPTION
The return type failed to correctly convert the result to the return
value type.  Explicitly perform the return value initialization.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
