### PR TITLE
Conform TimeAmount to AdditiveArithmetic

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -354,15 +354,15 @@ extension TimeAmount: AdditiveArithmetic {
     public static var zero: TimeAmount {
         return TimeAmount.nanoseconds(0)
     }
-    
+
     public static func + (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
         return TimeAmount(lhs.nanoseconds + rhs.nanoseconds)
     }
-    
+
     public static func - (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
          return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
     }
-    
+
     public static func * <T: BinaryInteger>(lhs: T, rhs: TimeAmount) -> TimeAmount {
         return TimeAmount(Int64(lhs) * rhs.nanoseconds)
     }

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -358,9 +358,17 @@ extension TimeAmount: AdditiveArithmetic {
     public static func + (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
         return TimeAmount(lhs.nanoseconds + rhs.nanoseconds)
     }
+    
+    public static func +=(lhs: inout TimeAmount, rhs: TimeAmount){
+        lhs = lhs + rhs
+    }
 
     public static func - (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
          return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
+    }
+    
+    public static func -=(lhs: inout TimeAmount, rhs: TimeAmount){
+        lhs = lhs - rhs
     }
 
     public static func * <T: BinaryInteger>(lhs: T, rhs: TimeAmount) -> TimeAmount {

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -277,9 +277,15 @@ extension EventLoopGroup {
 /// Represents a time _interval_.
 ///
 /// - note: `TimeAmount` should not be used to represent a point in time.
-public struct TimeAmount: Hashable {
+public struct TimeAmount: Hashable, AdditiveArithmetic {
+    
     @available(*, deprecated, message: "This typealias doesn't serve any purpose. Please use Int64 directly.")
     public typealias Value = Int64
+    
+    /// The zero value for `TimeAmount`.
+    public static var zero: TimeAmount {
+        return TimeAmount.nanoseconds(0)
+    }
 
     /// The nanoseconds representation of the `TimeAmount`.
     public let nanoseconds: Int64
@@ -353,8 +359,16 @@ extension TimeAmount {
     public static func + (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
         return TimeAmount(lhs.nanoseconds + rhs.nanoseconds)
     }
+    
+    public static func += (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
+        return TimeAmount(lhs.nanoseconds + rhs.nanoseconds)
+    }
 
     public static func - (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
+        return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
+    }
+    
+    public static func -= (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
         return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
     }
 

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -277,15 +277,10 @@ extension EventLoopGroup {
 /// Represents a time _interval_.
 ///
 /// - note: `TimeAmount` should not be used to represent a point in time.
-public struct TimeAmount: Hashable, AdditiveArithmetic {
+public struct TimeAmount: Hashable {
     
     @available(*, deprecated, message: "This typealias doesn't serve any purpose. Please use Int64 directly.")
     public typealias Value = Int64
-    
-    /// The zero value for `TimeAmount`.
-    public static var zero: TimeAmount {
-        return TimeAmount.nanoseconds(0)
-    }
 
     /// The nanoseconds representation of the `TimeAmount`.
     public let nanoseconds: Int64
@@ -355,23 +350,20 @@ extension TimeAmount: Comparable {
     }
 }
 
-extension TimeAmount {
+extension TimeAmount: AdditiveArithmetic {
+    /// The zero value for `TimeAmount`.
+    public static var zero: TimeAmount {
+        return TimeAmount.nanoseconds(0)
+    }
+    
     public static func + (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
         return TimeAmount(lhs.nanoseconds + rhs.nanoseconds)
     }
     
-    public static func += (lhs: inout TimeAmount, rhs: TimeAmount) -> TimeAmount {
-        return TimeAmount(lhs.nanoseconds + rhs.nanoseconds)
-    }
-
     public static func - (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
-        return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
+         TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
     }
     
-    public static func -= (lhs: inout TimeAmount, rhs: TimeAmount) -> TimeAmount {
-        return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
-    }
-
     public static func * <T: BinaryInteger>(lhs: T, rhs: TimeAmount) -> TimeAmount {
         return TimeAmount(Int64(lhs) * rhs.nanoseconds)
     }

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -361,7 +361,7 @@ extension TimeAmount: AdditiveArithmetic {
     }
     
     public static func - (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
-         TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
+         return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
     }
     
     public static func * <T: BinaryInteger>(lhs: T, rhs: TimeAmount) -> TimeAmount {

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -360,7 +360,7 @@ extension TimeAmount {
         return TimeAmount(lhs.nanoseconds + rhs.nanoseconds)
     }
     
-    public static func += (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
+    public static func += (lhs: inout TimeAmount, rhs: TimeAmount) -> TimeAmount {
         return TimeAmount(lhs.nanoseconds + rhs.nanoseconds)
     }
 
@@ -368,7 +368,7 @@ extension TimeAmount {
         return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
     }
     
-    public static func -= (lhs: TimeAmount, rhs: TimeAmount) -> TimeAmount {
+    public static func -= (lhs: inout TimeAmount, rhs: TimeAmount) -> TimeAmount {
         return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
     }
 

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -278,7 +278,6 @@ extension EventLoopGroup {
 ///
 /// - note: `TimeAmount` should not be used to represent a point in time.
 public struct TimeAmount: Hashable {
-    
     @available(*, deprecated, message: "This typealias doesn't serve any purpose. Please use Int64 directly.")
     public typealias Value = Int64
 

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -359,7 +359,7 @@ extension TimeAmount: AdditiveArithmetic {
         return TimeAmount(lhs.nanoseconds + rhs.nanoseconds)
     }
     
-    public static func +=(lhs: inout TimeAmount, rhs: TimeAmount){
+    public static func +=(lhs: inout TimeAmount, rhs: TimeAmount) {
         lhs = lhs + rhs
     }
 
@@ -367,7 +367,7 @@ extension TimeAmount: AdditiveArithmetic {
         return TimeAmount(lhs.nanoseconds - rhs.nanoseconds)
     }
     
-    public static func -=(lhs: inout TimeAmount, rhs: TimeAmount){
+    public static func -=(lhs: inout TimeAmount, rhs: TimeAmount) {
         lhs = lhs - rhs
     }
 

--- a/Tests/NIOTests/TimeAmountTests+XCTest.swift
+++ b/Tests/NIOTests/TimeAmountTests+XCTest.swift
@@ -29,6 +29,8 @@ extension TimeAmountTests {
       return [
                 ("testTimeAmountConversion", testTimeAmountConversion),
                 ("testTimeAmountIsHashable", testTimeAmountIsHashable),
+                ("testTimeAmountDoesAddTime", testTimeAmountDoesAddTime),
+                ("testTimeAmountDoesSubtractTime", testTimeAmountDoesSubtractTime),
            ]
    }
 }

--- a/Tests/NIOTests/TimeAmountTests+XCTest.swift
+++ b/Tests/NIOTests/TimeAmountTests+XCTest.swift
@@ -29,8 +29,6 @@ extension TimeAmountTests {
       return [
                 ("testTimeAmountConversion", testTimeAmountConversion),
                 ("testTimeAmountIsHashable", testTimeAmountIsHashable),
-                ("testTimeAmountDoesAddTime", testTimeAmountDoesAddTime),
-                ("testTimeAmountDoesSubtractTime", testTimeAmountDoesSubtractTime),
            ]
    }
 }

--- a/Tests/NIOTests/TimeAmountTests.swift
+++ b/Tests/NIOTests/TimeAmountTests.swift
@@ -28,4 +28,14 @@ class TimeAmountTests: XCTestCase {
         let amounts: Set<TimeAmount> = [.seconds(1), .milliseconds(4), .seconds(1)]
         XCTAssertEqual(amounts, [.seconds(1), .milliseconds(4)])
     }
+    
+    func testTimeAmountDoesAddTime() {
+        let amount = TimeAmount.milliseconds(0)
+        XCTAssertEqual(amount += .milliseconds(5), .milliseconds(5))
+    }
+    
+    func testTimeAmountDoesSubtractTime() {
+        let amount = TimeAmount.nanoseconds(5)
+        XCTAssertEqual(amount -= .nanoseconds(5), .zero)
+    }
 }

--- a/Tests/NIOTests/TimeAmountTests.swift
+++ b/Tests/NIOTests/TimeAmountTests.swift
@@ -22,6 +22,7 @@ class TimeAmountTests: XCTestCase {
         XCTAssertEqual(TimeAmount.seconds(9), .nanoseconds(9_000_000_000))
         XCTAssertEqual(TimeAmount.minutes(2), .nanoseconds(120_000_000_000))
         XCTAssertEqual(TimeAmount.hours(6), .nanoseconds(21_600_000_000_000))
+        XCTAssertEqual(TimeAmount.zero, .nanoseconds(0))
     }
 
     func testTimeAmountIsHashable() {
@@ -30,12 +31,16 @@ class TimeAmountTests: XCTestCase {
     }
     
     func testTimeAmountDoesAddTime() {
-        var amount = TimeAmount.milliseconds(0)
-        XCTAssertEqual(amount += .milliseconds(5), .milliseconds(5))
+        var lhs = TimeAmount.nanoseconds(0)
+        let rhs = TimeAmount.nanoseconds(5)
+        lhs += rhs
+        XCTAssertEqual(lhs, .nanoseconds(5))
     }
-    
+
     func testTimeAmountDoesSubtractTime() {
-        var amount = TimeAmount.nanoseconds(5)
-        XCTAssertEqual(amount -= .nanoseconds(5), .zero)
+        var lhs = TimeAmount.nanoseconds(5)
+        let rhs = TimeAmount.nanoseconds(5)
+        lhs -= rhs
+        XCTAssertEqual(lhs, .nanoseconds(0))
     }
 }

--- a/Tests/NIOTests/TimeAmountTests.swift
+++ b/Tests/NIOTests/TimeAmountTests.swift
@@ -30,12 +30,12 @@ class TimeAmountTests: XCTestCase {
     }
     
     func testTimeAmountDoesAddTime() {
-        let amount = TimeAmount.milliseconds(0)
+        var amount = TimeAmount.milliseconds(0)
         XCTAssertEqual(amount += .milliseconds(5), .milliseconds(5))
     }
     
     func testTimeAmountDoesSubtractTime() {
-        let amount = TimeAmount.nanoseconds(5)
+        var amount = TimeAmount.nanoseconds(5)
         XCTAssertEqual(amount -= .nanoseconds(5), .zero)
     }
 }


### PR DESCRIPTION
Conforms TimeAmount to AdditiveArithmetic, resolves #1690 

Motivation:
TimeAmount does not support -=, +=. Sometimes it is useful to manipulate time amounts when building up a delay and if that iteration fails, we would want to delay += .milliseconds(5) to add 5 milliseconds to our delay and try again.

Modifications:
Conformed TimeAmount to AdditiveArithmetic: added a static zero property and required operators.

Result:
TimeAmount conforms to AdditiveArithmetic.