### PR TITLE
Concurrency features are runtime-specific.

### DIFF
--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -22,6 +22,8 @@ extension EventLoopFuture {
     ///
     /// This function can be used to bridge an `EventLoopFuture` into the `async` world. Ie. if you're in an `async`
     /// function and want to get the result of this future.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @inlinable
     public func get() async throws -> Value {
         return try await withUnsafeThrowingContinuation { cont in
             self.whenComplete { result in
@@ -43,6 +45,8 @@ extension EventLoopPromise {
     ///
     /// - parameters:
     ///   - body: The `async` function to run.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @inlinable
     public func completeWithAsync(_ body: @escaping () async throws -> Value) {
         Task {
             do {
@@ -62,16 +66,22 @@ extension Channel {
     ///     - data: the data to write
     ///     - promise: the `EventLoopPromise` that will be notified once the `write` operation completes,
     ///                or `nil` if not interested in the outcome of the operation.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @inlinable
     public func writeAndFlush<T>(_ any: T) async throws {
         try await self.writeAndFlush(any).get()
     }
 
     /// Set `option` to `value` on this `Channel`.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @inlinable
     public func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) async throws {
         try await self.setOption(option, value: value).get()
     }
 
     /// Get the value of `option` for this `Channel`.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @inlinable
     public func getOption<Option: ChannelOption>(_ option: Option) async throws -> Option.Value {
         return try await self.getOption(option).get()
     }
@@ -81,6 +91,7 @@ extension ChannelOutboundInvoker {
     /// Register on an `EventLoop` and so have all its IO handled.
     ///
     /// - returns: the future which will be notified once the operation completes.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func register(file: StaticString = #file, line: UInt = #line) async throws {
         try await self.register(file: file, line: line).get()
     }
@@ -89,6 +100,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - to: the `SocketAddress` to which we should bind the `Channel`.
     /// - returns: the future which will be notified once the operation completes.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func bind(to address: SocketAddress, file: StaticString = #file, line: UInt = #line) async throws {
         try await self.bind(to: address, file: file, line: line).get()
     }
@@ -97,6 +109,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - to: the `SocketAddress` to which we should connect the `Channel`.
     /// - returns: the future which will be notified once the operation completes.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func connect(to address: SocketAddress, file: StaticString = #file, line: UInt = #line) async throws {
         try await self.connect(to: address, file: file, line: line).get()
     }
@@ -106,6 +119,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - data: the data to write
     /// - returns: the future which will be notified once the `write` operation completes.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func writeAndFlush(_ data: NIOAny, file: StaticString = #file, line: UInt = #line) async throws {
         try await self.writeAndFlush(data, file: file, line: line).get()
     }
@@ -115,6 +129,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - mode: the `CloseMode` that is used
     /// - returns: the future which will be notified once the operation completes.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func close(mode: CloseMode = .all, file: StaticString = #file, line: UInt = #line) async throws {
         try await self.close(mode: mode, file: file, line: line).get()
     }
@@ -124,47 +139,58 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - event: the event itself.
     /// - returns: the future which will be notified once the operation completes.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func triggerUserOutboundEvent(_ event: Any, file: StaticString = #file, line: UInt = #line) async throws {
         try await self.triggerUserOutboundEvent(event, file: file, line: line).get()
     }
 }
 
 extension ChannelPipeline {
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func addHandler(_ handler: ChannelHandler,
                            name: String? = nil,
                            position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandler(handler, name: name, position: position).get()
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func removeHandler(_ handler: RemovableChannelHandler) async throws {
         try await self.removeHandler(handler).get()
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func removeHandler(name: String) async throws {
         try await self.removeHandler(name: name).get()
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func removeHandler(context: ChannelHandlerContext) async throws {
         try await self.removeHandler(context: context).get()
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func context(handler: ChannelHandler) async throws -> ChannelHandlerContext {
         return try await self.context(handler: handler).get()
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func context(name: String) async throws -> ChannelHandlerContext {
         return try await self.context(name: name).get()
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @inlinable
     public func context<Handler: ChannelHandler>(handlerType: Handler.Type) async throws -> ChannelHandlerContext {
         return try await self.context(handlerType: handlerType).get()
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func addHandlers(_ handlers: [ChannelHandler],
                             position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandlers(handlers, position: position).get()
     }
 
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func addHandlers(_ handlers: ChannelHandler...,
                             position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandlers(handlers, position: position)


### PR DESCRIPTION
Motivation:

The Swift concurrency features are only available in specific releases
of platforms where the Swift runtime ships with the platform. We need to
add availability guards to reflect that.

Modifications:

- Added appropriate availability guards for the async/await methods.

Result:

More likely to compile on Apple platforms.
