### PR TITLE
DO NOT MERGE - Struct EventLoopFuture

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ var targets: [PackageDescription.Target] = [
                            "CNIOWindows",
                            "NIOConcurrencyHelpers",
                            "CNIOAtomics",
-                           "CNIOSHA1"]),
+                           "CNIOSHA1",
+                           .product(name: "Atomics", package: "swift-atomics")]),
     .target(name: "NIOFoundationCompat", dependencies: ["NIO"]),
     .target(name: "CNIOAtomics", dependencies: []),
     .target(name: "CNIOSHA1", dependencies: []),
@@ -96,6 +97,10 @@ let package = Package(
         .library(name: "NIOTestUtils", targets: ["NIOTestUtils"]),
     ],
     dependencies: [
+        .package(
+              url: "https://github.com/apple/swift-atomics.git",
+              from: "0.0.1"
+            )
     ],
     targets: targets
 )

--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -27,7 +27,7 @@
 
 private extension Array where Element == EventLoopFuture<Channel> {
     mutating func remove(element: Element) {
-        guard let channelIndex = self.firstIndex(where: { $0 === element }) else {
+        guard let channelIndex = self.firstIndex(where: { $0 == element }) else {
             return
         }
 
@@ -556,7 +556,7 @@ internal class HappyEyeballsConnector {
                     // The connection attempt failed. If we're in the complete state then there's nothing
                     // to do. Otherwise, notify the state machine of the failure.
                     if case .complete = self.state {
-                        assert(self.pendingConnections.firstIndex { $0 === channelFuture } == nil, "failed but was still in pending connections")
+                        assert(self.pendingConnections.firstIndex { $0 == channelFuture } == nil, "failed but was still in pending connections")
                     } else {
                         self.error.connectionErrors.append(SingleConnectionFailure(target: target, error: err))
                         self.pendingConnections.remove(element: channelFuture)

--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -95,14 +95,14 @@ internal final class SelectableEventLoop: EventLoop {
     private var _promiseCreationStore: [UInt: (file: StaticString, line: UInt)] = [:]
 
     @usableFromInline
-    internal func promiseCreationStoreAdd<T>(future: EventLoopFuture<T>, file: StaticString, line: UInt) {
+    internal func promiseCreationStoreAdd<T>(future: EventLoopFuture2<T>, file: StaticString, line: UInt) {
         precondition(_isDebugAssertConfiguration())
         self.promiseCreationStoreLock.withLock {
             self._promiseCreationStore[self.obfuscatePointerValue(future)] = (file: file, line: line)
         }
     }
 
-    internal func promiseCreationStoreRemove<T>(future: EventLoopFuture<T>) -> (file: StaticString, line: UInt) {
+    internal func promiseCreationStoreRemove<T>(future: EventLoopFuture2<T>) -> (file: StaticString, line: UInt) {
         precondition(_isDebugAssertConfiguration())
         return self.promiseCreationStoreLock.withLock {
             self._promiseCreationStore.removeValue(forKey: self.obfuscatePointerValue(future))!
@@ -346,7 +346,7 @@ internal final class SelectableEventLoop: EventLoop {
         }
     }
     
-    private func obfuscatePointerValue<T>(_ future: EventLoopFuture<T>) -> UInt {
+    private func obfuscatePointerValue<T>(_ future: EventLoopFuture2<T>) -> UInt {
         // Note:
         // 1. 0xbf15ca5d is randomly picked such that it fits into both 32 and 64 bit address spaces
         // 2. XOR with 0xbf15ca5d so that Memory Graph Debugger and other memory debugging tools

--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -95,14 +95,14 @@ internal final class SelectableEventLoop: EventLoop {
     private var _promiseCreationStore: [UInt: (file: StaticString, line: UInt)] = [:]
 
     @usableFromInline
-    internal func promiseCreationStoreAdd<T>(future: EventLoopFuture2<T>, file: StaticString, line: UInt) {
+    internal func promiseCreationStoreAdd<T>(future: RealEventLoopFuture<T>, file: StaticString, line: UInt) {
         precondition(_isDebugAssertConfiguration())
         self.promiseCreationStoreLock.withLock {
             self._promiseCreationStore[self.obfuscatePointerValue(future)] = (file: file, line: line)
         }
     }
 
-    internal func promiseCreationStoreRemove<T>(future: EventLoopFuture2<T>) -> (file: StaticString, line: UInt) {
+    internal func promiseCreationStoreRemove<T>(future: RealEventLoopFuture<T>) -> (file: StaticString, line: UInt) {
         precondition(_isDebugAssertConfiguration())
         return self.promiseCreationStoreLock.withLock {
             self._promiseCreationStore.removeValue(forKey: self.obfuscatePointerValue(future))!
@@ -346,7 +346,7 @@ internal final class SelectableEventLoop: EventLoop {
         }
     }
     
-    private func obfuscatePointerValue<T>(_ future: EventLoopFuture2<T>) -> UInt {
+    private func obfuscatePointerValue<T>(_ future: RealEventLoopFuture<T>) -> UInt {
         // Note:
         // 1. 0xbf15ca5d is randomly picked such that it fits into both 32 and 64 bit address spaces
         // 2. XOR with 0xbf15ca5d so that Memory Graph Debugger and other memory debugging tools

--- a/Tests/NIOTests/EventLoopFutureTest.swift
+++ b/Tests/NIOTests/EventLoopFutureTest.swift
@@ -764,7 +764,7 @@ class EventLoopFutureTest : XCTestCase {
 
         let noHoppingPromise = loop1.makePromise(of: Void.self)
         let noHoppingFuture = noHoppingPromise.futureResult.hop(to: loop1)
-        XCTAssertTrue(noHoppingFuture === noHoppingPromise.futureResult)
+        XCTAssertTrue(noHoppingFuture == noHoppingPromise.futureResult)
         noHoppingPromise.succeed(())
     }
 


### PR DESCRIPTION
An idea which was sitting in the back of my mind so I thought I'd sketch it out.

Make event loop future a struct - which for proper futures just contains the current EventLoopFuture but can directly contain the results when makeSucceeded, or makeFailed is used.

### Motivation:

Nio allocates loads of futures.  Allocation is known to be slow.

### Modifications:

Make event loop future a struct - which for proper futures just contains the current EventLoopFuture but can directly contain the results when makeSucceeded, or makeFailed is used.

### Result:

This is obviously API breaking.
It is source compatible though.
There are definitely fewer allocations when using this with current NIO applications.
**It is unfortunately also quite a lot slower** - I've not looked into why as it's just an idea for discussion.

There has previously been discussion of adding synchronous methods to NIO to avoid allocating futures which will be even faster than this.   When thinking about this from the point of view of adding channel handlers - if there was a sync method for adding handlers, you still need to allocate a future to return from the channelInitialiser method.  Of course that method could be changed too but if not careful all methods end up existing in sync and async forms with burden on the user and for maintenance.
