### PR TITLE
Use default SubSequence for StaticString

### DIFF
--- a/Sources/NIO/ContiguousCollection.swift
+++ b/Sources/NIO/ContiguousCollection.swift
@@ -20,7 +20,6 @@ public protocol ContiguousCollection: Collection {
 
 extension StaticString: Collection {
     public typealias Element = UInt8
-    public typealias SubSequence = ArraySlice<UInt8>
     
     public typealias _Index = Int
     

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1036,7 +1036,10 @@ class ByteBufferTest: XCTestCase {
             buf.write(bytes: ptr.dropFirst(0)) + buf.write(bytes: ptr.dropFirst(4 /* drop all of them */))
         }
 
-        let expected = Array(1...16) + Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ012345".utf8)
+        // StaticString.SubSequence
+        written += buf.write(bytes: ("0123456789" as StaticString).dropFirst(6))
+
+        let expected = Array(1...16) + Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".utf8)
 
         XCTAssertEqual(expected, buf.readBytes(length: written)!)
     }


### PR DESCRIPTION
### Motivation:

The default `SubSequence` for `Collection` is `Slice<Self>`. When using `ArraySlice<UInt8>`, we should provide an implementation of `subscript(_:)` for `Range<Int>`, but we don't. Therefore:
* The latest version of the compiler refuses to compile.
* Older versions use `subscript(_:)` for `R: RangeExpression` instead, which causes the app to crash when trying to slice `StaticString` due to infinite recursion.

### Modifications:

`StaticString.SubSequence` is now `Slice<StaticString>`.

### Result:

The code compiles with the latest version of the compiler and slicing a `StaticString` doesn't cause the app to crash.
