### PR TITLE
DatagramChannelTests: Handle receiving datagrams out-of-order in ECN tests

### DIFF
--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -706,11 +706,7 @@ final class DatagramChannelTests: XCTestCase {
                 // Datagrams may be received out-of-order, so we use the payload to associate the read.
                 let writeData = AddressedEnvelope(
                     remoteAddress: receiveChannel.localAddress!,
-                    data: sendChannel.allocator.buffer(
-                        integer: ecnStateIdx,
-                        endianness: .big,
-                        as: Int.self
-                    ),
+                    data: sendChannel.allocator.buffer(integer: ecnStateIdx),
                     metadata: .init(ecnState: ecnState, packetInfo: expectedPacketInfo)
                 )
                 // Sending extra data without flushing should trigger a vector send.
@@ -725,11 +721,7 @@ final class DatagramChannelTests: XCTestCase {
             XCTAssertEqual(reads.count, expectedNumReads)
             for read in reads {
                 // Datagrams may be received out-of-order, let's find the associated ecnStateIdx.
-                let ecnStateIdx = try XCTUnwrap(read.data.getInteger(
-                    at: 0,
-                    endianness: .big,
-                    as: Int.self
-                ))
+                let ecnStateIdx: Int = try XCTUnwrap(read.data.getInteger(at: read.data.readerIndex))
                 XCTAssertEqual(read.metadata?.ecnState, ecnStates[ecnStateIdx])
                 XCTAssertEqual(read.metadata?.packetInfo, expectedPacketInfo)
             }

--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -718,7 +718,7 @@ final class DatagramChannelTests: XCTestCase {
                 metadataWrites.append((ecnState.offset, writeData.metadata))
             }
 
-            let expectedNumReads = ecnStates.count * (vectorSend ? 2 : 1)
+            let expectedNumReads = metadataWrites.count
             let metadataReads = try receiveChannel.waitForDatagrams(count: expectedNumReads).map {
                 ($0.data.getInteger(at: $0.data.readerIndex, as: Int.self)!, $0.metadata)
             }


### PR DESCRIPTION
### Motivation:

#2114 and #2122 show that the tests that rely on the `testEcnAndPacketInfoReceive(address:vectorRead:vectorSend:receivePacketInfo:)` helper function have false negatives when datagrams are received out-of-order. The tests should be resilient to out-of-order delivery of datagrams.

### Modifications:

Modify the test helper to use an integer payload to associate the reads and writes before comparing the metadata.

### Result:

* Fixes #2114 
* Fixes #2122
