### PR TITLE
atomics: make add/sub @discardableResult

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_read_10000_chunks_from_file.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_read_10000_chunks_from_file.swift
@@ -56,7 +56,7 @@ func run(identifier: String) {
                                 chunkSize: 1,
                                 allocator: allocator,
                                 eventLoop: loop) { buffer in
-                _ = numberOfBytes.add(buffer.readableBytes)
+                numberOfBytes.add(buffer.readableBytes)
                 return loop.makeSucceededFuture(())
         }.wait()
         precondition(numberOfBytes.load() == numberOfChunks, "\(numberOfBytes.load()), \(numberOfChunks)")

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -89,6 +89,7 @@ public struct UnsafeEmbeddedAtomic<T: AtomicPrimitive> {
     ///
     /// - Parameter rhs: The value to add to this object.
     /// - Returns: The previous value of this object, before the addition occurred.
+    @discardableResult
     @inlinable
     public func add(_ rhs: T) -> T {
         return T.atomic_add(self.value, rhs)
@@ -102,6 +103,7 @@ public struct UnsafeEmbeddedAtomic<T: AtomicPrimitive> {
     ///
     /// - Parameter rhs: The value to subtract from this object.
     /// - Returns: The previous value of this object, before the subtraction occurred.
+    @discardableResult
     @inlinable
     public func sub(_ rhs: T) -> T {
         return T.atomic_sub(self.value, rhs)
@@ -210,6 +212,7 @@ public final class Atomic<T: AtomicPrimitive> {
     ///
     /// - Parameter rhs: The value to add to this object.
     /// - Returns: The previous value of this object, before the addition occurred.
+    @discardableResult
     @inlinable
     public func add(_ rhs: T) -> T {
         return self.embedded.add(rhs)
@@ -223,6 +226,7 @@ public final class Atomic<T: AtomicPrimitive> {
     ///
     /// - Parameter rhs: The value to subtract from this object.
     /// - Returns: The previous value of this object, before the subtraction occurred.
+    @discardableResult
     @inlinable
     public func sub(_ rhs: T) -> T {
         return self.embedded.sub(rhs)

--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
@@ -41,7 +41,7 @@ class NIOConcurrencyHelpersTests: XCTestCase {
                 everybodyHere.signal()
                 go.wait()
                 for _ in 0..<noCounts {
-                    _ = ai.add(thread)
+                    ai.add(thread)
                 }
             }
         }
@@ -253,7 +253,7 @@ class NIOConcurrencyHelpersTests: XCTestCase {
                 everybodyHere.signal()
                 go.wait()
                 for _ in 0..<noCounts {
-                    _ = ai.add(thread)
+                    ai.add(thread)
                 }
             }
         }
@@ -1050,6 +1050,6 @@ fileprivate class IntHolderWithDeallocationTracking {
 
     deinit {
         self.value = -1
-        _ = self.allDeallocations.add(1)
+        self.allDeallocations.add(1)
     }
 }

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -152,7 +152,7 @@ public final class EventLoopTest : XCTestCase {
         loop.scheduleRepeatedTask(initialDelay: initialDelay, delay: delay) { repeatedTask -> Void in
             XCTAssertTrue(loop.inEventLoop)
             let initialValue = counter.load()
-            _ = counter.add(1)
+            counter.add(1)
             if initialValue == 0 {
                 XCTAssertTrue(NIODeadline.now() - nanos >= initialDelay)
             } else if initialValue == count {

--- a/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
@@ -869,7 +869,7 @@ class NonBlockingFileIOTest: XCTestCase {
                                                          chunkSize: 1,
                                                          allocator: self.allocator,
                                                          eventLoop: self.eventLoop) { buffer in
-                _ = numberOfCalls.add(1)
+                numberOfCalls.add(1)
                 XCTAssertEqual(1, buffer.readableBytes)
                 XCTAssertEqual(UInt8(ascii: "X"), buffer.readableBytesView.first)
                 return self.eventLoop.makeSucceededFuture(())

--- a/Tests/NIOPosixTests/SelectorTest.swift
+++ b/Tests/NIOPosixTests/SelectorTest.swift
@@ -401,7 +401,7 @@ class SelectorTest: XCTestCase {
                                                            socket: socketFDs[0]), eventLoop: el)
         let sched = el.scheduleRepeatedTask(initialDelay: .microseconds(delayToUseInMicroSeconds),
                                             delay: .microseconds(delayToUseInMicroSeconds)) { (_: RepeatedTask) in
-            _ = numberFires.add(1)
+            numberFires.add(1)
         }
         XCTAssertNoThrow(try el.submit {
             // EL tick 1: this is used to

--- a/Tests/NIOPosixTests/SocketChannelTest.swift
+++ b/Tests/NIOPosixTests/SocketChannelTest.swift
@@ -54,12 +54,12 @@ public final class SocketChannelTest : XCTestCase {
         // event loops.
         let condition = NIOAtomic<Int>.makeAtomic(value: 0)
         let futureA = channelA.eventLoop.submit {
-            _ = condition.add(1)
+            condition.add(1)
             while condition.load() < 2 { }
             _ = channelB.setOption(ChannelOptions.backlog, value: 1)
         }
         let futureB = channelB.eventLoop.submit {
-            _ = condition.add(1)
+            condition.add(1)
             while condition.load() < 2 { }
             _ = channelA.setOption(ChannelOptions.backlog, value: 1)
         }

--- a/Tests/NIOPosixTests/StreamChannelsTest.swift
+++ b/Tests/NIOPosixTests/StreamChannelsTest.swift
@@ -352,7 +352,7 @@ class StreamChannelTest: XCTestCase {
                     // reliably trigger it for TCP sockets.
                     let myBuffer = allBuffer.readSlice(length: sends.load() == 0 ? receiveBufferSize : 1)!
                     sender.writeAndFlush(myBuffer).map {
-                        _ = sends.add(1)
+                        sends.add(1)
                         sender.eventLoop.scheduleTask(in: .microseconds(1)) {
                             send()
                         }


### PR DESCRIPTION
### Motivation:

It's annoying to have to write

```
_ = atomic.add(1)
_ = atomic.sub(1)
```

and for add/sub it's totally legit to ignore the result (in fact, it's the most common usage).

### Modifications:

- mark add/sub `@discardableResult`
- remove unnecessary `_ = `

### Result:

Nicer code in NIO and clients.