### PR TITLE
Reduce the alloc limits of `1000_tcpconnections` for main

### DIFF
--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -30,7 +30,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=153050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -30,7 +30,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=153050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050


### PR DESCRIPTION
The nightly builds have improved, so the alloc limits can drop slightly
