### PR TITLE
Only use ascii characters in perf test names.

### DIFF
--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -747,19 +747,19 @@ try measureAndPrint(desc: "websocket_encode_1kb_no_space_at_front_1k_frames",
  try measureAndPrint(desc: "websocket_decode_125b_100k_frames",
                      benchmark: WebSocketFrameDecoderBenchmark(dataSize: 125, runCount: 100_000))
 
-try measureAndPrint(desc: "websocket_decode_125b_with_а_masking_key_100k_frames",
+try measureAndPrint(desc: "websocket_decode_125b_with_a_masking_key_100k_frames",
                     benchmark: WebSocketFrameDecoderBenchmark(dataSize: 125, runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
 
 try measureAndPrint(desc: "websocket_decode_64kb_100k_frames",
                     benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max), runCount: 100_000))
 
-try measureAndPrint(desc: "websocket_decode_64kb_with_а_masking_key_100k_frames",
+try measureAndPrint(desc: "websocket_decode_64kb_with_a_masking_key_100k_frames",
                     benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max), runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
 
 try measureAndPrint(desc: "websocket_decode_64kb_+1_100k_frames",
                     benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max) + 1, runCount: 100_000))
 
-try measureAndPrint(desc: "websocket_decode_64kb_+1_with_а_masking_key_100k_frames",
+try measureAndPrint(desc: "websocket_decode_64kb_+1_with_a_masking_key_100k_frames",
                     benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max) + 1, runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
 
 try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1kb", benchmark: CircularBufferIntoByteBufferBenchmark(iterations: 10000, bufferSize: 1024))


### PR DESCRIPTION
Motivation:

Many other systems don't like non ascii characters.

Modifications:

Change a letter 'a' to a letter 'a' but with a more normal encoding.

Result:

Test names should be in ascii