### PR TITLE
Add static vars for common HTTP versions

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
@@ -27,7 +27,7 @@ final class RepeatedRequests: ChannelInboundHandler {
 	private var remainingNumberOfRequests: Int
 	private let isDonePromise: EventLoopPromise<Int>
 	static var requestHead: HTTPRequestHead {
-		var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/allocation-test-1")
+        var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/allocation-test-1")
 		head.headers.add(name: "Host", value: "foo-\(ObjectIdentifier(self)).com")
 		return head
 	}
@@ -71,7 +71,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
     private let numberOfAdditionalHeaders = 3
 
     private var responseHead: HTTPResponseHead {
-        var head = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok)
+        var head = HTTPResponseHead(version: .http1_1, status: .ok)
         head.headers.add(name: "Content-Length", value: "\(self.bodyLength)")
         for i in 0..<self.numberOfAdditionalHeaders {
             head.headers.add(name: "X-Random-Extra-Header", value: "\(i)")

--- a/Sources/NIO/SingleStepByteToMessageDecoder.swift
+++ b/Sources/NIO/SingleStepByteToMessageDecoder.swift
@@ -166,7 +166,7 @@ extension NIOSingleStepByteToMessageDecoder {
 ///                 headers.add(name: "content-length", value: String(responseBuffer.readableBytes))
 ///
 ///                 context.write(self.wrapOutboundOut(HTTPServerResponsePart.head(
-///                     HTTPResponseHead(version: .init(major: 1, minor: 1),
+///                     HTTPResponseHead(version: .http1_1,
 ///                                      status: .ok, headers: headers))), promise: nil)
 ///
 ///                 context.write(self.wrapOutboundOut(HTTPServerResponsePart.body(

--- a/Sources/NIOCrashTester/CrashTests+HTTP.swift
+++ b/Sources/NIOCrashTester/CrashTests+HTTP.swift
@@ -22,7 +22,7 @@ struct HTTPCrashTests {
             let channel = EmbeddedChannel(handler: HTTPRequestEncoder())
             _ = try? channel.writeAndFlush(
                 HTTPClientRequestPart.head(
-                    HTTPRequestHead(version: .init(major: 1, minor: 1),
+                    HTTPRequestHead(version: .http1_1,
                                     method: .POST,
                                     uri: "/",
                                     headers: ["content-Length": "1",
@@ -35,7 +35,7 @@ struct HTTPCrashTests {
             let channel = EmbeddedChannel(handler: HTTPResponseEncoder())
             _ = try? channel.writeAndFlush(
                 HTTPServerResponsePart.head(
-                    HTTPResponseHead(version: .init(major: 1, minor: 1),
+                    HTTPResponseHead(version: .http1_1,
                                      status: .ok,
                                      headers: ["content-Length": "1",
                                                "transfer-Encoding": "chunked"]))).wait()

--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -46,7 +46,7 @@ public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler, Removab
         // to come along and close the channel right after we return from this function.
         if !self.hasUnterminatedResponse {
             let headers = HTTPHeaders([("Connection", "close"), ("Content-Length", "0")])
-            let head = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .badRequest, headers: headers)
+            let head = HTTPResponseHead(version: .http1_1, status: .badRequest, headers: headers)
             context.write(self.wrapOutboundOut(.head(head)), promise: nil)
             context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
         }

--- a/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
@@ -267,7 +267,7 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
 
     /// Sends the 101 Switching Protocols response for the pipeline.
     private func sendUpgradeResponse(context: ChannelHandlerContext, upgradeRequest: HTTPRequestHead, responseHeaders: HTTPHeaders) -> EventLoopFuture<Void> {
-        var response = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .switchingProtocols)
+        var response = HTTPResponseHead(version: .http1_1, status: .switchingProtocols)
         response.headers = responseHeaders
         return context.writeAndFlush(wrapOutboundOut(HTTPServerResponsePart.head(response)))
     }

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -679,6 +679,20 @@ public struct HTTPVersion: Equatable {
         }
     }
 
+    /// HTTP/3
+    public static let http3 = HTTPVersion(major: 3, minor: 0)
+
+    /// HTTP/2
+    public static let http2 = HTTPVersion(major: 2, minor: 0)
+
+    /// HTTP/1.1
+    public static let http1_1 = HTTPVersion(major: 1, minor: 1)
+
+    /// HTTP/1.0
+    public static let http1_0 = HTTPVersion(major: 1, minor: 0)
+
+    /// HTTP/0.9 (not supported by SwiftNIO)
+    public static let http0_9 = HTTPVersion(major: 0, minor: 9)
 }
 
 extension HTTPParserError: CustomDebugStringConvertible {

--- a/Sources/NIOHTTP1/NIOHTTPObjectAggregator.swift
+++ b/Sources/NIOHTTP1/NIOHTTPObjectAggregator.swift
@@ -277,7 +277,7 @@ public final class NIOHTTPServerRequestAggregator: ChannelInboundHandler, Remova
 
     private func handleOversizeMessage(message: InboundIn) -> HTTPResponseHead {
         var payloadTooLargeHead = HTTPResponseHead(
-            version: self.fullMessageHead?.version ?? .init(major: 1, minor: 1),
+            version: self.fullMessageHead?.version ?? .http1_1,
             status: .payloadTooLarge,
             headers: HTTPHeaders([("content-length", "0")]))
 

--- a/Sources/NIOHTTP1Client/main.swift
+++ b/Sources/NIOHTTP1Client/main.swift
@@ -36,7 +36,7 @@ private final class HTTPEchoHandler: ChannelInboundHandler {
         // The sample server has more functionality which can be easily tested by playing with the URI.
         // For example, try "/dynamic/count-to-ten" or "/dynamic/client-ip"
         
-        let requestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
+        let requestHead = HTTPRequestHead(version: .http1_1,
                                           method: .GET,
                                           uri: "/dynamic/echo",
                                           headers: headers)

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -74,7 +74,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
     private let numberOfAdditionalHeaders = 10
 
     init() {
-        var head = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok)
+        var head = HTTPResponseHead(version: .http1_1, status: .ok)
         head.headers.add(name: "Content-Length", value: "\(self.bodyLength)")
         for i in 0..<self.numberOfAdditionalHeaders {
             head.headers.add(name: "X-Random-Extra-Header", value: "\(i)")
@@ -100,7 +100,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
                 context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
                 return
             case "/perf-test-2":
-                var req = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok)
+                var req = HTTPResponseHead(version: .http1_1, status: .ok)
                 for i in 1...8 {
                     req.headers.add(name: "X-ResponseHeader-\(i)", value: "foo")
                 }
@@ -133,7 +133,7 @@ defer {
     try! serverChannel.close().wait()
 }
 
-var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/perf-test-1")
+var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/perf-test-1")
 head.headers.add(name: "Host", value: "localhost")
 
 final class RepeatedRequests: ChannelInboundHandler {

--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -137,7 +137,7 @@ private final class AggregateBodyHandler: ChannelInboundHandler {
 ///     // Assert the server received the expected request.
 ///     // Use custom methods if you only want some specific assertions on part
 ///     // of the request.
-///     XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .init(major: 1, minor: 1),
+///     XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .http1_1,
 ///                                                 method: .GET,
 ///                                                 uri: "/some-route",
 ///                                                 headers: .init([
@@ -155,7 +155,7 @@ private final class AggregateBodyHandler: ChannelInboundHandler {
 ///     let responseBody = "pong"
 ///     var responseBuffer = allocator.buffer(capacity: 128)
 ///     responseBuffer.writeString(responseBody)
-///     XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .init(major: 1, minor: 1), status: .ok))))
+///     XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .http1_1, status: .ok))))
 ///     XCTAssertNoThrow(try testServer.writeOutbound(.body(.byteBuffer(responseBuffer))))
 ///     XCTAssertNoThrow(try testServer.writeOutbound(.end(nil)))
 ///

--- a/Sources/NIOWebSocketClient/main.swift
+++ b/Sources/NIOWebSocketClient/main.swift
@@ -33,7 +33,7 @@ private final class HTTPInitialRequestHandler: ChannelInboundHandler, RemovableC
         headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
         headers.add(name: "Content-Length", value: "\(0)")
         
-        let requestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
+        let requestHead = HTTPRequestHead(version: .http1_1,
                                           method: .GET,
                                           uri: "/",
                                           headers: headers)

--- a/Sources/NIOWebSocketServer/main.swift
+++ b/Sources/NIOWebSocketServer/main.swift
@@ -88,7 +88,7 @@ private final class HTTPHandler: ChannelInboundHandler, RemovableChannelHandler 
         var headers = HTTPHeaders()
         headers.add(name: "Connection", value: "close")
         headers.add(name: "Content-Length", value: "0")
-        let head = HTTPResponseHead(version: .init(major: 1, minor: 1),
+        let head = HTTPResponseHead(version: .http1_1,
                                     status: .methodNotAllowed,
                                     headers: headers)
         context.write(self.wrapOutboundOut(.head(head)), promise: nil)

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -217,7 +217,7 @@ extension ChannelInboundHandler where OutboundOut == HTTPClientRequestPart {
         headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
         headers.add(name: "Content-Length", value: "\(0)")
         
-        let requestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
+        let requestHead = HTTPRequestHead(version: .http1_1,
                                           method: .GET,
                                           uri: "/",
                                           headers: headers)
@@ -863,7 +863,7 @@ class HTTPClientUpgradeTestCase: XCTestCase {
         }
 
         // Send another outbound request during the upgrade.
-        let requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: "/")
+        let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
         let secondRequest: HTTPClientRequestPart = .head(requestHead)
         clientChannel.writeAndFlush(secondRequest, promise: promise)
         
@@ -910,7 +910,7 @@ class HTTPClientUpgradeTestCase: XCTestCase {
         
         let headers = HTTPHeaders([("Connection", "upgrade"),
                                    ("Upgrade", "\(upgradeProtocol)")])
-        let head = HTTPResponseHead(version: .init(major: 1, minor: 1),
+        let head = HTTPResponseHead(version: .http1_1,
                                     status: .switchingProtocols,
                                     headers: headers)
         let response = HTTPClientResponsePart.head(head)

--- a/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderLengthTest.swift
@@ -164,19 +164,19 @@ class HTTPDecoderLengthTest: XCTestCase {
     }
 
     func testHTTP11SemanticEOFOnChannelInactive() throws {
-        try assertSemanticEOFOnChannelInactiveResponse(version: .init(major:1, minor: 1), how: .channelInactive)
+        try assertSemanticEOFOnChannelInactiveResponse(version: .http1_1, how: .channelInactive)
     }
 
     func testHTTP10SemanticEOFOnChannelInactive() throws {
-        try assertSemanticEOFOnChannelInactiveResponse(version: .init(major:1, minor: 0), how: .channelInactive)
+        try assertSemanticEOFOnChannelInactiveResponse(version: .http1_0, how: .channelInactive)
     }
 
     func testHTTP11SemanticEOFOnHalfClosure() throws {
-        try assertSemanticEOFOnChannelInactiveResponse(version: .init(major:1, minor: 1), how: .halfClosure)
+        try assertSemanticEOFOnChannelInactiveResponse(version: .http1_1, how: .halfClosure)
     }
 
     func testHTTP10SemanticEOFOnHalfClosure() throws {
-        try assertSemanticEOFOnChannelInactiveResponse(version: .init(major:1, minor: 0), how: .halfClosure)
+        try assertSemanticEOFOnChannelInactiveResponse(version: .http1_0, how: .halfClosure)
     }
 
     private func assertIgnoresLengthFields(requestMethod: HTTPMethod,
@@ -189,7 +189,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         // Prime the decoder with a request and consume it.
-        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
+        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .http1_1,
                                                                                            method: requestMethod,
                                                                                            uri: "/"))).isFull)
         XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
@@ -330,7 +330,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         // Prime the decoder with a request and consume it.
-        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
+        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .http1_1,
                                                                                            method: .GET,
                                                                                            uri: "/"))).isFull)
         XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
@@ -369,7 +369,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
 
         // Prime the decoder with a request and consume it.
-        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
+        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .http1_1,
                                                                                            method: .GET,
                                                                                            uri: "/"))).isFull)
         XCTAssertNoThrow(XCTAssertNotNil(try channel.readOutbound(as: ByteBuffer.self)))
@@ -451,7 +451,7 @@ class HTTPDecoderLengthTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(ByteToMessageHandler(HTTPResponseDecoder())).wait())
 
         // Prime the decoder with a request.
-        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1),
+        XCTAssertTrue(try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .http1_1,
                                                                                            method: .GET,
                                                                                            uri: "/"))).isFull)
 

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -193,32 +193,32 @@ class HTTPHeadersTest : XCTestCase {
         var headers = HTTPHeaders([("Connection", "close")])
 
         XCTAssertEqual("close", headers["connection"].first)
-        XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
+        XCTAssertFalse(headers.isKeepAlive(version: .http1_1))
 
         headers.replaceOrAdd(name: "connection", value: "keep-alive")
 
         XCTAssertEqual("keep-alive", headers["connection"].first)
-        XCTAssertTrue(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
+        XCTAssertTrue(headers.isKeepAlive(version: .http1_1))
 
         headers.remove(name: "connection")
-        XCTAssertTrue(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
-        XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 0)))
+        XCTAssertTrue(headers.isKeepAlive(version: .http1_1))
+        XCTAssertFalse(headers.isKeepAlive(version: .http1_0))
     }
 
     func testKeepAliveStateStartsWithKeepAlive() {
         var headers = HTTPHeaders([("Connection", "keep-alive")])
 
         XCTAssertEqual("keep-alive", headers["connection"].first)
-        XCTAssertTrue(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
+        XCTAssertTrue(headers.isKeepAlive(version: .http1_1))
 
         headers.replaceOrAdd(name: "connection", value: "close")
 
         XCTAssertEqual("close", headers["connection"].first)
-        XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
+        XCTAssertFalse(headers.isKeepAlive(version: .http1_1))
 
         headers.remove(name: "connection")
-        XCTAssertTrue(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
-        XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 0)))
+        XCTAssertTrue(headers.isKeepAlive(version: .http1_1))
+        XCTAssertFalse(headers.isKeepAlive(version: .http1_0))
     }
 
     func testKeepAliveStateHasKeepAlive() {
@@ -226,7 +226,7 @@ class HTTPHeadersTest : XCTestCase {
                                    ("Content-Type", "text/html"),
                                    ("Connection", "server, x-options")])
         
