### PR TITLE
provide EventLoopGroup.any() which is sticky to the current EventLoop

### DIFF
--- a/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
+++ b/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
@@ -63,11 +63,12 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
 
     private let myGroupID: Int
     private let index = NIOAtomic<Int>.makeAtomic(value: 0)
-    private let eventLoops: [SelectableEventLoop]
+    private var eventLoops: [SelectableEventLoop]
     private let shutdownLock: Lock = Lock()
     private var runState: RunState = .running
 
     private static func runTheLoop(thread: NIOThread,
+                                   parentGroup: MultiThreadedEventLoopGroup? /* nil iff thread take-over */,
                                    canEventLoopBeShutdownIndividually: Bool,
                                    selectorFactory: @escaping () throws -> NIOPosix.Selector<NIORegistration>,
                                    initializer: @escaping ThreadInitializer,
@@ -77,6 +78,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
 
         do {
             let loop = SelectableEventLoop(thread: thread,
+                                           parentGroup: parentGroup,
                                            selector: try selectorFactory(),
                                            canBeShutdownIndividually: canEventLoopBeShutdownIndividually)
             threadSpecificEventLoop.currentValue = loop
@@ -93,6 +95,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     }
 
     private static func setupThreadAndEventLoop(name: String,
+                                                parentGroup: MultiThreadedEventLoopGroup,
                                                 selectorFactory: @escaping () throws -> NIOPosix.Selector<NIORegistration>,
                                                 initializer: @escaping ThreadInitializer)  -> SelectableEventLoop {
         let lock = Lock()
@@ -105,6 +108,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
         loopUpAndRunningGroup.enter()
         NIOThread.spawnAndRun(name: name, detachThread: false) { t in
             MultiThreadedEventLoopGroup.runTheLoop(thread: t,
+                                                   parentGroup: parentGroup,
                                                    canEventLoopBeShutdownIndividually: false, // part of MTELG
                                                    selectorFactory: selectorFactory,
                                                    initializer: initializer) { l in
@@ -147,9 +151,11 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
         let myGroupID = nextEventLoopGroupID.add(1)
         self.myGroupID = myGroupID
         var idx = 0
+        self.eventLoops = [] // Just so we're fully initialised and can vend `self` to the `SelectableEventLoop`.
         self.eventLoops = threadInitializers.map { initializer in
             // Maximum name length on linux is 16 by default.
             let ev = MultiThreadedEventLoopGroup.setupThreadAndEventLoop(name: "NIO-ELT-\(myGroupID)-#\(idx)",
+                                                                         parentGroup: self,
                                                                          selectorFactory: selectorFactory,
                                                                          initializer: initializer)
             idx += 1
@@ -161,6 +167,10 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     ///
     /// - returns: The current `EventLoop` for the calling thread or `nil` if none is assigned to the thread.
     public static var currentEventLoop: EventLoop? {
+        return self.currentSelectableEventLoop
+    }
+
+    internal static var currentSelectableEventLoop: SelectableEventLoop? {
         return threadSpecificEventLoop.currentValue
     }
 
@@ -178,6 +188,22 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     /// - returns: The next `EventLoop` to use.
     public func next() -> EventLoop {
         return eventLoops[abs(index.add(1) % eventLoops.count)]
+    }
+
+    /// Returns the current `EventLoop` if we are on an `EventLoop` of this `MultiThreadedEventLoopGroup` instance.
+    ///
+    /// - returns: The `EventLoop`.
+    public func any() -> EventLoop {
+        if let loop = Self.currentSelectableEventLoop,
+           // We are on `loop`'s thread, so we may ask for the its parent group.
+           loop.parentGroupCallableFromThisEventLoopOnly() === self {
+            // Nice, we can return this.
+            loop.assertInEventLoop()
+            return loop
+        } else {
+            // Oh well, let's just vend the next one then.
+            return self.next()
+        }
     }
 
     /// Shut this `MultiThreadedEventLoopGroup` down which causes the `EventLoop`s and their associated threads to be
@@ -285,6 +311,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     public static func withCurrentThreadAsEventLoop(_ callback: @escaping (EventLoop) -> Void) {
         let callingThread = NIOThread.current
         MultiThreadedEventLoopGroup.runTheLoop(thread: callingThread,
+                                               parentGroup: nil,
                                                canEventLoopBeShutdownIndividually: true,
                                                selectorFactory: NIOPosix.Selector<NIORegistration>.init,
                                                initializer: { _ in }) { loop in

--- a/Tests/NIOPosixTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest+XCTest.swift
@@ -84,6 +84,9 @@ extension EventLoopTest {
                 ("testSelectableEventLoopHasPreSucceededFuturesOnlyOnTheEventLoop", testSelectableEventLoopHasPreSucceededFuturesOnlyOnTheEventLoop),
                 ("testMakeCompletedFuture", testMakeCompletedFuture),
                 ("testMakeCompletedVoidFuture", testMakeCompletedVoidFuture),
+                ("testEventLoopGroupsWithoutAnyImplementationAreValid", testEventLoopGroupsWithoutAnyImplementationAreValid),
+                ("testCallingAnyOnAnMTELGThatIsNotSelfDoesNotReturnItself", testCallingAnyOnAnMTELGThatIsNotSelfDoesNotReturnItself),
+                ("testMultiThreadedEventLoopGroupSupportsStickyAnyImplementation", testMultiThreadedEventLoopGroupSupportsStickyAnyImplementation),
            ]
    }
 }

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -1398,6 +1398,60 @@ public final class EventLoopTest : XCTestCase {
         XCTAssert(future1 === future2)
         XCTAssert(future2 === future3)
     }
+
+    func testEventLoopGroupsWithoutAnyImplementationAreValid() {
+        let group = EventLoopGroupOf3WithoutAnAnyImplementation()
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        let submitDone = group.any().submit {
+            let el1 = group.any()
+            let el2 = group.any()
+            XCTAssert(el1 !== el2) // our group doesn't support `any()` and will fall back to `next()`.
+        }
+        group.makeIterator().forEach { el in
+            (el as! EmbeddedEventLoop).run()
+        }
+        XCTAssertNoThrow(try submitDone.wait())
+    }
+
+    func testCallingAnyOnAnMTELGThatIsNotSelfDoesNotReturnItself() {
+        let group1 = MultiThreadedEventLoopGroup(numberOfThreads: 3)
+        let group2 = MultiThreadedEventLoopGroup(numberOfThreads: 3)
+        defer {
+            XCTAssertNoThrow(try group2.syncShutdownGracefully())
+            XCTAssertNoThrow(try group1.syncShutdownGracefully())
+        }
+
+        XCTAssertNoThrow(try group1.any().submit {
+            let el1_1 = group1.any()
+            let el1_2 = group1.any()
+            let el2_1 = group2.any()
+            let el2_2 = group2.any()
+
+            XCTAssert(el1_1 === el1_2) // MTELG _does_ supprt `any()` so all these `EventLoop`s should be the same.
+            XCTAssert(el2_1 !== el2_2) // MTELG _does_ supprt `any()` but this `any()` call went across `group`s.
+            XCTAssert(el1_1 !== el2_1) // different groups...
+            XCTAssert(el1_1 !== el2_2) // different groups...
+
+            XCTAssert(el1_1 === MultiThreadedEventLoopGroup.currentEventLoop!)
+        }.wait())
+    }
+
+    func testMultiThreadedEventLoopGroupSupportsStickyAnyImplementation() {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 3)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        XCTAssertNoThrow(try group.any().submit {
+            let el1 = group.any()
+            let el2 = group.any()
+            XCTAssert(el1 === el2) // MTELG _does_ supprt `any()` so all these `EventLoop`s should be the same.
+            XCTAssert(el1 === MultiThreadedEventLoopGroup.currentEventLoop!)
+        }.wait())
+    }
 }
 
 fileprivate class EventLoopWithPreSucceededFuture: EventLoop {
@@ -1486,5 +1540,35 @@ fileprivate class EventLoopWithoutPreSucceededFuture: EventLoop {
         queue.async {
             callback(nil)
         }
+    }
+}
+
+final class EventLoopGroupOf3WithoutAnAnyImplementation: EventLoopGroup {
+    private let eventloops = [EmbeddedEventLoop(), EmbeddedEventLoop(), EmbeddedEventLoop()]
+    private let nextID = NIOAtomic<UInt64>.makeAtomic(value: 0)
+
+    func next() -> EventLoop {
+        return self.eventloops[Int(self.nextID.add(1) % UInt64(self.eventloops.count))]
+    }
+
+    func shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {
+        let g = DispatchGroup()
+
+
+        self.eventloops.forEach { el in
+            g.enter()
+            el.shutdownGracefully(queue: queue) { error in
+                XCTAssertNil(error)
+                g.leave()
+            }
+        }
+
+        g.notify(queue: queue) {
+            callback(nil)
+        }
+    }
+
+    func makeIterator() -> EventLoopIterator {
+        return .init(self.eventloops)
     }
 }


### PR DESCRIPTION
Motivation:

A lot of libraries that use SwiftNIO don't allow/require the user to
specify what `EventLoop`s a certain function runs on. Something like

```
myHTTPClient.get("https://example.com) -> EventLoopFuture<...>
```

Internally `MyHTTPClient` has not much choice but using the
`EventLoopGroup.next()` method to obtain an `EventLoop` on which to
create the `EventLoopFuture` (that is returned).

This all works fine but unfortunately it usually forces a thread switch
which is most of the time avoidable if we're already running on an
`EventLoop`.

Modifications:

Provide an `EventLoopGroup.any()` method which can be used like so:

```swift
func get(_ url: String) -> EventLoopFuture<Response> {
    let promise = self.group.any().makePromise(of: Response.self)

    [...]

    return promise.futureResult
}
```

`EventLoopGroup.any()` very much works like `EventLoopGroup.next()`
except that it tries -- if possible -- to return the _current_
`EventLoop`.

Note that this means that `any()` is _not_ the right solution if you
want to load balance. Likely, everything will now stay on the same
`EventLoop`.

Result:

Fewer thread switches.