### PR TITLE
NIOPerformanceTester: Add DeadlineNowBenchmark for NIODeadline.now()

### DIFF
--- a/Sources/NIOPerformanceTester/DeadlineNowBenchmark.swift
+++ b/Sources/NIOPerformanceTester/DeadlineNowBenchmark.swift
@@ -32,8 +32,7 @@ final class DeadlineNowBenchmark: Benchmark {
         for _ in 0..<self.iterations {
             let now = NIODeadline.now().uptimeNanoseconds
             counter &+= now
-
         }
-        return 1
+        return Int(truncatingIfNeeded: counter)
     }
 }

--- a/Sources/NIOPerformanceTester/DeadlineNowBenchmark.swift
+++ b/Sources/NIOPerformanceTester/DeadlineNowBenchmark.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+final class DeadlineNowBenchmark: Benchmark {
+    private let iterations: Int
+
+    init(iterations: Int) {
+        self.iterations = iterations
+    }
+
+    func setUp() throws {
+    }
+
+    func tearDown() {
+    }
+
+    func run() -> Int {
+        var counter: UInt64 = 0
+        for _ in 0..<self.iterations {
+            let now = NIODeadline.now().uptimeNanoseconds
+            counter &+= now
+
+        }
+        return 1
+    }
+}

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -1046,3 +1046,10 @@ try measureAndPrint(
         size: 1024
     )
 )
+
+try measureAndPrint(
+    desc: "deadline_now_1M_times",
+    benchmark: DeadlineNowBenchmark(
+        iterations: 1_000_000
+    )
+)


### PR DESCRIPTION
### Motivation:

`NIODeadline.now()` is a function that is called many times in typical workloads. It is currently implemented in terms of `DispatchTime.now()`, which is provided by libdispatch, on all platforms. The underlying implementation has a lot of branches to offer a more flexible API than we make use of. There might be a chance to improve the performance by dropping down to a lower-level implementation within NIO itself but we need a baseline measurement of performance to assess any future proposed improvements.

### Modifications:

Add performance benchmark for `NIODeadline.now()`.

### Result:

`NIOPerformanceTester` has benchmark test for `NIODeadline.now()`.