### PR TITLE
[NIOSingleStepByteToMessageProcessor] Only reclaim once at the end of the decode loop

### DIFF
--- a/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
+++ b/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
@@ -244,13 +244,6 @@ public final class NIOSingleStepByteToMessageProcessor<Decoder: NIOSingleStepByt
         assert(self._buffer != nil)
 
         func decodeOnce(buffer: inout ByteBuffer) throws -> Decoder.InboundOut? {
-            defer {
-                if buffer.readableBytes > 0 {
-                    if self.decoder.shouldReclaimBytes(buffer: buffer) {
-                        buffer.discardReadBytes()
-                    }
-                }
-            }
             if decodeMode == .normal {
                 return try self.decoder.decode(buffer: &buffer)
             } else {
@@ -267,7 +260,7 @@ public final class NIOSingleStepByteToMessageProcessor<Decoder: NIOSingleStepByt
         }
 
         // force unwrapping is safe because nil case is handled already and asserted above
-        if self._buffer!.readableBytes == 0 {
+        if self._buffer!.readerIndex > 0, self.decoder.shouldReclaimBytes(buffer: self._buffer!) {
             self._buffer!.discardReadBytes()
         }
     }

--- a/Tests/NIOPosixTests/SingleStepByteToMessageDecoderTest+XCTest.swift
+++ b/Tests/NIOPosixTests/SingleStepByteToMessageDecoderTest+XCTest.swift
@@ -36,6 +36,7 @@ extension NIOSingleStepByteToMessageDecoderTest {
                 ("testPayloadTooLarge", testPayloadTooLarge),
                 ("testPayloadTooLargeButHandlerOk", testPayloadTooLargeButHandlerOk),
                 ("testReentrancy", testReentrancy),
+                ("testWeDoNotCallShouldReclaimMemoryAsLongAsFramesAreProduced", testWeDoNotCallShouldReclaimMemoryAsLongAsFramesAreProduced),
            ]
    }
 }


### PR DESCRIPTION
Same issue as fixed #1733 for ByteToMessageHandler.

### Motivation:

`NIOSingleStepByteToMessageProcessor` called out to the decoder's shouldReclaimBytes method after every parsing attempt, even if the decoder returned a value (which means continue in the `decodeLoop`).

That's quite pointless because we won't add any bytes into the buffer before we're trying the decoder again. Further it is a huge performance penalty for a use-cases in which we only consume small frames from the buffer. (Like reading data rows in a database client)

### Modifications:

Only ask the decoder if we should reclaim bytes if the decoder actually is not able to process more frames from the input buffer.

### Result:

Faster, better, more sensible.