### PR TITLE
Fix casing of 'SocketAddress.init(packedIpAddress:port:)'

### DIFF
--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -336,14 +336,14 @@ public enum SocketAddress: CustomStringConvertible {
     /// Create a new `SocketAddress` for an IP address in ByteBuffer form.
     ///
     /// - parameters:
-    ///     - packedIpAddress: The IP address, in ByteBuffer form.
+    ///     - packedIPAddress: The IP address, in ByteBuffer form.
     ///     - port: The target port.
     /// - returns: the `SocketAddress` corresponding to this string and port combination.
     /// - throws: may throw `SocketAddressError.failedToParseIPByteBuffer` if the IP address cannot be parsed.
-    public init(packedIpAddress: ByteBuffer, port: Int) throws {
-        let packed = packedIpAddress.readableBytesView
+    public init(packedIPAddress: ByteBuffer, port: Int) throws {
+        let packed = packedIPAddress.readableBytesView
         
-        switch packedIpAddress.readableBytes {
+        switch packedIPAddress.readableBytes {
         case 4:
             var ipv4Addr = sockaddr_in()
             ipv4Addr.sin_family = sa_family_t(AF_INET)
@@ -357,7 +357,7 @@ public enum SocketAddress: CustomStringConvertible {
             withUnsafeMutableBytes(of: &ipv6Addr.sin6_addr) { $0.copyBytes(from: packed) }
             self = .v6(.init(address: ipv6Addr, host: ""))
         default:
-            throw SocketAddressError.FailedToParseIPByteBuffer(address: packedIpAddress)
+            throw SocketAddressError.FailedToParseIPByteBuffer(address: packedIPAddress)
         }
     }
 

--- a/Tests/NIOTests/SocketAddressTest.swift
+++ b/Tests/NIOTests/SocketAddressTest.swift
@@ -43,21 +43,21 @@ class SocketAddressTest: XCTestCase {
     func testDescriptionWorksWithByteBufferIPv4IP() throws {
         let IPv4: [UInt8] = [0x7F, 0x00, 0x00, 0x01]
         let ipv4Address: ByteBuffer = ByteBuffer.init(bytes: IPv4)
-        let sa = try! SocketAddress(packedIpAddress: ipv4Address, port: 12345)
+        let sa = try! SocketAddress(packedIPAddress: ipv4Address, port: 12345)
         XCTAssertEqual("[IPv4]127.0.0.1:12345", sa.description)
     }
     
     func testDescriptionWorksWithByteBufferIPv6IP() throws {
         let IPv6: [UInt8] = [0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05]
         let ipv6Address: ByteBuffer = ByteBuffer.init(bytes: IPv6)
-        let sa = try! SocketAddress(packedIpAddress: ipv6Address, port: 12345)
+        let sa = try! SocketAddress(packedIPAddress: ipv6Address, port: 12345)
         XCTAssertEqual("[IPv6]fe80::5:12345", sa.description)
     }
     
     func testRejectsWrongIPByteBufferLength() {
         let wrongIP: [UInt8] = [0x01, 0x7F, 0x00]
         let ipAddress: ByteBuffer = ByteBuffer.init(bytes: wrongIP)
-        XCTAssertThrowsError(try SocketAddress(packedIpAddress: ipAddress, port: 12345)) { error in
+        XCTAssertThrowsError(try SocketAddress(packedIPAddress: ipAddress, port: 12345)) { error in
             switch error {
             case is SocketAddressError.FailedToParseIPByteBuffer:
                 XCTAssertEqual(ipAddress, (error as! SocketAddressError.FailedToParseIPByteBuffer).address)


### PR DESCRIPTION
Motivation:

A new init was added to `SocketAddress` in #1692, but the casing of
`packedIpAddress` is incorrect, it should be `packedIPAddress`. This
hasn't been released yet so let's fix it while we still can!

Modifications:

- s/packedIpAddress/packedIPAddress

Result:

More consistent API