### PR TITLE
build: correct dependencies for `NIOCore`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import PackageDescription
 
 var targets: [PackageDescription.Target] = [
     .target(name: "NIOCore",
-            dependencies: ["NIOConcurrencyHelpers", "CNIOLinux"]),
+            dependencies: ["NIOConcurrencyHelpers", "CNIOLinux", "CNIOWindows"]),
     .target(name: "_NIODataStructures"),
     .target(name: "NIOEmbedded",
             dependencies: ["NIOCore",


### PR DESCRIPTION
The `NIOCore` depends on the platform specific implementation but the
dependency for the Windows platform content was missing.  Adjust this
to repair the build graph for Windows.