### PR TITLE
Enable all EventLoops to track promise creation.

### DIFF
--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -102,20 +102,21 @@ internal final class SelectableEventLoop: EventLoop {
     /// Creates a new `SelectableEventLoop` instance that is tied to the given `pthread_t`.
 
     private let promiseCreationStoreLock = Lock()
-    private var _promiseCreationStore: [UInt: (file: StaticString, line: UInt)] = [:]
+    private var _promiseCreationStore: [_NIOEventLoopFutureIdentifier: (file: StaticString, line: UInt)] = [:]
 
     @usableFromInline
-    internal func promiseCreationStoreAdd<T>(future: EventLoopFuture<T>, file: StaticString, line: UInt) {
+    internal func _promiseCreated(futureIdentifier: _NIOEventLoopFutureIdentifier, file: StaticString, line: UInt) {
         precondition(_isDebugAssertConfiguration())
         self.promiseCreationStoreLock.withLock {
-            self._promiseCreationStore[self.obfuscatePointerValue(future)] = (file: file, line: line)
+            self._promiseCreationStore[futureIdentifier] = (file: file, line: line)
         }
     }
 
-    internal func promiseCreationStoreRemove<T>(future: EventLoopFuture<T>) -> (file: StaticString, line: UInt) {
+    @usableFromInline
+    internal func _promiseCompleted(futureIdentifier: _NIOEventLoopFutureIdentifier) -> (file: StaticString, line: UInt)? {
         precondition(_isDebugAssertConfiguration())
         return self.promiseCreationStoreLock.withLock {
-            self._promiseCreationStore.removeValue(forKey: self.obfuscatePointerValue(future))!
+            self._promiseCreationStore.removeValue(forKey: futureIdentifier)!
         }
     }
 
@@ -389,14 +390,6 @@ Further information:
         } else {
             return .blockUntilTimeout(nextReady)
         }
-    }
-    
-    private func obfuscatePointerValue<T>(_ future: EventLoopFuture<T>) -> UInt {
-        // Note:
-        // 1. 0xbf15ca5d is randomly picked such that it fits into both 32 and 64 bit address spaces
-        // 2. XOR with 0xbf15ca5d so that Memory Graph Debugger and other memory debugging tools
-        // won't see it as a reference.
-        return UInt(bitPattern: ObjectIdentifier(future)) ^ 0xbf15ca5d
     }
 
     /// Start processing I/O and tasks for this `SelectableEventLoop`. This method will continue running (and so block) until the `SelectableEventLoop` is closed.


### PR DESCRIPTION
Motivation:

EventLoopFuture is capable of tracking where it was allocated from in
debug mode, to enable high-fidelity tracking of leaked promises.
Currently this behaviour is limited to SelectableEventLoop, but there is
no good reason to tie it so specifically to that loop.

Modifications:

- Extend `EventLoop` to allow all event loops to track promise
  allocation and destruction.
- Add helpers to `EmbeddedEventLoop` to let it participate.
- Add new type to express a future ID.

Result:

Wider support for diagnostics.
