### PR TITLE
Host header is requires for HTTP/1.1

### DIFF
--- a/Sources/NIOWebSocketClient/main.swift
+++ b/Sources/NIOWebSocketClient/main.swift
@@ -17,6 +17,11 @@ import NIOWebSocket
 
 print("Establishing connection.")
 
+enum ConnectTo {
+    case ip(host: String, port: Int)
+    case unixDomainSocket(path: String)
+}
+
 // The HTTP handler to be used to initiate the request.
 // This initial request will be adapted by the WebSocket upgrader to contain the upgrade header parameters.
 // Channel read will only be called if the upgrade fails.
@@ -169,11 +174,6 @@ let arg2 = arguments.dropFirst(2).first
 
 let defaultHost = "::1"
 let defaultPort: Int = 8888
-
-enum ConnectTo {
-    case ip(host: String, port: Int)
-    case unixDomainSocket(path: String)
-}
 
 let connectTarget: ConnectTo
 switch (arg1, arg1.flatMap(Int.init), arg2.flatMap(Int.init)) {

--- a/Sources/NIOWebSocketClient/main.swift
+++ b/Sources/NIOWebSocketClient/main.swift
@@ -30,6 +30,8 @@ private final class HTTPInitialRequestHandler: ChannelInboundHandler, RemovableC
         
         // We are connected. It's time to send the message to the server to initialize the upgrade dance.
         var headers = HTTPHeaders()
+        let host = context.remoteAddress!
+        headers.add(name: "Host", value: "\(host.ipAddress ?? "localhost"):\(host.port ?? 80)")
         headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
         headers.add(name: "Content-Length", value: "\(0)")
         


### PR DESCRIPTION
The `Host` header is required for HTTP/1.1 and standard-compliant servers will refuse to connect without it, causing new users of this library unneeded debugging frustration.

### Motivation:

I tried to connect to a websocket through NIO. The current example (NIOWebSocketClient) contains a lot of boilerplate which is hard to reason about for new users of this library. Assessing the correctness of this boilerplate while getting to a bare-minimum "just works" is hard to do. Most standard-compliant webservers will simply refuse to connect without the `Host` header. The library is not giving any indication of the problem, and eventually I had to compare the http traffic between this library and the equivalent in python. That's when I finally discovered that the example lacks the required `Host` header. Adding that, I finally got to a working websocket.

### Modifications:

This adds the `Host` header in the example. The host header ideally would be taken from the user's input on the command-line. If that's desired, I'd like to get some pointers on how to pass that value along.

### Result:

The required `Host` header will be present.