### PR TITLE
NIO: expose `LINGER` as a public type on Windows

### DIFF
--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -93,6 +93,7 @@ import struct WinSDK.socklen_t
 import struct WinSDK.u_long
 import struct WinSDK.DWORD
 import struct WinSDK.HANDLE
+import struct WinSDK.LINGER
 import struct WinSDK.OVERLAPPED
 import struct WinSDK.SOCKADDR
 import struct WinSDK.SOCKADDR_IN
@@ -104,6 +105,8 @@ internal typealias sockaddr_in = SOCKADDR_IN
 internal typealias sockaddr_in6 = SOCKADDR_IN6
 internal typealias sockaddr_un = SOCKADDR_UN
 internal typealias sockaddr_storage = SOCKADDR_STORAGE
+
+public typealias linger = LINGER
 
 import CNIOWindows
 


### PR DESCRIPTION
The Windows `LINGER` type is meant to be exposed as it is a low-level
system detail for `SocketChannelOptions`.  See #1673 for relevant
discussion.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
