### PR TITLE
NIOCore: import additional socket types on Windows

### DIFF
--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -27,6 +27,12 @@ import struct WinSDK.ADDRESS_FAMILY
 import struct WinSDK.IP_ADAPTER_ADDRESSES
 import struct WinSDK.IP_ADAPTER_UNICAST_ADDRESS
 
+import struct WinSDK.sockaddr
+import struct WinSDK.sockaddr_in
+import struct WinSDK.sockaddr_in6
+import struct WinSDK.sockaddr_storage
+import struct WinSDK.sockaddr_un
+
 import typealias WinSDK.UINT8
 #endif
 

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -25,6 +25,11 @@ import func WinSDK.GetAddrInfoW
 import struct WinSDK.ADDRESS_FAMILY
 import struct WinSDK.ADDRINFOW
 import struct WinSDK.in_addr_t
+import struct WinSDK.sockaddr
+import struct WinSDK.sockaddr_in
+import struct WinSDK.sockaddr_in6
+import struct WinSDK.sockaddr_storage
+import struct WinSDK.sockaddr_un
 
 import typealias WinSDK.u_short
 #elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)


### PR DESCRIPTION
Add imports for additional socket types to enable building more of
NIOCore on Windows.