### PR TITLE
Make ChannelHandler removal cheaper.

### DIFF
--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -21,8 +21,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=19035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=19035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9035
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -21,8 +21,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=19035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=19035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9035
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -21,8 +21,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=19035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=19035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9035
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -21,8 +21,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=19035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=19035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9035
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -21,8 +21,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
       - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=18035  # improvement from 5.3 which was 19035
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=18035  # improvement from 5.3 which was 19035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9035
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9035
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=50
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050


### PR DESCRIPTION
Motivation:

Any version of ChannelHandler removal that does not have a
ChannelHandlerContext already in hand is currently excessively
expensive. This is because it allocates a promise and a callback for
finding the context, despite already having a promise in hand for users
to complete.

We can remove a pair of allocations here by jumping to the event loop
directly and then running our operations synchronously.

Modifications:

- Rewrite removeHandler(name:promise:) and removeHandler(_:promise:) to
  jump directly to the event loops and then work synchronously.

Result:

Cheaper code