### PR TITLE
Minor rewording to clarify the location of the NIO 1 to NIO 2 migration guide

### DIFF
--- a/docs/migration-guide-NIO1-to-NIO2.md
+++ b/docs/migration-guide-NIO1-to-NIO2.md
@@ -1,3 +1,5 @@
 # NIO 1 to NIO 2 migration guide
 
-Please take a look at [SwiftNIO 2.29.0](https://github.com/apple/swift-nio/blob/2.29.0/docs/migration-guide-NIO1-to-NIO2.md), the last version with Swift 5.0 support. SwiftNIO 2.29.0 will also come with the `_NIO1APIShims` module which eases the migration.
+Please take a look at the [migration guide included with SwiftNIO 2.29.0](https://github.com/apple/swift-nio/blob/2.29.0/docs/migration-guide-NIO1-to-NIO2.md), the last version with Swift 5.0 support. 
+
+[SwiftNIO 2.29.0](https://github.com/apple/swift-nio/releases/tag/2.29.0) includes the `_NIO1APIShims` module which can help to ease the migration.


### PR DESCRIPTION
I've updated the label of the link to the NIO 1 to NIO 2 migration guide to be clearer.

### Motivation:

I found the current wording of https://github.com/apple/swift-nio/blob/main/docs/migration-guide-NIO1-to-NIO2.md confusing, and assumed that the link on that page was a link to the release, not the migration guide.

Hopefully this is a little clearer, but please — foist your feedback upon me!