### PR TITLE
force getSlice to be inlined into readSlice

### DIFF
--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -429,7 +429,7 @@ extension ByteBuffer {
     ///     - length: The number of bytes to slice off.
     /// - returns: A `ByteBuffer` sharing storage containing `length` bytes or `nil` if the not enough bytes were readable.
     public mutating func readSlice(length: Int) -> ByteBuffer? {
-        guard let result = self.getSlice(at: self.readerIndex, length: length) else {
+        guard let result = self.getSlice_inlineAlways(at: self.readerIndex, length: length) else {
             return nil
         }
         self._moveReaderIndex(forwardBy: length)

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -644,6 +644,11 @@ public struct ByteBuffer {
     /// - returns: A `ByteBuffer` containing the selected bytes as readable bytes or `nil` if the selected bytes were
     ///            not readable in the initial `ByteBuffer`.
     public func getSlice(at index: Int, length: Int) -> ByteBuffer? {
+        return self.getSlice_inlineAlways(at: index, length: length)
+    }
+
+    @inline(__always)
+    internal func getSlice_inlineAlways(at index: Int, length: Int) -> ByteBuffer? {
         guard index >= 0 && length >= 0 && index >= self.readerIndex && length <= self.writerIndex && index <= self.writerIndex &- length else {
             return nil
         }


### PR DESCRIPTION
### Motivation:

If `getSlice` isn't inlined into `readSlice`, then PRs like https://github.com/apple/swift-nio/pull/1979 become necessary. If `getSlice` is inlined into `readSlice`, then https://github.com/apple/swift-nio/pull/1979 doesn't actually make a difference.

### Modifications:

Force `getSlice` being inlined into `readSlice`.

### Result:

Better code for `readSlice`.