### PR TITLE
Remove unnecessary extra swift file.

### DIFF
--- a/IntegrationTests/tests_02_syscall_wrappers/defines.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/defines.sh
@@ -54,4 +54,5 @@ EOF
     ln -s "$here/../../Sources/CNIODarwin" "$tmpdir/syscallwrapper/Sources"
     mkdir "$tmpdir/syscallwrapper/Sources/NIOCore"
     touch "$tmpdir/syscallwrapper/Sources/NIOCore/empty.swift"
+    rm -rf "$tmpdir/syscallwrapper/Sources/syscallwrapper/syscallwrapper.swift"
 }


### PR DESCRIPTION
The nightly builders have started automatically adding a struct with
@main to packages generated using swift package init. This is
interfering with our syscallwrapper tests, so we should delete that
file.