### PR TITLE
Make Future.get() cancellable.

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -28,16 +28,26 @@ extension EventLoopFuture {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @inlinable
     public func get() async throws -> Value {
-        return try await withUnsafeThrowingContinuation { cont in
-            self.whenComplete { result in
-                switch result {
-                case .success(let value):
-                    cont.resume(returning: value)
-                case .failure(let error):
-                    cont.resume(throwing: error)
+        // We need an extra promise in order to make this cancellable.
+        let promise = self.eventLoop.makePromise(of: Value.self)
+        self.cascade(to: promise)
+
+        return try await withTaskCancellationHandler {
+            return try await withUnsafeThrowingContinuation { cont in
+                promise.futureResult.whenComplete { result in
+                    switch result {
+                    case .success(let value):
+                        cont.resume(returning: value)
+                    case .failure(let error):
+                        cont.resume(throwing: error)
+                    }
                 }
             }
+        } onCancel: {
+            promise.fail(CancellationError())
         }
+
+
     }
 }
 


### PR DESCRIPTION
This is a request for comments on a specific attempt to resolve #2087. 

In this instance, in addition to code review I'd like reviewers to consider two questions.

Firstly, should `Future.get()` attempt to cancel itself, or should we rely on users of the primitive arranging appropriate cancellation themselves? I think this is a legitimate question of priority: cancellation is never going to be entirely free, after all.

Secondly, is the cost of a new Promise acceptable to us? My gut instinct is no: it was just the fastest way to the right result. If it isn't acceptable then I think we need to add cancellation support, not to promises but to _future callbacks_. I'm envisioning something like this:

```swift
public struct NIOEventLoopFutureCancellationToken: Hashable {
    private var value: UInt64

    public init() {
        // We could also use an alternative construction, say a wrapping atomic counter.
        var rng = SystemRandomNumberGenerator()
        value = rng.next()
    }
}

let token = NIOEventLoopFutureCancellationToken()

future.whenComplete(cancellationToken: token) {
    // do whatever
}

future.cancelCallback(cancellationToken: token)
```

The Future would attach the cancellation token to the Future callbacks, and would be able to remove a callback from the `CallbackList` based on that token. This saves an allocation and provides more general purpose cancellation functionality.

Thoughts on this idea?

- - -

Motivation

Currently async tasks that are waiting on NIO's EventLoopFuture will get
stuck forever if that Task is cancelled. This inhibits the good
behaviour of TaskGroup and other structured concurrency patterns that
need to have all their subtasks exit before they can.

In general users need to do more cleanup than simply cancelling a
Future, however if they forget (or don't know what that cleanup is) it's
still useful to be able to cancel an operation in this way.

Modifications

Add an extra intermediary Promise that we can fail.
Add a cancellation handler that fails that Promise.

Result

EventLoopFuture.get() immediately fails on cancellation.
