### PR TITLE
Move the global helper function executeAndComplete() into EventLoop class.

### DIFF
--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -545,7 +545,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
     public final func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> EventLoopFuture<Void> {
         if eventLoop.inEventLoop {
             let promise = eventLoop.makePromise(of: Void.self)
-            executeAndComplete(promise) { try self.setOption0(option, value: value) }
+            eventLoop.executeAndComplete(promise) { try self.setOption0(option, value: value) }
             return promise.futureResult
         } else {
             return eventLoop.submit { try self.setOption0(option, value: value) }
@@ -646,7 +646,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
             return
         }
 
-        executeAndComplete(promise) {
+        self.eventLoop.executeAndComplete(promise) {
             try socket.bind(to: address)
             self.updateCachedAddressesFromSocket(updateRemote: false)
         }

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -229,6 +229,9 @@ public protocol EventLoop: EventLoopGroup {
     /// Submit a given task to be executed by the `EventLoop`
     func execute(_ task: @escaping () -> Void)
 
+    /// Execute the given function and synchronously complete the given `EventLoopPromise` (if not `nil`).
+    func executeAndComplete<T>(_ promise: EventLoopPromise<T>?, _ body: () throws -> T)
+
     /// Submit a given task to be executed by the `EventLoop`. Once the execution is complete the returned `EventLoopFuture` is notified.
     ///
     /// - parameters:
@@ -499,6 +502,17 @@ extension NIODeadline {
 }
 
 extension EventLoop {
+    /// Execute the given function and synchronously complete the given `EventLoopPromise` (if not `nil`).
+    @inlinable
+    public func executeAndComplete<T>(_ promise: EventLoopPromise<T>?, _ body: () throws -> T) {
+        do {
+            let result = try body()
+            promise?.succeed(result)
+        } catch let err {
+            promise?.fail(err)
+        }
+    }
+
     /// Submit `task` to be run on this `EventLoop`.
     ///
     /// The returned `EventLoopFuture` will be completed when `task` has finished running. It will be succeeded with

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -1305,17 +1305,6 @@ extension EventLoopFuture {
     }
 }
 
-/// Execute the given function and synchronously complete the given `EventLoopPromise` (if not `nil`).
-func executeAndComplete<Value>(_ promise: EventLoopPromise<Value>?, _ body: () throws -> Value) {
-    do {
-        let result = try body()
-        promise?.succeed(result)
-    } catch let e {
-        promise?.fail(e)
-    }
-}
-
-
 // MARK: always
 
 extension EventLoopFuture {

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -216,7 +216,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         }.whenFailure{ error in
             promise?.fail(error)
         }
-        executeAndComplete(p) {
+        self.eventLoop.executeAndComplete(p) {
             try socket.bind(to: address)
             self.updateCachedAddressesFromSocket(updateRemote: false)
             try self.socket.listen(backlog: backlog)

--- a/Sources/NIO/SocketOptionProvider.swift
+++ b/Sources/NIO/SocketOptionProvider.swift
@@ -288,7 +288,7 @@ extension BaseSocketChannel: SocketOptionProvider {
     func unsafeSetSocketOption<Value>(level: NIOBSDSocket.OptionLevel, name: NIOBSDSocket.Option, value: Value) -> EventLoopFuture<Void> {
         if eventLoop.inEventLoop {
             let promise = eventLoop.makePromise(of: Void.self)
-            executeAndComplete(promise) {
+            eventLoop.executeAndComplete(promise) {
                 try setSocketOption0(level: level, name: name, value: value)
             }
             return promise.futureResult
@@ -308,7 +308,7 @@ extension BaseSocketChannel: SocketOptionProvider {
     func unsafeGetSocketOption<Value>(level: NIOBSDSocket.OptionLevel, name: NIOBSDSocket.Option) -> EventLoopFuture<Value> {
         if eventLoop.inEventLoop {
             let promise = eventLoop.makePromise(of: Value.self)
-            executeAndComplete(promise) {
+            eventLoop.executeAndComplete(promise) {
                 try getSocketOption0(level: level, name: name)
             }
             return promise.futureResult


### PR DESCRIPTION
Move the global helper function executeAndComplete() into EventLoop class.

### Motivation:

- For better encapsulation.
- From either the caller's prospective or their internal implementation, executeAndComplete() is more likely an alternative to the submit() method of EventLoop class.

### Modifications:

- Moved global function executeAndComplete() to EventLoop class.

### Result:

Now it's looks more natural to use executeAndComplete() from the callers' prospective.