### PR TITLE
Allow HTTP Server to send multiple informational heads before actual response head

### DIFF
--- a/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
@@ -292,6 +292,8 @@ public final class HTTPServerPipelineHandler: ChannelDuplexHandler, RemovableCha
         debugOnly {
             let res = self.unwrapOutboundIn(data)
             switch res {
+            case .head(let head) where head.isInformational:
+                assert(self.nextExpectedOutboundMessage == .head)
             case .head:
                 assert(self.nextExpectedOutboundMessage == .head)
                 self.nextExpectedOutboundMessage = .bodyOrEnd

--- a/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift
@@ -57,6 +57,8 @@ public final class HTTPServerProtocolErrorHandler: ChannelDuplexHandler, Removab
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let res = self.unwrapOutboundIn(data)
         switch res {
+        case .head(let head) where head.isInformational:
+            precondition(!self.hasUnterminatedResponse)
         case .head:
             precondition(!self.hasUnterminatedResponse)
             self.hasUnterminatedResponse = true

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -228,6 +228,14 @@ public struct HTTPResponseHead: Equatable {
     }
 }
 
+extension HTTPResponseHead {
+    /// Determines if the head is purely informational. If a head is informational another head will follow this
+    /// head eventually.
+    var isInformational: Bool {
+        100 <= self.status.code && self.status.code < 200 && self.status.code != 101
+    }
+}
+
 private extension UInt8 {
     var isASCII: Bool {
         return self <= 127

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -55,6 +55,7 @@ extension HTTPDecoderTest {
                 ("testAppropriateErrorWhenReceivingUnsolicitedResponseDoesNotRecover", testAppropriateErrorWhenReceivingUnsolicitedResponseDoesNotRecover),
                 ("testOneRequestTwoResponses", testOneRequestTwoResponses),
                 ("testForwardContinueThenResponse", testForwardContinueThenResponse),
+                ("testForwardMultipleContinuesThenResponse", testForwardMultipleContinuesThenResponse),
                 ("testDropContinueThanForwardResponse", testDropContinueThanForwardResponse),
                 ("testRefusesRequestSmugglingAttempt", testRefusesRequestSmugglingAttempt),
                 ("testTrimsTrailingOWS", testTrimsTrailingOWS),

--- a/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest+XCTest.swift
@@ -51,6 +51,8 @@ extension HTTPServerPipelineHandlerTest {
                 ("testRemovingWithBufferedRequestForwards", testRemovingWithBufferedRequestForwards),
                 ("testQuiescingInAResponseThenRemovedFiresEventAndReads", testQuiescingInAResponseThenRemovedFiresEventAndReads),
                 ("testQuiescingInAResponseThenRemovedFiresEventAndDoesntRead", testQuiescingInAResponseThenRemovedFiresEventAndDoesntRead),
+                ("testServerCanRespondContinue", testServerCanRespondContinue),
+                ("testServerCanRespondProcessingMultipleTimes", testServerCanRespondProcessingMultipleTimes),
            ]
    }
 }

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest+XCTest.swift
@@ -31,6 +31,8 @@ extension HTTPServerProtocolErrorHandlerTest {
                 ("testIgnoresNonParserErrors", testIgnoresNonParserErrors),
                 ("testDoesNotSendAResponseIfResponseHasAlreadyStarted", testDoesNotSendAResponseIfResponseHasAlreadyStarted),
                 ("testCanHandleErrorsWhenResponseHasStarted", testCanHandleErrorsWhenResponseHasStarted),
+                ("testDoesSendAResponseIfInformationalHeaderWasSent", testDoesSendAResponseIfInformationalHeaderWasSent),
+                ("testDoesNotSendAResponseIfRealHeaderWasSentAfterInformationalHeader", testDoesNotSendAResponseIfRealHeaderWasSentAfterInformationalHeader),
            ]
    }
 }


### PR DESCRIPTION
To make testing in AHC easier we should support informational responses on the server side as well. This lands the changes already proposed in #1330 and and #1422.

### Motivation:

Server developers want to issue informational responses.

### Result:

Proper server support for informational responses.