### PR TITLE
HTTP server upgrade tests: cosmetic improvements

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -866,14 +866,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
 
         let channel = EmbeddedChannel()
         defer {
-            do {
-                let complete = try channel.finish()
-                XCTAssertTrue(complete.isClean)
-            } catch No.no {
-                // ok
-            } catch {
-                XCTFail("Unexpected error: \(error)")
-            }
+            XCTAssertTrue(try channel.finish().isClean)
         }
 
         var upgradingProtocol = ""
@@ -930,14 +923,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
 
         let channel = EmbeddedChannel()
         defer {
-            do {
-                let isCleanOnFinish = try channel.finish().isClean
-                XCTAssertTrue(isCleanOnFinish)
-            } catch No.no {
-                // ok
-            } catch {
-                XCTFail("Unexpected error: \(error)")
-            }
+            XCTAssertTrue(try channel.finish().isClean)
         }
 
         var upgradeRequested = false
@@ -996,14 +982,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
 
         let channel = EmbeddedChannel()
         defer {
-            do {
-                let isCleanOnFinish = try channel.finish().isClean
-                XCTAssertTrue(isCleanOnFinish)
-            } catch No.no {
-                // ok
-            } catch {
-                XCTFail("Unexpected error: \(error)")
-            }
+            XCTAssertTrue(try channel.finish().isClean)
         }
 
         var upgradeRequested = false


### PR DESCRIPTION
Motivation:

The HTTP server upgrade tests had unncessarily wide and also verbose
test assertions.

Modifications:

Rewrote them much simpler and narrowed what states are allowed.

Result:

- Neater code
- Works around https://bugs.swift.org/browse/SR-14253