### PR TITLE
Add async implementation of EventLoopGroup.shutdownGracefully to _NIOConcurrency

### DIFF
--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -57,6 +57,9 @@ func main() async {
         print(", response:", String(buffer: response2.body ?? ByteBuffer()))
 
         try await channel.close()
+
+        try await group.shutdownGracefully()
+
         print("all, done")
     } catch {
         print("ERROR: \(error)")

--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -33,9 +33,8 @@ func makeHTTPChannel(host: String, port: Int, group: EventLoopGroup) async throw
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func main() async {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     do {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-
         let channel = try await makeHTTPChannel(host: "httpbin.org", port: 80, group: group)
         print("OK, connected to \(channel)")
 
@@ -55,11 +54,18 @@ func main() async {
 
         try await channel.close()
 
+        print("Shutting down event loop group...")
         try await group.shutdownGracefully()
 
         print("all, done")
     } catch {
         print("ERROR: \(error)")
+        print("Shutting down event loop group (possibly for a second time)...")
+        do {
+            try await group.shutdownGracefully()
+        } catch {
+            print("Error shutting down event loop group: \(error)")
+        }
     }
 }
 

--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -38,6 +38,22 @@ extension EventLoopFuture {
     }
 }
 
+extension EventLoopGroup {
+    /// Shuts down the event loop gracefully.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @inlinable
+    public func shutdownGracefully() async throws {
+        return try await withCheckedThrowingContinuation { cont in
+            self.shutdownGracefully { error in
+                if let error = error {
+                    cont.resume(throwing: error)
+                }
+                cont.resume()
+            }
+        }
+    }
+}
+
 extension EventLoopPromise {
     /// Complete a future with the result (or error) of the `async` function `body`.
     ///

--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -47,8 +47,9 @@ extension EventLoopGroup {
             self.shutdownGracefully { error in
                 if let error = error {
                     cont.resume(throwing: error)
+                } else {
+                    cont.resume()
                 }
-                cont.resume()
             }
         }
     }


### PR DESCRIPTION
Adds a new extension to `EventLoopGroup` in `_NIOConcurrency` to provide an asynchronous `shutdownGracefully()`.

### Motivation

Shutting down an event loop was special because it used a completion handler and executed on a `DispatchQueue` because there would be no event loop to use an `EventLoopFuture`.

Now we have the new Swift concurrency features, we can provide an `async` `shutdownGracefully`.

Fixes #1878.

### Modifications

Adds `EventLoopGroup.shutdownGracefully() async` and some code to use it in `NIOAsyncAwaitDemo`.

There's no obvious way to ask an ELG if it has been shutdown but I made the following local-only changes to verify that this performs as expected:

```diff
diff --git a/Sources/NIO/EventLoop.swift b/Sources/NIO/EventLoop.swift
index d18a33dd..972b3b05 100644
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -840 +840 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
-    private enum RunState {
+    public enum RunState {
@@ -852 +852 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
-    private var runState: RunState = .running
+    public var runState: RunState = .running
diff --git a/Sources/NIOAsyncAwaitDemo/main.swift b/Sources/NIOAsyncAwaitDemo/main.swift
index 97a9c0c3..f8b29ace 100644
--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -60,0 +61 @@ func main() async {
+        print("elg state: \(group.runState)")  // .running
@@ -61,0 +63,7 @@ func main() async {
+        print("elg state: \(group.runState)")  // .closed(nil)
+
+        /// This causes the following error:
+        /// ERROR: Cannot schedule tasks on an EventLoop that has already shut down. This will be upgraded to a forced crash in future SwiftNIO versions.
+        group.next().execute {
+            print("This will not execute.")
+        }
```

