### PR TITLE
refactor registration IDs

### DIFF
--- a/Sources/NIO/BaseSocket.swift
+++ b/Sources/NIO/BaseSocket.swift
@@ -57,16 +57,10 @@ import struct WinSDK.socklen_t
 import CNIOWindows
 #endif
 
-/// A Registration on a `Selector`, which is interested in an `SelectorEventSet`.
-/// `sequenceIdentifier` is used by the event notification backends (kqueue, epoll, ...)
-/// to mark events to allow for filtering of received return values to not be delivered to a
-/// new `Registration` instance that receives the same file descriptor. Ok if it wraps.
-/// Needed for i.e. testWeDoNotDeliverEventsForPreviouslyClosedChannels to succeed.
-typealias RegistrationSequenceIdentifier = UInt32
 protocol Registration {
     /// The `SelectorEventSet` in which the `Registration` is interested.
     var interested: SelectorEventSet { get set }
-    var sequenceIdentifier: RegistrationSequenceIdentifier { get set }
+    var registrationID: SelectorRegistrationID { get set }
 }
 
 protocol SockAddrProtocol {

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -732,68 +732,23 @@ extension EventLoop {
 /// Whenever a `Selectable` is registered to a `Selector` a `Registration` is created internally that is also provided within the
 /// `SelectorEvent` that is provided to the user when an event is ready to be consumed for a `Selectable`. As we need to have access to the `ServerSocketChannel`
 /// and `SocketChannel` (to dispatch the events) we create our own `Registration` that holds a reference to these.
-/// The `RegistrationSequenceIdentifier` is used by the `Selector` to tag registrations with a sequence number that can be
+/// The `RegistrationID` is used by the `Selector` to tag registrations with a sequence number that can be
 /// used for external registrations (e.g. epoll, kqueue) to filter out outdated events when registrations with the same fd is repeatedly registered/deregistered.
-enum NIORegistration: Registration {
-    case serverSocketChannel(ServerSocketChannel, SelectorEventSet, RegistrationSequenceIdentifier)
-    case socketChannel(SocketChannel, SelectorEventSet, RegistrationSequenceIdentifier)
-    case datagramChannel(DatagramChannel, SelectorEventSet, RegistrationSequenceIdentifier)
-    case pipeChannel(PipeChannel, PipeChannel.Direction, SelectorEventSet, RegistrationSequenceIdentifier)
+struct NIORegistration: Registration {
+    enum ChannelType {
+        case serverSocketChannel(ServerSocketChannel)
+        case socketChannel(SocketChannel)
+        case datagramChannel(DatagramChannel)
+        case pipeChannel(PipeChannel, PipeChannel.Direction)
+    }
+
+    var channel: ChannelType
 
     /// The `SelectorEventSet` in which this `NIORegistration` is interested in.
-    var interested: SelectorEventSet {
-        set {
-            switch self {
-            case .serverSocketChannel(let c, _, let s):
-                self = .serverSocketChannel(c, newValue, s)
-            case .socketChannel(let c, _, let s):
-                self = .socketChannel(c, newValue, s)
-            case .datagramChannel(let c, _, let s):
-                self = .datagramChannel(c, newValue, s)
-            case .pipeChannel(let c, let d, _, let s):
-                self = .pipeChannel(c, d, newValue, s)
-            }
-        }
-        get {
-            switch self {
-            case .serverSocketChannel(_, let i, _):
-                return i
-            case .socketChannel(_, let i, _):
-                return i
-            case .datagramChannel(_, let i, _):
-                return i
-            case .pipeChannel(_, _, let i, _):
-                return i
-            }
-        }
-    }
-    /// The `sequenceIdentifier` for this `NIORegistration` used by the `Selector`
-    var sequenceIdentifier: RegistrationSequenceIdentifier {
-        set {
-            switch self {
-            case .serverSocketChannel(let c, let e, _):
-                self = .serverSocketChannel(c, e, newValue)
-            case .socketChannel(let c, let e, _):
-                self = .socketChannel(c, e, newValue)
-            case .datagramChannel(let c, let e, _):
-                self = .datagramChannel(c, e, newValue)
-            case .pipeChannel(let c, let d, let e, _):
-                self = .pipeChannel(c, d, e, newValue)
-            }
-        }
-        get {
-            switch self {
-            case .serverSocketChannel(_, _, let i):
-                return i
-            case .socketChannel(_, _, let i):
-                return i
-            case .datagramChannel(_, _, let i):
-                return i
-            case .pipeChannel(_, _, _, let i):
-                return i
-            }
-        }
-    }
+    var interested: SelectorEventSet
+
+    /// The registration ID for this `NIORegistration` used by the `Selector`.
+    var registrationID: SelectorRegistrationID
 }
 
 /// Provides an endless stream of `EventLoop`s to use.

--- a/Sources/NIO/IntegerBitPacking.swift
+++ b/Sources/NIO/IntegerBitPacking.swift
@@ -87,4 +87,15 @@ extension IntegerBitPacking {
     static func unpackUInt16UInt8(_ value: UInt32) -> (UInt16, UInt8) {
         return _IntegerBitPacking.unpackUU(value)
     }
+
+    @inlinable
+    static func packUInt32CInt(_ left: UInt32, _ right: CInt) -> UInt64 {
+        return _IntegerBitPacking.packUU(left, UInt32(truncatingIfNeeded: right))
+    }
+
+    @inlinable
+    static func unpackUInt32CInt(_ value: UInt64) -> (UInt32, CInt) {
+        let unpacked = _IntegerBitPacking.unpackUU(value, leftType: UInt32.self, rightType: UInt32.self)
+        return (unpacked.0, CInt(truncatingIfNeeded: unpacked.1))
+    }
 }

--- a/Sources/NIO/PipeChannel.swift
+++ b/Sources/NIO/PipeChannel.swift
@@ -30,12 +30,16 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
                        recvAllocator: AdaptiveRecvByteBufferAllocator())
     }
 
-    func registrationForInput(interested: SelectorEventSet) -> NIORegistration {
-        return .pipeChannel(self, .input, interested, 0)
+    func registrationForInput(interested: SelectorEventSet, registrationID: SelectorRegistrationID) -> NIORegistration {
+        return NIORegistration(channel: .pipeChannel(self, .input),
+                               interested: interested,
+                               registrationID: registrationID)
     }
 
-    func registrationForOutput(interested: SelectorEventSet) -> NIORegistration {
-        return .pipeChannel(self, .output, interested, 0)
+    func registrationForOutput(interested: SelectorEventSet, registrationID: SelectorRegistrationID) -> NIORegistration {
+        return NIORegistration(channel: .pipeChannel(self, .output),
+                               interested: interested,
+                               registrationID: registrationID)
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {
@@ -49,10 +53,10 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
     override func register(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws {
         try selector.register(selectable: self.pipePair.inputFD,
                               interested: interested.intersection([.read, .reset]),
-                              makeRegistration: self.registrationForInput(interested:))
+                              makeRegistration: self.registrationForInput)
         try selector.register(selectable: self.pipePair.outputFD,
                               interested: interested.intersection([.write, .reset]),
-                              makeRegistration: self.registrationForOutput(interested:))
+                              makeRegistration: self.registrationForOutput)
 
     }
 

--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -406,14 +406,14 @@ internal final class SelectableEventLoop: EventLoop {
             /* for macOS: in case any calls we make to Foundation put objects into an autoreleasepool */
             try withAutoReleasePool {
                 try self._selector.whenReady(strategy: currentSelectorStrategy(nextReadyTask: nextReadyTask)) { ev in
-                    switch ev.registration {
-                    case .serverSocketChannel(let chan, _, _):
+                    switch ev.registration.channel {
+                    case .serverSocketChannel(let chan):
                         self.handleEvent(ev.io, channel: chan)
-                    case .socketChannel(let chan, _, _):
+                    case .socketChannel(let chan):
                         self.handleEvent(ev.io, channel: chan)
-                    case .datagramChannel(let chan, _, _):
+                    case .datagramChannel(let chan):
                         self.handleEvent(ev.io, channel: chan)
-                    case .pipeChannel(let chan, let direction, _, _):
+                    case .pipeChannel(let chan, let direction):
                         var ev = ev
                         if ev.io.contains(.reset) {
                             // .reset needs special treatment here because we're dealing with two separate pipes instead

--- a/Sources/NIO/SelectorEpoll.swift
+++ b/Sources/NIO/SelectorEpoll.swift
@@ -93,6 +93,33 @@ extension SelectorEventSet {
     }
 }
 
+// EPollUserData supports (un)packing into an `UInt64` because epoll has a user info field that we can attach which is
+// up to 64 bits wide. We're using all of those 64 bits, 32 for a "registration ID" and 32 for the file descriptor.
+@usableFromInline struct EPollUserData {
+    @usableFromInline var registrationID: SelectorRegistrationID
+    @usableFromInline var fileDescriptor: CInt
+
+    @inlinable init(registrationID: SelectorRegistrationID, fileDescriptor: CInt) {
+        assert(MemoryLayout<UInt64>.size == MemoryLayout<EPollUserData>.size)
+        self.registrationID = registrationID
+        self.fileDescriptor = fileDescriptor
+    }
+
+    @inlinable init(rawValue: UInt64) {
+        let unpacked = IntegerBitPacking.unpackUInt32CInt(rawValue)
+        self = .init(registrationID: SelectorRegistrationID(rawValue: unpacked.0), fileDescriptor: unpacked.1)
+    }
+}
+
+extension UInt64 {
+    @inlinable
+    init(_ epollUserData: EPollUserData) {
+        let fd = epollUserData.fileDescriptor
+        assert(fd >= 0, "\(fd) is not a valid file descriptor")
+        self = IntegerBitPacking.packUInt32CInt(epollUserData.registrationID.rawValue, fd)
+    }
+}
+
 extension Selector: _SelectorBackendProtocol {
     func initialiseState0() throws {
         self.selectorFD = try Epoll.epoll_create(size: 128)
@@ -103,13 +130,15 @@ extension Selector: _SelectorBackendProtocol {
 
         var ev = Epoll.epoll_event()
         ev.events = SelectorEventSet.read.epollEventSet
-        ev.data.u64 = UInt64(self.eventFD)
+        ev.data.u64 = UInt64(EPollUserData(registrationID: .initialRegistrationID,
+                                           fileDescriptor: self.eventFD))
 
         try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_ADD, fd: self.eventFD, event: &ev)
 
         var timerev = Epoll.epoll_event()
         timerev.events = Epoll.EPOLLIN | Epoll.EPOLLERR | Epoll.EPOLLRDHUP
-        timerev.data.u64 = UInt64(self.timerFD)
+        timerev.data.u64 = UInt64(EPollUserData(registrationID: .initialRegistrationID,
+                                                fileDescriptor: self.timerFD))
         try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_ADD, fd: self.timerFD, event: &timerev)
     }
 
@@ -118,23 +147,30 @@ extension Selector: _SelectorBackendProtocol {
         assert(self.timerFD == -1, "self.timerFD == \(self.timerFD) in deinitAssertions0, forgot close?")
     }
 
-    func register0<S: Selectable>(selectable: S, fd: Int, interested: SelectorEventSet, sequenceIdentifier: RegistrationSequenceIdentifier) throws {
+    func register0<S: Selectable>(selectable: S,
+                                  fd: Int,
+                                  interested: SelectorEventSet,
+                                  registrationID: SelectorRegistrationID) throws {
         var ev = Epoll.epoll_event()
         ev.events = interested.epollEventSet
-        ev.data.u64 = UInt64(UInt64(sequenceIdentifier) << 32 + UInt64(fd)) // we put fd in lower 4 bytes to allow eventfd & timerfd to work as is
+        ev.data.u64 = UInt64(EPollUserData(registrationID: registrationID, fileDescriptor: CInt(fd)))
 
         try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_ADD, fd: Int32(fd), event: &ev)
     }
 
-    func reregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, newInterested: SelectorEventSet, sequenceIdentifier: RegistrationSequenceIdentifier) throws {
+    func reregister0<S: Selectable>(selectable: S,
+                                    fd: Int,
+                                    oldInterested: SelectorEventSet,
+                                    newInterested: SelectorEventSet,
+                                    registrationID: SelectorRegistrationID) throws {
         var ev = Epoll.epoll_event()
         ev.events = newInterested.epollEventSet
-        ev.data.u64 = UInt64(UInt64(sequenceIdentifier) << 32 + UInt64(fd))
+        ev.data.u64 = UInt64(EPollUserData(registrationID: registrationID, fileDescriptor: CInt(fd)))
 
         _ = try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_MOD, fd: Int32(fd), event: &ev)
     }
 
-    func deregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, sequenceIdentifier: RegistrationSequenceIdentifier) throws {
+    func deregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws {
         var ev = Epoll.epoll_event()
         _ = try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_DEL, fd: Int32(fd), event: &ev)
     }
@@ -173,8 +209,9 @@ extension Selector: _SelectorBackendProtocol {
 
         for i in 0..<ready {
             let ev = events[i]
-            let fd = Int32(UInt64(ev.data.u64 & 0x00000000FFFFFFFF))
-            let eventSequenceIdentifier = UInt32(UInt64(ev.data.u64 >> 32))
+            let epollUserData = EPollUserData(rawValue: ev.data.u64)
+            let fd = epollUserData.fileDescriptor
+            let eventRegistrationID = epollUserData.registrationID
             switch fd {
             case self.eventFD:
                 var val = EventFd.eventfd_t()
@@ -191,7 +228,7 @@ extension Selector: _SelectorBackendProtocol {
             default:
                 // If the registration is not in the Map anymore we deregistered it during the processing of whenReady(...). In this case just skip it.
                 if let registration = registrations[Int(fd)] {
-                    guard eventSequenceIdentifier == registration.sequenceIdentifier else {
+                    guard eventRegistrationID == registration.registrationID else {
                         continue
                     }
 

--- a/Sources/NIO/SelectorGeneric.swift
+++ b/Sources/NIO/SelectorGeneric.swift
@@ -98,9 +98,9 @@ protocol _SelectorBackendProtocol {
     associatedtype R: Registration
     func initialiseState0() throws
     func deinitAssertions0() // allows actual implementation to run some assertions as part of the class deinit
-    func register0<S: Selectable>(selectable: S, fd: Int, interested: SelectorEventSet, sequenceIdentifier: RegistrationSequenceIdentifier) throws
-    func reregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, newInterested: SelectorEventSet, sequenceIdentifier: RegistrationSequenceIdentifier) throws
-    func deregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, sequenceIdentifier: RegistrationSequenceIdentifier) throws
+    func register0<S: Selectable>(selectable: S, fd: Int, interested: SelectorEventSet, registrationID: SelectorRegistrationID) throws
+    func reregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, newInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws
+    func deregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws
     /* attention, this may (will!) be called from outside the event loop, ie. can't access mutable shared state (such as `self.open`) */
     func wakeup0() throws
     /// Apply the given `SelectorStrategy` and execute `body` once it's complete (which may produce `SelectorEvent`s to handle).
@@ -122,7 +122,7 @@ protocol _SelectorBackendProtocol {
 internal class Selector<R: Registration>  {
     var lifecycleState: SelectorLifecycleState
     var registrations = [Int: R]()
-    var sequenceIdentifier : RegistrationSequenceIdentifier = 1
+    var registrationID: SelectorRegistrationID = .initialRegistrationID
 
     let myThread: NIOThread
     // The rules for `self.selectorFD`, `self.eventFD`, and `self.timerFD`:
@@ -200,7 +200,9 @@ internal class Selector<R: Registration>  {
     ///     - selectable: The `Selectable` to register.
     ///     - interested: The `SelectorEventSet` in which we are interested and want to be notified about.
     ///     - makeRegistration: Creates the registration data for the given `SelectorEventSet`.
-    func register<S: Selectable>(selectable: S, interested: SelectorEventSet, makeRegistration: (SelectorEventSet) -> R) throws {
+    func register<S: Selectable>(selectable: S,
+                                 interested: SelectorEventSet,
+                                 makeRegistration: (SelectorEventSet, SelectorRegistrationID) -> R) throws {
         assert(self.myThread == NIOThread.current)
         assert(interested.contains(.reset))
         guard self.lifecycleState == .open else {
@@ -212,11 +214,9 @@ internal class Selector<R: Registration>  {
             try self.register0(selectable: selectable,
                                fd: Int(fd),
                                interested: interested,
-                               sequenceIdentifier: self.sequenceIdentifier)
-            var registration = makeRegistration(interested)
-            registration.sequenceIdentifier = self.sequenceIdentifier
+                               registrationID: self.registrationID)
+            let registration = makeRegistration(interested, self.registrationID.nextRegistrationID())
             registrations[Int(fd)] = registration
-            self.sequenceIdentifier &+= 1 // we are ok to overflow
         }
     }
 
@@ -237,7 +237,7 @@ internal class Selector<R: Registration>  {
                                  fd: Int(fd),
                                  oldInterested: reg.interested,
                                  newInterested: interested,
-                                 sequenceIdentifier: reg.sequenceIdentifier)
+                                 registrationID: reg.registrationID)
             reg.interested = interested
             self.registrations[Int(fd)] = reg
         }
@@ -262,7 +262,7 @@ internal class Selector<R: Registration>  {
             try self.deregister0(selectable: selectable,
                                  fd: Int(fd),
                                  oldInterested: reg.interested,
-                                 sequenceIdentifier: reg.sequenceIdentifier)
+                                 registrationID: reg.registrationID)
         }
     }
 
@@ -344,14 +344,14 @@ extension Selector where R == NIORegistration {
                 return chan.closeFuture
             }
 
-            switch reg {
-            case .serverSocketChannel(let chan, _, _):
+            switch reg.channel {
+            case .serverSocketChannel(let chan):
                 return closeChannel(chan)
-            case .socketChannel(let chan, _, _):
+            case .socketChannel(let chan):
                 return closeChannel(chan)
-            case .datagramChannel(let chan, _, _):
+            case .datagramChannel(let chan):
                 return closeChannel(chan)
-            case .pipeChannel(let chan, _, _, _):
+            case .pipeChannel(let chan, _):
                 return closeChannel(chan)
             }
         }.map { future in
@@ -382,4 +382,40 @@ enum SelectorStrategy {
 
     /// Try to select all ready IO at this point in time without blocking at all.
     case now
+}
+
+/// A Registration on a `Selector`, which is interested in an `SelectorEventSet`.
+/// `registrationID` is used by the event notification backends (kqueue, epoll, ...)
+/// to mark events to allow for filtering of received return values to not be delivered to a
+/// new `Registration` instance that receives the same file descriptor. Ok if it wraps.
+/// Needed for i.e. testWeDoNotDeliverEventsForPreviouslyClosedChannels to succeed.
+@usableFromInline struct SelectorRegistrationID: Hashable {
+    @usableFromInline var _rawValue: UInt32
+
+    @inlinable var rawValue: UInt32 {
+        return self._rawValue
+    }
+
+    @inlinable static var initialRegistrationID: SelectorRegistrationID {
+        return SelectorRegistrationID(rawValue: .max)
+    }
+
+    @inlinable mutating func nextRegistrationID() -> SelectorRegistrationID {
+        let current = self
+        // Overflow is okay here, this is just for very short-term disambiguation
+        self._rawValue = self._rawValue &+ 1
+        return current
+    }
+
+    @inlinable init(rawValue: UInt32) {
+        self._rawValue = rawValue
+    }
+
+    @inlinable static func ==(_ lhs: SelectorRegistrationID, _ rhs: SelectorRegistrationID) -> Bool {
+        return lhs._rawValue == rhs._rawValue
+    }
+
+    @inlinable func hash(into hasher: inout Hasher) {
+        hasher.combine(self._rawValue)
+    }
 }

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -88,8 +88,10 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
         }
     }
 
-    func registrationFor(interested: SelectorEventSet) -> NIORegistration {
-        return .socketChannel(self, interested, 0)
+    func registrationFor(interested: SelectorEventSet, registrationID: SelectorRegistrationID) -> NIORegistration {
+        return NIORegistration(channel: .socketChannel(self),
+                               interested: interested,
+                               registrationID: registrationID)
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {
@@ -119,7 +121,9 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
 
 
     override func register(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws {
-        try selector.register(selectable: self.socket, interested: interested, makeRegistration: self.registrationFor(interested:))
+        try selector.register(selectable: self.socket,
+                              interested: interested,
+                              makeRegistration: self.registrationFor)
     }
 
     override func deregister(selector: Selector<NIORegistration>, mode: CloseMode) throws {
@@ -162,8 +166,10 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         try self.socket.listen(backlog: backlog)
     }
 
-    func registrationFor(interested: SelectorEventSet) -> NIORegistration {
-        return .serverSocketChannel(self, interested, 0)
+    func registrationFor(interested: SelectorEventSet, registrationID: SelectorRegistrationID) -> NIORegistration {
+        return NIORegistration(channel: .serverSocketChannel(self),
+                               interested: interested,
+                               registrationID: registrationID)
     }
 
     override func setOption0<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
@@ -320,7 +326,9 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     }
 
     override func register(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws {
-        try selector.register(selectable: self.socket, interested: interested, makeRegistration: self.registrationFor(interested:))
+        try selector.register(selectable: self.socket,
+                              interested: interested,
+                              makeRegistration: self.registrationFor)
     }
 
     override func deregister(selector: Selector<NIORegistration>, mode: CloseMode) throws {
@@ -479,8 +487,10 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         }
     }
 
-    func registrationFor(interested: SelectorEventSet) -> NIORegistration {
-        return .datagramChannel(self, interested, 0)
+    func registrationFor(interested: SelectorEventSet, registrationID: SelectorRegistrationID) -> NIORegistration {
+        return NIORegistration(channel: .datagramChannel(self),
+                               interested: interested,
+                               registrationID: registrationID)
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {
@@ -699,7 +709,9 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     }
 
     override func register(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws {
-        try selector.register(selectable: self.socket, interested: interested, makeRegistration: self.registrationFor(interested:))
+        try selector.register(selectable: self.socket,
+                              interested: interested,
+                              makeRegistration: self.registrationFor)
     }
 
     override func deregister(selector: Selector<NIORegistration>, mode: CloseMode) throws {

--- a/Tests/NIOTests/IntegerBitPackingTests+XCTest.swift
+++ b/Tests/NIOTests/IntegerBitPackingTests+XCTest.swift
@@ -30,6 +30,7 @@ extension IntegerBitPackingTests {
                 ("testAllUInt8PairsRoundtrip", testAllUInt8PairsRoundtrip),
                 ("testExtremesWorkForUInt32UInt16UInt8", testExtremesWorkForUInt32UInt16UInt8),
                 ("testExtremesWorkForUInt16UInt8", testExtremesWorkForUInt16UInt8),
+                ("testExtremesWorkForUInt32CInt", testExtremesWorkForUInt32CInt),
            ]
    }
 }

--- a/Tests/NIOTests/IntegerBitPackingTests.swift
+++ b/Tests/NIOTests/IntegerBitPackingTests.swift
@@ -57,4 +57,25 @@ final class IntegerBitPackingTests: XCTestCase {
                     IntegerBitPacking.unpackUInt16UInt8(IntegerBitPacking.packUInt16UInt8(UInt16(1) << 15 | 1,
                                                                                           UInt8(1) << 7 | 1)))
     }
+
+    func testExtremesWorkForUInt32CInt() {
+        XCTAssert((.max, .max) == IntegerBitPacking.unpackUInt32CInt(IntegerBitPacking.packUInt32CInt(.max, .max)))
+
+        XCTAssert((0, 0) == IntegerBitPacking.unpackUInt32CInt(IntegerBitPacking.packUInt32CInt(0, 0)))
+
+        XCTAssert((.min, -1) == IntegerBitPacking.unpackUInt32CInt(IntegerBitPacking.packUInt32CInt(.min, -1)))
+
+        XCTAssert((.min, .min) == IntegerBitPacking.unpackUInt32CInt(IntegerBitPacking.packUInt32CInt(.min, .min)))
+
+        XCTAssert((UInt32(1) << 31 | 1, CInt(1) << 31) ==
+                    IntegerBitPacking.unpackUInt32CInt(IntegerBitPacking.packUInt32CInt(UInt32(1) << 31 | 1,
+                                                                                        CInt(1) << 31)))
+
+        let randomUInt32 = UInt32.random(in: .min ... .max)
+        let randomCInt = CInt.random(in: .min ... .max)
+        XCTAssert((randomUInt32, randomCInt) ==
+                    IntegerBitPacking.unpackUInt32CInt(IntegerBitPacking.packUInt32CInt(randomUInt32, randomCInt)),
+                  "\((randomUInt32, randomCInt)) didn't roundtrip")
+    }
+
 }

--- a/Tests/NIOTests/SelectorTest.swift
+++ b/Tests/NIOTests/SelectorTest.swift
@@ -28,9 +28,10 @@ class SelectorTest: XCTestCase {
 
     private func assertDeregisterWhileProcessingEvents(closeAfterDeregister: Bool) throws {
         struct TestRegistration: Registration {
-            var interested: SelectorEventSet
+
             let socket: Socket
-            var sequenceIdentifier: RegistrationSequenceIdentifier
+            var interested: SelectorEventSet
+            var registrationID: SelectorRegistrationID
         }
 
         let selector = try NIO.Selector<TestRegistration>()
@@ -73,12 +74,12 @@ class SelectorTest: XCTestCase {
         }
 
         // Register both sockets with .write. This will ensure both are ready when calling selector.whenReady.
-        try selector.register(selectable: socket1 , interested: [.reset, .write], makeRegistration: { ev in
-            TestRegistration(interested: ev, socket: socket1, sequenceIdentifier: 0)
+        try selector.register(selectable: socket1 , interested: [.reset, .write], makeRegistration: { ev, regID in
+            return TestRegistration(socket: socket1, interested: ev, registrationID: regID)
         })
 
-        try selector.register(selectable: socket2 , interested: [.reset, .write], makeRegistration: { ev in
-            TestRegistration(interested: ev, socket: socket2, sequenceIdentifier: 0)
+        try selector.register(selectable: socket2 , interested: [.reset, .write], makeRegistration: { ev, regID in
+            return TestRegistration(socket: socket2, interested: ev, registrationID: regID)
         })
 
         var readyCount = 0

--- a/Tests/NIOTests/StreamChannelsTest.swift
+++ b/Tests/NIOTests/StreamChannelsTest.swift
@@ -905,7 +905,7 @@ private func assertNoSelectorChanges(fd: CInt, file: StaticString = #file, line:
     var ev = Epoll.epoll_event()
     let numberOfEvents = try Epoll.epoll_wait(epfd: fd, events: &ev, maxevents: 1, timeout: 0)
     guard numberOfEvents == 0 else {
-        throw UnexpectedSelectorChanges(description: "\(ev)")
+        throw UnexpectedSelectorChanges(description: "\(ev) [userdata: \(EPollUserData(rawValue: ev.data.u64))]")
     }
     #else
     #warning("assertNoSelectorChanges unsupported on this OS.")


### PR DESCRIPTION
Motivation:

Instead of manual shifting / masking we can write the whole registration
ID code normally in Swift.

Modifications:

Refactored RegistrationID to use Swift instead of shifting / masking.

Result:

Nicer code.