### PR TITLE
Fix the double encoding issue in encodeAsByteBuffer

### DIFF
--- a/Sources/NIOFoundationCompat/Codable+ByteBuffer.swift
+++ b/Sources/NIOFoundationCompat/Codable+ByteBuffer.swift
@@ -133,7 +133,7 @@ extension JSONEncoder {
     public func encodeAsByteBuffer<T: Encodable>(_ value: T, allocator: ByteBufferAllocator) throws -> ByteBuffer {
         let data = try self.encode(value)
         var buffer = allocator.buffer(capacity: data.count)
-        try buffer.writeJSONEncodable(value, encoder: self)
+        buffer.writeBytes(data)
         return buffer
     }
 }


### PR DESCRIPTION
Fixes the double encoding issue with writing the bytes directly into the byte buffer in `encodeAsByteBuffer`.

### Motivation:
`encodeAsByteBuffer` encodes a value into bytes and then, during the `buffer.writeJSONEncodable(_, encoder:)` call, encodes the value into bytes again.

### Modifications:
The call to `buffer.writeJSONEncodable(_, encoder:)` is replaced with writing the bytes directly into the byte buffer.

### Result:
No more double encoding the value into bytes.
