### PR TITLE
Add benchmarks for copying CircularBuffer to Array

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_copying_circularbuffer_to_array.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_copying_circularbuffer_to_array.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOCore
+
+func run(identifier: String) {
+    let data = CircularBuffer(repeating: UInt8(0xfe), count: 1024)
+
+    measure(identifier: identifier) {
+        var count = 0
+
+        for _ in 0..<1_000 {
+            let copy = Array(data)
+            count &+= copy.count
+        }
+
+        return count
+    }
+}

--- a/Sources/NIOPerformanceTester/CircularBufferCopyToArrayBenchmark.swift
+++ b/Sources/NIOPerformanceTester/CircularBufferCopyToArrayBenchmark.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+final class CircularBufferViewCopyToArrayBenchmark: Benchmark {
+    private let iterations: Int
+    private let size: Int
+    private var buffer: CircularBuffer<UInt8>
+
+    init(iterations: Int, size: Int) {
+        self.iterations = iterations
+        self.size = size
+        self.buffer = CircularBuffer()
+    }
+
+    func setUp() throws {
+        self.buffer = CircularBuffer(repeating: UInt8(0xfe), count: self.size)
+    }
+
+    func tearDown() {
+    }
+
+    func run() -> Int {
+        var count = 0
+        for _ in 0..<self.iterations {
+            let array = Array(self.buffer)
+            count &+= array.count
+        }
+
+        return count
+    }
+}

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -846,3 +846,6 @@ try measureAndPrint(desc: "execute_10000",
 
 try measureAndPrint(desc: "bytebufferview_copy_to_array_1000_times_1kb",
                     benchmark: ByteBufferViewCopyToArrayBenchmark(iterations: 1000, size: 1024))
+
+try measureAndPrint(desc: "circularbuffer_copy_to_array_1000_times_1kb",
+                    benchmark: CircularBufferViewCopyToArrayBenchmark(iterations: 1000, size: 1024))


### PR DESCRIPTION
### Motivation:

#1827 suggests we implement some hooks on `Collection` and `Sequence` to get better performance for `CircularBuffer` but before we do we should have a benchmark in place to measure any potential improvements.

### Modifications:

Adds a benchmark for copying a `CircularBuffer` to an `Array` to the performance tests.

### Result:

We should have a baseline for a future PR that implements any of these hooks.