### PR TITLE
NIOCore: adjust the BSDSocketAPI for Windows

### DIFF
--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -57,6 +57,8 @@ import func WinSDK.inet_pton
 
 import func WinSDK.GetLastError
 import func WinSDK.WSAGetLastError
+
+internal typealias socklen_t = ucrt.size_t
 #elseif os(Linux) || os(Android)
 import Glibc
 import CNIOLinux


### PR DESCRIPTION
Windows does not provide a definition for `socklen_t`.  Create an
internal typealias for it to provide source stability to the internal
interfaces.