### PR TITLE
Add assertion helpers for NIOHTTP1TestServer

### DIFF
--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest+XCTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest+XCTest.swift
@@ -32,6 +32,9 @@ extension NIOHTTP1TestServerTest {
                 ("testConcurrentRequests", testConcurrentRequests),
                 ("testTestWebServerCanBeReleased", testTestWebServerCanBeReleased),
                 ("testStopClosesAcceptedChannel", testStopClosesAcceptedChannel),
+                ("testReceiveAndVerify", testReceiveAndVerify),
+                ("testReceive", testReceive),
+                ("testReceiveAndVerifyWrongPart", testReceiveAndVerifyWrongPart),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Verifying the contents of inbound request parts for `NIOHTTP1TestServer`
can be quite tedious and whenever I use `NIOHTTP1TestServer` in
different projects I find myself writing similar extensions to help
verify the inbound request parts are as expected.

Modifications:

- Add verification methods to `NIOHTTP1TestServer` which checks for the
  expected part and optionally verifies it further in a callback

Result:

It's easier to test with NIOHTTP1TestServer