### PR TITLE
BaseSocket: Remove dead code in BaseSocket.bind(to:)

### DIFF
--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -353,10 +353,6 @@ class BaseSocket: BaseSocketProtocol {
     /// - throws: An `IOError` if the operation failed.
     func bind(to address: SocketAddress) throws {
         try self.withUnsafeHandle { fd in
-            func doBind(ptr: UnsafePointer<sockaddr>, bytes: Int) throws {
-                try NIOBSDSocket.bind(socket: fd, address: ptr, address_len: socklen_t(bytes))
-            }
-
             try address.withSockAddr {
                 try NIOBSDSocket.bind(socket: fd, address: $0, address_len: socklen_t($1))
             }


### PR DESCRIPTION
### Motivation:

There's a local function created in `BaseSocket.bind(to:)` which doesn't appear to be used and is probably vestigial following an historic refactor.

### Modifications:

Remove the unused local function.

### Result:

Less unused code.