### PR TITLE
Add synchronous channel options

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet.swift
@@ -15,19 +15,20 @@
 import NIO
 
 func run(identifier: String) {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer {
+        try! group.syncShutdownGracefully()
+    }
+
+    let server = try! ServerBootstrap(group: group)
+      .bind(host: "127.0.0.1", port: 0)
+      .wait()
+    defer {
+        try! server.close().wait()
+    }
+
     measure(identifier: identifier) {
         let iterations = 1000
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            try! group.syncShutdownGracefully()
-        }
-
-        let server = try! ServerBootstrap(group: group)
-          .bind(host: "127.0.0.1", port: 0)
-          .wait()
-        defer {
-            try! server.close().wait()
-        }
 
         for _ in 0..<iterations {
             let autoReadOption = try! server.getOption(ChannelOptions.autoRead).wait()

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+func run(identifier: String) {
+    measure(identifier: identifier) {
+        let iterations = 1000
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            try! group.syncShutdownGracefully()
+        }
+
+        let server = try! ServerBootstrap(group: group)
+          .bind(host: "127.0.0.1", port: 0)
+          .wait()
+        defer {
+            try! server.close().wait()
+        }
+
+        for _ in 0..<iterations {
+            let autoReadOption = try! server.getOption(ChannelOptions.autoRead).wait()
+            try! server.setOption(ChannelOptions.autoRead, value: !autoReadOption).wait()
+        }
+
+        return iterations
+    }
+}

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet_sync.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet_sync.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+func run(identifier: String) {
+    measure(identifier: identifier) {
+        let iterations = 1000
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            try! group.syncShutdownGracefully()
+        }
+
+        let server = try! ServerBootstrap(group: group)
+          .bind(host: "127.0.0.1", port: 0)
+          .wait()
+        defer {
+            try! server.close().wait()
+        }
+
+        server.eventLoop.execute {
+            let syncOptions = server.syncOptions!
+
+            for _ in 0..<iterations {
+                let autoReadOption = try! syncOptions.getOption(ChannelOptions.autoRead)
+                try! syncOptions.setOption(ChannelOptions.autoRead, value: !autoReadOption)
+            }
+        }
+
+        return iterations
+    }
+}

--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -1267,3 +1267,29 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         fatalError("must override")
     }
 }
+
+extension BaseSocketChannel {
+    public struct SynchronousOptions: NIOSynchronousChannelOptions {
+        @usableFromInline // should be private
+        internal let _channel: BaseSocketChannel<SocketType>
+
+        @inlinable // should be fileprivate
+        internal init(_channel channel: BaseSocketChannel<SocketType>) {
+            self._channel = channel
+        }
+
+        @inlinable
+        public func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
+            try self._channel.setOption0(option, value: value)
+        }
+
+        @inlinable
+        public func getOption<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
+            try self._channel.getOption0(option)
+        }
+    }
+
+    public final var syncOptions: NIOSynchronousChannelOptions? {
+        return SynchronousOptions(_channel: self)
+    }
+}

--- a/Sources/NIO/BaseSocketChannel.swift
+++ b/Sources/NIO/BaseSocketChannel.swift
@@ -1285,7 +1285,7 @@ extension BaseSocketChannel {
 
         @inlinable
         public func getOption<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
-            try self._channel.getOption0(option)
+            return try self._channel.getOption0(option)
         }
     }
 

--- a/Sources/NIO/Bootstrap.swift
+++ b/Sources/NIO/Bootstrap.swift
@@ -536,7 +536,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     }
 
     /// Specifies a timeout to apply to a connection attempt.
-    //
+    ///
     /// - parameters:
     ///     - timeout: The timeout that will apply to the connection attempt.
     public func connectTimeout(_ timeout: TimeAmount) -> Self {

--- a/Sources/NIO/Channel.swift
+++ b/Sources/NIO/Channel.swift
@@ -140,6 +140,30 @@ public protocol Channel: AnyObject, ChannelOutboundInvoker {
     ///
     /// - warning: Unsafe, this is for use in NIO's core only.
     var _channelCore: ChannelCore { get }
+
+    /// Returns a view of the `Channel` exposing synchronous versions of `setOption` and `getOption`.
+    /// The default implementation returns `nil`, and `Channel` implementations must opt in to
+    /// support this behavior.
+    var syncOptions: NIOSynchronousChannelOptions? { get }
+}
+
+extension Channel {
+    /// Default implementation: `NIOSynchronousChannelOptions` are not supported.
+    public var syncOptions: NIOSynchronousChannelOptions? {
+        return nil
+    }
+}
+
+public protocol NIOSynchronousChannelOptions {
+    /// Set `option` to `value` on this `Channel`.
+    ///
+    /// - Important: Must be called on the `EventLoop` the `Channel` is running on.
+    func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) throws
+
+    /// Get the value of `option` for this `Channel`.
+    ///
+    /// - Important: Must be called on the `EventLoop` the `Channel` is running on.
+    func getOption<Option: ChannelOption>(_ option: Option) throws -> Option.Value
 }
 
 /// A `SelectableChannel` is a `Channel` that can be used with a `Selector` which notifies a user when certain events

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -632,15 +632,28 @@ public final class EmbeddedChannel: Channel {
     }
 
     /// - see: `Channel.setOption`
