### PR TITLE
Increase runtime of performance tests to O(10 ms) to increase SNR

### DIFF
--- a/Sources/NIOPerformanceTester/ChannelPipelineBenchmark.swift
+++ b/Sources/NIOPerformanceTester/ChannelPipelineBenchmark.swift
@@ -26,13 +26,11 @@ final class ChannelPipelineBenchmark: Benchmark {
     }
 
     private let channel: EmbeddedChannel
-    private let runCount: Int
     private let extraHandlers = 4
     private var handlers: [RemovableChannelHandler] = []
 
-    init(runCount: Int) {
+    init() {
         self.channel = EmbeddedChannel()
-        self.runCount = runCount
     }
 
     func setUp() throws {
@@ -55,7 +53,7 @@ final class ChannelPipelineBenchmark: Benchmark {
     }
 
     func run() -> Int {
-        for _ in 0..<self.runCount {
+        for _ in 0..<1_000_000 {
             self.channel.pipeline.fireChannelReadComplete()
         }
         return 1

--- a/Sources/NIOPerformanceTester/ChannelPipelineBenchmark.swift
+++ b/Sources/NIOPerformanceTester/ChannelPipelineBenchmark.swift
@@ -26,11 +26,13 @@ final class ChannelPipelineBenchmark: Benchmark {
     }
 
     private let channel: EmbeddedChannel
+    private let runCount: Int
     private let extraHandlers = 4
     private var handlers: [RemovableChannelHandler] = []
 
-    init() {
+    init(runCount: Int) {
         self.channel = EmbeddedChannel()
+        self.runCount = runCount
     }
 
     func setUp() throws {
@@ -53,7 +55,7 @@ final class ChannelPipelineBenchmark: Benchmark {
     }
 
     func run() -> Int {
-        for _ in 0..<1_000_000 {
+        for _ in 0..<self.runCount {
             self.channel.pipeline.fireChannelReadComplete()
         }
         return 1

--- a/Sources/NIOPerformanceTester/ExecuteBenchmark.swift
+++ b/Sources/NIOPerformanceTester/ExecuteBenchmark.swift
@@ -21,11 +21,6 @@ final class ExecuteBenchmark: Benchmark {
     private var loop: EventLoop!
     private var dg: DispatchGroup!
     private var counter = 0
-    private let numTasks: Int
-
-    init(numTasks: Int) {
-        self.numTasks = numTasks
-    }
 
     func setUp() throws {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -36,7 +31,7 @@ final class ExecuteBenchmark: Benchmark {
         // during the actual test
         try! self.loop.submit {
             var counter: Int = 0
-            for _ in 0..<self.numTasks {
+            for _ in 0..<100000 {
                 self.loop.scheduleTask(in: .nanoseconds(0)) {
                     counter &+= 1
                 }
@@ -48,7 +43,7 @@ final class ExecuteBenchmark: Benchmark {
 
     func run() -> Int {
         try! self.loop.submit {
-            for _ in 0..<self.numTasks {
+            for _ in 0..<10000 {
                 self.dg.enter()
 
                 self.loop.execute {

--- a/Sources/NIOPerformanceTester/ExecuteBenchmark.swift
+++ b/Sources/NIOPerformanceTester/ExecuteBenchmark.swift
@@ -21,6 +21,11 @@ final class ExecuteBenchmark: Benchmark {
     private var loop: EventLoop!
     private var dg: DispatchGroup!
     private var counter = 0
+    private let numTasks: Int
+
+    init(numTasks: Int) {
+        self.numTasks = numTasks
+    }
 
     func setUp() throws {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -31,7 +36,7 @@ final class ExecuteBenchmark: Benchmark {
         // during the actual test
         try! self.loop.submit {
             var counter: Int = 0
-            for _ in 0..<100000 {
+            for _ in 0..<self.numTasks {
                 self.loop.scheduleTask(in: .nanoseconds(0)) {
                     counter &+= 1
                 }
@@ -43,7 +48,7 @@ final class ExecuteBenchmark: Benchmark {
 
     func run() -> Int {
         try! self.loop.submit {
-            for _ in 0..<10000 {
+            for _ in 0..<self.numTasks {
                 self.dg.enter()
 
                 self.loop.execute {

--- a/Sources/NIOPerformanceTester/SchedulingAndRunningBenchmark.swift
+++ b/Sources/NIOPerformanceTester/SchedulingAndRunningBenchmark.swift
@@ -21,6 +21,11 @@ final class SchedulingAndRunningBenchmark: Benchmark {
     private var loop: EventLoop!
     private var dg: DispatchGroup!
     private var counter = 0
+    private let numTasks: Int
+
+    init(numTasks: Int) {
+        self.numTasks = numTasks
+    }
 
     func setUp() throws {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -31,7 +36,7 @@ final class SchedulingAndRunningBenchmark: Benchmark {
         // during the actual test
         try! self.loop.submit {
             var counter: Int = 0
-            for _ in 0..<100000 {
+            for _ in 0..<self.numTasks {
                 self.loop.scheduleTask(in: .nanoseconds(0)) {
                     counter &+= 1
                 }
@@ -43,7 +48,7 @@ final class SchedulingAndRunningBenchmark: Benchmark {
 
     func run() -> Int {
         try! self.loop.submit {
-            for _ in 0..<10000 {
+            for _ in 0..<self.numTasks {
                 self.dg.enter()
 
                 self.loop.scheduleTask(in: .nanoseconds(0)) {

--- a/Sources/NIOPerformanceTester/SchedulingAndRunningBenchmark.swift
+++ b/Sources/NIOPerformanceTester/SchedulingAndRunningBenchmark.swift
@@ -21,11 +21,6 @@ final class SchedulingAndRunningBenchmark: Benchmark {
     private var loop: EventLoop!
     private var dg: DispatchGroup!
     private var counter = 0
-    private let numTasks: Int
-
-    init(numTasks: Int) {
-        self.numTasks = numTasks
-    }
 
     func setUp() throws {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -36,7 +31,7 @@ final class SchedulingAndRunningBenchmark: Benchmark {
         // during the actual test
         try! self.loop.submit {
             var counter: Int = 0
-            for _ in 0..<self.numTasks {
+            for _ in 0..<100000 {
                 self.loop.scheduleTask(in: .nanoseconds(0)) {
                     counter &+= 1
                 }
@@ -48,7 +43,7 @@ final class SchedulingAndRunningBenchmark: Benchmark {
 
     func run() -> Int {
         try! self.loop.submit {
-            for _ in 0..<self.numTasks {
+            for _ in 0..<10000 {
                 self.dg.enter()
 
                 self.loop.scheduleTask(in: .nanoseconds(0)) {

--- a/Sources/NIOPerformanceTester/SchedulingBenchmark.swift
+++ b/Sources/NIOPerformanceTester/SchedulingBenchmark.swift
@@ -19,11 +19,6 @@ import NIOPosix
 final class SchedulingBenchmark: Benchmark {
     private var group: MultiThreadedEventLoopGroup!
     private var loop: EventLoop!
-    private let numTasks: Int
-
-    init(numTasks: Int) {
-        self.numTasks = numTasks
-    }
 
     func setUp() throws {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -33,7 +28,7 @@ final class SchedulingBenchmark: Benchmark {
         // during the actual test
         try! self.loop.submit {
             var counter: Int = 0
-            for _ in 0..<self.numTasks {
+            for _ in 0..<100000 {
                 self.loop.scheduleTask(in: .nanoseconds(0)) {
                     counter &+= 1
                 }
@@ -46,7 +41,7 @@ final class SchedulingBenchmark: Benchmark {
     func run() -> Int {
         let counter = try! self.loop.submit { () -> Int in
             var counter: Int = 0
-            for _ in 0..<self.numTasks {
+            for _ in 0..<10000 {
                 self.loop.scheduleTask(in: .hours(1)) {
                     counter &+= 1
                 }

--- a/Sources/NIOPerformanceTester/SchedulingBenchmark.swift
+++ b/Sources/NIOPerformanceTester/SchedulingBenchmark.swift
@@ -19,6 +19,11 @@ import NIOPosix
 final class SchedulingBenchmark: Benchmark {
     private var group: MultiThreadedEventLoopGroup!
     private var loop: EventLoop!
+    private let numTasks: Int
+
+    init(numTasks: Int) {
+        self.numTasks = numTasks
+    }
 
     func setUp() throws {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -28,7 +33,7 @@ final class SchedulingBenchmark: Benchmark {
         // during the actual test
         try! self.loop.submit {
             var counter: Int = 0
-            for _ in 0..<100000 {
+            for _ in 0..<self.numTasks {
                 self.loop.scheduleTask(in: .nanoseconds(0)) {
                     counter &+= 1
                 }
@@ -41,7 +46,7 @@ final class SchedulingBenchmark: Benchmark {
     func run() -> Int {
         let counter = try! self.loop.submit { () -> Int in
             var counter: Int = 0
-            for _ in 0..<10000 {
+            for _ in 0..<self.numTasks {
                 self.loop.scheduleTask(in: .hours(1)) {
                     counter &+= 1
                 }

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -996,8 +996,6 @@ try measureAndPrint(
     )
 )
 
-/*
-
 try measureAndPrint(
     desc: "lock_4_threads_1M_ops",
     benchmark: LockBenchmark(
@@ -1023,6 +1021,8 @@ try measureAndPrint(
     desc: "schedule_and_run_100k_tasks",
     benchmark: SchedulingAndRunningBenchmark(numTasks: 100_000)
 )
+
+/*
 
 try measureAndPrint(
     desc: "execute_100k_tasks",

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -1005,7 +1005,6 @@ try measureAndPrint(
     )
 )
 
-*/
 
 try measureAndPrint(
     desc: "lock_8_threads_1M_ops",
@@ -1014,12 +1013,13 @@ try measureAndPrint(
         lockOperationsPerThread: 125_000
     )
 )
-/*
+*/
 
 try measureAndPrint(
     desc: "schedule_1m_tasks",
     benchmark: SchedulingBenchmark(numTasks: 1_000_000)
 )
+/*
 
 try measureAndPrint(
     desc: "schedule_and_run_100k_tasks",

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -902,13 +902,13 @@ try measureAndPrint(
     )
 )
 
-//try measureAndPrint(
-//    desc: "websocket_decode_64kb_+1_10k_frames",
-//    benchmark: WebSocketFrameDecoderBenchmark(
-//        dataSize: Int(UInt16.max) + 1,
-//        runCount: 10_000
-//    )
-//)
+try measureAndPrint(
+    desc: "websocket_decode_64kb_+1_10k_frames",
+    benchmark: WebSocketFrameDecoderBenchmark(
+        dataSize: Int(UInt16.max) + 1,
+        runCount: 10_000
+    )
+)
 
 try measureAndPrint(
     desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -197,7 +197,7 @@ measureAndPrint(desc: "write_http_headers") {
     }
 
     var val = 0
-    for _ in 0..<1_000_000 {
+    for _ in 0..<100_000 {
         let headers = HTTPHeaders(headers)
         val += headers.underestimatedCount
     }
@@ -216,7 +216,7 @@ measureAndPrint(desc: "http_headers_canonical_form") {
 measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace") {
     let headers: HTTPHeaders = ["key": "         some   ,   trimming     "]
     var count = 0
-    for _ in 0..<10_000 {
+    for _ in 0..<100_000 {
         count &+= headers[canonicalForm: "key"].count
     }
     return count
@@ -225,7 +225,7 @@ measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace") {
 measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace_from_short_string") {
     let headers: HTTPHeaders = ["key": "   smallString   ,whenStripped"]
     var count = 0
-    for _ in 0..<10_000 {
+    for _ in 0..<100_000 {
         count &+= headers[canonicalForm: "key"].count
     }
     return count
@@ -234,7 +234,7 @@ measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace_from_shor
 measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace_from_long_string") {
     let headers: HTTPHeaders = ["key": " moreThan15CharactersWithAndWithoutWhitespace ,anotherValue"]
     var count = 0
-    for _ in 0..<10_000 {
+    for _ in 0..<100_000 {
         count &+= headers[canonicalForm: "key"].count
     }
     return count
@@ -244,7 +244,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_short_string_literals") {
     let bufferSize = 12 * 1024 * 1024
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
 
-    for _ in 0 ..< 3 {
+    for _ in 0 ..< 5 {
         buffer.clear()
         for _ in 0 ..< (bufferSize / 4) {
             buffer.writeString("abcd")
@@ -261,7 +261,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_short_calculated_strings") {
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
     let s = someString(size: 4)
 
-    for _ in 0 ..< 1 {
+    for _ in 0 ..< 5 {
         buffer.clear()
         for _ in  0 ..< (bufferSize / 4) {
             buffer.writeString(s)
@@ -277,7 +277,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_medium_string_literals") {
     let bufferSize = 12 * 1024 * 1024
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
 
-    for _ in 0 ..< 100 {
+    for _ in 0 ..< 10 {
         buffer.clear()
         for _ in  0 ..< (bufferSize / 24) {
             buffer.writeString("012345678901234567890123")
@@ -294,7 +294,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_medium_calculated_strings") {
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
     let s = someString(size: 24)
 
-    for _ in 0 ..< 5 {
+    for _ in 0 ..< 10 {
         buffer.clear()
         for _ in 0 ..< (bufferSize / 24) {
             buffer.writeString(s)
@@ -311,7 +311,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_large_calculated_strings") {
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
     let s = someString(size: 1024 * 1024)
 
-    for _ in 0 ..< 5 {
+    for _ in 0 ..< 10 {
         buffer.clear()
         for _ in 0 ..< 12 {
             buffer.writeString(s)
@@ -360,7 +360,7 @@ measureAndPrint(desc: "bytebuffer_lots_of_rw") {
         let str = buffer.readString(length: 1)
         precondition("A" == str, "\(str!)")
     }
-    for _ in 0 ..< 100_000 {
+    for _ in 0 ..< 1024*1024 {
         doWrites(buffer: &buffer, dispatchData: dispatchData, substring: substring)
         doReads(buffer: &buffer)
     }
@@ -529,7 +529,7 @@ measureAndPrint(desc: "bytebuffer_write_http_response_some_nonascii_as_staticstr
     return buffer.readableBytes
 }
 
-try measureAndPrint(desc: "no-net_http1_1k_reqs_1_conn") {
+try measureAndPrint(desc: "no-net_http1_10k_reqs_1_conn") {
     final class MeasuringHandler: ChannelDuplexHandler {
         typealias InboundIn = Never
         typealias InboundOut = ByteBuffer
@@ -589,9 +589,8 @@ try measureAndPrint(desc: "no-net_http1_1k_reqs_1_conn") {
     let eventLoop = EmbeddedEventLoop()
     let channel = EmbeddedChannel(handler: nil, loop: eventLoop)
     var done = false
-    let desiredRequests = 1_000
     var requestsDone = -1
-    let measuringHandler = MeasuringHandler(numberOfRequests: desiredRequests) { reqs in
+    let measuringHandler = MeasuringHandler(numberOfRequests: 10_000) { reqs in
         requestsDone = reqs
         done = true
     }
@@ -608,12 +607,12 @@ try measureAndPrint(desc: "no-net_http1_1k_reqs_1_conn") {
         eventLoop.run()
     }
     _ = try channel.finish()
-    precondition(requestsDone == desiredRequests)
+    precondition(requestsDone == 10_000)
     return requestsDone
 }
 
-measureAndPrint(desc: "http1_1k_reqs_1_conn") {
-    let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: 1_000, eventLoop: group.next())
+measureAndPrint(desc: "http1_10k_reqs_1_conn") {
+    let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: 10_000, eventLoop: group.next())
 
     let clientChannel = try! ClientBootstrap(group: group)
         .channelInitializer { channel in
@@ -629,14 +628,12 @@ measureAndPrint(desc: "http1_1k_reqs_1_conn") {
     return try! repeatedRequestsHandler.wait()
 }
 
-measureAndPrint(desc: "http1_1k_reqs_100_conns") {
+measureAndPrint(desc: "http1_10k_reqs_100_conns") {
     var reqs: [Int] = []
-    let numConns = 100
-    let numReqs = 1_000
-    let reqsPerConn = numReqs / numConns
+    let reqsPerConn = 100
     reqs.reserveCapacity(reqsPerConn)
-    for _ in 0..<numConns {
-        let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: reqsPerConn, eventLoop: group.next())
+    for _ in 0..<reqsPerConn {
+        let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: 100, eventLoop: group.next())
 
         let clientChannel = try! ClientBootstrap(group: group)
             .channelInitializer { channel in
@@ -651,7 +648,7 @@ measureAndPrint(desc: "http1_1k_reqs_100_conns") {
         try! clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
         reqs.append(try! repeatedRequestsHandler.wait())
     }
-    return reqs.reduce(0, +) / numConns
+    return reqs.reduce(0, +) / reqsPerConn
 }
 
 measureAndPrint(desc: "future_whenallsucceed_100k_immediately_succeeded_off_loop") {
@@ -672,9 +669,9 @@ measureAndPrint(desc: "future_whenallsucceed_100k_immediately_succeeded_on_loop"
     return allSucceeded.count
 }
 
-measureAndPrint(desc: "future_whenallsucceed_10k_deferred_off_loop") {
+measureAndPrint(desc: "future_whenallsucceed_100k_deferred_off_loop") {
     let loop = group.next()
-    let expected = Array(0..<10_000)
+    let expected = Array(0..<100_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
     let allSucceeded = EventLoopFuture.whenAllSucceed(promises.map { $0.futureResult }, on: loop)
     for (index, promise) in promises.enumerated() {
@@ -683,9 +680,9 @@ measureAndPrint(desc: "future_whenallsucceed_10k_deferred_off_loop") {
     return try! allSucceeded.wait().count
 }
 
-measureAndPrint(desc: "future_whenallsucceed_10k_deferred_on_loop") {
+measureAndPrint(desc: "future_whenallsucceed_100k_deferred_on_loop") {
     let loop = group.next()
-    let expected = Array(0..<10_000)
+    let expected = Array(0..<100_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
     let allSucceeded = try! loop.makeSucceededFuture(()).flatMap { _ -> EventLoopFuture<[Int]> in
         let result = EventLoopFuture.whenAllSucceed(promises.map { $0.futureResult }, on: loop)
@@ -716,9 +713,9 @@ measureAndPrint(desc: "future_whenallcomplete_100k_immediately_succeeded_on_loop
     return allSucceeded.count
 }
 
-measureAndPrint(desc: "future_whenallcomplete_10k_deferred_off_loop") {
+measureAndPrint(desc: "future_whenallcomplete_100k_deferred_off_loop") {
     let loop = group.next()
-    let expected = Array(0..<10_000)
+    let expected = Array(0..<100_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
     let allSucceeded = EventLoopFuture.whenAllComplete(promises.map { $0.futureResult }, on: loop)
     for (index, promise) in promises.enumerated() {
@@ -744,302 +741,111 @@ measureAndPrint(desc: "future_whenallcomplete_100k_deferred_on_loop") {
 measureAndPrint(desc: "future_reduce_10k_futures") {
     let el1 = group.next()
 
-    let futures = (1...10_000).map { i in el1.makeSucceededFuture(i) }
-    return try! EventLoopFuture<Int>.reduce(0, futures, on: el1, +).wait()
+    let oneHundredFutures = (1 ... 10_000).map { i in el1.makeSucceededFuture(i) }
+    return try! EventLoopFuture<Int>.reduce(0, oneHundredFutures, on: el1, +).wait()
 }
 
 measureAndPrint(desc: "future_reduce_into_10k_futures") {
     let el1 = group.next()
 
-    let futures = (1...10_000).map { i in el1.makeSucceededFuture(i) }
-    return try! EventLoopFuture<Int>.reduce(into: 0, futures, on: el1, { $0 += $1 }).wait()
+    let oneHundredFutures = (1 ... 10_000).map { i in el1.makeSucceededFuture(i) }
+    return try! EventLoopFuture<Int>.reduce(into: 0, oneHundredFutures, on: el1, { $0 += $1 }).wait()
 }
 
-try measureAndPrint(desc: "channel_pipeline_1m_events", benchmark: ChannelPipelineBenchmark(runCount: 1_000_000))
+try measureAndPrint(desc: "channel_pipeline_1m_events", benchmark: ChannelPipelineBenchmark())
 
-try measureAndPrint(
-    desc: "websocket_encode_50b_space_at_front_100k_frames_cow",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 50,
-        runCount: 100_000,
-        dataStrategy: .spaceAtFront,
-        cowStrategy: .always,
-        maskingKeyStrategy: .never
-    )
-)
+try measureAndPrint(desc: "websocket_encode_50b_space_at_front_1m_frames_cow",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
 
-try measureAndPrint(
-    desc: "websocket_encode_50b_space_at_front_1m_frames_cow_masking",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 50,
-        runCount: 1_000_000,
-        dataStrategy: .spaceAtFront,
-        cowStrategy: .always,
-        maskingKeyStrategy: .always
-    )
-)
+try measureAndPrint(desc: "websocket_encode_50b_space_at_front_1m_frames_cow_masking",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .always))
 
+try measureAndPrint(desc: "websocket_encode_1kb_space_at_front_100k_frames_cow",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
 
-try measureAndPrint(
-    desc: "websocket_encode_1kb_space_at_front_1m_frames_cow",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 1024,
-        runCount: 1_000_000,
-        dataStrategy: .spaceAtFront,
-        cowStrategy: .always,
-        maskingKeyStrategy: .never
-    )
-)
+try measureAndPrint(desc: "websocket_encode_50b_no_space_at_front_1m_frames_cow",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .noSpaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
 
-try measureAndPrint(
-    desc: "websocket_encode_50b_no_space_at_front_100k_frames_cow",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 50,
-        runCount: 100_000,
-        dataStrategy: .noSpaceAtFront,
-        cowStrategy: .always,
-        maskingKeyStrategy: .never
-    )
-)
+try measureAndPrint(desc: "websocket_encode_1kb_no_space_at_front_100k_frames_cow",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 100_000, dataStrategy: .noSpaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
 
-try measureAndPrint(
-    desc: "websocket_encode_1kb_no_space_at_front_100k_frames_cow",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 1024,
-        runCount: 100_000,
-        dataStrategy: .noSpaceAtFront,
-        cowStrategy: .always,
-        maskingKeyStrategy: .never
-    )
-)
+try measureAndPrint(desc: "websocket_encode_50b_space_at_front_10k_frames",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 10_000, dataStrategy: .spaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
 
-try measureAndPrint(
-    desc: "websocket_encode_50b_space_at_front_100k_frames",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 50,
-        runCount: 100_000,
-        dataStrategy: .spaceAtFront,
-        cowStrategy: .never,
-        maskingKeyStrategy: .never
-    )
-)
+try measureAndPrint(desc: "websocket_encode_50b_space_at_front_10k_frames_masking",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .never, maskingKeyStrategy: .always))
 
-try measureAndPrint(
-    desc: "websocket_encode_50b_space_at_front_10k_frames_masking",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 50,
-        runCount: 10_000,
-        dataStrategy: .spaceAtFront,
-        cowStrategy: .never,
-        maskingKeyStrategy: .always
-    )
-)
+try measureAndPrint(desc: "websocket_encode_1kb_space_at_front_1k_frames",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 1_000, dataStrategy: .spaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
 
-try measureAndPrint(
-    desc: "websocket_encode_1kb_space_at_front_10k_frames",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 1024,
-        runCount: 10_000,
-        dataStrategy: .spaceAtFront,
-        cowStrategy: .never,
-        maskingKeyStrategy: .never
-    )
-)
+try measureAndPrint(desc: "websocket_encode_50b_no_space_at_front_10k_frames",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 10_000, dataStrategy: .noSpaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
 
-try measureAndPrint(
-    desc: "websocket_encode_50b_no_space_at_front_100k_frames",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 50,
-        runCount: 100_000,
-        dataStrategy: .noSpaceAtFront,
-        cowStrategy: .never,
-        maskingKeyStrategy: .never
-    )
-)
+try measureAndPrint(desc: "websocket_encode_1kb_no_space_at_front_1k_frames",
+                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 1_000, dataStrategy: .noSpaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
 
-try measureAndPrint(
-    desc: "websocket_encode_1kb_no_space_at_front_10k_frames",
-    benchmark: WebSocketFrameEncoderBenchmark(
-        dataSize: 1024,
-        runCount: 10_000,
-        dataStrategy: .noSpaceAtFront,
-        cowStrategy: .never,
-        maskingKeyStrategy: .never
-    )
-)
+ try measureAndPrint(desc: "websocket_decode_125b_100k_frames",
+                     benchmark: WebSocketFrameDecoderBenchmark(dataSize: 125, runCount: 100_000))
 
-try measureAndPrint(
-    desc: "websocket_decode_125b_10k_frames",
-    benchmark: WebSocketFrameDecoderBenchmark(
-        dataSize: 125,
-        runCount: 10_000
-    )
-)
+try measureAndPrint(desc: "websocket_decode_125b_with_a_masking_key_100k_frames",
+                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: 125, runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
 
-try measureAndPrint(
-    desc: "websocket_decode_125b_with_a_masking_key_10k_frames",
-    benchmark: WebSocketFrameDecoderBenchmark(
-        dataSize: 125,
-        runCount: 10_000,
-        maskingKey: [0x80, 0x08, 0x10, 0x01]
-    )
-)
+try measureAndPrint(desc: "websocket_decode_64kb_100k_frames",
+                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max), runCount: 100_000))
 
-try measureAndPrint(
-    desc: "websocket_decode_64kb_10k_frames",
-    benchmark: WebSocketFrameDecoderBenchmark(
-        dataSize: Int(UInt16.max),
-        runCount: 10_000
-    )
-)
+try measureAndPrint(desc: "websocket_decode_64kb_with_a_masking_key_100k_frames",
+                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max), runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
 
-try measureAndPrint(
-    desc: "websocket_decode_64kb_with_a_masking_key_10k_frames",
-    benchmark: WebSocketFrameDecoderBenchmark(
-        dataSize: Int(UInt16.max),
-        runCount: 10_000,
-        maskingKey: [0x80, 0x08, 0x10, 0x01]
-    )
-)
+try measureAndPrint(desc: "websocket_decode_64kb_+1_100k_frames",
+                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max) + 1, runCount: 100_000))
 
-try measureAndPrint(
-    desc: "websocket_decode_64kb_+1_10k_frames",
-    benchmark: WebSocketFrameDecoderBenchmark(
-        dataSize: Int(UInt16.max) + 1,
-        runCount: 10_000
-    )
-)
+try measureAndPrint(desc: "websocket_decode_64kb_+1_with_a_masking_key_100k_frames",
+                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max) + 1, runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
 
-try measureAndPrint(
-    desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",
-    benchmark: WebSocketFrameDecoderBenchmark(
-        dataSize: Int(UInt16.max) + 1,
-        runCount: 10_000,
-        maskingKey: [0x80, 0x08, 0x10, 0x01]
-    )
-)
+try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1kb", benchmark: CircularBufferIntoByteBufferBenchmark(iterations: 10000, bufferSize: 1024))
 
-try measureAndPrint(
-    desc: "circular_buffer_into_byte_buffer_1kb",
-    benchmark: CircularBufferIntoByteBufferBenchmark(
-        iterations: 10_000,
-        bufferSize: 1024
-    )
-)
+try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1mb", benchmark: CircularBufferIntoByteBufferBenchmark(iterations: 20, bufferSize: 1024*1024))
 
-try measureAndPrint(
-    desc: "circular_buffer_into_byte_buffer_1mb",
-    benchmark: CircularBufferIntoByteBufferBenchmark(
-        iterations: 20,
-        bufferSize: 1024*1024
-    )
-)
+try measureAndPrint(desc: "byte_buffer_view_iterator_1mb", benchmark: ByteBufferViewIteratorBenchmark(iterations: 20, bufferSize: 1024*1024))
 
-try measureAndPrint(
-    desc: "byte_buffer_view_iterator_1mb",
-    benchmark: ByteBufferViewIteratorBenchmark(
-        iterations: 20,
-        bufferSize: 1024*1024
-    )
-)
+try measureAndPrint(desc: "byte_buffer_view_contains_12mb", benchmark: ByteBufferViewContainsBenchmark(iterations: 20, bufferSize: 12*1024*1024))
 
-try measureAndPrint(
-    desc: "byte_buffer_view_contains_12mb",
-    benchmark: ByteBufferViewContainsBenchmark(
-        iterations: 5,
-        bufferSize: 12*1024*1024
-    )
-)
-
-try measureAndPrint(
-    desc: "byte_to_message_decoder_decode_many_small",
-    benchmark: ByteToMessageDecoderDecodeManySmallsBenchmark(
-        iterations: 200,
-        bufferSize: 16384
-    )
-)
+try measureAndPrint(desc: "byte_to_message_decoder_decode_many_small",
+                    benchmark: ByteToMessageDecoderDecodeManySmallsBenchmark(iterations: 1_000, bufferSize: 16384))
 
 measureAndPrint(desc: "generate_10k_random_request_keys") {
-    let numKeys = 10_000
-    return (0 ..< numKeys).reduce(into: 0, { result, _ in
-        result &+= NIOWebSocketClientUpgrader.randomRequestKey().count
-    })
+    return (0 ..< 10_000).reduce(into: 0, { result, _ in result &+= NIOWebSocketClientUpgrader.randomRequestKey().count })
 }
 
-try measureAndPrint(
-    desc: "bytebuffer_rw_10_uint32s",
-    benchmark: ByteBufferReadWriteMultipleIntegersBenchmark<UInt32>(
-        iterations: 100_000,
-        numberOfInts: 10
-    )
-)
+try measureAndPrint(desc: "bytebuffer_rw_10_uint32s",
+                    benchmark: ByteBufferReadWriteMultipleIntegersBenchmark<UInt32>(iterations: 1_000_000, numberOfInts: 10))
 
-try measureAndPrint(
-    desc: "bytebuffer_multi_rw_10_uint32s",
-    benchmark: ByteBufferMultiReadWriteTenIntegersBenchmark<UInt32>(
-        iterations: 1_000_000
-    )
-)
+try measureAndPrint(desc: "bytebuffer_multi_rw_10_uint32s",
+                    benchmark: ByteBufferMultiReadWriteTenIntegersBenchmark<UInt32>(iterations: 1_000_000))
 
-try measureAndPrint(
-    desc: "lock_1_thread_1M_ops",
-    benchmark: LockBenchmark(
-        numberOfThreads: 1,
-        lockOperationsPerThread: 1_000_000
-    )
-)
+try measureAndPrint(desc: "lock_1_thread_10M_ops",
+                    benchmark: LockBenchmark(numberOfThreads: 1, lockOperationsPerThread: 10_000_000))
 
-try measureAndPrint(
-    desc: "lock_2_threads_1M_ops",
-    benchmark: LockBenchmark(
-        numberOfThreads: 2,
-        lockOperationsPerThread: 500_000
-    )
-)
+try measureAndPrint(desc: "lock_2_threads_10M_ops",
+                    benchmark: LockBenchmark(numberOfThreads: 2, lockOperationsPerThread: 5_000_000))
 
-try measureAndPrint(
-    desc: "lock_4_threads_1M_ops",
-    benchmark: LockBenchmark(
-        numberOfThreads: 4,
-        lockOperationsPerThread: 250_000
-    )
-)
+try measureAndPrint(desc: "lock_4_threads_10M_ops",
+                    benchmark: LockBenchmark(numberOfThreads: 4, lockOperationsPerThread: 2_500_000))
 
-try measureAndPrint(
-    desc: "lock_8_threads_1M_ops",
-    benchmark: LockBenchmark(
-        numberOfThreads: 8,
-        lockOperationsPerThread: 125_000
-    )
-)
+try measureAndPrint(desc: "lock_8_threads_10M_ops",
+                    benchmark: LockBenchmark(numberOfThreads: 8, lockOperationsPerThread: 1_250_000))
 
-try measureAndPrint(
-    desc: "schedule_1m_tasks",
-    benchmark: SchedulingBenchmark(numTasks: 1_000_000)
-)
+try measureAndPrint(desc: "schedule_10000_tasks",
+                    benchmark: SchedulingBenchmark())
 
-try measureAndPrint(
-    desc: "schedule_and_run_100k_tasks",
-    benchmark: SchedulingAndRunningBenchmark(numTasks: 100_000)
-)
+try measureAndPrint(desc: "schedule_and_run_10000_tasks",
+                    benchmark: SchedulingAndRunningBenchmark())
 
-try measureAndPrint(
-    desc: "execute_100k_tasks",
-    benchmark: ExecuteBenchmark(numTasks: 100_000)
-)
+try measureAndPrint(desc: "execute_10000",
+                    benchmark: ExecuteBenchmark())
 
-try measureAndPrint(
-    desc: "bytebufferview_copy_to_array_100k_times_1kb",
-    benchmark: ByteBufferViewCopyToArrayBenchmark(
-        iterations: 100_000,
-        size: 1024
-    )
-)
+try measureAndPrint(desc: "bytebufferview_copy_to_array_1000_times_1kb",
+                    benchmark: ByteBufferViewCopyToArrayBenchmark(iterations: 1000, size: 1024))
 
-try measureAndPrint(
-    desc: "circularbuffer_copy_to_array_10k_times_1kb",
-    benchmark: CircularBufferViewCopyToArrayBenchmark(
-        iterations: 10_000,
-        size: 1024
-    )
-)
+try measureAndPrint(desc: "circularbuffer_copy_to_array_1000_times_1kb",
+                    benchmark: CircularBufferViewCopyToArrayBenchmark(iterations: 1000, size: 1024))

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -933,7 +933,6 @@ try measureAndPrint(
         bufferSize: 1024*1024
     )
 )
-/*
 
 try measureAndPrint(
     desc: "byte_buffer_view_iterator_1mb",
@@ -996,6 +995,8 @@ try measureAndPrint(
         lockOperationsPerThread: 500_000
     )
 )
+
+/*
 
 try measureAndPrint(
     desc: "lock_4_threads_1M_ops",

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -902,13 +902,13 @@ try measureAndPrint(
     )
 )
 
-try measureAndPrint(
-    desc: "websocket_decode_64kb_+1_10k_frames",
-    benchmark: WebSocketFrameDecoderBenchmark(
-        dataSize: Int(UInt16.max) + 1,
-        runCount: 10_000
-    )
-)
+//try measureAndPrint(
+//    desc: "websocket_decode_64kb_+1_10k_frames",
+//    benchmark: WebSocketFrameDecoderBenchmark(
+//        dataSize: Int(UInt16.max) + 1,
+//        runCount: 10_000
+//    )
+//)
 
 try measureAndPrint(
     desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -197,7 +197,7 @@ measureAndPrint(desc: "write_http_headers") {
     }
 
     var val = 0
-    for _ in 0..<100_000 {
+    for _ in 0..<1_000_000 {
         let headers = HTTPHeaders(headers)
         val += headers.underestimatedCount
     }
@@ -216,7 +216,7 @@ measureAndPrint(desc: "http_headers_canonical_form") {
 measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace") {
     let headers: HTTPHeaders = ["key": "         some   ,   trimming     "]
     var count = 0
-    for _ in 0..<100_000 {
+    for _ in 0..<10_000 {
         count &+= headers[canonicalForm: "key"].count
     }
     return count
@@ -225,7 +225,7 @@ measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace") {
 measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace_from_short_string") {
     let headers: HTTPHeaders = ["key": "   smallString   ,whenStripped"]
     var count = 0
-    for _ in 0..<100_000 {
+    for _ in 0..<10_000 {
         count &+= headers[canonicalForm: "key"].count
     }
     return count
@@ -234,7 +234,7 @@ measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace_from_shor
 measureAndPrint(desc: "http_headers_canonical_form_trimming_whitespace_from_long_string") {
     let headers: HTTPHeaders = ["key": " moreThan15CharactersWithAndWithoutWhitespace ,anotherValue"]
     var count = 0
-    for _ in 0..<100_000 {
+    for _ in 0..<10_000 {
         count &+= headers[canonicalForm: "key"].count
     }
     return count
@@ -244,7 +244,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_short_string_literals") {
     let bufferSize = 12 * 1024 * 1024
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
 
-    for _ in 0 ..< 5 {
+    for _ in 0 ..< 3 {
         buffer.clear()
         for _ in 0 ..< (bufferSize / 4) {
             buffer.writeString("abcd")
@@ -261,7 +261,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_short_calculated_strings") {
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
     let s = someString(size: 4)
 
-    for _ in 0 ..< 5 {
+    for _ in 0 ..< 1 {
         buffer.clear()
         for _ in  0 ..< (bufferSize / 4) {
             buffer.writeString(s)
@@ -277,7 +277,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_medium_string_literals") {
     let bufferSize = 12 * 1024 * 1024
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
 
-    for _ in 0 ..< 10 {
+    for _ in 0 ..< 100 {
         buffer.clear()
         for _ in  0 ..< (bufferSize / 24) {
             buffer.writeString("012345678901234567890123")
@@ -294,7 +294,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_medium_calculated_strings") {
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
     let s = someString(size: 24)
 
-    for _ in 0 ..< 10 {
+    for _ in 0 ..< 5 {
         buffer.clear()
         for _ in 0 ..< (bufferSize / 24) {
             buffer.writeString(s)
@@ -311,7 +311,7 @@ measureAndPrint(desc: "bytebuffer_write_12MB_large_calculated_strings") {
     var buffer = ByteBufferAllocator().buffer(capacity: bufferSize)
     let s = someString(size: 1024 * 1024)
 
-    for _ in 0 ..< 10 {
+    for _ in 0 ..< 5 {
         buffer.clear()
         for _ in 0 ..< 12 {
             buffer.writeString(s)
@@ -360,7 +360,7 @@ measureAndPrint(desc: "bytebuffer_lots_of_rw") {
         let str = buffer.readString(length: 1)
         precondition("A" == str, "\(str!)")
     }
-    for _ in 0 ..< 1024*1024 {
+    for _ in 0 ..< 100_000 {
         doWrites(buffer: &buffer, dispatchData: dispatchData, substring: substring)
         doReads(buffer: &buffer)
     }
@@ -529,7 +529,7 @@ measureAndPrint(desc: "bytebuffer_write_http_response_some_nonascii_as_staticstr
     return buffer.readableBytes
 }
 
-try measureAndPrint(desc: "no-net_http1_10k_reqs_1_conn") {
+try measureAndPrint(desc: "no-net_http1_1k_reqs_1_conn") {
     final class MeasuringHandler: ChannelDuplexHandler {
         typealias InboundIn = Never
         typealias InboundOut = ByteBuffer
@@ -589,8 +589,9 @@ try measureAndPrint(desc: "no-net_http1_10k_reqs_1_conn") {
     let eventLoop = EmbeddedEventLoop()
     let channel = EmbeddedChannel(handler: nil, loop: eventLoop)
     var done = false
+    let desiredRequests = 1_000
     var requestsDone = -1
-    let measuringHandler = MeasuringHandler(numberOfRequests: 10_000) { reqs in
+    let measuringHandler = MeasuringHandler(numberOfRequests: desiredRequests) { reqs in
         requestsDone = reqs
         done = true
     }
@@ -607,12 +608,12 @@ try measureAndPrint(desc: "no-net_http1_10k_reqs_1_conn") {
         eventLoop.run()
     }
     _ = try channel.finish()
-    precondition(requestsDone == 10_000)
+    precondition(requestsDone == desiredRequests)
     return requestsDone
 }
 
-measureAndPrint(desc: "http1_10k_reqs_1_conn") {
-    let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: 10_000, eventLoop: group.next())
+measureAndPrint(desc: "http1_1k_reqs_1_conn") {
+    let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: 1_000, eventLoop: group.next())
 
     let clientChannel = try! ClientBootstrap(group: group)
         .channelInitializer { channel in
@@ -628,12 +629,14 @@ measureAndPrint(desc: "http1_10k_reqs_1_conn") {
     return try! repeatedRequestsHandler.wait()
 }
 
-measureAndPrint(desc: "http1_10k_reqs_100_conns") {
+measureAndPrint(desc: "http1_1k_reqs_100_conns") {
     var reqs: [Int] = []
-    let reqsPerConn = 100
+    let numConns = 100
+    let numReqs = 1_000
+    let reqsPerConn = numReqs / numConns
     reqs.reserveCapacity(reqsPerConn)
-    for _ in 0..<reqsPerConn {
-        let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: 100, eventLoop: group.next())
+    for _ in 0..<numConns {
+        let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: reqsPerConn, eventLoop: group.next())
 
         let clientChannel = try! ClientBootstrap(group: group)
             .channelInitializer { channel in
@@ -648,7 +651,7 @@ measureAndPrint(desc: "http1_10k_reqs_100_conns") {
         try! clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
         reqs.append(try! repeatedRequestsHandler.wait())
     }
-    return reqs.reduce(0, +) / reqsPerConn
+    return reqs.reduce(0, +) / numConns
 }
 
 measureAndPrint(desc: "future_whenallsucceed_100k_immediately_succeeded_off_loop") {
@@ -669,9 +672,9 @@ measureAndPrint(desc: "future_whenallsucceed_100k_immediately_succeeded_on_loop"
     return allSucceeded.count
 }
 
-measureAndPrint(desc: "future_whenallsucceed_100k_deferred_off_loop") {
+measureAndPrint(desc: "future_whenallsucceed_10k_deferred_off_loop") {
     let loop = group.next()
-    let expected = Array(0..<100_000)
+    let expected = Array(0..<10_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
     let allSucceeded = EventLoopFuture.whenAllSucceed(promises.map { $0.futureResult }, on: loop)
     for (index, promise) in promises.enumerated() {
@@ -680,9 +683,9 @@ measureAndPrint(desc: "future_whenallsucceed_100k_deferred_off_loop") {
     return try! allSucceeded.wait().count
 }
 
-measureAndPrint(desc: "future_whenallsucceed_100k_deferred_on_loop") {
+measureAndPrint(desc: "future_whenallsucceed_10k_deferred_on_loop") {
     let loop = group.next()
-    let expected = Array(0..<100_000)
+    let expected = Array(0..<10_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
     let allSucceeded = try! loop.makeSucceededFuture(()).flatMap { _ -> EventLoopFuture<[Int]> in
         let result = EventLoopFuture.whenAllSucceed(promises.map { $0.futureResult }, on: loop)
@@ -713,9 +716,9 @@ measureAndPrint(desc: "future_whenallcomplete_100k_immediately_succeeded_on_loop
     return allSucceeded.count
 }
 
-measureAndPrint(desc: "future_whenallcomplete_100k_deferred_off_loop") {
+measureAndPrint(desc: "future_whenallcomplete_10k_deferred_off_loop") {
     let loop = group.next()
-    let expected = Array(0..<100_000)
+    let expected = Array(0..<10_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
     let allSucceeded = EventLoopFuture.whenAllComplete(promises.map { $0.futureResult }, on: loop)
     for (index, promise) in promises.enumerated() {
@@ -741,111 +744,302 @@ measureAndPrint(desc: "future_whenallcomplete_100k_deferred_on_loop") {
 measureAndPrint(desc: "future_reduce_10k_futures") {
     let el1 = group.next()
 
-    let oneHundredFutures = (1 ... 10_000).map { i in el1.makeSucceededFuture(i) }
-    return try! EventLoopFuture<Int>.reduce(0, oneHundredFutures, on: el1, +).wait()
+    let futures = (1...10_000).map { i in el1.makeSucceededFuture(i) }
+    return try! EventLoopFuture<Int>.reduce(0, futures, on: el1, +).wait()
 }
 
 measureAndPrint(desc: "future_reduce_into_10k_futures") {
     let el1 = group.next()
 
-    let oneHundredFutures = (1 ... 10_000).map { i in el1.makeSucceededFuture(i) }
-    return try! EventLoopFuture<Int>.reduce(into: 0, oneHundredFutures, on: el1, { $0 += $1 }).wait()
+    let futures = (1...10_000).map { i in el1.makeSucceededFuture(i) }
+    return try! EventLoopFuture<Int>.reduce(into: 0, futures, on: el1, { $0 += $1 }).wait()
 }
 
-try measureAndPrint(desc: "channel_pipeline_1m_events", benchmark: ChannelPipelineBenchmark())
+try measureAndPrint(desc: "channel_pipeline_1m_events", benchmark: ChannelPipelineBenchmark(runCount: 1_000_000))
 
-try measureAndPrint(desc: "websocket_encode_50b_space_at_front_1m_frames_cow",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
+try measureAndPrint(
+    desc: "websocket_encode_50b_space_at_front_100k_frames_cow",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 50,
+        runCount: 100_000,
+        dataStrategy: .spaceAtFront,
+        cowStrategy: .always,
+        maskingKeyStrategy: .never
+    )
+)
 
-try measureAndPrint(desc: "websocket_encode_50b_space_at_front_1m_frames_cow_masking",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .always))
+try measureAndPrint(
+    desc: "websocket_encode_50b_space_at_front_1m_frames_cow_masking",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 50,
+        runCount: 1_000_000,
+        dataStrategy: .spaceAtFront,
+        cowStrategy: .always,
+        maskingKeyStrategy: .always
+    )
+)
 
-try measureAndPrint(desc: "websocket_encode_1kb_space_at_front_100k_frames_cow",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
 
-try measureAndPrint(desc: "websocket_encode_50b_no_space_at_front_1m_frames_cow",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 1_000_000, dataStrategy: .noSpaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
+try measureAndPrint(
+    desc: "websocket_encode_1kb_space_at_front_1m_frames_cow",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 1024,
+        runCount: 1_000_000,
+        dataStrategy: .spaceAtFront,
+        cowStrategy: .always,
+        maskingKeyStrategy: .never
+    )
+)
 
-try measureAndPrint(desc: "websocket_encode_1kb_no_space_at_front_100k_frames_cow",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 100_000, dataStrategy: .noSpaceAtFront, cowStrategy: .always, maskingKeyStrategy: .never))
+try measureAndPrint(
+    desc: "websocket_encode_50b_no_space_at_front_100k_frames_cow",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 50,
+        runCount: 100_000,
+        dataStrategy: .noSpaceAtFront,
+        cowStrategy: .always,
+        maskingKeyStrategy: .never
+    )
+)
 
-try measureAndPrint(desc: "websocket_encode_50b_space_at_front_10k_frames",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 10_000, dataStrategy: .spaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
+try measureAndPrint(
+    desc: "websocket_encode_1kb_no_space_at_front_100k_frames_cow",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 1024,
+        runCount: 100_000,
+        dataStrategy: .noSpaceAtFront,
+        cowStrategy: .always,
+        maskingKeyStrategy: .never
+    )
+)
 
-try measureAndPrint(desc: "websocket_encode_50b_space_at_front_10k_frames_masking",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 100_000, dataStrategy: .spaceAtFront, cowStrategy: .never, maskingKeyStrategy: .always))
+try measureAndPrint(
+    desc: "websocket_encode_50b_space_at_front_100k_frames",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 50,
+        runCount: 100_000,
+        dataStrategy: .spaceAtFront,
+        cowStrategy: .never,
+        maskingKeyStrategy: .never
+    )
+)
 
-try measureAndPrint(desc: "websocket_encode_1kb_space_at_front_1k_frames",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 1_000, dataStrategy: .spaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
+try measureAndPrint(
+    desc: "websocket_encode_50b_space_at_front_10k_frames_masking",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 50,
+        runCount: 10_000,
+        dataStrategy: .spaceAtFront,
+        cowStrategy: .never,
+        maskingKeyStrategy: .always
+    )
+)
 
-try measureAndPrint(desc: "websocket_encode_50b_no_space_at_front_10k_frames",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 50, runCount: 10_000, dataStrategy: .noSpaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
+try measureAndPrint(
+    desc: "websocket_encode_1kb_space_at_front_10k_frames",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 1024,
+        runCount: 10_000,
+        dataStrategy: .spaceAtFront,
+        cowStrategy: .never,
+        maskingKeyStrategy: .never
+    )
+)
 
-try measureAndPrint(desc: "websocket_encode_1kb_no_space_at_front_1k_frames",
-                    benchmark: WebSocketFrameEncoderBenchmark(dataSize: 1024, runCount: 1_000, dataStrategy: .noSpaceAtFront, cowStrategy: .never, maskingKeyStrategy: .never))
+try measureAndPrint(
+    desc: "websocket_encode_50b_no_space_at_front_100k_frames",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 50,
+        runCount: 100_000,
+        dataStrategy: .noSpaceAtFront,
+        cowStrategy: .never,
+        maskingKeyStrategy: .never
+    )
+)
 
- try measureAndPrint(desc: "websocket_decode_125b_100k_frames",
-                     benchmark: WebSocketFrameDecoderBenchmark(dataSize: 125, runCount: 100_000))
+try measureAndPrint(
+    desc: "websocket_encode_1kb_no_space_at_front_10k_frames",
+    benchmark: WebSocketFrameEncoderBenchmark(
+        dataSize: 1024,
+        runCount: 10_000,
+        dataStrategy: .noSpaceAtFront,
+        cowStrategy: .never,
+        maskingKeyStrategy: .never
+    )
+)
 
-try measureAndPrint(desc: "websocket_decode_125b_with_a_masking_key_100k_frames",
-                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: 125, runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
+try measureAndPrint(
+    desc: "websocket_decode_125b_10k_frames",
+    benchmark: WebSocketFrameDecoderBenchmark(
+        dataSize: 125,
+        runCount: 10_000
+    )
+)
 
-try measureAndPrint(desc: "websocket_decode_64kb_100k_frames",
-                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max), runCount: 100_000))
+try measureAndPrint(
+    desc: "websocket_decode_125b_with_a_masking_key_10k_frames",
+    benchmark: WebSocketFrameDecoderBenchmark(
+        dataSize: 125,
+        runCount: 10_000,
+        maskingKey: [0x80, 0x08, 0x10, 0x01]
+    )
+)
 
-try measureAndPrint(desc: "websocket_decode_64kb_with_a_masking_key_100k_frames",
-                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max), runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
+try measureAndPrint(
+    desc: "websocket_decode_64kb_10k_frames",
+    benchmark: WebSocketFrameDecoderBenchmark(
+        dataSize: Int(UInt16.max),
+        runCount: 10_000
+    )
+)
 
-try measureAndPrint(desc: "websocket_decode_64kb_+1_100k_frames",
-                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max) + 1, runCount: 100_000))
+try measureAndPrint(
+    desc: "websocket_decode_64kb_with_a_masking_key_10k_frames",
+    benchmark: WebSocketFrameDecoderBenchmark(
+        dataSize: Int(UInt16.max),
+        runCount: 10_000,
+        maskingKey: [0x80, 0x08, 0x10, 0x01]
+    )
+)
 
-try measureAndPrint(desc: "websocket_decode_64kb_+1_with_a_masking_key_100k_frames",
-                    benchmark: WebSocketFrameDecoderBenchmark(dataSize: Int(UInt16.max) + 1, runCount: 100_000, maskingKey: [0x80, 0x08, 0x10, 0x01]))
+try measureAndPrint(
+    desc: "websocket_decode_64kb_+1_10k_frames",
+    benchmark: WebSocketFrameDecoderBenchmark(
+        dataSize: Int(UInt16.max) + 1,
+        runCount: 10_000
+    )
+)
 
-try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1kb", benchmark: CircularBufferIntoByteBufferBenchmark(iterations: 10000, bufferSize: 1024))
+try measureAndPrint(
+    desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",
+    benchmark: WebSocketFrameDecoderBenchmark(
+        dataSize: Int(UInt16.max) + 1,
+        runCount: 10_000,
+        maskingKey: [0x80, 0x08, 0x10, 0x01]
+    )
+)
 
-try measureAndPrint(desc: "circular_buffer_into_byte_buffer_1mb", benchmark: CircularBufferIntoByteBufferBenchmark(iterations: 20, bufferSize: 1024*1024))
+try measureAndPrint(
+    desc: "circular_buffer_into_byte_buffer_1kb",
+    benchmark: CircularBufferIntoByteBufferBenchmark(
+        iterations: 10_000,
+        bufferSize: 1024
+    )
+)
 
-try measureAndPrint(desc: "byte_buffer_view_iterator_1mb", benchmark: ByteBufferViewIteratorBenchmark(iterations: 20, bufferSize: 1024*1024))
+try measureAndPrint(
+    desc: "circular_buffer_into_byte_buffer_1mb",
+    benchmark: CircularBufferIntoByteBufferBenchmark(
+        iterations: 20,
+        bufferSize: 1024*1024
+    )
+)
 
-try measureAndPrint(desc: "byte_buffer_view_contains_12mb", benchmark: ByteBufferViewContainsBenchmark(iterations: 20, bufferSize: 12*1024*1024))
+try measureAndPrint(
+    desc: "byte_buffer_view_iterator_1mb",
+    benchmark: ByteBufferViewIteratorBenchmark(
+        iterations: 20,
+        bufferSize: 1024*1024
+    )
+)
 
-try measureAndPrint(desc: "byte_to_message_decoder_decode_many_small",
-                    benchmark: ByteToMessageDecoderDecodeManySmallsBenchmark(iterations: 1_000, bufferSize: 16384))
+try measureAndPrint(
+    desc: "byte_buffer_view_contains_12mb",
+    benchmark: ByteBufferViewContainsBenchmark(
+        iterations: 5,
+        bufferSize: 12*1024*1024
+    )
+)
+
+try measureAndPrint(
+    desc: "byte_to_message_decoder_decode_many_small",
+    benchmark: ByteToMessageDecoderDecodeManySmallsBenchmark(
+        iterations: 200,
+        bufferSize: 16384
+    )
+)
 
 measureAndPrint(desc: "generate_10k_random_request_keys") {
-    return (0 ..< 10_000).reduce(into: 0, { result, _ in result &+= NIOWebSocketClientUpgrader.randomRequestKey().count })
+    let numKeys = 10_000
+    return (0 ..< numKeys).reduce(into: 0, { result, _ in
+        result &+= NIOWebSocketClientUpgrader.randomRequestKey().count
+    })
 }
 
-try measureAndPrint(desc: "bytebuffer_rw_10_uint32s",
-                    benchmark: ByteBufferReadWriteMultipleIntegersBenchmark<UInt32>(iterations: 1_000_000, numberOfInts: 10))
+try measureAndPrint(
+    desc: "bytebuffer_rw_10_uint32s",
+    benchmark: ByteBufferReadWriteMultipleIntegersBenchmark<UInt32>(
+        iterations: 100_000,
+        numberOfInts: 10
+    )
+)
 
-try measureAndPrint(desc: "bytebuffer_multi_rw_10_uint32s",
-                    benchmark: ByteBufferMultiReadWriteTenIntegersBenchmark<UInt32>(iterations: 1_000_000))
+try measureAndPrint(
+    desc: "bytebuffer_multi_rw_10_uint32s",
+    benchmark: ByteBufferMultiReadWriteTenIntegersBenchmark<UInt32>(
+        iterations: 1_000_000
+    )
+)
 
-try measureAndPrint(desc: "lock_1_thread_10M_ops",
-                    benchmark: LockBenchmark(numberOfThreads: 1, lockOperationsPerThread: 10_000_000))
+try measureAndPrint(
+    desc: "lock_1_thread_1M_ops",
+    benchmark: LockBenchmark(
+        numberOfThreads: 1,
+        lockOperationsPerThread: 1_000_000
+    )
+)
 
-try measureAndPrint(desc: "lock_2_threads_10M_ops",
-                    benchmark: LockBenchmark(numberOfThreads: 2, lockOperationsPerThread: 5_000_000))
+try measureAndPrint(
+    desc: "lock_2_threads_1M_ops",
+    benchmark: LockBenchmark(
+        numberOfThreads: 2,
+        lockOperationsPerThread: 500_000
+    )
+)
 
-try measureAndPrint(desc: "lock_4_threads_10M_ops",
-                    benchmark: LockBenchmark(numberOfThreads: 4, lockOperationsPerThread: 2_500_000))
+try measureAndPrint(
+    desc: "lock_4_threads_1M_ops",
+    benchmark: LockBenchmark(
+        numberOfThreads: 4,
+        lockOperationsPerThread: 250_000
+    )
+)
 
-try measureAndPrint(desc: "lock_8_threads_10M_ops",
-                    benchmark: LockBenchmark(numberOfThreads: 8, lockOperationsPerThread: 1_250_000))
+try measureAndPrint(
+    desc: "lock_8_threads_1M_ops",
+    benchmark: LockBenchmark(
+        numberOfThreads: 8,
+        lockOperationsPerThread: 125_000
+    )
+)
 
-try measureAndPrint(desc: "schedule_10000_tasks",
-                    benchmark: SchedulingBenchmark())
+try measureAndPrint(
+    desc: "schedule_1m_tasks",
+    benchmark: SchedulingBenchmark(numTasks: 1_000_000)
+)
 
-try measureAndPrint(desc: "schedule_and_run_10000_tasks",
-                    benchmark: SchedulingAndRunningBenchmark())
+try measureAndPrint(
+    desc: "schedule_and_run_100k_tasks",
+    benchmark: SchedulingAndRunningBenchmark(numTasks: 100_000)
+)
 
-try measureAndPrint(desc: "execute_10000",
-                    benchmark: ExecuteBenchmark())
+try measureAndPrint(
+    desc: "execute_100k_tasks",
+    benchmark: ExecuteBenchmark(numTasks: 100_000)
+)
 
-try measureAndPrint(desc: "bytebufferview_copy_to_array_1000_times_1kb",
-                    benchmark: ByteBufferViewCopyToArrayBenchmark(iterations: 1000, size: 1024))
+try measureAndPrint(
+    desc: "bytebufferview_copy_to_array_100k_times_1kb",
+    benchmark: ByteBufferViewCopyToArrayBenchmark(
+        iterations: 100_000,
+        size: 1024
+    )
+)
 
-try measureAndPrint(desc: "circularbuffer_copy_to_array_1000_times_1kb",
-                    benchmark: CircularBufferViewCopyToArrayBenchmark(iterations: 1000, size: 1024))
+try measureAndPrint(
+    desc: "circularbuffer_copy_to_array_10k_times_1kb",
+    benchmark: CircularBufferViewCopyToArrayBenchmark(
+        iterations: 10_000,
+        size: 1024
+    )
+)

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -189,7 +189,6 @@ private func someString(size: Int) -> String {
 }
 
 // MARK: Performance Tests
-/*
 
 measureAndPrint(desc: "write_http_headers") {
     var headers: [(String, String)] = []
@@ -1013,21 +1012,16 @@ try measureAndPrint(
         lockOperationsPerThread: 125_000
     )
 )
-*/
 
 try measureAndPrint(
-    desc: "schedule_1m_tasks",
-    benchmark: SchedulingBenchmark(numTasks: 1_000_000)
+    desc: "schedule_100k_tasks",
+    benchmark: SchedulingBenchmark(numTasks: 100_000)
 )
-/*
 
 try measureAndPrint(
     desc: "schedule_and_run_100k_tasks",
     benchmark: SchedulingAndRunningBenchmark(numTasks: 100_000)
 )
-
-
-
 
 try measureAndPrint(
     desc: "execute_100k_tasks",
@@ -1049,5 +1043,3 @@ try measureAndPrint(
         size: 1024
     )
 )
-
-*/

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -910,14 +910,14 @@ try measureAndPrint(
     )
 )
 
-try measureAndPrint(
-    desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",
-    benchmark: WebSocketFrameDecoderBenchmark(
-        dataSize: Int(UInt16.max) + 1,
-        runCount: 10_000,
-        maskingKey: [0x80, 0x08, 0x10, 0x01]
-    )
-)
+//try measureAndPrint(
+//    desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",
+//    benchmark: WebSocketFrameDecoderBenchmark(
+//        dataSize: Int(UInt16.max) + 1,
+//        runCount: 10_000,
+//        maskingKey: [0x80, 0x08, 0x10, 0x01]
+//    )
+//)
 
 try measureAndPrint(
     desc: "circular_buffer_into_byte_buffer_1kb",

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -529,7 +529,7 @@ measureAndPrint(desc: "bytebuffer_write_http_response_some_nonascii_as_staticstr
     return buffer.readableBytes
 }
 
-try measureAndPrint(desc: "no-net_http1_10k_reqs_1_conn") {
+try measureAndPrint(desc: "no-net_http1_1k_reqs_1_conn") {
     final class MeasuringHandler: ChannelDuplexHandler {
         typealias InboundIn = Never
         typealias InboundOut = ByteBuffer
@@ -612,7 +612,7 @@ try measureAndPrint(desc: "no-net_http1_10k_reqs_1_conn") {
     return requestsDone
 }
 
-measureAndPrint(desc: "http1_10k_reqs_1_conn") {
+measureAndPrint(desc: "http1_1k_reqs_1_conn") {
     let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: 1_000, eventLoop: group.next())
 
     let clientChannel = try! ClientBootstrap(group: group)
@@ -629,7 +629,7 @@ measureAndPrint(desc: "http1_10k_reqs_1_conn") {
     return try! repeatedRequestsHandler.wait()
 }
 
-measureAndPrint(desc: "http1_10k_reqs_100_conns") {
+measureAndPrint(desc: "http1_1k_reqs_100_conns") {
     var reqs: [Int] = []
     let numConns = 100
     let numReqs = 1_000
@@ -672,7 +672,7 @@ measureAndPrint(desc: "future_whenallsucceed_100k_immediately_succeeded_on_loop"
     return allSucceeded.count
 }
 
-measureAndPrint(desc: "future_whenallsucceed_100k_deferred_off_loop") {
+measureAndPrint(desc: "future_whenallsucceed_10k_deferred_off_loop") {
     let loop = group.next()
     let expected = Array(0..<10_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
@@ -683,7 +683,7 @@ measureAndPrint(desc: "future_whenallsucceed_100k_deferred_off_loop") {
     return try! allSucceeded.wait().count
 }
 
-measureAndPrint(desc: "future_whenallsucceed_100k_deferred_on_loop") {
+measureAndPrint(desc: "future_whenallsucceed_10k_deferred_on_loop") {
     let loop = group.next()
     let expected = Array(0..<10_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
@@ -716,7 +716,7 @@ measureAndPrint(desc: "future_whenallcomplete_100k_immediately_succeeded_on_loop
     return allSucceeded.count
 }
 
-measureAndPrint(desc: "future_whenallcomplete_100k_deferred_off_loop") {
+measureAndPrint(desc: "future_whenallcomplete_10k_deferred_off_loop") {
     let loop = group.next()
     let expected = Array(0..<10_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
@@ -758,7 +758,7 @@ measureAndPrint(desc: "future_reduce_into_10k_futures") {
 try measureAndPrint(desc: "channel_pipeline_1m_events", benchmark: ChannelPipelineBenchmark(runCount: 1_000_000))
 
 try measureAndPrint(
-    desc: "websocket_encode_50b_space_at_front_1m_frames_cow",
+    desc: "websocket_encode_50b_space_at_front_100k_frames_cow",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 50,
         runCount: 100_000,
@@ -781,7 +781,7 @@ try measureAndPrint(
 
 
 try measureAndPrint(
-    desc: "websocket_encode_1kb_space_at_front_100k_frames_cow",
+    desc: "websocket_encode_1kb_space_at_front_1m_frames_cow",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 1024,
         runCount: 1_000_000,
@@ -792,7 +792,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_50b_no_space_at_front_1m_frames_cow",
+    desc: "websocket_encode_50b_no_space_at_front_100k_frames_cow",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 50,
         runCount: 100_000,
@@ -814,7 +814,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_50b_space_at_front_10k_frames",
+    desc: "websocket_encode_50b_space_at_front_100k_frames",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 50,
         runCount: 100_000,
@@ -836,7 +836,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_1kb_space_at_front_1k_frames",
+    desc: "websocket_encode_1kb_space_at_front_10k_frames",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 1024,
         runCount: 10_000,
@@ -847,7 +847,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_50b_no_space_at_front_10k_frames",
+    desc: "websocket_encode_50b_no_space_at_front_100k_frames",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 50,
         runCount: 100_000,
@@ -858,7 +858,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_1kb_no_space_at_front_1k_frames",
+    desc: "websocket_encode_1kb_no_space_at_front_10k_frames",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 1024,
         runCount: 10_000,
@@ -869,7 +869,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_decode_125b_100k_frames",
+    desc: "websocket_decode_125b_10k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: 125,
         runCount: 10_000
@@ -877,7 +877,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_decode_125b_with_a_masking_key_100k_frames",
+    desc: "websocket_decode_125b_with_a_masking_key_10k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: 125,
         runCount: 10_000,
@@ -886,7 +886,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_decode_64kb_100k_frames",
+    desc: "websocket_decode_64kb_10k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: Int(UInt16.max),
         runCount: 10_000
@@ -894,7 +894,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_decode_64kb_with_a_masking_key_100k_frames",
+    desc: "websocket_decode_64kb_with_a_masking_key_10k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: Int(UInt16.max),
         runCount: 10_000,
@@ -902,16 +902,16 @@ try measureAndPrint(
     )
 )
 
-try measureAndPrint(
-    desc: "websocket_decode_64kb_+1_100k_frames",
-    benchmark: WebSocketFrameDecoderBenchmark(
-        dataSize: Int(UInt16.max) + 1,
-        runCount: 10_000
-    )
-)
+//try measureAndPrint(
+//    desc: "websocket_decode_64kb_+1_10k_frames",
+//    benchmark: WebSocketFrameDecoderBenchmark(
+//        dataSize: Int(UInt16.max) + 1,
+//        runCount: 10_000
+//    )
+//)
 
 try measureAndPrint(
-    desc: "websocket_decode_64kb_+1_with_a_masking_key_100k_frames",
+    desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: Int(UInt16.max) + 1,
         runCount: 10_000,
@@ -982,7 +982,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "lock_1_thread_10M_ops",
+    desc: "lock_1_thread_1M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 1,
         lockOperationsPerThread: 1_000_000
@@ -990,7 +990,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "lock_2_threads_10M_ops",
+    desc: "lock_2_threads_1M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 2,
         lockOperationsPerThread: 500_000
@@ -998,7 +998,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "lock_4_threads_10M_ops",
+    desc: "lock_4_threads_1M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 4,
         lockOperationsPerThread: 250_000
@@ -1006,7 +1006,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "lock_8_threads_10M_ops",
+    desc: "lock_8_threads_1M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 8,
         lockOperationsPerThread: 125_000
@@ -1014,22 +1014,22 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "schedule_10000_tasks",
+    desc: "schedule_1m_tasks",
     benchmark: SchedulingBenchmark(numTasks: 1_000_000)
 )
 
 try measureAndPrint(
-    desc: "schedule_and_run_10000_tasks",
+    desc: "schedule_and_run_100k_tasks",
     benchmark: SchedulingAndRunningBenchmark(numTasks: 100_000)
 )
 
 try measureAndPrint(
-    desc: "execute_10000",
+    desc: "execute_100k_tasks",
     benchmark: ExecuteBenchmark(numTasks: 100_000)
 )
 
 try measureAndPrint(
-    desc: "bytebufferview_copy_to_array_1000_times_1kb",
+    desc: "bytebufferview_copy_to_array_100k_times_1kb",
     benchmark: ByteBufferViewCopyToArrayBenchmark(
         iterations: 100_000,
         size: 1024
@@ -1037,7 +1037,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "circularbuffer_copy_to_array_1000_times_1kb",
+    desc: "circularbuffer_copy_to_array_10k_times_1kb",
     benchmark: CircularBufferViewCopyToArrayBenchmark(
         iterations: 10_000,
         size: 1024

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -779,6 +779,8 @@ try measureAndPrint(
     )
 )
 
+/*
+
 
 try measureAndPrint(
     desc: "websocket_encode_1kb_space_at_front_1m_frames_cow",
@@ -1043,3 +1045,5 @@ try measureAndPrint(
         size: 1024
     )
 )
+
+*/

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -189,6 +189,7 @@ private func someString(size: Int) -> String {
 }
 
 // MARK: Performance Tests
+/*
 
 measureAndPrint(desc: "write_http_headers") {
     var headers: [(String, String)] = []
@@ -1004,6 +1005,8 @@ try measureAndPrint(
     )
 )
 
+*/
+
 try measureAndPrint(
     desc: "lock_8_threads_1M_ops",
     benchmark: LockBenchmark(
@@ -1023,6 +1026,7 @@ try measureAndPrint(
 )
 
 /*
+
 
 try measureAndPrint(
     desc: "execute_100k_tasks",

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -779,9 +779,6 @@ try measureAndPrint(
     )
 )
 
-/*
-
-
 try measureAndPrint(
     desc: "websocket_encode_1kb_space_at_front_1m_frames_cow",
     benchmark: WebSocketFrameEncoderBenchmark(
@@ -936,6 +933,7 @@ try measureAndPrint(
         bufferSize: 1024*1024
     )
 )
+/*
 
 try measureAndPrint(
     desc: "byte_buffer_view_iterator_1mb",

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -910,14 +910,14 @@ try measureAndPrint(
     )
 )
 
-//try measureAndPrint(
-//    desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",
-//    benchmark: WebSocketFrameDecoderBenchmark(
-//        dataSize: Int(UInt16.max) + 1,
-//        runCount: 10_000,
-//        maskingKey: [0x80, 0x08, 0x10, 0x01]
-//    )
-//)
+try measureAndPrint(
+    desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",
+    benchmark: WebSocketFrameDecoderBenchmark(
+        dataSize: Int(UInt16.max) + 1,
+        runCount: 10_000,
+        maskingKey: [0x80, 0x08, 0x10, 0x01]
+    )
+)
 
 try measureAndPrint(
     desc: "circular_buffer_into_byte_buffer_1kb",

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -1014,6 +1014,7 @@ try measureAndPrint(
         lockOperationsPerThread: 125_000
     )
 )
+/*
 
 try measureAndPrint(
     desc: "schedule_1m_tasks",
@@ -1025,7 +1026,7 @@ try measureAndPrint(
     benchmark: SchedulingAndRunningBenchmark(numTasks: 100_000)
 )
 
-/*
+
 
 
 try measureAndPrint(

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -529,7 +529,7 @@ measureAndPrint(desc: "bytebuffer_write_http_response_some_nonascii_as_staticstr
     return buffer.readableBytes
 }
 
-try measureAndPrint(desc: "no-net_http1_1k_reqs_1_conn") {
+try measureAndPrint(desc: "no-net_http1_10k_reqs_1_conn") {
     final class MeasuringHandler: ChannelDuplexHandler {
         typealias InboundIn = Never
         typealias InboundOut = ByteBuffer
@@ -612,7 +612,7 @@ try measureAndPrint(desc: "no-net_http1_1k_reqs_1_conn") {
     return requestsDone
 }
 
-measureAndPrint(desc: "http1_1k_reqs_1_conn") {
+measureAndPrint(desc: "http1_10k_reqs_1_conn") {
     let repeatedRequestsHandler = RepeatedRequests(numberOfRequests: 1_000, eventLoop: group.next())
 
     let clientChannel = try! ClientBootstrap(group: group)
@@ -629,7 +629,7 @@ measureAndPrint(desc: "http1_1k_reqs_1_conn") {
     return try! repeatedRequestsHandler.wait()
 }
 
-measureAndPrint(desc: "http1_1k_reqs_100_conns") {
+measureAndPrint(desc: "http1_10k_reqs_100_conns") {
     var reqs: [Int] = []
     let numConns = 100
     let numReqs = 1_000
@@ -672,7 +672,7 @@ measureAndPrint(desc: "future_whenallsucceed_100k_immediately_succeeded_on_loop"
     return allSucceeded.count
 }
 
-measureAndPrint(desc: "future_whenallsucceed_10k_deferred_off_loop") {
+measureAndPrint(desc: "future_whenallsucceed_100k_deferred_off_loop") {
     let loop = group.next()
     let expected = Array(0..<10_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
@@ -683,7 +683,7 @@ measureAndPrint(desc: "future_whenallsucceed_10k_deferred_off_loop") {
     return try! allSucceeded.wait().count
 }
 
-measureAndPrint(desc: "future_whenallsucceed_10k_deferred_on_loop") {
+measureAndPrint(desc: "future_whenallsucceed_100k_deferred_on_loop") {
     let loop = group.next()
     let expected = Array(0..<10_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
@@ -716,7 +716,7 @@ measureAndPrint(desc: "future_whenallcomplete_100k_immediately_succeeded_on_loop
     return allSucceeded.count
 }
 
-measureAndPrint(desc: "future_whenallcomplete_10k_deferred_off_loop") {
+measureAndPrint(desc: "future_whenallcomplete_100k_deferred_off_loop") {
     let loop = group.next()
     let expected = Array(0..<10_000)
     let promises = expected.map { _ in loop.makePromise(of: Int.self) }
@@ -758,7 +758,7 @@ measureAndPrint(desc: "future_reduce_into_10k_futures") {
 try measureAndPrint(desc: "channel_pipeline_1m_events", benchmark: ChannelPipelineBenchmark(runCount: 1_000_000))
 
 try measureAndPrint(
-    desc: "websocket_encode_50b_space_at_front_100k_frames_cow",
+    desc: "websocket_encode_50b_space_at_front_1m_frames_cow",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 50,
         runCount: 100_000,
@@ -781,7 +781,7 @@ try measureAndPrint(
 
 
 try measureAndPrint(
-    desc: "websocket_encode_1kb_space_at_front_1m_frames_cow",
+    desc: "websocket_encode_1kb_space_at_front_100k_frames_cow",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 1024,
         runCount: 1_000_000,
@@ -792,7 +792,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_50b_no_space_at_front_100k_frames_cow",
+    desc: "websocket_encode_50b_no_space_at_front_1m_frames_cow",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 50,
         runCount: 100_000,
@@ -814,7 +814,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_50b_space_at_front_100k_frames",
+    desc: "websocket_encode_50b_space_at_front_10k_frames",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 50,
         runCount: 100_000,
@@ -836,7 +836,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_1kb_space_at_front_10k_frames",
+    desc: "websocket_encode_1kb_space_at_front_1k_frames",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 1024,
         runCount: 10_000,
@@ -847,7 +847,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_50b_no_space_at_front_100k_frames",
+    desc: "websocket_encode_50b_no_space_at_front_10k_frames",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 50,
         runCount: 100_000,
@@ -858,7 +858,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_encode_1kb_no_space_at_front_10k_frames",
+    desc: "websocket_encode_1kb_no_space_at_front_1k_frames",
     benchmark: WebSocketFrameEncoderBenchmark(
         dataSize: 1024,
         runCount: 10_000,
@@ -869,7 +869,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_decode_125b_10k_frames",
+    desc: "websocket_decode_125b_100k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: 125,
         runCount: 10_000
@@ -877,7 +877,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_decode_125b_with_a_masking_key_10k_frames",
+    desc: "websocket_decode_125b_with_a_masking_key_100k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: 125,
         runCount: 10_000,
@@ -886,7 +886,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_decode_64kb_10k_frames",
+    desc: "websocket_decode_64kb_100k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: Int(UInt16.max),
         runCount: 10_000
@@ -894,7 +894,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "websocket_decode_64kb_with_a_masking_key_10k_frames",
+    desc: "websocket_decode_64kb_with_a_masking_key_100k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: Int(UInt16.max),
         runCount: 10_000,
@@ -902,16 +902,16 @@ try measureAndPrint(
     )
 )
 
-//try measureAndPrint(
-//    desc: "websocket_decode_64kb_+1_10k_frames",
-//    benchmark: WebSocketFrameDecoderBenchmark(
-//        dataSize: Int(UInt16.max) + 1,
-//        runCount: 10_000
-//    )
-//)
+try measureAndPrint(
+    desc: "websocket_decode_64kb_+1_100k_frames",
+    benchmark: WebSocketFrameDecoderBenchmark(
+        dataSize: Int(UInt16.max) + 1,
+        runCount: 10_000
+    )
+)
 
 try measureAndPrint(
-    desc: "websocket_decode_64kb_+1_with_a_masking_key_10k_frames",
+    desc: "websocket_decode_64kb_+1_with_a_masking_key_100k_frames",
     benchmark: WebSocketFrameDecoderBenchmark(
         dataSize: Int(UInt16.max) + 1,
         runCount: 10_000,
@@ -982,7 +982,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "lock_1_thread_1M_ops",
+    desc: "lock_1_thread_10M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 1,
         lockOperationsPerThread: 1_000_000
@@ -990,7 +990,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "lock_2_threads_1M_ops",
+    desc: "lock_2_threads_10M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 2,
         lockOperationsPerThread: 500_000
@@ -998,7 +998,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "lock_4_threads_1M_ops",
+    desc: "lock_4_threads_10M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 4,
         lockOperationsPerThread: 250_000
@@ -1006,7 +1006,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "lock_8_threads_1M_ops",
+    desc: "lock_8_threads_10M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 8,
         lockOperationsPerThread: 125_000
@@ -1014,22 +1014,22 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "schedule_1m_tasks",
+    desc: "schedule_10000_tasks",
     benchmark: SchedulingBenchmark(numTasks: 1_000_000)
 )
 
 try measureAndPrint(
-    desc: "schedule_and_run_100k_tasks",
+    desc: "schedule_and_run_10000_tasks",
     benchmark: SchedulingAndRunningBenchmark(numTasks: 100_000)
 )
 
 try measureAndPrint(
-    desc: "execute_100k_tasks",
+    desc: "execute_10000",
     benchmark: ExecuteBenchmark(numTasks: 100_000)
 )
 
 try measureAndPrint(
-    desc: "bytebufferview_copy_to_array_100k_times_1kb",
+    desc: "bytebufferview_copy_to_array_1000_times_1kb",
     benchmark: ByteBufferViewCopyToArrayBenchmark(
         iterations: 100_000,
         size: 1024
@@ -1037,7 +1037,7 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "circularbuffer_copy_to_array_10k_times_1kb",
+    desc: "circularbuffer_copy_to_array_1000_times_1kb",
     benchmark: CircularBufferViewCopyToArrayBenchmark(
         iterations: 10_000,
         size: 1024


### PR DESCRIPTION
### Motivation:

The current running time of some of the performance benchmarks is O(1 ms) which can lead to low signal in the results. It would be better if these tests ran for O(10 ms).

### Modifications:

* Increase the iteration counts in all the tests within `NIOPerformanceTester` to aim for O(10 ms) measurements with the current code.
* Exception: `execute_100k_tasks` which is still too quick but the CI cannot handle 1M tasks. 

### Result:

* All benchmarks bodies should now take O(100 ms).  

### Notes:

The scaling factors were determined by looking at the `current` column from a recent report on #2059:

```sh 
$ python3 scaling_factors.py perf-output
Loading file: perf-output...
Loaded 62 results.
Scaling tests so that runtime is O(10 ms)

name                                                               current_s    O(current_s)    O(desired_s)  scale_by
write_http_headers                                                 0.004221364  1E-3            1E-2          1E1
http_headers_canonical_form                                        0.085858433  1E-2            1E-2          1E0
http_headers_canonical_form_trimming_whitespace                    0.162971487  1E-1            1E-2          1E-1
http_headers_canonical_form_trimming_whitespace_from_short_string  0.148830606  1E-1            1E-2          1E-1
http_headers_canonical_form_trimming_whitespace_from_long_string   0.229662477  1E-1            1E-2          1E-1
bytebuffer_write_12MB_short_string_literals                        0.151619987  1E-1            1E-2          1E-1
bytebuffer_write_12MB_short_calculated_strings                     0.297283243  1E-1            1E-2          1E-1
bytebuffer_write_12MB_medium_string_literals                       0.058404425  1E-2            1E-2          1E0
bytebuffer_write_12MB_medium_calculated_strings                    0.15610171   1E-1            1E-2          1E-1
bytebuffer_write_12MB_large_calculated_strings                     0.142773805  1E-1            1E-2          1E-1
bytebuffer_lots_of_rw                                              0.433748776  1E-1            1E-2          1E-1
bytebuffer_write_http_response_ascii_only_as_string                0.039572042  1E-2            1E-2          1E0
bytebuffer_write_http_response_ascii_only_as_staticstring          0.030672688  1E-2            1E-2          1E0
bytebuffer_write_http_response_some_nonascii_as_string             0.039276667  1E-2            1E-2          1E0
bytebuffer_write_http_response_some_nonascii_as_staticstring       0.030416912  1E-2            1E-2          1E0
no-net_http1_10k_reqs_1_conn                                       0.105070526  1E-1            1E-2          1E-1
http1_10k_reqs_1_conn                                              0.589343003  1E-1            1E-2          1E-1
http1_10k_reqs_100_conns                                           0.581899912  1E-1            1E-2          1E-1
future_whenallsucceed_100k_immediately_succeeded_off_loop          0.070154794  1E-2            1E-2          1E0
future_whenallsucceed_100k_immediately_succeeded_on_loop           0.071029944  1E-2            1E-2          1E0
future_whenallsucceed_100k_deferred_off_loop                       0.331273236  1E-1            1E-2          1E-1
future_whenallsucceed_100k_deferred_on_loop                        0.121564379  1E-1            1E-2          1E-1
future_whenallcomplete_100k_immediately_succeeded_off_loop         0.030060621  1E-2            1E-2          1E0
future_whenallcomplete_100k_immediately_succeeded_on_loop          0.030060624  1E-2            1E-2          1E0
future_whenallcomplete_100k_deferred_off_loop                      0.258080927  1E-1            1E-2          1E-1
future_whenallcomplete_100k_deferred_on_loop                       0.061702521  1E-2            1E-2          1E0
future_reduce_10k_futures                                          0.03736344   1E-2            1E-2          1E0
future_reduce_into_10k_futures                                     0.035719515  1E-2            1E-2          1E0
channel_pipeline_1m_events                                         0.095089666  1E-2            1E-2          1E0
websocket_encode_50b_space_at_front_1m_frames_cow                  0.491598504  1E-1            1E-2          1E-1
websocket_encode_50b_space_at_front_1m_frames_cow_masking          0.065660544  1E-2            1E-2          1E0
websocket_encode_1kb_space_at_front_100k_frames_cow                0.05179348   1E-2            1E-2          1E0
websocket_encode_50b_no_space_at_front_1m_frames_cow               0.492513012  1E-1            1E-2          1E-1
websocket_encode_1kb_no_space_at_front_100k_frames_cow             0.051848542  1E-2            1E-2          1E0
websocket_encode_50b_space_at_front_10k_frames                     0.006663117  1E-3            1E-2          1E1
websocket_encode_50b_space_at_front_10k_frames_masking             0.083932953  1E-2            1E-2          1E0
websocket_encode_1kb_space_at_front_1k_frames                      0.001293064  1E-3            1E-2          1E1
websocket_encode_50b_no_space_at_front_10k_frames                  0.006696183  1E-3            1E-2          1E1
websocket_encode_1kb_no_space_at_front_1k_frames                   0.001222385  1E-3            1E-2          1E1
websocket_decode_125b_100k_frames                                  0.115220387  1E-1            1E-2          1E-1
websocket_decode_125b_with_a_masking_key_100k_frames               0.118480726  1E-1            1E-2          1E-1
websocket_decode_64kb_100k_frames                                  0.118017645  1E-1            1E-2          1E-1
websocket_decode_64kb_with_a_masking_key_100k_frames               0.120845408  1E-1            1E-2          1E-1
websocket_decode_64kb_+1_100k_frames                               0.117700529  1E-1            1E-2          1E-1
websocket_decode_64kb_+1_with_a_masking_key_100k_frames            0.12086373   1E-1            1E-2          1E-1
circular_buffer_into_byte_buffer_1kb                               0.036630641  1E-2            1E-2          1E0
circular_buffer_into_byte_buffer_1mb                               0.07287621   1E-2            1E-2          1E0
byte_buffer_view_iterator_1mb                                      0.020055745  1E-2            1E-2          1E0
byte_buffer_view_contains_12mb                                     0.207476717  1E-1            1E-2          1E-1
byte_to_message_decoder_decode_many_small                          0.170375659  1E-1            1E-2          1E-1
generate_10k_random_request_keys                                   0.089314066  1E-2            1E-2          1E0
bytebuffer_rw_10_uint32s                                           0.28914708   1E-1            1E-2          1E-1
bytebuffer_multi_rw_10_uint32s                                     0.05438756   1E-2            1E-2          1E0
lock_1_thread_10M_ops                                              0.155880855  1E-1            1E-2          1E-1
lock_2_threads_10M_ops                                             0.872071354  1E-1            1E-2          1E-1
lock_4_threads_10M_ops                                             0.944893321  1E-1            1E-2          1E-1
lock_8_threads_10M_ops                                             0.905209719  1E-1            1E-2          1E-1
schedule_10000_tasks                                               0.005108103  1E-3            1E-2          1E1
schedule_and_run_10000_tasks                                       0.031540699  1E-2            1E-2          1E0
execute_10000                                                      0.016732096  1E-2            1E-2          1E0
bytebufferview_copy_to_array_1000_times_1kb                        0.000123618  1E-4            1E-2          1E2
circularbuffer_copy_to_array_1000_times_1kb                        0.001885264  1E-3            1E-2          1E1
```