### PR TITLE
surface errors when connection reset through pipeline

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -669,10 +669,10 @@ public final class ChannelPipeline: ChannelInvoker {
 
     public func fireErrorCaught(_ error: Error) {
         if eventLoop.inEventLoop {
-            fireErrorCaught0(error: error)
+            self.fireErrorCaught0(error)
         } else {
             eventLoop.execute {
-                self.fireErrorCaught0(error: error)
+                self.fireErrorCaught0(error)
             }
         }
     }
@@ -893,7 +893,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    func fireErrorCaught0(error: Error) {
+    func fireErrorCaught0(_ error: Error) {
         assert((error as? ChannelError).map { $0 != .eof } ?? true)
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeErrorCaught(error)

--- a/Tests/NIOTests/ChannelTests.swift
+++ b/Tests/NIOTests/ChannelTests.swift
@@ -2128,7 +2128,6 @@ public final class ChannelTests: XCTestCase {
 
     func testSocketFailingAsyncCorrectlyTearsTheChannelDownAndDoesntCrash() throws {
         // regression test for #302
-        enum DummyError: Error { case dummy }
         class SocketFailingAsyncConnect: Socket {
             init() throws {
                 try super.init(protocolFamily: .inet, type: .stream, setNonBlocking: true)
@@ -2174,7 +2173,6 @@ public final class ChannelTests: XCTestCase {
 
     func testSocketErroringSynchronouslyCorrectlyTearsTheChannelDown() throws {
         // regression test for #322
-        enum DummyError: Error { case dummy }
         class SocketFailingConnect: Socket {
             init() throws {
                 try super.init(protocolFamily: .inet, type: .stream, setNonBlocking: true)
@@ -2241,7 +2239,6 @@ public final class ChannelTests: XCTestCase {
     }
 
     func testCloseInUnregister() throws {
-        enum DummyError: Error { case dummy }
         class SocketFailingClose: Socket {
             init() throws {
                 try super.init(protocolFamily: .inet, type: .stream, setNonBlocking: true)
@@ -2833,6 +2830,10 @@ fileprivate final class FailRegistrationAndDelayCloseHandler: ChannelOutboundHan
     }
 }
 
+fileprivate enum DummyError: Error {
+    case dummy
+}
+
 fileprivate class VerifyConnectionFailureHandler: ChannelInboundHandler {
     typealias InboundIn = Never
     private let allDone: EventLoopPromise<Void>
@@ -2854,7 +2855,9 @@ fileprivate class VerifyConnectionFailureHandler: ChannelInboundHandler {
 
     func channelReadComplete(context: ChannelHandlerContext) { XCTFail("should never readComplete") }
 
-    func errorCaught(context: ChannelHandlerContext, error: Error) { XCTFail("pipeline shouldn't be told about connect error") }
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        XCTAssertEqual(.dummy, error as? DummyError)
+    }
 
     func channelRegistered(context: ChannelHandlerContext) {
         XCTAssertEqual(.fresh, self.state)

--- a/Tests/NIOTests/SocketChannelTest+XCTest.swift
+++ b/Tests/NIOTests/SocketChannelTest+XCTest.swift
@@ -54,6 +54,7 @@ extension SocketChannelTest {
                 ("testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheServerSide", testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheServerSide),
                 ("testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheClientSide", testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheClientSide),
                 ("testServerClosesTheConnectionImmediately", testServerClosesTheConnectionImmediately),
+                ("testConnectErrorIsObservedInPipeline", testConnectErrorIsObservedInPipeline),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously, NIO wouldn't send errors that we pulled out of the socket on
connection reset through the pipeline. That meant that you wouldn't for
example see connect errors.

Modification:

Send errors through the pipeline if the channel is still alive after
trying to read all bytes.

Result:

- More erorrs surfaced to the user.
- fixes #1756 