### PR TITLE
Remove an allocation from addHandlers

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_addHandlers.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_addHandlers.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+fileprivate final class SimpleHandler: ChannelInboundHandler {
+    typealias InboundIn = NIOAny
+}
+
+func run(identifier: String) {
+    measure(identifier: identifier) {
+        let iterations = 1000
+        for _ in 0..<iterations {
+            let channel = EmbeddedChannel()
+            defer {
+                _ = try! channel.finish()
+            }
+            try! channel.pipeline.addHandlers([
+                SimpleHandler(),
+                SimpleHandler()
+            ]).wait()
+        }
+        return iterations
+    }
+}

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.2
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=480050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=478050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]
 

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -41,6 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]
 

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -41,6 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:16.04-5.3
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=475050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=473050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -41,6 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=108050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
 
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31990
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=952050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=950050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4500
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=108050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
 
 
   performance-test:

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -19,7 +19,7 @@ services:
     image: swift-nio:18.04-5.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=477050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=475050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -41,6 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
 
 
   performance-test:

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=48050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
 
 
   performance-test:


### PR DESCRIPTION
Remove an allocation from addHandlers
    
Motivation:
    
Fewer allocations should improve performance.
    
Modifications:
    
Split out a sub function from addHandlers.
    
I originally thought I'd have to change the part of this
function which reads `var handlers = handlers` as there was
a surprising allocation at the beginning of this function.
It seems that breaking out some of the logic is sufficient
to remove an allocation.
    
Result:
    
1 fewer allocation.