### PR TITLE
Lock: use PTHREAD_MUTEX_ADAPTIVE_NP

### DIFF
--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -43,6 +43,9 @@ public final class Lock {
 #else
         var attr = pthread_mutexattr_t()
         pthread_mutexattr_init(&attr)
+#if os(Linux)
+        pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ADAPTIVE_NP))
+#endif
         debugOnly {
             pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
         }


### PR DESCRIPTION
Motivation:

For consistent, short critical sections, [`PTHREAD_MUTEX_ADAPTIVE_NP`](https://stackoverflow.com/questions/19863734/what-is-pthread-mutex-adaptive-np) might be beneficial (under contention).

Modification:

Use `PTHREAD_MUTEX_ADAPTIVE_NP` on Linux.

Result:

Could be a perf advantage (let's see the benchmarks).