### PR TITLE
Adopt `Sendable` for `NIOFileHandle.Mode` and `NIOFileHandle.Flags`

### DIFF
--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -89,7 +89,7 @@ public final class NIOFileHandle: FileDescriptor {
 
 extension NIOFileHandle {
     /// `Mode` represents file access modes.
-    public struct Mode: OptionSet {
+    public struct Mode: OptionSet, NIOSendable {
         public let rawValue: UInt8
 
         public init(rawValue: UInt8) {
@@ -116,7 +116,7 @@ extension NIOFileHandle {
     }
 
     /// `Flags` allows to specify additional flags to `Mode`, such as permission for file creation.
-    public struct Flags {
+    public struct Flags: NIOSendable {
         internal var posixMode: mode_t
         internal var posixFlags: CInt
 

--- a/Sources/NIOCore/FileRegion.swift
+++ b/Sources/NIOCore/FileRegion.swift
@@ -31,6 +31,7 @@ import Glibc
 /// need access to the bytes (in a `ByteBuffer`) to transform these.
 ///
 /// - note: It is important to manually manage the lifetime of the `NIOFileHandle` used to create a `FileRegion`.
+/// - warning: `FileRegion` objects are not thread-safe and are mutable. They also cannot be fully thread-safe as they refer to a global underlying file descriptor.
 public struct FileRegion {
 
     /// The `NIOFileHandle` that is used by this `FileRegion`.


### PR DESCRIPTION
`NIOFileHandler` and `FileRegion` are not thread-safe and can not conform to `Sendable`