### PR TITLE
[ByteBuffer] Reduce ARC traffic when reading

### DIFF
--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -45,10 +45,11 @@ extension ByteBuffer {
     ///     - length: The number of bytes to be read from this `ByteBuffer`.
     /// - returns: A `[UInt8]` value containing `length` bytes or `nil` if there aren't at least `length` bytes readable.
     public mutating func readBytes(length: Int) -> [UInt8]? {
-        return self.getBytes(at: self.readerIndex, length: length).map {
-            self._moveReaderIndex(forwardBy: length)
-            return $0
+        guard let result = self.getBytes(at: self.readerIndex, length: length) else {
+            return nil
         }
+        self._moveReaderIndex(forwardBy: length)
+        return result
     }
 
     // MARK: StaticString APIs
@@ -149,10 +150,11 @@ extension ByteBuffer {
     ///     - length: The number of bytes making up the string.
     /// - returns: A `String` value deserialized from this `ByteBuffer` or `nil` if there aren't at least `length` bytes readable.
     public mutating func readString(length: Int) -> String? {
-        return self.getString(at: self.readerIndex, length: length).map {
-            self._moveReaderIndex(forwardBy: length)
-            return $0
+        guard let result = self.getString(at: self.readerIndex, length: length) else {
+            return nil
         }
+        self._moveReaderIndex(forwardBy: length)
+        return result
     }
 
     // MARK: Substring APIs
@@ -238,10 +240,11 @@ extension ByteBuffer {
     ///     - length: The number of bytes.
     /// - returns: A `DispatchData` value containing the bytes from this `ByteBuffer` or `nil` if there aren't at least `length` bytes readable.
     public mutating func readDispatchData(length: Int) -> DispatchData? {
-        return self.getDispatchData(at: self.readerIndex, length: length).map {
-            self._moveReaderIndex(forwardBy: length)
-            return $0
+        guard let result = self.getDispatchData(at: self.readerIndex, length: length) else {
+            return nil
         }
+        self._moveReaderIndex(forwardBy: length)
+        return result
     }
 
 
@@ -426,10 +429,11 @@ extension ByteBuffer {
     ///     - length: The number of bytes to slice off.
     /// - returns: A `ByteBuffer` sharing storage containing `length` bytes or `nil` if the not enough bytes were readable.
     public mutating func readSlice(length: Int) -> ByteBuffer? {
-        return self.getSlice(at: self.readerIndex, length: length).map {
-            self._moveReaderIndex(forwardBy: length)
-            return $0
+        guard let result = self.getSlice(at: self.readerIndex, length: length) else {
+            return nil
         }
+        self._moveReaderIndex(forwardBy: length)
+        return result
     }
 
     @discardableResult

--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -31,10 +31,11 @@ extension ByteBuffer {
     /// - returns: An integer value deserialized from this `ByteBuffer` or `nil` if there aren't enough bytes readable.
     @inlinable
     public mutating func readInteger<T: FixedWidthInteger>(endianness: Endianness = .big, as: T.Type = T.self) -> T? {
-        return self.getInteger(at: self.readerIndex, endianness: endianness, as: T.self).map {
-            self._moveReaderIndex(forwardBy: MemoryLayout<T>.size)
-            return $0
+        guard let result = self.getInteger(at: self.readerIndex, endianness: endianness, as: T.self) else {
+            return nil
         }
+        self._moveReaderIndex(forwardBy: MemoryLayout<T>.size)
+        return result
     }
 
     /// Get the integer at `index` from this `ByteBuffer`. Does not move the reader index.

--- a/Sources/NIOCore/ByteBuffer-lengthPrefix.swift
+++ b/Sources/NIOCore/ByteBuffer-lengthPrefix.swift
@@ -112,10 +112,11 @@ extension ByteBuffer {
         endianness: Endianness = .big,
         as integer: Integer.Type
     ) -> ByteBuffer? where Integer: FixedWidthInteger {
-        self.getLengthPrefixedSlice(at: self.readerIndex, endianness: endianness, as: Integer.self).map {
-            self._moveReaderIndex(forwardBy: MemoryLayout<Integer>.size + $0.readableBytes)
-            return $0
+        guard let result = self.getLengthPrefixedSlice(at: self.readerIndex, endianness: endianness, as: Integer.self) else {
+            return nil
         }
+        self._moveReaderIndex(forwardBy: MemoryLayout<Integer>.size + result.readableBytes)
+        return result
     }
     
     /// Gets an `Integer` from `self` and gets a slice of that length from `self` and returns it.


### PR DESCRIPTION
In my local testing it seems that the compiler adds a retain and release cycle around the use of map here.

### Modifications:

- Replaced the use of `.map` with a `guard let` in the byteBuffer read methods.

### Result:

Faster reads on `ByteBuffer`.
