### PR TITLE
NIOCore: import the C library interfaces

### DIFF
--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Windows)
+import ucrt
+
 import let WinSDK.AF_INET
 import let WinSDK.AF_INET6
 


### PR DESCRIPTION
The socket address handling logic depends on multiple C library
interfaces which requires the import of the C library.  Add that on
Windows.