### PR TITLE
Remove last occurrences of sanity

### DIFF
--- a/Sources/CNIOSHA1/update_and_patch_sha1.sh
+++ b/Sources/CNIOSHA1/update_and_patch_sha1.sh
@@ -53,9 +53,7 @@ $sed -e $'/#define _CRYPTO_SHA1_H_/a #include <stdint.h>\\\n#include <stddef.h>'
 $sed -e 's/u_int\([0-9]\+\)_t/uint\1_t/g'                                        \
      -e '/^#include/d'                                                           \
      -e $'/__FBSDID/c #include "include/CNIOSHA1.h"\\n#include <string.h>\\n#if !defined(bzero)\\n#define bzero(b,l) memset((b), \'\\\\0\', (l))\\n#endif\\n#if !defined(bcopy)\\n#define bcopy(s,d,l) memmove((d), (s), (l))\\n#endif\\n#ifdef __ANDROID__\\n#include <sys/endian.h>\\n#elif __linux__\\n#include <sys/types.h>\\n#endif' \
-     -i "$here/c_nio_sha1.c"
-     
-$sed -e 's/sanity check/soundness check/g' \
+     -e 's/sanit[y]/soundness/g'                                                 \
      -i "$here/c_nio_sha1.c"
 
 mv "$here/c_nio_sha1.h" "$here/include/CNIOSHA1.h"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,10 +22,6 @@ services:
       - CAP_NET_RAW
       - CAP_NET_BIND_SERVICE
 
-  sanity:
-    <<: *common
-    command: /bin/bash -xcl "./scripts/soundness.sh"
-
   soundness:
     <<: *common
     command: /bin/bash -xcl "./scripts/soundness.sh"

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -40,9 +40,7 @@ unacceptable_terms=(
     -e blacklis[t]
     -e whitelis[t]
     -e slav[e]
-# this needs to be commented out until we have changed the CI to pick up the
-# soundness check instead.
-#    -e sanit[y]
+    -e sanit[y]
 )
 if git grep --color=never -i "${unacceptable_terms[@]}" > /dev/null; then
     printf "\033[0;31mUnacceptable language found.\033[0m\n"


### PR DESCRIPTION
Final pr regarding using welcoming language. (Follow up to #1728 and #1731)

### Modifications:

- the soundness script now enforces that "sanity" isn't used anymore
- the `sanity` build step has been removed from CI
- fix to `update_and_patch_sha1.sh` so that it isn't flagged from the soundness script

### Result:

SwiftNIO's language is more welcoming to developers from all backgrounds.