### PR TITLE
Fix doc comment formatting in `SingleStepByteToMessageDecoder.swift`

### DIFF
--- a/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
+++ b/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
@@ -18,7 +18,7 @@
 /// to the `ByteBuffer` when returning. This allows for greatly simplified processing.
 ///
 /// Many `ByteToMessageDecoder`'s can trivially be translated to `NIOSingleStepByteToMessageDecoder`'s. You should not implement
-/// `ByteToMessageDecoder`'s decode` and `decodeLast` methods.
+/// `ByteToMessageDecoder`'s `decode` and `decodeLast` methods.
 public protocol NIOSingleStepByteToMessageDecoder: ByteToMessageDecoder {
     /// The decoded type this `NIOSingleStepByteToMessageDecoder` decodes to. To conform to `ByteToMessageDecoder` it must be called
     /// `InboundOut` - see https://bugs.swift.org/browse/SR-11868.


### PR DESCRIPTION
### Motivation:

Rendering of this doc comment is currently broken, here's a screenshot from DocC:

<img width="791" alt="Screenshot 2022-04-12 at 12 53 17" src="https://user-images.githubusercontent.com/112310/162955829-24452bac-ce77-4938-b647-5e5d2f59b689.png">

`decode` in the comment is currently missing a starting backquote, which is fixed in this PR.