### PR TITLE
Adopt `Sendable` in NIOConcurrencyHelpers

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
@@ -311,3 +311,9 @@ public final class NIOAtomic<T: NIOAtomicPrimitive> {
         }
     }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension NIOAtomic: Sendable {
+
+}
+#endif

--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -286,3 +286,12 @@ public final class ConditionLock<T: Equatable> {
 internal func debugOnly(_ body: () -> Void) {
     assert({ body(); return true }())
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension Lock: Sendable {
+
+}
+extension ConditionLock: @unchecked Sendable {
+
+}
+#endif


### PR DESCRIPTION
Stop `Sendable` related warnings when using types defined inside `NIOConcurrencyHelpers`. All the code should actually already be thread safe, so no changes needed other than labelling some classes as either `Sendable` or `@unchecked Sendable`.