### PR TITLE
fix 5.4. docker setup

### DIFF
--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -6,8 +6,8 @@ services:
     image: swift-nio:20.04-5.4
     build:
       args:
-        base_image: "swift:5.4-focal"
         ubuntu_version: "focal"
+        swift_version: "5.4"
 
   unit-tests:
     image: swift-nio:20.04-5.4


### PR DESCRIPTION
motivation: update syntax for release images

changes: replace use of "base_image" with "ubuntu_version" and "swift_version" pair, which the intended way to use release images
