### PR TITLE
Adds Equatable and ExpressibleByArrayLiteral conformance to ByteBufferView

### DIFF
--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -191,7 +191,17 @@ extension ByteBuffer {
 extension ByteBufferView: Equatable {
     /// required by `Equatable`
     public static func == (lhs: ByteBufferView, rhs: ByteBufferView) -> Bool {
-        lhs._buffer == rhs._buffer
+
+        guard lhs._range.count == rhs._range.count else {
+            return false 
+        }
+
+        let leftBufferSlice = lhs._buffer.getSlice(at: lhs._range.startIndex, length: lhs._range.count)
+        let rightBufferSlice = rhs._buffer.getSlice(at: rhs._range.startIndex, length: rhs._range.count)
+        
+        return leftBufferSlice == rightBufferSlice
+    }
+}
     }
 }
 

--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -202,6 +202,11 @@ extension ByteBufferView: Equatable {
         return leftBufferSlice == rightBufferSlice
     }
 }
+
+extension ByteBufferView: Hashable {
+    /// required by `Hashable`
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_buffer.getSlice(at: _range.startIndex, length: _range.count))
     }
 }
 

--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -209,7 +209,7 @@ extension ByteBufferView: Hashable {
     /// required by `Hashable`
     public func hash(into hasher: inout Hasher) {
         // A well-formed ByteBufferView can never have a range that is out-of-bounds of the backing ByteBuffer.
-        // As a result, this getSlice call can never fail, and we'd like to know it if they do.
+        // As a result, this getSlice call can never fail, and we'd like to know it if it does.
         hasher.combine(self._buffer.getSlice(at: self._range.startIndex, length: self._range.count)!)
     }
 }

--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -187,3 +187,17 @@ extension ByteBuffer {
         self = view._buffer.getSlice(at: view.startIndex, length: view.count)!
     }
 }
+
+extension ByteBufferView: Equatable {
+    /// required by `Equatable`
+    public static func == (lhs: ByteBufferView, rhs: ByteBufferView) -> Bool {
+        lhs._buffer == rhs._buffer
+    }
+}
+
+extension ByteBufferView: ExpressibleByArrayLiteral {
+    /// required by `ExpressibleByArrayLiteral`
+    public init(arrayLiteral elements: Element...) {
+        self.init(elements)
+    }
+}

--- a/Sources/NIO/ByteBuffer-views.swift
+++ b/Sources/NIO/ByteBuffer-views.swift
@@ -196,8 +196,10 @@ extension ByteBufferView: Equatable {
             return false 
         }
 
-        let leftBufferSlice = lhs._buffer.getSlice(at: lhs._range.startIndex, length: lhs._range.count)
-        let rightBufferSlice = rhs._buffer.getSlice(at: rhs._range.startIndex, length: rhs._range.count)
+        // A well-formed ByteBufferView can never have a range that is out-of-bounds of the backing ByteBuffer.
+        // As a result, these getSlice calls can never fail, and we'd like to know it if they do.
+        let leftBufferSlice = lhs._buffer.getSlice(at: lhs._range.startIndex, length: lhs._range.count)!
+        let rightBufferSlice = rhs._buffer.getSlice(at: rhs._range.startIndex, length: rhs._range.count)!
         
         return leftBufferSlice == rightBufferSlice
     }