-        XCTAssertTrue(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
+        XCTAssertTrue(headers.isKeepAlive(version: .http1_1))
     }
 
     func testKeepAliveStateHasClose() {
@@ -234,7 +234,7 @@ class HTTPHeadersTest : XCTestCase {
                                    ("Content-Type", "text/html"),
                                    ("Connection", "server,     clOse")])
         
-        XCTAssertFalse(headers.isKeepAlive(version: HTTPVersion(major: 1, minor: 1)))
+        XCTAssertFalse(headers.isKeepAlive(version: .http1_1))
     }
         
     func testRandomAccess() {
@@ -268,10 +268,10 @@ class HTTPHeadersTest : XCTestCase {
     func testSeedDominatesActualValue() {
         // we may later on decide that this test doesn't make sense but for now we want to keep the seeding behaviour
         let headersSeededWithClose = HTTPHeaders([], keepAliveState: .close)
-        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .http1_1))
 
         let headersSeededWithKeepAlive = HTTPHeaders([], keepAliveState: .keepAlive)
-        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .http1_0))
     }
 
     func testSeedDominatesEvenAfterMutation() {
@@ -280,61 +280,61 @@ class HTTPHeadersTest : XCTestCase {
         headersSeededWithClose.add(name: "foo", value: "bar")
         headersSeededWithClose.add(name: "bar", value: "qux")
         headersSeededWithClose.remove(name: "bar")
-        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 1)))
+        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .http1_1))
 
         var headersSeededWithKeepAlive = HTTPHeaders([], keepAliveState: .keepAlive)
         headersSeededWithKeepAlive.add(name: "foo", value: "bar")
         headersSeededWithKeepAlive.add(name: "bar", value: "qux")
         headersSeededWithKeepAlive.remove(name: "bar")
