### PR TITLE
Make all imports of CNIOLinux conditional on OS

### DIFF
--- a/Sources/NIO/GetaddrinfoResolver.swift
+++ b/Sources/NIO/GetaddrinfoResolver.swift
@@ -21,7 +21,9 @@
 /// needed to implement it.
 ///
 /// This resolver is a single-use object: it can only be used to perform a single host resolution.
+#if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
+#endif
 
 #if os(Windows)
 import let WinSDK.AF_INET

--- a/Sources/NIO/Interfaces.swift
+++ b/Sources/NIO/Interfaces.swift
@@ -18,7 +18,9 @@
 //  Created by Cory Benfield on 27/02/2018.
 //
 
+#if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
+#endif
 
 #if os(Windows)
 import let WinSDK.AF_INET

--- a/Sources/NIO/Linux.swift
+++ b/Sources/NIO/Linux.swift
@@ -14,9 +14,10 @@
 
 // This is a companion to System.swift that provides only Linux specials: either things that exist
 // only on Linux, or things that have Linux-specific extensions.
-import CNIOLinux
 
 #if os(Linux) || os(Android)
+import CNIOLinux
+
 internal enum TimerFd {
     public static let TFD_CLOEXEC = CNIOLinux.TFD_CLOEXEC
     public static let TFD_NONBLOCK = CNIOLinux.TFD_NONBLOCK

--- a/Sources/NIO/LinuxCPUSet.swift
+++ b/Sources/NIO/LinuxCPUSet.swift
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import CNIOLinux
 
 #if os(Linux) || os(Android)
+import CNIOLinux
 
     /// A set that contains CPU ids to use.
     struct LinuxCPUSet {

--- a/Sources/NIO/SocketAddresses.swift
+++ b/Sources/NIO/SocketAddresses.swift
@@ -13,7 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 /// Special `Error` that may be thrown if we fail to create a `SocketAddress`.
+#if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
+#endif
 
 #if os(Windows)
 import let WinSDK.AF_INET

--- a/Sources/NIO/Thread.swift
+++ b/Sources/NIO/Thread.swift
@@ -12,7 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
+#endif
 
 enum LowLevelThreadOperations {
     

--- a/Sources/NIO/Utilities.swift
+++ b/Sources/NIO/Utilities.swift
@@ -12,7 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
+#endif
 
 #if os(Windows)
 import let WinSDK.RelationProcessorCore


### PR DESCRIPTION
Motivation:

Some users are including NIO in Xcode workspaces
rather than using SPM.  When this is done, if all
imports of CNIOLinux are conditional they can
remove this project from their workspace.

Modifications:

Make all imports of CNIOLinux conditional on Linux,
Android or FreeBSD

Result:

No user visible change.