### PR TITLE
Improve the performance of copying CircularBuffer

### DIFF
--- a/Sources/NIOCore/CircularBuffer.swift
+++ b/Sources/NIOCore/CircularBuffer.swift
@@ -247,7 +247,7 @@ extension CircularBuffer: Collection, MutableCollection {
             }
         }
 
-        return (self[endIndex..<self.endIndex].makeIterator(), self.count)
+        return (self[self.endIndex..<self.endIndex].makeIterator(), self.count)
     }
 }
 

--- a/Sources/NIOCore/CircularBuffer.swift
+++ b/Sources/NIOCore/CircularBuffer.swift
@@ -224,7 +224,7 @@ extension CircularBuffer: Collection, MutableCollection {
     }
 
     @inlinable
-    public __consuming func _copyContents(
+    public func _copyContents(
         initializing buffer: UnsafeMutableBufferPointer<Element>
     ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
         precondition(buffer.count >= self.count)

--- a/Sources/NIOCore/CircularBuffer.swift
+++ b/Sources/NIOCore/CircularBuffer.swift
@@ -226,7 +226,7 @@ extension CircularBuffer: Collection, MutableCollection {
     @inlinable
     public func _copyContents(
         initializing buffer: UnsafeMutableBufferPointer<Element>
-    ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
+    ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
         precondition(buffer.count >= self.count)
 
         guard var ptr = buffer.baseAddress else {

--- a/Sources/NIOCore/CircularBuffer.swift
+++ b/Sources/NIOCore/CircularBuffer.swift
@@ -237,7 +237,7 @@ extension CircularBuffer: Collection, MutableCollection {
         if self.tailBackingIndex >= self.headBackingIndex {
             indexRanges = [self.headBackingIndex..<self.tailBackingIndex]
         } else {
-            indexRanges = [ self.headBackingIndex..<self._buffer.count, 0..<self.tailBackingIndex ]
+            indexRanges = [ self.headBackingIndex..<self._buffer.endIndex, 0..<self.tailBackingIndex ]
         }
 
         for indexRange in indexRanges {

--- a/Sources/NIOCore/CircularBuffer.swift
+++ b/Sources/NIOCore/CircularBuffer.swift
@@ -233,23 +233,20 @@ extension CircularBuffer: Collection, MutableCollection {
             return (self.makeIterator(), buffer.startIndex)
         }
 
-        @inline(__always)
-        func copy(
-            range: Range<Int>,
-            from src: ContiguousArray<Element?>,
-            to ptr: inout UnsafeMutablePointer<Element>
-        ) {
-            for index in range {
+        if self.tailBackingIndex >= self.headBackingIndex {
+            for index in self.headBackingIndex..<self.tailBackingIndex {
                 ptr.initialize(to: self._buffer[index]!)
                 ptr += 1
             }
-        }
-
-        if self.tailBackingIndex >= self.headBackingIndex {
-            copy(range: self.headBackingIndex..<self.tailBackingIndex, from: self._buffer, to: &ptr)
         } else {
-            copy(range: self.headBackingIndex..<self._buffer.endIndex, from: self._buffer, to: &ptr)
-            copy(range: 0..<self.tailBackingIndex, from: self._buffer, to: &ptr)
+            for index in self.headBackingIndex..<self._buffer.endIndex {
+                ptr.initialize(to: self._buffer[index]!)
+                ptr += 1
+            }
+            for index in 0..<self.tailBackingIndex {
+                ptr.initialize(to: self._buffer[index]!)
+                ptr += 1
+            }
         }
 
         return (self[self.endIndex..<self.endIndex].makeIterator(), self.count)

--- a/Tests/NIOPosixTests/CircularBufferTests+XCTest.swift
+++ b/Tests/NIOPosixTests/CircularBufferTests+XCTest.swift
@@ -80,7 +80,7 @@ extension CircularBufferTests {
                 ("testArrayLiteralInit", testArrayLiteralInit),
                 ("testFirstWorks", testFirstWorks),
                 ("testReserveCapacityActuallyDoesSomething", testReserveCapacityActuallyDoesSomething),
-                ("testCopyContents_bufferFullAndHeadBehindTail", testCopyContents_bufferFullAndHeadBehindTail),
+                ("testCopyContents", testCopyContents),
            ]
    }
 }

--- a/Tests/NIOPosixTests/CircularBufferTests+XCTest.swift
+++ b/Tests/NIOPosixTests/CircularBufferTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -80,6 +80,7 @@ extension CircularBufferTests {
                 ("testArrayLiteralInit", testArrayLiteralInit),
                 ("testFirstWorks", testFirstWorks),
                 ("testReserveCapacityActuallyDoesSomething", testReserveCapacityActuallyDoesSomething),
+                ("testCopyContents_bufferFullAndHeadBehindTail", testCopyContents_bufferFullAndHeadBehindTail),
            ]
    }
 }

--- a/Tests/NIOPosixTests/CircularBufferTests.swift
+++ b/Tests/NIOPosixTests/CircularBufferTests.swift
@@ -1040,7 +1040,7 @@ class CircularBufferTests: XCTestCase {
         XCTAssertEqual(buffer.capacity, 32)
     }
 
-    func testCopyContents_bufferFullAndHeadBehindTail() {
+    func testCopyContents() {
         var buffer = CircularBuffer<String>(initialCapacity: 4)
 
         // Test with no elements.

--- a/Tests/NIOPosixTests/CircularBufferTests.swift
+++ b/Tests/NIOPosixTests/CircularBufferTests.swift
@@ -1039,4 +1039,27 @@ class CircularBufferTests: XCTestCase {
         buffer.reserveCapacity(0)
         XCTAssertEqual(buffer.capacity, 32)
     }
+
+    func testCopyContents_bufferFullAndHeadBehindTail() {
+        var buffer = CircularBuffer<String>(initialCapacity: 4)
+
+        // Test with no elements.
+        XCTAssertEqual(buffer._buffer.count, 4)
+        XCTAssertEqual(Array(buffer), [])
+
+        // Test with head < tail.
+        buffer.append(contentsOf: ["a", "b", "c"])
+        XCTAssertEqual(buffer._buffer.count, 4)
+        XCTAssertEqual(buffer.count, 3)
+        XCTAssertLessThan(buffer.headBackingIndex, buffer.tailBackingIndex)
+        XCTAssertEqual(Array(buffer), ["a", "b", "c"])
+
+        // Test with head > tail.
+        buffer.removeFirst()
+        buffer.append("d")
+        XCTAssertEqual(buffer._buffer.count, 4)
+        XCTAssertEqual(buffer.count, 3)
+        XCTAssertGreaterThan(buffer.headBackingIndex, buffer.tailBackingIndex)
+        XCTAssertEqual(Array(buffer), ["b", "c", "d"])
+    }
 }


### PR DESCRIPTION
### Motivation:

#1827 suggests we implement some hooks on Collection and Sequence to get better performance for CircularBuffer to increase performance. #2058 added the benchmarks so we can see the improvement from this change.

### Modifications:

Implement `Sequence._copyContents` for `CircularBuffer` in terms of its underlying `ContiguousArray` to avoid going through the extra layer of indices.

### Result:

Copying `CircularBuffer` should be faster.