### PR TITLE
Rewrite RecvByteBufferAllocator.

### DIFF
--- a/Sources/NIO/ByteBuffer-int.swift
+++ b/Sources/NIO/ByteBuffer-int.swift
@@ -110,6 +110,16 @@ extension FixedWidthInteger {
         }
         return 1 << (Self.bitWidth - (self - 1).leadingZeroBitCount)
     }
+
+    /// Returns the previous power of 2, or self if it already is.
+    @inlinable
+    func previousPowerOf2() -> Self {
+        guard self != 0 else {
+            return 0
+        }
+
+        return 1 << ((Self.bitWidth - 1) - self.leadingZeroBitCount)
+    }
 }
 
 extension UInt32 {

--- a/Tests/NIOTests/RecvByteBufAllocatorTest+XCTest.swift
+++ b/Tests/NIOTests/RecvByteBufAllocatorTest+XCTest.swift
@@ -29,6 +29,9 @@ extension AdaptiveRecvByteBufferAllocatorTest {
       return [
                 ("testAdaptive", testAdaptive),
                 ("testFixed", testFixed),
+                ("testMaxAllocSizeIsIntMax", testMaxAllocSizeIsIntMax),
+                ("testAdaptiveRoundsValues", testAdaptiveRoundsValues),
+                ("testSettingMinimumAboveMaxAllowed", testSettingMinimumAboveMaxAllowed),
            ]
    }
 }

--- a/Tests/NIOTests/RecvByteBufAllocatorTest.swift
+++ b/Tests/NIOTests/RecvByteBufAllocatorTest.swift
@@ -15,47 +15,85 @@
 import XCTest
 import NIO
 
-public final class AdaptiveRecvByteBufferAllocatorTest : XCTestCase {
+final class AdaptiveRecvByteBufferAllocatorTest: XCTestCase {
     private let allocator = ByteBufferAllocator()
-    private var adaptive = AdaptiveRecvByteBufferAllocator(minimum: 64, initial: 1024, maximum: 16 * 1024)
-    private var fixed = FixedSizeRecvByteBufferAllocator(capacity: 1024)
+    private var adaptive: AdaptiveRecvByteBufferAllocator!
+    private var fixed: FixedSizeRecvByteBufferAllocator!
+
+    override func setUp() {
+        self.adaptive = AdaptiveRecvByteBufferAllocator(minimum: 64, initial: 1024, maximum: 16 * 1024)
+        self.fixed = FixedSizeRecvByteBufferAllocator(capacity: 1024)
+    }
+
+    override func tearDown() {
+        self.adaptive = nil
+        self.fixed = nil
+    }
 
     func testAdaptive() throws {
         let buffer = adaptive.buffer(allocator: allocator)
         XCTAssertEqual(1024, buffer.capacity)
 
-        testActualReadBytes(mayGrow: false, actualReadBytes: 1024, expectedCapacity: 16384)
+        // We double every time.
+        testActualReadBytes(mayGrow: true, actualReadBytes: 1024, expectedCapacity: 2048)
+        testActualReadBytes(mayGrow: true, actualReadBytes: 16384, expectedCapacity: 4096)
+        testActualReadBytes(mayGrow: true, actualReadBytes: 16384, expectedCapacity: 8192)
         testActualReadBytes(mayGrow: true, actualReadBytes: 16384, expectedCapacity: 16384)
 
         // Will never go over maximum
-        testActualReadBytes(mayGrow: true, actualReadBytes: 32768, expectedCapacity: 16384)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 32768, expectedCapacity: 16384)
 
+        // Shrinks if two successive reads below half happen
         testActualReadBytes(mayGrow: false, actualReadBytes: 4096, expectedCapacity: 16384)
-        testActualReadBytes(mayGrow: false, actualReadBytes: 8192, expectedCapacity: 16384)
-        testActualReadBytes(mayGrow: false, actualReadBytes: 4096, expectedCapacity: 8192)
-        testActualReadBytes(mayGrow: false, actualReadBytes: 4096, expectedCapacity: 8192)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 8192, expectedCapacity: 8192)
 
-        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 8192)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 4096, expectedCapacity: 8192)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 4096, expectedCapacity: 4096)
+
+        // But not if an intermediate read is above half.
+        testActualReadBytes(mayGrow: false, actualReadBytes: 2048, expectedCapacity: 4096)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 2049, expectedCapacity: 4096)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 2048, expectedCapacity: 4096)
+
+        // Or if we grow in-between.
+        testActualReadBytes(mayGrow: true, actualReadBytes: 4096, expectedCapacity: 8192)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 4096, expectedCapacity: 8192)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 4096, expectedCapacity: 4096)
+
+        // Reads above half never shrink the capacity
+        for _ in 0..<10 {
+            testActualReadBytes(mayGrow: false, actualReadBytes: 2049, expectedCapacity: 4096)
+        }
+
+        // Consistently reading below half does shrink all the way down.
         testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 4096)
