### PR TITLE
Add benchmarks for copying BBV to Array.

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_copying_bytebufferview_to_array.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_copying_bytebufferview_to_array.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOCore
+
+func run(identifier: String) {
+    let data = ByteBuffer(repeating: 0xfe, count: 1024).readableBytesView
+
+    measure(identifier: identifier) {
+        var count = 0
+
+        for _ in 0..<1_000 {
+            let copy = Array(data)
+            count &+= copy.count
+        }
+
+        return count
+    }
+}

--- a/Sources/NIOPerformanceTester/ByteBufferViewCopyToArrayBenchmark.swift
+++ b/Sources/NIOPerformanceTester/ByteBufferViewCopyToArrayBenchmark.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+final class ByteBufferViewCopyToArrayBenchmark: Benchmark {
+    private let iterations: Int
+    private let size: Int
+    private var view: ByteBufferView
+
+    init(iterations: Int, size: Int) {
+        self.iterations = iterations
+        self.size = size
+        self.view = ByteBufferView()
+    }
+
+    func setUp() throws {
+        self.view = ByteBuffer(repeating: 0xfe, count: self.size).readableBytesView
+    }
+
+    func tearDown() {
+    }
+
+    func run() -> Int {
+        var count = 0
+        for _ in 0..<self.iterations {
+            let array = Array(self.view)
+            count &+= array.count
+        }
+
+        return count
+    }
+}

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -841,3 +841,6 @@ try measureAndPrint(desc: "schedule_and_run_10000_tasks",
 
 try measureAndPrint(desc: "execute_10000",
                     benchmark: ExecuteBenchmark())
+
+try measureAndPrint(desc: "bytebufferview_copy_to_array_1000_times_1kb",
+                    benchmark: ByteBufferViewCopyToArrayBenchmark(iterations: 1000, size: 1024))


### PR DESCRIPTION
Motivation:

Protocols like Sequence have "private" hooks that can be implemented to
provide fast-paths for some operations. We missed a few on BBV, and I'd
like to add them. This is one use-case where they can help.

Modifications:

- Add an allocation-counter benchmark and a runtime benchmark for
  copying BBV to Array.

Result:

We have some benchmarks.
