### PR TITLE
relax-precondition

### DIFF
--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -124,6 +124,11 @@ private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_m
 #endif
 
 private func isUnacceptableErrno(_ code: Int32) -> Bool {
+    // On iOS, EBADF is a possible result when a file descriptor has been reaped in the background.
+    // In particular, it's possible to get EBADF from accept(), where the underlying accept() FD
+    // is valid but the accepted one is not. The right solution here is to perform a check for
+    // SO_ISDEFUNCT when we see this happen, but we haven't yet invested the time to do that.
+    // In the meantime, we just tolerate EBADF on iOS.
     #if os(iOS)
     switch code {
     case EFAULT:

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -124,12 +124,21 @@ private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_m
 #endif
 
 private func isUnacceptableErrno(_ code: Int32) -> Bool {
+    #if os(iOS)
+    switch code {
+    case EFAULT:
+        return true
+    default:
+        return false
+    }
+    #else
     switch code {
     case EFAULT, EBADF:
         return true
     default:
         return false
     }
+    #endif
 }
 
 private func preconditionIsNotUnacceptableErrno(err: CInt, where function: String) -> Void {


### PR DESCRIPTION
Relax precondition for ```EBAF``` on iOS

### Motivation:
Under most circumstances, a syscall returning EBAF would be from a programming error.  However, on iOS the operating system can reclaim file descriptors when the app goes into background mode.  Due to the constraints of what systems calls can return for errors EBAF is reused to represent an FD being reclaimed by the OS. 


### Modifications:
Relax the unacceptable errors to not include EBAF on iOS

### Result:
Instead of crashing SwiftNIO will return an error in this case.