-        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .http1_0))
     }
 
     func testSeedGetsUpdatedToDefaultOnConnectionHeaderModification() {
         var headersSeededWithClose = HTTPHeaders([], keepAliveState: .close)
         headersSeededWithClose.add(name: "connection", value: "bar")
-        XCTAssertEqual(true, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 1)))
-        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(true, headersSeededWithClose.isKeepAlive(version: .http1_1))
+        XCTAssertEqual(false, headersSeededWithClose.isKeepAlive(version: .http1_0))
 
         var headersSeededWithKeepAlive = HTTPHeaders([], keepAliveState: .keepAlive)
         headersSeededWithKeepAlive.add(name: "connection", value: "bar")
-        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 1)))
-        XCTAssertEqual(false, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(true, headersSeededWithKeepAlive.isKeepAlive(version: .http1_1))
+        XCTAssertEqual(false, headersSeededWithKeepAlive.isKeepAlive(version: .http1_0))
     }
 
     func testSeedGetsUpdatedToWhateverTheHeaderSaysIfPresent() {
         var headersSeededWithClose = HTTPHeaders([], keepAliveState: .close)
         headersSeededWithClose.add(name: "connection", value: "bar,keep-alive,true")
-        XCTAssertEqual(true, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 1)))
-        XCTAssertEqual(true, headersSeededWithClose.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(true, headersSeededWithClose.isKeepAlive(version: .http1_1))
+        XCTAssertEqual(true, headersSeededWithClose.isKeepAlive(version: .http1_0))
 
         var headersSeededWithKeepAlive = HTTPHeaders([], keepAliveState: .keepAlive)
         headersSeededWithKeepAlive.add(name: "connection", value: "bar,close,true")
-        XCTAssertEqual(false, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 1)))
-        XCTAssertEqual(false, headersSeededWithKeepAlive.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(false, headersSeededWithKeepAlive.isKeepAlive(version: .http1_1))
+        XCTAssertEqual(false, headersSeededWithKeepAlive.isKeepAlive(version: .http1_0))
     }
 
     func testWeDefaultToCloseIfDoesNotMakeSense() {
         var nonSenseInOneHeaderCK = HTTPHeaders([])
         nonSenseInOneHeaderCK.add(name: "connection", value: "close,keep-alive")
-        XCTAssertEqual(false, nonSenseInOneHeaderCK.isKeepAlive(version: .init(major: 1, minor: 1)))
-        XCTAssertEqual(false, nonSenseInOneHeaderCK.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(false, nonSenseInOneHeaderCK.isKeepAlive(version: .http1_1))
+        XCTAssertEqual(false, nonSenseInOneHeaderCK.isKeepAlive(version: .http1_0))
 
         var nonSenseInMultipleHeadersCK = HTTPHeaders([])
         nonSenseInMultipleHeadersCK.add(name: "connection", value: "close")
         nonSenseInMultipleHeadersCK.add(name: "connection", value: "keep-alive")
-        XCTAssertEqual(false, nonSenseInMultipleHeadersCK.isKeepAlive(version: .init(major: 1, minor: 1)))
-        XCTAssertEqual(false, nonSenseInMultipleHeadersCK.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(false, nonSenseInMultipleHeadersCK.isKeepAlive(version: .http1_1))
+        XCTAssertEqual(false, nonSenseInMultipleHeadersCK.isKeepAlive(version: .http1_0))
 
         var nonSenseInOneHeaderKC = HTTPHeaders([])
         nonSenseInOneHeaderKC.add(name: "connection", value: "keep-alive,close")
-        XCTAssertEqual(false, nonSenseInOneHeaderKC.isKeepAlive(version: .init(major: 1, minor: 1)))
-        XCTAssertEqual(false, nonSenseInOneHeaderKC.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(false, nonSenseInOneHeaderKC.isKeepAlive(version: .http1_1))
+        XCTAssertEqual(false, nonSenseInOneHeaderKC.isKeepAlive(version: .http1_0))
 
         var nonSenseInMultipleHeadersKC = HTTPHeaders([])
         nonSenseInMultipleHeadersKC.add(name: "connection", value: "keep-alive")
         nonSenseInMultipleHeadersKC.add(name: "connection", value: "close")
-        XCTAssertEqual(false, nonSenseInMultipleHeadersKC.isKeepAlive(version: .init(major: 1, minor: 1)))
-        XCTAssertEqual(false, nonSenseInMultipleHeadersKC.isKeepAlive(version: .init(major: 1, minor: 0)))
+        XCTAssertEqual(false, nonSenseInMultipleHeadersKC.isKeepAlive(version: .http1_1))
+        XCTAssertEqual(false, nonSenseInMultipleHeadersKC.isKeepAlive(version: .http1_0))
     }
 
     func testAddingSequenceOfPairs() {

--- a/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPRequestEncoderTest.swift
@@ -30,7 +30,7 @@ class HTTPRequestEncoderTests: XCTestCase {
         }
 
         try channel.pipeline.addHandler(HTTPRequestEncoder()).wait()
-        var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: method, uri: "/uri")
+        var request = HTTPRequestHead(version: .http1_1, method: method, uri: "/uri")
         request.headers = headers
         try channel.writeOutbound(HTTPClientRequestPart.head(request))
         if let buffer = try channel.readOutbound(as: ByteBuffer.self) {
@@ -93,7 +93,7 @@ class HTTPRequestEncoderTests: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
 
         // This request contains neither Transfer-Encoding: chunked or Content-Length.
-        let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:0), method: .GET, uri: "/uri")
+        let request = HTTPRequestHead(version: .http1_0, method: .GET, uri: "/uri")
         XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(request)))
         let writtenData = try channel.readOutbound(as: ByteBuffer.self)!
         let writtenResponse = writtenData.getString(at: writtenData.readerIndex, length: writtenData.readableBytes)!
