### PR TITLE
Clarify the support status of NIO1

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,26 @@ APNS | ✅ | ❌ | [kylebrowning/APNSwift](https://github.com/kylebrowning/APNSw
 PostgreSQL | ✅ | ❌ | [vapor/postgres-nio](https://github.com/vapor/postgres-nio) | `PostgresNIO` | SSWG community project
 Redis | ✅ | ❌ | [mordil/swift-redi-stack](https://gitlab.com/Mordil/swift-redi-stack) | `RediStack` | SSWG community project
 
+### Supported Versions
+
+### SwiftNIO 1
+SwiftNIO 1 is considered end of life - it is strongly recommended that you move to a newer version.  The Core NIO team does not actively work on this version.  No new features will be added to this version but PRs which fix bugs will be accepted until the end of May 2022.
+
+If you have a SwiftNIO 1 application or library that you would like to migrate to SwiftNIO 2, please check out the [migration guide](docs/migration-guide-NIO1-to-NIO2.md) we prepared for you.
+
+The latest released SwiftNIO 1 version supports Swift 4.0, 4.1, 4.2, and 5.0.
+
+### SwiftNIO 2
+This is the current version of SwiftNIO and will be supported for the forseeable future.
+
+The latest released SwiftNIO 2 version supports Swift 5.2, 5.3, and 5.4. NIO 2.29.0 and older support Swift 5.0+.
+
 ### Supported Platforms
 
 SwiftNIO aims to support all of the platforms where Swift is supported. Currently, it is developed and tested on macOS and Linux, and is known to support the following operating system versions:
 
 * Ubuntu 18.04+
 * macOS 10.9+, iOS 7+; (macOS 10.14+, iOS 12+, tvOS 12+ or watchOS 6+ with [swift-nio-transport-services][repo-nio-transport-services])
-
-### Swift versions
-
-#### SwiftNIO 1
-
-The latest released SwiftNIO 1 version supports Swift 4.0, 4.1, 4.2, and 5.0.
-
-#### SwiftNIO 2
-
-The latest released SwiftNIO 2 version supports Swift 5.2, 5.3, and 5.4. If you have a SwiftNIO 1 application or library that you would like to migrate to SwiftNIO 2, please check out the [migration guide](docs/migration-guide-NIO1-to-NIO2.md) we prepared for you.
 
 ### Compatibility
 


### PR DESCRIPTION
Motivation:

It's currently unclear that SwiftNIO1 is end of life.

Modifications:

Update the README to set a deadline on patches to NIO1

Result:

Everyone knows where the core team stands on supporting NIO1