### PR TITLE
NIOCore: add missing import for `IO`

### DIFF
--- a/Sources/NIOCore/IO.swift
+++ b/Sources/NIOCore/IO.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Windows)
+import ucrt
 import typealias WinSDK.DWORD
 #elseif os(Linux) || os(Android)
 import Glibc


### PR DESCRIPTION
Import `ucrt` for access to `strerror` on Windows.