### PR TITLE
Move SocketAddress and NIOBSDSocket to NIOCore

### DIFF
--- a/IntegrationTests/tests_02_syscall_wrappers/defines.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/defines.sh
@@ -39,11 +39,13 @@ let package = Package(
 )
 EOF
     cp "$here/../../Tests/NIOTests/SystemCallWrapperHelpers.swift" \
-        "$here/../../Sources/NIO/BSDSocketAPI.swift" \
+        "$here/../../Sources/NIOCore/BSDSocketAPI.swift" \
+        "$here/../../Sources/NIO/BSDSocketAPICommon.swift" \
         "$here/../../Sources/NIO/BSDSocketAPIPosix.swift" \
         "$here/../../Sources/NIO/System.swift" \
-        "$here/../../Sources/NIO/IO.swift" \
+        "$here/../../Sources/NIOCore/IO.swift" \
         "$tmpdir/syscallwrapper/Sources/syscallwrapper"
+    cp "$here/../../Sources/NIO/IO.swift" "$tmpdir/syscallwrapper/Sources/syscallwrapper/NIOIO.swift"
     ln -s "$here/../../Sources/CNIOLinux" "$tmpdir/syscallwrapper/Sources"
     ln -s "$here/../../Sources/CNIODarwin" "$tmpdir/syscallwrapper/Sources"
 }

--- a/Sources/NIO/BSDSocketAPICommon.swift
+++ b/Sources/NIO/BSDSocketAPICommon.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2020-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -78,13 +78,7 @@ internal enum Shutdown: _SocketShutdownProtocol {
     case RDWR
 }
 
-public enum NIOBSDSocket {
-#if os(Windows)
-    public typealias Handle = SOCKET
-#else
-    public typealias Handle = CInt
-#endif
-
+extension NIOBSDSocket {
 #if os(Windows)
     internal static let invalidHandle: Handle = INVALID_SOCKET
 #else
@@ -109,112 +103,6 @@ extension NIOBSDSocket.SocketType: Equatable {
 extension NIOBSDSocket.SocketType: Hashable {
 }
 
-extension NIOBSDSocket {
-    /// Specifies the addressing scheme that the socket can use.
-    public struct AddressFamily: RawRepresentable {
-        public typealias RawValue = CInt
-        public var rawValue: RawValue
-        public init(rawValue: RawValue) {
-            self.rawValue = rawValue
-        }
-    }
-}
-
-extension NIOBSDSocket.AddressFamily: Equatable {
-}
-
-extension NIOBSDSocket.AddressFamily: Hashable {
-}
-
-extension NIOBSDSocket {
-    /// Specifies the type of protocol that the socket can use.
-    public struct ProtocolFamily: RawRepresentable {
-        public typealias RawValue = CInt
-        public var rawValue: RawValue
-        public init(rawValue: RawValue) {
-            self.rawValue = rawValue
-        }
-    }
-}
-
-extension NIOBSDSocket.ProtocolFamily: Equatable {
-}
-
-extension NIOBSDSocket.ProtocolFamily: Hashable {
-}
-
-extension NIOBSDSocket {
-    /// Defines socket option levels.
-    public struct OptionLevel: RawRepresentable {
-        public typealias RawValue = CInt
-        public var rawValue: RawValue
-        public init(rawValue: RawValue) {
-            self.rawValue = rawValue
-        }
-    }
-}
-
-extension NIOBSDSocket.OptionLevel: Equatable {
-}
-
-extension NIOBSDSocket.OptionLevel: Hashable {
-}
-
-extension NIOBSDSocket {
-    /// Defines configuration option names.
-    public struct Option: RawRepresentable {
-        public typealias RawValue = CInt
-        public var rawValue: RawValue
-        public init(rawValue: RawValue) {
-            self.rawValue = rawValue
-        }
-    }
-}
-
-extension NIOBSDSocket.Option: Equatable {
-}
-
-extension NIOBSDSocket.Option: Hashable {
-}
-
-// Address Family
-extension NIOBSDSocket.AddressFamily {
-    /// Address for IP version 4.
-    public static let inet: NIOBSDSocket.AddressFamily =
-            NIOBSDSocket.AddressFamily(rawValue: AF_INET)
-
-    /// Address for IP version 6.
-    public static let inet6: NIOBSDSocket.AddressFamily =
-            NIOBSDSocket.AddressFamily(rawValue: AF_INET6)
-
-    /// Unix local to host address.
-    public static let unix: NIOBSDSocket.AddressFamily =
-            NIOBSDSocket.AddressFamily(rawValue: AF_UNIX)
-}
-
-// Protocol Family
-extension NIOBSDSocket.ProtocolFamily {
-    /// IP network 4 protocol.
-    public static let inet: NIOBSDSocket.ProtocolFamily =
-            NIOBSDSocket.ProtocolFamily(rawValue: PF_INET)
-
-    /// IP network 6 protocol.
-    public static let inet6: NIOBSDSocket.ProtocolFamily =
-            NIOBSDSocket.ProtocolFamily(rawValue: PF_INET6)
-
-    /// UNIX local to the host.
-    public static let unix: NIOBSDSocket.ProtocolFamily =
-            NIOBSDSocket.ProtocolFamily(rawValue: PF_UNIX)
-}
-
-#if !os(Windows)
-    extension NIOBSDSocket.ProtocolFamily {
-        /// UNIX local to the host, alias for `PF_UNIX` (`.unix`)
-        public static let local: NIOBSDSocket.ProtocolFamily =
-                NIOBSDSocket.ProtocolFamily(rawValue: PF_LOCAL)
-    }
-#endif
-
 // Socket Types
 extension NIOBSDSocket.SocketType {
     /// Supports datagrams, which are connectionless, unreliable messages of a
@@ -238,68 +126,8 @@ extension NIOBSDSocket.SocketType {
     #endif
 }
 
-// Option Level
-extension NIOBSDSocket.OptionLevel {
-    /// Socket options that apply only to IP sockets.
-    #if os(Linux) || os(Android)
-        public static let ip: NIOBSDSocket.OptionLevel =
-                NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_IP))
-    #else
-        public static let ip: NIOBSDSocket.OptionLevel =
-                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_IP)
-    #endif
-
-    /// Socket options that apply only to IPv6 sockets.
-    #if os(Linux) || os(Android)
-        public static let ipv6: NIOBSDSocket.OptionLevel =
-                NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_IPV6))
-    #elseif os(Windows)
-        public static let ipv6: NIOBSDSocket.OptionLevel =
-                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_IPV6.rawValue)
-    #else
-        public static let ipv6: NIOBSDSocket.OptionLevel =
-                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_IPV6)
-    #endif
-
-    /// Socket options that apply only to TCP sockets.
-    #if os(Linux) || os(Android)
-        public static let tcp: NIOBSDSocket.OptionLevel =
-                NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_TCP))
-    #elseif os(Windows)
-        public static let tcp: NIOBSDSocket.OptionLevel =
-                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_TCP.rawValue)
-    #else
-        public static let tcp: NIOBSDSocket.OptionLevel =
-                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_TCP)
-    #endif
-
-    /// Socket options that apply to all sockets.
-    public static let socket: NIOBSDSocket.OptionLevel =
-            NIOBSDSocket.OptionLevel(rawValue: SOL_SOCKET)
-}
-
 // IPv4 Options
 extension NIOBSDSocket.Option {
-    /// Add a multicast group membership.
-    public static let ip_add_membership: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IP_ADD_MEMBERSHIP)
-
-    /// Drop a multicast group membership.
-    public static let ip_drop_membership: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IP_DROP_MEMBERSHIP)
-
-    /// Set the interface for outgoing multicast packets.
-    public static let ip_multicast_if: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IP_MULTICAST_IF)
-
-    /// Control multicast loopback.
-    public static let ip_multicast_loop: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IP_MULTICAST_LOOP)
-
-    /// Control multicast time-to-live.
-    public static let ip_multicast_ttl: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IP_MULTICAST_TTL)
-
     /// Request that we are passed type of service details when receiving
     /// datagrams.
     ///
