### PR TITLE
Add a synchronous pipeline view

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_addHandlers_sync.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_addHandlers_sync.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+fileprivate final class SimpleHandler: ChannelInboundHandler {
+    typealias InboundIn = NIOAny
+}
+
+func run(identifier: String) {
+    measure(identifier: identifier) {
+        let iterations = 1000
+        for _ in 0..<iterations {
+            let channel = EmbeddedChannel()
+            defer {
+                _ = try! channel.finish()
+            }
+            try! channel.pipeline.syncOperations.addHandlers([
+              SimpleHandler(),
+              SimpleHandler()
+            ])
+        }
+        return iterations
+    }
+}

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_getHandlers.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_getHandlers.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+fileprivate final class SimpleHandler: ChannelInboundHandler {
+    typealias InboundIn = NIOAny
+}
+
+func run(identifier: String) {
+    measure(identifier: identifier) {
+        let iterations = 1000
+        let channel = EmbeddedChannel()
+        defer {
+            _ = try! channel.finish()
+        }
+        try! channel.pipeline.syncOperations.addHandler(SimpleHandler())
+
+        for _ in 0..<iterations {
+            _ = try! channel.pipeline.handler(type: SimpleHandler.self).wait()
+        }
+        return iterations
+    }
+}

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_getHandlers_sync.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_getHandlers_sync.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+fileprivate final class SimpleHandler: ChannelInboundHandler {
+    typealias InboundIn = NIOAny
+}
+
+func run(identifier: String) {
+    measure(identifier: identifier) {
+        let iterations = 1000
+        let channel = EmbeddedChannel()
+        defer {
+            _ = try! channel.finish()
+        }
+        try! channel.pipeline.syncOperations.addHandler(SimpleHandler())
+
+        for _ in 0..<iterations {
+            _ = try! channel.pipeline.syncOperations.handler(type: SimpleHandler.self)
+        }
+        return iterations
+    }
+}

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -163,7 +163,7 @@ public final class ChannelPipeline: ChannelInvoker {
     /// Add a `ChannelHandler` to the `ChannelPipeline`.
     ///
     /// - parameters:
-    ///     - name: the name to use for the `ChannelHandler` when its added. If none is specified it will generate a name.
+    ///     - name: the name to use for the `ChannelHandler` when it's added. If none is specified it will generate a name.
     ///     - handler: the `ChannelHandler` to add
     ///     - position: The position in the `ChannelPipeline` to add `handler`. Defaults to `.last`.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was added.
@@ -172,10 +172,10 @@ public final class ChannelPipeline: ChannelInvoker {
                            position: ChannelPipeline.Position = .last) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         if self.eventLoop.inEventLoop {
-            promise.completeWith(self._add(handler, name: name, position: position))
+            promise.completeWith(self.addHandlerSync(handler, name: name, position: position))
         } else {
             self.eventLoop.execute {
-                promise.completeWith(self._add(handler, name: name, position: position))
+                promise.completeWith(self.addHandlerSync(handler, name: name, position: position))
             }
         }
 
@@ -187,13 +187,13 @@ public final class ChannelPipeline: ChannelInvoker {
     /// May only be called from on the event loop.
     ///
     /// - parameters:
-    ///     - name: the name to use for the `ChannelHandler` when its added. If none is specified it will generate a name.
     ///     - handler: the `ChannelHandler` to add
+    ///     - name: the name to use for the `ChannelHandler` when it's added. If none is specified a name will be generated.
     ///     - position: The position in the `ChannelPipeline` to add `handler`. Defaults to `.last`.
     /// - returns: the result of adding this handler - either success or failure with an error code if this could not be completed.
-    private func _add(_ handler: ChannelHandler,
-                      name: String? = nil,
-                      position: ChannelPipeline.Position = .last) -> Result<Void, Error> {
+    fileprivate func addHandlerSync(_ handler: ChannelHandler,
+                                    name: String? = nil,
+                                    position: ChannelPipeline.Position = .last) -> Result<Void, Error> {
         self.eventLoop.assertInEventLoop()
 
         if self.destroyed {
@@ -278,7 +278,7 @@ public final class ChannelPipeline: ChannelInvoker {
                       operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void) -> Result<Void, Error> {
         self.eventLoop.assertInEventLoop()
 
-        if destroyed {
+        if self.destroyed {
             return .failure(ChannelError.ioOnClosedChannel)
         }
 
@@ -366,9 +366,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - handler: the `ChannelHandler` to remove.
     ///     - promise: An `EventLoopPromise` that will complete when the `ChannelHandler` is removed.
     public func removeHandler(_ handler: RemovableChannelHandler, promise: EventLoopPromise<Void>?) {
-        let contextFuture = self.context0 {
-            return $0.handler === handler
-        }.map { context in
+        let contextFuture = self.context(handler: handler).map { context in
             self.removeHandler(context: context, promise: promise)
         }
 
@@ -381,9 +379,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - name: the name that was used to add the `ChannelHandler` to the `ChannelPipeline` before.
     ///     - promise: An `EventLoopPromise` that will complete when the `ChannelHandler` is removed.
     public func removeHandler(name: String, promise: EventLoopPromise<Void>?) {
-        let contextFuture = self.context0 {
-            $0.name == name
-        }.map { context in
+        let contextFuture = self.context(name: name).map { context in
             self.removeHandler(context: context, promise: promise)
         }
 
@@ -416,10 +412,30 @@ public final class ChannelPipeline: ChannelInvoker {
     /// Returns the `ChannelHandlerContext` that belongs to a `ChannelHandler`.
     ///
     /// - parameters:
-    ///     - handler: the `ChannelHandler` for which the `ChannelHandlerContext` shoud be returned
+    ///     - handler: the `ChannelHandler` for which the `ChannelHandlerContext` should be returned
     /// - returns: the `EventLoopFuture` which will be notified once the the operation completes.
     public func context(handler: ChannelHandler) -> EventLoopFuture<ChannelHandlerContext> {
-        return context0({ $0.handler === handler })
+        let promise = self.eventLoop.makePromise(of: ChannelHandlerContext.self)
+
+        if self.eventLoop.inEventLoop {
+            promise.completeWith(self.contextSync(handler: handler))
+        } else {
+            self.eventLoop.execute {
+                promise.completeWith(self.contextSync(handler: handler))
+            }
+        }
+
+        return promise.futureResult
+    }
+
+    /// Synchronously returns the `ChannelHandlerContext` that belongs to a `ChannelHandler`.
+    ///
+    /// - Important: This must be called on the `EventLoop`.
+    /// - parameters:
+    ///     - handler: the `ChannelHandler` for which the `ChannelHandlerContext` should be returned
+    /// - returns: the `ChannelHandlerContext` that belongs to the `ChannelHandler`, if one exists.
+    fileprivate func contextSync(handler: ChannelHandler) -> Result<ChannelHandlerContext, Error> {
+        return self._contextSync({ $0.handler === handler })
     }
 
     /// Returns the `ChannelHandlerContext` that belongs to a `ChannelHandler`.
@@ -428,7 +444,27 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - name: the name that was used to add the `ChannelHandler` to the `ChannelPipeline` before.
     /// - returns: the `EventLoopFuture` which will be notified once the the operation completes.
     public func context(name: String) -> EventLoopFuture<ChannelHandlerContext> {
-        return context0({ $0.name == name })
+        let promise = self.eventLoop.makePromise(of: ChannelHandlerContext.self)
+
+        if self.eventLoop.inEventLoop {
+            promise.completeWith(self.contextSync(name: name))
+        } else {
+            self.eventLoop.execute {
+                promise.completeWith(self.contextSync(name: name))
+            }
+        }
+
+        return promise.futureResult
+    }
+
+    /// Synchronously finds and returns the `ChannelHandlerContext` that belongs to the
+    /// `ChannelHandler` with the given name.
+    ///
+    /// - Important: This must be called on the `EventLoop`.
+    /// - Parameter name: The name of the `ChannelHandler` to find.
+    /// - Returns: the `ChannelHandlerContext` that belongs to the `ChannelHandler`, if one exists.
+    fileprivate func contextSync(name: String) -> Result<ChannelHandlerContext, Error> {
+        return self._contextSync({ $0.name == name })
     }
 
     /// Returns the `ChannelHandlerContext` that belongs to a `ChannelHandler` of the given type.
@@ -439,30 +475,43 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - handlerType: The type of the handler to search for.
     /// - returns: the `EventLoopFuture` which will be notified once the the operation completes.
+    @inlinable
     public func context<Handler: ChannelHandler>(handlerType: Handler.Type) -> EventLoopFuture<ChannelHandlerContext> {
-        return context0({ $0.handler is Handler })
+        let promise = self.eventLoop.makePromise(of: ChannelHandlerContext.self)
+
+        if self.eventLoop.inEventLoop {
+            promise.completeWith(self._contextSync(handlerType: handlerType))
+        } else {
+            self.eventLoop.execute {
+                promise.completeWith(self._contextSync(handlerType: handlerType))
+            }
+        }
+
+        return promise.futureResult
     }
 
-    /// Find a `ChannelHandlerContext` in the `ChannelPipeline`.
-    private func context0(_ body: @escaping ((ChannelHandlerContext) -> Bool)) -> EventLoopFuture<ChannelHandlerContext> {
-        let promise = eventLoop.makePromise(of: ChannelHandlerContext.self)
+    /// Synchronously finds and returns the `ChannelHandlerContext` that belongs to the first
+    /// `ChannelHandler` of the given type.
+    ///
+    /// - Important: This must be called on the `EventLoop`.
+    /// - Parameter handlerType: The type of handler to search for.
+    /// - Returns: the `ChannelHandlerContext` that belongs to the `ChannelHandler`, if one exists.
+    @inlinable // should be fileprivate
+    internal func _contextSync<Handler: ChannelHandler>(handlerType: Handler.Type) -> Result<ChannelHandlerContext, Error> {
+        return self._contextSync({ $0.handler is Handler })
+    }
 
-        func _context0() {
-            if let context = self.contextForPredicate0(body) {
-                promise.succeed(context)
-            } else {
-                promise.fail(ChannelPipelineError.notFound)
-            }
-        }
+    /// Synchronously finds a `ChannelHandlerContext` in the `ChannelPipeline`.
+    /// - Important: This must be called on the `EventLoop`.
+    @usableFromInline // should be fileprivate
+    internal func _contextSync(_ body: @escaping ((ChannelHandlerContext) -> Bool)) -> Result<ChannelHandlerContext, Error> {
+        self.eventLoop.assertInEventLoop()
 
-        if eventLoop.inEventLoop {
-            _context0()
+        if let context = self.contextForPredicate0(body) {
+            return .success(context)
         } else {
-            eventLoop.execute {
-                _context0()
-            }
+            return .failure(ChannelPipelineError.notFound)
         }
-        return promise.futureResult
     }
 
     /// Returns a `ChannelHandlerContext` which matches.
@@ -471,7 +520,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///
     /// - parameters:
     ///     - body: The predicate to execute per `ChannelHandlerContext` in the `ChannelPipeline`.
-    /// -returns: The first `ChannelHandlerContext` that matches or `nil` if none did.
+    /// - returns: The first `ChannelHandlerContext` that matches or `nil` if none did.
     private func contextForPredicate0(_ body: @escaping((ChannelHandlerContext) -> Bool)) -> ChannelHandlerContext? {
         var curCtx: ChannelHandlerContext? = self.head?.next
         while let context = curCtx, context !== self.tail {
@@ -885,53 +934,17 @@ extension ChannelPipeline {
     /// - returns: A future that will be completed when all of the supplied `ChannelHandler`s were added.
     public func addHandlers(_ handlers: [ChannelHandler],
                             position: ChannelPipeline.Position = .last) -> EventLoopFuture<Void> {
-        var handlers = handlers
-        let individualPosition: ChannelPipeline.Position
-        switch position {
-        case .first:
-            handlers.reverse()
-            individualPosition = .first
-        case .last:
-            individualPosition = .last
-        case .before(let handler):
-            individualPosition = .before(handler)
-        case .after(let handler):
-            handlers.reverse()
-            individualPosition = .after(handler)
+        let promise = self.eventLoop.makePromise(of: Void.self)
+
+        if self.eventLoop.inEventLoop {
+            promise.completeWith(self.addHandlersSync(handlers, position: position))
+        } else {
+            self.eventLoop.execute {
+                promise.completeWith(self.addHandlersSync(handlers, position: position))
+            }
         }
 
-        func addHandlersMakingPromise(handlers: [ChannelHandler],
-                                      transformedPosition: ChannelPipeline.Position) -> EventLoopFuture<Void> {
-            let promise = self.eventLoop.makePromise(of: Void.self)
-
-            // Add all the handlers.
-            func addAllHandlersAndComplete() {
-                for handler in handlers {
-                    let addResult = self._add(handler, position: transformedPosition)
-                    switch addResult {
-                    case .success:
-                        break // Keep going.
-                    case .failure:
-                        // Report failure and return.
-                        promise.completeWith(addResult)
-                        return
-                    }
-                }
-                promise.succeed(())
-            }
-
-            if self.eventLoop.inEventLoop {
-                addAllHandlersAndComplete()
-            } else {
-                self.eventLoop.execute {
-                    addAllHandlersAndComplete()
-                }
-            }
-
-            return promise.futureResult
-        }
-
-        return addHandlersMakingPromise(handlers: handlers, transformedPosition: individualPosition)
+        return promise.futureResult
     }
 
     /// Adds the provided channel handlers to the pipeline in the order given, taking account
@@ -944,7 +957,144 @@ extension ChannelPipeline {
     /// - returns: A future that will be completed when all of the supplied `ChannelHandler`s were added.
     public func addHandlers(_ handlers: ChannelHandler...,
                             position: ChannelPipeline.Position = .last) -> EventLoopFuture<Void> {
-        return addHandlers(handlers, position: position)
+        return self.addHandlers(handlers, position: position)
+    }
+
+    /// Synchronously adds the provided `ChannelHandler`s to the pipeline in the order given, taking
+    /// account of the behaviour of `ChannelHandler.add(first:)`.
+    ///
+    /// - Important: Must be called on the `EventLoop`.
+    /// - Parameters:
+    ///   - handlers: The array of `ChannelHandler`s to add.
+    ///   - position: The position in the `ChannelPipeline` to add the handlers.
+    /// - Returns: A result representing whether the handlers were added or not.
+    fileprivate func addHandlersSync(_ handlers: [ChannelHandler],
+                                     position: ChannelPipeline.Position) -> Result<Void, Error> {
+        switch position {
+        case .first, .after:
+            return self._addHandlersSync(handlers.reversed(), position: position)
+        case .last, .before:
+            return self._addHandlersSync(handlers, position: position)
+        }
+    }
+
+    /// Synchronously adds a sequence of `ChannelHandlers` to the pipeline at the given position.
+    ///
+    /// - Important: Must be called on the `EventLoop`.
+    /// - Parameters:
+    ///   - handlers: A sequence of handlers to add.
+    ///   - position: The position in the `ChannelPipeline` to add the handlers.
+    /// - Returns: A result representing whether the handlers were added or not.
+    private func _addHandlersSync<Handlers: Sequence>(_ handlers: Handlers,
+                                                      position: ChannelPipeline.Position) -> Result<Void, Error> where Handlers.Element == ChannelHandler {
+        self.eventLoop.assertInEventLoop()
+
+        for handler in handlers {
+            let result = self.addHandlerSync(handler, position: position)
+            switch result {
+            case .success:
+                ()
+            case .failure:
+                return result
+            }
+        }
+
+        return .success(())
+    }
+}
+
+// MARK: - Synchronous View
+
+extension ChannelPipeline {
+    /// A view of a `ChannelPipeline` which may be used to invoke synchronous operations.
+    ///
+    /// All functions **must** be called from the pipeline's event loop.
+    public struct SynchronousOperations {
+        @usableFromInline
+        internal let _pipeline: ChannelPipeline
+
+        fileprivate init(pipeline: ChannelPipeline) {
+            self._pipeline = pipeline
+        }
+
+        /// Add a handler to the pipeline.
+        ///
+        /// - Important: This *must* be called on the event loop.
+        /// - Parameters:
+        ///   - handler: The handler to add.
+        ///   - name: The name to use for the `ChannelHandler` when it's added. If no name is specified the one will be generated.
+        ///   - position: The position in the `ChannelPipeline` to add `handler`. Defaults to `.last`.
+        public func addHandler(_ handler: ChannelHandler,
+                               name: String? = nil,
+                               position: ChannelPipeline.Position = .last) throws {
+            try self._pipeline.addHandlerSync(handler, name: name, position: position).get()
+        }
+
+        /// Add an array of handlers to the pipeline.
+        ///
+        /// - Important: This *must* be called on the event loop.
+        /// - Parameters:
+        ///   - handlers: The handlers to add.
+        ///   - position: The position in the `ChannelPipeline` to add `handlers`. Defaults to `.last`.
+        public func addHandlers(_ handlers: [ChannelHandler],
+                                position: ChannelPipeline.Position = .last) throws {
+            try self._pipeline.addHandlersSync(handlers, position: position).get()
+        }
+
+        /// Add one or more handlers to the pipeline.
+        ///
+        /// - Important: This *must* be called on the event loop.
+        /// - Parameters:
+        ///   - handlers: The handlers to add.
+        ///   - position: The position in the `ChannelPipeline` to add `handlers`. Defaults to `.last`.
+        public func addHandlers(_ handlers: ChannelHandler...,
+                                position: ChannelPipeline.Position = .last) throws {
+            try self._pipeline.addHandlersSync(handlers, position: position).get()
+        }
+
+        /// Returns the `ChannelHandlerContext` for the given handler instance if it is in
+        /// the `ChannelPipeline`, if it exists.
+        ///
+        /// - Important: This *must* be called on the event loop.
+        /// - Parameter handler: The handler belonging to the context to fetch.
+        /// - Returns: The `ChannelHandlerContext` associated with the handler.
+        public func context(handler: ChannelHandler) throws -> ChannelHandlerContext {
+            return try self._pipeline._contextSync({ $0.handler === handler }).get()
+        }
+
+        /// Returns the `ChannelHandlerContext` for the handler with the given name, if one exists.
+        ///
+        /// - Important: This *must* be called on the event loop.
+        /// - Parameter name: The name of the handler whose context is being fetched.
+        /// - Returns: The `ChannelHandlerContext` associated with the handler.
+        public func context(name: String) throws -> ChannelHandlerContext {
+            return try self._pipeline.contextSync(name: name).get()
+        }
+
+        /// Returns the `ChannelHandlerContext` for the handler of given type, if one exists.
+        ///
+        /// - Important: This *must* be called on the event loop.
+        /// - Parameter name: The name of the handler whose context is being fetched.
+        /// - Returns: The `ChannelHandlerContext` associated with the handler.
+        @inlinable
+        public func context<Handler: ChannelHandler>(handlerType: Handler.Type) throws -> ChannelHandlerContext {
+            return try self._pipeline._contextSync(handlerType: handlerType).get()
+        }
+
+        /// Returns the `ChannelHandler` of the given type from the `ChannelPipeline`, if it exists.
+        ///
+        /// - Important: This *must* be called on the event loop.
+        /// - Returns: A `ChannelHandler` of the given type if one exists in the `ChannelPipeline`.
+        @inlinable
+        public func handler<Handler: ChannelHandler>(type _: Handler.Type) throws -> Handler {
+            return try self._pipeline._handlerSync(type: Handler.self).get()
+        }
+    }
+
+    /// Returns a view of operations which can be performed synchronously on this pipeline. All
+    /// operations **must** be called on the event loop.
+    public var syncOperations: SynchronousOperations {
+        return SynchronousOperations(pipeline: self)
     }
 }
 
@@ -1604,13 +1754,29 @@ extension ChannelPipeline: CustomDebugStringConvertible {
     /// Returns the first `ChannelHandler` of the given type.
     ///
     /// - parameters:
-    ///     - handlerType: the type of `ChannelHandler` to return.
+    ///     - type: the type of `ChannelHandler` to return.
+    @inlinable
     public func handler<Handler: ChannelHandler>(type _: Handler.Type) -> EventLoopFuture<Handler> {
         return self.context(handlerType: Handler.self).map { context in
             guard let typedContext = context.handler as? Handler else {
                 preconditionFailure("Expected channel handler of type \(Handler.self), got \(type(of: context.handler)) instead.")
             }
             
+            return typedContext
+        }
+    }
+
+    /// Synchronously finds and returns the first `ChannelHandler` of the given type.
+    ///
+    /// - Important: This must be called on the `EventLoop`.
+    /// - Parameters:
+    ///     - type: the type of `ChannelHandler` to return.
+    @inlinable // should be fileprivate
+    internal func _handlerSync<Handler: ChannelHandler>(type _: Handler.Type) -> Result<Handler, Error> {
+        return self._contextSync(handlerType: Handler.self).map { context in
+            guard let typedContext = context.handler as? Handler else {
+                preconditionFailure("Expected channel handler of type \(Handler.self), got \(type(of: context.handler)) instead.")
+            }
             return typedContext
         }
     }

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -63,6 +63,11 @@ extension ChannelPipelineTest {
                 ("testPipelineDebugDescription", testPipelineDebugDescription),
                 ("testWeDontCallHandlerRemovedTwiceIfAHandlerCompletesRemovalOnlyAfterChannelTeardown", testWeDontCallHandlerRemovedTwiceIfAHandlerCompletesRemovalOnlyAfterChannelTeardown),
                 ("testWeFailTheSecondRemoval", testWeFailTheSecondRemoval),
+                ("testSynchronousViewAddHandler", testSynchronousViewAddHandler),
+                ("testSynchronousViewAddHandlerAfterDestroyed", testSynchronousViewAddHandlerAfterDestroyed),
+                ("testSynchronousViewAddHandlers", testSynchronousViewAddHandlers),
+                ("testSynchronousViewContext", testSynchronousViewContext),
+                ("testSynchronousViewGetTypedHandler", testSynchronousViewGetTypedHandler),
            ]
    }
 }

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -19,6 +19,9 @@ services:
     image: swift-nio:16.04-5.2
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180010

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -19,6 +19,9 @@ services:
     image: swift-nio:16.04-5.3
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=179010

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,6 +19,9 @@ services:
     image: swift-nio:18.04-5.0
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31990
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=188050

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -19,6 +19,9 @@ services:
     image: swift-nio:18.04-5.1
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3100
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=180050


### PR DESCRIPTION
Motivation:

`ChannelPipeline` is explicitly thread-safe, any of the operations may
be called from outside of the channel's event loop. However, there are
often cases where it is known that the caller be on the right event
loop, and an asynchronous API is unnecessary.

In some cases -- such as when a pipeline is configured dynamically and
handlers are added from the 'channelRead' implementation of one handler
-- it forces the caller to write code that they might not actually need:
such as buffering events which may happen before the future completes.
This is unnecessary complexity when the caller knows that they must
already be on an event loop.

Modifications:

- Add a 'SynchronousVew' to the 'ChannelPipeline' which is only
  available to callers via 'withSynchronousViewIfAvailable'.
- An error is thrown if the caller is not on the event loop.
- The synchronous view supports: adding a handler, adding multiple
  handlers, retrieving a context via various predicates and retrieving a
  handler of a given type.
- Some of the operations in 'ChannelPipeline' were refactored to have an
  explicitly synchronous version, asynchronous versions complete their
  promise based on the result of these calls.
- Various minor documentation fixes and addition of 'self' where it was
  not used explicitly.

Result:

Users can perform synchronous operations on the 'ChannelPipeline' if
they know they are on the right event loop.