### PR TITLE
Add `Hashable` conformance to `HTTPResponseStatus`

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -1281,18 +1281,9 @@ public enum HTTPResponseStatus {
     }
 }
 
-extension HTTPResponseStatus: Equatable {
-    public static func ==(lhs: HTTPResponseStatus, rhs: HTTPResponseStatus) -> Bool {
-        switch (lhs, rhs) {
-        case (.custom(let lcode, let lreason), .custom(let rcode, let rreason)):
-            return lcode == rcode && lreason == rreason
-        case (.custom, _), (_, .custom):
-            return false
-        default:
-            return lhs.code == rhs.code
-        }
-    }
-}
+extension HTTPResponseStatus: Equatable {}
+
+extension HTTPResponseStatus: Hashable {}
 
 extension HTTPRequestHead: CustomStringConvertible {
     public var description: String {


### PR DESCRIPTION
# Motivation
`HTTPResponseStatus` is currently not conforming to `Hashable`.

# Modification
Add `Hashable` conformance to `HTTPResponseStatus`

# Result
`HTTPResponseStatus` is `Hashable`
