### PR TITLE
Stop measuring alloc counts on 5.0

### DIFF
--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -6,7 +6,7 @@ set -o pipefail
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
 
-for f in 50 51 52 53 54 -nightly; do
+for f in 51 52 53 54 -nightly; do
     echo "swift$f"
     url="https://ci.swiftserver.group/job/swift-nio2-swift$f-prb/lastCompletedBuild/consoleFull"
     echo "$url"

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -32,7 +32,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=170050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=95000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=95050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=450050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -18,38 +18,7 @@ services:
   test:
     image: swift-nio:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=31950
-      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=179050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=14050
-      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=101050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=927050
-      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
-      - MAX_ALLOCS_ALLOWED_creating_10000_headers=10050
-      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=3
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
-      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
-      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
-      - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4450
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=220050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=14200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=199050
+      - INTEGRATION_TESTS_ARG=-f tests_0[012356789]
 
   performance-test:
     image: swift-nio:18.04-5.0


### PR DESCRIPTION
Motivation:

5.0 is several years old now, and while we still support it there is
beginning to be some conflict with performance optimizations for newer
Swift versions. We should stop counting the allocation counts on this
version now: we no longer care as much about regressions.

Modifications:

- Stop setting alloc counter limits on 5.0
- Remove the script that tries to add them back.

Result:

No longer measure allocs on 5.0
