### PR TITLE
Wait a little longer for our repeated task

### DIFF
--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -769,7 +769,7 @@ public final class EventLoopTest : XCTestCase {
         let task = loop.scheduleRepeatedTask(initialDelay: .milliseconds(0), delay: .milliseconds(10), notifying: promise1) { task in
             expectRuns.fulfill()
         }
-        XCTAssertEqual(XCTWaiter.wait(for: [expectRuns], timeout: 0.05), .completed)
+        XCTAssertEqual(XCTWaiter.wait(for: [expectRuns], timeout: 0.1), .completed)
         let expect1 = XCTestExpectation(description: "Initializer promise was fulfilled")
         let expect2 = XCTestExpectation(description: "Cancellation-specific promise was fulfilled")
         promise1.futureResult.whenSuccess { expect1.fulfill() }


### PR DESCRIPTION
Motivation:

We currently expect two runs of a repeated task in a test to happen with
relatively little breathing room: the minimum delay is 10ms, and we
won't wait longer than 50ms. We should widen this a bit.

Modifications:

- Double the deadline from 50ms to 100ms.

Result:

This test passes consistently.

Resolves #2053.