### PR TITLE
Add performance and allocation tests for canonical form headers

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_get_100000_headers_canonical_form.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_get_100000_headers_canonical_form.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOHTTP1
+
+func run(identifier: String) {
+    measure(identifier: identifier) {
+        let headers: HTTPHeaders = ["key": "no,trimming"]
+        var count = 0
+        for _ in 0..<100_000 {
+            count &+= headers[canonicalForm: "key"].count
+        }
+        return count
+    }
+
+    measure(identifier: identifier + "_trimming_whitespace") {
+        let headers: HTTPHeaders = ["key": "         some   ,   trimming     "]
+        var count = 0
+        for _ in 0..<100_000 {
+            count &+= headers[canonicalForm: "key"].count
+        }
+        return count
+    }
+
+    measure(identifier: identifier + "_trimming_whitespace_from_short_string") {
+        // first components has length > 15 with whitespace and <= 15 without.
+        let headers: HTTPHeaders = ["key": "   smallString   ,whenStripped"]
+        var count = 0
+        for _ in 0..<100_000 {
+            count &+= headers[canonicalForm: "key"].count
+        }
+        return count
+    }
+
+    measure(identifier: identifier + "_trimming_whitespace_from_long_string") {
+        let headers: HTTPHeaders = ["key": " moreThan15CharactersWithAndWithoutWhitespace ,anotherValue"]
+        var count = 0
+        for _ in 0..<100_000 {
+            count &+= headers[canonicalForm: "key"].count
+        }
+        return count
+    }
+}

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -204,6 +204,42 @@ measureAndPrint(desc: "write_http_headers") {
     return val
 }
 
+measureAndPrint(desc: "http_headers_canonical_form") {
+    let headers: HTTPHeaders = ["key": "no,trimming"]
+    var count = 0
+    for _ in 0..<100_000 {
+        count &+= headers[canonicalForm: "key"].count
+    }
+    return count
+}
+
+measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace") {
+    let headers: HTTPHeaders = ["key": "         some   ,   trimming     "]
+    var count = 0
+    for _ in 0..<100_000 {
+        count &+= headers[canonicalForm: "key"].count
+    }
+    return count
+}
+
+measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace_from_short_string") {
+    let headers: HTTPHeaders = ["key": "   smallString   ,whenStripped"]
+    var count = 0
+    for _ in 0..<100_000 {
+        count &+= headers[canonicalForm: "key"].count
+    }
+    return count
+}
+
+measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace_from_long_string") {
+    let headers: HTTPHeaders = ["key": " moreThan15CharactersWithAndWithoutWhitespace ,anotherValue"]
+    var count = 0
+    for _ in 0..<100_000 {
+        count &+= headers[canonicalForm: "key"].count
+    }
+    return count
+}
+
 measureAndPrint(desc: "bytebuffer_write_12MB_short_string_literals") {
     let bufferSize = 12 * 1024 * 1024
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -43,6 +43,10 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -43,6 +43,10 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -43,6 +43,10 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -42,6 +42,10 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -43,6 +43,10 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400


### PR DESCRIPTION
Motivation:

To justify performance changes we need to measure the code being
changed. We believe that `HTTPHeaders.subscript(canonicalForm:)` is a
little slow.

Modifications:

- Add allocation and performance tests for fetching header values in
  their canonical form

Results:

More benchmarks!