### PR TITLE
Reducing allocations in future chains

### DIFF
--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -588,10 +588,13 @@ extension EventLoopFuture {
             self.whenSuccess(callback as! (Value) -> Void)
             return self as! EventLoopFuture<NewValue>
         } else {
-            return self.flatMap(file: file, line: line) { return EventLoopFuture<NewValue>(eventLoop: self.eventLoop, value: callback($0), file: file, line: line) }
+            let next = EventLoopPromise<NewValue>(eventLoop: eventLoop, file: file, line: line)
+            self._whenComplete {
+                return next._setValue(value: self._value!.map(callback))
+            }
+            return next.futureResult
         }
     }
-
 
     /// When the current `EventLoopFuture<Value>` is in an error state, run the provided callback, which
     /// may recover from the error by returning an `EventLoopFuture<NewValue>`. The callback is intended to potentially
@@ -643,14 +646,21 @@ extension EventLoopFuture {
     public func flatMapResult<NewValue, SomeError: Error>(file: StaticString = #file,
                                                           line: UInt = #line,
                                                           _ body: @escaping (Value) -> Result<NewValue, SomeError>) -> EventLoopFuture<NewValue> {
-        return self.flatMap(file: file, line: line) { value in
-            switch body(value) {
+        let next = EventLoopPromise<NewValue>(eventLoop: eventLoop, file: file, line: line)
+        self._whenComplete {
+            switch self._value! {
             case .success(let value):
-                return self.eventLoop.makeSucceededFuture(value, file: file, line: line)
-            case .failure(let error):
-                return self.eventLoop.makeFailedFuture(error, file: file, line: line)
+                switch body(value) {
+                case .success(let newValue):
+                    return next._setValue(value: .success(newValue))
+                case .failure(let error):
+                    return next._setValue(value: .failure(error))
+                }
+            case .failure(let e):
+                return next._setValue(value: .failure(e))
             }
         }
+        return next.futureResult
     }
 
     /// When the current `EventLoopFuture<Value>` is in an error state, run the provided callback, which
@@ -667,9 +677,16 @@ extension EventLoopFuture {
     /// - returns: A future that will receive the recovered value.
     @inlinable
     public func recover(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) -> Value) -> EventLoopFuture<Value> {
-        return self.flatMapError(file: file, line: line) {
-            return EventLoopFuture<Value>(eventLoop: self.eventLoop, value: callback($0), file: file, line: line)
+        let next = EventLoopPromise<Value>(eventLoop: eventLoop, file: file, line: line)
+        self._whenComplete {
+            switch self._value! {
+            case .success(let t):
+                return next._setValue(value: .success(t))
+            case .failure(let e):
+                return next._setValue(value: .success(callback(e)))
+            }
         }
+        return next.futureResult
     }
 
 
@@ -693,14 +710,6 @@ extension EventLoopFuture {
             self.eventLoop.execute {
                 self._addCallback(callback)._run()
             }
-        }
-    }
-
-    @inlinable
-    internal func _whenCompleteWithValue(_ callback: @escaping (Result<Value, Error>) -> Void) {
-        self._whenComplete {
-            callback(self._value!)
-            return CallbackList()
         }
     }
 

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -25,15 +25,15 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=175050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=171050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=467050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=96050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=455000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
@@ -49,7 +49,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=196050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=188050
       - SANITIZER_ARG=--sanitize=thread
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]
 

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -25,15 +25,15 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=174050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=170050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=99050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=462050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=95000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=450050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
@@ -49,7 +49,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=196050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=188050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -25,15 +25,15 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31950
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=183050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=179050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=14050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=105050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=939050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=101050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=927050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10050
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4450
@@ -49,7 +49,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=14200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=207050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=199050
 
   performance-test:
     image: swift-nio:18.04-5.0

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -25,15 +25,15 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=175050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=171050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=464000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=96050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=452050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=10050
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
@@ -49,7 +49,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=196050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=188050
 
   performance-test:
     image: swift-nio:18.04-5.1

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -25,15 +25,15 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=176050 # regression from 5.3 which was 174050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=172050 # regression from 5.3 which was 170050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=465050 # regression from 5.3 which was 462050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=96050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=453050 # regression from 5.3 which was 450050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
@@ -49,7 +49,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=198050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=190050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -25,15 +25,15 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=12050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=176050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=172050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=100050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=465050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=96050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=453000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=66050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
@@ -49,7 +49,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=198050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=190050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
       - SWIFT_TEST_VERB=build # WARNING: THIS DISABLES ALL TESTS. Please remove (workaround https://bugs.swift.org/browse/SR-14268)
 


### PR DESCRIPTION
Less allocs = Faster code. Follow up to #1816

### Motivation:

- We alloc quite a lot with in implementations of EventLoopFuture chaining methods.
- While we don't use Futures a lot in NIO itself a lot of our users, depend quite a bit on them. Let's make their code faster.

### Modifications:

Create a `Promise` and use `_whenComplete` directly instead of going through another `flatMap`/`map` methods

### Result:

- Less allocations when using EventLoopFuture chains.
- We now have done what we is possible for: https://github.com/apple/swift-nio/issues/1697