### PR TITLE
Add custom cleanup hook to allow PipeChannel to properly deregister during halfclose

### DIFF
--- a/Sources/NIO/BaseStreamSocketChannel.swift
+++ b/Sources/NIO/BaseStreamSocketChannel.swift
@@ -75,14 +75,14 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
     // Hook for customizable socket shutdown processing for subclasses, e.g. PipeChannel
     func shutdownSocket(mode: CloseMode) throws {
         switch mode {
-            case .output:
-                try self.socket.shutdown(how: .WR)
-                self.outputShutdown = true
-            case .input:
-                try socket.shutdown(how: .RD)
-                self.inputShutdown = true
-            case .all:
-                break
+        case .output:
+            try self.socket.shutdown(how: .WR)
+            self.outputShutdown = true
+        case .input:
+            try socket.shutdown(how: .RD)
+            self.inputShutdown = true
+        case .all:
+            break
         }
     }
 

--- a/Sources/NIO/PipeChannel.swift
+++ b/Sources/NIO/PipeChannel.swift
@@ -92,6 +92,17 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
         try! self.selectableEventLoop.deregister(channel: self, mode: .output)
         try! self.pipePair.outputFD.close()
     }
+
+    override func _close0Cleanup(mode: CloseMode) {
+        switch mode {
+            case .input:
+                try! self.selectableEventLoop.deregister(channel: self, mode: .input)
+            case .output:
+                try! self.selectableEventLoop.deregister(channel: self, mode: .output)
+            case .all: // deregistration will be done in super.super.close0...
+                break
+        }
+    }
 }
 
 extension PipeChannel: CustomStringConvertible {

--- a/Sources/NIO/PipeChannel.swift
+++ b/Sources/NIO/PipeChannel.swift
@@ -95,12 +95,12 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
 
     override func shutdownSocket(mode: CloseMode) throws {
         switch mode {
-            case .input:
-                try! self.selectableEventLoop.deregister(channel: self, mode: .input)
-            case .output:
-                try! self.selectableEventLoop.deregister(channel: self, mode: .output)
-            case .all:
-                break
+        case .input:
+            try! self.selectableEventLoop.deregister(channel: self, mode: .input)
+        case .output:
+            try! self.selectableEventLoop.deregister(channel: self, mode: .output)
+        case .all:
+            break
         }
         try super.shutdownSocket(mode: mode)
     }

--- a/Sources/NIO/PipeChannel.swift
+++ b/Sources/NIO/PipeChannel.swift
@@ -93,15 +93,16 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
         try! self.pipePair.outputFD.close()
     }
 
-    override func _close0Cleanup(mode: CloseMode) {
+    override func shutdownSocket(mode: CloseMode) throws {
         switch mode {
             case .input:
                 try! self.selectableEventLoop.deregister(channel: self, mode: .input)
             case .output:
                 try! self.selectableEventLoop.deregister(channel: self, mode: .output)
-            case .all: // deregistration will be done in super.super.close0...
+            case .all:
                 break
         }
+        try super.shutdownSocket(mode: mode)
     }
 }
 


### PR DESCRIPTION
### Motivation:
Currently PipeChannel doesn't properly deregister from the selector during half-closes.
This means that some backend implementations will keep a reference on the kernel side
which means that the POLLHUP will not be delivered for the read end of a pipe in
e.g. NIOTests.StreamChannelTest/testHalfCloseOwnOutput - this has the test failing
in #1761 / #1788.

### Modification:

Add a custom cleanup hook in BaseStreamSocketChannel in close0 to allow PipeChannel
to properly deregister.

### Result:

The final reference to the fd is dropped resulting in a POLLHUP being delivered
as needed - making NIOTests.StreamChannelTest/testHalfCloseOwnOutput to pass
for io_uring.
