### PR TITLE
Add multiple channel handlers in a single async call.

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -909,6 +909,8 @@ extension ChannelPipeline {
             individualPosition = .after(handler)
         }
 
+        let promise = self.eventLoop.makePromise(of: Void.self)
+
         // Add all the handlers.
         func addAllHandlersAndComplete() {
             // Function for reducing to propagate errors.
@@ -927,7 +929,6 @@ extension ChannelPipeline {
             promise.completeWith(result)
         }
 
-        let promise = self.eventLoop.makePromise(of: Void.self)
         if self.eventLoop.inEventLoop {
             addAllHandlersAndComplete()
         } else {

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -192,8 +192,8 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - position: The position in the `ChannelPipeline` to add `handler`. Defaults to `.last`.
     /// - returns: the result of adding this handler - either success or failure with an error code if this could not be completed.
     private func _add(_ handler: ChannelHandler,
-              name: String? = nil,
-              position: ChannelPipeline.Position = .last) -> Result<Void, Error> {
+                      name: String? = nil,
+                      position: ChannelPipeline.Position = .last) -> Result<Void, Error> {
         self.eventLoop.assertInEventLoop()
 
         if self.destroyed {
@@ -203,24 +203,24 @@ public final class ChannelPipeline: ChannelInvoker {
         switch position {
         case .first:
             return self.add0(name: name,
-                      handler: handler,
-                      relativeContext: head!,
-                      operation: self.add0(context:after:))
+                             handler: handler,
+                             relativeContext: head!,
+                             operation: self.add0(context:after:))
         case .last:
             return self.add0(name: name,
-                      handler: handler,
-                      relativeContext: tail!,
-                      operation: self.add0(context:before:))
+                             handler: handler,
+                             relativeContext: tail!,
+                             operation: self.add0(context:before:))
         case .before(let beforeHandler):
             return self.add0(name: name,
-                      handler: handler,
-                      relativeHandler: beforeHandler,
-                      operation: self.add0(context:before:))
+                             handler: handler,
+                             relativeHandler: beforeHandler,
+                             operation: self.add0(context:before:))
         case .after(let afterHandler):
             return self.add0(name: name,
-                      handler: handler,
-                      relativeHandler: afterHandler,
-                      operation: self.add0(context:after:))
+                             handler: handler,
+                             relativeHandler: afterHandler,
+                             operation: self.add0(context:after:))
         }
     }
 

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -171,50 +171,57 @@ public final class ChannelPipeline: ChannelInvoker {
                            name: String? = nil,
                            position: ChannelPipeline.Position = .last) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
-
-        func _add() {
-            if self.destroyed {
-                promise.fail(ChannelError.ioOnClosedChannel)
-                return
-            }
-
-            switch position {
-            case .first:
-                self.add0(name: name,
-                          handler: handler,
-                          relativeContext: head!,
-                          operation: self.add0(context:after:),
-                          promise: promise)
-            case .last:
-                self.add0(name: name,
-                          handler: handler,
-                          relativeContext: tail!,
-                          operation: self.add0(context:before:),
-                          promise: promise)
-            case .before(let beforeHandler):
-                self.add0(name: name,
-                          handler: handler,
-                          relativeHandler: beforeHandler,
-                          operation: self.add0(context:before:),
-                          promise: promise)
-            case .after(let afterHandler):
-                self.add0(name: name,
-                          handler: handler,
-                          relativeHandler: afterHandler,
-                          operation: self.add0(context:after:),
-                          promise: promise)
-            }
-        }
-
         if self.eventLoop.inEventLoop {
-            _add()
+            promise.completeWith(self._add(handler, name: name, position: position))
         } else {
             self.eventLoop.execute {
-                _add()
+                promise.completeWith(self._add(handler, name: name, position: position))
             }
         }
 
         return promise.futureResult
+    }
+
+    /// Synchronously add a `ChannelHandler` to the `ChannelPipeline`.
+    ///
+    /// May only be called from on the event loop.
+    ///
+    /// - parameters:
+    ///     - name: the name to use for the `ChannelHandler` when its added. If none is specified it will generate a name.
+    ///     - handler: the `ChannelHandler` to add
+    ///     - position: The position in the `ChannelPipeline` to add `handler`. Defaults to `.last`.
+    /// - returns: the result of adding this handler - either success or failure with an error code if this could not be completed.
+    private func _add(_ handler: ChannelHandler,
+              name: String? = nil,
+              position: ChannelPipeline.Position = .last) -> Result<Void, Error> {
+        self.eventLoop.assertInEventLoop()
+
+        if self.destroyed {
+            return .failure(ChannelError.ioOnClosedChannel)
+        }
+
+        switch position {
+        case .first:
+            return self.add0(name: name,
+                      handler: handler,
+                      relativeContext: head!,
+                      operation: self.add0(context:after:))
+        case .last:
+            return self.add0(name: name,
+                      handler: handler,
+                      relativeContext: tail!,
+                      operation: self.add0(context:before:))
+        case .before(let beforeHandler):
+            return self.add0(name: name,
+                      handler: handler,
+                      relativeHandler: beforeHandler,
+                      operation: self.add0(context:before:))
+        case .after(let afterHandler):
+            return self.add0(name: name,
+                      handler: handler,
+                      relativeHandler: afterHandler,
+                      operation: self.add0(context:after:))
+        }
     }
 
     /// Synchronously add a `ChannelHandler` to the pipeline, relative to another `ChannelHandler`,
