### PR TITLE
wip: Use clock_gettime for NIODeadline.now()

### DIFF
--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -26,6 +26,7 @@ void CNIOLinux_i_do_nothing_just_working_around_a_darwin_toolchain_bug(void) {}
 #include <sys/prctl.h>
 #include <unistd.h>
 #include <assert.h>
+#include <time.h>
 
 _Static_assert(sizeof(CNIOLinux_mmsghdr) == sizeof(struct mmsghdr),
                "sizes of CNIOLinux_mmsghdr and struct mmsghdr differ");

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -14,7 +14,9 @@
 
 import NIOConcurrencyHelpers
 import Dispatch
+#if os(Linux)
 import CNIOLinux
+#endif // os(Linux)
 
 /// Returned once a task was scheduled on the `EventLoop` for later execution.
 ///
@@ -480,18 +482,16 @@ public struct NIODeadline: Equatable, Hashable, NIOSendable {
     }
 
 
-//#if os(Linux)
     @inline(__always)
     private static func timeNow() -> UInt64 {
-        if #available(macOS 10.12, *) {
-            var ts = timespec()
-            clock_gettime(CLOCK_MONOTONIC, &ts)
-            return UInt64(ts.tv_sec) &* 1_000_000_000 &+ UInt64(ts.tv_nsec)
-        } else {
-            return DispatchTime.now().uptimeNanoseconds
-        }
+#if os(Linux)
+        var ts = timespec()
+        clock_gettime(CLOCK_MONOTONIC, &ts)
+        return UInt64(ts.tv_sec) &* 1_000_000_000 &+ UInt64(ts.tv_nsec)
+#else // os(Linux)
+        return DispatchTime.now().uptimeNanoseconds
+#endif // os(Linux)
     }
-//#endif
 
     public static func now() -> NIODeadline {
         return NIODeadline.uptimeNanoseconds(timeNow())

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -482,11 +482,24 @@ public struct NIODeadline: Equatable, Hashable, NIOSendable {
     }
 
 
+    /// Getting the time is a very common operation so it warrants optimization.
+    ///
+    /// Prior to this function, NIO relied on `DispatchTime.now()`, on all platforms. In addition to
+    /// the overhead of making a library call, the underlying implementation has a lot of branches
+    /// because `libdispatch` supports many more usecases than we are making use of here.
+    ///
+    /// On Linux, `DispachTime.now()` _always_ results in a simple call to `clock_gettime(3)` and so
+    /// we make that call here, directly from NIO.
+    ///
+    /// - TODO: Investigate optimizing the call to `DispatchTime.now()` away on other platforms too.
     @inline(__always)
     private static func timeNow() -> UInt64 {
 #if os(Linux)
         var ts = timespec()
         clock_gettime(CLOCK_MONOTONIC, &ts)
+        /// We use unsafe arithmetic here because `UInt64.max` nanoseconds is more than 580 years,
+        /// and the odds that this code will still be running 530 years from now is very, very low,
+        /// so as a practical matter this will never overflow.
         return UInt64(ts.tv_sec) &* 1_000_000_000 &+ UInt64(ts.tv_nsec)
 #else // os(Linux)
         return DispatchTime.now().uptimeNanoseconds


### PR DESCRIPTION
### Motivation:

`NIODeadline.now()` is a function that is called many times in typical workloads. It is currently implemented in terms of `DispatchTime.now()`, which is provided by `libdispatch`, on all platforms. The underlying implementation has a lot of branches to offer a more flexible API than we make use of and also involves a call to another library. The way in which NIO calls this function as part of `NIODeadline.now()` _always_ results in a simple call to `clock_gettime(3)`. Calling this directly might yield a performance benefit.

### Modifications:

* Replace call to `DispatchTime.now()` with call to `clock_gettime` in `NIODeadline.now()`.

### Result:

* About a 10% speedup (on Linux only for now).