@@ -206,7 +208,9 @@ extension ByteBufferView: Equatable {
 extension ByteBufferView: Hashable {
     /// required by `Hashable`
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_buffer.getSlice(at: _range.startIndex, length: _range.count))
+        // A well-formed ByteBufferView can never have a range that is out-of-bounds of the backing ByteBuffer.
+        // As a result, this getSlice call can never fail, and we'd like to know it if they do.
+        hasher.combine(self._buffer.getSlice(at: self._range.startIndex, length: self._range.count)!)
     }
 }
 

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -214,6 +214,7 @@ extension ByteBufferTest {
                 ("testCreateArrayFromBuffer", testCreateArrayFromBuffer),
                 ("testCreateStringFromBuffer", testCreateStringFromBuffer),
                 ("testCreateDispatchDataFromBuffer", testCreateDispatchDataFromBuffer),
+                ("testCreateBufferFromArray", testCreateBufferFromArray),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -218,6 +218,9 @@ extension ByteBufferTest {
                 ("testByteBufferViewEqualityWithRange", testByteBufferViewEqualityWithRange),
                 ("testInvalidBufferEqualityWithDifferentRange", testInvalidBufferEqualityWithDifferentRange),
                 ("testInvalidBufferEqualityWithDifferentContent", testInvalidBufferEqualityWithDifferentContent),
+                ("testHashableConformance", testHashableConformance),
+                ("testInvalidHash", testInvalidHash),
+                ("testValidHashFromSlice", testValidHashFromSlice),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferTest+XCTest.swift
@@ -215,6 +215,9 @@ extension ByteBufferTest {
                 ("testCreateStringFromBuffer", testCreateStringFromBuffer),
                 ("testCreateDispatchDataFromBuffer", testCreateDispatchDataFromBuffer),
                 ("testCreateBufferFromArray", testCreateBufferFromArray),
+                ("testByteBufferViewEqualityWithRange", testByteBufferViewEqualityWithRange),
+                ("testInvalidBufferEqualityWithDifferentRange", testInvalidBufferEqualityWithDifferentRange),
+                ("testInvalidBufferEqualityWithDifferentContent", testInvalidBufferEqualityWithDifferentContent),
            ]
    }
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -3062,4 +3062,35 @@ extension ByteBufferTest {
         
         XCTAssert(buffer.readableBytesView == [0x00, 0x01, 0x02])
     }
+
+    func testByteBufferViewEqualityWithRange() {
+        var buffer = self.allocator.buffer(capacity: 8)
+        buffer.writeString("AAAABBBB")
+        
+        let view = ByteBufferView(buffer: buffer, range: 2..<6) // 
+        let comparisonBuffer: ByteBufferView = [0x41, 0x41, 0x42, 0x42]
+
+        XCTAssert(view == comparisonBuffer)
+    }
+
+    func testInvalidBufferEqualityWithDifferentRange() {
+        var buffer = self.allocator.buffer(capacity: 4)
+        buffer.writeString("AAAA")
+        
+        let view = ByteBufferView(buffer: buffer, range: 0..<2)
+        let comparisonBuffer: ByteBufferView = [0x41, 0x41, 0x41, 0x41]
+
+        XCTAssertFalse(view == comparisonBuffer)
+    }
+
+    func testInvalidBufferEqualityWithDifferentContent() {
+        var buffer = self.allocator.buffer(capacity: 4)
+        buffer.writeString("AAAA")
+        
+        let view = ByteBufferView(buffer: buffer, range: 0..<4)
+        let comparisonBuffer: ByteBufferView = [0x41, 0x41, 0x00, 0x00]
+
+        XCTAssertFalse(view == comparisonBuffer)
+    }
+
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -3091,6 +3091,33 @@ extension ByteBufferTest {
         let comparisonBuffer: ByteBufferView = [0x41, 0x41, 0x00, 0x00]
 
         XCTAssertFalse(view == comparisonBuffer)
+
+// MARK: - Hashable
+extension ByteBufferTest {
+
+    func testHashableConformance() {
+        let bufferView: ByteBufferView = [0x00, 0x01, 0x02]
+        let comparisonBufferView: ByteBufferView = [0x00, 0x01, 0x02]
+
+        XCTAssert(bufferView.hashValue == comparisonBufferView.hashValue)
+    }
+
+
+    func testInvalidHash() {
+        let bufferView: ByteBufferView = [0x00, 0x00, 0x00]
+        let comparisonBufferView: ByteBufferView = [0x00, 0x01, 0x02]
+
+        XCTAssert(bufferView.hashValue != comparisonBufferView.hashValue)
+    }
+
+    func testValidHashFromSlice() {
+        var buffer = self.allocator.buffer(capacity: 4)
+        buffer.writeString("AAAA")
+
+        let bufferView = ByteBufferView(buffer: buffer, range: 0..<2)
+        let comparisonBufferView = ByteBufferView(buffer: buffer, range: 2..<4)
+
+        XCTAssert(bufferView.hashValue == comparisonBufferView.hashValue)
     }
 
 }

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -3052,3 +3052,14 @@ extension ByteBufferTest {
     }
     
 }
+
+// MARK: - ExpressibleByArrayLiteral init
+extension ByteBufferTest {
+    
+    func testCreateBufferFromArray() {
+        let bufferView: ByteBufferView = [0x00, 0x01, 0x02]
+        let buffer = ByteBuffer(ByteBufferView(bufferView))
+        
+        XCTAssert(buffer.readableBytesView == [0x00, 0x01, 0x02])
+    }
+}

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -3060,17 +3060,22 @@ extension ByteBufferTest {
         let bufferView: ByteBufferView = [0x00, 0x01, 0x02]
         let buffer = ByteBuffer(ByteBufferView(bufferView))
         
-        XCTAssert(buffer.readableBytesView == [0x00, 0x01, 0x02])
+        XCTAssertEqual(buffer.readableBytesView, [0x00, 0x01, 0x02])
     }
+
+}
+
+// MARK: - Equatable
+extension ByteBufferTest {
 
     func testByteBufferViewEqualityWithRange() {
         var buffer = self.allocator.buffer(capacity: 8)
         buffer.writeString("AAAABBBB")
         
-        let view = ByteBufferView(buffer: buffer, range: 2..<6) // 
+        let view = ByteBufferView(buffer: buffer, range: 2..<6)
         let comparisonBuffer: ByteBufferView = [0x41, 0x41, 0x42, 0x42]
 
-        XCTAssert(view == comparisonBuffer)
+        XCTAssertEqual(view, comparisonBuffer)
     }
 
     func testInvalidBufferEqualityWithDifferentRange() {
@@ -3080,7 +3085,7 @@ extension ByteBufferTest {
         let view = ByteBufferView(buffer: buffer, range: 0..<2)
         let comparisonBuffer: ByteBufferView = [0x41, 0x41, 0x41, 0x41]
 
-        XCTAssertFalse(view == comparisonBuffer)
+        XCTAssertNotEqual(view, comparisonBuffer)
     }
 
     func testInvalidBufferEqualityWithDifferentContent() {
@@ -3090,7 +3095,10 @@ extension ByteBufferTest {
         let view = ByteBufferView(buffer: buffer, range: 0..<4)
         let comparisonBuffer: ByteBufferView = [0x41, 0x41, 0x00, 0x00]
 
-        XCTAssertFalse(view == comparisonBuffer)
+        XCTAssertNotEqual(view, comparisonBuffer)
+    }
+
+}
 
 // MARK: - Hashable
 extension ByteBufferTest {
@@ -3099,7 +3107,7 @@ extension ByteBufferTest {
         let bufferView: ByteBufferView = [0x00, 0x01, 0x02]
         let comparisonBufferView: ByteBufferView = [0x00, 0x01, 0x02]
 
-        XCTAssert(bufferView.hashValue == comparisonBufferView.hashValue)
+        XCTAssertEqual(bufferView.hashValue, comparisonBufferView.hashValue)
     }
 
 
@@ -3107,7 +3115,7 @@ extension ByteBufferTest {
         let bufferView: ByteBufferView = [0x00, 0x00, 0x00]
         let comparisonBufferView: ByteBufferView = [0x00, 0x01, 0x02]
 
-        XCTAssert(bufferView.hashValue != comparisonBufferView.hashValue)
+        XCTAssertNotEqual(bufferView.hashValue, comparisonBufferView.hashValue)
     }
 
     func testValidHashFromSlice() {
@@ -3117,7 +3125,7 @@ extension ByteBufferTest {
         let bufferView = ByteBufferView(buffer: buffer, range: 0..<2)
         let comparisonBufferView = ByteBufferView(buffer: buffer, range: 2..<4)
 
-        XCTAssert(bufferView.hashValue == comparisonBufferView.hashValue)
+        XCTAssertEqual(bufferView.hashValue, comparisonBufferView.hashValue)
     }
 
 }


### PR DESCRIPTION
Hi!

This PR aims to close issue #1870 , adding `ExpressibleByArrayLiteral` and `Equatable` to `ByteBufferView`. 

This allows writing expressions such as:

```swift
(buffer.readableBytesView == [0x00, 0x01, 0x02])
```