### PR TITLE
Correct typo in SelectableEventLoop class doc.

### DIFF
--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -455,7 +455,7 @@ internal final class SelectableEventLoop: EventLoop {
                     break
                 }
 
-                // Execute all the tasks that were summited
+                // Execute all the tasks that were submitted
                 for task in self.tasksCopy {
                     /* for macOS: in case any calls we make to Foundation put objects into an autoreleasepool */
                     withAutoReleasePool {


### PR DESCRIPTION
Correct a typo in the doc of SelectableEventLoop class.

### Motivation:

This piece of code could be visited often by the readers who want to track the asynchronous executions. It's better to avoid misspelling.

### Modifications:

Replaced `summited ` with `submitted `

### Result:

No misleading.
