### PR TITLE
Fix stale hyperlinks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,18 +348,18 @@ apt-get install -y git curl libatomic1 libxml2 netcat-openbsd lsof perl
 dnf install swift-lang /usr/bin/nc /usr/bin/lsof /usr/bin/shasum
 ```
 
-[ch]: https://apple.github.io/swift-nio/docs/current/NIOCore/Protocols/ChannelHandler.html
-[c]: https://apple.github.io/swift-nio/docs/current/NIOCore/Protocols/Channel.html
-[chc]: https://apple.github.io/swift-nio/docs/current/NIOCore/Classes/ChannelHandlerContext.html
-[ec]: https://apple.github.io/swift-nio/docs/current/NIOCore/Classes/EmbeddedChannel.html
-[el]: https://apple.github.io/swift-nio/docs/current/NIOCore/Protocols/EventLoop.html
-[eel]: https://apple.github.io/swift-nio/docs/current/NIOCore/Classes/EmbeddedEventLoop.html
-[elg]: https://apple.github.io/swift-nio/docs/current/NIOCore/Protocols/EventLoopGroup.html
-[bb]: https://apple.github.io/swift-nio/docs/current/NIOCore/Structs/ByteBuffer.html
-[elf]: https://apple.github.io/swift-nio/docs/current/NIOCore/Classes/EventLoopFuture.html
-[elp]: https://apple.github.io/swift-nio/docs/current/NIOCore/Structs/EventLoopPromise.html
-[cp]: https://apple.github.io/swift-nio/docs/current/NIOCore/Classes/ChannelPipeline.html
-[mtelg]: https://apple.github.io/swift-nio/docs/current/NIOPosix/Classes/MultiThreadedEventLoopGroup.html
+[ch]: https://apple.github.io/swift-nio/docs/current/NIO/Protocols/ChannelHandler.html
+[c]: https://apple.github.io/swift-nio/docs/current/NIO/Protocols/Channel.html
+[chc]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/ChannelHandlerContext.html
+[ec]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/EmbeddedChannel.html
+[el]: https://apple.github.io/swift-nio/docs/current/NIO/Protocols/EventLoop.html
+[eel]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/EmbeddedEventLoop.html
+[elg]: https://apple.github.io/swift-nio/docs/current/NIO/Protocols/EventLoopGroup.html
+[bb]: https://apple.github.io/swift-nio/docs/current/NIO/Structs/ByteBuffer.html
+[elf]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/EventLoopFuture.html
+[elp]: https://apple.github.io/swift-nio/docs/current/NIO/Structs/EventLoopPromise.html
+[cp]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/ChannelPipeline.html
+[mtelg]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/MultiThreadedEventLoopGroup.html
 [pthreads]: https://en.wikipedia.org/wiki/POSIX_Threads
 [kqueue]: https://en.wikipedia.org/wiki/Kqueue
 [epoll]: https://en.wikipedia.org/wiki/Epoll

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ While it is possible to configure and register [`Channel`][c]s with [`EventLoop`
 
 For this reason, SwiftNIO ships a number of `Bootstrap` objects whose purpose is to streamline the creation of channels. Some `Bootstrap` objects also provide other functionality, such as support for Happy Eyeballs for making TCP connection attempts.
 
-Currently SwiftNIO ships with three `Bootstrap` objects in the `NIOPosix` module: [`ServerBootstrap`](https://apple.github.io/swift-nio/docs/current/NIOPosix/Classes/ServerBootstrap.html), for bootstrapping listening channels; [`ClientBootstrap`](https://apple.github.io/swift-nio/docs/current/NIOPosix/Classes/ClientBootstrap.html), for bootstrapping client TCP channels; and [`DatagramBootstrap`](https://apple.github.io/swift-nio/docs/current/NIOPosix/Classes/DatagramBootstrap.html) for bootstrapping UDP channels.
+Currently SwiftNIO ships with three `Bootstrap` objects in the `NIOPosix` module: [`ServerBootstrap`][sboot], for bootstrapping listening channels; [`ClientBootstrap`][cboot], for bootstrapping client TCP channels; and [`DatagramBootstrap`][dboot] for bootstrapping UDP channels.
 
 #### ByteBuffer
 
@@ -359,6 +359,9 @@ dnf install swift-lang /usr/bin/nc /usr/bin/lsof /usr/bin/shasum
 [elf]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/EventLoopFuture.html
 [elp]: https://apple.github.io/swift-nio/docs/current/NIO/Structs/EventLoopPromise.html
 [cp]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/ChannelPipeline.html
+[sboot]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/ServerBootstrap.html
+[cboot]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/ClientBootstrap.html
+[dboot]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/DatagramBootstrap.html
 [mtelg]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/MultiThreadedEventLoopGroup.html
 [pthreads]: https://en.wikipedia.org/wiki/POSIX_Threads
 [kqueue]: https://en.wikipedia.org/wiki/Kqueue


### PR DESCRIPTION
Fix broken hyperlinks in README

### Motivation:

Fix broken hyperlinks in the README.

### Modifications:

Changed the links pointing to the documentation of various protocols and classes.  For Bootstrap-related links, centralize the definitions of the links so that they are easy to change if they break in the future.  This follows the convention of the current document.

### Result:

Links that resolve. 🥇 
