### PR TITLE
docs: debugging from the OS level

### DIFF
--- a/docs/debug-os-level.md
+++ b/docs/debug-os-level.md
@@ -1,0 +1,74 @@
+# Debugging NIO programs from the OS level
+
+
+## List all file descriptors
+
+```
+lsof -p $(pgrep NIOEchoServer)
+```
+
+## Dump traffic to file
+
+For example to dump everything on port `12345` on interface `en0`:
+
+```
+sudo tcpdump -i en0 -w /tmp/dump.pcap '' 'port 12345'
+```
+
+## List event file descriptors
+
+### macOS
+
+```
+lskq -p $(pgrep NIOEchoServer)
+```
+
+### Linux
+
+```
+pid=$(pgrep NIOEchoServer); for fd_file in /proc/$pid/fd/*; do if [[ "$(readlink "$fd_file")" =~ eventpoll ]]; then fd=$(basename "$fd_file"); echo "Epoll $fd"; echo =====; cat "/proc/$pid/fdinfo/$fd"; fi; done
+```
+
+
+## Info about UNIX Domain Socket connections
+
+### Linux
+
+```
+sudo netstat --protocol=unix -peona
+```
+
+### macOS
+
+```
+netstat -n -a -f unix
+```
+
+## Info about TCP connections
+
+### Linux
+
+```
+sudo netstat --tcp -peona
+```
+
+### macOS
+
+```
+netstat -n -p tcp -a
+```
+
+## Info about TCP connections
+
+
+### Linux
+
+```
+sudo netstat --udp -peona
+```
+
+### macOS
+
+```
+netstat -n -p udp -a
+```


### PR DESCRIPTION
Motivation:

When users have problems like missing data or similar, it's often useful
to debug from the OS level. The commands are a bit arcane and it saves
time if we don't have to remember them all the time.

Modification:

Add some macOS and Linux examples.

Result:

Better docs