### PR TITLE
Make HTTP Parser import implementationOnly

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
+#if compiler(>=5.1)
+@_implementationOnly import CNIOHTTPParser
+#else
 import CNIOHTTPParser
+#endif
 
 private extension UnsafeMutablePointer where Pointee == http_parser {
     /// Returns the `KeepAliveState` for the current message that is parsed.


### PR DESCRIPTION
Motivation:

Non-implementation-only imports in Swift have an annoying tendency to
put C header files into all downstream build paths. The result is that
leaf packages that include any C header files run a very high risk of
colliding with declarations in the inner header files. In this case,
we've had users bump into issues with the HTTP_STATUS_* enum cases
already.

Modifications:

- Make CNIOHTTPParser import implementationOnly where possible.

Result:

Fewer risks of colliding symbols.