### PR TITLE
Add allocation test for adding multiple handlers

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_addHandlers.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_addHandlers.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+fileprivate final class SimpleHandler: ChannelInboundHandler {
+    typealias InboundIn = NIOAny
+}
+
+func run(identifier: String) {
+    measure(identifier: identifier) {
+        let iterations = 1000
+        for _ in 0..<iterations {
+            let channel = EmbeddedChannel()
+            defer {
+                _ = try! channel.finish()
+            }
+            try! channel.pipeline.addHandlers([
+                SimpleHandler(),
+                SimpleHandler()
+            ]).wait()
+        }
+        return iterations
+    }
+}

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -41,6 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]
 

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -41,6 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -41,6 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=108050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
 
 
   performance-test:

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -41,6 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
 
 
   performance-test:


### PR DESCRIPTION
Motivation:

I believe there is at least 1 avoidable allocation in this area.
Even if there isn't, making sure we don't increase allocations is good.

Modifications:

Add a test of allocations when adding multiple handlers.
Set limits for docker images.

Result:

Allocations when adding multiple handlers are now checked.