### PR TITLE
Change the `class` restriction on our protocols to `AnyObject`

### DIFF
--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -19,7 +19,7 @@ import NIOConcurrencyHelpers
 /// - warning: If you are not implementing a custom `Channel` type, you should never call any of these.
 ///
 /// - note: All methods must be called from the `EventLoop` thread.
-public protocol ChannelCore: class {
+public protocol ChannelCore: AnyObject {
     /// Returns the local bound `SocketAddress`.
     func localAddress0() throws -> SocketAddress
 
@@ -102,7 +102,7 @@ public protocol ChannelCore: class {
 /// passed to or returned by the operations are used to retrieve the result of an operation after it has completed.
 ///
 /// A `Channel` owns its `ChannelPipeline` which handles all I/O events and requests associated with the `Channel`.
-public protocol Channel: class, ChannelOutboundInvoker {
+public protocol Channel: AnyObject, ChannelOutboundInvoker {
     /// The `Channel`'s `ByteBuffer` allocator. This is _the only_ supported way of allocating `ByteBuffer`s to be used with this `Channel`.
     var allocator: ByteBufferAllocator { get }
 

--- a/Sources/NIO/ChannelHandler.swift
+++ b/Sources/NIO/ChannelHandler.swift
@@ -17,7 +17,7 @@
 /// All methods are called from within the `EventLoop` that is assigned to the `Channel` itself.
 //
 /// You should _never_ implement this protocol directly. Please implement one of its sub-protocols.
-public protocol ChannelHandler: class {
+public protocol ChannelHandler: AnyObject {
     /// Called when this `ChannelHandler` is added to the `ChannelPipeline`.
     ///
     /// - parameters:

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -732,7 +732,7 @@ enum NIORegistration: Registration {
 }
 
 /// Provides an endless stream of `EventLoop`s to use.
-public protocol EventLoopGroup: class {
+public protocol EventLoopGroup: AnyObject {
     /// Returns the next `EventLoop` to use.
     ///
     /// The algorithm that is used to select the next `EventLoop` is specific to each `EventLoopGroup`. A common choice

--- a/Sources/NIO/PendingWritesManager.swift
+++ b/Sources/NIO/PendingWritesManager.swift
@@ -453,7 +453,7 @@ internal enum WriteMechanism {
     case nothingToBeWritten
 }
 
-internal protocol PendingWritesManager: class {
+internal protocol PendingWritesManager: AnyObject {
     var isOpen: Bool { get }
     var isFlushPending: Bool { get }
     var writeSpinCount: UInt { get }

--- a/Sources/NIOPerformanceTester/Benchmark.swift
+++ b/Sources/NIOPerformanceTester/Benchmark.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-protocol Benchmark: class {
+protocol Benchmark: AnyObject {
     func setUp() throws
     func tearDown()
     func run() throws -> Int


### PR DESCRIPTION
Motivation:

In all contemporary Swift versions, the `class` and the `AnyObject`
protocol restriction is the same. And `class` is deprecated which warns
on newer Swift compilers.

Modifications:

Replace `class` with `AnyObject`.

Result:

No warnings on newer Swift compilers.