### PR TITLE
NIOCore: correct typo in error namespace on Windows

### DIFF
--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -412,7 +412,7 @@ public enum SocketAddress: CustomStringConvertible, NIOSendable {
                     }
                 }
 
-                throw SocketAddressErro.unsupported
+                throw SocketAddressError.unsupported
             }
         }
 #else


### PR DESCRIPTION
There was a missing `r` in the error type which caused a build failure
on Windows.  Correct the spelling for the error on Windows.