### PR TITLE
Fix crash: Create ByteBuffer Slice from ByteBuffer Slice after 16MB

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -640,8 +640,8 @@ public struct ByteBuffer {
             // the slice's begin is past the maximum supported slice begin value (16 MiB) so the only option we have
             // is copy the slice into a fresh buffer. The slice begin will then be at index 0.
             var new = self
-            new._moveWriterIndex(to: sliceStartIndex + length)
-            new._moveReaderIndex(to: sliceStartIndex)
+            new._moveWriterIndex(to: index + length)
+            new._moveReaderIndex(to: index)
             new._copyStorageAndRebase(capacity: length, resetIndices: true)
             return new
         }

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -134,6 +134,7 @@ extension ByteBufferTest {
                 ("testByteBufferFitsInACoupleOfEnums", testByteBufferFitsInACoupleOfEnums),
                 ("testLargeSliceBegin16MBIsOkayAndDoesNotCopy", testLargeSliceBegin16MBIsOkayAndDoesNotCopy),
                 ("testLargeSliceBeginMoreThan16MBIsOkay", testLargeSliceBeginMoreThan16MBIsOkay),
+                ("testSliceOnSliceAfterHitting16MBMark", testSliceOnSliceAfterHitting16MBMark),
                 ("testDiscardReadBytesOnConsumedBuffer", testDiscardReadBytesOnConsumedBuffer),
                 ("testDumpBytesFormat", testDumpBytesFormat),
                 ("testReadableBytesView", testReadableBytesView),

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1725,7 +1725,8 @@ class ByteBufferTest: XCTestCase {
         
         let finalSliceLength = 1
         // let's create a new buffer that uses all but one byte
-        XCTAssertEqual(remainingSlice.readBytes(length: remainingSliceLength - finalSliceLength), [UInt8](repeating: 2, count: remainingSliceLength - finalSliceLength))
+        XCTAssertEqual(remainingSlice.readBytes(length: remainingSliceLength - finalSliceLength),
+                       Array<UInt8>(repeating: 2, count: remainingSliceLength - finalSliceLength))
         
         // there should only be one byte left.
         XCTAssertEqual(remainingSlice.readableBytes, finalSliceLength)

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1711,7 +1711,7 @@ class ByteBufferTest: XCTestCase {
         
         // create a buffer with 16MiB + 1 byte
         let inputBufferLength = 16 * 1024 * 1024 + 1
-        var inputBuffer = ByteBuffer.Allocator().buffer(capacity: inputBufferLength)
+        var inputBuffer = ByteBufferAllocator().buffer(capacity: inputBufferLength)
         inputBuffer.writeRepeatingByte(1, count: 8)
         inputBuffer.writeRepeatingByte(2, count: inputBufferLength - 9)
         inputBuffer.writeRepeatingByte(3, count: 1)


### PR DESCRIPTION
Fixes an issue that could lead to an assert in Debug mode and to undefined behavior in Release mode.

Motivation:

- When reading a new `ByteBuffer` slice from an originating `ByteBuffer` slice where the new `ByteBuffer` slice starts more than 16MiB into the underlying `ByteBuffer` storage, the new `ByteBuffer` slice will get a new 0 based storage.
- When creating the storage for the new slice we have an issue in where storage based indices were used which should have been slice based indices.

Modifications:

- Using the correct indices, when creating a `ByteBuffer` slice which is more than 16MiB into its originating storage.

Result:

- We can create `ByteBuffer` slices from slices after the 16MiB threshold.
- Fixes an [issue that was raised in PostgresNIO](https://github.com/vapor/postgres-nio/issues/148)