### PR TITLE
Work around Xcode 13 GM SDK issues.

### DIFF
--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -22,7 +22,11 @@ import Glibc
 
 let sysMalloc: @convention(c) (size_t) -> UnsafeMutableRawPointer? = malloc
 let sysRealloc: @convention(c) (UnsafeMutableRawPointer?, size_t) -> UnsafeMutableRawPointer? = realloc
-let sysFree: @convention(c) (UnsafeMutableRawPointer?) -> Void = free
+
+/// Xcode 13 GM shipped with a bug in the SDK that caused `free`'s first argument to be annotated as
+/// non-nullable. To that end, we define a thunk through to `free` that matches that constraint, as we
+/// never pass a `nil` pointer to it.
+let sysFree: @convention(c) (UnsafeMutableRawPointer) -> Void = { free($0) }
 
 extension _ByteBufferSlice: Equatable {}
 
@@ -82,7 +86,7 @@ public struct ByteBufferAllocator {
 
     internal init(hookedMalloc: @escaping @convention(c) (size_t) -> UnsafeMutableRawPointer?,
                   hookedRealloc: @escaping @convention(c) (UnsafeMutableRawPointer?, size_t) -> UnsafeMutableRawPointer?,
-                  hookedFree: @escaping @convention(c) (UnsafeMutableRawPointer?) -> Void,
+                  hookedFree: @escaping @convention(c) (UnsafeMutableRawPointer) -> Void,
                   hookedMemcpy: @escaping @convention(c) (UnsafeMutableRawPointer, UnsafeRawPointer, size_t) -> Void) {
         self.malloc = hookedMalloc
         self.realloc = hookedRealloc
@@ -112,7 +116,7 @@ public struct ByteBufferAllocator {
 
     internal let malloc: @convention(c) (size_t) -> UnsafeMutableRawPointer?
     internal let realloc: @convention(c) (UnsafeMutableRawPointer?, size_t) -> UnsafeMutableRawPointer?
-    internal let free: @convention(c) (UnsafeMutableRawPointer?) -> Void
+    internal let free: @convention(c) (UnsafeMutableRawPointer) -> Void
     internal let memcpy: @convention(c) (UnsafeMutableRawPointer, UnsafeRawPointer, size_t) -> Void
 }
 

--- a/Tests/NIOPosixTests/ByteBufferTest.swift
+++ b/Tests/NIOPosixTests/ByteBufferTest.swift
@@ -2989,7 +2989,7 @@ private func testAllocationOfReallyBigByteBuffer_memcpyHook(_ dst: UnsafeMutable
 
 private var testReserveCapacityLarger_reallocCount = 0
 private var testReserveCapacityLarger_mallocCount = 0
-private func testReserveCapacityLarger_freeHook( _ ptr: UnsafeMutableRawPointer?) -> Void {
+private func testReserveCapacityLarger_freeHook( _ ptr: UnsafeMutableRawPointer) -> Void {
     free(ptr)
 }
 

--- a/Tests/NIOPosixTests/CodecTest.swift
+++ b/Tests/NIOPosixTests/CodecTest.swift
@@ -19,7 +19,7 @@ import NIOEmbedded
 
 private var testDecoderIsNotQuadratic_mallocs = 0
 private var testDecoderIsNotQuadratic_reallocs = 0
-private func testDecoderIsNotQuadratic_freeHook(_ ptr: UnsafeMutableRawPointer?) -> Void {
+private func testDecoderIsNotQuadratic_freeHook(_ ptr: UnsafeMutableRawPointer) -> Void {
     free(ptr)
 }
 

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -29,11 +29,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=172050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=168050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=96050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=453000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=93050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=450050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -42,7 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=59050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
@@ -50,11 +50,11 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=160050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=190050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=188050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
       - SWIFT_TEST_VERB=build # WARNING: THIS DISABLES ALL TESTS. Please remove (workaround https://bugs.swift.org/browse/SR-14268)
 

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -23,7 +23,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=28050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37


### PR DESCRIPTION
Motivation:

Xcode 13 GM shipped with a Swift overlay for libsystem in macOS that
marked free's first argument as non-nullable. This leads to an awkward
breakage for us, because we're trying to hold a reference to free as a
function pointer, and to do that we had an explicit type annotation.

We'd like to keep NIO compiling in Xcode 13 GM.

Modifications:

- Defined the free function as a thunk that passes through to the
  underlying OS free call, but takes its first argument as non-nullable.

Result:

Should compile on the Xcode 13 GM again.

Resolves #1955.