### PR TITLE
NIO1 Fix Ruby version in CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,12 +41,10 @@ RUN [ -z $install_curl_from_source ] || ( cd $HOME/.curl && ./configure --with-s
 RUN [ -z $install_curl_from_source ] || ldconfig
 
 # ruby and jazzy for docs generation
-ARG skip_ruby_from_ppa
-RUN [ -n "$skip_ruby_from_ppa" ] || apt-add-repository -y ppa:brightbox/ruby-ng
-RUN [ -n "$skip_ruby_from_ppa" ] || { apt-get update && apt-get install -y ruby2.6 ruby2.6-dev; }
-RUN [ -z "$skip_ruby_from_ppa" ] || { apt-get update && apt-get install -y ruby ruby-dev; }
+RUN apt-add-repository -y ppa:brightbox/ruby-ng
+RUN apt-get update && apt-get install -y ruby2.6 ruby2.6-dev;
 RUN apt-get update && apt-get install -y libsqlite3-dev
-RUN gem install jazzy --no-document
+RUN gem install jazzy -v 0.13.7 --no-document
 
 # swift
 ARG swift_version=4.0.3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,10 +43,10 @@ RUN [ -z $install_curl_from_source ] || ldconfig
 # ruby and jazzy for docs generation
 ARG skip_ruby_from_ppa
 RUN [ -n "$skip_ruby_from_ppa" ] || apt-add-repository -y ppa:brightbox/ruby-ng
-RUN [ -n "$skip_ruby_from_ppa" ] || { apt-get update && apt-get install -y ruby2.4 ruby2.4-dev; }
+RUN [ -n "$skip_ruby_from_ppa" ] || { apt-get update && apt-get install -y ruby2.6 ruby2.6-dev; }
 RUN [ -z "$skip_ruby_from_ppa" ] || { apt-get update && apt-get install -y ruby ruby-dev; }
 RUN apt-get update && apt-get install -y libsqlite3-dev
-RUN gem install jazzy --no-ri --no-rdoc
+RUN gem install jazzy --no-document
 
 # swift
 ARG swift_version=4.0.3

--- a/docker/docker-compose.1804.42.yaml
+++ b/docker/docker-compose.1804.42.yaml
@@ -8,7 +8,6 @@ services:
       args:
         ubuntu_version : "18.04"
         swift_version : "4.2"
-        skip_ruby_from_ppa : "true"
 
   unit-tests:
     image: swift-nio:18.04-4.2

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,7 +8,6 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        skip_ruby_from_ppa: "true"
 
   unit-tests:
     image: swift-nio:18.04-5.0


### PR DESCRIPTION
### Motivation:

Jazzy and its dependencies require Ruby >= 2.6.

### Changes:

* Update Ruby to version 2.6
* Pin Jazzy to version 0.13.7 (because version 0.14.0 requires Ruby >= 2.6.3)
* Replace deprecated --no-ri and --no-doc flags

### Result:

The CI tests should pass.