### PR TITLE
Support result builders in ByteBuffer

### DIFF
--- a/Sources/NIO/ByteBuffer-builder.swift
+++ b/Sources/NIO/ByteBuffer-builder.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+
+public protocol ByteBufferSerializable {
+    
+    @discardableResult func write(into buffer: inout ByteBuffer) -> Int
+    
+}
+
+extension String: ByteBufferSerializable {
+    
+    public func write(into buffer: inout ByteBuffer) -> Int {
+        buffer.writeString(self)
+    }
+    
+}
+
+@resultBuilder
+public struct BufferBuilder {
+    public static func buildBlock(_ components: ByteBufferSerializable...) -> [ByteBufferSerializable] {
+        components
+    }
+}
+
+extension ByteBuffer {
+ 
+    init(@BufferBuilder contents: () -> [ByteBufferSerializable]) {
+        self.init()
+        for part in contents() {
+            part.write(into: &self)
+        }
+    }
+    
+    public mutating func write(@BufferBuilder contents: () -> [ByteBufferSerializable]) -> Int {
+        contents().map { $0.write(into: &self) }.reduce(0, +)
+    }
+    
+}

--- a/Sources/NIO/ByteBuffer-builder.swift
+++ b/Sources/NIO/ByteBuffer-builder.swift
@@ -14,6 +14,8 @@
 
 import Dispatch
 
+// MARK: - Serializable
+
 public protocol ByteBufferSerializable {
     
     @discardableResult func write(into buffer: inout ByteBuffer) -> Int
@@ -27,6 +29,51 @@ extension String: ByteBufferSerializable {
     }
     
 }
+
+extension Substring: ByteBufferSerializable {
+    
+    public func write(into buffer: inout ByteBuffer) -> Int {
+        buffer.writeSubstring(self)
+    }
+    
+}
+
+extension StaticString: ByteBufferSerializable {
+    
+    public func write(into buffer: inout ByteBuffer) -> Int {
+        buffer.writeStaticString(self)
+    }
+    
+}
+
+extension Sequence where Element == UInt8 {
+    
+    public func write(into buffer: inout ByteBuffer) -> Int {
+        buffer.writeBytes(self)
+    }
+    
+}
+
+extension FixedWidthInteger where Self: ByteBufferSerializable {
+    
+    public func write(into buffer: inout ByteBuffer) -> Int {
+        buffer.writeInteger(self)
+    }
+    
+}
+
+extension Int: ByteBufferSerializable {}
+extension Int8: ByteBufferSerializable {}
+extension Int16: ByteBufferSerializable {}
+extension Int32: ByteBufferSerializable {}
+extension Int64: ByteBufferSerializable {}
+extension UInt: ByteBufferSerializable {}
+extension UInt8: ByteBufferSerializable {}
+extension UInt16: ByteBufferSerializable {}
+extension UInt32: ByteBufferSerializable {}
+extension UInt64: ByteBufferSerializable {}
+
+// MARK: - Buffer builder
 
 @resultBuilder
 public struct BufferBuilder {

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -2903,3 +2903,60 @@ extension ByteBufferTest {
     }
     
 }
+
+// MARK: - Buffer building
+extension ByteBufferTest {
+    
+    func testCreateBufferEmpty() {
+        var buffer = ByteBuffer { }
+        XCTAssertEqual(buffer.readableBytes, 0)
+    }
+    
+    func testCreateBufferSingle() {
+        var buffer = ByteBuffer { "hello" }
+        XCTAssertEqual(buffer.readString(length: 5), "hello")
+        XCTAssertEqual(buffer.readableBytes, 0)
+    }
+    
+    func testCreateBufferMultiple() {
+        var buffer = ByteBuffer {
+            "hello"
+            "world"
+        }
+        XCTAssertEqual(buffer.readString(length: 5), "hello")
+        XCTAssertEqual(buffer.readString(length: 5), "world")
+        XCTAssertEqual(buffer.readableBytes, 0)
+    }
+    
+    func testWriteEmpty() {
+        var buffer = ByteBuffer()
+        XCTAssertEqual(buffer.readableBytes, 0)
+        XCTAssertEqual(buffer.write {}, 0)
+        XCTAssertEqual(buffer.readableBytes, 0)
+    }
+    
+    func testWriteSingle() {
+        var buffer = ByteBuffer()
+        XCTAssertEqual(buffer.readableBytes, 0)
+        XCTAssertEqual(buffer.write { "hello" }, 5)
+        XCTAssertEqual(buffer.readableBytes, 5)
+        
+        XCTAssertEqual(buffer.readString(length: 5), "hello")
+        XCTAssertEqual(buffer.readableBytes, 0)
+    }
+    
+    func testWriteMultiple() {
+        var buffer = ByteBuffer()
+        XCTAssertEqual(buffer.readableBytes, 0)
+        XCTAssertEqual(buffer.write {
+            "hello"
+            "world"
+        }, 10)
+        XCTAssertEqual(buffer.readableBytes, 10)
+        
+        XCTAssertEqual(buffer.readString(length: 5), "hello")
+        XCTAssertEqual(buffer.readString(length: 5), "world")
+        XCTAssertEqual(buffer.readableBytes, 0)
+    }
+    
+}

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -2908,7 +2908,7 @@ extension ByteBufferTest {
 extension ByteBufferTest {
     
     func testCreateBufferEmpty() {
-        var buffer = ByteBuffer { }
+        let buffer = ByteBuffer { }
         XCTAssertEqual(buffer.readableBytes, 0)
     }
     


### PR DESCRIPTION
Add support for creating and writing to ByteBuffers using result builders.

### Motivation:

When writing multiple data types, or a lot of the same type, this is an easier way to push data into a byte buffer.

### Modifications:

Add a new init and write method that takes a result builder as an argument, calls that builder, and then writes each part to the buffer. Also defined a `ByteBufferSerializable` protocol that can be used to enable custom types to be used in a result builder.

### Result:

Old initialisation:
```
var buffer = ByteBuffer()
buffer.writeString("hello")
buffer.writeString("world")
```

New initialisation:
```
var buffer = ByteBuffer {
    "hello"
    "world"
}

-----------------------------------

Old writing:
```
var size = 0
size += buffer.writeString("hello")
size += buffer.writeInteger(1234)
size += buffer.writeString("world")
```

New writing
```
size = buffer.write {
    "hello"
    1234
    "world"
}