### PR TITLE
Selectors: make file descriptors CInts everywhere

### DIFF
--- a/Sources/NIO/Linux.swift
+++ b/Sources/NIO/Linux.swift
@@ -23,14 +23,14 @@ internal enum TimerFd {
     internal static let TFD_NONBLOCK = CNIOLinux.TFD_NONBLOCK
 
     @inline(never)
-    internal static func timerfd_settime(fd: Int32, flags: Int32, newValue: UnsafePointer<itimerspec>, oldValue: UnsafeMutablePointer<itimerspec>?) throws  {
+    internal static func timerfd_settime(fd: CInt, flags: CInt, newValue: UnsafePointer<itimerspec>, oldValue: UnsafeMutablePointer<itimerspec>?) throws  {
         _ = try syscall(blocking: false) {
             CNIOLinux.timerfd_settime(fd, flags, newValue, oldValue)
         }
     }
 
     @inline(never)
-    internal static func timerfd_create(clockId: Int32, flags: Int32) throws -> Int32 {
+    internal static func timerfd_create(clockId: CInt, flags: CInt) throws -> CInt {
         return try syscall(blocking: false) {
             CNIOLinux.timerfd_create(clockId, flags)
         }.result
@@ -43,21 +43,21 @@ internal enum EventFd {
     internal typealias eventfd_t = CNIOLinux.eventfd_t
 
     @inline(never)
-    internal static func eventfd_write(fd: Int32, value: UInt64) throws -> Int32 {
+    internal static func eventfd_write(fd: CInt, value: UInt64) throws -> CInt {
         return try syscall(blocking: false) {
             CNIOLinux.eventfd_write(fd, value)
         }.result
     }
 
     @inline(never)
-    internal static func eventfd_read(fd: Int32, value: UnsafeMutablePointer<UInt64>) throws -> Int32 {
+    internal static func eventfd_read(fd: CInt, value: UnsafeMutablePointer<UInt64>) throws -> CInt {
         return try syscall(blocking: false) {
             CNIOLinux.eventfd_read(fd, value)
         }.result
     }
 
     @inline(never)
-    internal static func eventfd(initval: UInt32, flags: Int32) throws -> Int32 {
+    internal static func eventfd(initval: CUnsignedInt, flags: CInt) throws -> CInt {
         return try syscall(blocking: false) {
             // Note: Please do _not_ remove the `numericCast`, this is to allow compilation in Ubuntu 14.04 and
             // other Linux distros which ship a glibc from before this commit:
@@ -95,7 +95,7 @@ internal enum Epoll {
 
 
     @inline(never)
-    internal static func epoll_create(size: Int32) throws -> Int32 {
+    internal static func epoll_create(size: CInt) throws -> CInt {
         return try syscall(blocking: false) {
             CNIOLinux.epoll_create(size)
         }.result
@@ -103,14 +103,14 @@ internal enum Epoll {
 
     @inline(never)
     @discardableResult
-    internal static func epoll_ctl(epfd: Int32, op: Int32, fd: Int32, event: UnsafeMutablePointer<epoll_event>) throws -> Int32 {
+    internal static func epoll_ctl(epfd: CInt, op: CInt, fd: CInt, event: UnsafeMutablePointer<epoll_event>) throws -> CInt {
         return try syscall(blocking: false) {
             CNIOLinux.epoll_ctl(epfd, op, fd, event)
         }.result
     }
 
     @inline(never)
-    internal static func epoll_wait(epfd: Int32, events: UnsafeMutablePointer<epoll_event>, maxevents: Int32, timeout: Int32) throws -> Int32 {
+    internal static func epoll_wait(epfd: CInt, events: UnsafeMutablePointer<epoll_event>, maxevents: CInt, timeout: CInt) throws -> CInt {
         return try syscall(blocking: false) {
             CNIOLinux.epoll_wait(epfd, events, maxevents, timeout)
         }.result

--- a/Sources/NIO/PipePair.swift
+++ b/Sources/NIO/PipePair.swift
@@ -103,7 +103,7 @@ final class PipePair: SocketProtocol {
         throw ChannelError.operationUnsupported
     }
 
-    func sendFile(fd: Int32, offset: Int, count: Int) throws -> IOResult<Int> {
+    func sendFile(fd: CInt, offset: Int, count: Int) throws -> IOResult<Int> {
         throw ChannelError.operationUnsupported
     }
 

--- a/Sources/NIO/SelectorEpoll.swift
+++ b/Sources/NIO/SelectorEpoll.swift
@@ -148,31 +148,31 @@ extension Selector: _SelectorBackendProtocol {
     }
 
     func register0<S: Selectable>(selectable: S,
-                                  fd: Int,
+                                  fileDescriptor: CInt,
                                   interested: SelectorEventSet,
                                   registrationID: SelectorRegistrationID) throws {
         var ev = Epoll.epoll_event()
         ev.events = interested.epollEventSet
-        ev.data.u64 = UInt64(EPollUserData(registrationID: registrationID, fileDescriptor: CInt(fd)))
+        ev.data.u64 = UInt64(EPollUserData(registrationID: registrationID, fileDescriptor: fileDescriptor))
 
-        try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_ADD, fd: Int32(fd), event: &ev)
+        try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_ADD, fd: fileDescriptor, event: &ev)
     }
 
     func reregister0<S: Selectable>(selectable: S,
-                                    fd: Int,
+                                    fileDescriptor: CInt,
                                     oldInterested: SelectorEventSet,
                                     newInterested: SelectorEventSet,
                                     registrationID: SelectorRegistrationID) throws {
         var ev = Epoll.epoll_event()
         ev.events = newInterested.epollEventSet
-        ev.data.u64 = UInt64(EPollUserData(registrationID: registrationID, fileDescriptor: CInt(fd)))
+        ev.data.u64 = UInt64(EPollUserData(registrationID: registrationID, fileDescriptor: fileDescriptor))
 
-        _ = try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_MOD, fd: Int32(fd), event: &ev)
+        _ = try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_MOD, fd: fileDescriptor, event: &ev)
     }
 
-    func deregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws {
+    func deregister0<S: Selectable>(selectable: S, fileDescriptor: CInt, oldInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws {
         var ev = Epoll.epoll_event()
-        _ = try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_DEL, fd: Int32(fd), event: &ev)
+        _ = try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_DEL, fd: fileDescriptor, event: &ev)
     }
     
     /// Apply the given `SelectorStrategy` and execute `body` once it's complete (which may produce `SelectorEvent`s to handle).

--- a/Sources/NIO/SelectorGeneric.swift
+++ b/Sources/NIO/SelectorGeneric.swift
@@ -98,9 +98,9 @@ protocol _SelectorBackendProtocol {
     associatedtype R: Registration
     func initialiseState0() throws
     func deinitAssertions0() // allows actual implementation to run some assertions as part of the class deinit
-    func register0<S: Selectable>(selectable: S, fd: Int, interested: SelectorEventSet, registrationID: SelectorRegistrationID) throws
-    func reregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, newInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws
-    func deregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws
+    func register0<S: Selectable>(selectable: S, fileDescriptor: CInt, interested: SelectorEventSet, registrationID: SelectorRegistrationID) throws
+    func reregister0<S: Selectable>(selectable: S, fileDescriptor: CInt, oldInterested: SelectorEventSet, newInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws
+    func deregister0<S: Selectable>(selectable: S, fileDescriptor: CInt, oldInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws
     /* attention, this may (will!) be called from outside the event loop, ie. can't access mutable shared state (such as `self.open`) */
     func wakeup0() throws
     /// Apply the given `SelectorStrategy` and execute `body` once it's complete (which may produce `SelectorEvent`s to handle).
@@ -212,7 +212,7 @@ internal class Selector<R: Registration>  {
         try selectable.withUnsafeHandle { fd in
             assert(registrations[Int(fd)] == nil)
             try self.register0(selectable: selectable,
-                               fd: Int(fd),
+                               fileDescriptor: fd,
                                interested: interested,
                                registrationID: self.registrationID)
             let registration = makeRegistration(interested, self.registrationID.nextRegistrationID())
@@ -234,7 +234,7 @@ internal class Selector<R: Registration>  {
         try selectable.withUnsafeHandle { fd in
             var reg = registrations[Int(fd)]!
             try self.reregister0(selectable: selectable,
-                                 fd: Int(fd),
+                                 fileDescriptor: fd,
                                  oldInterested: reg.interested,
                                  newInterested: interested,
                                  registrationID: reg.registrationID)
@@ -260,7 +260,7 @@ internal class Selector<R: Registration>  {
                 return
             }
             try self.deregister0(selectable: selectable,
-                                 fd: Int(fd),
+                                 fileDescriptor: fd,
                                  oldInterested: reg.interested,
                                  registrationID: reg.registrationID)
         }

--- a/Sources/NIO/SelectorKqueue.swift
+++ b/Sources/NIO/SelectorKqueue.swift
@@ -187,15 +187,15 @@ extension Selector: _SelectorBackendProtocol {
     func deinitAssertions0() {
     }
     
-    func register0<S: Selectable>(selectable: S, fd: Int, interested: SelectorEventSet, registrationID: SelectorRegistrationID) throws {
+    func register0<S: Selectable>(selectable: S, fileDescriptor: CInt, interested: SelectorEventSet, registrationID: SelectorRegistrationID) throws {
         try kqueueUpdateEventNotifications(selectable: selectable, interested: interested, oldInterested: nil, registrationID: registrationID)
     }
 
-    func reregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, newInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws {
+    func reregister0<S: Selectable>(selectable: S, fileDescriptor: CInt, oldInterested: SelectorEventSet, newInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws {
         try kqueueUpdateEventNotifications(selectable: selectable, interested: newInterested, oldInterested: oldInterested, registrationID: registrationID)
     }
     
-    func deregister0<S: Selectable>(selectable: S, fd: Int, oldInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws {
+    func deregister0<S: Selectable>(selectable: S, fileDescriptor: CInt, oldInterested: SelectorEventSet, registrationID: SelectorRegistrationID) throws {
         try kqueueUpdateEventNotifications(selectable: selectable, interested: .reset, oldInterested: oldInterested, registrationID: registrationID)
     }
 

--- a/Sources/NIO/Socket.swift
+++ b/Sources/NIO/Socket.swift
@@ -281,7 +281,7 @@ typealias IOVector = iovec
     ///     - count: The number of bytes to send.
     /// - returns: The `IOResult` which indicates how much data could be send and if the operation returned before all could be send (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
-    func sendFile(fd: Int32, offset: Int, count: Int) throws -> IOResult<Int> {
+    func sendFile(fd: CInt, offset: Int, count: Int) throws -> IOResult<Int> {
         return try withUnsafeHandle {
             try NIOBSDSocket.sendfile(socket: $0, fd: fd, offset: off_t(offset),
                                       len: off_t(count))

--- a/Sources/NIO/SocketProtocols.swift
+++ b/Sources/NIO/SocketProtocols.swift
@@ -57,7 +57,7 @@ protocol SocketProtocol: BaseSocketProtocol {
                  destinationSize: socklen_t,
                  controlBytes: UnsafeMutableRawBufferPointer) throws -> IOResult<Int>
 
-    func sendFile(fd: Int32, offset: Int, count: Int) throws -> IOResult<Int>
+    func sendFile(fd: CInt, offset: Int, count: Int) throws -> IOResult<Int>
 
     func recvmmsg(msgs: UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int>
 


### PR DESCRIPTION
Motivation:

We and the OSes only support `CInt` as file descriptors. For some reason
we had interfaces that took `Int`s as fds which requires frequent
casting around. This is unnecessary.

Modifications:

- make fds `CInt` (internally)
- clean up some `Int32` as `CInt` use

Result:

cleaner code, less casting