### PR TITLE
Convert `ScheduledTask` to a struct to reduce allocations for scheduling

### DIFF
--- a/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
+++ b/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
@@ -338,14 +338,17 @@ extension MultiThreadedEventLoopGroup: CustomStringConvertible {
 }
 
 @usableFromInline
-internal final class ScheduledTask {
+internal struct ScheduledTask {
+    @usableFromInline
+    let id: UInt64
     let task: () -> Void
     private let failFn: (Error) ->()
     @usableFromInline
     internal let _readyTime: NIODeadline
 
     @usableFromInline
-    init(_ task: @escaping () -> Void, _ failFn: @escaping (Error) -> Void, _ time: NIODeadline) {
+    init(id: UInt64, _ task: @escaping () -> Void, _ failFn: @escaping (Error) -> Void, _ time: NIODeadline) {
+        self.id = id
         self.task = task
         self.failFn = failFn
         self._readyTime = time
@@ -378,6 +381,6 @@ extension ScheduledTask: Comparable {
 
     @usableFromInline
     static func == (lhs: ScheduledTask, rhs: ScheduledTask) -> Bool {
-        return lhs === rhs
+        return lhs.id == rhs.id
     }
 }

--- a/Sources/_NIODataStructures/Heap.swift
+++ b/Sources/_NIODataStructures/Heap.swift
@@ -20,7 +20,7 @@ import Glibc
 @usableFromInline
 internal struct Heap<Element: Comparable> {
     @usableFromInline
-    internal private(set) var storage: ContiguousArray<Element>
+    internal private(set) var storage: Array<Element>
 
     @inlinable
     internal init() {
@@ -114,6 +114,19 @@ internal struct Heap<Element: Comparable> {
         } else {
             return false
         }
+    }
+    
+    @inlinable
+    internal mutating func removeFirst(where shouldBeRemoved: (Element) throws -> Bool) rethrows {
+        guard self.storage.count > 0 else {
+            return
+        }
+
+        guard let index = try self.storage.firstIndex(where: shouldBeRemoved) else {
+            return
+        }
+        
+        self._remove(index: index)
     }
 
     @discardableResult

--- a/Sources/_NIODataStructures/PriorityQueue.swift
+++ b/Sources/_NIODataStructures/PriorityQueue.swift
@@ -25,6 +25,11 @@ public struct PriorityQueue<Element: Comparable> {
     public mutating func remove(_ key: Element) {
         self._heap.remove(value: key)
     }
+    
+    @inlinable
+    public mutating func removeFirst(where shouldBeRemoved: (Element) throws -> Bool) rethrows {
+        try self._heap.removeFirst(where: shouldBeRemoved)
+    }
 
     @inlinable
     public mutating func push(_ key: Element) {

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -18,22 +18,22 @@ services:
   test:
     image: swift-nio:16.04-5.3
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=170050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=163050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=95050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=450050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=89500
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=428000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -50,12 +50,12 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=100050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=188050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -18,22 +18,22 @@ services:
   test:
     image: swift-nio:18.04-5.2
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=32050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=28050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=171050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=164050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=96050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=455000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=90500
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=433000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -50,12 +50,12 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=200050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=100050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=188050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050
       # - SANITIZER_ARG=--sanitize=thread broken on 18.04
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]
 

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -18,22 +18,22 @@ services:
   test:
     image: swift-nio:20.04-5.4
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=172050 # regression from 5.3 which was 170050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=165050 # regression from 5.3 which was 163050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=96050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=453050 # regression from 5.3 which was 450050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=90500
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=431000 # regression from 5.3 which was 428000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -50,12 +50,12 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=100050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=190050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=179050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -18,22 +18,22 @@ services:
   test:
     image: swift-nio:20.04-5.5
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=29050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=172050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=165050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=96050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=453000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=90500
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=431000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -41,6 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
+      - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
@@ -49,12 +50,12 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=100050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=190050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=179050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -18,22 +18,22 @@ services:
   test:
     image: swift-nio:20.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=28050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=24050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=168050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=161050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=93050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=450050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=87050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=428050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -50,12 +50,12 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=160050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=90150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=100050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=20150
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=150050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=188050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:


### PR DESCRIPTION
### Motivation:

In my previous PR https://github.com/apple/swift-nio/pull/2009, I added baseline performance and allocation tests around `scheduleTask` and `execute`. After analysing, the various allocations that happen when scheduling a task there were only a few that could be optimized away potentially.

### Modifications:

This PR converts the `ScheduledTask` class to a struct which will reduce the number of allocations for scheduling tasks by 1. The only thing that needs to be worked around when converting to a struct is giving it an identity so that we can implement `Equatable` conformance properly. I explored two options. First, using an `ObjectIdentifier` passed to the init. Second, using an atomic counter per EventLoop. I went with the latter since the former requires an additional allocation in the case of calling `execute`

### Result:

`scheduleTask` and `execute` require one less allocation