### PR TITLE
Add appropriate Sendable conformances.

### DIFF
--- a/Sources/NIO/Embedded.swift
+++ b/Sources/NIO/Embedded.swift
@@ -746,3 +746,13 @@ extension EmbeddedChannel {
         return SynchronousOptions(channel: self)
     }
 }
+
+#if compiler(>=5.5)
+// EmbeddedEventLoop is _not_ sendable, but the EventLoop protocol requires that it is.
+// As this is a testing-only tool, we allow this escape hatch.
+extension EmbeddedEventLoop: @unchecked Sendable { }
+
+// EmbeddedChannel is _not_ sendable, but the Channel protocol requires that it is.
+// As this is a testing-only tool, we allow this escape hatch.
+extension EmbeddedChannel: @unchecked Sendable { }
+#endif

--- a/Sources/NIO/HappyEyeballs.swift
+++ b/Sources/NIO/HappyEyeballs.swift
@@ -639,3 +639,8 @@ internal class HappyEyeballsConnector {
         processInput(.resolutionDelayElapsed)
     }
 }
+
+#if compiler(>=5.5)
+// SingleConnectionFailure is a value type and so is always Sendable.
+extension SingleConnectionFailure: Sendable { }
+#endif

--- a/Sources/NIO/MultiThreadedEventLoopGroup.swift
+++ b/Sources/NIO/MultiThreadedEventLoopGroup.swift
@@ -353,3 +353,9 @@ extension ScheduledTask: Comparable {
         return lhs === rhs
     }
 }
+
+#if compiler(>=5.5)
+// EventLoopGroups are required to be thread-safe and Sendable. MTELG is, but the compiler
+// can't prove it.
+extension MultiThreadedEventLoopGroup: @unchecked Sendable { }
+#endif

--- a/Sources/NIO/NetworkDevices.swift
+++ b/Sources/NIO/NetworkDevices.swift
@@ -365,3 +365,9 @@ extension NIONetworkDevice: Hashable {
         hasher.combine(self.interfaceIndex)
     }
 }
+
+#if compiler(>=5.5)
+// NIONetworkDevice is a value type and so is always Sendable. However, as it uses
+// the CoW pattern the compiler cannot prove this, and so we use unchecked.
+extension NIONetworkDevice: @unchecked Sendable { }
+#endif

--- a/Sources/NIO/SelectableEventLoop.swift
+++ b/Sources/NIO/SelectableEventLoop.swift
@@ -643,3 +643,9 @@ extension SelectableEventLoop: CustomStringConvertible, CustomDebugStringConvert
         }
     }
 }
+
+#if compiler(>=5.5)
+// EventLoop requires that SelectableEventLoop be thread-safe, and it is. However, the
+// compiler can't prove it.
+extension SelectableEventLoop: @unchecked Sendable { }
+#endif

--- a/Sources/NIOCore/AddressedEnvelope.swift
+++ b/Sources/NIOCore/AddressedEnvelope.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -79,3 +79,17 @@ public struct NIOPacketInfo: Hashable {
         self.interfaceIndex = interfaceIndex
     }
 }
+
+#if compiler(>=5.5)
+// AddressedEnvelope is a value type, so when the data within it is Sendable, it is too.
+extension AddressedEnvelope: Sendable where DataType: Sendable { }
+
+// AddressedEnvelope.Metadata is a value type, and so it's Sendable.
+extension AddressedEnvelope.Metadata: Sendable { }
+
+// NIOExplicitCongestionNotificationState is a trivial enum, and so it's Sendable.
+extension NIOExplicitCongestionNotificationState: Sendable { }
+
+// NIOPacketInfo is a value type, and so it's Sendable.
+extension NIOPacketInfo: Sendable { }
+#endif

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -378,3 +378,14 @@ extension NIOBSDSocket {
         #endif
     }
 }
