### PR TITLE
Remove use of removeAll(keepingCapacity:).

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -281,7 +281,10 @@ class EmbeddedChannelCore: ChannelCore {
 
     func flush0() {
         let pendings = self.pendingOutboundBuffer
-        self.pendingOutboundBuffer.removeAll(keepingCapacity: true)
+        // removeAll(keepingCapacity:) is strictly more expensive than doing this, see
+        // https://bugs.swift.org/browse/SR-13923.
+        self.pendingOutboundBuffer = []
+        self.pendingOutboundBuffer.reserveCapacity(pendings.capacity)
         for dataAndPromise in pendings {
             self.addToBuffer(buffer: &self.outboundBuffer, data: dataAndPromise.0)
             dataAndPromise.1?.succeed(())


### PR DESCRIPTION
Motivation:

As outlined in https://bugs.swift.org/browse/SR-13923,
removeAll(keepingCapacity:) on Array has particularly negative
performance when that Array is not uniquely referenced. In this case, in
EmbeddedChannel, we _arrange_ to multiply reference it. This makes it
swamp our HTTP/2 microbenchmarks, spending more cycles copying this
buffer around than doing anything else.

Modifications:

- Just allocate a new buffer instead.

Result:

Much less copying.