### PR TITLE
5.4 fixes: TSan still broken, assertion format change, alloc changes

### DIFF
--- a/Sources/NIOCrashTester/CrashTests+ByteBuffer.swift
+++ b/Sources/NIOCrashTester/CrashTests+ByteBuffer.swift
@@ -16,14 +16,14 @@ import NIO
 
 struct ByteBufferCrashTests {
     let testMovingReaderIndexPastWriterIndex = CrashTest(
-        regex: #"^Precondition failed: new readerIndex: 1, expected: range\(0, 0\)"#
+        regex: #"Precondition failed: new readerIndex: 1, expected: range\(0, 0\)"#
     ) {
         var buffer = ByteBufferAllocator().buffer(capacity: 16)
         buffer.moveReaderIndex(forwardBy: 1)
     }
 
     let testAllocatingNegativeSize = CrashTest(
-        regex: #"^Precondition failed: ByteBuffer capacity must be positive."#
+        regex: #"Precondition failed: ByteBuffer capacity must be positive."#
     ) {
         _ = ByteBufferAllocator().buffer(capacity: -1)
     }

--- a/Sources/NIOCrashTester/CrashTests+EventLoop.swift
+++ b/Sources/NIOCrashTester/CrashTests+EventLoop.swift
@@ -18,13 +18,13 @@ fileprivate let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
 
 struct EventLoopCrashTests {
     let testMultiThreadedELGCrashesOnZeroThreads = CrashTest(
-        regex: "^Precondition failed: numberOfThreads must be positive"
+        regex: "Precondition failed: numberOfThreads must be positive"
     ) {
         try? MultiThreadedEventLoopGroup(numberOfThreads: 0).syncShutdownGracefully()
     }
 
     let testWaitCrashesWhenOnEL = CrashTest(
-        regex: #"^Precondition failed: BUG DETECTED: wait\(\) must not be called when on an EventLoop"#
+        regex: #"Precondition failed: BUG DETECTED: wait\(\) must not be called when on an EventLoop"#
     ) {
         let promise = group.next().makePromise(of: Void.self)
         try? group.next().submit {
@@ -33,19 +33,19 @@ struct EventLoopCrashTests {
     }
 
     let testAssertInEventLoop = CrashTest(
-        regex: "^Precondition failed: file DUMMY, line 42"
+        regex: "Precondition failed"
     ) {
         group.next().assertInEventLoop(file: "DUMMY", line: 42)
     }
 
     let testPreconditionInEventLoop = CrashTest(
-        regex: "^Precondition failed: file DUMMY, line 42"
+        regex: "Precondition failed"
     ) {
         group.next().preconditionInEventLoop(file: "DUMMY", line: 42)
     }
 
     let testAssertNotInEventLoop = CrashTest(
-        regex: "^Precondition failed: file DUMMY, line 42"
+        regex: "Precondition failed"
     ) {
         let el = group.next()
         try? el.submit {
@@ -54,7 +54,7 @@ struct EventLoopCrashTests {
     }
 
     let testPreconditionNotInEventLoop = CrashTest(
-        regex: "^Precondition failed: file DUMMY, line 42"
+        regex: "Precondition failed"
     ) {
         let el = group.next()
         try? el.submit {
@@ -63,7 +63,7 @@ struct EventLoopCrashTests {
     }
 
     let testSchedulingEndlesslyInELShutdown = CrashTest(
-        regex: #"^Precondition failed: EventLoop SelectableEventLoop \{ .* \} didn't quiesce after 1000 ticks."#
+        regex: #"Precondition failed: EventLoop SelectableEventLoop \{ .* \} didn't quiesce after 1000 ticks."#
     ) {
         let group = MultiThreadedEventLoopGroup.init(numberOfThreads: 1)
         defer {

--- a/Sources/NIOCrashTester/CrashTests+HTTP.swift
+++ b/Sources/NIOCrashTester/CrashTests+HTTP.swift
@@ -17,7 +17,7 @@ import NIOHTTP1
 
 struct HTTPCrashTests {
     let testEncodingChunkedAndContentLengthForRequestsCrashes = CrashTest(
-        regex: "^Assertion failed: illegal HTTP sent: HTTPRequestHead .* contains both a content-length and transfer-encoding:chunked",
+        regex: "Assertion failed: illegal HTTP sent: HTTPRequestHead .* contains both a content-length and transfer-encoding:chunked",
         {
             let channel = EmbeddedChannel(handler: HTTPRequestEncoder())
             _ = try? channel.writeAndFlush(
@@ -30,7 +30,7 @@ struct HTTPCrashTests {
         })
 
     let testEncodingChunkedAndContentLengthForResponseCrashes = CrashTest(
-        regex: "^Assertion failed: illegal HTTP sent: HTTPResponseHead .* contains both a content-length and transfer-encoding:chunked",
+        regex: "Assertion failed: illegal HTTP sent: HTTPResponseHead .* contains both a content-length and transfer-encoding:chunked",
         {
             let channel = EmbeddedChannel(handler: HTTPResponseEncoder())
             _ = try? channel.writeAndFlush(

--- a/Sources/NIOCrashTester/CrashTests+System.swift
+++ b/Sources/NIOCrashTester/CrashTests+System.swift
@@ -19,7 +19,7 @@ fileprivate let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
 struct SystemCrashTests {
     let testEBADFIsUnacceptable = CrashTest(
-        regex: "^Precondition failed: unacceptable errno \(EBADF) Bad file descriptor in", {
+        regex: "Precondition failed: unacceptable errno \(EBADF) Bad file descriptor in", {
             _ = try? NIOPipeBootstrap(group: group).withPipes(inputDescriptor: .max, outputDescriptor: .max - 1).wait()
         })
 }

--- a/Sources/NIOCrashTester/OutputGrepper.swift
+++ b/Sources/NIOCrashTester/OutputGrepper.swift
@@ -65,9 +65,9 @@ private final class GrepHandler: ChannelInboundHandler {
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let line = self.unwrapInboundIn(data)
-        if line.lowercased().starts(with: "fatal error: ") ||
-            line.lowercased().starts(with: "precondition failed: ") ||
-            line.lowercased().starts(with: "assertion failed: ") {
+        if line.lowercased().contains("fatal error") ||
+            line.lowercased().contains("precondition failed") ||
+            line.lowercased().contains("assertion failed") {
             self.promise.succeed(line)
             context.close(promise: nil)
         }

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -26,18 +26,18 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=50
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30540
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4100
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=179010
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=181050 # regression from 5.3 which was 179010
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2000
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=101050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=471050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050 # regression from 5.3 which was 101050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=473050 # regression from 5.3 which was 471050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2100
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=100
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=1000
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=1000
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5010
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5010
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75010
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=50
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2010
@@ -46,8 +46,8 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16250
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=202050
-      - SANITIZER_ARG=--sanitize=thread
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=204050 # regression from 5.3 which was 202050
+      # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:
     image: swift-nio:20.04-5.4


### PR DESCRIPTION
Motivation:

5.4 should work in CI.

Modification:
- disable TSan, still broken on Ubuntu != 16.04
- format changes for assertions (from `Precondition failed: MESSAGE, FILE:LINE` to `FILE:LINE: Precondition failed: MESSAGE`)
- alloc changes.

Result:

5.4 works.