### PR TITLE
NIOCore: import `INET{,6}_ADDRSTRLEN` constants

### DIFF
--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -16,6 +16,9 @@
 import let WinSDK.AF_INET
 import let WinSDK.AF_INET6
 
+import let WinSDK.INET_ADDRSTRLEN
+import let WinSDK.INET6_ADDRSTRLEN
+
 import func WinSDK.FreeAddrInfoW
 import func WinSDK.GetAddrInfoW
 


### PR DESCRIPTION
This imports the address string length constants from WinSock for
Windows.