### PR TITLE
Replace unwelcoming language in sha1

### DIFF
--- a/Sources/CNIOSHA1/c_nio_sha1.c
+++ b/Sources/CNIOSHA1/c_nio_sha1.c
@@ -3,6 +3,7 @@
     - removed the _KERNEL include guards
     - defined the __min_size macro inline
     - included sys/endian.h on Android
+    - use welcoming language (soundness check)
 */
 /*	$KAME: sha1.c,v 1.5 2000/11/08 06:13:08 itojun Exp $	*/
 /*-
@@ -103,8 +104,7 @@ static uint32_t _K[] = { 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xca62c1d6 };
 static void sha1_step(struct sha1_ctxt *);
 
 static void
-sha1_step(ctxt)
-	struct sha1_ctxt *ctxt;
+sha1_step(struct sha1_ctxt *ctxt)
 {
 	uint32_t	a, b, c, d, e;
 	size_t t, s;
@@ -188,8 +188,7 @@ sha1_step(ctxt)
 /*------------------------------------------------------------*/
 
 void
-c_nio_sha1_init(ctxt)
-	struct sha1_ctxt *ctxt;
+c_nio_sha1_init(struct sha1_ctxt *ctxt)
 {
 	bzero(ctxt, sizeof(struct sha1_ctxt));
 	H(0) = 0x67452301;
@@ -200,8 +199,7 @@ c_nio_sha1_init(ctxt)
 }
 
 void
-c_nio_sha1_pad(ctxt)
-	struct sha1_ctxt *ctxt;
+c_nio_sha1_pad(struct sha1_ctxt *ctxt)
 {
 	size_t padlen;		/*pad length in bytes*/
 	size_t padstart;
@@ -235,10 +233,7 @@ c_nio_sha1_pad(ctxt)
 }
 
 void
-c_nio_sha1_loop(ctxt, input, len)
-	struct sha1_ctxt *ctxt;
-	const uint8_t *input;
-	size_t len;
+c_nio_sha1_loop(struct sha1_ctxt *ctxt, const uint8_t *input, size_t len)
 {
 	size_t gaplen;
 	size_t gapstart;

--- a/Sources/CNIOSHA1/include/CNIOSHA1.h
+++ b/Sources/CNIOSHA1/include/CNIOSHA1.h
@@ -1,10 +1,9 @@
 /* Additional changes for SwiftNIO:
     - prefixed all symbols by 'c_nio_'
-    - replaced the sys/systm.h include by strings.h
     - removed the _KERNEL include guards
     - defined the __min_size macro inline
-    - included sys/types.h in c_nio_sha1.h
     - included sys/endian.h on Android
+    - use welcoming language (soundness check)
 */
 /*	$FreeBSD$	*/
 /*	$KAME: sha1.h,v 1.5 2000/03/27 04:36:23 sumikawa Exp $	*/

--- a/Sources/CNIOSHA1/update_and_patch_sha1.sh
+++ b/Sources/CNIOSHA1/update_and_patch_sha1.sh
@@ -32,6 +32,7 @@ for f in sha1.c sha1.h; do
       echo "    - removed the _KERNEL include guards"
       echo "    - defined the __min_size macro inline"
       echo "    - included sys/endian.h on Android"
+      echo "    - use welcoming language (soundness check)"
       echo "*/"
       curl -Ls "https://raw.githubusercontent.com/freebsd/freebsd/master/sys/crypto/$f"
     ) > "$here/c_nio_$f"
@@ -52,6 +53,9 @@ $sed -e $'/#define _CRYPTO_SHA1_H_/a #include <stdint.h>\\\n#include <stddef.h>'
 $sed -e 's/u_int\([0-9]\+\)_t/uint\1_t/g'                                        \
      -e '/^#include/d'                                                           \
      -e $'/__FBSDID/c #include "include/CNIOSHA1.h"\\n#include <string.h>\\n#if !defined(bzero)\\n#define bzero(b,l) memset((b), \'\\\\0\', (l))\\n#endif\\n#if !defined(bcopy)\\n#define bcopy(s,d,l) memmove((d), (s), (l))\\n#endif\\n#ifdef __ANDROID__\\n#include <sys/endian.h>\\n#elif __linux__\\n#include <sys/types.h>\\n#endif' \
+     -i "$here/c_nio_sha1.c"
+     
+$sed -e 's/sanity check/soundness check/g' \
      -i "$here/c_nio_sha1.c"
 
 mv "$here/c_nio_sha1.h" "$here/include/CNIOSHA1.h"


### PR DESCRIPTION
Follow up to #1728

### Modifications:

- In `update_and_patch_sha1.sh` we replace occurrences of `sanity check` with `soundness check`

### Result:

`c_nio_sha1.h` and `c_nio_sha1.c` don't have manual changes anymore.
