### PR TITLE
Call the `cancellationTask` of `Scheduled` directly

### DIFF
--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -18,8 +18,8 @@ services:
   test:
     image: swift-nio:16.04-5.3
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=45050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
@@ -27,13 +27,13 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=162050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=163050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=89500
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=428000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=427000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -51,8 +51,8 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -18,22 +18,22 @@ services:
   test:
     image: swift-nio:18.04-5.2
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=45050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=28050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=163050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=164050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=90500
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=433000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=432000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -50,11 +50,11 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050
       # - SANITIZER_ARG=--sanitize=thread broken on 18.04
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -18,22 +18,22 @@ services:
   test:
     image: swift-nio:20.04-5.4
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=45050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=164050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=165050 # regression from 5.3 which was 163050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=90500
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=431000 # regression from 5.3 which was 428000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=430000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -50,11 +50,11 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=179050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -18,22 +18,22 @@ services:
   test:
     image: swift-nio:20.04-5.5
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=45050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=165050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=164050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=90500
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=431000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=430050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -52,8 +52,8 @@ services:
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=179050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -18,22 +18,22 @@ services:
   test:
     image: swift-nio:20.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=46050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=45050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=24050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=161050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=160050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=87050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=428050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=427050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -51,8 +51,8 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=150050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=80150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=90050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050


### PR DESCRIPTION
### Motivation:

In my previous PR https://github.com/apple/swift-nio/pull/2010, I was able to decrease the allocations for both `scheduleTask` and `execute` by 1 already. Gladly, there are no more allocations left to remove from `execute` now; however, `scheduleTask` still provides a couple of allocations that we can try to get rid of.

### Modifications:

This PR removes two allocations inside `Scheduled` where we were using the passed in `EventLoopPromise` to call the `cancellationTask` once the `EventLoopFuture` of the promise fails. This requires two allocations inside `whenFailure` and inside `_whenComplete`. However, since we are passing the `cancellationTask` to `Scheduled` anyhow and `Scheduled` is also the one that is failing the promise from the `cancel()` method. We can just go ahead and store the `cancellationTask` inside `Scheduled` and call it from the `cancel()` method directly instead of going through the future.

Importantly, here is that the `cancellationTask` is not allowed to retain the `ScheduledTask.task` otherwise we would change the semantics and retain the `ScheduledTask.task` longer than necessary. My previous PR https://github.com/apple/swift-nio/pull/2010, already implemented the work to get rid of the retain from the `cancellationTask` closure. So we are good to go ahead and store the `cancellationTask` inside `Scheduled` now

### Result:

`scheduleTask` requires two fewer allocations
