### PR TITLE
docs: formatting comments with double slash

### DIFF
--- a/Sources/NIO/ChannelHandlers.swift
+++ b/Sources/NIO/ChannelHandlers.swift
@@ -98,7 +98,7 @@ public final class AcceptBackoffHandler: ChannelDuplexHandler, RemovableChannelH
     }
 
     private func doRead(_ context: ChannelHandlerContext) {
-        /// Reset the backoff time and read.
+        // Reset the backoff time and read.
         self.nextReadDeadlineNS = nil
         self.scheduledRead = nil
         context.read()

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -834,7 +834,7 @@ extension DatagramChannel: MulticastChannel {
             return
         }
 
-        /// Check if the device supports multicast
+        // Check if the device supports multicast
         if let device = device {
             guard device.multicastSupported else {
                 promise?.fail(NIOMulticastNotSupportedError(device: device))


### PR DESCRIPTION
### Motivation:

Triple slashes should be for exportable documentation (like functions declarations).

### Modifications:

Replaced `///` with `//`.

### Result:

Better looking code comments.