### PR TITLE
Update _NIOConcurrency for Swift 5.5 latest changes

### DIFF
--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -14,11 +14,9 @@
 
 import NIO
 
-#if compiler(>=5.5) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 import _Concurrency
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension EventLoopFuture {
     /// Get the value/error from an `EventLoopFuture` in an `async` context.
     ///
@@ -38,7 +36,6 @@ extension EventLoopFuture {
     }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension EventLoopPromise {
     /// Complete a future with the result (or error) of the `async` function `body`.
     ///
@@ -58,7 +55,6 @@ extension EventLoopPromise {
     }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Channel {
     /// Shortcut for calling `write` and `flush`.
     ///
@@ -81,7 +77,6 @@ extension Channel {
     }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension ChannelOutboundInvoker {
     /// Register on an `EventLoop` and so have all its IO handled.
     ///
@@ -134,7 +129,6 @@ extension ChannelOutboundInvoker {
     }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension ChannelPipeline {
     public func addHandler(_ handler: ChannelHandler,
                            name: String? = nil,
@@ -176,5 +170,4 @@ extension ChannelPipeline {
         try await self.addHandlers(handlers, position: position)
     }
 }
-#endif
 #endif

--- a/Sources/_NIOConcurrency/Helpers.swift
+++ b/Sources/_NIOConcurrency/Helpers.swift
@@ -14,14 +14,8 @@
 
 import NIO
 
-// note: We have to define the variable `hasAsyncAwait` here because if we copy this code into the property below,
-// it doesn't compile on Swift 5.0.
-#if compiler(>=5.5) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 fileprivate let hasAsyncAwait = true
-#else
-fileprivate let hasAsyncAwait = false
-#endif
 #else
 fileprivate let hasAsyncAwait = false
 #endif


### PR DESCRIPTION
Remove availability checks and `$AsyncAwait` from `_NIOConcurrency`

### Motivation:

The latest changes in Swift 5.5 mean you no longer need the availability checks for concurrency.

### Modifications:

Removes the availability checks and compiler directives that are no longer required

### Result:

Easier to use `_NIOConcurrency`
