### PR TITLE
Convert Lock to use os_unfair_lock on Darwin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -87,6 +87,7 @@ var targets: [PackageDescription.Target] = [
 
 let package = Package(
     name: "swift-nio",
+    platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v3)],
     products: [
         .library(name: "NIO", targets: ["NIO"]),
         .library(name: "_NIO1APIShims", targets: ["_NIO1APIShims"]),


### PR DESCRIPTION
Convert Lock to use `os_unfair_lock` on Darwin to match the unfair behaviour on Linux.

### Motivation:

`pthread_mutex` is fair on Darwin, but unfair on Linux. In this case unfair is desirable as it's faster.

### Modifications:

Convert `Lock` to use `os_unfair_lock` on `Darwin`, but keep `pthread_mutex` inside `ConditionLock`. `os_unfair_lock` doesn't support conditions, and would require spinning (it's a replacement for `OSSpinLock`.

### Result:

Fast locking.
