### PR TITLE
Add sequenceIdentifier to Registrations to handle outdated events

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -58,9 +58,15 @@ import CNIOWindows
 #endif
 
 /// A Registration on a `Selector`, which is interested in an `SelectorEventSet`.
+/// `sequenceIdentifier` is used by the event notification backends (kqueue, epoll, ...)
+/// to mark events to allow for filtering of received return values to not be delivered to a
+/// new `Registration` instance that receives the same file descriptor. Ok if it wraps.
+/// Needed for i.e. testWeDoNotDeliverEventsForPreviouslyClosedChannels to succeed.
+typealias RegistrationSequenceIdentifier = UInt32
 protocol Registration {
     /// The `SelectorEventSet` in which the `Registration` is interested.
     var interested: SelectorEventSet { get set }
+    var sequenceIdentifier: RegistrationSequenceIdentifier { get set }
 }
 
 protocol SockAddrProtocol {

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -732,35 +732,64 @@ extension EventLoop {
 /// Whenever a `Selectable` is registered to a `Selector` a `Registration` is created internally that is also provided within the
 /// `SelectorEvent` that is provided to the user when an event is ready to be consumed for a `Selectable`. As we need to have access to the `ServerSocketChannel`
 /// and `SocketChannel` (to dispatch the events) we create our own `Registration` that holds a reference to these.
+/// The `RegistrationSequenceIdentifier` is used by the `Selector` to tag registrations with a sequence number that can be
+/// used for external registrations (e.g. epoll, kqueue) to filter out outdated events when registrations with the same fd is repeatedly registered/deregistered.
 enum NIORegistration: Registration {
-    case serverSocketChannel(ServerSocketChannel, SelectorEventSet)
-    case socketChannel(SocketChannel, SelectorEventSet)
-    case datagramChannel(DatagramChannel, SelectorEventSet)
-    case pipeChannel(PipeChannel, PipeChannel.Direction, SelectorEventSet)
+    case serverSocketChannel(ServerSocketChannel, SelectorEventSet, RegistrationSequenceIdentifier)
+    case socketChannel(SocketChannel, SelectorEventSet, RegistrationSequenceIdentifier)
+    case datagramChannel(DatagramChannel, SelectorEventSet, RegistrationSequenceIdentifier)
+    case pipeChannel(PipeChannel, PipeChannel.Direction, SelectorEventSet, RegistrationSequenceIdentifier)
 
     /// The `SelectorEventSet` in which this `NIORegistration` is interested in.
     var interested: SelectorEventSet {
         set {
             switch self {
-            case .serverSocketChannel(let c, _):
-                self = .serverSocketChannel(c, newValue)
-            case .socketChannel(let c, _):
-                self = .socketChannel(c, newValue)
-            case .datagramChannel(let c, _):
-                self = .datagramChannel(c, newValue)
-            case .pipeChannel(let c, let d, _):
-                self = .pipeChannel(c, d, newValue)
+            case .serverSocketChannel(let c, _, let s):
+                self = .serverSocketChannel(c, newValue, s)
+            case .socketChannel(let c, _, let s):
+                self = .socketChannel(c, newValue, s)
+            case .datagramChannel(let c, _, let s):
+                self = .datagramChannel(c, newValue, s)
+            case .pipeChannel(let c, let d, _, let s):
+                self = .pipeChannel(c, d, newValue, s)
             }
         }
         get {
             switch self {
-            case .serverSocketChannel(_, let i):
+            case .serverSocketChannel(_, let i, _):
                 return i
-            case .socketChannel(_, let i):
+            case .socketChannel(_, let i, _):
                 return i
-            case .datagramChannel(_, let i):
+            case .datagramChannel(_, let i, _):
                 return i
-            case .pipeChannel(_, _, let i):
+            case .pipeChannel(_, _, let i, _):
+                return i
+            }
+        }
+    }
+    /// The `sequenceIdentifier` for this `NIORegistration` used by the `Selector`
+    var sequenceIdentifier: RegistrationSequenceIdentifier {
+        set {
+            switch self {
+            case .serverSocketChannel(let c, let e, _):
+                self = .serverSocketChannel(c, e, newValue)
+            case .socketChannel(let c, let e, _):
+                self = .socketChannel(c, e, newValue)
+            case .datagramChannel(let c, let e, _):
+                self = .datagramChannel(c, e, newValue)
+            case .pipeChannel(let c, let d, let e, _):
+                self = .pipeChannel(c, d, e, newValue)
+            }
+        }
+        get {
+            switch self {
+            case .serverSocketChannel(_, _, let i):
+                return i
+            case .socketChannel(_, _, let i):
+                return i
+            case .datagramChannel(_, _, let i):
+                return i
+            case .pipeChannel(_, _, _, let i):
                 return i
             }
         }

--- a/Sources/NIO/PipeChannel.swift
+++ b/Sources/NIO/PipeChannel.swift
@@ -31,11 +31,11 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
     }
 
     func registrationForInput(interested: SelectorEventSet) -> NIORegistration {
-        return .pipeChannel(self, .input, interested)
+        return .pipeChannel(self, .input, interested, 0)
     }
 
     func registrationForOutput(interested: SelectorEventSet) -> NIORegistration {
-        return .pipeChannel(self, .output, interested)
+        return .pipeChannel(self, .output, interested, 0)
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {

--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -407,13 +407,13 @@ internal final class SelectableEventLoop: EventLoop {
             try withAutoReleasePool {
                 try self._selector.whenReady(strategy: currentSelectorStrategy(nextReadyTask: nextReadyTask)) { ev in
                     switch ev.registration {
-                    case .serverSocketChannel(let chan, _):
+                    case .serverSocketChannel(let chan, _, _):
                         self.handleEvent(ev.io, channel: chan)
-                    case .socketChannel(let chan, _):
+                    case .socketChannel(let chan, _, _):
                         self.handleEvent(ev.io, channel: chan)
-                    case .datagramChannel(let chan, _):
+                    case .datagramChannel(let chan, _, _):
                         self.handleEvent(ev.io, channel: chan)
-                    case .pipeChannel(let chan, let direction, _):
+                    case .pipeChannel(let chan, let direction, _, _):
                         var ev = ev
                         if ev.io.contains(.reset) {
                             // .reset needs special treatment here because we're dealing with two separate pipes instead

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -89,7 +89,7 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
     }
 
     func registrationFor(interested: SelectorEventSet) -> NIORegistration {
-        return .socketChannel(self, interested)
+        return .socketChannel(self, interested, 0)
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {
@@ -163,7 +163,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     }
 
     func registrationFor(interested: SelectorEventSet) -> NIORegistration {
-        return .serverSocketChannel(self, interested)
+        return .serverSocketChannel(self, interested, 0)
     }
 
     override func setOption0<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
@@ -480,7 +480,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     }
 
     func registrationFor(interested: SelectorEventSet) -> NIORegistration {
-        return .datagramChannel(self, interested)
+        return .datagramChannel(self, interested, 0)
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {

--- a/Tests/NIOTests/SALChannelTests.swift
+++ b/Tests/NIOTests/SALChannelTests.swift
@@ -135,7 +135,7 @@ final class SALChannelTest: XCTestCase, SALTest {
             // Before sending back the writable notification, we know that that'll trigger a Channel writability change
             XCTAssertTrue(writableNotificationStepExpectation.compareAndExchange(expected: 1, desired: 2))
             try self.assertWaitingForNotification(result: .some(.init(io: [.write],
-                                                                      registration: .socketChannel(channel, [.write]))))
+                                                                      registration: .socketChannel(channel, [.write], 0))))
             try self.assertWrite(expectedFD: .max,
                                  expectedBytes: buffer.getSlice(at: 1, length: 1)!,
                                  return: .processed(1))
@@ -150,7 +150,7 @@ final class SALChannelTest: XCTestCase, SALTest {
 
             // Let's send them another 'writable' notification:
             try self.assertWaitingForNotification(result: .some(.init(io: [.write],
-                                                                      registration: .socketChannel(channel, [.write]))))
+                                                                      registration: .socketChannel(channel, [.write], 0))))
 
             // This time, we'll make the write write everything which should also lead to a final channelWritability
             // change.
@@ -227,7 +227,7 @@ final class SALChannelTest: XCTestCase, SALTest {
 
         XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
             try self.assertWaitingForNotification(result: .some(.init(io: [.read],
-                                                                      registration: .socketChannel(channel, [.read]))))
+                                                                      registration: .socketChannel(channel, [.read], 0))))
             try self.assertRead(expectedFD: .max, expectedBufferSpace: 2048, return: buffer)
         }) {
             channel.pipeline.addHandler(SignalGroupOnRead(group: g))

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -30,6 +30,7 @@ class SelectorTest: XCTestCase {
         struct TestRegistration: Registration {
             var interested: SelectorEventSet
             let socket: Socket
+            var sequenceIdentifier: RegistrationSequenceIdentifier
         }
 
         let selector = try NIO.Selector<TestRegistration>()
@@ -73,11 +74,11 @@ class SelectorTest: XCTestCase {
 
         // Register both sockets with .write. This will ensure both are ready when calling selector.whenReady.
         try selector.register(selectable: socket1 , interested: [.reset, .write], makeRegistration: { ev in
-            TestRegistration(interested: ev, socket: socket1)
+            TestRegistration(interested: ev, socket: socket1, sequenceIdentifier: 0)
         })
 
         try selector.register(selectable: socket2 , interested: [.reset, .write], makeRegistration: { ev in
-            TestRegistration(interested: ev, socket: socket2)
+            TestRegistration(interested: ev, socket: socket2, sequenceIdentifier: 0)
         })
 
         var readyCount = 0

--- a/Tests/NIOTests/SyscallAbstractionLayer.swift
+++ b/Tests/NIOTests/SyscallAbstractionLayer.swift
@@ -555,7 +555,7 @@ extension SALTest {
             try self.assertLocalAddress(address: localAddress)
             try self.assertRemoteAddress(address: remoteAddress)
             try self.assertRegister { selectable, eventSet, registration in
-                if case .socketChannel(let channel, let registrationEventSet) = registration {
+                if case .socketChannel(let channel, let registrationEventSet, _) = registration {
                     XCTAssertEqual(localAddress, channel.localAddress)
                     XCTAssertEqual(remoteAddress, channel.remoteAddress)
                     XCTAssertEqual(eventSet, registrationEventSet)


### PR DESCRIPTION
### Motivation:

Currently the selector implementation just discards all pending events from the kernel when a deregistration
has occurred during the event loop tick. This has been needed to not fail the test testWeDoNotDeliverEventsForPreviouslyClosedChannels.

A cleanup case has been around for a while at: https://github.com/apple/swift-nio/issues/381

And when discussing this in https://github.com/apple/swift-nio/pull/1788 (to solve https://github.com/apple/swift-nio/issues/1761)

We came to the conclusion that the solution with tagging registrations on the backend could not suit only io_uring, but also solve the issue robustly for kqueue and epoll.

### Modification:

Added sequenceIdentifier to the Registration and add support for it throughout.
Mask in sequence identifier into user data in both kqueue and epoll.
In kqueue, we just store the sequence identifier in the udata field (to support 32-bit properly).
In epoll, where we know we have 64-bits, we mask it in together with fd.
Removed all references to the old workaround from #381.

### Result:

New solution that doesn't need to discard all events when deregistrations are done during the event loop tick.
