### PR TITLE
[SelectableEventLoop] SR-15872; Save allocations when appending task

### DIFF
--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -22,7 +22,7 @@ url_prefix=${1-"https://ci.swiftserver.group/job/swift-nio2-swift"}
 target_repo=${2-"$here/.."}
 tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
 
-for f in 52 53 54 55 -nightly; do
+for f in 52 53 54 55 56 -nightly; do
     echo "swift$f"
     url="$url_prefix$f-prb/lastCompletedBuild/consoleFull"
     echo "$url"

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -23,18 +23,18 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=21050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=162050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=156050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=89500
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=427000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -51,13 +51,13 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4350
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=170050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=98
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050
       - SANITIZER_ARG=--sanitize=thread
 
   performance-test:

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -31,9 +31,9 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=156050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12000
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=82900
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
@@ -42,7 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -31,10 +31,10 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=156050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12000
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=82900
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -33,7 +33,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83850
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=84000
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=411000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -23,18 +23,18 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=28050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=24050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=163050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=90500
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=432000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83950
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=411000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -52,12 +52,12 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=190050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050
       # - SANITIZER_ARG=--sanitize=thread broken on 18.04
       - INTEGRATION_TESTS_ARG=-f tests_0[013-9]
 

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -33,7 +33,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83950
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83850
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=411000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
@@ -42,7 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -23,18 +23,18 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=21050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=164050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=158050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12000
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=90500
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=430000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83800
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -52,12 +52,12 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=179050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=170050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=98
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=168050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -33,7 +33,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=158050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83950
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=84050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
@@ -56,7 +56,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=98
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=168050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -31,10 +31,10 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=158050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12000
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83800
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=83950
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -42,7 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -34,7 +34,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=84000
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -42,7 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
@@ -56,7 +56,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=98
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=168050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -23,18 +23,18 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=21050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=164050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=158050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=90500
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=430050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=84000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -52,12 +52,12 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=180050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=179050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=170050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=98
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=168050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -33,7 +33,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=158050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=84000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=84050
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -23,18 +23,18 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=24050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=20050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=160050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=87050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=427050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -42,7 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=59050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
@@ -51,13 +51,13 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=150050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4350
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=140050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -23,18 +23,18 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=24050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=20050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
+      - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=160050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=87050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=427050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -51,13 +51,13 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=150050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60150
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=70050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=10150
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4350
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=140050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=177050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   performance-test:

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -33,8 +33,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=80950
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -56,7 +56,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -33,8 +33,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=80950
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -42,7 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
-      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=59050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
@@ -56,7 +56,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -14,3 +14,4 @@ or cases where the Swift compiler was unable to sufficiently optimize the code:
 - https://github.com/apple/swift-nio/pull/1814
 - https://github.com/apple/swift-nio/pull/1956
 - https://github.com/apple/swift-nio/pull/1961
+- https://github.com/apple/swift-nio/pull/2046


### PR DESCRIPTION
We should probably wait for #2047, before we merge this one.

### Motivation

- Workaround for [SR-15872](https://bugs.swift.org/browse/SR-15872). We don't want to occur an allocate for every task that shall be allocated.

### Changes

- Use `[ScheduledTask]` instead of `[() -> Void]`

### Result

- Fewer allocations = faster code

### Alternatives

We could create a struct that really only wraps the closure.