### PR TITLE
NIOCore: import and alias some BSD socket types on Windows

### DIFF
--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -24,6 +24,9 @@ import func WinSDK.GetAddrInfoW
 
 import struct WinSDK.ADDRESS_FAMILY
 import struct WinSDK.ADDRINFOW
+import struct WinSDK.IN_ADDR
+import struct WinSDK.IN6_ADDR
+
 import struct WinSDK.in_addr_t
 import struct WinSDK.sockaddr
 import struct WinSDK.sockaddr_in
@@ -32,6 +35,11 @@ import struct WinSDK.sockaddr_storage
 import struct WinSDK.sockaddr_un
 
 import typealias WinSDK.u_short
+
+fileprivate typealias in_addr = WinSDK.IN_ADDR
+fileprivate typealias in6_addr = WinSDK.IN6_ADDR
+fileprivate typealias in_port_t = WinSDK.u_short
+fileprivate typealias sa_family_t = WinSDK.ADDRESS_FAMILY
 #elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 import Darwin
 #elseif os(Linux) || os(FreeBSD) || os(Android)


### PR DESCRIPTION
Although WinSock conceptually supports many of the BSD Socket APIs, it
does not provide source compatibility.  This adds a few type aliases for
adjusting towards source compatibility.