### PR TITLE
Create `EmbeddedChannel` with multiple handlers

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -618,17 +618,9 @@ public final class EmbeddedChannel: Channel {
     /// - parameters:
     ///     - handler: The `ChannelHandler` to add to the `ChannelPipeline` before register or `nil` if none should be added.
     ///     - loop: The `EmbeddedEventLoop` to use.
-    public init(handler: ChannelHandler? = nil, loop: EmbeddedEventLoop = EmbeddedEventLoop()) {
-        self.embeddedEventLoop = loop
-        self._pipeline = ChannelPipeline(channel: self)
-
-        if let handler = handler {
-            // This will be propagated via fireErrorCaught
-            _ = try? _pipeline.addHandler(handler).wait()
-        }
-
-        // This will never throw...
-        try! register().wait()
+    public convenience init(handler: ChannelHandler? = nil, loop: EmbeddedEventLoop = EmbeddedEventLoop()) {
+        let handlers = handler == nil ? [] : [handler!]
+        self.init(handlers: handlers, loop: loop)
     }
     
     /// Create a new instance.
@@ -636,7 +628,7 @@ public final class EmbeddedChannel: Channel {
     /// During creation it will automatically also register itself on the `EmbeddedEventLoop`.
     ///
     /// - parameters:
-    ///     - handlesr: The `ChannelHandler`s to add to the `ChannelPipeline` before register or `nil` if none should be added.
+    ///     - handlers: The `ChannelHandler`s to add to the `ChannelPipeline` before register.
     ///     - loop: The `EmbeddedEventLoop` to use.
     public init(handlers: [ChannelHandler], loop: EmbeddedEventLoop = EmbeddedEventLoop()) {
         self.embeddedEventLoop = loop

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -630,6 +630,23 @@ public final class EmbeddedChannel: Channel {
         // This will never throw...
         try! register().wait()
     }
+    
+    /// Create a new instance.
+    ///
+    /// During creation it will automatically also register itself on the `EmbeddedEventLoop`.
+    ///
+    /// - parameters:
+    ///     - handlesr: The `ChannelHandler`s to add to the `ChannelPipeline` before register or `nil` if none should be added.
+    ///     - loop: The `EmbeddedEventLoop` to use.
+    public init(handlers: [ChannelHandler], loop: EmbeddedEventLoop = EmbeddedEventLoop()) {
+        self.embeddedEventLoop = loop
+        self._pipeline = ChannelPipeline(channel: self)
+
+        _ = try? _pipeline.addHandlers(handlers).wait()
+
+        // This will never throw...
+        try! register().wait()
+    }
 
     /// - see: `Channel.setOption`
     @inlinable

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -634,7 +634,7 @@ public final class EmbeddedChannel: Channel {
         self.embeddedEventLoop = loop
         self._pipeline = ChannelPipeline(channel: self)
 
-        try! _pipeline.syncOperations.addHandlers(handlers)
+        try! self._pipeline.syncOperations.addHandlers(handlers)
 
         // This will never throw...
         try! register().wait()

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -619,7 +619,7 @@ public final class EmbeddedChannel: Channel {
     ///     - handler: The `ChannelHandler` to add to the `ChannelPipeline` before register or `nil` if none should be added.
     ///     - loop: The `EmbeddedEventLoop` to use.
     public convenience init(handler: ChannelHandler? = nil, loop: EmbeddedEventLoop = EmbeddedEventLoop()) {
-        let handlers = handler == nil ? [] : [handler!]
+        let handlers = handler.map { [$0] } ?? []
         self.init(handlers: handlers, loop: loop)
     }
     

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -634,7 +634,9 @@ public final class EmbeddedChannel: Channel {
         self.embeddedEventLoop = loop
         self._pipeline = ChannelPipeline(channel: self)
 
-        _ = try? _pipeline.addHandlers(handlers).wait()
+        if !handlers.isEmpty {
+            _ = try? _pipeline.addHandlers(handlers).wait()
+        }
 
         // This will never throw...
         try! register().wait()

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -634,9 +634,7 @@ public final class EmbeddedChannel: Channel {
         self.embeddedEventLoop = loop
         self._pipeline = ChannelPipeline(channel: self)
 
-        if !handlers.isEmpty {
-            _ = try? _pipeline.addHandlers(handlers).wait()
-        }
+        try! _pipeline.syncOperations.addHandlers(handlers)
 
         // This will never throw...
         try! register().wait()

--- a/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOTests/EmbeddedChannelTest+XCTest.swift
@@ -27,6 +27,9 @@ extension EmbeddedChannelTest {
    @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (EmbeddedChannelTest) -> () throws -> Void)] {
       return [
+                ("testSingleHandlerInit", testSingleHandlerInit),
+                ("testSingleHandlerInitNil", testSingleHandlerInitNil),
+                ("testMultipleHandlerInit", testMultipleHandlerInit),
                 ("testWriteOutboundByteBuffer", testWriteOutboundByteBuffer),
                 ("testWriteOutboundByteBufferMultipleTimes", testWriteOutboundByteBufferMultipleTimes),
                 ("testWriteInboundByteBuffer", testWriteInboundByteBuffer),


### PR DESCRIPTION
Add an initialiser to `EmbeddedChannel` that adds multiple `ChannelHandler`s

### Motivation:

I have several use-cases in my tests where it's necessary to have an `EmbeddedChannel` with multiple `ChannelHandler`s.

### Modifications:

Add an initialiser that takes an array of `ChannelHandler`s, and adds them to the `ChannelPipeline`.

### Result:

Previously:
```swift
let embeddedChannel = EmbeddedChannel(handler: ...)
_ = try! embeddedChannel.pipeline.addHandlers([...]).wait()
```

Now:
```swift
let embeddedChannel = EmbeddedChannel(handlers: ...)
```
