### PR TITLE
NIOCore: add explicit type cast for Windows compatibility

### DIFF
--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -370,7 +370,7 @@ extension NIONetworkDevice {
                     try! NIOBSDSocket.inet_ntop(addressFamily: .inet,
                                                 addressBytes: &mask,
                                                 addressDescription: $0.baseAddress!,
-                                                addressDescriptionLength: INET_ADDRSTRLEN)
+                                                addressDescriptionLength: socklen_t(INET_ADDRSTRLEN))
                 }
                 return SocketAddress(mask)
             }
@@ -383,7 +383,7 @@ extension NIONetworkDevice {
                     try! NIOBSDSocket.inet_ntop(addressFamily: .inet6,
                                                 addressBytes: &mask,
                                                 addressDescription: $0.baseAddress!,
-                                                addressDescriptionLength: INET6_ADDRSTRLEN)
+                                                addressDescriptionLength: socklen_t(INET6_ADDRSTRLEN))
                 }
                 return SocketAddress(mask)
             }


### PR DESCRIPTION
Windows does not have a `socklen_t` type, instead using `CInt` for the
value.  This adds an explicit type cast to repair the build on Windows.