### PR TITLE
NIOCore: use `errno` accessor on Windows

### DIFF
--- a/Sources/NIOCore/SystemCallHelpers.swift
+++ b/Sources/NIOCore/SystemCallHelpers.swift
@@ -68,7 +68,12 @@ internal func syscall<T: FixedWidthInteger>(blocking: Bool,
     while true {
         let res = try body()
         if res == -1 {
+#if os(Windows)
+            var err: CInt = 0
+            ucrt._get_errno(&err)
+#else
             let err = errno
+#endif
             switch (err, blocking) {
             case (EINTR, _):
                 continue
@@ -96,7 +101,12 @@ enum SystemCalls {
     internal static func close(descriptor: CInt) throws {
         let res = sysClose(descriptor)
         if res == -1 {
+#if os(Windows)
+            var err: CInt = 0
+            ucrt._get_errno(&err)
+#else
             let err = errno
+#endif
 
             // There is really nothing "sane" we can do when EINTR was reported on close.
             // So just ignore it and "assume" everything is fine == we closed the file descriptor.


### PR DESCRIPTION
`errno` on Windows cannot be access as a raw name as it goes through a
"complex" macro for the TLS access.  Use the `_get_errno` helper instead
of accessing the `errno` through the macro for building on Windows.