### PR TITLE
[Concurrency] `completeWithTask` expects to receive a `@Sendable` closure

### DIFF
--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -66,7 +66,7 @@ extension EventLoopPromise {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     @discardableResult
     @inlinable
-    public func completeWithTask(_ body: @escaping () async throws -> Value) -> Task<Void, Never> {
+    public func completeWithTask(_ body: @escaping @Sendable () async throws -> Value) -> Task<Void, Never> {
         Task {
             do {
                 let value = try await body()


### PR DESCRIPTION
### Motivation

On the Swift main branch, the `Sendable` checking has been enabled. It currently emits warnings. Since we test with `-warnings-as-errors`, our CI does not succeed in the `nightly-main` step.

### Changes

- Make `EventLoopPromise.completeWithTask` require a `@Sendable` closure

### Result

- CI should pass on Swift main again