@@ -232,25 +239,21 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - relativeHandler: The `ChannelHandler` already in the `ChannelPipeline` that `handler` will be
     ///         inserted relative to.
     ///     - operation: A callback that will insert `handler` relative to `relativeHandler`.
-    ///     - promise: An `EventLoopPromise<Void>` that will fire when the operation is complete, or will fire with
-    ///         an error if it could not be completed.
+    /// - returns: the result of adding this handler - either success or failure with an error code if this could not be completed.
     private func add0(name: String?,
                       handler: ChannelHandler,
                       relativeHandler: ChannelHandler,
-                      operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void,
-                      promise: EventLoopPromise<Void>) {
+                      operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void) -> Result<Void, Error> {
         self.eventLoop.assertInEventLoop()
         if self.destroyed {
-            promise.fail(ChannelError.ioOnClosedChannel)
-            return
+            return .failure(ChannelError.ioOnClosedChannel)
         }
 
         guard let context = self.contextForPredicate0({ $0.handler === relativeHandler }) else {
-            promise.fail(ChannelPipelineError.notFound)
-            return
+            return .failure(ChannelPipelineError.notFound)
         }
 
-        self.add0(name: name, handler: handler, relativeContext: context, operation: operation, promise: promise)
+        return self.add0(name: name, handler: handler, relativeContext: context, operation: operation)
     }
 
     /// Synchronously add a `ChannelHandler` to the pipeline, relative to a `ChannelHandlerContext`,
@@ -268,18 +271,15 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - relativeContext: The `ChannelHandlerContext` already in the `ChannelPipeline` that `handler` will be
     ///         inserted relative to.
     ///     - operation: A callback that will insert `handler` relative to `relativeHandler`.
-    ///     - promise: An `EventLoopPromise<Void>` that will fire when the operation is complete, or will fire with
-    ///         an error if it could not be completed.
+    /// - returns: the result of adding this handler - either success or failure with an error code if this could not be completed.
     private func add0(name: String?,
                       handler: ChannelHandler,
                       relativeContext: ChannelHandlerContext,
-                      operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void,
-                      promise: EventLoopPromise<Void>) {
+                      operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void) -> Result<Void, Error> {
         self.eventLoop.assertInEventLoop()
 
         if destroyed {
-            promise.fail(ChannelError.ioOnClosedChannel)
-            return
+            return .failure(ChannelError.ioOnClosedChannel)
         }
 
         let context = ChannelHandlerContext(name: name ?? nextName(), handler: handler, pipeline: self)
@@ -287,10 +287,10 @@ public final class ChannelPipeline: ChannelInvoker {
 
         do {
             try context.invokeHandlerAdded()
-            promise.succeed(())
+            return .success(())
         } catch let err {
             removeHandlerFromPipeline(context: context, promise: nil)
-            promise.fail(err)
+            return .failure(err)
         }
     }
 
@@ -907,9 +907,36 @@ extension ChannelPipeline {
         case .after(let handler):
             handlers.reverse()
             individualPosition = .after(handler)
-
         }
-        return .andAllSucceed(handlers.map { addHandler($0, position: individualPosition) }, on: eventLoop)
+
+        // Add all the handlers.
+        func addAllHandlersAndComplete() {
+            // Function for reducing to propagate errors.
+            func firstErrorOrSuccess(initial: Result<Void, Error>, current: Result<Void, Error>) ->Result<Void, Error> {
+                switch initial {
+                case .success:
+                    return current
+                case .failure:
+                    return initial
+                }
+            }
+
+            let result = handlers.map {
+                _add($0, position: individualPosition)
+            }.reduce(.success(()), firstErrorOrSuccess)
+            promise.completeWith(result)
+        }
+
+        let promise = self.eventLoop.makePromise(of: Void.self)
+        if self.eventLoop.inEventLoop {
+            addAllHandlersAndComplete()
+        } else {
+            self.eventLoop.execute {
+                addAllHandlersAndComplete()
+            }
+        }
+
+        return promise.futureResult
     }
 
     /// Adds the provided channel handlers to the pipeline in the order given, taking account

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.2
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=482050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=481050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.2
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=481050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=480050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.2
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=487050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=482050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.3
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=477050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=476050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.3
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=476050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=475050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.3
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=482050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=477050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31990
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=954050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=953050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4500
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31990
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=959050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=954050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4500
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31990
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=953050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=952050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4500
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=484050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=479050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=479050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=478050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=478050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=477050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010


### PR DESCRIPTION
Motivation:

Curently adding multiple channel handlers makes a call to the
async version of addHandler for each handler resulting in
n+1 futures.  It feels better to use just one future and add
all the handlers synchoronously.

Modifications:

Change sync functions with take a promise to instead return a Result.
Feed this back until reaching addHandlers.

Result:

Multiple handlers can be added more quickly.