### PR TITLE
NIOCore: duplicate the NIODevice implementation on Windows

### DIFF
--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -87,6 +87,63 @@ public final class NIONetworkInterface {
     /// The index of the interface, as provided by `if_nametoindex`.
     public let interfaceIndex: Int
 
+#if os(Windows)
+    internal init?(_ pAdapter: UnsafeMutablePointer<IP_ADAPTER_ADDRESSES>,
+                   _ pAddress: UnsafeMutablePointer<IP_ADAPTER_UNICAST_ADDRESS>) {
+        self.name = String(decodingCString: pAdapter.pointee.FriendlyName,
+                           as: UTF16.self)
+        guard let address = pAddress.pointee.Address.lpSockaddr.convert() else {
+            return nil
+        }
+        self.address = address
+
+        // TODO: convert the prefix length to the mask itself
+        let v4mask: (UINT8) -> SocketAddress? = { _ in
+            var buffer: [CChar] =
+                Array<CChar>(repeating: 0, count: Int(INET_ADDRSTRLEN))
+            var mask: sockaddr_in = sockaddr_in()
+            mask.sin_family = ADDRESS_FAMILY(AF_INET)
+            _ = buffer.withUnsafeMutableBufferPointer {
+                try! NIOBSDSocket.inet_ntop(addressFamily: .inet,
+                                            addressBytes: &mask,
+                                            addressDescription: $0.baseAddress!,
+                                            addressDescriptionLength: socklen_t(INET_ADDRSTRLEN))
+            }
+            return SocketAddress(mask)
+        }
+        let v6mask: (UINT8) -> SocketAddress? = { _ in
+            var buffer: [CChar] =
+                Array<CChar>(repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            var mask: sockaddr_in6 = sockaddr_in6()
+            mask.sin6_family = ADDRESS_FAMILY(AF_INET6)
+            _ = buffer.withUnsafeMutableBufferPointer {
+                try! NIOBSDSocket.inet_ntop(addressFamily: .inet6,
+                                            addressBytes: &mask,
+                                            addressDescription: $0.baseAddress!,
+                                            addressDescriptionLength: socklen_t(INET6_ADDRSTRLEN))
+            }
+            return SocketAddress(mask)
+        }
+
+        switch pAddress.pointee.Address.lpSockaddr.pointee.sa_family {
+        case ADDRESS_FAMILY(AF_INET):
+            self.netmask = v4mask(pAddress.pointee.OnLinkPrefixLength)
+            self.interfaceIndex = Int(pAdapter.pointee.IfIndex)
+            break
+        case ADDRESS_FAMILY(AF_INET6):
+            self.netmask = v6mask(pAddress.pointee.OnLinkPrefixLength)
+            self.interfaceIndex = Int(pAdapter.pointee.Ipv6IfIndex)
+            break
+        default:
+            return nil
+        }
+
+        // TODO(compnerd) handle broadcast/ppp/multicast information
+        self.broadcastAddress = nil
+        self.pointToPointDestinationAddress = nil
+        self.multicastSupported = false
+    }
+#else
     internal init?(_ caddr: ifaddrs) {
         self.name = String(cString: caddr.ifa_name)
 
@@ -128,6 +185,7 @@ public final class NIONetworkInterface {
             return nil
         }
     }
+#endif
 }
 
 @available(*, deprecated, renamed: "NIONetworkDevice")


### PR DESCRIPTION
Windows does not have an `ifaddr` interface, and instead we need to
construct the interface from the adapter and logical interface.
Replicate this for the construction of the deprecated type just for
repairing the build.