### PR TITLE
Backport: add setters to complete implementations of MutableCollection (#1925)

### DIFF
--- a/Sources/NIO/CircularBuffer.swift
+++ b/Sources/NIO/CircularBuffer.swift
@@ -227,14 +227,6 @@ extension CircularBuffer: Collection, MutableCollection {
 // MARK: RandomAccessCollection implementation
 extension CircularBuffer: RandomAccessCollection {
     /// Returns the index offset by `distance` from `index`.
-    @inlinable
-    public func index(_ i: Index, offsetBy distance: Int) -> Index {
-        return .init(backingIndex: (i.backingIndex &+ distance) & self.mask,
-                     backingCount: self.count,
-                     backingIndexOfHead: self.headBackingIndex)
-    }
-
-    /// Returns an index that is the specified distance from the given index.
     ///
     /// The following example obtains an index advanced four positions from a
     /// string's starting index and then prints the character at that position.
@@ -262,14 +254,29 @@ extension CircularBuffer: RandomAccessCollection {
     ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
     ///   value of `distance`.
     @inlinable
-    public subscript(bounds: Range<Index>) -> SubSequence {
-        precondition(self.distance(from: self.startIndex, to: bounds.lowerBound) >= 0)
-        precondition(self.distance(from: bounds.upperBound, to: self.endIndex) >= 0)
+    public func index(_ i: Index, offsetBy distance: Int) -> Index {
+        return .init(backingIndex: (i.backingIndex &+ distance) & self.mask,
+                     backingCount: self.count,
+                     backingIndexOfHead: self.headBackingIndex)
+    }
 
-        var newRing = self
-        newRing.headBackingIndex = bounds.lowerBound.backingIndex
-        newRing.tailBackingIndex = bounds.upperBound.backingIndex
-        return newRing
+    @inlinable
+    public subscript(bounds: Range<Index>) -> SubSequence {
+        get {
+            precondition(self.distance(from: self.startIndex, to: bounds.lowerBound) >= 0)
+            precondition(self.distance(from: bounds.upperBound, to: self.endIndex) >= 0)
+
+            var newRing = self
+            newRing.headBackingIndex = bounds.lowerBound.backingIndex
+            newRing.tailBackingIndex = bounds.upperBound.backingIndex
+            return newRing
+        }
+        set {
+            precondition(self.distance(from: self.startIndex, to: bounds.lowerBound) >= 0)
+            precondition(self.distance(from: bounds.upperBound, to: self.endIndex) >= 0)
+
+            self.replaceSubrange(bounds, with: newValue)
+        }
     }
 }
 

--- a/Sources/NIO/MarkedCircularBuffer.swift
+++ b/Sources/NIO/MarkedCircularBuffer.swift
@@ -161,6 +161,15 @@ extension MarkedCircularBuffer: Collection, MutableCollection {
         get {
             return self._buffer[bounds]
         }
+        set {
+            var index = bounds.lowerBound
+            var iterator = newValue.makeIterator()
+            while let newElement = iterator.next(), index != bounds.upperBound {
+                self._buffer[index] = newElement
+                formIndex(after: &index)
+            }
+            precondition(iterator.next() == nil && index == bounds.upperBound)
+        }
     }
 }
 

--- a/Tests/NIOTests/CircularBufferTests+XCTest.swift
+++ b/Tests/NIOTests/CircularBufferTests+XCTest.swift
@@ -42,6 +42,7 @@ extension CircularBufferTests {
                 ("testReplaceSubrangeWithSubrangeLargerThanTargetRange", testReplaceSubrangeWithSubrangeLargerThanTargetRange),
                 ("testReplaceSubrangeSameSize", testReplaceSubrangeSameSize),
                 ("testReplaceSubrangeReplaceBufferWithEmptyArray", testReplaceSubrangeReplaceBufferWithEmptyArray),
+                ("testRangeSubscriptExpanding", testRangeSubscriptExpanding),
                 ("testWeCanDistinguishBetweenEmptyAndFull", testWeCanDistinguishBetweenEmptyAndFull),
                 ("testExpandZeroBasedRingWorks", testExpandZeroBasedRingWorks),
                 ("testExpandNonZeroBasedRingWorks", testExpandNonZeroBasedRingWorks),

--- a/Tests/NIOTests/CircularBufferTests.swift
+++ b/Tests/NIOTests/CircularBufferTests.swift
@@ -325,6 +325,23 @@ class CircularBufferTests: XCTestCase {
         XCTAssertTrue(ring.isEmpty)
     }
 
+    func testRangeSubscriptExpanding() {
+        var ring = CircularBuffer<Int>(initialCapacity: 4)
+        for idx in 0..<5 {
+            ring.prepend(idx)
+        }
+        XCTAssertEqual(5, ring.count)
+
+        let index = ring.firstIndex(of: 1)!
+        let originalCount = ring.count
+        XCTAssertEqual(ring[index..<ring.endIndex].count, 2)
+        ring[index..<ring.endIndex] = [10,11,12,13,14,15,16,17,18,19]
+        XCTAssertTrue(ring.testOnly_verifyInvariantsForNonSlices())
+        XCTAssertEqual(originalCount + 8, ring.count)
+        XCTAssertEqual(4, ring.first)
+        XCTAssertEqual(19, ring.last)
+    }
+
     func testWeCanDistinguishBetweenEmptyAndFull() {
         var ring = CircularBuffer<Int>(initialCapacity: 4)
         XCTAssertTrue(ring.isEmpty)

--- a/Tests/NIOTests/MarkedCircularBufferTests+XCTest.swift
+++ b/Tests/NIOTests/MarkedCircularBufferTests+XCTest.swift
@@ -35,6 +35,7 @@ extension MarkedCircularBufferTests {
                 ("testFirst", testFirst),
                 ("testCount", testCount),
                 ("testSubscript", testSubscript),
+                ("testRangeSubscript", testRangeSubscript),
                 ("testIsEmpty", testIsEmpty),
                 ("testPopFirst", testPopFirst),
            ]

--- a/Tests/NIOTests/MarkedCircularBufferTests.swift
+++ b/Tests/NIOTests/MarkedCircularBufferTests.swift
@@ -117,6 +117,18 @@ class MarkedCircularBufferTests: XCTestCase {
         XCTAssertEqual(buf[buf.index(buf.startIndex, offsetBy: 3)], 4)
     }
 
+    func testRangeSubscript() throws {
+        var buf = MarkedCircularBuffer<Int>(initialCapacity: 4)
+        for i in 1...4 {
+            buf.append(i)
+        }
+        let range = buf.startIndex..<buf.index(buf.startIndex, offsetBy: 2)
+        XCTAssertEqual(buf[range].count, 2)
+        buf[range] = [0,1]
+        XCTAssertEqual(buf.firstIndex(of: 2), nil)
+        XCTAssertEqual(buf.count, 4)
+    }
+
     func testIsEmpty() throws {
         var buf = MarkedCircularBuffer<Int>(initialCapacity: 4)
         for i in 1...4 {


### PR DESCRIPTION
This backports #1925 to the 2.31 release so that we can tag a 2.31.1 and unblock the Swift source compatibility suite.

(cherry picked from commit 5b1f0c6e91644d54fd1e0baa7510b6a150c7e0b3)

