### PR TITLE
http_parser uses "main" as the main branch

### DIFF
--- a/Sources/CNIOHTTPParser/update_and_patch_http_parser.sh
+++ b/Sources/CNIOHTTPParser/update_and_patch_http_parser.sh
@@ -35,14 +35,14 @@ fi
 
 for f in LICENSE-MIT AUTHORS; do
     curl -o "${f}" \
-         -Ls "https://raw.githubusercontent.com/nodejs/http-parser/master/${f}"
+         -Ls "https://raw.githubusercontent.com/nodejs/http-parser/main/${f}"
 done
 
 for f in http_parser.c http_parser.h; do
     ( echo "/* Additional changes for SwiftNIO:"
       echo "    - prefixed all symbols by 'c_nio_'"
       echo "*/"
-      curl -Ls "https://raw.githubusercontent.com/nodejs/http-parser/master/$f"
+      curl -Ls "https://raw.githubusercontent.com/nodejs/http-parser/main/$f"
     ) > "$here/c_nio_$f"
 
     "$sed" -i \


### PR DESCRIPTION
### Motivation:

`http_parser` has moved to a `main` branch.

### Modifications:

Make `http_parser`'s main branch `main`.

### Result:

Get latest code.