@@ -107,7 +107,7 @@ class HTTPRequestEncoderTests: XCTestCase {
         }
 
         try channel.pipeline.addHandler(HTTPRequestEncoder()).wait()
-        var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .POST, uri: "/uri")
+        var request = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/uri")
         request.headers.add(name: "content-length", value: "4")
 
         var buf = channel.allocator.buffer(capacity: 4)
@@ -130,7 +130,7 @@ class HTTPRequestEncoderTests: XCTestCase {
 
         let uri = "server.example.com:80"
         try channel.pipeline.addHandler(HTTPRequestEncoder()).wait()
-        var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .CONNECT, uri: uri)
+        var request = HTTPRequestHead(version: .http1_1, method: .CONNECT, uri: uri)
         request.headers.add(name: "Host", value: uri)
 
         XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(request)))
@@ -145,7 +145,7 @@ class HTTPRequestEncoderTests: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 16)
         var expected = channel.allocator.buffer(capacity: 32)
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(.init(version: .init(major: 1, minor: 1),
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(.init(version: .http1_1,
                                                                                     method: .POST,
                                                                                     uri: "/"))))
         expected.writeString("POST / HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n")
@@ -177,7 +177,7 @@ class HTTPRequestEncoderTests: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 16)
         var expected = channel.allocator.buffer(capacity: 32)
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(.init(version: .init(major: 1, minor: 1),
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(.init(version: .http1_1,
                                                                                     method: .POST,
                                                                                     uri: "/",
                                                                                     headers: ["TrAnSfEr-encoding": "chuNKED"]))))
