### PR TITLE
Adopt `Sendable` in `_NIODataStructures`

### DIFF
--- a/Sources/_NIODataStructures/Heap.swift
+++ b/Sources/_NIODataStructures/Heap.swift
@@ -261,3 +261,10 @@ extension Heap: Sequence {
         return self.storage.count
     }
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+
+extension Heap: Sendable where Element: Sendable {}
+extension HeapIterator: Sendable where Element: Sendable {}
+
+#endif

--- a/Sources/_NIODataStructures/PriorityQueue.swift
+++ b/Sources/_NIODataStructures/PriorityQueue.swift
@@ -101,3 +101,10 @@ extension PriorityQueue: CustomStringConvertible {
         return "PriorityQueue(count: \(self.count)): \(Array(self))"
     }
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+
+extension PriorityQueue: Sendable where Element: Sendable {}
+extension PriorityQueue.Iterator: Sendable where Element: Sendable {}
+
+#endif


### PR DESCRIPTION
Adopt sendable in `_NIODataStructures` for all types in `_NIODataStructures`.
It does not use `NIOSendable` as it is defined in `NIOCore` and we currently do not depend on in it  in `_NIODataStructures` and we should also not start depending on it.