@@ -321,31 +149,6 @@ extension NIOBSDSocket.Option {
 
 // IPv6 Options
 extension NIOBSDSocket.Option {
-    /// Add an IPv6 group membership.
-    public static let ipv6_join_group: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IPV6_JOIN_GROUP)
-
-    /// Drop an IPv6 group membership.
-    public static let ipv6_leave_group: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IPV6_LEAVE_GROUP)
-
-    /// Specify the maximum number of router hops for an IPv6 packet.
-    public static let ipv6_multicast_hops: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IPV6_MULTICAST_HOPS)
-
-    /// Set the interface for outgoing multicast packets.
-    public static let ipv6_multicast_if: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IPV6_MULTICAST_IF)
-
-    /// Control multicast loopback.
-    public static let ipv6_multicast_loop: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IPV6_MULTICAST_LOOP)
-
-    /// Indicates if a socket created for the `AF_INET6` address family is
-    /// restricted to IPv6 only.
-    public static let ipv6_v6only: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: IPV6_V6ONLY)
-
     /// Request that we are passed traffic class details when receiving
     /// datagrams.
     ///
@@ -364,67 +167,6 @@ extension NIOBSDSocket.Option {
     static let ipv6_recv_pktinfo: NIOBSDSocket.Option =
         NIOBSDSocket.Option(rawValue: Posix.IPV6_RECVPKTINFO)
 }