@@ -210,7 +210,7 @@ class HTTPRequestEncoderTests: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 16)
         var expected = channel.allocator.buffer(capacity: 32)
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(.init(version: .init(major: 1, minor: 1),
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(.init(version: .http1_1,
                                                                                     method: .POST,
                                                                                     uri: "/"))))
         expected.writeString("POST / HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n")
@@ -234,7 +234,7 @@ class HTTPRequestEncoderTests: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 16)
         var expected = channel.allocator.buffer(capacity: 32)
 
-        channel.write(HTTPClientRequestPart.head(.init(version: .init(major: 1, minor: 1),
+        channel.write(HTTPClientRequestPart.head(.init(version: .http1_1,
                                                        method: .POST,
                                                        uri: "/")), promise: nil)
         channel.flush()

--- a/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
@@ -30,7 +30,7 @@ class HTTPResponseEncoderTests: XCTestCase {
         }
 
         XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait())
-        var switchingResponse = HTTPResponseHead(version: HTTPVersion(major: 1, minor:1), status: status)
+        var switchingResponse = HTTPResponseHead(version: .http1_1, status: status)
         switchingResponse.headers = headers
         XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(switchingResponse)))
         do {
@@ -108,7 +108,7 @@ class HTTPResponseEncoderTests: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait())
 
         // This response contains neither Transfer-Encoding: chunked or Content-Length.
