### PR TITLE
CI: print out version info

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
 
   soundness:
     <<: *common
-    command: /bin/bash -xcl "./scripts/soundness.sh"
+    command: /bin/bash -xcl "swift -version && uname -a && ./scripts/soundness.sh"
 
   unit-tests:
     <<: *common


### PR DESCRIPTION
Motivation:

Sometimes it's useful to know the kernel & Swift versions that CI uses.

Modifications:

Print the versions in the soundness check.

Result:

More info.
