### PR TITLE
NIOPerformanceTester: Increase operations used in lock benchmarks from 1M to 10M

### DIFF
--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -984,35 +984,35 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
-    desc: "lock_1_thread_1M_ops",
+    desc: "lock_1_thread_10M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 1,
-        lockOperationsPerThread: 1_000_000
+        lockOperationsPerThread: 10_000_000
     )
 )
 
 try measureAndPrint(
-    desc: "lock_2_threads_1M_ops",
+    desc: "lock_2_threads_10M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 2,
-        lockOperationsPerThread: 500_000
+        lockOperationsPerThread: 5_000_000
     )
 )
 
 try measureAndPrint(
-    desc: "lock_4_threads_1M_ops",
+    desc: "lock_4_threads_10M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 4,
-        lockOperationsPerThread: 250_000
+        lockOperationsPerThread: 2_500_000
     )
 )
 
 
 try measureAndPrint(
-    desc: "lock_8_threads_1M_ops",
+    desc: "lock_8_threads_10M_ops",
     benchmark: LockBenchmark(
         numberOfThreads: 8,
-        lockOperationsPerThread: 125_000
+        lockOperationsPerThread: 1_250_000
     )
 )
 


### PR DESCRIPTION
### Motivation:

There is currently significant noise in the `lock_*_thread_1M_ops` performance benchmarks. This is illustrated pretty clearly in #2120, an empty PR which claimed a 255% regression. We'd like these numbers to be more stable in the absence of meaningful change to that logic.

### Modifications:

Increase the iterations of the locking benchmarks by 10x, from 1M operations to 10M.

### Result:

(Hopefully) these benchmarks will be more stable.