+
+#if compiler(>=5.5)
+// The various components of NIOBSDSocket are all trivial value types, and so are Sendable.
+extension NIOBSDSocket.AddressFamily: Sendable { }
+
+extension NIOBSDSocket.ProtocolFamily: Sendable { }
+
+extension NIOBSDSocket.OptionLevel: Sendable { }
+
+extension NIOBSDSocket.Option: Sendable { }
+#endif

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -987,3 +987,16 @@ extension ByteBuffer {
         return indexFromReaderIndex ..< (indexFromReaderIndex+length)
     }
 }
+
+#if compiler(>=5.5)
+// ByteBuffer is a value type and so is always Sendable. However,
+// as we implement this using the CoW-pattern the compiler cannot
+// verify this, so we mark this unchecked.
+extension ByteBuffer: @unchecked Sendable { }
+
+// _ByteBufferSlice is a value type and so is always Sendable.
+extension _ByteBufferSlice: Sendable { }
+
+// ByteBufferAllocator is a value type and so is always Sendable.
+extension ByteBufferAllocator: Sendable { }
+#endif

--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -173,4 +173,7 @@ public enum Endianness {
     case little
 }
 
-
+#if compiler(>=5.5)
+// Endianness is a trivial enum, and so it's Sendable.
+extension Endianness: Sendable { }
+#endif

--- a/Sources/NIOCore/ByteBuffer-views.swift
+++ b/Sources/NIOCore/ByteBuffer-views.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -220,3 +220,8 @@ extension ByteBufferView: ExpressibleByArrayLiteral {
         self.init(elements)
     }
 }
+
+#if compiler(>=5.5)
+// ByteBufferView is a value type, and so it's Sendable.
+extension ByteBufferView: Sendable { }
+#endif

--- a/Sources/NIOCore/Channel.swift
+++ b/Sources/NIOCore/Channel.swift
@@ -395,3 +395,11 @@ public struct ChannelShouldQuiesceEvent {
     public init() {
     }
 }
+
+#if compiler(>=5.5)
+// ChannelEvent is a trivial enum, and so it's Sendable.
+extension ChannelEvent: Sendable { }
+
+// ChannelShouldQuiesceEvent is a trivial empty struct, so it's Sendable.
+extension ChannelShouldQuiesceEvent: Sendable { }
+#endif

--- a/Sources/NIOCore/ChannelInvoker.swift
+++ b/Sources/NIOCore/ChannelInvoker.swift
@@ -243,3 +243,8 @@ public enum CloseMode {
     /// Close the whole `Channel (file descriptor).
     case all
 }
+
+#if compiler(>=5.5)
+// CloseMode is a trivial enum, and so it's Sendable.
+extension CloseMode: Sendable { }
+#endif

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -385,3 +385,46 @@ extension ChannelOptions {
         }
     }
 }
+
+#if compiler(>=5.5)
+// SocketOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.SocketOption: Sendable { }
+
+// AllocatorOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.AllocatorOption: Sendable { }
+
+// RecvAllocatorOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.RecvAllocatorOption: Sendable { }
+
+// AutoRead is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.AutoReadOption: Sendable { }
+
+// WriteSpinOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.WriteSpinOption: Sendable { }
+
+// MaxMessagesPerReadOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.MaxMessagesPerReadOption: Sendable { }
+
+// BacklogOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.BacklogOption: Sendable { }
+
+// DatagramVectorReadMessageCountOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.DatagramVectorReadMessageCountOption: Sendable { }
+
+// ExplicitCongestionNotificationsOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.ExplicitCongestionNotificationsOption: Sendable { }
+
+// ConnectTimeoutOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.ConnectTimeoutOption: Sendable { }
+
+// AllowRemoteHalfClosureOption is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.AllowRemoteHalfClosureOption: Sendable { }
+
+// ReceivePacketInfo is a trivial value type, so it's Sendable.
+extension ChannelOptions.Types.ReceivePacketInfo: Sendable { }
+
+// ChannelOptions.Storage is a value type, so it's Sendable. However, the compiler
+// can't prove this because it relies on Channel, which we cannot require to be Sendable
+// yet, so we just assert that this is true.
+extension ChannelOptions.Storage: @unchecked Sendable { }
+#endif

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -1977,3 +1977,16 @@ extension ChannelPipeline: CustomDebugStringConvertible {
         return handlers
     }
 }
