### PR TITLE
dev/scripts: add missing license headers

### DIFF
--- a/dev/alloc-limits-from-test-output
+++ b/dev/alloc-limits-from-test-output
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 # This script allows you to consume any Jenkins/alloc counter run output and
 # convert it into the right for for the docker-compose script.

--- a/dev/lldb-smoker
+++ b/dev/lldb-smoker
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 set -eu
 

--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 set -eu
 set -o pipefail

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -147,10 +147,18 @@ EOF
 
   (
     cd "$here/.."
-    find . \
-      \( \! -path './.build/*' -a \
-      \( "${matching_files[@]}" \) -a \
-      \( \! \( "${exceptions[@]}" \) \) \) | while read line; do
+    {
+        find . \
+            \( \! -path './.build/*' -a \
+            \( "${matching_files[@]}" \) -a \
+            \( \! \( "${exceptions[@]}" \) \) \)
+
+        if [[ "$language" = bash ]]; then
+            # add everything with a shell shebang too
+            git grep --full-name -l '#!/bin/bash'
+            git grep --full-name -l '#!/bin/sh'
+        fi
+    } | while read line; do
       if [[ "$(cat "$line" | replace_acceptable_years | head -n $expected_lines | shasum)" != "$expected_sha" ]]; then
         printf "\033[0;31mmissing headers in file '$line'!\033[0m\n"
         diff -u <(cat "$line" | replace_acceptable_years | head -n $expected_lines) "$tmp"


### PR DESCRIPTION
Motivation:

We need license headers but the soundness script couldn't check if the
scripts don't have a `.sh` extension.

Modification:

- Add missing license headers.
- Better license checking (search for shell shebangs too)

Result:

Proper license attribution.