-
-// TCP Options
-extension NIOBSDSocket.Option {
-    /// Disables the Nagle algorithm for send coalescing.
-    public static let tcp_nodelay: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: TCP_NODELAY)
-}
-
-#if os(Linux) || os(FreeBSD) || os(Android)
-extension NIOBSDSocket.Option {
-    /// Get information about the TCP connection.
-    public static let tcp_info: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: TCP_INFO)
-}
-#endif
-
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-extension NIOBSDSocket.Option {
-    /// Get information about the TCP connection.
-    public static let tcp_connection_info: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: TCP_CONNECTION_INFO)
-}
-#endif
-
-// Socket Options
-extension NIOBSDSocket.Option {
-    /// Get the error status and clear.
-    public static let so_error: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: SO_ERROR)
-
-    /// Use keep-alives.
-    public static let so_keepalive: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: SO_KEEPALIVE)
-
-    /// Linger on close if unsent data is present.
-    public static let so_linger: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: SO_LINGER)
-
-    /// Specifies the total per-socket buffer space reserved for receives.
-    public static let so_rcvbuf: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: SO_RCVBUF)
-
-    /// Specifies the receive timeout.
-    public static let so_rcvtimeo: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: SO_RCVTIMEO)
-
-    /// Allows the socket to be bound to an address that is already in use.
-    public static let so_reuseaddr: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: SO_REUSEADDR)
-}
-
-#if !os(Windows)
-extension NIOBSDSocket.Option {
-    /// Indicate when to generate timestamps.
-    public static let so_timestamp: NIOBSDSocket.Option =
-            NIOBSDSocket.Option(rawValue: SO_TIMESTAMP)
-}
-#endif
-
-/// The requested UDS path exists and has wrong type (not a socket).
-public struct UnixDomainSocketPathWrongType: Error {}
 
 /// This protocol defines the methods that are expected to be found on
 /// `NIOBSDSocket`. While defined as a protocol there is no expectation that any
@@ -533,15 +275,6 @@ protocol _BSDSocketProtocol {
                      timeout: CInt) throws -> CInt
 #endif
 
-    static func inet_ntop(af family: NIOBSDSocket.AddressFamily,
-                          src addr: UnsafeRawPointer,
-                          dst dstBuf: UnsafeMutablePointer<CChar>,
-                          size dstSize: socklen_t) throws -> UnsafePointer<CChar>?
-
-    static func inet_pton(af family: NIOBSDSocket.AddressFamily,
-                          src description: UnsafePointer<CChar>,
-                          dst address: UnsafeMutableRawPointer) throws
-
     static func sendfile(socket s: NIOBSDSocket.Handle,
                          fd: CInt,
                          offset: off_t,
@@ -585,3 +318,6 @@ protocol _BSDSocketControlMessageProtocol {
 /// If this extension is hitting a compile error, your platform is missing one
 /// of the functions defined above!
 enum NIOBSDSocketControlMessage: _BSDSocketControlMessageProtocol { }
+
+/// The requested UDS path exists and has wrong type (not a socket).
+public struct UnixDomainSocketPathWrongType: Error {}

--- a/Sources/NIO/BSDSocketAPIPosix.swift
+++ b/Sources/NIO/BSDSocketAPIPosix.swift
@@ -175,25 +175,6 @@ extension NIOBSDSocket {
         return try Posix.poll(fds: fds, nfds: nfds, timeout: timeout)
     }
 
-    @discardableResult
-    static func inet_ntop(af family: NIOBSDSocket.AddressFamily,
-                          src addr: UnsafeRawPointer,
-                          dst dstBuf: UnsafeMutablePointer<CChar>,
-                          size dstSize: socklen_t) throws -> UnsafePointer<CChar>? {
-        return try Posix.inet_ntop(addressFamily: sa_family_t(family.rawValue),
-                                   addressBytes: addr,
-                                   addressDescription: dstBuf,
-                                   addressDescriptionLength: dstSize)
-    }
-
-    static func inet_pton(af family: NIOBSDSocket.AddressFamily,
-                          src description: UnsafePointer<CChar>,
-                          dst address: UnsafeMutableRawPointer) throws {
-        return try Posix.inet_pton(addressFamily: sa_family_t(family.rawValue),
-                                   addressDescription: description,
-                                   address: address)
-    }
-
     static func sendfile(socket s: NIOBSDSocket.Handle,
                          fd: CInt,
                          offset: off_t,

--- a/Sources/NIO/BSDSocketAPIWindows.swift
+++ b/Sources/NIO/BSDSocketAPIWindows.swift
@@ -77,8 +77,6 @@ import func WinSDK.closesocket
 import func WinSDK.connect
 import func WinSDK.getpeername
 import func WinSDK.getsockname
-import func WinSDK.inet_ntop
-import func WinSDK.inet_pton
 import func WinSDK.ioctlsocket
 import func WinSDK.listen
 import func WinSDK.shutdown
@@ -408,32 +406,6 @@ extension NIOBSDSocket {
             throw IOError(windows: GetLastError(), reason: "WriteFile")
         }
         return .processed(size_t(nNumberOfBytesWritten))
-    }
-
-    @discardableResult
-    @inline(never)
-    static func inet_ntop(af family: NIOBSDSocket.AddressFamily,
-                          src addr: UnsafeRawPointer,
-                          dst dstBuf: UnsafeMutablePointer<CChar>,
-                          size dstSize: socklen_t) throws -> UnsafePointer<CChar>? {
-        // TODO(compnerd) use `InetNtopW` to ensure that we handle unicode properly
-        guard let result = WinSDK.inet_ntop(family.rawValue, addr, dstBuf,
-                                            Int(dstSize)) else {
-            throw IOError(windows: GetLastError(), reason: "inet_ntop")
-        }
-        return result
-    }
-
-    @inline(never)
-    static func inet_pton(af family: NIOBSDSocket.AddressFamily,
-                          src description: UnsafePointer<CChar>,
-                          dst address: UnsafeMutableRawPointer) throws {
-        // TODO(compnerd) use `InetPtonW` to ensure that we handle unicode properly
-         switch WinSDK.inet_pton(family.rawValue, description, address) {
-         case 0: throw IOError(errnoCode: EINVAL, reason: "inet_pton")
-         case 1: return
-         default: throw IOError(winsock: WSAGetLastError(), reason: "inet_pton")
-         }
     }
 
     @inline(never)

--- a/Sources/NIO/Interfaces.swift
+++ b/Sources/NIO/Interfaces.swift
@@ -254,7 +254,7 @@ extension NIONetworkDevice {
                                                 dst: $0.baseAddress!,
                                                 size: INET_ADDRSTRLEN)
                 }
-                return SocketAddress(mask, host: mask.addressDescription())
+                return SocketAddress(mask)
             }
             let v6mask: (UINT8) -> SocketAddress? = { _ in
                 var buffer: [CChar] =
@@ -266,7 +266,7 @@ extension NIONetworkDevice {
                                                 dst: $0.baseAddress!,
                                                 size: INET6_ADDRSTRLEN)
                 }