-        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 4096)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 2048)
 
         testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 2048)
-        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 2048)
-
-        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 1024)
         testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 1024)
 
-        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 512)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 1024)
         testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 512)
 
-        testActualReadBytes(mayGrow: false, actualReadBytes: 32, expectedCapacity: 512)
-        testActualReadBytes(mayGrow: false, actualReadBytes: 32, expectedCapacity: 512)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 512)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 256)
+
+        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 256)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 128)
+
+        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 128)
+        testActualReadBytes(mayGrow: false, actualReadBytes: 64, expectedCapacity: 64)
+
+        // Until the bottom, where it stays forever.
+        for _ in 0..<10 {
+            testActualReadBytes(mayGrow: false, actualReadBytes: 1, expectedCapacity: 64)
+        }
     }
 
-    private func testActualReadBytes(mayGrow: Bool, actualReadBytes: Int, expectedCapacity: Int) {
-        XCTAssertEqual(mayGrow, adaptive.record(actualReadBytes: actualReadBytes))
+    private func testActualReadBytes(mayGrow: Bool, actualReadBytes: Int, expectedCapacity: Int, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(mayGrow, adaptive.record(actualReadBytes: actualReadBytes), "unexpected value for mayGrow", file: file, line: line)
         let buffer = adaptive.buffer(allocator: allocator)
-        XCTAssertEqual(expectedCapacity, buffer.capacity)
+        XCTAssertEqual(expectedCapacity, buffer.capacity, "unexpected capacity", file: file, line: line)
     }
 
     func testFixed() throws {
@@ -67,5 +105,39 @@ public final class AdaptiveRecvByteBufferAllocatorTest : XCTestCase {
         XCTAssert(!fixed.record(actualReadBytes: 64))
         buffer = fixed.buffer(allocator: allocator)
         XCTAssertEqual(fixed.capacity, buffer.capacity)
+    }
+
+    func testMaxAllocSizeIsIntMax() {
+        // To find the max alloc size, we're going to search for a fixed point in resizing. To do that we're just going to
+        // keep saying we read max until we can't resize any longer.
+        self.adaptive = AdaptiveRecvByteBufferAllocator(minimum: 0, initial: .max / 2, maximum: .max)
+        var mayGrow = true
+        while mayGrow {
+            mayGrow = self.adaptive.record(actualReadBytes: .max)
+        }
+
+        let buffer = self.adaptive.buffer(allocator: self.allocator)
+        XCTAssertEqual(buffer.capacity, 1 << 31)
+        XCTAssertEqual(self.adaptive.maximum, 1 << 31)
+        XCTAssertEqual(self.adaptive.minimum, 0)
+    }
+
+    func testAdaptiveRoundsValues() {
+        let adaptive = AdaptiveRecvByteBufferAllocator(minimum: 9, initial: 677, maximum: 111111)
+        XCTAssertEqual(adaptive.minimum, 8)
+        XCTAssertEqual(adaptive.maximum, 131072)
+        XCTAssertEqual(adaptive.initial, 512)
+    }
+
+    func testSettingMinimumAboveMaxAllowed() {
+        guard let targetValue = Int(exactly: Int64.max / 2) else {
+            // On a 32-bit word platform, this test cannot do anything sensible.
+            return
+        }
+
+        let adaptive = AdaptiveRecvByteBufferAllocator(minimum: targetValue, initial: targetValue + 1, maximum: targetValue + 2)
+        XCTAssertEqual(adaptive.minimum, 1 << 31)
+        XCTAssertEqual(adaptive.maximum, 1 << 31)
+        XCTAssertEqual(adaptive.initial, 1 << 31)
     }
 }


### PR DESCRIPTION
Motivation:

Platforms with 32-bit integers continue to exist. On those platforms,
the way we calculate the size table for AdaptiveRecvByteBufferAllocator
will trap, as we attempt to compare an Int to UInt32.max as a loop
termination condition.

While I was amending this code, I noticed that
AdaptiveRecvByteBufferAllocator had a number of very strange behaviours,
and was arguably excessively complex. To that end, this patch
constitutes a substantial rewrite of the allocator. To understand what
it does, we need to describe the previous allocator algorithm.

The goal of AdaptiveRecvByteBufferAllocator is to attempt to dynamically
track the throughput of a TCP connection and to minimise the memory
usage required to get it to achieve maximum throughput, within
user-defined constraints. To that end, it implements a fairly simple
resizing algorithm.

At a high level, the algorithm is as follows. The allocator keeps track
of the size of the buffer it is offering the user. When the user reports
how much of that buffer they actually used, the allocator determines
whether better throughput could be achieved with larger allocation
sizes, or whether throughput would not be harmed with smaller allocation
sizes. It then adjusts accordingly.

When does the allocator believe beetter throughput could be achieved
with larger allocation sizes? When the allocation was entirely filled.
If a network recv() entirely fills the buffer, that means there was
likely more data to read that could not be added to the buffer. Improved
throughput would be gained by using larger buffers, as fewer system
calls would be necessary.

Similarly, the allocator believes it could shrink the buffer size
without harming throughput when the recv() uses less memory than the
next buffer size down. However, the algorithm attempts to detect the
possibility that we have "read until the end". The reason this is
relevant is that after a read completes we will often serve other work
on the loop for a while, causing data to pile up. As a result, we don't
want to shrink the buffer if the average read size would be higher, just
because one read happened to be short.

The original implementation's algorithm was based on a bucketed
scheme. For allocation sizes below 512 bytes, the allocation buckets
moved 16 bytes at a time. In principle this gave the allocator 16 byte
granularity. For allocation sizes above 512 bytes, the allocation
buckets would double: 512, 1024, 2048, 4096, and so on, up to
UInt32.max. This, incidentally, was the source of the crash on 32-bit
systems.

Unfortunately, this scheme had a few failings.

Firstly, the implementation complexity was fairly high. The bounds
provided by the user needed to be turned into bucket indices,
necessitating an awkward and complex binary search of the bucket array.
The bucket array itself needed to be generated, forcing a dispatch_once
to guard it and dirtying memory.

Secondly, the scheme was weighted very heavily toward growing memory and
not giving it back. Whenever the buffer was filled and a new size up
wanted to be chosen, the allocator would jump _4_ size buckets. As the
default initial size was 2048 bytes, and the default maximum was 65kB,
the first read of 2048 bytes would cause the allocator to immediately
jump up to allocating 32kB of memory for the next read: a huge leap! It
would then only release memory after two short reads, at which point it
would drop back only 1 bucket, meaning that there was a very aggressive
sawtooth pattern favouring higher memory usage. This pattern favours
benchmarks, where high-throughput localhost connections will naturally
want larger buffer sizes, but it is unnecessarily aggressive for
real-world networks.

Thirdly, the scheme had a bug that would mean it did not require two
_consecutive_ short reads to shrink the buffer, just two short reads
between an increase. This means that it had a tendency not to stabilise:
two "read to the end"s in two different event loop ticks would cause
the buffer to shrink, even if there had been 10 almost-full-reads
in between.

Fourthly, the system would occasionally report that the Channel should
reallocate the buffer because it was larger, when in fact it wasn't:
we'd hit the max, and were never going to get larger. This forced
high-throughput Channels to excessively allocate, albeit only in systems
that customized this allocator (and basically no-one does).

Fifthly, the bucketing system was defeated by ByteBuffer. While having
16-byte granularity was nice in principle, ByteBuffer only allows
power-of-two allocation sizes. This meant that, at the low end, there
were several wasted buckets that were effectively identical. Between 256
bytes and 512 bytes there were 15 redundant buckets!

This last point is the main reason to justify a rewrite. The complexity
of the scheme was in principle justified by having fine, granular
control of allocation sizes. Given that those don't exist, there is no
reason not to simply resort to power-of-two sizing. Once we do that, we
can replace the complex bucketing system by simple shift-and-multiply
math. The effect of this is to produce smaller code (we save about 30%
of the instructions, even as we add some extra safety preconditions)
with no additional branching, and no need to load from a random table in
memory. This avoids the need to keep that table in cache, reducing cache
pressure in the hot read loop. Additionally, we can drop the index into
the table, which lets us save some per-Channel memory, further reducing
cache pressure.

Additionally, constructing one of these is now vastly cheaper. That
matters less (it's not really hot-code), but it does improve Channel
creation time somewhat.

Modifications:

- Remove the size table.
- Round all values to powers of two.
- Implement new "previous power of two" function.
- Cap the allocation size at the largest power of 2 representable in a
  32-bit Int.
- Add more tests.

Result:

The result is less code, simpler code, and faster code. No trapping on
32-bit integer platforms.

Resolves #1848 