### PR TITLE
Specialise succeeded Void futures so we allocate less

### DIFF
--- a/Tests/NIOTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOTests/EventLoopTest+XCTest.swift
@@ -79,6 +79,9 @@ extension EventLoopTest {
                 ("testSchedulingTaskOnFutureFailedByELShutdownDoesNotMakeUsExplode", testSchedulingTaskOnFutureFailedByELShutdownDoesNotMakeUsExplode),
                 ("testEventLoopGroupProvider", testEventLoopGroupProvider),
                 ("testScheduleMaximum", testScheduleMaximum),
+                ("testEventLoopsWithPreSucceededFuturesCacheThem", testEventLoopsWithPreSucceededFuturesCacheThem),
+                ("testEventLoopsWithoutPreSucceededFuturesDoNotCacheThem", testEventLoopsWithoutPreSucceededFuturesDoNotCacheThem),
+                ("testSelectableEventLoopHasPreSucceededFuturesOnlyOnTheEventLoop", testSelectableEventLoopHasPreSucceededFuturesOnlyOnTheEventLoop),
            ]
    }
 }

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -21,11 +21,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181010
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=478050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=476050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=100 # 5.2 improvement 10000
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010 # 5.2 improvement 4000
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -21,11 +21,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=179010
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=473050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=101050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=471050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=100
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200500 #5.3 improvement 210050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190500
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -21,11 +21,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31990
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=189050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=188050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=108050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=950050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=107050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=948050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4500
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=230050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=220050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=18250

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -21,11 +21,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=475050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=473050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250


### PR DESCRIPTION
Motivation:

Succeeded `EventLoopFuture<Void>`s are quite important in SwiftNIO, they
happen all over the place. Unfortunately, we usually allocate each time,
unnecessarily.

Modifications:

Offer `EventLoop`s the option to cache succeeded void futures.

Result:

Fewer allocations.