### PR TITLE
Fix flake AsyncEmbeddedEventLoopTest

### DIFF
--- a/Tests/NIOEmbeddedTests/AsyncEmbeddedEventLoopTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncEmbeddedEventLoopTests.swift
@@ -499,10 +499,7 @@ final class NIOAsyncEmbeddedEventLoopTests: XCTestCase {
 
             let scheduled = make()
             scheduled.cancel()
-
-            XCTAssertNotNil(weakThing)
-            await eventLoop.run()
-            XCTAssertNil(weakThing)
+            assert(weakThing == nil, within: .seconds(1))
             await XCTAssertThrowsError(try await eventLoop.awaitFuture(scheduled.futureResult, timeout: .seconds(1))) { error in
                 XCTAssertEqual(EventLoopError.cancelled, error as? EventLoopError)
             }


### PR DESCRIPTION
Motivation:

Flaky tests are really annoying.

Modifications:

- Stop assuming that the item is not immediately nil

Result:

Test now passes consistently.

Fixes #2105.