### PR TITLE
implement CircularBuffer.first: to prevent allocs

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -672,6 +672,16 @@ extension CircularBuffer: RangeReplaceableCollection {
 
         return element
     }
+
+    /// The first `Element` of the `CircularBuffer` (or `nil` if empty).
+    @inlinable
+    public var first: Element? {
+        // We implement this here to work around https://bugs.swift.org/browse/SR-14516
+        guard !self.isEmpty else {
+            return nil
+        }
+        return self[self.startIndex]
+    }
 }
 
 extension CircularBuffer {

--- a/Tests/NIOTests/CircularBufferTests+XCTest.swift
+++ b/Tests/NIOTests/CircularBufferTests+XCTest.swift
@@ -77,6 +77,7 @@ extension CircularBufferTests {
                 ("testEquality", testEquality),
                 ("testHash", testHash),
                 ("testArrayLiteralInit", testArrayLiteralInit),
+                ("testFirstWorks", testFirstWorks),
            ]
    }
 }

--- a/Tests/NIOTests/CircularBufferTests.swift
+++ b/Tests/NIOTests/CircularBufferTests.swift
@@ -984,4 +984,25 @@ class CircularBufferTests: XCTestCase {
         XCTAssertEqual(someInts.count, 7)
         XCTAssert(zip(someInts, someIntsArray).allSatisfy(==))
     }
+
+    func testFirstWorks() {
+        var buffer = CircularBuffer<Int>(initialCapacity: 4)
+        XCTAssertNil(buffer.first)
+
+        buffer.append(1)
+        XCTAssertEqual(1, buffer.first)
+        XCTAssertEqual(1, buffer.removeFirst())
+
+        XCTAssertNil(buffer.first)
+
+        for n in 0..<10 {
+            buffer.append(contentsOf: 0...n)
+
+            for i in 0...n {
+                XCTAssertEqual(i, buffer.first)
+                XCTAssertEqual(i, buffer.removeFirst())
+            }
+            XCTAssertNil(buffer.first)
+        }
+    }
 }

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -30,17 +30,17 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=178050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=470050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5050
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
@@ -48,8 +48,8 @@ services:
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=200050
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=196050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]
 

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -30,17 +30,17 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=177050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=101050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=465001
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=99050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=465050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5050
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
@@ -48,8 +48,8 @@ services:
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=200050
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=196050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -30,17 +30,17 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31950
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=186050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=18050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=107050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=104050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=942050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10050
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5050
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
@@ -48,8 +48,8 @@ services:
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=220050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=18200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=211050
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=205050
 
   performance-test:
     image: swift-nio:18.04-5.0

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -30,17 +30,17 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=178050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=467050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10050
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5050
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
@@ -48,8 +48,8 @@ services:
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=200050
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=196050
 
   performance-test:
     image: swift-nio:18.04-5.1

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -30,9 +30,9 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=179050 # regression from 5.3 which was 177010
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=16050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=102050 # regression from 5.3 which was 101050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=468050 # regression from 5.3 which was 465050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
@@ -48,8 +48,8 @@ services:
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=16200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=202050 # regression from 5.3 which was 200050
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=198050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -30,17 +30,17 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=179050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=14050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=101050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=468050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=5050 # regression from 5.3 which was 3050
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=5050 #regression from 5.3 which was 3050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
@@ -48,8 +48,8 @@ services:
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=14200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=200050
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=198050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
       - SWIFT_TEST_VERB=build # WARNING: THIS DISABLES ALL TESTS. Please remove (workaround https://bugs.swift.org/browse/SR-14268)
 

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -11,3 +11,4 @@ or cases where the Swift compiler was unable to sufficiently optimize the code:
 - https://github.com/apple/swift-nio/pull/494
 - https://github.com/apple/swift-nio/pull/420
 - https://github.com/apple/swift-nio/commit/abc963cfe1e1d4856c41421c9d53ea778102e9e8
+- https://github.com/apple/swift-nio/pull/1814


### PR DESCRIPTION
Motivation:

Due to https://bugs.swift.org/browse/SR-14516 , we sometimes get
allocating (!?) `subscript.read` accessors in the CircularBuffer.first
depending on the `Element` type...

Modifications:

Implement `CircularBuffer.first` instead of inheriting it from
Collection.

Result:

Fewer allocs in some cases.