-        let response = HTTPResponseHead(version: HTTPVersion(major: 1, minor:0), status: .ok)
+        let response = HTTPResponseHead(version: .http1_0, status: .ok)
         XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(response)))
         guard let b = try channel.readOutbound(as: ByteBuffer.self) else {
             XCTFail("Could not read byte buffer")

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -325,7 +325,7 @@ class HTTPServerClientTest : XCTestCase {
     }
 
     private func testSimpleGet(_ mode: SendMode,
-                               httpVersion: HTTPVersion = .init(major: 1, minor: 1),
+                               httpVersion: HTTPVersion = .http1_1,
                                uri: String = "/helloworld",
                                expectedHeaders maybeExpectedHeaders: HTTPHeaders? = nil) throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -391,7 +391,7 @@ class HTTPServerClientTest : XCTestCase {
         expectedHeaders.add(name: "transfer-encoding", value: "chunked")
         expectedHeaders.add(name: "connection", value: "close")
 
-        let accumulation = HTTPClientResponsePartAssertHandler(HTTPVersion(major: 1, minor: 1), .ok, expectedHeaders, "12345678910")
+        let accumulation = HTTPClientResponsePartAssertHandler(.http1_1, .ok, expectedHeaders, "12345678910")
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
@@ -422,7 +422,7 @@ class HTTPServerClientTest : XCTestCase {
             XCTAssertNoThrow(try clientChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/count-to-ten")
+        var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/count-to-ten")
         head.headers.add(name: "Host", value: "apple.com")
         clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
         try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
@@ -451,7 +451,7 @@ class HTTPServerClientTest : XCTestCase {
         expectedTrailers.add(name: "x-url-path", value: "/trailers")
         expectedTrailers.add(name: "x-should-trail", value: "sure")
 
-        let accumulation = HTTPClientResponsePartAssertHandler(HTTPVersion(major: 1, minor: 1), .ok, expectedHeaders, "12345678910", expectedTrailers)
+        let accumulation = HTTPClientResponsePartAssertHandler(.http1_1, .ok, expectedHeaders, "12345678910", expectedTrailers)
 
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
@@ -478,7 +478,7 @@ class HTTPServerClientTest : XCTestCase {
             XCTAssertNoThrow(try clientChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/trailers")
+        var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/trailers")
         head.headers.add(name: "Host", value: "apple.com")
         clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
         try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
@@ -549,7 +549,7 @@ class HTTPServerClientTest : XCTestCase {
         expectedHeaders.add(name: "content-length", value: "5000")
         expectedHeaders.add(name: "connection", value: "close")
 
-        let accumulation = HTTPClientResponsePartAssertHandler(HTTPVersion(major: 1, minor: 1), .ok, expectedHeaders, "")
+        let accumulation = HTTPClientResponsePartAssertHandler(.http1_1, .ok, expectedHeaders, "")
 
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
@@ -576,7 +576,7 @@ class HTTPServerClientTest : XCTestCase {
             XCTAssertNoThrow(try clientChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .HEAD, uri: "/head")
+        var head = HTTPRequestHead(version: .http1_1, method: .HEAD, uri: "/head")
         head.headers.add(name: "Host", value: "apple.com")
         clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
         try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
@@ -593,7 +593,7 @@ class HTTPServerClientTest : XCTestCase {
         var expectedHeaders = HTTPHeaders()
         expectedHeaders.add(name: "connection", value: "keep-alive")
 
-        let accumulation = HTTPClientResponsePartAssertHandler(HTTPVersion(major: 1, minor: 1), .noContent, expectedHeaders, "")
+        let accumulation = HTTPClientResponsePartAssertHandler(.http1_1, .noContent, expectedHeaders, "")
 
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
@@ -619,7 +619,7 @@ class HTTPServerClientTest : XCTestCase {
             XCTAssertNoThrow(try clientChannel.syncCloseAcceptingAlreadyClosed())
         }
 
-        var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/204")
+        var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/204")
         head.headers.add(name: "Host", value: "apple.com")
         clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
         try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
@@ -629,7 +629,7 @@ class HTTPServerClientTest : XCTestCase {
 
     func testNoResponseHeaders() {
         XCTAssertNoThrow(try self.testSimpleGet(.byteBuffer,
-                                                httpVersion: .init(major: 1, minor: 0),
+                                                httpVersion: .http1_0,
                                                 uri: "/no-headers",
                                                 expectedHeaders: [:]))
     }

--- a/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
@@ -122,10 +122,10 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(self.readRecorder).wait())
         XCTAssertNoThrow(try channel.pipeline.addHandler(self.quiesceEventRecorder).wait())
 
-        self.requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: "/path")
+        self.requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/path")
         self.requestHead.headers.add(name: "Host", value: "example.com")
 
-        self.responseHead = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok)
+        self.responseHead = HTTPResponseHead(version: .http1_1, status: .ok)
         self.responseHead.headers.add(name: "Server", value: "SwiftNIO")
 
         // this activates the channel
@@ -403,7 +403,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
 
     func testRecursiveChannelReadInvocationsDoNotCauseIssues() throws {
         func makeRequestHead(uri: String) -> HTTPRequestHead {
-            var requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: uri)
+            var requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: uri)
             requestHead.headers.add(name: "Host", value: "example.com")
             return requestHead
         }
@@ -454,7 +454,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                     default:
                         XCTFail("didn't expect \(head)")
                     }
-                    context.write(self.wrapOutboundOut(.head(HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok))), promise: nil)
+                    context.write(self.wrapOutboundOut(.head(HTTPResponseHead(version: .http1_1, status: .ok))), promise: nil)
                     if sendEnd {
                         context.write(self.wrapOutboundOut(.end(nil)), promise: nil)
                     }
@@ -467,7 +467,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                         self.state = .req3HeadExpected
 
                         // this will cause `channelRead` to be recursively called and we need to make sure everything then still works
-                        try! (context.channel as! EmbeddedChannel).writeInbound(HTTPServerRequestPart.head(HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: "/req_boom")))
+                        try! (context.channel as! EmbeddedChannel).writeInbound(HTTPServerRequestPart.head(HTTPRequestHead(version: .http1_1, method: .GET, uri: "/req_boom")))
                         try! (context.channel as! EmbeddedChannel).writeInbound(HTTPServerRequestPart.end(nil))
                     case .req3EndExpected:
                         self.state = .reqBoomHeadExpected
@@ -763,7 +763,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
 
     func testLegitRequestFollowedByParserErrorArrivingWhilstResponseOutstanding() throws {
         func makeRequestHead(uri: String) -> HTTPRequestHead {
-            var requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: uri)
+            var requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: uri)
             requestHead.headers.add(name: "Host", value: "example.com")
             return requestHead
         }
@@ -792,7 +792,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                     // We dispatch this to the event loop so that it doesn't happen immediately but rather can be
                     // run from the driving test code whenever it wants by running the EmbeddedEventLoop.
                     context.eventLoop.execute {
-                        context.writeAndFlush(self.wrapOutboundOut(.head(.init(version: HTTPVersion(major: 1, minor: 1),
+                        context.writeAndFlush(self.wrapOutboundOut(.head(.init(version: .http1_1,
                                                                            status: .ok))),
                                           promise: nil)
                     }

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -80,7 +80,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
         }
 
         XCTAssertNoThrow(try channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false, withErrorHandling: true).wait())
-        let res = HTTPServerResponsePart.head(.init(version: HTTPVersion(major: 1, minor: 1),
+        let res = HTTPServerResponsePart.head(.init(version: .http1_1,
                                                     status: .ok,
                                                     headers: .init([("Content-Length", "0")])))
         XCTAssertNoThrow(try channel.writeAndFlush(res).wait())
@@ -113,7 +113,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
                 case .head:
                     XCTAssertEqual(.head, self.nextExpected)
                     self.nextExpected = .end
-                    let res = HTTPServerResponsePart.head(.init(version: HTTPVersion(major: 1, minor: 1),
+                    let res = HTTPServerResponsePart.head(.init(version: .http1_1,
                                                                 status: .ok,
                                                                 headers: .init([("Content-Length", "0")])))
                     context.writeAndFlush(self.wrapOutboundOut(res), promise: nil)

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -623,7 +623,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
                 XCTAssertEqual(proto, "myproto")
                 XCTAssertEqual(req.method, .OPTIONS)
                 XCTAssertEqual(req.uri, "*")
-                XCTAssertEqual(req.version, HTTPVersion(major: 1, minor: 1))
+                XCTAssertEqual(req.version, .http1_1)
             } else {
                 XCTFail("Unexpected event: \(eventSaver.events[0])")
             }
@@ -1031,7 +1031,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
 
         // We now need to inject an extra buffered request. To do this we grab the context for the HTTPRequestDecoder and inject some reads.
         XCTAssertNoThrow(try channel.pipeline.context(handlerType: ByteToMessageHandler<HTTPRequestDecoder>.self).map { context in
-            let requestHead = HTTPServerRequestPart.head(.init(version: .init(major: 1, minor: 1), method: .GET, uri: "/test"))
+            let requestHead = HTTPServerRequestPart.head(.init(version: .http1_1, method: .GET, uri: "/test"))
             context.fireChannelRead(NIOAny(requestHead))
             context.fireChannelRead(NIOAny(HTTPServerRequestPart.end(nil)))
         }.wait())

--- a/Tests/NIOHTTP1Tests/HTTPTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest.swift
@@ -157,27 +157,27 @@ class HTTPTest: XCTestCase {
     }
 
     func testHTTPSimpleNoHeaders() throws {
-        try checkHTTPRequest(HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/"))
+        try checkHTTPRequest(HTTPRequestHead(version: .http1_1, method: .GET, uri: "/"))
     }
 
     func testHTTPSimple1Header() throws {
-        var req = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/hello/world")
+        var req = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/hello/world")
         req.headers.add(name: "foo", value: "bar")
         try checkHTTPRequest(req)
     }
 
     func testHTTPSimpleSomeHeader() throws {
-        var req = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/foo/bar/buz?qux=quux")
+        var req = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/foo/bar/buz?qux=quux")
         req.headers.add(name: "foo", value: "bar")
         req.headers.add(name: "qux", value: "quuux")
         try checkHTTPRequest(req)
     }
 
     func testHTTPPipelining() throws {
-        var req1 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/foo/bar/buz?qux=quux")
+        var req1 = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/foo/bar/buz?qux=quux")
         req1.headers.add(name: "foo", value: "bar")
         req1.headers.add(name: "qux", value: "quuux")
-        var req2 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/")
+        var req2 = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
         req2.headers.add(name: "a", value: "b")
         req2.headers.add(name: "C", value: "D")
 
@@ -186,17 +186,17 @@ class HTTPTest: XCTestCase {
     }
 
     func testHTTPBody() throws {
-        try checkHTTPRequest(HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/"),
+        try checkHTTPRequest(HTTPRequestHead(version: .http1_1, method: .GET, uri: "/"),
                              body: "hello world")
     }
 
     func test1ByteHTTPBody() throws {
-        try checkHTTPRequest(HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/"),
+        try checkHTTPRequest(HTTPRequestHead(version: .http1_1, method: .GET, uri: "/"),
                              body: "1")
     }
 
     func testHTTPPipeliningWithBody() throws {
-        try checkHTTPRequests(Array(repeating: HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
+        try checkHTTPRequests(Array(repeating: HTTPRequestHead(version: .http1_1,
                                                                method: .GET, uri: "/"),
                                     count: 20),
                              body: "1")
@@ -206,18 +206,18 @@ class HTTPTest: XCTestCase {
         var trailers = HTTPHeaders()
         trailers.add(name: "X-Key", value: "X-Value")
         trailers.add(name: "Something", value: "Else")
-        try checkHTTPRequest(HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .POST, uri: "/"), body: "100", trailers: trailers)
+        try checkHTTPRequest(HTTPRequestHead(version: .http1_1, method: .POST, uri: "/"), body: "100", trailers: trailers)
     }
 
     func testHTTPRequestHeadCoWWorks() throws {
         let headers = HTTPHeaders([("foo", "bar")])
-        var httpReq = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/uri")
+        var httpReq = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/uri")
         httpReq.headers = headers
 
         var modVersion = httpReq
-        modVersion.version = HTTPVersion(major: 2, minor: 0)
-        XCTAssertEqual(HTTPVersion(major: 1, minor: 1), httpReq.version)
-        XCTAssertEqual(HTTPVersion(major: 2, minor: 0), modVersion.version)
+        modVersion.version = .http2
+        XCTAssertEqual(.http1_1, httpReq.version)
+        XCTAssertEqual(.http2, modVersion.version)
 
         var modMethod = httpReq
         modMethod.method = .POST
@@ -243,12 +243,12 @@ class HTTPTest: XCTestCase {
 
     func testHTTPResponseHeadCoWWorks() throws {
         let headers = HTTPHeaders([("foo", "bar")])
-        let httpRes = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok, headers: headers)
+        let httpRes = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
 
         var modVersion = httpRes
-        modVersion.version = HTTPVersion(major: 2, minor: 0)
-        XCTAssertEqual(HTTPVersion(major: 1, minor: 1), httpRes.version)
-        XCTAssertEqual(HTTPVersion(major: 2, minor: 0), modVersion.version)
+        modVersion.version = .http2
+        XCTAssertEqual(.http1_1, httpRes.version)
+        XCTAssertEqual(.http2, modVersion.version)
 
         var modStatus = httpRes
         modStatus.status = .notFound

--- a/Tests/NIOHTTP1Tests/NIOHTTPObjectAggregatorTest.swift
+++ b/Tests/NIOHTTP1Tests/NIOHTTPObjectAggregatorTest.swift
@@ -115,11 +115,11 @@ class NIOHTTPServerRequestAggregatorTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(self.aggregatorHandler).wait())
         XCTAssertNoThrow(try channel.pipeline.addHandler(self.readRecorder).wait())
         
-        self.requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .PUT, uri: "/path")
+        self.requestHead = HTTPRequestHead(version: .http1_1, method: .PUT, uri: "/path")
         self.requestHead.headers.add(name: "Host", value: "example.com")
         self.requestHead.headers.add(name: "X-Test", value: "True")
         
-        self.responseHead = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok)
+        self.responseHead = HTTPResponseHead(version: .http1_1, status: .ok)
         self.responseHead.headers.add(name: "Server", value: "SwiftNIO")
         
         // this activates the channel
@@ -225,7 +225,7 @@ class NIOHTTPServerRequestAggregatorTest: XCTestCase {
         }
 
         let resTooLarge = HTTPResponseHead(
-            version: .init(major: 1, minor: 1),
+            version: .http1_1,
             status: .payloadTooLarge,
             headers: HTTPHeaders([("Content-Length", "0"), ("connection", "close")]))
         
@@ -244,7 +244,7 @@ class NIOHTTPServerRequestAggregatorTest: XCTestCase {
 
         // send an HTTP/1.0 request with no keep-alive header
         let requestHead: HTTPRequestHead = HTTPRequestHead(
-            version: .init(major: 1, minor: 0),
+            version: .http1_0,
             method: .PUT, uri: "/path",
             headers: HTTPHeaders(
                 [("Host", "example.com"), ("X-Test", "True"), ("content-length", "5")]))
@@ -252,7 +252,7 @@ class NIOHTTPServerRequestAggregatorTest: XCTestCase {
         XCTAssertThrowsError(try self.channel.writeInbound(HTTPServerRequestPart.head(requestHead)))
 
         let resTooLarge = HTTPResponseHead(
-            version: .init(major: 1, minor: 0),
+            version: .http1_0,
             status: .payloadTooLarge,
             headers: HTTPHeaders([("Content-Length", "0"), ("connection", "close")]))
 
@@ -273,7 +273,7 @@ class NIOHTTPServerRequestAggregatorTest: XCTestCase {
 
         // HTTP/1.1 uses Keep-Alive unless told otherwise
         let requestHead: HTTPRequestHead = HTTPRequestHead(
-            version: .init(major: 1, minor: 1),
+            version: .http1_1,
             method: .PUT, uri: "/path",
             headers: HTTPHeaders(
                 [("Host", "example.com"), ("X-Test", "True"), ("content-length", "8")]))
@@ -344,11 +344,11 @@ class NIOHTTPClientResponseAggregatorTest: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.addHandler(self.aggregatorHandler).wait())
         XCTAssertNoThrow(try channel.pipeline.addHandler(self.readRecorder).wait())
 
-        self.requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .PUT, uri: "/path")
+        self.requestHead = HTTPRequestHead(version: .http1_1, method: .PUT, uri: "/path")
         self.requestHead.headers.add(name: "Host", value: "example.com")
         self.requestHead.headers.add(name: "X-Test", value: "True")
 
-        self.responseHead = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok)
+        self.responseHead = HTTPResponseHead(version: .http1_1, status: .ok)
         self.responseHead.headers.add(name: "Server", value: "SwiftNIO")
 
         // this activates the channel

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -50,7 +50,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
         headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
         headers.add(name: "Content-Length", value: "\(requestBuffer.readableBytes)")
 
-        let requestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
+        let requestHead = HTTPRequestHead(version: .http1_1,
                                           method: .GET,
                                           uri: uri,
                                           headers: headers)
@@ -87,7 +87,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
         // Assert the server received the expected request.
         // Use custom methods if you only want some specific assertions on part
         // of the request.
-        XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .init(major: 1, minor: 1),
+        XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .http1_1,
                                                     method: .GET,
                                                     uri: "/some-route",
                                                     headers: .init([
@@ -105,7 +105,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
         let responseBody = "pong"
         var responseBuffer = allocator.buffer(capacity: 128)
         responseBuffer.writeString(responseBody)
-        XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .init(major: 1, minor: 1), status: .ok))))
+        XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .http1_1, status: .ok))))
         XCTAssertNoThrow(try testServer.writeOutbound(.body(.byteBuffer(responseBuffer))))
         XCTAssertNoThrow(try testServer.writeOutbound(.end(nil)))
 
@@ -138,7 +138,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
 
         // Send the response to the client
         let responseBuffer = allocator.buffer(string: responseMessage)
-        XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .init(major: 1, minor: 1), status: .ok))))
+        XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .http1_1, status: .ok))))
         XCTAssertNoThrow(try testServer.writeOutbound(.body(.byteBuffer(responseBuffer))))
         XCTAssertNoThrow(try testServer.writeOutbound(.end(nil)))
 
