### PR TITLE
add a missing `subscript(bounds:)` implementation

### DIFF
--- a/Sources/_NIO1APIShims/NIO1APIShims.swift
+++ b/Sources/_NIO1APIShims/NIO1APIShims.swift
@@ -67,6 +67,15 @@ extension StaticString: Collection {
         precondition(position < self.utf8CodeUnitCount, "index \(position) out of bounds")
         return self.utf8Start.advanced(by: position).pointee
     }
+
+    @available(*, deprecated, message: "don't use the StaticString: Collection extension please")
+    public subscript(bounds: Range<Int>) -> SubSequence {
+        precondition(startIndex <= bounds.lowerBound &&
+                     bounds.lowerBound <= bounds.upperBound &&
+                     bounds.upperBound <= endIndex,
+                     "indices out of bounds")
+        return withUTF8Buffer { return ArraySlice($0[bounds]) }
+    }
 }
 
 extension ChannelPipeline {


### PR DESCRIPTION
An older version of the standard library supplied a bogus implementation by error.  
Calling *that* would have been a crashing bug.

### Motivation:

Fix https://github.com/apple/swift-nio/issues/1892,  
which was triggered by https://github.com/apple/swift/pull/38161,  
which is a fix for https://bugs.swift.org/browse/SR-14848.

### Modifications:

Add the missing `subscript(bounds:)` implementation. It should always have been there.

### Result:

Package should build with the July 8 2021 snapshot of Swift.