### PR TITLE
restore test case from #164 that was modified

### DIFF
--- a/Tests/NIOTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOTests/ChannelTests+XCTest.swift
@@ -57,7 +57,7 @@ extension ChannelTests {
                 ("testAskForLocalAndRemoteAddressesAfterChannelIsClosed", testAskForLocalAndRemoteAddressesAfterChannelIsClosed),
                 ("testReceiveAddressAfterAccept", testReceiveAddressAfterAccept),
                 ("testWeDontJamSocketsInANoIOState", testWeDontJamSocketsInANoIOState),
-                ("testNoChannelReadBeforeEOFIfNoAutoRead", testNoChannelReadBeforeEOFIfNoAutoRead),
+                ("testNoChannelReadIfNoAutoRead", testNoChannelReadIfNoAutoRead),
                 ("testCloseInEOFdChannelReadBehavesCorrectly", testCloseInEOFdChannelReadBehavesCorrectly),
                 ("testCloseInSameReadThatEOFGetsDelivered", testCloseInSameReadThatEOFGetsDelivered),
                 ("testEOFReceivedWithoutReadRequests", testEOFReceivedWithoutReadRequests),


### PR DESCRIPTION
Motivation:

`testNoChannelReadIfNoAutoRead` from #164 was modified to allow data to
be received through `channelRead` for unclear reasons.

Modification:

Undo the modifications (apart from NIO 2 port).

Result:

Tighter test case.