### PR TITLE
Sometimes @escaping is a lie.

### DIFF
--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -527,7 +527,7 @@ public final class ChannelPipeline: ChannelInvoker {
     /// Synchronously finds a `ChannelHandlerContext` in the `ChannelPipeline`.
     /// - Important: This must be called on the `EventLoop`.
     @usableFromInline // should be fileprivate
-    internal func _contextSync(_ body: @escaping ((ChannelHandlerContext) -> Bool)) -> Result<ChannelHandlerContext, Error> {
+    internal func _contextSync(_ body: (ChannelHandlerContext) -> Bool) -> Result<ChannelHandlerContext, Error> {
         self.eventLoop.assertInEventLoop()
 
         if let context = self.contextForPredicate0(body) {
@@ -544,7 +544,7 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - body: The predicate to execute per `ChannelHandlerContext` in the `ChannelPipeline`.
     /// - returns: The first `ChannelHandlerContext` that matches or `nil` if none did.
-    private func contextForPredicate0(_ body: @escaping((ChannelHandlerContext) -> Bool)) -> ChannelHandlerContext? {
+    private func contextForPredicate0(_ body: (ChannelHandlerContext) -> Bool) -> ChannelHandlerContext? {
         var curCtx: ChannelHandlerContext? = self.head?.next
         while let context = curCtx, context !== self.tail {
             if body(context) {


### PR DESCRIPTION
Motivation:

_contextSync and contextForPredicate0 both accept their closure as
@escaping. _contextSync does so presumably only becuase
contextForPredicate0 does. However, this @escaping directive is
unnecessary: the closure does not escape, and never could.

In general this doesn't matter as these methods are internal, and called
from within the library. However, _contextSync is @usableFromInline, and
is called on several @inlinable call paths, including:

- `ChannelPipeline.handler(type:)`
- `ChannelPipeline.context(handlerType:)`
- `ChannelPipeline.SynchronousOperations.context(handlerType:)`
- `ChannelPipeline.SynchronousOperations.handler(type:)`

All of these presumably allocate more than they need to because there's
an optimisation boundary preventing user code from observing that the
closure does not actually allocate.

Modifications:

Delete `@escaping`.

Result:

Presumably faster code.
