### PR TITLE
Get Android constants used by Channel from Bionic instead

### DIFF
--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -67,16 +67,16 @@ private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutable
 private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> CInt = inet_pton
 #endif
 
-// Work around SO_TIMESTAMP/SO_RCVTIMEO being awkwardly defined in glibc.
 #if os(Android)
-let IFF_BROADCAST: CUnsignedInt = numericCast(CNIOLinux.IFF_BROADCAST.rawValue)
-let IFF_POINTOPOINT: CUnsignedInt = numericCast(CNIOLinux.IFF_POINTOPOINT.rawValue)
-let IFF_MULTICAST: CUnsignedInt = numericCast(CNIOLinux.IFF_MULTICAST.rawValue)
+let IFF_BROADCAST: CUnsignedInt = numericCast(SwiftGlibc.IFF_BROADCAST.rawValue)
+let IFF_POINTOPOINT: CUnsignedInt = numericCast(SwiftGlibc.IFF_POINTOPOINT.rawValue)
+let IFF_MULTICAST: CUnsignedInt = numericCast(SwiftGlibc.IFF_MULTICAST.rawValue)
 #if arch(arm)
 let SO_RCVTIMEO = SO_RCVTIMEO_OLD
 let SO_TIMESTAMP = SO_TIMESTAMP_OLD
 #endif
 #elseif os(Linux)
+// Work around SO_TIMESTAMP/SO_RCVTIMEO being awkwardly defined in glibc.
 let SO_TIMESTAMP = CNIOLinux_SO_TIMESTAMP
 let SO_RCVTIMEO = CNIOLinux_SO_RCVTIMEO
 #endif

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -36,9 +36,9 @@ let badOS = { fatalError("unsupported OS") }()
 
 #if os(Android)
 let INADDR_ANY = UInt32(0) // #define INADDR_ANY ((unsigned long int) 0x00000000)
-let IFF_BROADCAST: CUnsignedInt = numericCast(CNIOLinux.IFF_BROADCAST.rawValue)
-let IFF_POINTOPOINT: CUnsignedInt = numericCast(CNIOLinux.IFF_POINTOPOINT.rawValue)
-let IFF_MULTICAST: CUnsignedInt = numericCast(CNIOLinux.IFF_MULTICAST.rawValue)
+let IFF_BROADCAST: CUnsignedInt = numericCast(SwiftGlibc.IFF_BROADCAST.rawValue)
+let IFF_POINTOPOINT: CUnsignedInt = numericCast(SwiftGlibc.IFF_POINTOPOINT.rawValue)
+let IFF_MULTICAST: CUnsignedInt = numericCast(SwiftGlibc.IFF_MULTICAST.rawValue)
 internal typealias in_port_t = UInt16
 extension ipv6_mreq { // http://lkml.iu.edu/hypermail/linux/kernel/0106.1/0080.html
     init (ipv6mr_multiaddr: in6_addr, ipv6mr_interface: UInt32) {


### PR DESCRIPTION
### Motivation:

An upcoming pull, apple/swift#35707, moves Android to the same single-header modulemap for Bionic as used on linux, but that doesn't work unless this is changed. This approach works both with the current release toolchain and with that new modulemap.

### Modifications:

Change how these Bionic constants are imported.

### Result:

This repo compiles for Android and the tests pass with both modulemap approaches.

I've been using [an earlier version of this pull to cross-compile this repo on my Android CI](https://github.com/buttaface/swift-android-sdk/blob/main/package-patches/swift-nio-trunk.patch), where [I apply that modulemap pull to the trunk SDK](https://github.com/buttaface/swift-android-sdk/commit/e174127eb23e069c38373f545c52bab8c8615b87#diff-76992bc322b65ab94f299c05ba3cbd8b3ab2e32ebfdde6db5adba70fa9f5a26aR118). Without it, I get the following error with the new modulemap, because of [this definition](https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/kernel/uapi/linux/if.h#33):
```
swift-nio/Sources/NIOCore/Interfaces.swift:102:31: error: initializer 'init(_:)' requires that 'net_device_flags' conform to 'BinaryInteger'
```

That Bionic pull should be merged into trunk soon, once Daniel, who maintains the community Android CI, approves it. In the meantime, this pull gets this repo working with both approaches.