### PR TITLE
Get unit tests running again on nightly builds.

### DIFF
--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -638,3 +638,26 @@ extension sockaddr_storage: SockAddrProtocol {
     }
 }
 
+// MARK: Workarounds for SR-14268
+// We need these free functions to expose our extension methods, because otherwise
+// the compiler falls over when we try to access them from test code. As these functions
+// exist purely to make the behaviours accessible from test code, we name them truly awfully.
+func __testOnly_addressDescription(_ addr: inout sockaddr_in) -> String {
+    return addr.addressDescription()
+}
+
+func __testOnly_addressDescription(_ addr: inout sockaddr_in6) -> String {
+    return addr.addressDescription()
+}
+
+func __testOnly_withSockAddr<ReturnType>(
+    _ addr: inout sockaddr_in, _ body: (UnsafePointer<sockaddr>, Int) throws -> ReturnType
+) rethrows -> ReturnType {
+    return try addr.withSockAddr(body)
+}
+
+func __testOnly_withSockAddr<ReturnType>(
+    _ addr: inout sockaddr_in6, _ body: (UnsafePointer<sockaddr>, Int) throws -> ReturnType
+) rethrows -> ReturnType {
+    return try addr.withSockAddr(body)
+}

--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -411,3 +411,25 @@ extension BaseSocket: CustomStringConvertible {
         return "BaseSocket { fd=\(self.descriptor) }"
     }
 }
+
+// MARK: Workarounds for SR-14268
+// We need these free functions to expose our extension methods, because otherwise
+// the compiler falls over when we try to access them from test code. As these functions
+// exist purely to make the behaviours accessible from test code, we name them truly awfully.
+func __testOnly_convertSockAddr(_ addr: inout sockaddr_storage) -> sockaddr_in {
+    return addr.convert()
+}
+
+func __testOnly_convertSockAddr(_ addr: inout sockaddr_storage) -> sockaddr_in6 {
+    return addr.convert()
+}
+
+func __testOnly_convertSockAddr(_ addr: inout sockaddr_storage) -> sockaddr_un {
+    return addr.convert()
+}
+
+func __testOnly_withMutableSockAddr<ReturnType>(
+    _ addr: inout sockaddr_storage, _ body: (UnsafeMutablePointer<sockaddr>, Int) throws -> ReturnType
+) rethrows -> ReturnType {
+    return try addr.withMutableSockAddr(body)
+}

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -274,10 +274,10 @@ func resolverDebugInformation(eventLoop: EventLoop, host: String, previouslyRece
             return "uds"
         case .v4(let sa):
             var addr = sa.address
-            return addr.addressDescription()
+            return __testOnly_addressDescription(&addr)
         case .v6(let sa):
             var addr = sa.address
-            return addr.addressDescription()
+            return __testOnly_addressDescription(&addr)
         }
     }
     let res = GetaddrinfoResolver(loop: eventLoop, aiSocktype: .stream, aiProtocol: CInt(IPPROTO_TCP))

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -56,7 +56,6 @@ services:
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=188050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
-      - SWIFT_TEST_VERB=build # WARNING: THIS DISABLES ALL TESTS. Please remove (workaround https://bugs.swift.org/browse/SR-14268)
 
   performance-test:
     image: swift-nio:20.04-main


### PR DESCRIPTION
Motivation:

In February, @weissi noticed that the nightly builds of Swift could no
longer compile the unit tests. We disabled them at that time and
reported an upstream bug, https://bugs.swift.org/browse/SR-14268. This
is not an ideal situation, but the Swift core team has provided a
workaround we can use to re-enable the tests.

Modifications:

Provide free functions that wrap some specific extension methods that
are called in unit tests, and amend the call sites to use them.

Result:

We can re-enable the nightly tests.
