### PR TITLE
Wrap concurrency code with @available(macOS 9999, etc)

### DIFF
--- a/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
+++ b/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
@@ -17,6 +17,7 @@ import NIOHTTP1
 
 #if compiler(>=5.5) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
 #if compiler(>=5.5) && $AsyncAwait
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct AsyncChannelIO<Request, Response> {
     let channel: Channel
 

--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -27,6 +27,7 @@ defer {
     try! group.syncShutdownGracefully()
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func makeHTTPChannel(host: String, port: Int) async throws -> AsyncChannelIO<HTTPRequestHead, NIOHTTPClientResponseFull> {
     let channel = try await ClientBootstrap(group: group).connect(host: host, port: port).get()
     try await channel.pipeline.addHTTPClientHandlers().get()
@@ -35,6 +36,7 @@ func makeHTTPChannel(host: String, port: Int) async throws -> AsyncChannelIO<HTT
     return try await AsyncChannelIO<HTTPRequestHead, NIOHTTPClientResponseFull>(channel).start()
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func main() async {
     do {
         let channel = try await makeHTTPChannel(host: "httpbin.org", port: 80)
@@ -63,8 +65,12 @@ func main() async {
 
 let dg = DispatchGroup()
 dg.enter()
-let task = detach {
-    await main()
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    detach {
+        await main()
+        dg.leave()
+    }
+} else {
     dg.leave()
 }
 dg.wait()

--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -18,6 +18,7 @@ import NIO
 #if compiler(>=5.5) && $AsyncAwait
 import _Concurrency
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension EventLoopFuture {
     /// Get the value/error from an `EventLoopFuture` in an `async` context.
     ///
@@ -37,6 +38,7 @@ extension EventLoopFuture {
     }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension EventLoopPromise {
     /// Complete a future with the result (or error) of the `async` function `body`.
     ///
@@ -56,6 +58,7 @@ extension EventLoopPromise {
     }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Channel {
     /// Shortcut for calling `write` and `flush`.
     ///
@@ -78,6 +81,7 @@ extension Channel {
     }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension ChannelOutboundInvoker {
     /// Register on an `EventLoop` and so have all its IO handled.
     ///
@@ -130,6 +134,7 @@ extension ChannelOutboundInvoker {
     }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension ChannelPipeline {
     public func addHandler(_ handler: ChannelHandler,
                            name: String? = nil,


### PR DESCRIPTION
Latest Swift development snapshot (2021-04-10) has wrapped all the Concurrency primitives with @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *). 

This PR does the same for the SwiftNIO concurrency extensions
