### PR TITLE
[WIP] Add stream support to ChannelHandlerContext

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -1656,6 +1656,7 @@ extension ChannelPipeline: CustomDebugStringConvertible {
 
 extension ChannelHandlerContext {
     
+    /// Used to stream data into a `ChannelHandlerContext`
     public class Stream {
         
         fileprivate var buffer: ByteBuffer
@@ -1666,6 +1667,10 @@ extension ChannelHandlerContext {
         
     }
     
+    /// Streams data to a `ChannelHandlerContext` and then flushes.
+    /// - parameter initialCapacity: The initial capacity of the stream, defaults to 1024 bytes.
+    /// - parameter promise: An `EventLoopPromise` that will be notified when writing to the `ChannelHandlerContext` is complete.
+    /// - parameter writer: A closure that takes a `Stream` as it's first and only argument. You then write to this `Stream` using the `<<<` operator.
     public func writeOutboundWithStream(initialCapacity: Int = 1024, promise: EventLoopPromise<Void>? = nil, _ writer: (Stream) -> Void) {
         let stream = Stream(buffer: self.channel.allocator.buffer(capacity: initialCapacity))
         writer(stream)
@@ -1682,27 +1687,27 @@ infix operator <<<: StreamPrecedence
 
 extension ChannelHandlerContext.Stream {
     
-    @discardableResult static func <<< (left: ChannelHandlerContext.Stream, right: String) -> ChannelHandlerContext.Stream {
+    @discardableResult public static func <<< (left: ChannelHandlerContext.Stream, right: String) -> ChannelHandlerContext.Stream {
         left.buffer.writeString(right)
         return left
     }
     
-    @discardableResult static func <<< (left: ChannelHandlerContext.Stream, right: Substring) -> ChannelHandlerContext.Stream {
+    @discardableResult public static func <<< (left: ChannelHandlerContext.Stream, right: Substring) -> ChannelHandlerContext.Stream {
         left.buffer.writeSubstring(right)
         return left
     }
     
-    @discardableResult static func <<< (left: ChannelHandlerContext.Stream, right: StaticString) -> ChannelHandlerContext.Stream {
+    @discardableResult public static func <<< (left: ChannelHandlerContext.Stream, right: StaticString) -> ChannelHandlerContext.Stream {
         left.buffer.writeStaticString(right)
         return left
     }
     
-    @discardableResult static func <<< <T: FixedWidthInteger>(left: ChannelHandlerContext.Stream, right: T) -> ChannelHandlerContext.Stream {
+    @discardableResult public static func <<< <T: FixedWidthInteger>(left: ChannelHandlerContext.Stream, right: T) -> ChannelHandlerContext.Stream {
         left.buffer.writeInteger(right)
         return left
     }
     
-    @discardableResult static func <<< <T: Sequence>(left: ChannelHandlerContext.Stream, right: T) -> ChannelHandlerContext.Stream where T.Element == UInt8 {
+    @discardableResult public static func <<< <T: Sequence>(left: ChannelHandlerContext.Stream, right: T) -> ChannelHandlerContext.Stream where T.Element == UInt8 {
         left.buffer.writeBytes(right)
         return left
     }

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -1663,6 +1663,31 @@ extension ChannelHandlerContext {
         return self.writeAndFlush(NIOAny(stream.buffer), promise: promise)
     }
     
+    @resultBuilder
+    struct StreamBlock {
+        
+        static func buildBlock(_ content: Any...) -> [Any] {
+                content
+            }
+    }
+    
+    public func writeOutboundWithStream_builder(promise: EventLoopPromise<Void>?, @StreamBlock _ content: () -> [Any]) {
+        var buffer = ByteBuffer()
+        for part in content() {
+            switch part {
+            case is String:
+                buffer.writeString(part as! String)
+            case is Substring:
+                buffer.writeSubstring(part as! Substring)
+            case is StaticString:
+                buffer.writeStaticString(part as! StaticString)
+            default:
+                ()
+            }
+        }
+        return self.writeAndFlush(NIOAny(buffer), promise: promise)
+    }
+    
 }
 
 infix operator <<<: MultiplicationPrecedence

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -1665,11 +1665,7 @@ extension ChannelHandlerContext {
     
 }
 
-precedencegroup StreamPrecedence {
-    associativity: left
-}
-
-infix operator <<<: StreamPrecedence
+infix operator <<<: MultiplicationPrecedence
 
 extension ChannelHandlerContext.Stream {
     

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -1640,20 +1640,6 @@ extension ChannelPipeline: CustomDebugStringConvertible {
     }
 }
 
-//===----------------------------------------------------------------------===//
-//
-// This source file is part of the SwiftNIO open source project
-//
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
-// Licensed under Apache License v2.0
-//
-// See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-//===----------------------------------------------------------------------===//
-
 extension ChannelHandlerContext {
     
     /// Used to stream data into a `ChannelHandlerContext`

--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -84,6 +84,7 @@ extension ChannelTests {
                 ("testFixedSizeRecvByteBufferAllocatorSizeIsConstant", testFixedSizeRecvByteBufferAllocatorSizeIsConstant),
                 ("testCloseInConnectPromise", testCloseInConnectPromise),
                 ("testWritabilityChangeDuringReentrantFlushNow", testWritabilityChangeDuringReentrantFlushNow),
+                ("testStreaming", testStreaming),
            ]
    }
 }

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2977,6 +2977,7 @@ extension ChannelTests {
                     String("hello")
                     substring
                     StaticString(stringLiteral: "test")
+                    123
                 }
             }
             
@@ -2990,6 +2991,7 @@ extension ChannelTests {
         XCTAssertEqual(outbound?.readString(length: 5), "hello")
         XCTAssertEqual(outbound?.readString(length: 3), "234")
         XCTAssertEqual(outbound?.readString(length: 4), "test")
+        XCTAssertEqual(outbound?.readInteger(), 123)
         XCTAssertEqual(outbound?.readableBytes, 0)
     }
     


### PR DESCRIPTION
Resolves #14

### Motivation:

The API is easier to use when outbound writing a variety of data types.

### Modifications:

Add a new `Stream` class, and a new method `writeOutboundWithStream` to `ChannelHandlerContext`. You provide a closure as the last argument to this method, which takes  a `Stream` as it's only argument. You then write to the stream using the new `<<<` operator.

Multiple types are supported including:
- `String`
- `StaticString`
- `Substring`
- `[UInt8]`
- `FixedWidthInteger`

### Result:

```
var buffer = ByteBuffer()
buffer.writeString("Hello")
buffer.writeString("world")
buffer.writeInteger(1234)
context.writeAndFlush(NIOAny(buffer), promise: promise)
```

turns into

```
context.writeOutboundWithStream(promise: promise) { stream in
    stream <<< "hello" <<< "world" <<< 1234
}
```