### PR TITLE
order perf tests by name in docker files

### DIFF
--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -18,30 +18,30 @@ services:
   test:
     image: swift-nio:16.04-5.2
     environment:
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
+      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181010
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=478050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=100 # 5.2 improvement 10000
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5010
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5010
-      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
+      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010 # 5.2 improvement 4000
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=202050
-      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181010
-      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]
 

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -18,30 +18,30 @@ services:
   test:
     image: swift-nio:16.04-5.3
     environment:
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
+      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=473050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=100
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5010
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5010
-      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
+      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200500 #5.3 improvement 210050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=202050
-      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010
-      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -18,31 +18,30 @@ services:
   test:
     image: swift-nio:18.04-5.0
     environment:
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31990
+      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=189050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
+      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=108050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=950050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4500
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
-      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5010
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5010
-      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
+      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4500
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=230050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=18250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=213050
-      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=189050
-      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=108050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-
 
   performance-test:
     image: swift-nio:18.04-5.0

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -18,31 +18,30 @@ services:
   test:
     image: swift-nio:18.04-5.1
     environment:
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
+      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=475050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10100
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5010
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5010
-      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
+      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6010
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4440
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=210050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=202050
-      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181050
-      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=103050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-
 
   performance-test:
     image: swift-nio:18.04-5.1


### PR DESCRIPTION
Motivation:

When you make a change that affects many performance tests, it's often
easier to just copy the results from CI. Unfortunately, that makes the
diff hard to read because the order is arbitrary.

Modifications:

Sort the list so you can always easily get to the same order as the
docker file by using `| sort` or `:sort` in vim.

Result:

Easier to update perf tests.