### PR TITLE
NIOCore: import `WSAGetLastError`, `GetLastError`

### DIFF
--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -54,6 +54,9 @@ import struct WinSDK.SOCKET
 
 import func WinSDK.inet_ntop
 import func WinSDK.inet_pton
+
+import func WinSDK.GetLastError
+import func WinSDK.WSAGetLastError
 #elseif os(Linux) || os(Android)
 import Glibc
 import CNIOLinux


### PR DESCRIPTION
We use these functions to report errors from WinSock.  This was likely
excluded accidentally from previous commits.