### PR TITLE
Allow allocation slack to be configured

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_allocation_counts.sh
+++ b/IntegrationTests/tests_04_performance/test_01_allocation_counts.sh
@@ -36,6 +36,7 @@ for test in "${all_tests[@]}"; do
         total_allocations=$(grep "^test_$test_case.total_allocations:" "$tmp/output" | cut -d: -f2 | sed 's/ //g')
         not_freed_allocations=$(grep "^test_$test_case.remaining_allocations:" "$tmp/output" | cut -d: -f2 | sed 's/ //g')
         max_allowed_env_name="MAX_ALLOCS_ALLOWED_$test_case"
+        slack_allowed_env_name="SLACK_ALLOCS_ALLOWED_$test_case"
 
         info "$test_case: allocations not freed: $not_freed_allocations"
         info "$test_case: total number of mallocs: $total_allocations"
@@ -50,8 +51,9 @@ for test in "${all_tests[@]}"; do
             fi
         else
             max_allowed=${!max_allowed_env_name}
+            slack_allowed=${!slack_allowed_env_name:-1000}
             assert_less_than_or_equal "$total_allocations" "$max_allowed"
-            assert_greater_than "$total_allocations" "$(( max_allowed - 1000))"
+            assert_greater_than "$total_allocations" "$(( max_allowed - slack_allowed ))"
         fi
     done < <(grep "^test_$test[^\W]*.total_allocations:" "$tmp/output" | cut -d: -f1 | cut -d. -f1 | sort | uniq)
 done


### PR DESCRIPTION
Motivation:

Allocation counting tests check that the number of allocations during a
test is no more than a user defined limit and not lower than that limit
minus 1000. Most tests perform 1000 iterations so the slack is more like
one allocation per iteration. However not all tests are stable enough to
fall within this limit.

Modifications:

- Allow a `SLACK_ALLOCS_ALLOWED_<TEST>` variable to override the default
  slack of 1000 allocations

Result:

- Allowed slack is configurable per allocation counting test
- If not set, the limit remains as 1000