### PR TITLE
Conform EventLoopFuture/Promise to Sendable

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -12,6 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.5) && canImport(_Concurrency)
+public typealias NIOSendable = Swift.Sendable
+#else
+public typealias NIOSendable = Any
+#endif
+
 #if compiler(>=5.5) && canImport(_Concurrency)
 
 extension EventLoopFuture {

--- a/Sources/NIOCore/EventLoopFuture.swift
+++ b/Sources/NIOCore/EventLoopFuture.swift
@@ -151,7 +151,7 @@ internal struct OperationPlaceholderError: Error {
 ///     or `eventLoop.newFailedFuture(error:)`.
 ///
 /// - note: `EventLoopPromise` has reference semantics.
-public struct EventLoopPromise<Value> {
+public struct EventLoopPromise<Value>: Sendable {
     /// The `EventLoopFuture` which is used by the `EventLoopPromise`. You can use it to add callbacks which are notified once the
     /// `EventLoopPromise` is completed.
     public let futureResult: EventLoopFuture<Value>
@@ -370,7 +370,7 @@ public struct EventLoopPromise<Value> {
 /// or `EventLoopFuture` callbacks need to invoke a lock (either directly or in the form of `DispatchQueue`) this
 /// should be considered a code smell worth investigating: the `EventLoop`-based synchronization guarantees of
 /// `EventLoopFuture` should be sufficient to guarantee thread-safety.
-public final class EventLoopFuture<Value> {
+public final class EventLoopFuture<Value>: @unchecked Sendable {
     // TODO: Provide a tracing facility.  It would be nice to be able to set '.debugTrace = true' on any EventLoopFuture or EventLoopPromise and have every subsequent chained EventLoopFuture report the success result or failure error.  That would simplify some debugging scenarios.
     @usableFromInline
     internal var _value: Optional<Result<Value, Error>>

--- a/Sources/NIOCore/EventLoopFuture.swift
+++ b/Sources/NIOCore/EventLoopFuture.swift
@@ -1571,13 +1571,14 @@ public struct _NIOEventLoopFutureIdentifier: Hashable {
     }
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
 // EventLoopPromise is a reference type, but by its very nature is Sendable.
-extension EventLoopPromise: Sendable { }
+extension EventLoopPromise: NIOSendable { }
+
+#if swift(>=5.5) && canImport(_Concurrency)
 
 // EventLoopFuture is a reference type, but it is Sendable. However, we enforce
 // that by way of the guarantees of the EventLoop protocol, so the compiler cannot
 // check it.
-extension EventLoopFuture: @unchecked Sendable { }
+extension EventLoopFuture: @unchecked NIOSendable { }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif


### PR DESCRIPTION
Conform `EventLoopFuture` and `EventLoopPromise` to `Sendable`

### Motivation:

Fixes compile warnings

Based off discussion in #1928