### PR TITLE
Add 5.6 nightly CI

### DIFF
--- a/Tests/NIOPosixTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2018-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2018-2022 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -1,0 +1,71 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio:20.04-5.6
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-5.6-focal"
+        ubuntu_version: "focal"
+
+  unit-tests:
+    image: swift-nio:20.04-5.6
+
+  integration-tests:
+    image: swift-nio:20.04-5.6
+
+  test:
+    image: swift-nio:20.04-5.6
+    environment:
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=45050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=24050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
+      - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=160050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
+      - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=87050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=427050
+      - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
+      - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
+      - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer=3
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
+      - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
+      - MAX_ALLOCS_ALLOWED_future_erase_result=4050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=59050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
+      - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
+      - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=150050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050
+      # - SANITIZER_ARG=--sanitize=thread # TSan broken still
+
+  performance-test:
+    image: swift-nio:20.04-5.6
+
+  shell:
+    image: swift-nio:20.04-5.6
+
+  echo:
+    image: swift-nio:20.04-5.6
+
+  http:
+    image: swift-nio:20.04-5.6


### PR DESCRIPTION
The 5.6 nightly images are available, let's use them.

@tomerd can you enable a 5.6 CI job here?