### PR TITLE
Rebind less load more

### DIFF
--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -149,19 +149,14 @@ extension NIONetworkInterface: Equatable {
 extension UnsafeMutablePointer where Pointee == sockaddr {
     /// Converts the `sockaddr` to a `SocketAddress`.
     fileprivate func convert() -> SocketAddress? {
+        let addressBytes = UnsafeRawPointer(self)
         switch NIOBSDSocket.AddressFamily(rawValue: CInt(pointee.sa_family)) {
         case .inet:
-            return self.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
-                SocketAddress($0.pointee)
-            }
+            return SocketAddress(addressBytes.load(as: sockaddr_in.self))
         case .inet6:
-            return self.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
-                SocketAddress($0.pointee)
-            }
+            return SocketAddress(addressBytes.load(as: sockaddr_in6.self))
         case .unix:
-            return self.withMemoryRebound(to: sockaddr_un.self, capacity: 1) {
-                SocketAddress($0.pointee)
-            }
+            return SocketAddress(addressBytes.load(as: sockaddr_un.self))
         default:
             return nil
         }

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -434,8 +434,8 @@ public enum SocketAddress: CustomStringConvertible {
             }
         }
 
-        if let info = info {
-            let addressBytes = UnsafeRawPointer(info.pointee.ai_addr!)
+        if let info = info, let addrPointer = info.pointee.ai_addr {
+            let addressBytes = UnsafeRawPointer(addrPointer)
             switch NIOBSDSocket.AddressFamily(rawValue: info.pointee.ai_family) {
             case .inet:
                 return .v4(.init(address: addressBytes.load(as: sockaddr_in.self), host: host))

--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -82,9 +82,9 @@ extension sockaddr_storage {
     /// Converts the `socketaddr_storage` to a `sockaddr_in`.
     ///
     /// This will crash if `ss_family` != AF_INET!
-    mutating func convert() -> sockaddr_in {
+    func convert() -> sockaddr_in {
         precondition(self.ss_family == NIOBSDSocket.AddressFamily.inet.rawValue)
-        return withUnsafeMutableBytes(of: &self) {
+        return withUnsafeBytes(of: self) {
             $0.load(as: sockaddr_in.self)
         }
     }
@@ -92,9 +92,9 @@ extension sockaddr_storage {
     /// Converts the `socketaddr_storage` to a `sockaddr_in6`.
     ///
     /// This will crash if `ss_family` != AF_INET6!
-    mutating func convert() -> sockaddr_in6 {
+    func convert() -> sockaddr_in6 {
         precondition(self.ss_family == NIOBSDSocket.AddressFamily.inet6.rawValue)
-        return withUnsafeMutableBytes(of: &self) {
+        return withUnsafeBytes(of: self) {
             $0.load(as: sockaddr_in6.self)
         }
     }
@@ -102,15 +102,15 @@ extension sockaddr_storage {
     /// Converts the `socketaddr_storage` to a `sockaddr_un`.
     ///
     /// This will crash if `ss_family` != AF_UNIX!
-    mutating func convert() -> sockaddr_un {
+    func convert() -> sockaddr_un {
         precondition(self.ss_family == NIOBSDSocket.AddressFamily.unix.rawValue)
-        return withUnsafeMutableBytes(of: &self) {
+        return withUnsafeBytes(of: self) {
             $0.load(as: sockaddr_un.self)
         }
     }
 
     /// Converts the `socketaddr_storage` to a `SocketAddress`.
-    mutating func convert() -> SocketAddress {
+    func convert() -> SocketAddress {
         switch NIOBSDSocket.AddressFamily(rawValue: CInt(self.ss_family)) {
         case .inet:
             let sockAddr: sockaddr_in = self.convert()
@@ -405,15 +405,15 @@ extension BaseSocket: CustomStringConvertible {
 // We need these free functions to expose our extension methods, because otherwise
 // the compiler falls over when we try to access them from test code. As these functions
 // exist purely to make the behaviours accessible from test code, we name them truly awfully.
-func __testOnly_convertSockAddr(_ addr: inout sockaddr_storage) -> sockaddr_in {
+func __testOnly_convertSockAddr(_ addr: sockaddr_storage) -> sockaddr_in {
     return addr.convert()
 }
 
-func __testOnly_convertSockAddr(_ addr: inout sockaddr_storage) -> sockaddr_in6 {
+func __testOnly_convertSockAddr(_ addr: sockaddr_storage) -> sockaddr_in6 {
     return addr.convert()
 }
 
-func __testOnly_convertSockAddr(_ addr: inout sockaddr_storage) -> sockaddr_un {
+func __testOnly_convertSockAddr(_ addr: sockaddr_storage) -> sockaddr_un {
     return addr.convert()
 }
 

--- a/Sources/NIOPosix/GetaddrinfoResolver.swift
+++ b/Sources/NIOPosix/GetaddrinfoResolver.swift
@@ -188,12 +188,14 @@ internal class GetaddrinfoResolver: Resolver {
 
         var info: UnsafeMutablePointer<CAddrInfo> = info
         while true {
-            let addressBytes = UnsafeRawPointer(info.pointee.ai_addr!)
+            let addressBytes = UnsafeRawPointer(info.pointee.ai_addr)
             switch NIOBSDSocket.AddressFamily(rawValue: info.pointee.ai_family) {
             case .inet:
-                v4Results.append(.init(addressBytes.load(as: sockaddr_in.self), host: host))
+                // Force-unwrap must be safe, or libc did the wrong thing.
+                v4Results.append(.init(addressBytes!.load(as: sockaddr_in.self), host: host))
             case .inet6:
-                v6Results.append(.init(addressBytes.load(as: sockaddr_in6.self), host: host))
+                // Force-unwrap must be safe, or libc did the wrong thing.
+                v6Results.append(.init(addressBytes!.load(as: sockaddr_in6.self), host: host))
             default:
                 self.fail(SocketAddressError.unsupported)
                 return

--- a/Sources/NIOPosix/GetaddrinfoResolver.swift
+++ b/Sources/NIOPosix/GetaddrinfoResolver.swift
@@ -188,15 +188,12 @@ internal class GetaddrinfoResolver: Resolver {
 
         var info: UnsafeMutablePointer<CAddrInfo> = info
         while true {
+            let addressBytes = UnsafeRawPointer(info.pointee.ai_addr!)
             switch NIOBSDSocket.AddressFamily(rawValue: info.pointee.ai_family) {
             case .inet:
-                info.pointee.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { ptr in
-                    v4Results.append(.init(ptr.pointee, host: host))
-                }
+                v4Results.append(.init(addressBytes.load(as: sockaddr_in.self), host: host))
             case .inet6:
-                info.pointee.ai_addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { ptr in
-                    v6Results.append(.init(ptr.pointee, host: host))
-                }
+                v6Results.append(.init(addressBytes.load(as: sockaddr_in6.self), host: host))
             default:
                 self.fail(SocketAddressError.unsupported)
                 return

--- a/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
@@ -19,19 +19,15 @@ import XCTest
 
 private extension SocketAddress {
     init(_ addr: UnsafePointer<sockaddr>) {
+        let erased = UnsafeRawPointer(addr)
+
         switch NIOBSDSocket.AddressFamily(rawValue: CInt(addr.pointee.sa_family)) {
         case .unix:
-            self = addr.withMemoryRebound(to: sockaddr_un.self, capacity: 1) {
-                SocketAddress($0.pointee)
-            }
+            self = SocketAddress(erased.load(as: sockaddr_un.self))
         case .inet:
-            self = addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
-                SocketAddress($0.pointee, host: "")
-            }
+            self = SocketAddress(erased.load(as: sockaddr_in.self))
         case .inet6:
-            self = addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
-                SocketAddress($0.pointee, host: "")
-            }
+            self = SocketAddress(erased.load(as: sockaddr_in6.self))
         default:
             fatalError("Unexpected family type")
         }

--- a/Tests/NIOPosixTests/SocketAddressTest.swift
+++ b/Tests/NIOPosixTests/SocketAddressTest.swift
@@ -87,7 +87,7 @@ class SocketAddressTest: XCTestCase {
             $0.baseAddress!.bindMemory(to: in6_addr.self, capacity: 1).pointee
         }
 
-        let s = __testOnly_addressDescription(&address)
+        let s = __testOnly_addressDescription(address)
         XCTAssertEqual(s.count, sampleString.count,
                        "Address description has unexpected length 😱")
         XCTAssertEqual(s, sampleString,
@@ -183,19 +183,19 @@ class SocketAddressTest: XCTestCase {
             _ = withUnsafeMutableBytes(of: &storage) { temp in
                 memcpy(temp.baseAddress!, outer.baseAddress!, MemoryLayout<sockaddr_in>.size)
             }
-            return __testOnly_convertSockAddr(&storage)
+            return __testOnly_convertSockAddr(storage)
         }
         var secondCopy: sockaddr_in6 = withUnsafeBytes(of: &secondIPAddress) { outer in
             _ = withUnsafeMutableBytes(of: &storage) { temp in
                 memcpy(temp.baseAddress!, outer.baseAddress!, MemoryLayout<sockaddr_in6>.size)
             }
-            return __testOnly_convertSockAddr(&storage)
+            return __testOnly_convertSockAddr(storage)
         }
         var thirdCopy: sockaddr_un = withUnsafeBytes(of: &thirdIPAddress) { outer in
             _ = withUnsafeMutableBytes(of: &storage) { temp in
                 memcpy(temp.baseAddress!, outer.baseAddress!, MemoryLayout<sockaddr_un>.size)
             }
-            return __testOnly_convertSockAddr(&storage)
+            return __testOnly_convertSockAddr(storage)
         }
 
         XCTAssertEqual(memcmp(&firstIPAddress, &firstCopy, MemoryLayout<sockaddr_in>.size), 0)
@@ -221,19 +221,19 @@ class SocketAddressTest: XCTestCase {
             return
         }
 
-        var firstIPAddress = firstAddress.address
-        var secondIPAddress = secondAddress.address
-        var thirdIPAddress = thirdAddress.address
+        let firstIPAddress = firstAddress.address
+        let secondIPAddress = secondAddress.address
+        let thirdIPAddress = thirdAddress.address
 
         first.withSockAddr { outerAddr, outerSize in
-            __testOnly_withSockAddr(&firstIPAddress) { innerAddr, innerSize in
+            __testOnly_withSockAddr(firstIPAddress) { innerAddr, innerSize in
                 XCTAssertEqual(outerSize, innerSize)
                 XCTAssertEqual(memcmp(innerAddr, outerAddr, min(outerSize, innerSize)), 0)
                 XCTAssertNotEqual(outerAddr, innerAddr)
             }
         }
         second.withSockAddr { outerAddr, outerSize in
-            __testOnly_withSockAddr(&secondIPAddress) { innerAddr, innerSize in
+            __testOnly_withSockAddr(secondIPAddress) { innerAddr, innerSize in
                 XCTAssertEqual(outerSize, innerSize)
                 XCTAssertEqual(memcmp(innerAddr, outerAddr, min(outerSize, innerSize)), 0)
                 XCTAssertNotEqual(outerAddr, innerAddr)

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -273,11 +273,9 @@ func resolverDebugInformation(eventLoop: EventLoop, host: String, previouslyRece
         case .unixDomainSocket(_):
             return "uds"
         case .v4(let sa):
-            var addr = sa.address
-            return __testOnly_addressDescription(&addr)
+            return __testOnly_addressDescription(sa.address)
         case .v6(let sa):
-            var addr = sa.address
-            return __testOnly_addressDescription(&addr)
+            return __testOnly_addressDescription(sa.address)
         }
     }
     let res = GetaddrinfoResolver(loop: eventLoop, aiSocktype: .stream, aiProtocol: CInt(IPPROTO_TCP))


### PR DESCRIPTION
Reduce the amount of rebinding we do with sockaddr types.

### Motivation:

[SR-15912](https://bugs.swift.org/browse/SR-15912) recently caused a bunch of issues with compilation of NIO in the nightlies. While these were arguably Swift bugs, we're also skating pretty close to the edge by using `withMemoryRebound` here: it's often safer for us to load the structures, rather than use random pointers.

### Modifications:

- Replace a bunch of rebindings with loads

### Result:

Fewer calls with `withMemoryRebound`.
