### PR TITLE
Reduce the alloc limits for main

### DIFF
--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -34,7 +34,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=405050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=403050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -53,8 +53,8 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4350
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=140050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -34,7 +34,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=405050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=403050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -53,8 +53,8 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4350
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=140050
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
-      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
+      - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050


### PR DESCRIPTION
The nightly builds have improved, so the alloc limits can drop slightly
