### PR TITLE
Don't count CR or LF as whitespace when trimming canonical header values

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -115,7 +115,7 @@ public struct HTTPRequestHead: Equatable {
     public static func ==(lhs: HTTPRequestHead, rhs: HTTPRequestHead) -> Bool {
         return lhs.method == rhs.method && lhs.uri == rhs.uri && lhs.version == rhs.version && lhs.headers == rhs.headers
     }
-    
+
     private mutating func copyStorageIfNotUniquelyReferenced () {
         if !isKnownUniquelyReferenced(&self._storage) {
             self._storage = self._storage.copy()
@@ -220,7 +220,7 @@ public struct HTTPResponseHead: Equatable {
     public static func ==(lhs: HTTPResponseHead, rhs: HTTPResponseHead) -> Bool {
         return lhs.status == rhs.status && lhs.version == rhs.version && lhs.headers == rhs.headers
     }
-    
+
     private mutating func copyStorageIfNotUniquelyReferenced () {
         if !isKnownUniquelyReferenced(&self._storage) {
             self._storage = self._storage.copy()
@@ -310,7 +310,7 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
         // Otherwise we'd only have the one below with a default argument for `allocator`.
         self.init(headers, keepAliveState: .unknown)
     }
-    
+
     /// Construct a `HTTPHeaders` structure.
     ///
     /// - parameters
@@ -511,7 +511,7 @@ extension ByteBuffer {
 
 extension HTTPHeaders: RandomAccessCollection {
     public typealias Element = (name: String, value: String)
-    
+
     public struct Index: Comparable {
         fileprivate let base: Array<(String, String)>.Index
         public static func < (lhs: Index, rhs: Index) -> Bool {
@@ -544,9 +544,7 @@ extension UTF8.CodeUnit {
     var isASCIIWhitespace: Bool {
         switch self {
         case UInt8(ascii: " "),
-             UInt8(ascii: "\t"),
-             UInt8(ascii: "\r"),
-             UInt8(ascii: "\n"):
+             UInt8(ascii: "\t"):
           return true
 
         default:
@@ -1381,7 +1379,7 @@ extension HTTPMethod: RawRepresentable {
                 return value
         }
     }
-        
+
     public init(rawValue: String) {
         switch rawValue {
             case "GET":

--- a/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeadersTest.swift
@@ -153,7 +153,7 @@ class HTTPHeadersTest : XCTestCase {
 
     func testTrimWhitespaceWorksOnOnlyWhitespace() {
         let expected = ""
-        for wsString in [" ", "\t", "\r", "\n", "\r\n", "\n\r", "  \r\n \n\r\t\r\t\n"] {
+        for wsString in [" ", "\t", "  \t\t \t  "] {
             let actual = String(wsString.trimASCIIWhitespace())
             XCTAssertEqual(expected, actual)
         }
@@ -161,7 +161,7 @@ class HTTPHeadersTest : XCTestCase {
 
     func testTrimWorksWithCharactersInTheMiddleAndWhitespaceAround() {
         let expected = "x"
-        let actual = String("         x\n\n\n".trimASCIIWhitespace())
+        let actual = String("         x\t  ".trimASCIIWhitespace())
         XCTAssertEqual(expected, actual)
     }
 
@@ -189,7 +189,7 @@ class HTTPHeadersTest : XCTestCase {
         XCTAssertEqual(headers.first(name: "custom-key"), "value-1,value-2")
         XCTAssertNil(headers.first(name: "not-present"))
     }
-    
+
     func testKeepAliveStateStartsWithClose() {
         var headers = HTTPHeaders([("Connection", "close")])
 
@@ -226,7 +226,7 @@ class HTTPHeadersTest : XCTestCase {
         let headers = HTTPHeaders([("Connection", "other, keEP-alive"),
                                    ("Content-Type", "text/html"),
                                    ("Connection", "server, x-options")])
-        
+
         XCTAssertTrue(headers.isKeepAlive(version: .http1_1))
     }
 
@@ -234,24 +234,24 @@ class HTTPHeadersTest : XCTestCase {
         let headers = HTTPHeaders([("Connection", "x-options,  other"),
                                    ("Content-Type", "text/html"),
                                    ("Connection", "server,     clOse")])
-        
+
         XCTAssertFalse(headers.isKeepAlive(version: .http1_1))
     }
-        
+
     func testRandomAccess() {
         let originalHeaders = [ ("X-first", "one"),
                                 ("X-second", "two")]
         let headers = HTTPHeaders(originalHeaders)
-        
+
         XCTAssertEqual(headers[headers.startIndex].name, originalHeaders.first?.0)
         XCTAssertEqual(headers[headers.startIndex].value, originalHeaders.first?.1)
         XCTAssertEqual(headers[headers.index(before: headers.endIndex)].name, originalHeaders.last?.0)
         XCTAssertEqual(headers[headers.index(before: headers.endIndex)].value, originalHeaders.last?.1)
-        
+
         let beforeLast = headers[headers.index(before: headers.endIndex)]
         XCTAssertEqual(beforeLast.name, originalHeaders[originalHeaders.endIndex - 1].0)
         XCTAssertEqual(beforeLast.value, originalHeaders[originalHeaders.endIndex - 1].1)
-        
+
         let afterFirst = headers[headers.index(after: headers.startIndex)]
         XCTAssertEqual(afterFirst.name, originalHeaders[originalHeaders.startIndex + 1].0)
         XCTAssertEqual(afterFirst.value, originalHeaders[originalHeaders.startIndex + 1].1)


### PR DESCRIPTION
Motivation:

Follow up to https://github.com/apple/swift-nio/pull/1952#discussion_r707351015

The OWS rule from the HTTP semantics draft only considers 'SP' and
'HTAB' to be whitespace. We also (unnecessarily) consider CR and LF to
be whitespace.

Modifications:

- Remove CR and LF from the characters we consider to be whitespace
- Update tests

Result:

We no longer consider CR or LF to be whitespace when trimming
whitespace when producing the canonical form of header values.