### PR TITLE
Add more synchronous pipeline operations.

### DIFF
--- a/Sources/NIO/BaseStreamSocketChannel.swift
+++ b/Sources/NIO/BaseStreamSocketChannel.swift
@@ -118,7 +118,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
                     self.readPending = false
 
                     assert(self.isActive)
-                    self.pipeline.fireChannelRead0(NIOAny(buffer))
+                    self.pipeline.syncOperations.fireChannelRead(NIOAny(buffer))
                     result = .some
 
                     if buffer.writableBytes > 0 {
@@ -250,7 +250,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         let data = data.forceAsIOData()
 
         if !self.pendingWrites.add(data: data, promise: promise) {
-            self.pipeline.fireChannelWritabilityChanged0()
+            self.pipeline.syncOperations.fireChannelWritabilityChanged()
         }
     }
 }

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -1206,7 +1206,7 @@ extension ChannelPipeline {
             self._pipeline.flush0()
         }
 
-        /// Fires `flush` from the tail to the head.
+        /// Fires `read` from the tail to the head.
         ///
         /// This method should typically only be called by `Channel` implementations directly.
         public func read() {

--- a/Sources/NIO/ChannelPipeline.swift
+++ b/Sources/NIO/ChannelPipeline.swift
@@ -800,7 +800,7 @@ public final class ChannelPipeline: ChannelInvoker {
         return self.head?.next
     }
 
-    func close0(mode: CloseMode, promise: EventLoopPromise<Void>?) {
+    private func close0(mode: CloseMode, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeClose(mode: mode, promise: promise)
         } else {
@@ -808,19 +808,19 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    func flush0() {
+    private func flush0() {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeFlush()
         }
     }
 
-    func read0() {
+    private func read0() {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeRead()
         }
     }
 
-    func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+    private func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWrite(data, promise: promise)
         } else {
@@ -828,7 +828,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    func writeAndFlush0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+    private func writeAndFlush0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWriteAndFlush(data, promise: promise)
         } else {
@@ -836,7 +836,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    func bind0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
+    private func bind0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeBind(to: address, promise: promise)
         } else {
@@ -844,7 +844,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    func connect0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
+    private func connect0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeConnect(to: address, promise: promise)
         } else {
@@ -852,7 +852,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    func register0(promise: EventLoopPromise<Void>?) {
+    private func register0(promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeRegister(promise: promise)
         } else {
@@ -860,7 +860,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
+    private func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeTriggerUserOutboundEvent(event, promise: promise)
         } else {
@@ -868,55 +868,55 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    func fireChannelRegistered0() {
+    private func fireChannelRegistered0() {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelRegistered()
         }
     }
 
-    func fireChannelUnregistered0() {
+    private func fireChannelUnregistered0() {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelUnregistered()
         }
     }
 
-    func fireChannelInactive0() {
+    private func fireChannelInactive0() {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelInactive()
         }
     }
 
-    func fireChannelActive0() {
+    private func fireChannelActive0() {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelActive()
         }
     }
 
-    func fireChannelRead0(_ data: NIOAny) {
+    private func fireChannelRead0(_ data: NIOAny) {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelRead(data)
         }
     }
 
-    func fireChannelReadComplete0() {
+    private func fireChannelReadComplete0() {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelReadComplete()
         }
     }
 
-    func fireChannelWritabilityChanged0() {
+    private func fireChannelWritabilityChanged0() {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelWritabilityChanged()
         }
     }
 
-    func fireUserInboundEventTriggered0(_ event: Any) {
+    private func fireUserInboundEventTriggered0(_ event: Any) {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeUserInboundEventTriggered(event)
         }
     }
 
-    func fireErrorCaught0(error: Error) {
+    private func fireErrorCaught0(error: Error) {
         assert((error as? ChannelError).map { $0 != .eof } ?? true)
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeErrorCaught(error)
@@ -1116,6 +1116,150 @@ extension ChannelPipeline {
         @inlinable
         public func handler<Handler: ChannelHandler>(type _: Handler.Type) throws -> Handler {
             return try self._pipeline._handlerSync(type: Handler.self).get()
+        }
+
+        /// Fires `channelRegistered` from the head to the tail.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func fireChannelRegistered() {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.fireChannelRegistered0()
+        }
+
+        /// Fires `channelUnregistered` from the head to the tail.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func fireChannelUnregistered() {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.fireChannelUnregistered0()
+        }
+
+        /// Fires `channelInactive` from the head to the tail.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func fireChannelInactive() {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.fireChannelInactive0()
+        }
+
+        /// Fires `channelActive` from the head to the tail.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func fireChannelActive() {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.fireChannelActive0()
+        }
+
+        /// Fires `channelRead` from the head to the tail.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func fireChannelRead(_ data: NIOAny) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.fireChannelRead0(data)
+        }
+
+        /// Fires `channelReadComplete` from the head to the tail.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func fireChannelReadComplete() {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.fireChannelReadComplete0()
+        }
+
+        /// Fires `channelWritabilityChanged` from the head to the tail.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func fireChannelWritabilityChanged() {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.fireChannelWritabilityChanged0()
+        }
+
+        /// Fires `userInboundEventTriggered` from the head to the tail.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func fireUserInboundEventTriggered(_ event: Any) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.fireUserInboundEventTriggered0(event)
+        }
+
+        /// Fires `errorCaught` from the head to the tail.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func fireErrorCaught(_ error: Error) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.fireErrorCaught0(error: error)
+        }
+
+        /// Fires `close` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func close(mode: CloseMode = .all, promise: EventLoopPromise<Void>?) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.close0(mode: mode, promise: promise)
+        }
+
+        /// Fires `flush` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func flush() {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.flush0()
+        }
+
+        /// Fires `flush` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func read() {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.read0()
+        }
+
+        /// Fires `write` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func write(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.write0(data, promise: promise)
+        }
+
+        /// Fires `writeAndFlush` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.writeAndFlush0(data, promise: promise)
+        }
+
+        /// Fires `bind` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func bind(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.bind0(to: address, promise: promise)
+        }
+
+        /// Fires `connect` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func connect(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.connect0(to: address, promise: promise)
+        }
+
+        /// Fires `register` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func register(promise: EventLoopPromise<Void>?) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.register0(promise: promise)
+        }
+
+        /// Fires `triggerUserOutboundEvent` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {
+            self.eventLoop.assertInEventLoop()
+            self._pipeline.triggerUserOutboundEvent0(event, promise: promise)
         }
     }
 

