### PR TITLE
Retry on EPROTOTYPE on socket writes.

### DIFF
--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -150,6 +150,7 @@ private func preconditionIsNotUnacceptableErrno(err: CInt, where function: Strin
 @inline(__always)
 @discardableResult
 internal func syscall<T: FixedWidthInteger>(blocking: Bool,
+                                            eprototypeWorkaround: Bool = false,
                                             where function: String = #function,
                                             _ body: () throws -> T)
         throws -> IOResult<T> {
@@ -157,11 +158,18 @@ internal func syscall<T: FixedWidthInteger>(blocking: Bool,
         let res = try body()
         if res == -1 {
             let err = errno
-            switch (err, blocking) {
-            case (EINTR, _):
+            switch (err, blocking, eprototypeWorkaround) {
+            case (EINTR, _, _):
                 continue
-            case (EWOULDBLOCK, true):
+            case (EWOULDBLOCK, true, _):
                 return .wouldBlock(0)
+            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            case (EPROTOTYPE, _, true):
+                // EPROTOTYPE can, on Darwin platforms, sometimes fire due to a race in the XNU kernel.
+                // The socket in question is about to shut down, so we can just retry the syscall and get
+                // the actual error (usually, but not necessarily, EPIPE).
+                continue
+            #endif
             default:
                 preconditionIsNotUnacceptableErrno(err: err, where: function)
                 throw IOError(errnoCode: err, reason: function)
@@ -356,7 +364,7 @@ internal enum Posix {
     
     @inline(never)
     public static func write(descriptor: CInt, pointer: UnsafeRawPointer, size: Int) throws -> IOResult<Int> {
-        return try syscall(blocking: true) {
+        return try syscall(blocking: true, eprototypeWorkaround: true) {
             sysWrite(descriptor, pointer, size)
         }
     }
@@ -371,7 +379,7 @@ internal enum Posix {
 #if !os(Windows)
     @inline(never)
     public static func writev(descriptor: CInt, iovecs: UnsafeBufferPointer<IOVector>) throws -> IOResult<Int> {
-        return try syscall(blocking: true) {
+        return try syscall(blocking: true, eprototypeWorkaround: true) {
             sysWritev(descriptor, iovecs.baseAddress!, CInt(iovecs.count))
         }
     }
@@ -445,7 +453,7 @@ internal enum Posix {
     public static func sendfile(descriptor: CInt, fd: CInt, offset: off_t, count: size_t) throws -> IOResult<Int> {
         var written: off_t = 0
         do {
-            _ = try syscall(blocking: false) { () -> ssize_t in
+            _ = try syscall(blocking: false, eprototypeWorkaround: true) { () -> ssize_t in
                 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
                     var w: off_t = off_t(count)
                     let result: CInt = Darwin.sendfile(fd, descriptor, offset, &w, nil, 0)

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -84,6 +84,7 @@ extension ChannelTests {
                 ("testFixedSizeRecvByteBufferAllocatorSizeIsConstant", testFixedSizeRecvByteBufferAllocatorSizeIsConstant),
                 ("testCloseInConnectPromise", testCloseInConnectPromise),
                 ("testWritabilityChangeDuringReentrantFlushNow", testWritabilityChangeDuringReentrantFlushNow),
+                ("testTriggerEPROTOTYPE", testTriggerEPROTOTYPE),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When writing to a network socket on Apple platforms it is possible to
see EPROTOTYPE returned as an error. This is an undocumented and
special-case error code that appears to be associated with socket
shutdown, and so can fire when writing to a socket that is being shut
down by the other side. This should not be fired into the pipeline but
instead should be retried.

Modifications:

- Retry EPROTOTYPE errors on socket write methods.
- Add an (unfortunately) probabilistic test bed.

Result:

Should avoid weird error cases.
Resolves swift-server/async-http-client#322.