### PR TITLE
Add internal perf framework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,8 @@ var targets: [PackageDescription.Target] = [
             dependencies: ["NIO", "NIOHTTP1"]),
     .target(name: "NIOCrashTester",
             dependencies: ["NIO", "NIOHTTP1", "NIOWebSocket", "NIOFoundationCompat"]),
+    .target(name: "_NIOPerformanceFramework",
+            dependencies: ["NIO"]),
     .testTarget(name: "NIOTests",
                 dependencies: ["NIO", "NIOFoundationCompat", "NIOTestUtils", "NIOConcurrencyHelpers"]),
     .testTarget(name: "NIOConcurrencyHelpersTests",
@@ -92,6 +94,7 @@ let package = Package(
         .library(name: "NIOFoundationCompat", targets: ["NIOFoundationCompat"]),
         .library(name: "NIOWebSocket", targets: ["NIOWebSocket"]),
         .library(name: "NIOTestUtils", targets: ["NIOTestUtils"]),
+        .library(name: "_NIOPerformanceFramework", targets: ["_NIOPerformanceFramework"])
     ],
     dependencies: [
     ],

--- a/Sources/_NIOPerformanceFramework/Benchmark.swift
+++ b/Sources/_NIOPerformanceFramework/Benchmark.swift
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+fileprivate let benchmarkRunCount = 10
+
+/// Defines an interface for what an individual performance test should look like
+public protocol _Benchmark: AnyObject {
+    
+    /// Used to identify the test, e.g. *nio_http1_1000_get_requests*
+    var description: String { get }
+    
+    /// Perform any necessary setup such as state
+    func setUp() throws
+    
+    /// E.g. clear state if needed
+    func tearDown()
+    
+    /// Run the actual performance tests
+    func run() throws -> Int
+}
+
+extension _Benchmark {
+
+    fileprivate func measureAndPrint(limitSet: Set<String>, fn: () throws -> Int) rethrows {
+        
+        var warning: String = ""
+        assert({
+            print("======================================================")
+            print("= YOU ARE RUNNING NIOPerformanceTester IN DEBUG MODE =")
+            print("======================================================")
+            warning = " <<< DEBUG MODE >>>"
+            return true
+        }())
+        
+        if limitSet.count == 0 || limitSet.contains(self.description) {
+            print("measuring\(warning): \(self.description): ", terminator: "")
+            let measurements = try measure(fn)
+            print(measurements.reduce("") { $0 + "\($1), " })
+        } else {
+            print("skipping '\(self.description)', limit set = \(limitSet)")
+        }
+    }
+    
+    fileprivate func measure(_ fn: () throws -> Int) rethrows -> [TimeInterval] {
+        func measureOne(_ fn: () throws -> Int) rethrows -> TimeInterval {
+            let start = Date()
+            _ = try fn()
+            let end = Date()
+            return end.timeIntervalSince(start)
+        }
+
+        _ = try measureOne(fn) /* pre-heat and throw away */
+        var measurements = Array(repeating: 0.0, count: Config.benchmarkRunCount)
+        for i in 0 ..< Config.benchmarkRunCount {
+            measurements[i] = try measureOne(fn)
+        }
+
+        return measurements
+    }
+    
+    fileprivate func runBenchmark(limitSet: Set<String>) throws {
+        try self.setUp()
+        defer {
+            self.tearDown()
+        }
+        try measureAndPrint(limitSet: limitSet) {
+            return try self.run()
+        }
+    }
+    
+}
+
+struct Config {
+    static let benchmarkRunCount = 10
+}
+
+/// Used to run a collection of benchmarks
+public struct _PerformanceTester {
+    
+    public init() {
+        
+    }
+ 
+    /// Runs a collection of benchmarks
+    public func runBenchmarks(_ benchmarks: [_Benchmark]) throws {
+        let limitSet = Set(CommandLine.arguments.dropFirst())
+        try benchmarks.forEach { try $0.runBenchmark(limitSet: limitSet) }
+    }
+    
+}


### PR DESCRIPTION
Add a lightweight performance framework that can be used to run benchmarks against NIO family projects.

### Motivation:

It seems extremely counter-intuitive to have to copy our performance testing code between repositories. This makes life much easier when setting up new projects, and has the added benefit of us being able to modify the framework in one place.

### Modifications:

Define a `Benchmark` protocol inside `_NIOPerformanceFramework` that can be used in NIO family projects.

### Result:

```
import _NIOPerformanceFramework

let benchmarks = <Make some benchmarks here>
try _PerformanceTester().runBenchmarks(benchmarks)
```
