### PR TITLE
Only include concurrency features on new OSes

### DIFF
--- a/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
+++ b/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
@@ -15,7 +15,7 @@
 import NIOCore
 import NIOHTTP1
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 struct AsyncChannelIO<Request, Response> {
     let channel: Channel

--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -17,7 +17,7 @@ import _NIOConcurrency
 import NIOHTTP1
 import Dispatch
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 func makeHTTPChannel(host: String, port: Int, group: EventLoopGroup) async throws -> AsyncChannelIO<HTTPRequestHead, NIOHTTPClientResponseFull> {

--- a/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
+++ b/Sources/_NIOConcurrency/AsyncAwaitSupport.swift
@@ -14,7 +14,7 @@
 
 import NIOCore
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 extension EventLoopFuture {
     /// Get the value/error from an `EventLoopFuture` in an `async` context.

--- a/Tests/NIOPosixTests/ByteBufferTest.swift
+++ b/Tests/NIOPosixTests/ByteBufferTest.swift
@@ -2965,7 +2965,7 @@ private func testAllocationOfReallyBigByteBuffer_freeHook(_ ptr: UnsafeMutableRa
     precondition(AllocationExpectationState.reallocDone == testAllocationOfReallyBigByteBuffer_state)
     testAllocationOfReallyBigByteBuffer_state = .freeDone
     /* free the pointer initially produced by malloc and then rebased by realloc offsetting it back */
-    free(ptr?.advanced(by: Int(Int32.max)))
+    free(ptr!.advanced(by: Int(Int32.max)))
 }
 
 private func testAllocationOfReallyBigByteBuffer_mallocHook(_ size: Int) -> UnsafeMutableRawPointer? {


### PR DESCRIPTION
Motivation:

Swift 5.5 provides concurrency support on almost all platforms where it
is available. However, the Xcode 13 GM currently provides a macOS 11 SDK
with Swift 5.5, and the concurrency features are not available in that
SDK. As a result, NIO's concurrency features cause compile errors when
building the concurrency library on macOS using Xcode 13 GM.

Modifications:

- Only build the concurrency features when the concurrency library is
  present.

Result:

We can build NIO using Xcode 13 GM.
