### PR TITLE
Implement reserveCapacity for CircularBuffer.

### DIFF
--- a/Tests/NIOTests/CircularBufferTests+XCTest.swift
+++ b/Tests/NIOTests/CircularBufferTests+XCTest.swift
@@ -78,6 +78,7 @@ extension CircularBufferTests {
                 ("testHash", testHash),
                 ("testArrayLiteralInit", testArrayLiteralInit),
                 ("testFirstWorks", testFirstWorks),
+                ("testReserveCapacityActuallyDoesSomething", testReserveCapacityActuallyDoesSomething),
            ]
    }
 }

--- a/Tests/NIOTests/CircularBufferTests.swift
+++ b/Tests/NIOTests/CircularBufferTests.swift
@@ -1005,4 +1005,21 @@ class CircularBufferTests: XCTestCase {
             XCTAssertNil(buffer.first)
         }
     }
+
+    func testReserveCapacityActuallyDoesSomething() {
+        var buffer = CircularBuffer<Int>(initialCapacity: 4)
+        XCTAssertEqual(buffer.capacity, 4)
+
+        buffer.reserveCapacity(16)
+        XCTAssertEqual(buffer.capacity, 16)
+
+        buffer.reserveCapacity(8)
+        XCTAssertEqual(buffer.capacity, 16)
+
+        buffer.reserveCapacity(20)
+        XCTAssertEqual(buffer.capacity, 32)
+
+        buffer.reserveCapacity(0)
+        XCTAssertEqual(buffer.capacity, 32)
+    }
 }


### PR DESCRIPTION
Motivation:

While spelunking through the code I noticed we called
CircularBuffer.reserveCapacity, but never actually implemented it. This
means it never did anything. It should do something.

Modifications:

- Implemented reserveCapacity.

Result:

reserveCapacity does something now.