### PR TITLE
Update NIOAsyncAwaitDemo to use correct @available checks (post WWDC '21)

### DIFF
--- a/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
+++ b/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
@@ -15,9 +15,8 @@
 import NIOCore
 import NIOHTTP1
 
-#if compiler(>=5.5) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
-#if compiler(>=5.5) && $AsyncAwait
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+#if compiler(>=5.5)
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 struct AsyncChannelIO<Request, Response> {
     let channel: Channel
 
@@ -40,5 +39,4 @@ struct AsyncChannelIO<Request, Response> {
         try await self.channel.close()
     }
 }
-#endif
 #endif

--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -18,7 +18,6 @@ import NIOHTTP1
 import Dispatch
 
 #if compiler(>=5.5)
-import _Concurrency
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 func makeHTTPChannel(host: String, port: Int, group: EventLoopGroup) async throws -> AsyncChannelIO<HTTPRequestHead, NIOHTTPClientResponseFull> {

--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -17,12 +17,10 @@ import _NIOConcurrency
 import NIOHTTP1
 import Dispatch
 
-#if compiler(>=5.5) // we cannot write this on one line with `&&` because Swift 5.0 doesn't like it...
-#if compiler(>=5.5) && $AsyncAwait
-
+#if compiler(>=5.5)
 import _Concurrency
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 func makeHTTPChannel(host: String, port: Int, group: EventLoopGroup) async throws -> AsyncChannelIO<HTTPRequestHead, NIOHTTPClientResponseFull> {
     let channel = try await ClientBootstrap(group: group).connect(host: host, port: port).get()
     try await channel.pipeline.addHTTPClientHandlers().get()
@@ -31,7 +29,7 @@ func makeHTTPChannel(host: String, port: Int, group: EventLoopGroup) async throw
     return try await AsyncChannelIO<HTTPRequestHead, NIOHTTPClientResponseFull>(channel).start()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 func main() async {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     do {
@@ -71,7 +69,7 @@ func main() async {
 
 let dg = DispatchGroup()
 dg.enter()
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
     Task {
         await main()
         dg.leave()
@@ -81,9 +79,5 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 }
 dg.wait()
 #else
-print("ERROR: This demo only works with async/await enabled (NIO.System.hasAsyncAwaitSupport = \(NIO.System.hasAsyncAwaitSupport))")
-print("Try:   swift run -Xswiftc -Xfrontend -Xswiftc -enable-experimental-concurrency NIOAsyncAwaitDemo")
-#endif
-#else
-print("ERROR: Concurrency only supported on Swift > 5.4.")
+print("ERROR: Concurrency only supported on Swift > 5.5.")
 #endif

--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -79,5 +79,5 @@ if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
 }
 dg.wait()
 #else
-print("ERROR: Concurrency only supported on Swift > 5.5.")
+print("ERROR: Concurrency only supported on Swift >= 5.5.")
 #endif

--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -15,7 +15,6 @@
 import NIOCore
 
 #if compiler(>=5.5)
-import _Concurrency
 
 extension EventLoopFuture {
     /// Get the value/error from an `EventLoopFuture` in an `async` context.


### PR DESCRIPTION
### Motivation

`import _Concurrency` was needed to enable Swift 5.5 new async/await support. Gladly this is no longer needed.

### Changes

- Remove `import _Concurrency` statements

### Result

- Cleaner imports
- static-stdlib linking works on 5.5 (it does not if we explicitly import _Concurrency)