### PR TITLE
Made the extern to const in CNIODarwin

### DIFF
--- a/Sources/CNIODarwin/include/CNIODarwin.h
+++ b/Sources/CNIODarwin/include/CNIODarwin.h
@@ -31,11 +31,11 @@ typedef struct {
     unsigned int msg_len;
 } CNIODarwin_mmsghdr;
 
-extern int CNIODarwin_IPTOS_ECN_NOTECT;
-extern int CNIODarwin_IPTOS_ECN_MASK;
-extern int CNIODarwin_IPTOS_ECN_ECT0;
-extern int CNIODarwin_IPTOS_ECN_ECT1;
-extern int CNIODarwin_IPTOS_ECN_CE;
+extern const int CNIODarwin_IPTOS_ECN_NOTECT;
+extern const int CNIODarwin_IPTOS_ECN_MASK;
+extern const int CNIODarwin_IPTOS_ECN_ECT0;
+extern const int CNIODarwin_IPTOS_ECN_ECT1;
+extern const int CNIODarwin_IPTOS_ECN_CE;
 
 int CNIODarwin_sendmmsg(int sockfd, CNIODarwin_mmsghdr *msgvec, unsigned int vlen, int flags);
 int CNIODarwin_recvmmsg(int sockfd, CNIODarwin_mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout);

--- a/Sources/CNIODarwin/shim.c
+++ b/Sources/CNIODarwin/shim.c
@@ -81,10 +81,10 @@ size_t CNIODarwin_CMSG_SPACE(size_t payloadSizeBytes) {
     return CMSG_SPACE(payloadSizeBytes);
 }
 
-int CNIODarwin_IPTOS_ECN_NOTECT = IPTOS_ECN_NOTECT;
-int CNIODarwin_IPTOS_ECN_MASK = IPTOS_ECN_MASK;
-int CNIODarwin_IPTOS_ECN_ECT0 = IPTOS_ECN_ECT0;
-int CNIODarwin_IPTOS_ECN_ECT1 = IPTOS_ECN_ECT1;
-int CNIODarwin_IPTOS_ECN_CE = IPTOS_ECN_CE;
+const int CNIODarwin_IPTOS_ECN_NOTECT = IPTOS_ECN_NOTECT;
+const int CNIODarwin_IPTOS_ECN_MASK = IPTOS_ECN_MASK;
+const int CNIODarwin_IPTOS_ECN_ECT0 = IPTOS_ECN_ECT0;
+const int CNIODarwin_IPTOS_ECN_ECT1 = IPTOS_ECN_ECT1;
+const int CNIODarwin_IPTOS_ECN_CE = IPTOS_ECN_CE;
 
 #endif  // __APPLE__


### PR DESCRIPTION
Externs in CNIODarwin are now const
### Motivation:

Externs should be immutable as per #1867.

### Modifications:

Externs in CNIODarwin got added the const keyword.

### Result:

Externs are now immutable
