### PR TITLE
Implement the _failEarlyRangeCheck methods as no-ops

### DIFF
--- a/Sources/NIOCore/CircularBuffer.swift
+++ b/Sources/NIOCore/CircularBuffer.swift
@@ -251,6 +251,10 @@ extension CircularBuffer: Collection, MutableCollection {
 
         return (self[self.endIndex..<self.endIndex].makeIterator(), self.count)
     }
+    
+    public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {}
+    public func _failEarlyRangeCheck(_ index: Index, bounds: ClosedRange<Index>) {}
+    public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {}
 }
 
 // MARK: RandomAccessCollection implementation


### PR DESCRIPTION
Implements all versions of the `_failEarlyRangeCheck(_:bounds:)` Collection methods as no-ops.

### Motivation:
https://github.com/apple/swift-nio/issues/1827 specifies the missing Collection customization points that we would like to customize.

It seems that the `_failEarlyRangeCheck(_:bounds:)` should be implemented as no-ops.

### Modifications:

Adds three methods to the `CircularBuffer` conforming to `Collection`

### Result:

The default implementations of the `_failEarlyRangeCheck` methods are going to be customized to be no-ops in the `CircularBuffer` struct.
