### PR TITLE
Use welcoming language

### DIFF
--- a/Sources/CNIOSHA1/c_nio_sha1.c
+++ b/Sources/CNIOSHA1/c_nio_sha1.c
@@ -58,7 +58,7 @@
 
 
 
-/* sanity check */
+/* soundness check */
 #if BYTE_ORDER != BIG_ENDIAN
 # if BYTE_ORDER != LITTLE_ENDIAN
 #  define unsupported 1

--- a/Sources/NIOTLS/SNIHandler.swift
+++ b/Sources/NIOTLS/SNIHandler.swift
@@ -245,7 +245,7 @@ public final class SNIHandler: ByteToMessageDecoder {
         //          } body;
         //      } Handshake;
         //
-        // For the sake of our own sanity, we should check the handshake type and
+        // For the sake of our own happiness, we should check the handshake type and
         // validate its length. uint24 is a stupid type, so we have to play some
         // games here to get this to work. If we check that we have 4 bytes up-front
         // we can use unsafe reads: fewer than 4 bytes makes this message bogus.

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -806,7 +806,7 @@ class HTTPClientUpgradeTestCase: XCTestCase {
         // Run the processing of the response, but with the upgrade delayed by the client upgrader.
         clientChannel.embeddedEventLoop.run()
         
-        // Sanity check that the upgrade was delayed.
+        // Soundness check that the upgrade was delayed.
         XCTAssertEqual(0, clientUpgrader.upgradedHandler.handlerAddedContextCallCount)
         
         // Add some non-http data.
@@ -875,7 +875,7 @@ class HTTPClientUpgradeTestCase: XCTestCase {
         let promiseError = errorOnAdditionalChannelWrite as! NIOHTTPClientUpgradeError
         XCTAssertEqual(NIOHTTPClientUpgradeError.writingToHandlerDuringUpgrade, promiseError)
         
-        // Sanity check that the upgrade was delayed.
+        // Soundness check that the upgrade was delayed.
         XCTAssertEqual(0, clientUpgrader.upgradedHandler.handlerAddedContextCallCount)
         
         // Upgrade now.

--- a/Tests/NIOTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOTests/SocketOptionProviderTest.swift
@@ -274,7 +274,7 @@ final class SocketOptionProviderTest: XCTestCase {
         let channel = self.clientChannel! as! SocketOptionProvider
         let tcpInfo = try assertNoThrowWithValue(channel.getTCPInfo().wait())
 
-        // We just need to sanity check something here to ensure that the data is vaguely reasonable.
+        // We just need to soundness check something here to ensure that the data is vaguely reasonable.
         XCTAssertEqual(tcpInfo.tcpi_state, UInt8(TCP_ESTABLISHED))
         #endif
     }
@@ -286,7 +286,7 @@ final class SocketOptionProviderTest: XCTestCase {
         let tcpConnectionInfo = try assertNoThrowWithValue(channel.getTCPConnectionInfo().wait())
 
         #if os(macOS) // deliberately only on macOS
-        // We just need to sanity check something here to ensure that the data is vaguely reasonable.
+        // We just need to soundness check something here to ensure that the data is vaguely reasonable.
         XCTAssertEqual(tcpConnectionInfo.tcpi_state, UInt8(TSI_S_ESTABLISHED))
         #endif
         #endif

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -24,7 +24,11 @@ services:
 
   sanity:
     <<: *common
-    command: /bin/bash -xcl "./scripts/sanity.sh"
+    command: /bin/bash -xcl "./scripts/soundness.sh"
+
+  soundness:
+    <<: *common
+    command: /bin/bash -xcl "./scripts/soundness.sh"
 
   unit-tests:
     <<: *common

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -40,6 +40,9 @@ unacceptable_terms=(
     -e blacklis[t]
     -e whitelis[t]
     -e slav[e]
+# this needs to be commented out until we have changed the CI to pick up the
+# soundness check instead.
+#    -e sanit[y]
 )
 if git grep --color=never -i "${unacceptable_terms[@]}" > /dev/null; then
     printf "\033[0;31mUnacceptable language found.\033[0m\n"
@@ -49,7 +52,7 @@ fi
 printf "\033[0;32mokay.\033[0m\n"
 
 printf "=> Checking license headers... "
-tmp=$(mktemp /tmp/.swift-nio-sanity_XXXXXX)
+tmp=$(mktemp /tmp/.swift-nio-soundness_XXXXXX)
 
 for language in swift-or-c bash dtrace python; do
   declare -a matching_files


### PR DESCRIPTION
To comply with the new [Swift code of conduct](https://swift.org/code-of-conduct/), let's make the language a little more welcoming.

### Modifications:

- Replaced usages of "sanity" with more welcoming alternatives
- Added "sanity" to the list of unacceptable terms. (Commented out, until the CI has been updated to use the new soundness check) 

### Result:

- Swift NIO is nicer.
