### PR TITLE
`ChannelOption.Value: Sendable`

### DIFF
--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -14,8 +14,13 @@
 
 /// A configuration option that can be set on a `Channel` to configure different behaviour.
 public protocol ChannelOption: Equatable, NIOPreconcurrencySendable {
+    #if swift(>=5.6)
+    /// The type of the `ChannelOption`'s value.
+    associatedtype Value: Sendable
+    #else
     /// The type of the `ChannelOption`'s value.
     associatedtype Value
+    #endif
 }
 
 public typealias SocketOptionName = Int32

--- a/Sources/NIOCore/RecvByteBufferAllocator.swift
+++ b/Sources/NIOCore/RecvByteBufferAllocator.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Allocates `ByteBuffer`s to be used to read bytes from a `Channel` and records the number of the actual bytes that were used.
-public protocol RecvByteBufferAllocator {
+public protocol RecvByteBufferAllocator: NIOPreconcurrencySendable {
     /// Allocates a new `ByteBuffer` that will be used to read bytes from a `Channel`.
     func buffer(allocator: ByteBufferAllocator) -> ByteBuffer
 


### PR DESCRIPTION
It looks like requiring `ChannelOption.Value` to conform to `Sendable` is a source breaking change e.g. our own `RecvAllocatorOption` no longer compiles as the `RecvByteBufferAllocator` protocol wasn't required to be `Sendable`.
To my knowledge, `@preconcurrency` can not be applied to associated types which would normally be the solution to this kind of problem.