### PR TITLE
Fix tests for 32-bit platforms, tested for Android armv7

### DIFF
--- a/Sources/NIO/IntegerTypes.swift
+++ b/Sources/NIO/IntegerTypes.swift
@@ -75,7 +75,8 @@ struct _UInt56 {
 
     static let bitWidth: Int = 56
 
-    static let max: _UInt56 = .init((1 << 56) - 1)
+    private static let initializeUInt64 : UInt64 = (1 << 56) - 1
+    static let max: _UInt56 = .init(initializeUInt64)
     static let min: _UInt56 = .init(0)
 }
 

--- a/Tests/NIOTests/RecvByteBufAllocatorTest.swift
+++ b/Tests/NIOTests/RecvByteBufAllocatorTest.swift
@@ -117,8 +117,8 @@ final class AdaptiveRecvByteBufferAllocatorTest: XCTestCase {
         }
 
         let buffer = self.adaptive.buffer(allocator: self.allocator)
-        XCTAssertEqual(buffer.capacity, 1 << 31)
-        XCTAssertEqual(self.adaptive.maximum, 1 << 31)
+        XCTAssertEqual(buffer.capacity, 1 << 30)
+        XCTAssertEqual(self.adaptive.maximum, 1 << 30)
         XCTAssertEqual(self.adaptive.minimum, 0)
     }
 
@@ -136,8 +136,8 @@ final class AdaptiveRecvByteBufferAllocatorTest: XCTestCase {
         }
 
         let adaptive = AdaptiveRecvByteBufferAllocator(minimum: targetValue, initial: targetValue + 1, maximum: targetValue + 2)
-        XCTAssertEqual(adaptive.minimum, 1 << 31)
-        XCTAssertEqual(adaptive.maximum, 1 << 31)
-        XCTAssertEqual(adaptive.initial, 1 << 31)
+        XCTAssertEqual(adaptive.minimum, 1 << 30)
+        XCTAssertEqual(adaptive.maximum, 1 << 30)
+        XCTAssertEqual(adaptive.initial, 1 << 30)
     }
 }

--- a/Tests/NIOTests/SystemTest.swift
+++ b/Tests/NIOTests/SystemTest.swift
@@ -62,6 +62,21 @@ class SystemTest: XCTestCase {
     private static let cmsghdr_secondDataCount = 1
     private static let cmsghdr_firstType = IP_RECVDSTADDR
     private static let cmsghdr_secondType = IP_RECVTOS
+    #elseif os(Android) && arch(arm)
+    private static let cmsghdrExample: [UInt8] = [0x10, 0x00, 0x00, 0x00, // Length 16 including header
+                                                  0x00, 0x00, 0x00, 0x00, // IPPROTO_IP
+                                                  0x08, 0x00, 0x00, 0x00, // IP_PKTINFO
+                                                  0x7F, 0x00, 0x00, 0x01, // 127.0.0.1
+                                                  0x0D, 0x00, 0x00, 0x00, // Length 13 including header
+                                                  0x00, 0x00, 0x00, 0x00, // IPPROTO_IP
+                                                  0x01, 0x00, 0x00, 0x00, // IP_TOS
+                                                  0x01, 0x00, 0x00, 0x00] // ECT-1 (1 byte)
+    private static let cmsghdr_secondStartPosition = 16
+    private static let cmsghdr_firstDataStart = 12
+    private static let cmsghdr_firstDataCount = 4
+    private static let cmsghdr_secondDataCount = 1
+    private static let cmsghdr_firstType = IP_PKTINFO
+    private static let cmsghdr_secondType = IP_TOS
     #elseif os(Linux) || os(Android)
     // Example twin data options captured on Linux
     private static let cmsghdrExample: [UInt8] = [


### PR DESCRIPTION
Motivation:

Get the tests passing on 32-bit platforms again.

Modifications:

- Change the way _UInt56.max is initialized.
- Set the proper max capacity for AdaptiveRecvByteBufferAllocator and change the test to match it.
- Add a cmsghdrExample for Android armv7.

Result:

All the same tests pass on Android armv7 as Android AArch64.

Now that I have a working Android armv7 5.4 toolchain again, termux/termux-packages#6941, I noticed that the armv7 tests had regressed since February. These changes got me to parity with AArch64, ie only `BootstrapTest/testClientBindWorksOnSocketsBoundToEitherIPv4OrIPv6Only` fails now, will look into that later.