### PR TITLE
readme: Fix API docs link following NIOCore refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The core SwiftNIO repository will contain a few extremely important protocol imp
 
 ## Documentation
 
- - [API documentation](https://apple.github.io/swift-nio/docs/current/NIO/index.html)
+ - [API documentation](https://apple.github.io/swift-nio/docs/current/NIOCore/index.html)
 
 ## Example Usage
 


### PR DESCRIPTION
### Motivation:

The link in the README to the API documentation no longer works because the link still contains `NIO` (cf. `NIOCore`).

### Modifications:

Update the link to point to the new rendered documentation.

### Result:

Link in README now works.

Fixes #2125.