### PR TITLE
Update documentation related to allocation troubleshooting on Linux and the ability to run unit tests in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,10 @@ dnf install swift-lang /usr/bin/nc /usr/bin/lsof /usr/bin/shasum
 [repo-nio-ssl]: https://github.com/apple/swift-nio-ssl
 [repo-nio-transport-services]: https://github.com/apple/swift-nio-transport-services
 [repo-nio-ssh]: https://github.com/apple/swift-nio-ssh
+
+### Speeding up testing
+It's possible to run the test suite in parallel, it can save significant time if you have a larger multi-core machine, just add `--parallel` when running the tests. This can speed up the run time of the test suite with 30x or more.
+
+```
+swift test --parallel
+```


### PR DESCRIPTION
### Motivation:

It's not obvious how to do analysis of allocation regressions on Linux, so some documentation would be helpful.
The run time for the unit tests can be quite long (a couple of minutes), can be cut down significantly if running tests in parallel, adding a hint about that.

### Modification:

Updated documentation.

### Result:

Easier to troubleshoot mallocs on Linux and faster running of unit tests.
