### PR TITLE
Copy Android constants needed by Channel over to NIOCore too

### DIFF
--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -68,9 +68,14 @@ private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMut
 #endif
 
 // Work around SO_TIMESTAMP/SO_RCVTIMEO being awkwardly defined in glibc.
-#if os(Android) && arch(arm)
+#if os(Android)
+let IFF_BROADCAST: CUnsignedInt = numericCast(CNIOLinux.IFF_BROADCAST.rawValue)
+let IFF_POINTOPOINT: CUnsignedInt = numericCast(CNIOLinux.IFF_POINTOPOINT.rawValue)
+let IFF_MULTICAST: CUnsignedInt = numericCast(CNIOLinux.IFF_MULTICAST.rawValue)
+#if arch(arm)
 let SO_RCVTIMEO = SO_RCVTIMEO_OLD
 let SO_TIMESTAMP = SO_TIMESTAMP_OLD
+#endif
 #elseif os(Linux)
 let SO_TIMESTAMP = CNIOLinux_SO_TIMESTAMP
 let SO_RCVTIMEO = CNIOLinux_SO_RCVTIMEO


### PR DESCRIPTION
Motivation:

Unbreak Android build from NIOCore not having these constants defined.

Modifications:

Copy the same constants that Channel was using in NIO over.

Result:

Android compiles again and the same tests pass.

This is a consequence of #1920, which [broke my daily Android CI](https://github.com/buttaface/swift-android-sdk/runs/3229068619?check_suite_focus=true#step:13:21).