### PR TITLE
Work around awkward SO_TIMESTAMP definition.

### DIFF
--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -72,5 +72,9 @@ const void *CNIOLinux_CMSG_DATA(const struct cmsghdr *);
 void *CNIOLinux_CMSG_DATA_MUTABLE(struct cmsghdr *);
 size_t CNIOLinux_CMSG_LEN(size_t);
 size_t CNIOLinux_CMSG_SPACE(size_t);
+
+// awkward time_T pain
+extern int CNIOLinux_SO_TIMESTAMP;
+extern int CNIOLinux_SO_RCVTIMEO;
 #endif
 #endif

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -143,4 +143,7 @@ size_t CNIOLinux_CMSG_LEN(size_t payloadSizeBytes) {
 size_t CNIOLinux_CMSG_SPACE(size_t payloadSizeBytes) {
     return CMSG_SPACE(payloadSizeBytes);
 }
+
+int CNIOLinux_SO_TIMESTAMP = SO_TIMESTAMP;
+int CNIOLinux_SO_RCVTIMEO = SO_RCVTIMEO;
 #endif

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -58,6 +58,12 @@ let S_IFBLK = UInt32(SwiftGlibc.S_IFBLK)
 #endif
 #endif
 
+// Work around SO_TIMESTAMP/SO_RCVTIMEO being awkwardly defined in glibc.
+#if os(Linux)
+let SO_TIMESTAMP = CNIOLinux_SO_TIMESTAMP
+let SO_RCVTIMEO = CNIOLinux_SO_RCVTIMEO
+#endif
+
 // Declare aliases to share more code and not need to repeat #if #else blocks
 #if !os(Windows)
 private let sysClose = close


### PR DESCRIPTION
Motivation:

On some Linux platforms the definition of SO_TIMESTAMP is too complex
for the clang importer to handle. Delegate to C to find out what it
should be.

Modifications:

- Define SO_TIMESTAMP in CNIOLinux instead.

Result:

Should build on the awkward Linux platforms.
Resolves #1861 