-                return SocketAddress(mask, host: mask.addressDescription())
+                return SocketAddress(mask)
             }
 
             switch pAddress.pointee.Address.lpSockaddr.pointee.sa_family {
@@ -430,7 +430,7 @@ public final class NIONetworkInterface {
                                             dst: $0.baseAddress!,
                                             size: INET_ADDRSTRLEN)
             }
-            return SocketAddress(mask, host: mask.addressDescription())
+            return SocketAddress(mask)
         }
         let v6mask: (UINT8) -> SocketAddress? = { _ in
             var buffer: [CChar] =
@@ -442,7 +442,7 @@ public final class NIONetworkInterface {
                                             dst: $0.baseAddress!,
                                             size: INET6_ADDRSTRLEN)
             }
-            return SocketAddress(mask, host: mask.addressDescription())
+            return SocketAddress(mask)
         }
 
         switch pAddress.pointee.Address.lpSockaddr.pointee.sa_family {

--- a/Sources/NIO/System.swift
+++ b/Sources/NIO/System.swift
@@ -112,8 +112,6 @@ private let sysGetifaddrs: @convention(c) (UnsafeMutablePointer<UnsafeMutablePoi
 private let sysFreeifaddrs: @convention(c) (UnsafeMutablePointer<ifaddrs>?) -> Void = freeifaddrs
 private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsignedInt = if_nametoindex
 #if !os(Windows)
-private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
-private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> CInt = inet_pton
 private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>?) -> CInt = socketpair
 #endif
 
@@ -438,23 +436,6 @@ internal enum Posix {
     }
 
 #if !os(Windows)
-    @discardableResult
-    @inline(never)
-    internal static func inet_ntop(addressFamily: sa_family_t, addressBytes: UnsafeRawPointer, addressDescription: UnsafeMutablePointer<CChar>, addressDescriptionLength: socklen_t) throws -> UnsafePointer<CChar> {
-        return try wrapErrorIsNullReturnCall {
-            sysInet_ntop(CInt(addressFamily), addressBytes, addressDescription, addressDescriptionLength)
-        }
-    }
-
-    @inline(never)
-    internal static func inet_pton(addressFamily: sa_family_t, addressDescription: UnsafePointer<CChar>, address: UnsafeMutableRawPointer) throws {
-        switch sysInet_pton(CInt(addressFamily), addressDescription, address) {
-        case 0: throw IOError(errnoCode: EINVAL, reason: #function)
-        case 1: return
-        default: throw IOError(errnoCode: errno, reason: #function)
-        }
-    }
-
     // It's not really posix but exists on Linux and MacOS / BSD so just put it here for now to keep it simple
     @inline(never)
     internal static func sendfile(descriptor: CInt, fd: CInt, offset: off_t, count: size_t) throws -> IOResult<Int> {

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -1,0 +1,370 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020-2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+import ucrt
+
+import let WinSDK.IPPROTO_IP
+import let WinSDK.IPPROTO_IPV6
+import let WinSDK.IPPROTO_TCP
+
+import let WinSDK.IP_ADD_MEMBERSHIP
+import let WinSDK.IP_DROP_MEMBERSHIP
+import let WinSDK.IP_MULTICAST_IF
+import let WinSDK.IP_MULTICAST_LOOP
+import let WinSDK.IP_MULTICAST_TTL
+import let WinSDK.IPV6_JOIN_GROUP
+import let WinSDK.IPV6_LEAVE_GROUP
+import let WinSDK.IPV6_MULTICAST_HOPS
+import let WinSDK.IPV6_MULTICAST_IF
+import let WinSDK.IPV6_MULTICAST_LOOP
+import let WinSDK.IPV6_V6ONLY
+
+import let WinSDK.AF_INET
+import let WinSDK.AF_INET6
+import let WinSDK.AF_UNIX
+
+import let WinSDK.PF_INET
+import let WinSDK.PF_INET6
+import let WinSDK.PF_UNIX
+
+import let WinSDK.SO_ERROR
+import let WinSDK.SO_KEEPALIVE
+import let WinSDK.SO_LINGER
+import let WinSDK.SO_RCVBUF
+import let WinSDK.SO_RCVTIMEO
+import let WinSDK.SO_REUSEADDR
+
+import let WinSDK.SOL_SOCKET
+
+import let WinSDK.TCP_NODELAY
+
+import struct WinSDK.SOCKET
+
+import func WinSDK.inet_ntop
+import func WinSDK.inet_pton
+#elseif os(Linux) || os(Android)
+import Glibc
+
+private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
+private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> CInt = inet_pton
+#elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+
+private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
+private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> CInt = inet_pton
+#endif
+
+public enum NIOBSDSocket {
+#if os(Windows)
+    public typealias Handle = SOCKET
+#else
+    public typealias Handle = CInt
+#endif
+}
+
+extension NIOBSDSocket {
+    /// Specifies the addressing scheme that the socket can use.
+    public struct AddressFamily: RawRepresentable {
+        public typealias RawValue = CInt
+        public var rawValue: RawValue
+        public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+        }
+    }
+}
+
+extension NIOBSDSocket.AddressFamily: Equatable {
+}
+
+extension NIOBSDSocket.AddressFamily: Hashable {
+}
+
+extension NIOBSDSocket {
+    /// Specifies the type of protocol that the socket can use.
+    public struct ProtocolFamily: RawRepresentable {
+        public typealias RawValue = CInt
+        public var rawValue: RawValue
+        public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+        }
+    }
+}
+
+extension NIOBSDSocket.ProtocolFamily: Equatable {
+}
+
+extension NIOBSDSocket.ProtocolFamily: Hashable {
+}
+
+extension NIOBSDSocket {
+    /// Defines socket option levels.
+    public struct OptionLevel: RawRepresentable {
+        public typealias RawValue = CInt
+        public var rawValue: RawValue
+        public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+        }
+    }
+}
+
+extension NIOBSDSocket.OptionLevel: Equatable {
+}
+
+extension NIOBSDSocket.OptionLevel: Hashable {
+}
+
+extension NIOBSDSocket {
+    /// Defines configuration option names.
+    public struct Option: RawRepresentable {
+        public typealias RawValue = CInt
+        public var rawValue: RawValue
+        public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+        }
+    }
+}
+
+extension NIOBSDSocket.Option: Equatable {
+}
+
+extension NIOBSDSocket.Option: Hashable {
+}
+
+// Address Family
+extension NIOBSDSocket.AddressFamily {
+    /// Address for IP version 4.
+    public static let inet: NIOBSDSocket.AddressFamily =
+            NIOBSDSocket.AddressFamily(rawValue: AF_INET)
+
+    /// Address for IP version 6.
+    public static let inet6: NIOBSDSocket.AddressFamily =
+            NIOBSDSocket.AddressFamily(rawValue: AF_INET6)
+
+    /// Unix local to host address.
+    public static let unix: NIOBSDSocket.AddressFamily =
+            NIOBSDSocket.AddressFamily(rawValue: AF_UNIX)
+}
+
+// Protocol Family
+extension NIOBSDSocket.ProtocolFamily {
+    /// IP network 4 protocol.
+    public static let inet: NIOBSDSocket.ProtocolFamily =
+            NIOBSDSocket.ProtocolFamily(rawValue: PF_INET)
+
+    /// IP network 6 protocol.
+    public static let inet6: NIOBSDSocket.ProtocolFamily =
+            NIOBSDSocket.ProtocolFamily(rawValue: PF_INET6)
+
+    /// UNIX local to the host.
+    public static let unix: NIOBSDSocket.ProtocolFamily =
+            NIOBSDSocket.ProtocolFamily(rawValue: PF_UNIX)
+}
+
+#if !os(Windows)
+    extension NIOBSDSocket.ProtocolFamily {
+        /// UNIX local to the host, alias for `PF_UNIX` (`.unix`)
+        public static let local: NIOBSDSocket.ProtocolFamily =
+                NIOBSDSocket.ProtocolFamily(rawValue: PF_LOCAL)
+    }
+#endif
+
+
+// Option Level
+extension NIOBSDSocket.OptionLevel {
+    /// Socket options that apply only to IP sockets.
+    #if os(Linux) || os(Android)
+        public static let ip: NIOBSDSocket.OptionLevel =
+                NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_IP))
+    #else
+        public static let ip: NIOBSDSocket.OptionLevel =
+                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_IP)
+    #endif
+
+    /// Socket options that apply only to IPv6 sockets.
+    #if os(Linux) || os(Android)
+        public static let ipv6: NIOBSDSocket.OptionLevel =
+                NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_IPV6))
+    #elseif os(Windows)
+        public static let ipv6: NIOBSDSocket.OptionLevel =
+                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_IPV6.rawValue)
+    #else
+        public static let ipv6: NIOBSDSocket.OptionLevel =
+                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_IPV6)
+    #endif
+
+    /// Socket options that apply only to TCP sockets.
+    #if os(Linux) || os(Android)
+        public static let tcp: NIOBSDSocket.OptionLevel =
+                NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_TCP))
+    #elseif os(Windows)
+        public static let tcp: NIOBSDSocket.OptionLevel =
+                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_TCP.rawValue)
+    #else
+        public static let tcp: NIOBSDSocket.OptionLevel =
+                NIOBSDSocket.OptionLevel(rawValue: IPPROTO_TCP)
+    #endif
+
+    /// Socket options that apply to all sockets.
+    public static let socket: NIOBSDSocket.OptionLevel =
+            NIOBSDSocket.OptionLevel(rawValue: SOL_SOCKET)
+}
+
+// IPv4 Options
+extension NIOBSDSocket.Option {
+    /// Add a multicast group membership.
+    public static let ip_add_membership: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IP_ADD_MEMBERSHIP)
+
+    /// Drop a multicast group membership.
+    public static let ip_drop_membership: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IP_DROP_MEMBERSHIP)
+
+    /// Set the interface for outgoing multicast packets.
+    public static let ip_multicast_if: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IP_MULTICAST_IF)
+
+    /// Control multicast loopback.
+    public static let ip_multicast_loop: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IP_MULTICAST_LOOP)
+
+    /// Control multicast time-to-live.
+    public static let ip_multicast_ttl: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IP_MULTICAST_TTL)
+}
+
+// IPv6 Options
+extension NIOBSDSocket.Option {
+    /// Add an IPv6 group membership.
+    public static let ipv6_join_group: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IPV6_JOIN_GROUP)
+
+    /// Drop an IPv6 group membership.
+    public static let ipv6_leave_group: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IPV6_LEAVE_GROUP)
+
+    /// Specify the maximum number of router hops for an IPv6 packet.
+    public static let ipv6_multicast_hops: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IPV6_MULTICAST_HOPS)
+
+    /// Set the interface for outgoing multicast packets.
+    public static let ipv6_multicast_if: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IPV6_MULTICAST_IF)
+
+    /// Control multicast loopback.
+    public static let ipv6_multicast_loop: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IPV6_MULTICAST_LOOP)
+
+    /// Indicates if a socket created for the `AF_INET6` address family is
+    /// restricted to IPv6 only.
+    public static let ipv6_v6only: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: IPV6_V6ONLY)
+}
+
+// TCP Options
+extension NIOBSDSocket.Option {
+    /// Disables the Nagle algorithm for send coalescing.
+    public static let tcp_nodelay: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: TCP_NODELAY)
+}
+
+#if os(Linux) || os(FreeBSD) || os(Android)
+extension NIOBSDSocket.Option {
+    /// Get information about the TCP connection.
+    public static let tcp_info: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: TCP_INFO)
+}
+#endif
+
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+extension NIOBSDSocket.Option {
+    /// Get information about the TCP connection.
+    public static let tcp_connection_info: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: TCP_CONNECTION_INFO)
+}
+#endif
+
+// Socket Options
+extension NIOBSDSocket.Option {
+    /// Get the error status and clear.
+    public static let so_error: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: SO_ERROR)
+
+    /// Use keep-alives.
+    public static let so_keepalive: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: SO_KEEPALIVE)
+
+    /// Linger on close if unsent data is present.
+    public static let so_linger: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: SO_LINGER)
+
+    /// Specifies the total per-socket buffer space reserved for receives.
+    public static let so_rcvbuf: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: SO_RCVBUF)
+
+    /// Specifies the receive timeout.
+    public static let so_rcvtimeo: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: SO_RCVTIMEO)
+
+    /// Allows the socket to be bound to an address that is already in use.
+    public static let so_reuseaddr: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: SO_REUSEADDR)
+}
+
+#if !os(Windows)
+extension NIOBSDSocket.Option {
+    /// Indicate when to generate timestamps.
+    public static let so_timestamp: NIOBSDSocket.Option =
+            NIOBSDSocket.Option(rawValue: SO_TIMESTAMP)
+}
+#endif
+
+extension NIOBSDSocket {
+    // Sadly this was defined on BSDSocket, and we need it for SocketAddress.
+    @inline(never)
+    internal static func inet_pton(addressFamily: NIOBSDSocket.AddressFamily, addressDescription: UnsafePointer<CChar>, address: UnsafeMutableRawPointer) throws {
+        #if os(Windows)
+        // TODO(compnerd) use `InetPtonW` to ensure that we handle unicode properly
+        switch WinSDK.inet_pton(family.rawValue, addressDescription, address) {
+        case 0: throw IOError(errnoCode: EINVAL, reason: "inet_pton")
+        case 1: return
+        default: throw IOError(winsock: WSAGetLastError(), reason: "inet_pton")
+        }
+        #else
+        switch sysInet_pton(CInt(addressFamily.rawValue), addressDescription, address) {
+        case 0: throw IOError(errnoCode: EINVAL, reason: #function)
+        case 1: return
+        default: throw IOError(errnoCode: errno, reason: #function)
+        }
+        #endif
+    }
+
+    @discardableResult
+    @inline(never)
+    internal static func inet_ntop(addressFamily: NIOBSDSocket.AddressFamily, addressBytes: UnsafeRawPointer, addressDescription: UnsafeMutablePointer<CChar>, addressDescriptionLength: socklen_t) throws -> UnsafePointer<CChar> {
+        #if os(Windows)
+        // TODO(compnerd) use `InetNtopW` to ensure that we handle unicode properly
+        guard let result = WinSDK.inet_ntop(family.rawValue, addressBytes, addressDescription,
+                                            Int(addressDescriptionLength)) else {
+            throw IOError(windows: GetLastError(), reason: "inet_ntop")
+        }
+        return result
+        #else
+        switch sysInet_ntop(CInt(addressFamily.rawValue), addressBytes, addressDescription, addressDescriptionLength) {
+        case .none: throw IOError(errnoCode: errno, reason: #function)
+        case .some(let ptr): return ptr
+        }
+        #endif
+    }
+}

--- a/Sources/NIOCore/IO.swift
+++ b/Sources/NIOCore/IO.swift
@@ -1,0 +1,117 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+import typealias WinSDK.DWORD
+#elseif os(Linux) || os(Android)
+import Glibc
+#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+import Darwin
+#endif
+
+/// An `Error` for an IO operation.
+public struct IOError: Swift.Error {
+    @available(*, deprecated, message: "NIO no longer uses FailureDescription.")
+    public enum FailureDescription {
+        case function(StaticString)
+        case reason(String)
+    }
+
+    /// The actual reason (in an human-readable form) for this `IOError`.
+    private var failureDescription: String
+
+    @available(*, deprecated, message: "NIO no longer uses FailureDescription, use IOError.description for a human-readable error description")
+    public var reason: FailureDescription {
+        return .reason(self.failureDescription)
+    }
+
+    private enum Error {
+        #if os(Windows)
+            case windows(DWORD)
+            case winsock(CInt)
+        #endif
+        case errno(CInt)
+    }
+
+    private let error: Error
+
+    /// The `errno` that was set for the operation.
+    public var errnoCode: CInt {
+        switch self.error {
+        case .errno(let code):
+            return code
+        #if os(Windows)
+            default:
+                fatalError("IOError domain is not `errno`")
+        #endif
+        }
+    }
+
+#if os(Windows)
+    public init(windows code: DWORD, reason: String) {
+        self.error = .windows(code)
+        self.failureDescription = reason
+    }
+
+    public init(winsock code: CInt, reason: String) {
+        self.error = .winsock(code)
+        self.failureDescription = reason
+    }
+#endif
+
+    /// Creates a new `IOError``
+    ///
+    /// - parameters:
+    ///     - errorCode: the `errno` that was set for the operation.
+    ///     - reason: the actual reason (in an human-readable form).
+    public init(errnoCode code: CInt, reason: String) {
+        self.error = .errno(code)
+        self.failureDescription = reason
+    }
+
+    /// Creates a new `IOError``
+    ///
+    /// - parameters:
+    ///     - errorCode: the `errno` that was set for the operation.
+    ///     - function: The function the error happened in, the human readable description will be generated automatically when needed.
+    @available(*, deprecated, renamed: "init(errnoCode:reason:)")
+    public init(errnoCode code: CInt, function: StaticString) {
+        self.error = .errno(code)
+        self.failureDescription = "\(function)"
+    }
+}
+
+/// Returns a reason to use when constructing a `IOError`.
+///
+/// - parameters:
+///     - errorCode: the `errno` that was set for the operation.
+///     - reason: what failed
+/// - returns: the constructed reason.
+private func reasonForError(errnoCode: CInt, reason: String) -> String {
+    if let errorDescC = strerror(errnoCode) {
+        return "\(reason): \(String(cString: errorDescC)) (errno: \(errnoCode))"
+    } else {
+        return "\(reason): Broken strerror, unknown error: \(errnoCode)"
+    }
+}
+
+extension IOError: CustomStringConvertible {
+    public var description: String {
+        return self.localizedDescription
+    }
+
+    public var localizedDescription: String {
+        return reasonForError(errnoCode: self.errnoCode, reason: self.failureDescription)
+    }
+}

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -22,3 +22,11 @@ internal func debugOnly(_ body: () -> Void) {
     // FIXME: duplicated with NIO.
     assert({ body(); return true }())
 }
+
+/// Allows to "box" another value.
+final class Box<T> {
+    // FIXME: Duplicated with NIO.
+    let value: T
+    init(_ value: T) { self.value = value }
+}
+

--- a/Tests/NIOTests/HappyEyeballsTest.swift
+++ b/Tests/NIOTests/HappyEyeballsTest.swift
@@ -18,6 +18,7 @@
     import Glibc
 #endif
 import XCTest
+@testable import NIOCore
 @testable import NIO
 
 private let CONNECT_RECORDER = "connectRecorder"
@@ -128,7 +129,7 @@ private extension SocketAddress {
     init(host: String, ipAddress: String, port: Int) {
         do {
             var v4addr = in_addr()
-            try NIOBSDSocket.inet_pton(af: .inet, src: ipAddress, dst: &v4addr)
+            try NIOBSDSocket.inet_pton(addressFamily: .inet, addressDescription: ipAddress, address: &v4addr)
 
             var sockaddr = sockaddr_in()
             sockaddr.sin_family = sa_family_t(NIOBSDSocket.AddressFamily.inet.rawValue)
@@ -138,7 +139,7 @@ private extension SocketAddress {
         } catch {
             do {
                 var v6addr = in6_addr()
-                try NIOBSDSocket.inet_pton(af: .inet6, src: ipAddress, dst: &v6addr)
+                try NIOBSDSocket.inet_pton(addressFamily: .inet6, addressDescription: ipAddress, address: &v6addr)
 
                 var sockaddr = sockaddr_in6()
                 sockaddr.sin6_family = sa_family_t(NIOBSDSocket.AddressFamily.inet6.rawValue)
@@ -158,10 +159,10 @@ private extension SocketAddress {
         switch self {
         case .v4(let address):
             var baseAddress = address.address
-            precondition(try! NIOBSDSocket.inet_ntop(af: .inet, src: &baseAddress.sin_addr, dst: ptr, size: 256) != nil)
+            try! NIOBSDSocket.inet_ntop(addressFamily: .inet, addressBytes: &baseAddress.sin_addr, addressDescription: ptr, addressDescriptionLength: 256)
         case .v6(let address):
             var baseAddress = address.address
-            precondition(try! NIOBSDSocket.inet_ntop(af: .inet6, src: &baseAddress.sin6_addr, dst: ptr, size: 256) != nil)
+            try! NIOBSDSocket.inet_ntop(addressFamily: .inet6, addressBytes: &baseAddress.sin6_addr, addressDescription: ptr, addressDescriptionLength: 256)
         case .unixDomainSocket:
             fatalError("No UDS support in happy eyeballs.")
         }

--- a/Tests/NIOTests/SocketAddressTest+XCTest.swift
+++ b/Tests/NIOTests/SocketAddressTest+XCTest.swift
@@ -38,8 +38,6 @@ extension SocketAddressTest {
                 ("testCanCreateIPv4AddressFromString", testCanCreateIPv4AddressFromString),
                 ("testCanCreateIPv6AddressFromString", testCanCreateIPv6AddressFromString),
                 ("testRejectsNonIPStrings", testRejectsNonIPStrings),
-                ("testWithMutableAddressCopiesFaithfully", testWithMutableAddressCopiesFaithfully),
-                ("testWithMutableAddressAllowsMutationWithoutPersistence", testWithMutableAddressAllowsMutationWithoutPersistence),
                 ("testConvertingStorage", testConvertingStorage),
                 ("testComparingSockaddrs", testComparingSockaddrs),
                 ("testEqualSocketAddresses", testEqualSocketAddresses),

--- a/Tests/NIOTests/TestUtils.swift
+++ b/Tests/NIOTests/TestUtils.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+@testable import NIOCore
 @testable import NIO
 import NIOConcurrencyHelpers
 


### PR DESCRIPTION
Motivation:

This is the next stage of our move of common interchange objects to
NIOCore and out of the NIO module. This time around we need
SocketAddress, which is part of the Channel API. Sadly, SocketAddress is
not as clean as some of the other ports, because it leaks a number of
POSIX-y concepts. This also forces us to bring along NIOBSDSocket, which
ideally we would not move, but we foolishly exposed as API on
SocketAddress.

Modifications:

- Move NIOBSDSocket API components into NIOCore.
- Split out the internal abstractions for NIOBSDSocket and leave those
  in NIO.
- Move SocketAddress into NIOCore.

Result:

SocketAddress will be sitting in NIOCore.