+
+#if compiler(>=5.5)
+// ChannelPipeline's API surface is almost entirely thread-safe, though a few of it's computed properties are not.
+// For this reason, it's safe to pass it across thread boundaries.
+extension ChannelPipeline: @unchecked Sendable { }
+
+// ChannelPipeline.Position is a trivial value type, so it's Sendable. The compiler can't
+// see this because we're holding ChannelHandlers, but it remains true.
+extension ChannelPipeline.Position: @unchecked Sendable { }
+
+// RemovalTokens are trivially Sendable.
+extension ChannelHandlerContext.RemovalToken: Sendable { }
+#endif

--- a/Sources/NIOCore/CircularBuffer.swift
+++ b/Sources/NIOCore/CircularBuffer.swift
@@ -784,3 +784,11 @@ extension CircularBuffer: ExpressibleByArrayLiteral {
         self.init(elements)
     }
 }
+
+#if compiler(>=5.5)
+// CircularBuffer is a value type, so it's Sendable when its elements are.
+extension CircularBuffer: Sendable where Element: Sendable { }
+
+// CircularBuffer.Index is a value type and always Sendable.
+extension CircularBuffer.Index: Sendable { }
+#endif

--- a/Sources/NIOCore/ConvenienceOptionSupport.swift
+++ b/Sources/NIOCore/ConvenienceOptionSupport.swift
@@ -184,3 +184,11 @@ extension ChannelOptions {
         }
     }
 }
+
+#if compiler(>=5.5)
+// ConvenienceOptionValue is Sendable if its ValueType is Sendable.
+extension ChannelOptions.Types.ConvenienceOptionValue: Sendable where ValueType: Sendable { }
+
+// TCPConvenienceOption is a trivial ValueType and it's Sendable.
+extension ChannelOptions.TCPConvenienceOption: Sendable { }
+#endif

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -775,7 +775,6 @@ extension EventLoop {
     }
 }
 
-/// Provides an endless stream of `EventLoop`s to use.
 public protocol EventLoopGroup: AnyObject {
     /// Returns the next `EventLoop` to use.
     ///
@@ -875,3 +874,27 @@ extension EventLoopError: CustomStringConvertible {
         }
     }
 }
+
+#if compiler(>=5.5)
+// Scheduled is a reference type, but safe to use across concurrency boundaries.
+extension Scheduled: Sendable { }
+
+// RepeatedTask is a reference type implemented as a class. It uses EventLoop to
+// make itself thread-safe, but the compiler cannot prove this, and so we are
+// forced to assert that it's true.
+extension RepeatedTask: @unchecked Sendable { }
+
+// EventLoopIterator should be trivially Sendable. However, as we can't make
+// EventLoop require Sendable, we have to tell the compiler this, it cannot prove it.
+extension EventLoopIterator: @unchecked Sendable { }
+
+// TimeAmount is trivially Sendable.
+extension TimeAmount: Sendable { }
+
+// NIODeadline is trivially Sendable.
+extension NIODeadline: Sendable { }
+
+/// NIOEventLoopGroupProvider is trivially Sendable. However, as we can't make
+// EventLoop require Sendable, we have to tell the compiler this, it cannot prove it.
+extension NIOEventLoopGroupProvider: @unchecked Sendable { }
+#endif

--- a/Sources/NIOCore/EventLoopFuture.swift
+++ b/Sources/NIOCore/EventLoopFuture.swift
@@ -1570,3 +1570,16 @@ public struct _NIOEventLoopFutureIdentifier: Hashable {
         return UInt(bitPattern: ObjectIdentifier(future)) ^ 0xbf15ca5d
     }
 }
