### PR TITLE
Less allocs during `flatMapErrorThrowing` and `flatMapThrowing`

### DIFF
--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -29,11 +29,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=178050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=175050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=470050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=467050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,10 +41,10 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4450
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -29,11 +29,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=177050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=174050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=99050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=465050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=462050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -29,11 +29,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31950
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=186050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=183050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=14050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=105050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=942050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=939050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10050
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4450

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -29,11 +29,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=178050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=175050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=467050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=464000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10050
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -29,11 +29,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=179050 # regression from 5.3 which was 177010
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=176050 # regression from 5.3 which was 174050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=468050 # regression from 5.3 which was 465050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=465050 # regression from 5.3 which was 462050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,10 +41,10 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4450
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -29,11 +29,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=179050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=176050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=468050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=465050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,10 +41,10 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=75050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4450
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150


### PR DESCRIPTION
Less allocs = Faster code

### Motivation:

- We alloc quite a lot with our implementations of `flatMapThrowing` and `flatMapErrorThrowing`.
- While we don't use Futures a lot in NIO itself a lot of our users, depend quite a bit on them. Let's make their code faster.

### Modifications:

- Create a `Promise` and use `_whenComplete` directly instead of going through another `flatMap` method

### Result:

- In my testing I see a reduction of 3 allocs per invocation 🎉 
