### PR TITLE
B2MD: Fix default memory reclamation strategy to match its documentation

### DIFF
--- a/Sources/NIO/Codec.swift
+++ b/Sources/NIO/Codec.swift
@@ -222,13 +222,13 @@ extension ByteToMessageDecoder {
     public func shouldReclaimBytes(buffer: ByteBuffer) -> Bool {
         // We want to reclaim in the following cases:
         //
-        // 1. If there is more than 2kB of memory to reclaim
+        // 1. If there is at least 2kB of memory to reclaim
         // 2. If the buffer is more than 50% reclaimable memory and is at least
         //    1kB in size.
-        if buffer.readerIndex > 2048 {
+        if buffer.readerIndex >= 2048 {
             return true
         }
-        return buffer.capacity > 1024 && (buffer.capacity - buffer.readerIndex) >= buffer.readerIndex
+        return buffer.storageCapacity > 1024 && (buffer.storageCapacity - buffer.readerIndex) < buffer.readerIndex
     }
 
     public func wrapInboundOut(_ value: InboundOut) -> NIOAny {

--- a/Tests/NIOTests/CodecTest.swift
+++ b/Tests/NIOTests/CodecTest.swift
@@ -210,19 +210,43 @@ public final class ByteToMessageDecoderTest: XCTestCase {
         _ = try channel.pipeline.addHandler(decoder).wait()
 
         // We're going to send in 513 bytes. This will cause a chunk to be passed on, and will leave
-        // a 512-byte empty region in a 513 byte buffer. This will not cause a shrink.
+        // a 512-byte empty region in a byte buffer with a capacity of 1024 bytes. Since 512 empty
+        // bytes are exactly 50% of the buffers capacity and not one tiny bit more, the empty space
+        // will not be reclaimed.
         var buffer = channel.allocator.buffer(capacity: 513)
         buffer.writeBytes(Array(repeating: 0x04, count: 513))
         XCTAssertTrue(try channel.writeInbound(buffer).isFull)
 
+        XCTAssertEqual(decoder.cumulationBuffer!.capacity, 1024)
         XCTAssertEqual(decoder.cumulationBuffer!.readableBytes, 1)
         XCTAssertEqual(decoder.cumulationBuffer!.readerIndex, 512)
 
-        // Now we're going to send in another 513 bytes. This will cause another chunk to be passed in,
-        // but now we'll shrink the buffer.
+        // Next we're going to send in another 513 bytes. This will cause another chunk to be passed
+        // into our decoder buffer, which has a capacity of 1024 bytes, before we pass in another
+        // 513 bytes. Since we already have written to 513 bytes, there isn't enough space in the
+        // buffer, which will cause a resize to a new underlying storage with 2048 bytes. Since the
+        // `LargeChunkDecoder` has consumed another 512 bytes, there are now two bytes left to read
+        // (513 + 513) - (512 + 512). The reader index is at 1024. The empty space has not been
+        // reclaimed: While the capacity is more than 1024 bytes (2048 bytes), the reader index is
+        // now at 1024. This means the buffer is exactly 50% consumed and not a tiny bit more, which
+        // means no space will be reclaimed.
         XCTAssertTrue(try channel.writeInbound(buffer).isFull)
 
+        XCTAssertEqual(decoder.cumulationBuffer!.capacity, 2048)
         XCTAssertEqual(decoder.cumulationBuffer!.readableBytes, 2)
+        XCTAssertEqual(decoder.cumulationBuffer!.readerIndex, 1024)
+        
+        // Finally we're going to send in another 513 bytes. This will cause another chunk to be
+        // passed into our decoder buffer, which has a capacity of 2048 bytes. Since the buffer has
+        // enough available space (1022 bytes) there will be no buffer resize before the decoding.
+        // After the decoding of another 512 bytes, the buffer will have 1536 empty bytes
+        // (3 * 512 bytes). This means that 75% of the buffer's capacity can now be reclaimed, which
+        // will lead to a reclaim. The resulting buffer will have a capacity of 2048 bytes (based
+        // on its previous growth), with 3 readable bytes remaining.
+        XCTAssertTrue(try channel.writeInbound(buffer).isFull)
+        
+        XCTAssertEqual(decoder.cumulationBuffer!.capacity, 2048)
+        XCTAssertEqual(decoder.cumulationBuffer!.readableBytes, 3)
         XCTAssertEqual(decoder.cumulationBuffer!.readerIndex, 0)
     }
 


### PR DESCRIPTION
In cases in which only a small amount of bytes were consumed from a `ByteBuffer` during decoding a small error in our logic could lead to extensive reclaims of memory, degrading the overall performance and allocating way to much memory.

### Motivation:

- In cases in which only a small amount was decoded from the `ByteToMessageHandler`'s internal byteBuffer, we ran into reallocations based on our previous logic. If the byteBuffer was larger than 1kb and less than 50% were consumed we reallocated.
- This leads to performance problems
- But more importantly if within the decode function a byteBuffer slice is read, the internal `ByteToMessageHandler`'s byteBuffer's storage is now referenced at multiple locations a leading to fast and excessive memory growth.

### Modifications:

- A logic bug has been fixed, we reclaim memory now, if more than 50% of the byteBuffer has been read.
- The tests have been adjusted to reflect the fixed logic bug.

### Result:

- Faster decoding of small messages
- Less memory footprint when reading slices in small messages.