+
+#if compiler(>=5.5)
+// EventLoopPromise is a reference type, but by its very nature is Sendable.
+extension EventLoopPromise: Sendable { }
+
+// EventLoopFuture is a reference type, but it is Sendable. However, we enforce
+// that by way of the guarantees of the EventLoop protocol, so the compiler cannot
+// check it.
+extension EventLoopFuture: @unchecked Sendable { }
+
+// _NIOEventLoopFutureIdentifier is required to be Sendable.
+extension _NIOEventLoopFutureIdentifier: Sendable { }
+#endif

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -168,3 +168,11 @@ extension NIOFileHandle: CustomStringConvertible {
         return "FileHandle { descriptor: \(self.descriptor) }"
     }
 }
+
+#if compiler(>=5.5)
+// Mode is a straightforward value type, so it's always Sendable.
+extension NIOFileHandle.Mode: Sendable { }
+
+// Flags is a straightforward value type, so it's always Sendable.
+extension NIOFileHandle.Flags: Sendable { }
+#endif

--- a/Sources/NIOCore/IntegerTypes.swift
+++ b/Sources/NIOCore/IntegerTypes.swift
@@ -114,3 +114,11 @@ extension _UInt56: CustomStringConvertible {
         return UInt64(self).description
     }
 }
+
+#if compiler(>=5.5)
+// _UInt24 is a value type and so is always Sendable.
+extension _UInt24: Sendable { }
+
+// _UInt56 is a value type and so is always Sendable.
+extension _UInt56: Sendable { }
+#endif

--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -173,3 +173,9 @@ extension UnsafeMutablePointer where Pointee == sockaddr {
         }
     }
 }
+
+#if compiler(>=5.5)
+// NIONetworkInterface is a value type and so is always Sendable.
+@available(*, deprecated, renamed: "NIONetworkDevice")
+extension NIONetworkInterface: Sendable { }
+#endif

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -638,3 +638,22 @@ extension sockaddr_storage: SockAddrProtocol {
     }
 }
 
+#if compiler(>=5.5)
+// SocketAddress is Sendable because it's a value type.
+extension SocketAddress: Sendable { }
+
+// IPv4Address is Sendable because it's a value type. However,
+// due to https://bugs.swift.org/browse/SR-15017 we have to disable compiler
+// checking.
+extension SocketAddress.IPv4Address: @unchecked Sendable { }
+
+// IPv6Address is Sendable because it's a value type. However,
+// due to https://bugs.swift.org/browse/SR-15017 we have to disable compiler
+// checking.
+extension SocketAddress.IPv6Address: @unchecked Sendable { }
+
+// UnixSocketAddress is Sendable because it's a value type. However,
+// due to https://bugs.swift.org/browse/SR-15017 we have to disable compiler
+// checking.
+extension SocketAddress.UnixSocketAddress: @unchecked Sendable { }
+#endif

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -30,3 +30,6 @@ final class Box<T> {
     init(_ value: T) { self.value = value }
 }
 
+#if compiler(>=5.5)
+extension Box: Sendable where T: Sendable { }
+#endif

--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -64,7 +64,7 @@ extension EventLoopPromise {
     ///   - body: The `async` function to run.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     @inlinable
-    public func completeWithAsync(_ body: @escaping () async throws -> Value) {
+    public func completeWithAsync(_ body: @escaping @Sendable () async throws -> Value) {
         Task {
             do {
                 let value = try await body()


### PR DESCRIPTION
Motivation:

As part of the adoption of 5.5 there is now some limited amount of
runtime enforcement of thread-safety in the form of the Sendable marker
protocol. A number of NIO's types are safe to share across threads, so
to smooth the path to wider adoption of Sendable we should adopt this
marker protocol where we can.

Modifications:

- Added Sendable to many, many types.

Result:

Users can use NIO in concurrency-aware contexts more easily.
