### PR TITLE
Avoid EventLoopFuture.wait knowing about specific implementations.

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -188,6 +188,12 @@ public final class EmbeddedEventLoop: EventLoop {
         }
     }
 
+    public func _preconditionSafeToWait(file: StaticString, line: UInt) {
+        // EmbeddedEventLoop always allows a wait, as waiting will essentially always block
+        // wait()
+        return
+    }
+
     deinit {
         precondition(scheduledTasks.isEmpty, "Embedded event loop freed with unexecuted scheduled tasks!")
     }

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -279,6 +279,9 @@ public protocol EventLoop: EventLoopGroup {
     /// This method is a debugging hook that can be used to override the behaviour of `EventLoopFuture.wait()` when called.
     /// By default this simply becomes `preconditionNotInEventLoop`, but some `EventLoop`s are capable of more exhaustive
     /// checking and can validate that the wait is not occuring on an entire `EventLoopGroup`, or even more broadly.
+    ///
+    /// This method should not be called by users directly, it should only be implemented by `EventLoop` implementers that
+    /// need to customise the behaviour.
     func _preconditionSafeToWait(file: StaticString, line: UInt)
 }
 

--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -273,12 +273,23 @@ public protocol EventLoop: EventLoopGroup {
     /// Contrary to `makeSucceededFuture`, `makeSucceededVoidFuture` is a customization point for `EventLoop`s which
     /// allows `EventLoop`s to cache a pre-succeded `Void` future to prevent superfluous allocations.
     func makeSucceededVoidFuture() -> EventLoopFuture<Void>
+
+    /// Must crash if it is not safe to call `wait()` on an `EventLoopFuture`.
+    ///
+    /// This method is a debugging hook that can be used to override the behaviour of `EventLoopFuture.wait()` when called.
+    /// By default this simply becomes `preconditionNotInEventLoop`, but some `EventLoop`s are capable of more exhaustive
+    /// checking and can validate that the wait is not occuring on an entire `EventLoopGroup`, or even more broadly.
+    func _preconditionSafeToWait(file: StaticString, line: UInt)
 }
 
 extension EventLoop {
     /// Default implementation of `makeSucceededVoidFuture`: Return a fresh future (which will allocate).
     public func makeSucceededVoidFuture() -> EventLoopFuture<Void> {
         return EventLoopFuture(eventLoop: self, value: (), file: "n/a", line: 0)
+    }
+
+    public func _preconditionSafeToWait(file: StaticString, line: UInt) {
+        self.preconditionNotInEventLoop(file: file, line: line)
     }
 }
 

--- a/Sources/NIO/EventLoopFuture.swift
+++ b/Sources/NIO/EventLoopFuture.swift
@@ -922,21 +922,7 @@ extension EventLoopFuture {
     /// - throws: The error value of the `EventLoopFuture` if it errors.
     @inlinable
     public func wait(file: StaticString = #file, line: UInt = #line) throws -> Value {
-        if !(self.eventLoop is EmbeddedEventLoop) {
-            let explainer: () -> String = { """
-BUG DETECTED: wait() must not be called when on an EventLoop.
-Calling wait() on any EventLoop can lead to
-- deadlocks
-- stalling processing of other connections (Channels) that are handled on the EventLoop that wait was called on
-
-Further information:
-- current eventLoop: \(MultiThreadedEventLoopGroup.currentEventLoop.debugDescription)
-- event loop associated to future: \(self.eventLoop)
-"""
-            }
-            precondition(!eventLoop.inEventLoop, explainer(), file: file, line: line)
-            precondition(MultiThreadedEventLoopGroup.currentEventLoop == nil, explainer(), file: file, line: line)
-        }
+        self.eventLoop._preconditionSafeToWait(file: file, line: line)
 
         var v: Result<Value, Error>? = nil
         let lock = ConditionLock(value: 0)


### PR DESCRIPTION
Motivation:

As we break apart NIO, it's a bit awkward that EventLoopFuture.wait
knows about two specific EventLoop implementations. It does this in
order to detect deadlocks, so we should try to preserve the capability
as best as possible.

Modifications:

- Add EventLoop._preconditionSafeToWait, which can reproduce much of the
  logic currently in EventLoopFuture.wait().
- Provide implementations for SelectableEventLoop and EmbeddedEventLoop.

Result:

Partial reproduction of the current behaviour of EventLoopFuture.wait().
Unfortunately this cannot completely reimplement this behaviour, as we
cannot safely call MultiThreadedEventLoopGroup.currentEventLoop for all
event loops. This is as close as we can safely get without breaking the
abstraction boundary, sadly.
