### PR TITLE
Deprecate unsafe methods for adding/removing non-`Sendable` `ChannelHandler`s

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport+OldXcodes.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport+OldXcodes.swift
@@ -163,28 +163,6 @@ extension ChannelOutboundInvoker {
 
 extension ChannelPipeline {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    public func addHandler(_ handler: ChannelHandler,
-                           name: String? = nil,
-                           position: ChannelPipeline.Position = .last) async throws {
-        try await self.addHandler(handler, name: name, position: position).get()
-    }
-
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    public func removeHandler(_ handler: RemovableChannelHandler) async throws {
-        try await self.removeHandler(handler).get()
-    }
-
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    public func removeHandler(name: String) async throws {
-        try await self.removeHandler(name: name).get()
-    }
-
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    public func removeHandler(context: ChannelHandlerContext) async throws {
-        try await self.removeHandler(context: context).get()
-    }
-
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func context(handler: ChannelHandler) async throws -> ChannelHandlerContext {
         return try await self.context(handler: handler).get()
     }
@@ -199,17 +177,76 @@ extension ChannelPipeline {
     public func context<Handler: ChannelHandler>(handlerType: Handler.Type) async throws -> ChannelHandlerContext {
         return try await self.context(handlerType: handlerType).get()
     }
-
+    
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func removeHandler(name: String) async throws {
+        try await self.removeHandler(name: name).get()
+    }
+}
+
+extension ChannelPipeline {
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @available(*, deprecated, message: "ChannelHandler is not Sendable and it is therefore not safe to be send to a different thread")
     public func addHandlers(_ handlers: [ChannelHandler],
                             position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandlers(handlers, position: position).get()
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @available(*, deprecated, message: "ChannelHandler is not Sendable and it is therefore not safe to be send to a different thread")
     public func addHandlers(_ handlers: ChannelHandler...,
                             position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandlers(handlers, position: position)
     }
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @available(*, deprecated, message: "ChannelHandler is not Sendable and it is therefore not safe to be send to a different thread")
+    public func addHandler(_ handler: ChannelHandler,
+                           name: String? = nil,
+                           position: ChannelPipeline.Position = .last) async throws {
+        try await self.addHandler(handler, name: name, position: position).get()
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @available(*, deprecated, message: "ChannelHandler is not Sendable and it is therefore not safe to be send to a different thread")
+    public func removeHandler(_ handler: RemovableChannelHandler) async throws {
+        try await self.removeHandler(handler).get()
+    }
+    
+    @available(*, deprecated, message: "ChannelHandlerContext is not Sendable and it is therefore not safe to be send to a different thread")
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func removeHandler(context: ChannelHandlerContext) async throws {
+        try await self.removeHandler(context: context).get()
+    }
 }
+
+extension ChannelPipeline {
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func addHandlers(_ handlers: [ChannelHandler & Sendable],
+                            position: ChannelPipeline.Position = .last) async throws {
+        try await self.addHandlers(handlers, position: position).get()
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func addHandlers(_ handlers: ChannelHandler & Sendable...,
+                            position: ChannelPipeline.Position = .last) async throws {
+        try await self.addHandlers(handlers, position: position)
+    }
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func addHandler(_ handler: ChannelHandler & Sendable,
+                           name: String? = nil,
+                           position: ChannelPipeline.Position = .last) async throws {
+        try await self.addHandler(handler, name: name, position: position).get()
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func removeHandler(_ handler: RemovableChannelHandler & Sendable) async throws {
+        try await self.removeHandler(handler).get()
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func removeHandler(context: ChannelHandlerContext & Sendable) async throws {
+        try await self.removeHandler(context: context).get()
+    }
+}
+
 #endif

--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -163,28 +163,6 @@ extension ChannelOutboundInvoker {
 
 extension ChannelPipeline {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func addHandler(_ handler: ChannelHandler,
-                           name: String? = nil,
-                           position: ChannelPipeline.Position = .last) async throws {
-        try await self.addHandler(handler, name: name, position: position).get()
-    }
-
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func removeHandler(_ handler: RemovableChannelHandler) async throws {
-        try await self.removeHandler(handler).get()
-    }
-
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func removeHandler(name: String) async throws {
-        try await self.removeHandler(name: name).get()
-    }
-
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func removeHandler(context: ChannelHandlerContext) async throws {
-        try await self.removeHandler(context: context).get()
-    }
-
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func context(handler: ChannelHandler) async throws -> ChannelHandlerContext {
         return try await self.context(handler: handler).get()
     }
@@ -199,19 +177,78 @@ extension ChannelPipeline {
     public func context<Handler: ChannelHandler>(handlerType: Handler.Type) async throws -> ChannelHandlerContext {
         return try await self.context(handlerType: handlerType).get()
     }
-
+    
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public func removeHandler(name: String) async throws {
+        try await self.removeHandler(name: name).get()
+    }
+}
+
+extension ChannelPipeline {
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(*, deprecated, message: "ChannelHandler is not Sendable and it is therefore not safe to be send to a different thread")
     public func addHandlers(_ handlers: [ChannelHandler],
                             position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandlers(handlers, position: position).get()
     }
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(*, deprecated, message: "ChannelHandler is not Sendable and it is therefore not safe to be send to a different thread")
     public func addHandlers(_ handlers: ChannelHandler...,
                             position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandlers(handlers, position: position)
     }
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(*, deprecated, message: "ChannelHandler is not Sendable and it is therefore not safe to be send to a different thread")
+    public func addHandler(_ handler: ChannelHandler,
+                           name: String? = nil,
+                           position: ChannelPipeline.Position = .last) async throws {
+        try await self.addHandler(handler, name: name, position: position).get()
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(*, deprecated, message: "ChannelHandler is not Sendable and it is therefore not safe to be send to a different thread")
+    public func removeHandler(_ handler: RemovableChannelHandler) async throws {
+        try await self.removeHandler(handler).get()
+    }
+    
+    @available(*, deprecated, message: "ChannelHandlerContext is not Sendable and it is therefore not safe to be send to a different thread")
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public func removeHandler(context: ChannelHandlerContext) async throws {
+        try await self.removeHandler(context: context).get()
+    }
 }
+
+extension ChannelPipeline {
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public func addHandlers(_ handlers: [ChannelHandler & Sendable],
+                            position: ChannelPipeline.Position = .last) async throws {
+        try await self.addHandlers(handlers, position: position).get()
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public func addHandlers(_ handlers: ChannelHandler & Sendable...,
+                            position: ChannelPipeline.Position = .last) async throws {
+        try await self.addHandlers(handlers, position: position)
+    }
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public func addHandler(_ handler: ChannelHandler & Sendable,
+                           name: String? = nil,
+                           position: ChannelPipeline.Position = .last) async throws {
+        try await self.addHandler(handler, name: name, position: position).get()
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public func removeHandler(_ handler: RemovableChannelHandler & Sendable) async throws {
+        try await self.removeHandler(handler).get()
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public func removeHandler(context: ChannelHandlerContext & Sendable) async throws {
+        try await self.removeHandler(context: context).get()
+    }
+}
+    
 
 public struct NIOTooManyBytesError: Error {
      public init() {}


### PR DESCRIPTION
### Motivation:

`ChannelHandler`s are not required to be thread-safe and we need to assume they can only be used on their `Channel`s `EventLoop`.

### Modifications:

- deprecate method which take non-`Sendable` `ChannelHandler`s
- add new methods which take `Sendable` `ChannelHandler`s

### Result:

Better thread-safety