### PR TITLE
Add performance test for web socket client random request key

### DIFF
--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -16,6 +16,7 @@ import NIO
 import NIOHTTP1
 import NIOFoundationCompat
 import Dispatch
+import NIOWebSocket
 
 // MARK: Test Harness
 
@@ -770,3 +771,8 @@ try measureAndPrint(desc: "byte_buffer_view_iterator_1mb", benchmark: ByteBuffer
 
 try measureAndPrint(desc: "byte_to_message_decoder_decode_many_small",
                     benchmark: ByteToMessageDecoderDecodeManySmallsBenchmark(iterations: 1_000, bufferSize: 16384))
+
+measureAndPrint(desc: "generate_10k_random_request_keys") {
+    let keys = (0 ..< 10_000).map { _ in NIOWebSocketClientUpgrader.randomRequestKey() }
+    return keys.count
+}

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -773,6 +773,5 @@ try measureAndPrint(desc: "byte_to_message_decoder_decode_many_small",
                     benchmark: ByteToMessageDecoderDecodeManySmallsBenchmark(iterations: 1_000, bufferSize: 16384))
 
 measureAndPrint(desc: "generate_10k_random_request_keys") {
-    let keys = (0 ..< 10_000).map { _ in NIOWebSocketClientUpgrader.randomRequestKey() }
-    return keys.count
+    return (0 ..< 10_000).reduce(into: 0, { result, _ in result &+= NIOWebSocketClientUpgrader.randomRequestKey().count })
 }


### PR DESCRIPTION
Adding performance test for random request key creation

### Motivation:

Adding this performance test in order to compare performance improvements of base64 encode method

### Modifications:

Adding one performance test

### Result:

Performance test can be executed and the performance characteristics of base64 encode method can be measured and tracked
