### PR TITLE
_NIODataStructures: repair the build on Windows

### DIFF
--- a/Sources/_NIODataStructures/Heap.swift
+++ b/Sources/_NIODataStructures/Heap.swift
@@ -15,6 +15,8 @@
 import Darwin.C
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
+#elseif os(Windows)
+import ucrt
 #endif
 
 @usableFromInline


### PR DESCRIPTION
Import `ucrt` which is the MSVC C library to match the behaviour of the
other platforms.  This allows building `_NIODataStructures` on Windows.