### PR TITLE
Decrease overhead of internal size table used in AdaptiveRecvByteBufferAllocator

### DIFF
--- a/Sources/NIO/RecvByteBufferAllocator.swift
+++ b/Sources/NIO/RecvByteBufferAllocator.swift
@@ -62,7 +62,7 @@ public struct AdaptiveRecvByteBufferAllocator: RecvByteBufferAllocator {
         }
 
         i = 512
-        while i > 0 {
+        while i < UInt32.max { // 1 << 32 max buffer size
             sizeTable.append(i)
             i <<= 1
         }


### PR DESCRIPTION
### Motivation:
Decrease overhead of internal size table used in AdaptiveRecvByteBufferAllocator.
It currently has a fairly large number of entries that reasonably never will
be used in real life. Just a minor polish.

### Modifications:

Change the maximum size slot allocated to 1 << 32 for the buffer and
doesn't use unsigned wrap around as a stop condition anymore for the setup.

### Result:

Save roughly 256 bytes, easier to read code.
