### PR TITLE
update version support (new floor: Ubuntu 18.04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Redis | ✅ | ❌ | [mordil/swift-redi-stack](https://gitlab.com/Mordil/swift-re
 
 SwiftNIO aims to support all of the platforms where Swift is supported. Currently, it is developed and tested on macOS and Linux, and is known to support the following operating system versions:
 
-* Ubuntu 14.04+
+* Ubuntu 18.04+
 * macOS 10.9+, iOS 7+; (macOS 10.14+, iOS 12+, tvOS 12+ or watchOS 6+ with [swift-nio-transport-services][repo-nio-transport-services])
 
 ### Swift versions
@@ -64,7 +64,7 @@ The latest released SwiftNIO 1 version supports Swift 4.0, 4.1, 4.2, and 5.0.
 
 #### SwiftNIO 2
 
-The latest released SwiftNIO 2 version supports Swift 5.0, 5.1, 5.2, and 5.3. If you have a SwiftNIO 1 application or library that you would like to migrate to SwiftNIO 2, please check out the [migration guide](docs/migration-guide-NIO1-to-NIO2.md) we prepared for you.
+The latest released SwiftNIO 2 version supports Swift 5.0, 5.1, 5.2, 5.3, and 5.4. If you have a SwiftNIO 1 application or library that you would like to migrate to SwiftNIO 2, please check out the [migration guide](docs/migration-guide-NIO1-to-NIO2.md) we prepared for you.
 
 ### Compatibility
 
@@ -289,9 +289,9 @@ First make sure you have [Docker](https://www.docker.com/community-edition) inst
   Will create a base image, compile SwiftNIO, and run a sample `NIOHTTP1Server` on
   `localhost:8888`. Test it by `curl http://localhost:8888`
 
-- `docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.1604.53.yaml run test`
+- `docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.2004.54.yaml run test`
 
-  Will create a base image using ubuntu 16.04 and swift 5.3, compile SwiftNIO and run the unit and integration tests.  Files exist for other ubuntu and swift versions in the docker directory.
+  Will create a base image using Ubuntu 20.04 and swift 5.4, compile SwiftNIO and run the unit and integration tests.  Files exist for other ubuntu and swift versions in the docker directory.
 
 
 ## Developing SwiftNIO
@@ -313,7 +313,7 @@ have a few prerequisites installed on your system.
 
 ### Linux
 
-- Swift 5.0, 5.1, 5.2, or 5.3 from [swift.org/download](https://swift.org/download/#releases). We always recommend to use the latest released version.
+- Swift 5.0, 5.1, 5.2, 5.3, or 5.4 from [swift.org/download](https://swift.org/download/#releases). We always recommend to use the latest released version.
 - netcat (for integration tests only)
 - lsof (for integration tests only)
 - shasum (for integration tests only)


### PR DESCRIPTION
Motivation:

Ubuntu 14.04 ... 17.10 are all not supported anymore by the end of the day.
Also Swift 5.4 was released recently.

Modification:

- support Ubuntu 18.04+
- officially support Swift 5.4

Result:

More sensible and correct version support info.