### PR TITLE
Introduce internal `UnsafeTransfer` type

### DIFF
--- a/Sources/NIOCore/NIOSendable.swift
+++ b/Sources/NIOCore/NIOSendable.swift
@@ -23,3 +23,19 @@ public typealias NIOSendable = Any
 #else
 public protocol NIOPreconcurrencySendable {}
 #endif
+
+#if swift(>=5.5) && canImport(_Concurrency)
+@usableFromInline
+struct UnsafeTransfer<Wrapped> : @unchecked Sendable {
+    @usableFromInline
+    var wrappedValue: Wrapped
+    
+    @inlinable
+    init(_ wrappedValue: Wrapped) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension UnsafeTransfer: Equatable where Wrapped: Equatable {}
+extension UnsafeTransfer: Hashable where Wrapped: Hashable {}
+#endif

--- a/Sources/NIOCore/NIOSendable.swift
+++ b/Sources/NIOCore/NIOSendable.swift
@@ -25,8 +25,11 @@ public protocol NIOPreconcurrencySendable {}
 #endif
 
 #if swift(>=5.5) && canImport(_Concurrency)
+/// ``UnsafeTransfer`` can be used to make non-`Sendable` values `Sendable`.
+/// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler.
+/// It can be used similar to `@unsafe Sendable` but for values instead of types.
 @usableFromInline
-struct UnsafeTransfer<Wrapped> : @unchecked Sendable {
+struct UnsafeTransfer<Wrapped>: @unchecked Sendable {
     @usableFromInline
     var wrappedValue: Wrapped
     


### PR DESCRIPTION
### Motivation:
Soon we will need to silence some `Sendable` warnings. [The recommended way is to use a wrapper type that is unconditionally `Sendable`.](https://github.com/apple/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md#adaptor-types-for-legacy-codebases)
### Modifications:
- add internal `UnsafeTransfer` type

### Result:

We can silence `Sendable` warnings and errors by using `UnsafeTransfer` to pass non-`Sendable` values around.