@@ -188,7 +188,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
         // Send the response to client1
         let response1Message = "Response #1"
         let response1Buffer = allocator.buffer(string: response1Message)
-        XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .init(major: 1, minor: 1), status: .ok))))
+        XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .http1_1, status: .ok))))
         XCTAssertNoThrow(try testServer.writeOutbound(.body(.byteBuffer(response1Buffer))))
         XCTAssertNoThrow(try testServer.writeOutbound(.end(nil)))
 
@@ -200,7 +200,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
         // Send the response to client2
         let response2Message = "Response #2"
         let response2Buffer = allocator.buffer(string: response2Message)
-        XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .init(major: 1, minor: 1), status: .ok))))
+        XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .http1_1, status: .ok))))
         XCTAssertNoThrow(try testServer.writeOutbound(.body(.byteBuffer(response2Buffer))))
         XCTAssertNoThrow(try testServer.writeOutbound(.end(nil)))
 

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -110,7 +110,7 @@ extension ChannelInboundHandler where OutboundOut == HTTPClientRequestPart {
         headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
         headers.add(name: "Content-Length", value: "\(0)")
         
-        let requestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
+        let requestHead = HTTPRequestHead(version: .http1_1,
                                           method: .GET,
                                           uri: "/",
                                           headers: headers)


### PR DESCRIPTION
Motivation:

I'm sick of typing `.init(major: 1, minor: 1)`.

Modifications:

- Added static vars for common HTTP versions.

Result:

Maybe I'll never type `.init(major: 1, minor: 1)` ever again.
