### PR TITLE
Better error type for inactive thread pools

### DIFF
--- a/Sources/NIO/NIOThreadPool.swift
+++ b/Sources/NIO/NIOThreadPool.swift
@@ -15,6 +15,13 @@
 import Dispatch
 import NIOConcurrencyHelpers
 
+/// Errors that may be thrown when ececuting work on a `NIOThreadPool`
+public enum NIOThreadPoolError {
+    
+    /// The thread pool was not active.
+    public struct ThreadPoolInactive: Error { }
+}
+
 
 /// A thread pool that should be used if some (kernel thread) blocking work
 /// needs to be performed for which no non-blocking API exists.
@@ -206,6 +213,7 @@ public final class NIOThreadPool {
 }
 
 extension NIOThreadPool {
+    
     /// Runs the submitted closure if the thread pool is still active, otherwise fails the promise.
     /// The closure will be run on the thread pool so can do blocking work.
     ///
@@ -217,7 +225,7 @@ extension NIOThreadPool {
         let promise = eventLoop.makePromise(of: T.self)
         self.submit { shouldRun in
             guard case shouldRun = NIOThreadPool.WorkItemState.active else {
-                promise.fail(ChannelError.ioOnClosedChannel)
+                promise.fail(NIOThreadPoolError.ThreadPoolInactive())
                 return
             }
             do {

--- a/Sources/NIO/NIOThreadPool.swift
+++ b/Sources/NIO/NIOThreadPool.swift
@@ -15,10 +15,10 @@
 import Dispatch
 import NIOConcurrencyHelpers
 
-/// Errors that may be thrown when ececuting work on a `NIOThreadPool`
+/// Errors that may be thrown when executing work on a `NIOThreadPool`
 public enum NIOThreadPoolError {
     
-    /// The thread pool was not active.
+    /// The `NIOThreadPool` was not active.
     public struct ThreadPoolInactive: Error { }
 }
 

--- a/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest+XCTest.swift
@@ -71,6 +71,7 @@ extension NonBlockingFileIOTest {
                 ("testReadFromEOFDeliversExactlyOneChunk", testReadFromEOFDeliversExactlyOneChunk),
                 ("testReadChunkedFromOffsetFileRegion", testReadChunkedFromOffsetFileRegion),
                 ("testReadManyChunks", testReadManyChunks),
+                ("testThrowsErrorOnUnstartedPool", testThrowsErrorOnUnstartedPool),
            ]
    }
 }

--- a/Tests/NIOTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOTests/NonBlockingFileIOTest.swift
@@ -917,8 +917,7 @@ class NonBlockingFileIOTest: XCTestCase {
     }
     
     func testThrowsErrorOnUnstartedPool() throws {
-        
-        try withTemporaryFile(content: "hello, world") { fileHandle, path in
+        withTemporaryFile(content: "hello, world") { fileHandle, path in
             let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
             defer {
                 XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())


### PR DESCRIPTION
Running work on an inactive `NIOThreadPool` now throws an error `NIOThreadPoolError.ThreadPoolInactive`.

### Motivation:

Previously it threw `ChannelError.ioOnClosedChannel`, which was very misleading.

### Modifications:

Define the new error type and add a test to `NonBlockFileIO`

### Result:

A more descriptive error is thrown.
