### PR TITLE
Update alloc limits for nightly.

### DIFF
--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -22,7 +22,7 @@ url_prefix=${1-"https://ci.swiftserver.group/job/swift-nio2-swift"}
 target_repo=${2-"$here/.."}
 tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
 
-for f in 52 53 54 55 56 -nightly; do
+for f in 52 53 54 55 56 57 -nightly; do
     echo "swift$f"
     url="$url_prefix$f-prb/lastCompletedBuild/consoleFull"
     echo "$url"

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -50,7 +50,7 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
-      - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
+      - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4350
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=140050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -50,7 +50,7 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
-      - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
+      - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4350
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=140050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100


### PR DESCRIPTION
We regressed allocs in nightly, probably for a Swift bug. Fixing it is
tracked in #2070, for now we're going to raise the limits so CI isn't
moaning all the time.
