### PR TITLE
Use CircularBuffer in EmbeddedChannel.

### DIFF
--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -26,11 +26,11 @@ services:
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=100 # 5.2 improvement 10000
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=4010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
-      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5010
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010 # 5.2 improvement 4000
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -26,11 +26,11 @@ services:
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=100
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=4010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
-      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5010
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200500 #5.3 improvement 210050

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -26,11 +26,11 @@ services:
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=4010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
-      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5010
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=230050

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -26,11 +26,11 @@ services:
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=4010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=4010
-      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1000
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5010
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050


### PR DESCRIPTION
Motivation:

When running load through EmbeddedChannel we spend an enormous amount of
time screwing around with removing things from Arrays. Arrays are not a
natural data type for `removeFirst()`, and in fact that method is
linear-time on Array due to the need for Array to be zero-indexed. Let's
stop using (and indeed misusing) Array on EmbeddedChannel.

While we're here, if we add some judicious @inlinable annotations we can
also save additional work generating results that users don't need.

Modifications:

- Replace arrays with circular buffers (including marked versions).
- Avoid CoWs and extra allocations on flush.
- Make some API methods inlinable to make them cheaper.

Result:

- Much cheaper EmbeddedChannel for benchmark purposes.