### PR TITLE
async/await: adopt latest "main" renames

### DIFF
--- a/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
+++ b/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
@@ -15,8 +15,8 @@
 import NIO
 import NIOHTTP1
 
-#if compiler(>=5.4) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
-#if compiler(>=5.4) && $AsyncAwait
+#if compiler(>=5.5) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
+#if compiler(>=5.5) && $AsyncAwait
 struct AsyncChannelIO<Request, Response> {
     let channel: Channel
 

--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -17,8 +17,8 @@ import _NIOConcurrency
 import NIOHTTP1
 import Dispatch
 
-#if compiler(>=5.4) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
-#if compiler(>=5.4) && $AsyncAwait
+#if compiler(>=5.5) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
+#if compiler(>=5.5) && $AsyncAwait
 
 import _Concurrency
 
@@ -63,7 +63,7 @@ func main() async {
 
 let dg = DispatchGroup()
 dg.enter()
-let task = Task.runDetached {
+let task = detach {
     await main()
     dg.leave()
 }

--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -14,8 +14,8 @@
 
 import NIO
 
-#if compiler(>=5.4) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
-#if compiler(>=5.4) && $AsyncAwait
+#if compiler(>=5.5) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
+#if compiler(>=5.5) && $AsyncAwait
 import _Concurrency
 
 extension EventLoopFuture {
@@ -45,7 +45,7 @@ extension EventLoopPromise {
     /// - parameters:
     ///   - body: The `async` function to run.
     public func completeWithAsync(_ body: @escaping () async throws -> Value) {
-        Task.runDetached {
+        detach {
             do {
                 let value = try await body()
                 self.succeed(value)

--- a/Sources/_NIOConcurrency/Helpers.swift
+++ b/Sources/_NIOConcurrency/Helpers.swift
@@ -16,8 +16,8 @@ import NIO
 
 // note: We have to define the variable `hasAsyncAwait` here because if we copy this code into the property below,
 // it doesn't compile on Swift 5.0.
-#if compiler(>=5.4) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
-#if compiler(>=5.4) && $AsyncAwait
+#if compiler(>=5.5) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
+#if compiler(>=5.5) && $AsyncAwait
 fileprivate let hasAsyncAwait = true
 #else
 fileprivate let hasAsyncAwait = false


### PR DESCRIPTION
### Motivation:

On Swift's `main` branch `Task.runDetached` has been renamed to `detach`.

### Modifications:

Adopt the new spelling.

### Result:

Compiles again on the `main` nightlies.