### PR TITLE
Add safer abstraction for kqueue filter set.

### DIFF
--- a/Sources/NIOPosix/SelectorKqueue.swift
+++ b/Sources/NIOPosix/SelectorKqueue.swift
@@ -376,7 +376,7 @@ fileprivate struct KeventTriple {
 
     mutating func withUnsafeBufferPointer(_ body: (UnsafeMutableBufferPointer<kevent>) throws -> Void) rethrows {
         try withUnsafeMutablePointer(to: &self.kevents) { keventPtr in
-            // Pointer to a homogeneous tupe of a given type is also implicitly bound to the element type, so
+            // Pointer to a homogeneous tuple of a given type is also implicitly bound to the element type, so
             // we can safely pun this here.
             let typedPointer = UnsafeMutableRawPointer(keventPtr).assumingMemoryBound(to: kevent.self)
             let typedBufferPointer = UnsafeMutableBufferPointer(start: typedPointer, count: self.initialized)


### PR DESCRIPTION
Motivation:

Our kqueue filter set differ logic attempted to stack allocate some
kevent objects and then treat them as a fixed size array by creating a
tuple and then grabbing a pointer to it. That's fairly gratuitously
unsafe, and we should shrink the amount of code that can touch unsafe
stuff.

Modifications:

- Defined KeventTriple, a value type that encapsulates a fixed-size
  array and a length.
- Rewrote calculateKQueueFilterSetChanges to use the new type.

Result:

Safer code in the NIO core
