### PR TITLE
Provide IPAddress wrapper type

### DIFF
--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -72,7 +72,16 @@ public enum IPAddress: CustomStringConvertible {
             addressString = "\(addr.address)"
             type = "IPv4"
         case .v6(let addr):
-            let hexRepresentation = Mirror(reflecting: addr.address).children.map {String(format: "%02X", $0.value as! UInt8)}
+            let hexRepresentation: [UInt16] = [
+                addr.address.0 | addr.address.1 << 8,
+                addr.address.2 | addr.address.3 << 8,
+                addr.address.4 | addr.address.5 << 8,
+                addr.address.6 | addr.address.7 << 8,
+                addr.address.8 | addr.address.9 << 8,
+                addr.address.10 | addr.address.11 << 8,
+                addr.address.12 | addr.address.13 << 8,
+                addr.address.14 | addr.address.15 << 8
+            ].map {String(format: "%02X", $0)}
             addressString = "\(hexRepresentation.joined(separator: ":"))"
             
             if let zone = addr.zone {
@@ -99,12 +108,9 @@ public enum IPAddress: CustomStringConvertible {
     
     public init(bytes: [UInt8]) {
         if bytes.count == 16 {
-            var byteTuple: IPv6Bytes = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
-            withUnsafeMutablePointer(to: &byteTuple) { dst -> () in
-                memcpy(dst, bytes, 16)
-                return
-            }
-            self = .v6(.init(address: byteTuple))
+            self = .v6(.init(address: (
+                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+            )))
         } else {
             // TODO: throw exception
             self = .v4(.init(address: (0,0,0,0)))

--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Darwin
+import CNIOLinux
+import CoreFoundation
+
+public typealias IPv4Bytes = (UInt8, UInt8, UInt8, UInt8)
+public typealias IPv6Bytes = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+
+
+/// Represent a IP address
+public enum IPAddress: CustomStringConvertible {
+    
+    /// A single IPv4 address for `IPAddress`.
+    public struct IPv4Address {
+        /// The libc ip address for an IPv4 address.
+        /// 8b.8b.8b.8b => 32b Int
+        private let _storage: IPv4Bytes
+        
+        public var address: IPv4Bytes {
+            return _storage
+        }
+    
+        fileprivate init(address: IPv4Bytes) {
+            self._storage = address
+        }
+    }
+    
+    /// A single IPv6 address for `IPAddress`
+    public struct IPv6Address {
+        /// The libc ip address for an IPv6 address.
+        private let _storage: Box<(address: IPv6Bytes, zone: String?)>
+        
+        public var address: IPv6Bytes {
+            return self._storage.value.address
+        }
+        
+        public var zone: String? {
+            return self._storage.value.zone
+        }
+    
+        fileprivate init(address: IPv6Bytes, zone: String?=nil) {
+            self._storage = Box((address: address, zone: zone))
+        }
+    }
+        
+    /// An IPv4 `IPAddress`.
+    case v4(IPv4Address)
+
+    /// An IPv6 `IPAddress`.
+    case v6(IPv6Address)
+
+    /// A human-readable description of this `IPAddress`. Mostly useful for logging.
+    public var description: String {
+        var addressString: String
+        let type: String
+        switch self {
+        case .v4(let addr):
+            addressString = "\(addr.address)"
+            type = "IPv4"
+        case .v6(let addr):
+            let hexRepresentation = Mirror(reflecting: addr.address).children.map {String(format: "%02X", $0.value as! UInt8)}
+            addressString = "\(hexRepresentation.joined(separator: ":"))"
+            
+            if let zone = addr.zone {
+                addressString += "%<\(zone)>"
+            }
+            type = "IPv6"
+        }
+        return "[\(type)]\(addressString)"
+    }
+    
+// TODO:
+//    "While NIO requires that we be able to produce C types, we don't need to store things there!"
+//    accept: IPv4 a.b.c.d
+//    accept: IPv6
+//       a) x:x:x:x:x:x:x:x with x one to four hex digits
+//       b) x:x:x::x:x where '::' represents fill up zeros
+//       c) x:x:x:x:x:x:d.d.d.d where d's are decimal values of the four low-order 8-bit pieces
+//       d) <address>%<zone_id> where address is a literal IPv6 address and zone_id is a string identifying the zone
+
+
+    public init(string: String) {
+        self = .v4(.init(address: (0,0,0,0)))
+    }
+    
+    public init(bytes: [UInt8]) {
+        if bytes.count == 16 {
+            var byteTuple: IPv6Bytes = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
+            withUnsafeMutablePointer(to: &byteTuple) { dst -> () in
+                memcpy(dst, bytes, 16)
+                return
+            }
+            self = .v6(.init(address: byteTuple))
+        } else {
+            // TODO: throw exception
+            self = .v4(.init(address: (0,0,0,0)))
+        }
+    }
+    
+    /*
+    public init(_ addr: in_addr) {
+        self = .v4(.init(address: addr.s_addr))
+    }
+    */
+    
+    public init(_ addr: in6_addr) {
+        self = .v6(.init(address: addr.__u6_addr.__u6_addr8))
+    }
+    
+}

--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -16,7 +16,7 @@
 import Darwin
 import CNIOLinux
 import CoreFoundation
-import Foundation
+
 
 public enum IPAddressError: Error {
     /// Given string input is not supported IPv4 Style
@@ -24,8 +24,6 @@ public enum IPAddressError: Error {
     /// Given string input is not supported IP Address
     case unsupportedIPAddress
 }
-
-
 
 extension UInt8 {
     var hexValue: String {

--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -27,18 +27,6 @@ public enum IPAddressError: Error {
     case bytesArrayHasWrongLength(Int)
 }
 
-extension UInt8 {
-    var hexValue: String {
-        let table: StaticString = "0123456789ABCDEF"
-        
-        return String.init(cString: [table.withUTF8Buffer { table in
-            table[Int(self >> 4)]
-        }, table.withUTF8Buffer { table in
-            table[Int(self & 0x0F)]
-        }])
-    }
-}
-
 public typealias IPv4BytesTuple = (UInt8, UInt8, UInt8, UInt8)
 public typealias IPv6BytesTuple = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 
@@ -122,6 +110,30 @@ public struct IPv6Bytes: Collection {
     }
 }
 
+extension UInt16 {
+    func toHex() -> String {
+        switch self {
+        case 0: return "0"
+        case 1: return "1"
+        case 2: return "2"
+        case 3: return "3"
+        case 4: return "4"
+        case 5: return "5"
+        case 6: return "6"
+        case 7: return "7"
+        case 8: return "8"
+        case 9: return "9"
+        case 10: return "A"
+        case 11: return "B"
+        case 12: return "C"
+        case 13: return "D"
+        case 14: return "E"
+        case 15: return "F"
+        default: return ""
+        }
+    }
+}
+
 /// Represent a IP address
 public enum IPAddress: CustomStringConvertible {
     public typealias Element = UInt8
@@ -184,7 +196,15 @@ public enum IPAddress: CustomStringConvertible {
             return addr.address.map({String($0)}).joined(separator: ".")
         case .v6(let addr):
             return stride(from: 0, to: 15, by: 2).map({ idx in
-                addr.address[idx].hexValue + addr.address[idx + 1].hexValue
+                UInt16(addr.address[idx]) << 8 + UInt16(addr.address[idx + 1])
+            }).map({ (segment: UInt16) in
+                var segment = segment
+                var segmentString = ""
+                repeat {
+                    segmentString = (segment & 0x000F).toHex() + segmentString
+                    segment = segment >> 4
+                } while segment > 0
+                return segmentString
             }).joined(separator: ":")
         }
     }

--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -29,7 +29,7 @@ public enum IPAddressError: Error {
 public typealias IPv4BytesTuple = (UInt8, UInt8, UInt8, UInt8)
 public typealias IPv6BytesTuple = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 
-/// Represent the bytes for an IPv4Address.
+/// Represent the bytes for an `IPv4Address`.
 public struct IPv4Bytes {
     private let ipv4BytesTuple: IPv4BytesTuple
     
@@ -42,7 +42,7 @@ public struct IPv4Bytes {
     }
 }
 
-/// Represent the bytes for an IPv6Address.
+/// Represent the bytes for an `IPv6Address.
 public struct IPv6Bytes {
     private let ipv6BytesTuple: IPv6BytesTuple
     

--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -193,7 +193,7 @@ public enum IPAddress: CustomStringConvertible {
     public var ipAddress: String {
         switch self {
         case .v4(let addr):
-            return addr.address.map({String($0)}).joined(separator: ".")
+            return addr.address.lazy.map({String($0)}).joined(separator: ".")
         case .v6(let addr):
             return stride(from: 0, to: 15, by: 2).lazy.map({ idx in
                 let hexValues = [

--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -57,8 +57,6 @@ public struct IPv6Bytes {
 
 /// Represent a single `IPAddress`.
 public enum IPAddress {
-    public typealias Element = UInt8
-    
     /// A single IPv4 address for `IPAddress`.
     public struct IPv4Address {
         /// The bytes storing the address of the IPv4 address.

--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -245,7 +245,6 @@ public enum IPAddress: CustomStringConvertible {
                     idx += 1
                 } else if let number = char.wholeNumberValue {
                     if idx > 3 || bytes[idx] > 25 || (255 - number < (bytes[idx] * 10)) {
-                        // if this is the case, the calculations would result in arithmetic overflow
                         throw IPAddressError.failedToParseIPv4String
                     }
                     bytes[idx] = bytes[idx] * 10 + UInt8(number)
@@ -281,7 +280,6 @@ public enum IPAddress: CustomStringConvertible {
                     isLastCharSeparator = false
                     if let number = char.hexDigitValue {
                         if idx > 7 || ipv6Bytes[idx] > 4095 || (65535 - number < (ipv6Bytes[idx] * 16)) {
-                            // if this is the case, the calculations would result in arithmetic overflow
                             throw IPAddressError.failedToParseIPString(string)
                         }
                         ipv6Bytes[idx] = ipv6Bytes[idx]*16 + UInt16(number)

--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -42,30 +42,6 @@ public struct IPv4Bytes {
     }
 }
 
-extension IPv4Bytes: Collection {
-    public typealias Index = Int
-    public typealias Element = UInt8
-    
-    public var startIndex: Index { 0 }
-    public var endIndex: Index { 4 }
-    
-    public subscript(position: Index) -> Element {
-        get {
-            switch position {
-            case 0: return self.bytes.0
-            case 1: return self.bytes.1
-            case 2: return self.bytes.2
-            case 3: return self.bytes.3
-            default: preconditionFailure()
-            }
-        }
-    }
-    
-    public func index(after: Index) -> Index {
-        return after + 1
-    }
-}
-
 /// Represent the bytes for an IPv6Address.
 public struct IPv6Bytes {
     private let ipv6BytesTuple: IPv6BytesTuple
@@ -76,67 +52,6 @@ public struct IPv6Bytes {
     
     init(_ bytes: IPv6BytesTuple) {
         self.ipv6BytesTuple = bytes
-    }
-}
-
-extension IPv6Bytes: Collection {
-    public typealias Index = Int
-    public typealias Element = UInt8
-    
-    public var startIndex: Index { 0 }
-    public var endIndex: Index { 16 }
-    
-    public subscript(position: Index) -> Element {
-        get {
-            switch position {
-            case 0: return self.bytes.0
-            case 1: return self.bytes.1
-            case 2: return self.bytes.2
-            case 3: return self.bytes.3
-            case 4: return self.bytes.4
-            case 5: return self.bytes.5
-            case 6: return self.bytes.6
-            case 7: return self.bytes.7
-            case 8: return self.bytes.8
-            case 9: return self.bytes.9
-            case 10: return self.bytes.10
-            case 11: return self.bytes.11
-            case 12: return self.bytes.12
-            case 13: return self.bytes.13
-            case 14: return self.bytes.14
-            case 15: return self.bytes.15
-            default: preconditionFailure()
-            }
-        }
-    }
-    
-    public func index(after: Index) -> Index {
-        return after + 1
-    }
-}
-
-extension UInt8 {
-    /// Convenience function especially useful for representing IPv6 bytes as readable string.
-    func toHex() -> Character {
-        switch self {
-        case 0: return "0"
-        case 1: return "1"
-        case 2: return "2"
-        case 3: return "3"
-        case 4: return "4"
-        case 5: return "5"
-        case 6: return "6"
-        case 7: return "7"
-        case 8: return "8"
-        case 9: return "9"
-        case 10: return "A"
-        case 11: return "B"
-        case 12: return "C"
-        case 13: return "D"
-        case 14: return "E"
-        case 15: return "F"
-        default: preconditionFailure()
-        }
     }
 }
 
@@ -404,6 +319,93 @@ public enum IPAddress {
     ///     - posixIPv6Address: libc ipv6 address.
     public init(posixIPv6Address: in6_addr) {
         self = .v6(.init(address: .init(posixIPv6Address.__u6_addr.__u6_addr8)))
+    }
+}
+
+extension UInt8 {
+    /// Convenience function especially useful for representing IPv6 bytes as readable string.
+    func toHex() -> Character {
+        switch self {
+        case 0: return "0"
+        case 1: return "1"
+        case 2: return "2"
+        case 3: return "3"
+        case 4: return "4"
+        case 5: return "5"
+        case 6: return "6"
+        case 7: return "7"
+        case 8: return "8"
+        case 9: return "9"
+        case 10: return "A"
+        case 11: return "B"
+        case 12: return "C"
+        case 13: return "D"
+        case 14: return "E"
+        case 15: return "F"
+        default: preconditionFailure()
+        }
+    }
+}
+
+/// We define an extension on `IPv4Bytes` that gives it a collection conformance.
+extension IPv4Bytes: Collection {
+    public typealias Index = Int
+    public typealias Element = UInt8
+    
+    public var startIndex: Index { 0 }
+    public var endIndex: Index { 4 }
+    
+    public subscript(position: Index) -> Element {
+        get {
+            switch position {
+            case 0: return self.bytes.0
+            case 1: return self.bytes.1
+            case 2: return self.bytes.2
+            case 3: return self.bytes.3
+            default: preconditionFailure()
+            }
+        }
+    }
+    
+    public func index(after: Index) -> Index {
+        return after + 1
+    }
+}
+
+/// We define an extension on `IPv6Bytes` that gives it a collection conformance.
+extension IPv6Bytes: Collection {
+    public typealias Index = Int
+    public typealias Element = UInt8
+    
+    public var startIndex: Index { 0 }
+    public var endIndex: Index { 16 }
+    
+    public subscript(position: Index) -> Element {
+        get {
+            switch position {
+            case 0: return self.bytes.0
+            case 1: return self.bytes.1
+            case 2: return self.bytes.2
+            case 3: return self.bytes.3
+            case 4: return self.bytes.4
+            case 5: return self.bytes.5
+            case 6: return self.bytes.6
+            case 7: return self.bytes.7
+            case 8: return self.bytes.8
+            case 9: return self.bytes.9
+            case 10: return self.bytes.10
+            case 11: return self.bytes.11
+            case 12: return self.bytes.12
+            case 13: return self.bytes.13
+            case 14: return self.bytes.14
+            case 15: return self.bytes.15
+            default: preconditionFailure()
+            }
+        }
+    }
+    
+    public func index(after: Index) -> Index {
+        return after + 1
     }
 }
 

--- a/Sources/NIOCore/IPAddresses.swift
+++ b/Sources/NIOCore/IPAddresses.swift
@@ -159,7 +159,7 @@ public enum IPAddress: CustomStringConvertible {
             self.address = address
         }
         
-        public init(packedBytes bytes: [UInt8]) {
+        public init<Bytes: Collection>(packedBytes bytes: Bytes) where Element == UInt8 {
             self = .init(address: .init((
                 bytes[0], bytes[1], bytes[2], bytes[3]
             )))
@@ -226,7 +226,7 @@ public enum IPAddress: CustomStringConvertible {
             self.address = address
         }
         
-        public init(packedBytes bytes: [UInt8]) {
+        public init<Bytes: Collection>(packedBytes bytes: Bytes) where Element == UInt8 {
             self = .init(address: .init((
                 bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
             )))
@@ -273,7 +273,7 @@ public enum IPAddress: CustomStringConvertible {
                 }
             } else {
                 if (idx != ipv6Bytes.count - 1) {
-                    // if IPv6 wasn't shortened, every byte should be set explicitly
+                    // if IPv6 wasn't shortened, every segment should be set explicitly
                     throw IPAddressError.failedToParseIPString(string)
                 }
             }
@@ -323,7 +323,7 @@ public enum IPAddress: CustomStringConvertible {
     ///
     /// - parameters:
     ///     - string: String representation of IPv4 or IPv6 Address
-    /// - returns: The `IPAddress` for the given string or `nil` if the string representation is not supported.
+    /// - returns: The `IPAddress` for the given string
     /// - throws: May throw `IPAddressError.failedToParseIPString` if the string cannot be parsed to IPv4 or IPv6.
     public init(string: String) throws {
         do {
@@ -339,7 +339,7 @@ public enum IPAddress: CustomStringConvertible {
     ///     - bytes: Either 4 or 16 bytes representing the IPAddress value.
     /// - returns: The `IPAddress` for the given string or `nil` if the string representation is not supported.
     // TODO: update to init<Bytes: Collection>(packedBytes bytes: Bytes) where Element == UInt8
-    public init(packedBytes bytes: [UInt8]) throws {
+    public init<Bytes: Collection>(packedBytes bytes: Bytes) where Element == UInt8 {
         switch bytes.count {
         case 4: self = .v4(.init(packedBytes: bytes))
         case 16: self = .v6(.init(packedBytes: bytes))

--- a/Tests/NIOPosixTests/IPAddressTest.swift
+++ b/Tests/NIOPosixTests/IPAddressTest.swift
@@ -28,7 +28,7 @@ class IPAddressTest: XCTestCase {
     func testDescriptionWorksIPv6() throws {
         let ipAddress = IPAddress(packedBytes: [
             0, 1, 255, 3, 128, 5, 6, 54, 8, 9, 100, 11, 132, 13, 104, 15
-        ])
+        ], zone: "testzone")
         
         print(ipAddress.description)
     }

--- a/Tests/NIOPosixTests/IPAddressTest.swift
+++ b/Tests/NIOPosixTests/IPAddressTest.swift
@@ -19,16 +19,32 @@ import XCTest
 class IPAddressTest: XCTestCase {
     
     func testDescriptionWorksIPv4() throws {
-        let ipAddress = IPAddress(bytes: [
+        let ipAddress = IPAddress(packedBytes: [
             1, 2, 3, 4
         ])
         print(ipAddress.description)
     }
     
     func testDescriptionWorksIPv6() throws {
-        let ipAddress = IPAddress(bytes: [
+        let ipAddress = IPAddress(packedBytes: [
             0, 1, 255, 3, 128, 5, 6, 54, 8, 9, 100, 11, 132, 13, 104, 15
         ])
+        
+        print(ipAddress.description)
+    }
+    
+    func testPosixInitWorksIPv4() throws {
+        // TODO: not more than 24 bits? Using _UInt24
+        // TODO: Only netmask?
+        let addr: in_addr = .init(s_addr: 255 * 256 * 256 + 7 * 256 + 40)
+        let ipAddress = IPAddress(posixIPv4Address: addr)
+        
+        print(ipAddress.description)
+    }
+    
+    func testPosixInitWorksIPv6() throws {
+        let addr: in6_addr = .init(__u6_addr: .init(__u6_addr8:(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)))
+        let ipAddress = IPAddress(posixIPv6Address: addr)
         
         print(ipAddress.description)
     }

--- a/Tests/NIOPosixTests/IPAddressTest.swift
+++ b/Tests/NIOPosixTests/IPAddressTest.swift
@@ -119,7 +119,7 @@ class IPAddressTest: XCTestCase {
         let ipAddress1 = try IPAddress(packedBytes: [255, 255, 0, 0, 0, 24, 1, 224, 0, 0, 0, 0, 0, 6, 0, 0])
         let ipAddress2 = try IPAddress(string: "FFFF:0:18:1E0:0:0:6:0")
         
-        let expectedDescription = "[IPv6]FFFF:0000:0018:01E0:0000:0000:0006:0000"
+        let expectedDescription = "[IPv6]FFFF:0:18:1E0:0:0:6:0"
         
         XCTAssertEqual(ipAddress1.description, expectedDescription)
         XCTAssertEqual(ipAddress2.description, expectedDescription)

--- a/Tests/NIOPosixTests/IPAddressTest.swift
+++ b/Tests/NIOPosixTests/IPAddressTest.swift
@@ -33,12 +33,55 @@ class IPAddressTest: XCTestCase {
         print(ipAddress.description)
     }
     
+    func testStringInitWorksIPv4() throws {
+        let address = "255.7.40.128"
+        
+        var posix: in_addr = .init()
+        inet_aton(address, &posix)
+        
+        dump(posix)
+        let ipAddress = IPAddress(string: address)
+        switch ipAddress {
+        case .v4(let iPv4Address):
+            dump(iPv4Address.posix)
+            XCTAssertEqual(posix.s_addr, iPv4Address.posix.s_addr)
+        default:
+            print("ups")
+        }
+    }
+    
+    func testStringInitWorksIPv6() throws {
+        let ipAddress = IPAddress(string: "1:2:123:67:0:0:0:7")
+        
+        if let ipAddress = ipAddress {
+            dump(ipAddress.description)
+        }
+    }
+    
+    func testStringInitWorksIPv6WithZone() throws {
+        let ipAddress = IPAddress(string: "1:2:123:67:FF:0:0:7%testzone")
+        
+        if let ipAddress = ipAddress {
+            dump(ipAddress.description)
+        }
+    }
+    
     func testPosixInitWorksIPv4() throws {
-        // TODO: not more than 24 bits? Using _UInt24
-        // TODO: Only netmask?
-        let addr: in_addr = .init(s_addr: 255 * 256 * 256 + 7 * 256 + 40)
+        let addr: in_addr = .init(s_addr: 255 << 24 + 7 << 16 + 40 << 8 + 128)
         let ipAddress = IPAddress(posixIPv4Address: addr)
         
+        switch ipAddress {
+        case .v4(let iPv4Address):
+            let address = "255.7.40.128"
+            var posix: in_addr = .init()
+            inet_aton(address, &posix)
+            
+            dump(posix)
+            dump(iPv4Address.posix)
+            XCTAssertEqual(posix.s_addr, iPv4Address.posix.s_addr)
+        case .v6(_):
+            return
+        }
         print(ipAddress.description)
     }
     
@@ -49,3 +92,4 @@ class IPAddressTest: XCTestCase {
         print(ipAddress.description)
     }
 }
+

--- a/Tests/NIOPosixTests/IPAddressTest.swift
+++ b/Tests/NIOPosixTests/IPAddressTest.swift
@@ -18,11 +18,18 @@ import XCTest
 
 class IPAddressTest: XCTestCase {
     
-    func testDescriptionWorks() throws {
+    func testDescriptionWorksIPv4() throws {
         let ipAddress = IPAddress(bytes: [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+            1, 2, 3, 4
         ])
         print(ipAddress.description)
     }
     
+    func testDescriptionWorksIPv6() throws {
+        let ipAddress = IPAddress(bytes: [
+            0, 1, 255, 3, 128, 5, 6, 54, 8, 9, 100, 11, 132, 13, 104, 15
+        ])
+        
+        print(ipAddress.description)
+    }
 }

--- a/Tests/NIOPosixTests/IPAddressTest.swift
+++ b/Tests/NIOPosixTests/IPAddressTest.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import NIOCore
+@testable import NIOPosix
+
+class IPAddressTest: XCTestCase {
+    
+    func testDescriptionWorks() throws {
+        let ipAddress = IPAddress(bytes: [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+        ])
+        print(ipAddress.description)
+    }
+    
+}


### PR DESCRIPTION
Provide IPAddress type. 

### Motivation:

As described in #1650, we currently need to hold a libc `in_addr` or `in6_addr` to represent an IP address. Similar to `SocketAddress`, there should be an `IPAddress` helper to simplify the handling of IP addresses. 

### Modifications:

Implements `IPAddress` and `IPAddressTest`. The `IPAddress` allows initialisations from strings(IPv4 and IPv6), from libc `in_addr` and `in6_addr`, from byte collection and from a tuple of 4 (IPv4) or 16 (IPv6) bytes. 

They are stored as a tuple of `UInt8` bytes and can be read as string, `in_addr`, `in6_addr` and byte collection.  

### Result:

With this handy `IPAddress` enum for ip addresses, code that does only need to work with the IP address can now be written more expressive and is user-friendly than relying on `in_addr` and `in6_addr` for that. 