### PR TITLE
NIO: silence error on Windows

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -379,7 +379,7 @@ class BaseSocket: BaseSocketProtocol {
     }
 
     func ignoreSIGPIPE() throws {
-        try BaseSocket.ignoreSIGPIPE(descriptor: self.descriptor)
+        try BaseSocket.ignoreSIGPIPE(socket: self.descriptor)
     }
 
     /// Set the socket as non-blocking.

--- a/Sources/NIO/SocketProtocols.swift
+++ b/Sources/NIO/SocketProtocols.swift
@@ -101,4 +101,12 @@ extension BaseSocketProtocol {
         }
         #endif
     }
+
+    internal static func ignoreSIGPIPE(socket handle: NIOBSDSocket.Handle) throws {
+        #if os(Windows)
+        // Deliberately empty: SIGPIPE just ain't a thing on Windows
+        #else
+            try ignoreSIGPIPE(descriptor: handle)
+        #endif
+    }
 }


### PR DESCRIPTION
The `ignoreSIGPIPE` does nothing on Windows.  However, we must truncate
the socket descriptor as the SIGPIPE takes a FD which is 32-bits but the
socket handle is 64-bits.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
