### PR TITLE
Guarantee ordering of `scheduleTask` with same deadline

### DIFF
--- a/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
+++ b/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
@@ -339,6 +339,11 @@ extension MultiThreadedEventLoopGroup: CustomStringConvertible {
 
 @usableFromInline
 internal struct ScheduledTask {
+    /// The id of the scheduled task.
+    ///
+    /// - Important: This id has two purposes. First, it is used to give this struct an identity so that we can implement ``Equatable``
+    ///     Second, it is used to give the tasks an order which we use to execute them.
+    ///     This means, the ids need to be unique for a given ``SelectableEventLoop`` and they need to be in ascending order.
     @usableFromInline
     let id: UInt64
     let task: () -> Void
@@ -376,7 +381,11 @@ extension ScheduledTask: CustomStringConvertible {
 extension ScheduledTask: Comparable {
     @usableFromInline
     static func < (lhs: ScheduledTask, rhs: ScheduledTask) -> Bool {
-        return lhs._readyTime < rhs._readyTime
+        if lhs._readyTime == rhs._readyTime {
+            return lhs.id < rhs.id
+        } else {
+            return lhs._readyTime < rhs._readyTime
+        }
     }
 
     @usableFromInline

--- a/Tests/NIOPosixTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest+XCTest.swift
@@ -34,6 +34,7 @@ extension EventLoopTest {
                 ("testFlatScheduleCancelled", testFlatScheduleCancelled),
                 ("testScheduleRepeatedTask", testScheduleRepeatedTask),
                 ("testScheduledTaskThatIsImmediatelyCancelledNeverFires", testScheduledTaskThatIsImmediatelyCancelledNeverFires),
+                ("testScheduledTasksAreOrdered", testScheduledTasksAreOrdered),
                 ("testFlatScheduledTaskThatIsImmediatelyCancelledNeverFires", testFlatScheduledTaskThatIsImmediatelyCancelledNeverFires),
                 ("testRepeatedTaskThatIsImmediatelyCancelledNeverFires", testRepeatedTaskThatIsImmediatelyCancelledNeverFires),
                 ("testScheduleRepeatedTaskCancelFromDifferentThread", testScheduleRepeatedTaskCancelFromDifferentThread),


### PR DESCRIPTION
### Motivation:

When scheduling tasks with the same deadline the current order of execution is undefined. Fixes https://github.com/apple/swift-nio/issues/1541

### Modifications:

In my previous PR https://github.com/apple/swift-nio/pull/2010, I added an internal id to every `ScheduledTask` to give them an identity for cancellation purposes. In this PR, I am now using the same id to also ensure that the execution of tasks with the same deadline is the same as the order they were scheduled in.

### Result:

`ScheduledTask`s are now executed in their scheduled order when they have the same deadline.