### PR TITLE
Removes misleading docs for EventLoopFuture.whenComplete(_:)

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -727,10 +727,6 @@ extension EventLoopFuture {
     /// Adds an observer callback to this `EventLoopFuture` that is called when the
     /// `EventLoopFuture` has any result.
     ///
-    /// Unlike its friends `whenSuccess` and `whenFailure`, `whenComplete` does not receive the result
-    /// of the `EventLoopFuture`. This is because its primary purpose is to do the appropriate cleanup
-    /// of any resources that needed to be kept open until the `EventLoopFuture` had resolved.
-    ///
     /// - parameters:
     ///     - callback: The callback that is called when the `EventLoopFuture` is fulfilled.
     @inlinable
@@ -1463,10 +1459,6 @@ extension EventLoopFuture {
 
     /// Adds an observer callback to this `EventLoopFuture` that is called when the
     /// `EventLoopFuture` has any result. The observer callback is permitted to block.
-    ///
-    /// Unlike its friends `whenSuccess` and `whenFailure`, `whenComplete` does not receive the result
-    /// of the `EventLoopFuture`. This is because its primary purpose is to do the appropriate cleanup
-    /// of any resources that needed to be kept open until the `EventLoopFuture` had resolved.
     ///
     /// - parameters:
     ///     - onto: the `DispatchQueue` on which the blocking IO / task specified by `callbackMayBlock` is schedulded.


### PR DESCRIPTION
Removes documentation from `EventLoopFuture.whenComplete(_:)` that is no longer accurate.

### Motivation:

Upon the addition of `Result` in the Swift standard library, #734
updated `EventLoopFuture.whenComplete(_:)` to pass a `Result<T, Error>` to
its `callback`, but the documentation still confusingly states:

> Unlike its friends… `whenComplete` does not receive the result of the
> `EventLoopFuture`.

It would appear the documentation and functionality are no longer in sync and 
could thus cause confusion.

### Modifications:

This patch removes the (now inaccurate) lines from the documentation.

### Result:

The documentation now correctly reflects the functionality of 
`EventLoopFuture.whenComplete(_:)`.