### PR TITLE
Add an allocation test for execute which needs to hop threads.

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_execute_hop_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_execute_hop_10000_tasks.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import NIOPosix
+
+func run(identifier: String) {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let loop = group.next()
+    let dg = DispatchGroup()
+
+    measure(identifier: identifier) {
+        for _ in 0..<10000 {
+            dg.enter()
+            loop.execute { dg.leave() }
+        }
+        dg.wait()
+        return 10_000
+    }
+
+    try! group.syncShutdownGracefully()
+}

--- a/docker/docker-compose.1604.53.yaml
+++ b/docker/docker-compose.1604.53.yaml
@@ -25,6 +25,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
+      - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
@@ -41,6 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -25,6 +25,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=28050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
+      - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
@@ -41,6 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -25,6 +25,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
+      - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
@@ -41,6 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -25,6 +25,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=25050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
+      - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
@@ -41,6 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=60050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -25,6 +25,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=24050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
+      - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
@@ -41,6 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=59050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -25,6 +25,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=24050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
+      - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30450
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
@@ -41,6 +42,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_holding_buffer_with_space=3
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer=3050
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space=3050
+      - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=10000
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
       - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=59050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050


### PR DESCRIPTION
We have a bunch of allocation tests around scheduling tasks. However we have calls execute on an `EventLoop` that we are not executing on.

### Motivation:

- Know how expensive a call to `execute` is, if we are of the `EventLoop`.

### Modifications:

- Add an allocation test for execute which needs to hop threads.

### Result:

The more allocation knowledge, the better to optimize.