### PR TITLE
EventLoopFuture: Support cancellation in async get()

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -74,6 +74,7 @@ class LinuxMainRunnerImpl: LinuxMainRunner {
              testCase(EmbeddedChannelTest.allTests),
              testCase(EmbeddedEventLoopTest.allTests),
              testCase(EventCounterHandlerTest.allTests),
+             testCase(EventLoopFutureAsyncAwaitSupportTest.allTests),
              testCase(EventLoopFutureTest.allTests),
              testCase(EventLoopTest.allTests),
              testCase(FileRegionTest.allTests),

--- a/Tests/NIOPosixTests/EventLoopFutureAsyncAwaitSupportTest.swift
+++ b/Tests/NIOPosixTests/EventLoopFutureAsyncAwaitSupportTest.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOEmbedded
+import XCTest
+
+class EventLoopFutureAsyncAwaitSupportTest : XCTestCase {
+    func testAsyncGetHappyPath() throws {
+        #if compiler(>=5.5.2) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        XCTAsyncTest {
+            let eventLoop = EmbeddedEventLoop()
+            let p = eventLoop.makePromise(of: Void.self)
+
+            p.completeWithTask {
+                try await Task.sleep(nanoseconds: 1000)
+            }
+
+            await XCTAssertNoThrowWithResult(try await p.futureResult.get())
+        }
+        #endif
+    }
+
+    func testAsyncGetCancellation() throws {
+        #if compiler(>=5.5.2) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        XCTAsyncTest {
+            let eventLoop = EmbeddedEventLoop()
+            let p = eventLoop.makePromise(of: Void.self)
+
+            p.completeWithTask {
+                try await Task.sleep(nanoseconds: 1000)
+            }
+
+            let task = Task {
+                await XCTAssertThrowsError(try await p.futureResult.get()) { error in
+                    XCTAssert(error is CancellationError)
+                }
+            }
+            task.cancel()
+
+            await XCTAssertNoThrowWithResult(try await task.value)
+        }
+        #endif
+    }
+}

--- a/Tests/NIOPosixTests/XCTest+AsyncAwait.swift
+++ b/Tests/NIOPosixTests/XCTest+AsyncAwait.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2021 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import XCTest
+
+extension XCTestCase {
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    /// Cross-platform XCTest support for async-await tests.
+    ///
+    /// Currently the Linux implementation of XCTest doesn't have async-await support.
+    /// Until it does, we make use of this shim which uses a detached `Task` along with
+    /// `XCTest.wait(for:timeout:)` to wrap the operation.
+    ///
+    /// - NOTE: Support for Linux is tracked by https://bugs.swift.org/browse/SR-14403.
+    /// - NOTE: Implementation currently in progress: https://github.com/apple/swift-corelibs-xctest/pull/326
+    func XCTAsyncTest(
+        expectationDescription: String = "Async operation",
+        timeout: TimeInterval = 30,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        function: StaticString = #function,
+        operation: @escaping @Sendable () async throws -> Void
+    ) {
+        let expectation = self.expectation(description: expectationDescription)
+        Task {
+            do {
+                try await operation()
+            } catch {
+                XCTFail("Error thrown while executing \(function): \(error)", file: file, line: line)
+                Thread.callStackSymbols.forEach { print($0) }
+            }
+            expectation.fulfill()
+        }
+        self.wait(for: [expectation], timeout: timeout)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+internal func XCTAssertThrowsError<T>(
+    _ expression: @autoclosure () async throws -> T,
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (Error) -> Void = { _ in }
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expression did not throw error", file: file, line: line)
+    } catch {
+        verify(error)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+internal func XCTAssertNoThrowWithResult<Result>(
+    _ expression: @autoclosure () async throws -> Result,
+    file: StaticString = #file,
+    line: UInt = #line
+) async -> Result? {
+    do {
+        return try await expression()
+    } catch {
+        XCTFail("Expression did throw: \(error)", file: file, line: line)
+    }
+    return nil
+}
+
+#endif


### PR DESCRIPTION
### Motivation:

`EventLoopFuture.get() async throws` does not support cancellation. If the task from which it is being called is cancelled it should unblock. 

### Modifications:

Add cancellation handler in `EventLoopFuture.get()` and set the future value to `CancellationError()` if the waiting task is cancelled.

### Result:

Cancelling the task waiting for a future will fail the future with `CancellationError()`.

Fixes #2087.