### PR TITLE
Fix spelling of detach

### DIFF
--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -66,7 +66,7 @@ func main() async {
 let dg = DispatchGroup()
 dg.enter()
 if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
-    detach {
+    Task.detached {
         await main()
         dg.leave()
     }

--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -47,7 +47,7 @@ extension EventLoopPromise {
     /// - parameters:
     ///   - body: The `async` function to run.
     public func completeWithAsync(_ body: @escaping () async throws -> Value) {
-        detach {
+        Task.detached {
             do {
                 let value = try await body()
                 self.succeed(value)


### PR DESCRIPTION
Motivation:

The spelling of detach changed. This patch adopts the new spelling.

Modifications:

Changed detach to Task.detached.

Result:

5.5 should build again.
