### PR TITLE
Clean up typo in method argument.

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -901,13 +901,13 @@ extension ChannelPipeline {
         }
 
         func addHandlersMakingPromise(handlers: [ChannelHandler],
-                                      individualPositin: ChannelPipeline.Position) -> EventLoopFuture<Void> {
+                                      transformedPosition: ChannelPipeline.Position) -> EventLoopFuture<Void> {
             let promise = self.eventLoop.makePromise(of: Void.self)
 
             // Add all the handlers.
             func addAllHandlersAndComplete() {
                 for handler in handlers {
-                    let addResult = self._add(handler, position: individualPosition)
+                    let addResult = self._add(handler, position: transformedPosition)
                     switch addResult {
                     case .success:
                         break // Keep going.
@@ -931,7 +931,7 @@ extension ChannelPipeline {
             return promise.futureResult
         }
 
-        return addHandlersMakingPromise(handlers: handlers, individualPositin: individualPosition)
+        return addHandlersMakingPromise(handlers: handlers, transformedPosition: individualPosition)
     }
 
     /// Adds the provided channel handlers to the pipeline in the order given, taking account


### PR DESCRIPTION
Motivation:

PR #1710 introduced a typo into the code. This typo was missed because
the argument name was shadowing a variable from parent scope, which was
inadvertently closed over.

Best to avoid that confusion.

Modifications:

- Fixed the typo
- Renamed the argument to reduce the risk of this happening again

Result:

Better code organisation.
