### PR TITLE
Add canImport(_Concurrency) for Xcode 13.0

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport+OldXcodes.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport+OldXcodes.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && !compiler(>=5.5.2)
+#if compiler(>=5.5) && !compiler(>=5.5.2) && canImport(_Concurrency) 
 
 extension EventLoopFuture {
     /// Get the value/error from an `EventLoopFuture` in an `async` context.


### PR DESCRIPTION
Xcode 13.0 lacked concurrency support for macOS. We need to make sure we only use _Concurrency features, if the platform supports them.

### Modifications:

- Add `canImport(_Concurrency)` for Xcode 13.0 in `AsyncAwaitSupport+OldXcodes.swift`

### Result:

Users can compile for macOS with Xcode 13.0.
