### PR TITLE
Add initial support for connected datagram sockets

### DIFF
--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -140,12 +140,18 @@ private struct SocketChannelLifecycleManager {
                 pipeline.syncOperations.fireChannelUnregistered()
             }
 
+        // TODO: This is to support connect after bind for connected-mode datagram sockets. Might need a better solution for this.
+        // origin: .activated
+        case (.activated, .activate):
+            return { promise, pipeline in
+                promise?.succeed(())
+            }
+
         // bad transitions
         case (.fresh, .activate),                  // should go through .registered first
              (.preRegistered, .activate),       // need to first be fully registered
              (.preRegistered, .beginRegistration), // already registered
              (.fullyRegistered, .beginRegistration),  // already registered
-             (.activated, .activate),              // already activated
              (.activated, .beginRegistration),        // already fully registered (and activated)
              (.activated, .finishRegistration),         // already fully registered (and activated)
              (.fullyRegistered, .finishRegistration),   // already fully registered

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -445,7 +445,7 @@ final class PendingDatagramWritesManager: PendingWritesManager {
     ///     - scalarWriteOperation: An operation that writes a single, contiguous array of bytes (usually `sendmsg`).
     ///     - vectorWriteOperation: An operation that writes multiple contiguous arrays of bytes (usually `sendmmsg`).
     /// - returns: The `WriteResult` and whether the `Channel` is now writable.
-    func triggerAppropriateWriteOperations(scalarWriteOperation: (UnsafeRawBufferPointer, UnsafePointer<sockaddr>, socklen_t, AddressedEnvelope<ByteBuffer>.Metadata?) throws -> IOResult<Int>,
+    func triggerAppropriateWriteOperations(scalarWriteOperation: (UnsafeRawBufferPointer, UnsafePointer<sockaddr>?, socklen_t, AddressedEnvelope<ByteBuffer>.Metadata?) throws -> IOResult<Int>,
                                            vectorWriteOperation: (UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int>) throws -> OverallWriteResult {
         return try self.triggerWriteOperations { writeMechanism in
             switch writeMechanism {
@@ -515,7 +515,7 @@ final class PendingDatagramWritesManager: PendingWritesManager {
     ///
     /// - parameters:
     ///     - scalarWriteOperation: An operation that writes a single, contiguous array of bytes (usually `sendto`).
-    private func triggerScalarBufferWrite(scalarWriteOperation: (UnsafeRawBufferPointer, UnsafePointer<sockaddr>, socklen_t, AddressedEnvelope<ByteBuffer>.Metadata?) throws -> IOResult<Int>) rethrows -> OneWriteOperationResult {
+    private func triggerScalarBufferWrite(scalarWriteOperation: (UnsafeRawBufferPointer, UnsafePointer<sockaddr>?, socklen_t, AddressedEnvelope<ByteBuffer>.Metadata?) throws -> IOResult<Int>) rethrows -> OneWriteOperationResult {
         assert(self.state.isFlushPending && self.isOpen && !self.state.isEmpty,
                "illegal state for scalar datagram write operation: flushPending: \(self.state.isFlushPending), isOpen: \(self.isOpen), empty: \(self.state.isEmpty)")
         let pending = self.state.nextWrite!

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -140,6 +140,7 @@ private struct PendingDatagramWritesState {
     private var pendingWrites = MarkedCircularBuffer<PendingDatagramWrite>(initialCapacity: 16)
     private var chunks: Int = 0
     public private(set) var bytes: Int64 = 0
+    private(set) var isConnected: Bool = false
 
     public var nextWrite: PendingDatagramWrite? {
         return self.pendingWrites.first
@@ -192,6 +193,10 @@ private struct PendingDatagramWritesState {
     /// All writes before this checkpoint will eventually be written to the socket.
     public mutating func markFlushCheckpoint() {
         self.pendingWrites.mark()
+    }
+
+    mutating func markConnected() {
+        self.isConnected = true
     }
 
     /// Indicate that a write has happened, this may be a write of multiple outstanding writes (using for example `sendmmsg`).
@@ -400,6 +405,10 @@ final class PendingDatagramWritesManager: PendingWritesManager {
     /// Mark the flush checkpoint.
     func markFlushCheckpoint() {
         self.state.markFlushCheckpoint()
+    }
+
+    func markConnected() {
+        self.state.markConnected()
     }
 
     /// Is there a flush pending?

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -442,7 +442,7 @@ final class PendingDatagramWritesManager: PendingWritesManager {
     /// On platforms that do not support a gathering write operation,
     ///
     /// - parameters:
-    ///     - scalarWriteOperation: An operation that writes a single, contiguous array of bytes (usually `sendto`).
+    ///     - scalarWriteOperation: An operation that writes a single, contiguous array of bytes (usually `sendmsg`).
     ///     - vectorWriteOperation: An operation that writes multiple contiguous arrays of bytes (usually `sendmmsg`).
     /// - returns: The `WriteResult` and whether the `Channel` is now writable.
     func triggerAppropriateWriteOperations(scalarWriteOperation: (UnsafeRawBufferPointer, UnsafePointer<sockaddr>, socklen_t, AddressedEnvelope<ByteBuffer>.Metadata?) throws -> IOResult<Int>,

--- a/Sources/NIOPosix/PipePair.swift
+++ b/Sources/NIOPosix/PipePair.swift
@@ -98,7 +98,7 @@ final class PipePair: SocketProtocol {
     }
     
     func sendmsg(pointer: UnsafeRawBufferPointer,
-                 destinationPtr: UnsafePointer<sockaddr>,
+                 destinationPtr: UnsafePointer<sockaddr>?,
                  destinationSize: socklen_t,
                  controlBytes: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
         throw ChannelError.operationUnsupported

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -151,7 +151,7 @@ typealias IOVector = iovec
     /// (because the socket is in non-blocking mode).
     /// - throws: An `IOError` if the operation failed.
     func sendmsg(pointer: UnsafeRawBufferPointer,
-                 destinationPtr: UnsafePointer<sockaddr>,
+                 destinationPtr: UnsafePointer<sockaddr>?,
                  destinationSize: socklen_t,
                  controlBytes: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
         // Dubious const casts - it should be OK as there is no reason why this should get mutated

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -526,12 +526,16 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {
-        // For now we don't support operating in connected mode for datagram channels.
-        throw ChannelError.operationUnsupported
+        if try self.socket.connect(to: address) {
+            self.pendingWrites.markConnected()
+            return true
+        } else {
+            preconditionFailure("Connect of datagram socket did not complete synchronously.")
+        }
     }
 
     override func finishConnectSocket() throws {
-        // For now we don't support operating in connected mode for datagram channels.
+        // This is not required for connected datagram channels connect is a synchronous operation.
         throw ChannelError.operationUnsupported
     }
 

--- a/Sources/NIOPosix/SocketProtocols.swift
+++ b/Sources/NIOPosix/SocketProtocols.swift
@@ -54,7 +54,7 @@ protocol SocketProtocol: BaseSocketProtocol {
                  controlBytes: inout UnsafeReceivedControlBytes) throws -> IOResult<Int>
     
     func sendmsg(pointer: UnsafeRawBufferPointer,
-                 destinationPtr: UnsafePointer<sockaddr>,
+                 destinationPtr: UnsafePointer<sockaddr>?,
                  destinationSize: socklen_t,
                  controlBytes: UnsafeMutableRawBufferPointer) throws -> IOResult<Int>
 

--- a/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2018-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2018-2022 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
@@ -29,7 +29,6 @@ extension DatagramChannelTests {
       return [
                 ("testBasicChannelCommunication", testBasicChannelCommunication),
                 ("testManyWrites", testManyWrites),
-                ("testConnectionFails", testConnectionFails),
                 ("testDatagramChannelHasWatermark", testDatagramChannelHasWatermark),
                 ("testWriteFuturesFailWhenChannelClosed", testWriteFuturesFailWhenChannelClosed),
                 ("testManyManyDatagramWrites", testManyManyDatagramWrites),

--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -173,12 +173,6 @@ final class DatagramChannelTests: XCTestCase {
         }
     }
 
-    func testConnectionFails() throws {
-        XCTAssertThrowsError(try self.firstChannel.connect(to: self.secondChannel.localAddress!).wait()) { error in
-            XCTAssertEqual(.operationUnsupported, error as? ChannelError)
-        }
-    }
-
     func testDatagramChannelHasWatermark() throws {
         _ = try self.firstChannel.setOption(ChannelOptions.writeBufferWaterMark, value: ChannelOptions.Types.WriteBufferWaterMark(low: 1, high: 1024)).wait()
 

--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -102,10 +102,10 @@ private class DatagramReadRecorder<DataType>: ChannelInboundHandler {
     }
 }
 
-final class DatagramChannelTests: XCTestCase {
+class DatagramChannelTests: XCTestCase {
     private var group: MultiThreadedEventLoopGroup! = nil
-    private var firstChannel: Channel! = nil
-    private var secondChannel: Channel! = nil
+    var firstChannel: Channel! = nil
+    var secondChannel: Channel! = nil
 
     private func buildChannel(group: EventLoopGroup, host: String = "127.0.0.1") throws -> Channel {
         return try DatagramBootstrap(group: group)
@@ -126,11 +126,11 @@ final class DatagramChannelTests: XCTestCase {
         }
     }
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        self.firstChannel = try! buildChannel(group: group)
-        self.secondChannel = try! buildChannel(group: group)
+        self.firstChannel = try buildChannel(group: group)
+        self.secondChannel = try buildChannel(group: group)
     }
 
     override func tearDown() {
@@ -904,5 +904,13 @@ final class DatagramChannelTests: XCTestCase {
             return // need to skip IPv6 tests if we don't support it.
         }
         testEcnAndPacketInfoReceive(address: "::1", vectorRead: true, vectorSend: true, receivePacketInfo: true)
+    }
+}
+
+final class ConnectedDatagramChannelTests: DatagramChannelTests {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try self.firstChannel.connect(to: self.secondChannel.localAddress!).wait()
+        try self.secondChannel.connect(to: self.firstChannel.localAddress!).wait()
     }
 }

--- a/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
@@ -126,7 +126,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                     if expected.count > singleState {
                         XCTAssertGreaterThan(returns.count, everythingState)
                         XCTAssertEqual(expected[singleState].0, buf.count, "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].0) bytes expected but \(buf.count) actual", file: (file), line: line)
-                        XCTAssertEqual(expected[singleState].1, SocketAddress(addr), "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].1) address expected but \(SocketAddress(addr)) received", file: (file), line: line)
+                        XCTAssertEqual(expected[singleState].1, addr.map(SocketAddress.init), "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].1) address expected but \(String(describing: addr.map(SocketAddress.init))) received", file: (file), line: line)
                         XCTAssertEqual(expected[singleState].1.expectedSize, len, "in single write \(singleState) (overall \(everythingState)), \(expected[singleState].1.expectedSize) socklen expected but \(len) received", file: (file), line: line)
 
                         switch returns[everythingState] {


### PR DESCRIPTION
### Motivation:

From the man page for `connect(2)`:
>     The parameter socket is a socket.  If it is of type SOCK_DGRAM, this call specifies the peer
>     with which the socket is to be associated; this address is that to which datagrams are to be
>     sent, and the only address from which datagrams are to be received.

This presents an opportunity for some performance optimisations for applications that want to use UDP with a fixed peer, but is currently prohibited in NIO.

This PR adds some preliminary support for connected datagram sockets and allow further work to optimise that code path.

### Modifications:

* Allow the calling of `sendmsg(2)` with `NULL` for `msg_name` by changing the `Socket` types.
* Keep track of whether the `DatagramChannel` is connected in `PendingDatagramWritesManager` and, if it is connected, use `NULL` for `msg_name` in the headers for scalar and vector writes.
* Allow connect to be called after bind in `BaseSocketChannel`.
* Allow `connectSocket(to:)` to be called on `DatagramChannel`.
* Rename `DatagramBootstrap.bind0(makeChannel:registerAndBind:)` to `withNewChannel(makeChannel:bringup:)` to account for the fact that it isn't only used for `bind`.
* Add set of `DatagramBootstrap.connect(...)` APIs.
* Remove DatagramChannelTests.testConnectionFails because that doesn't fail anymore.
* Add ConnectedDatagramChannelTests, inheriting from DatagramChannelTests but connecting both channels together.
* Use connected-mode UDP in NIOUDPEchoClient.

### Result:

* Can now call `Channel.connect(to:)` when using datagram sockets.
* Some minor performance improvements in `PendingDatagramWritesManager` because the address is no longer used (or copied).
* Opportunities for future performance enhancements.
* All tests pass on Darwin.

### Considerations:

* Should we add support for `disconnectx(2)`?
* To support `connect` after `bind` the state machine in `BaseSocketChannel` was made more lenient. Is this acceptable? 
* Is the `NIOUDPEchoClient` considered API? If not, can we rework the argument parsing so we can include a `--connect` flag?
* Need to make sure we're testing the codepaths on Windows (different socket API) and Linux (which uses `sendmmsg` for vector writes).
