### PR TITLE
fix #if AsyncAwait check

### DIFF
--- a/Sources/_NIOConcurrency/Helpers.swift
+++ b/Sources/_NIOConcurrency/Helpers.swift
@@ -16,8 +16,8 @@ import NIO
 
 // note: We have to define the variable `hasAsyncAwait` here because if we copy this code into the property below,
 // it doesn't compile on Swift 5.0.
-#if compiler(>=5.4)
 #if compiler(>=5.4) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
+#if compiler(>=5.4) && $AsyncAwait
 fileprivate let hasAsyncAwait = true
 #else
 fileprivate let hasAsyncAwait = false


### PR DESCRIPTION
Motivation:

I accidentally put in the wrong check for A/A, thanks @theMomax for
spotting!

Modification:

Fix the check to be

```
#if compiler(>=5.4) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
#if compiler(>=5.4) && $AsyncAwait
```

which works on Swift 5.0+.

Result:

Correct checks.