### PR TITLE
Better default for safe loop shutdown.

### DIFF
--- a/Sources/NIO/EventLoop.swift
+++ b/Sources/NIO/EventLoop.swift
@@ -821,9 +821,7 @@ public protocol EventLoopGroup: AnyObject {
     /// Must crash if it's not safe to call `syncShutdownGracefully` in the current context.
     ///
     /// This method is a debug hook that can be used to override the behaviour of `syncShutdownGracefully`
-    /// when called. By default it iterates the `EventLoopIterator` returned by `makeIterator` and calls
-    /// `preconditionNotInEventLoop`, but implementations may extend this with other logic if they can detect
-    /// more complex failure cases.
+    /// when called. By default it does nothing.
     func _preconditionSafeToSyncShutdown(file: StaticString, line: UInt)
 }
 
@@ -855,9 +853,7 @@ extension EventLoopGroup {
     }
 
     public func _preconditionSafeToSyncShutdown(file: StaticString, line: UInt) {
-        for loop in self.makeIterator() {
-            loop.preconditionNotInEventLoop(file: file, line: line)
-        }
+        return
     }
 }
 

--- a/Tests/NIOTests/EventLoopTest.swift
+++ b/Tests/NIOTests/EventLoopTest.swift
@@ -1447,10 +1447,6 @@ fileprivate class EventLoopWithPreSucceededFuture: EventLoop {
             callback(nil)
         }
     }
-
-    func _preconditionSafeToSyncShutdown(file: StaticString, line: UInt) {
-        return
-    }
 }
 
 fileprivate class EventLoopWithoutPreSucceededFuture: EventLoop {
@@ -1488,9 +1484,5 @@ fileprivate class EventLoopWithoutPreSucceededFuture: EventLoop {
         queue.async {
             callback(nil)
         }
-    }
-
-    func _preconditionSafeToSyncShutdown(file: StaticString, line: UInt) {
-        return
     }
 }


### PR DESCRIPTION
Motivation:

In #1904 we included a change to add a debugging hook to confirm a group
could safely be shut down. Sadly, the default behaviour was too
aggressive, and would cause failures in downstream projects.

Modifications:

- Change the default behaviour of _preconditionSafeToSyncShutdown to be
  a no-op, as it currently is in NIO programs today.

Result:

Downstream projects won't break.
