### PR TITLE
remove/deprecate the file:line: parameters from flatMap and friends

### DIFF
--- a/Sources/NIOCore/EventLoop+Deprecated.swift
+++ b/Sources/NIOCore/EventLoop+Deprecated.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension EventLoop {
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func makeFailedFuture<T>(_ error: Error, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<T> {
+        return self.makeFailedFuture(error)
+    }
+
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func makeSucceededFuture<Success>(_ value: Success, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Success> {
+        return self.makeSucceededFuture(value)
+    }
+}

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -312,7 +312,7 @@ public protocol EventLoop: EventLoopGroup {
 extension EventLoop {
     /// Default implementation of `makeSucceededVoidFuture`: Return a fresh future (which will allocate).
     public func makeSucceededVoidFuture() -> EventLoopFuture<Void> {
-        return EventLoopFuture(eventLoop: self, value: (), file: "n/a", line: 0)
+        return EventLoopFuture(eventLoop: self, value: ())
     }
 
     public func _preconditionSafeToWait(file: StaticString, line: UInt) {
@@ -637,8 +637,8 @@ extension EventLoop {
     ///     - error: the `Error` that is used by the `EventLoopFuture`.
     /// - returns: a failed `EventLoopFuture`.
     @inlinable
-    public func makeFailedFuture<T>(_ error: Error, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<T> {
-        return EventLoopFuture<T>(eventLoop: self, error: error, file: file, line: line)
+    public func makeFailedFuture<T>(_ error: Error) -> EventLoopFuture<T> {
+        return EventLoopFuture<T>(eventLoop: self, error: error)
     }
 
     /// Creates and returns a new `EventLoopFuture` that is already marked as success. Notifications will be done using this `EventLoop` as execution `NIOThread`.
@@ -647,12 +647,12 @@ extension EventLoop {
     ///     - result: the value that is used by the `EventLoopFuture`.
     /// - returns: a succeeded `EventLoopFuture`.
     @inlinable
-    public func makeSucceededFuture<Success>(_ value: Success, file: StaticString = #file, line: UInt = #line) -> EventLoopFuture<Success> {
+    public func makeSucceededFuture<Success>(_ value: Success) -> EventLoopFuture<Success> {
         if Success.self == Void.self {
             // The as! will always succeed because we previously checked that Success.self == Void.self.
             return self.makeSucceededVoidFuture() as! EventLoopFuture<Success>
         } else {
-            return EventLoopFuture<Success>(eventLoop: self, value: value, file: file, line: line)
+            return EventLoopFuture<Success>(eventLoop: self, value: value)
         }
     }
 

--- a/Sources/NIOCore/EventLoopFuture+Deprecated.swift
+++ b/Sources/NIOCore/EventLoopFuture+Deprecated.swift
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension EventLoopFuture {
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Value) -> EventLoopFuture<NewValue>) -> EventLoopFuture<NewValue> {
+        return self.flatMap(callback)
+    }
+
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func flatMapThrowing<NewValue>(file: StaticString = #file,
+                                line: UInt = #line,
+                                _ callback: @escaping (Value) throws -> NewValue) -> EventLoopFuture<NewValue> {
+        return self.flatMapThrowing(callback)
+    }
+
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func flatMapErrorThrowing(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) throws -> Value) -> EventLoopFuture<Value> {
+        return self.flatMapErrorThrowing(callback)
+    }
+
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func map<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Value) -> (NewValue)) -> EventLoopFuture<NewValue> {
+        return self.map(callback)
+    }
+
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func flatMapError(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) -> EventLoopFuture<Value>) -> EventLoopFuture<Value> {
+        return self.flatMapError(callback)
+    }
+
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func flatMapResult<NewValue, SomeError: Error>(file: StaticString = #file,
+                                                          line: UInt = #line,
+                                                          _ body: @escaping (Value) -> Result<NewValue, SomeError>) -> EventLoopFuture<NewValue> {
+        return self.flatMapResult(body)
+    }
+
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func recover(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) -> Value) -> EventLoopFuture<Value> {
+        return self.recover(callback)
+    }
+
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func and<OtherValue>(_ other: EventLoopFuture<OtherValue>,
+                                file: StaticString = #file,
+                                line: UInt = #line) -> EventLoopFuture<(Value, OtherValue)> {
+        return self.and(other)
+    }
+
+    @inlinable
+    @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+    public func and<OtherValue>(value: OtherValue,
+                                file: StaticString = #file,
+                                line: UInt = #line) -> EventLoopFuture<(Value, OtherValue)> {
+        return self.and(value: value)
+    }
+}

--- a/Sources/NIOCrashTester/CrashTests+EventLoop.swift
+++ b/Sources/NIOCrashTester/CrashTests+EventLoop.swift
@@ -91,4 +91,17 @@ struct EventLoopCrashTests {
             f()
         }
     }
+
+    let testLeakingAPromiseCrashes = CrashTest(
+        regex: #"Fatal error: leaking promise created at"#
+    ) {
+        @inline(never)
+        func leaker() {
+            _ = group.next().makePromise(of: Void.self)
+        }
+        leaker()
+        for el in group.makeIterator() {
+            try! el.submit {}.wait()
+        }
+    }
 }

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -206,8 +206,7 @@ public final class EmbeddedEventLoop: EventLoop {
 
     public func _promiseCompleted(futureIdentifier: _NIOEventLoopFutureIdentifier) -> (file: StaticString, line: UInt)? {
         precondition(_isDebugAssertConfiguration())
-        // The force-unwrap is safe: we know that we must have tracked all the futures.
-        return self._promiseCreationStore.removeValue(forKey: futureIdentifier)!
+        return self._promiseCreationStore.removeValue(forKey: futureIdentifier)
     }
 
     public func _preconditionSafeToSyncShutdown(file: StaticString, line: UInt) {

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -118,7 +118,7 @@ internal final class SelectableEventLoop: EventLoop {
     internal func _promiseCompleted(futureIdentifier: _NIOEventLoopFutureIdentifier) -> (file: StaticString, line: UInt)? {
         precondition(_isDebugAssertConfiguration())
         return self.promiseCreationStoreLock.withLock {
-            self._promiseCreationStore.removeValue(forKey: futureIdentifier)!
+            self._promiseCreationStore.removeValue(forKey: futureIdentifier)
         }
     }
 

--- a/Tests/NIOPosixTests/EventLoopFutureTest.swift
+++ b/Tests/NIOPosixTests/EventLoopFutureTest.swift
@@ -25,13 +25,13 @@ enum EventLoopFutureTestError : Error {
 class EventLoopFutureTest : XCTestCase {
     func testFutureFulfilledIfHasResult() throws {
         let eventLoop = EmbeddedEventLoop()
-        let f = EventLoopFuture(eventLoop: eventLoop, value: 5, file: #file, line: #line)
+        let f = EventLoopFuture(eventLoop: eventLoop, value: 5)
         XCTAssertTrue(f.isFulfilled)
     }
 
     func testFutureFulfilledIfHasError() throws {
         let eventLoop = EmbeddedEventLoop()
-        let f = EventLoopFuture<Void>(eventLoop: eventLoop, error: EventLoopFutureTestError.example, file: #file, line: #line)
+        let f = EventLoopFuture<Void>(eventLoop: eventLoop, error: EventLoopFutureTestError.example)
         XCTAssertTrue(f.isFulfilled)
     }
 

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -1440,7 +1440,7 @@ fileprivate class EventLoopWithPreSucceededFuture: EventLoop {
     }
 
     init() {
-        self._succeededVoidFuture = EventLoopFuture(eventLoop: self, value: (), file: "n/a", line: 0)
+        self._succeededVoidFuture = EventLoopFuture(eventLoop: self, value: ())
     }
 
     func shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {


### PR DESCRIPTION
Motivation:

For NIO's 'promise leak detector' we added file:line: labels to
makePromise and there it makes sense. A user might create a promise and
then never fulfil it, bad. With the file:line: arguments we can give
good diagnostics.

However, we (probably that @weissi again) also added it to flatMap and
friends where it doesn't make sense at all.

Sure, EventLoopFuture's implementation may create a promise in the
implementation of flatMap but this promise is never leaked unless the
previous future is never fulfilled (or NIO has a terrible bug). Suffice
to say that in a future chain, it's never a flatMap etc which is
responsible for leaking the first promise...

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modifications:

Remove all unnecessary `file:line:` parameters whilst keeping the public
API intact.

Result:

- More sensible code.
- fixes #1997 