### PR TITLE
Add missing implementation of subscript(_ bounds:) to StaticString

### DIFF
--- a/Sources/NIO/ContiguousCollection.swift
+++ b/Sources/NIO/ContiguousCollection.swift
@@ -32,6 +32,14 @@ extension StaticString: Collection {
         precondition(position < self.utf8CodeUnitCount, "index \(position) out of bounds")
         return self.utf8Start.advanced(by: position).pointee
     }
+    
+    public subscript(bounds: Range<Int>) -> SubSequence {
+        precondition(startIndex <= bounds.lowerBound &&
+                        bounds.lowerBound <= bounds.upperBound &&
+                        bounds.upperBound <= endIndex,
+                     "indices out of bounds")
+        return withUTF8Buffer { return ArraySlice($0[bounds]) }
+    }
 }
 extension UnsafeRawBufferPointer: ContiguousCollection {
     @_inlineable


### PR DESCRIPTION
### Motivation:

This is a backport of #1893 for SwiftNIO1.

### Modifications:

Add an implementation of `subscript(_ bounds:)` to `StaticString`.

### Result:

* `StaticString` can be sliced without crashing, though in O(n) time.
* The package should build with the July 8 2021 snapshot of Swift.