### PR TITLE
NIOCore: replace `mode_t` with `CInt`

### DIFF
--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -19,6 +19,12 @@ import Darwin
 import Glibc
 #endif
 
+#if os(Windows)
+public typealias NIOPOSIXFileMode = CInt
+#else
+public typealias NIOPOSIXFileMode = mode_t
+#endif
+
 /// A `NIOFileHandle` is a handle to an open file.
 ///
 /// When creating a `NIOFileHandle` it takes ownership of the underlying file descriptor. When a `NIOFileHandle` is no longer
@@ -117,7 +123,7 @@ extension NIOFileHandle {
 
     /// `Flags` allows to specify additional flags to `Mode`, such as permission for file creation.
     public struct Flags: NIOSendable {
-        internal var posixMode: mode_t
+        internal var posixMode: NIOPOSIXFileMode
         internal var posixFlags: CInt
 
         public static let `default` = Flags(posixMode: 0, posixFlags: 0)
@@ -126,7 +132,7 @@ extension NIOFileHandle {
         ///
         /// - parameters:
         ///     - posixMode: `file mode` applied when file is created. Default permissions are: read and write for fileowner, read for owners group and others.
-        public static func allowFileCreation(posixMode: mode_t = S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH) -> Flags {
+        public static func allowFileCreation(posixMode: NIOPOSIXFileMode = S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH ) -> Flags {
             return Flags(posixMode: posixMode, posixFlags: O_CREAT)
         }
 
@@ -136,7 +142,7 @@ extension NIOFileHandle {
         ///     - flags: The POSIX open flags (the second parameter for `open(2)`).
         ///     - mode: The POSIX mode (the third parameter for `open(2)`).
         /// - returns: A `NIOFileHandle.Mode` equivalent to the given POSIX flags and mode.
-        public static func posix(flags: CInt, mode: mode_t) -> Flags {
+        public static func posix(flags: CInt, mode: NIOPOSIXFileMode) -> Flags {
             return Flags(posixMode: mode, posixFlags: flags)
         }
     }

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -132,7 +132,7 @@ extension NIOFileHandle {
         ///
         /// - parameters:
         ///     - posixMode: `file mode` applied when file is created. Default permissions are: read and write for fileowner, read for owners group and others.
-        public static func allowFileCreation(posixMode: NIOPOSIXFileMode = S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH ) -> Flags {
+        public static func allowFileCreation(posixMode: NIOPOSIXFileMode = S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH) -> Flags {
             return Flags(posixMode: posixMode, posixFlags: O_CREAT)
         }
 

--- a/Sources/NIOCore/SystemCallHelpers.swift
+++ b/Sources/NIOCore/SystemCallHelpers.swift
@@ -31,7 +31,7 @@ import CNIOWindows
 
 private let sysDup: @convention(c) (CInt) -> CInt = dup
 private let sysClose: @convention(c) (CInt) -> CInt = close
-private let sysOpenWithMode: @convention(c) (UnsafePointer<CChar>, CInt, mode_t) -> CInt = open
+private let sysOpenWithMode: @convention(c) (UnsafePointer<CChar>, CInt, NIOPOSIXFileMode) -> CInt = open
 private let sysLseek: @convention(c) (CInt, off_t, CInt) -> off_t = lseek
 private let sysRead: @convention(c) (CInt, UnsafeMutableRawPointer?, size_t) -> size_t = read
 private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsignedInt = if_nametoindex
@@ -112,7 +112,7 @@ enum SystemCalls {
     }
 
     @inline(never)
-    internal static func open(file: UnsafePointer<CChar>, oFlag: CInt, mode: mode_t) throws -> CInt {
+    internal static func open(file: UnsafePointer<CChar>, oFlag: CInt, mode: NIOPOSIXFileMode) throws -> CInt {
         return try syscall(blocking: false) {
             sysOpenWithMode(file, oFlag, mode)
         }.result


### PR DESCRIPTION
Windows does not have a `mode_t` type alias, instead using the
de-sugared `CInt` type.  De-sugar the instances to permit building on
Windows.