--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -276,8 +276,8 @@ class EmbeddedChannelCore: ChannelCore {
         promise?.succeed(())
 
         // As we called register() in the constructor of EmbeddedChannel we also need to ensure we call unregistered here.
-        pipeline.fireChannelInactive0()
-        pipeline.fireChannelUnregistered0()
+        self.pipeline.syncOperations.fireChannelInactive()
+        self.pipeline.syncOperations.fireChannelUnregistered()
 
         eventLoop.execute {
             // ensure this is executed in a delayed fashion as the users code may still traverse the pipeline
@@ -295,20 +295,20 @@ class EmbeddedChannelCore: ChannelCore {
     func connect0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         isActive = true
         promise?.succeed(())
-        pipeline.fireChannelActive0()
+        self.pipeline.syncOperations.fireChannelActive()
     }
 
     @usableFromInline
     func register0(promise: EventLoopPromise<Void>?) {
         promise?.succeed(())
-        pipeline.fireChannelRegistered0()
+        self.pipeline.syncOperations.fireChannelRegistered()
     }
 
     @usableFromInline
     func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
         isActive = true
         register0(promise: promise)
-        pipeline.fireChannelActive0()
+        self.pipeline.syncOperations.fireChannelActive()
     }
 
     @usableFromInline

--- a/Sources/NIO/SocketChannel.swift
+++ b/Sources/NIO/SocketChannel.swift
@@ -251,7 +251,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
                                                  parent: self,
                                                  eventLoop: group.next() as! SelectableEventLoop)
                     assert(self.isActive)
-                    pipeline.fireChannelRead0(NIOAny(chan))
+                    self.pipeline.syncOperations.fireChannelRead(NIOAny(chan))
                 } catch {
                     try? accepted.close()
                     throw error
@@ -589,7 +589,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                                             data: buffer,
                                             metadata: metadata)
                 assert(self.isActive)
-                pipeline.fireChannelRead0(NIOAny(msg))
+                self.pipeline.syncOperations.fireChannelRead(NIOAny(msg))
                 if mayGrow && i < maxMessagesPerRead {
                     buffer = recvAllocator.buffer(allocator: allocator)
                 }
@@ -673,7 +673,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
         if !self.pendingWrites.add(envelope: data, promise: promise) {
             assert(self.isActive)
-            pipeline.fireChannelWritabilityChanged0()
+            self.pipeline.syncOperations.fireChannelWritabilityChanged()
         }
     }
 

--- a/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
+++ b/Tests/NIOTests/ChannelPipelineTest+XCTest.swift
@@ -68,6 +68,7 @@ extension ChannelPipelineTest {
                 ("testSynchronousViewAddHandlers", testSynchronousViewAddHandlers),
                 ("testSynchronousViewContext", testSynchronousViewContext),
                 ("testSynchronousViewGetTypedHandler", testSynchronousViewGetTypedHandler),
+                ("testSynchronousViewPerformOperations", testSynchronousViewPerformOperations),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

NIO provides some scope for performing "synchronous" ChannelPipeline
operations. These are only safe to perform from the event loop to which
the pipeline is bound, and they avoid the need to check what thread
context you're running on in release mode.

Several of the built-in channels currently skip the public, thread-safe
API to ChannelPipeline in favour of directly calling into the
synchronous pipeline interface. This is going to cause us some trouble
when we pull ChannelPipeline out into NIOCore.

To that end, we should add the rest of the ChannelPipeline API surface
area to the SyncOperations structure and convert ourselves over to using
them.

Modifications:

- Implemented the pipeline operations on SyncOperations
- Added a test
- Swapped our channels to use the new APIs.

Result:

Better abstraction between ChannelPipeline and the Channels
