### PR TITLE
alloc limit updater: allow other repos

### DIFF
--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -4,20 +4,23 @@ set -eu
 set -o pipefail
 
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+url_prefix=${1-"https://ci.swiftserver.group/job/swift-nio2-swift"}
+target_repo=${2-"$here/.."}
 tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
 
 for f in 51 52 53 54 -nightly; do
     echo "swift$f"
-    url="https://ci.swiftserver.group/job/swift-nio2-swift$f-prb/lastCompletedBuild/consoleFull"
+    url="$url_prefix$f-prb/lastCompletedBuild/consoleFull"
     echo "$url"
     curl -s "$url" | "$here/alloc-limits-from-test-output" > "$tmpdir/limits$f"
 
-    if [[ "$(wc -l < "$tmpdir/limits$f")" -lt 20 ]]; then
-        echo >&2 "ERROR: fewer than 20 limits found, something's not right"
+    if [[ "$(wc -l < "$tmpdir/limits$f")" -lt 5 ]]; then
+        echo >&2 "ERROR: fewer than 5 limits found, something's not right"
         exit 1
     fi
 
-    docker_file=$(if [[ "$f" == "-nightly" ]]; then f=main; fi && ls "$here/../docker/docker-compose."*"$f"*".yaml")
+    docker_file=$(if [[ "$f" == "-nightly" ]]; then f=main; fi && ls "$target_repo/docker/docker-compose."*"$f"*".yaml")
 
     echo "$docker_file"
     cat "$tmpdir/limits$f"


### PR DESCRIPTION
Motivation:

The allocation limit updater script is handy but so far only worked for
the SwiftNIO core repo.

Modifications:

- allow the user to pass other URL prefixes and repos

Result:

Can be used for other repos