### PR TITLE
[NIOSingleStepByteToMessageProcessor] Inline process methods

### DIFF
--- a/Sources/NIOCore/Codec.swift
+++ b/Sources/NIOCore/Codec.swift
@@ -38,7 +38,9 @@ public enum ByteToMessageDecoderError: Error {
 extension ByteToMessageDecoderError {
     // TODO: For NIO 3, make this an enum case (or whatever best way for Errors we have come up with).
     /// This error can be thrown by `ByteToMessageDecoder`s if the incoming payload is larger than the max specified.
-    public struct PayloadTooLargeError: Error {}
+    public struct PayloadTooLargeError: Error {
+        public init() {}
+    }
 }
 
 


### PR DESCRIPTION
We like speed. To make `NIOSingleStepByteToMessageProcessor` even faster, we should mark the process method as `@inlinable`.

NIOSingleStepByteToMessageProcessor overhead is reduced:

Previous:
<img width="1144" alt="without_inline" src="https://user-images.githubusercontent.com/6780861/133748703-eec57f86-6446-4b81-a10f-04a9f953a9a1.png">

Inlined:
<img width="1299" alt="with_inline" src="https://user-images.githubusercontent.com/6780861/133748694-073efc8c-944b-4d43-b5d9-e3e48c00ae8d.png">

The important bit is the relative performance improvement between `withNonCowBuffer` and the actual decode invocation.

### Result:

Faster `NIOSingleStepByteToMessageProcessor`.