+    @inlinable
     public func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> EventLoopFuture<Void> {
+        self.setOptionSync(option, value: value)
+        return self.eventLoop.makeSucceededVoidFuture()
+    }
+
+    @inlinable
+    internal func setOptionSync<Option: ChannelOption>(_ option: Option, value: Option.Value) {
         // No options supported
         fatalError("no options supported")
     }
 
     /// - see: `Channel.getOption`
+    @inlinable
     public func getOption<Option: ChannelOption>(_ option: Option) -> EventLoopFuture<Option.Value>  {
+        return self.eventLoop.makeSucceededFuture(self.getOptionSync(option))
+    }
+
+    @inlinable
+    internal func getOptionSync<Option: ChannelOption>(_ option: Option) -> Option.Value {
         if option is ChannelOptions.Types.AutoReadOption {
-            return self.eventLoop.makeSucceededFuture(true as! Option.Value)
+            return true as! Option.Value
         }
         fatalError("option \(option) not supported")
     }
@@ -671,5 +684,30 @@ public final class EmbeddedChannel: Channel {
             self.remoteAddress = address
         }
         pipeline.connect(to: address, promise: promise)
+    }
+}
+
+extension EmbeddedChannel {
+    public struct SynchronousOptions: NIOSynchronousChannelOptions {
+        @usableFromInline
+        internal let channel: EmbeddedChannel
+
+        fileprivate init(channel: EmbeddedChannel) {
+            self.channel = channel
+        }
+
+        @inlinable
+        public func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
+            self.channel.setOptionSync(option, value: value)
+        }
+
+        @inlinable
+        public func getOption<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
+            self.channel.getOptionSync(option)
+        }
+    }
+
+    public final var syncOptions: NIOSynchronousChannelOptions? {
+        return SynchronousOptions(channel: self)
     }
 }

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -703,7 +703,7 @@ extension EmbeddedChannel {
 
         @inlinable
         public func getOption<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
-            self.channel.getOptionSync(option)
+            return self.channel.getOptionSync(option)
         }
     }
 

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -48,6 +48,7 @@ extension EmbeddedChannelTest {
                 ("testUnprocessedOutboundUserEventFailsOnEmbeddedChannel", testUnprocessedOutboundUserEventFailsOnEmbeddedChannel),
                 ("testEmbeddedChannelWritabilityIsWritable", testEmbeddedChannelWritabilityIsWritable),
                 ("testFinishWithRecursivelyScheduledTasks", testFinishWithRecursivelyScheduledTasks),
+                ("testSyncOptionsAreSupported", testSyncOptionsAreSupported),
            ]
    }
 }

--- a/Tests/NIOTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest.swift
@@ -384,4 +384,12 @@ class EmbeddedChannelTest: XCTestCase {
         XCTAssertEqual(invocations, 1)
     }
 
+    func testSyncOptionsAreSupported() throws {
+        let channel = EmbeddedChannel()
+        let options = channel.syncOptions
+        XCTAssertNotNil(options)
+        // Unconditonally returns true.
+        XCTAssertEqual(try options?.getOption(ChannelOptions.autoRead), true)
+        // (Setting options isn't supported.)
+    }
 }

--- a/Tests/NIOTests/StreamChannelsTest+XCTest.swift
+++ b/Tests/NIOTests/StreamChannelsTest+XCTest.swift
@@ -28,6 +28,8 @@ extension StreamChannelTest {
    static var allTests : [(String, (StreamChannelTest) -> () throws -> Void)] {
       return [
                 ("testEchoBasic", testEchoBasic),
+                ("testSyncChannelOptions", testSyncChannelOptions),
+                ("testChannelReturnsNilForDefaultSyncOptionsImplementation", testChannelReturnsNilForDefaultSyncOptionsImplementation),
                 ("testWritabilityStartsTrueGoesFalseAndBackToTrue", testWritabilityStartsTrueGoesFalseAndBackToTrue),
                 ("testHalfCloseOwnOutput", testHalfCloseOwnOutput),
                 ("testHalfCloseOwnInput", testHalfCloseOwnInput),

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -20,8 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -20,6 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -20,8 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -20,6 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -20,8 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31990

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -20,6 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31990

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -20,8 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -20,6 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -20,8 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
-        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -20,6 +20,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=33250
+        MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=250
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540


### PR DESCRIPTION
Motivation:

The functions for getting and setting channel options are currently
asynchronous. This ensures that options are set and retrieved safely.
However, in some cases the caller knows they are on the correct event
loop but still has to pay the cost of allocating a future to either get
or set an option.

Modifications:

- Add a 'NIOSynchronousChannelOptions' protocol for getting and setting
  options
- Add a customisation point to 'Channel' to return 'NIOSynchronousChannelOptions'.
- Default implementation returns nil so as to not break API.
- Add implementations for 'EmbeddedChannel' and 'BaseSocketChannel'
- Allocation tests for getting and setting autoRead

Results:

Options can be get and set synchronously.