### PR TITLE
Avoid syncShutdownGracefully knowing about MTELG.

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -208,6 +208,11 @@ public final class EmbeddedEventLoop: EventLoop {
         return self._promiseCreationStore.removeValue(forKey: futureIdentifier)!
     }
 
+    public func _preconditionSafeToSyncShutdown(file: StaticString, line: UInt) {
+        // EmbeddedEventLoop always allows a sync shutdown.
+        return
+    }
+
     deinit {
         precondition(scheduledTasks.isEmpty, "Embedded event loop freed with unexecuted scheduled tasks!")
     }

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -1447,6 +1447,10 @@ fileprivate class EventLoopWithPreSucceededFuture: EventLoop {
             callback(nil)
         }
     }
+
+    func _preconditionSafeToSyncShutdown(file: StaticString, line: UInt) {
+        return
+    }
 }
 
 fileprivate class EventLoopWithoutPreSucceededFuture: EventLoop {
@@ -1484,5 +1488,9 @@ fileprivate class EventLoopWithoutPreSucceededFuture: EventLoop {
         queue.async {
             callback(nil)
         }
+    }
+
+    func _preconditionSafeToSyncShutdown(file: StaticString, line: UInt) {
+        return
     }
 }


### PR DESCRIPTION
Motivation:

As part of the ongoing split of NIO into two components, we need to
decouple EventLoopGroup from MultiThreadedEventLoopGroup. This is
largely straightforward, but EventLoopGroup.syncShutdownGracefully uses
a hook on MTELG to try to provide debugging help.

That hook cannot stand, so we must break it. Unfortunately this slightly
reduces our ability to detect possible blocks of a SelectableEventLoop,
but in return we get to increase our ability to detect blocks of other
event loop groups.

Modifications:

- Added a debugging hook to detect possible blocking of event loops.

Result:

Less coupling.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
