### PR TITLE
Remove extra whitespace when generating license header for linux tests

### DIFF
--- a/Tests/NIOTests/ByteBufferLengthPrefixTests+XCTest.swift
+++ b/Tests/NIOTests/ByteBufferLengthPrefixTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -63,7 +63,7 @@ def extractCopyright(log)
     if Integer(year) < startYear
         startYear = Integer(year)
     end
-        
+
   end
 
   # If the years end up being the same
@@ -76,7 +76,7 @@ end
 
 def header(fileName)
   log = %x(git log --follow -p #{fileName})
-  copyrightYears = extractCopyright(log)
+  copyrightYears = extractCopyright(log).strip
 
   string = <<-eos
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Motivation:

The soundness check is failing because of the generated year range is
not as it should be. Moreover when re-generating the linux tests for the
length prefix tests (which are failing soundness) the generated header
has extra whitespace before the year; this also fails the soundness
check.

Modifications:

- Strip whitespace from the copyright year range generated for linux
  tests
- Re-generate the test manifest for ByteBufferLengthPrefixTests

Result:

- Soundness is happier