### PR TITLE
NIOPosix: reduce imports for Windows

### DIFF
--- a/Sources/NIOPosix/BSDSocketAPICommon.swift
+++ b/Sources/NIOPosix/BSDSocketAPICommon.swift
@@ -18,55 +18,13 @@ import ucrt
 
 import let WinSDK.INVALID_SOCKET
 
-import let WinSDK.IPPROTO_IP
-import let WinSDK.IPPROTO_IPV6
-import let WinSDK.IPPROTO_TCP
-
-import let WinSDK.IP_ADD_MEMBERSHIP
-import let WinSDK.IP_DROP_MEMBERSHIP
-import let WinSDK.IP_MULTICAST_IF
-import let WinSDK.IP_MULTICAST_LOOP
-import let WinSDK.IP_MULTICAST_TTL
 import let WinSDK.IP_RECVTOS
-import let WinSDK.IPV6_JOIN_GROUP
-import let WinSDK.IPV6_LEAVE_GROUP
-import let WinSDK.IPV6_MULTICAST_HOPS
-import let WinSDK.IPV6_MULTICAST_IF
-import let WinSDK.IPV6_MULTICAST_LOOP
 import let WinSDK.IPV6_RECVTCLASS
-import let WinSDK.IPV6_V6ONLY
-
-import let WinSDK.AF_INET
-import let WinSDK.AF_INET6
-import let WinSDK.AF_UNIX
-
-import let WinSDK.PF_INET
-import let WinSDK.PF_INET6
-import let WinSDK.PF_UNIX
 
 import let WinSDK.SOCK_DGRAM
 import let WinSDK.SOCK_STREAM
 
-import let WinSDK.SO_ERROR
-import let WinSDK.SO_KEEPALIVE
-import let WinSDK.SO_LINGER
-import let WinSDK.SO_RCVBUF
-import let WinSDK.SO_RCVTIMEO
-import let WinSDK.SO_REUSEADDR
-
-import let WinSDK.SOL_SOCKET
-
-import let WinSDK.TCP_NODELAY
-
-import struct WinSDK.SOCKET
-
-import struct WinSDK.WSACMSGHDR
-import struct WinSDK.WSAMSG
-
 import struct WinSDK.socklen_t
-
-internal typealias msghdr = WSAMSG
-internal typealias cmsghdr = WSACMSGHDR
 #endif
 
 protocol _SocketShutdownProtocol {

--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -102,9 +102,13 @@ import struct WinSDK.SOCKADDR_IN
 import struct WinSDK.SOCKADDR_IN6
 import struct WinSDK.SOCKADDR_UN
 import struct WinSDK.SOCKADDR_STORAGE
+import struct WinSDK.WSACMSGHDR
+import struct WinSDK.WSAMSG
 
 import typealias WinSDK.LPFN_WSARECVMSG
 
+internal typealias cmsghdr = WSACMSGHDR
+internal typealias msghdr = WSAMSG
 internal typealias in_addr = IN_ADDR
 internal typealias in_port_t = USHORT
 internal typealias sa_family_t = ADDRESS_FAMILY
@@ -112,6 +116,7 @@ internal typealias sockaddr_in = SOCKADDR_IN
 internal typealias sockaddr_in6 = SOCKADDR_IN6
 internal typealias sockaddr_un = SOCKADDR_UN
 internal typealias sockaddr_storage = SOCKADDR_STORAGE
+
 
 fileprivate var IOC_IN: DWORD {
   0x8000_0000

--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -18,44 +18,8 @@ import NIOConcurrencyHelpers
 #if os(Windows)
 import let WinSDK.EAFNOSUPPORT
 import let WinSDK.EBADF
-import let WinSDK.ENOENT
 
-import let WinSDK.FILE_ATTRIBUTE_REPARSE_POINT
-import let WinSDK.FILE_FLAG_BACKUP_SEMANTICS
-import let WinSDK.FILE_FLAG_OPEN_REPARSE_POINT
-import let WinSDK.FILE_SHARE_DELETE
-import let WinSDK.FILE_SHARE_READ
-import let WinSDK.FILE_SHARE_WRITE
-import let WinSDK.FileDispositionInfoEx
-
-import let WinSDK.GENERIC_READ
-
-import let WinSDK.INET_ADDRSTRLEN
-import let WinSDK.INET6_ADDRSTRLEN
-
-import let WinSDK.INVALID_HANDLE_VALUE
-import let WinSDK.INVALID_SOCKET
-
-import let WinSDK.IO_REPARSE_TAG_AF_UNIX
-
-import let WinSDK.NO_ERROR
-
-import let WinSDK.OPEN_EXISTING
-
-import func WinSDK.CloseHandle
-import func WinSDK.CreateFileW
-import func WinSDK.DeviceIoControl
-import func WinSDK.GetFileInformationByHandle
-import func WinSDK.GetFileType
-import func WinSDK.GetLastError
-import func WinSDK.SetFileInformationByHandle
-
-import struct WinSDK.BY_HANDLE_FILE_INFORMATION
-import struct WinSDK.DWORD
-import struct WinSDK.FILE_DISPOSITION_INFO
 import struct WinSDK.socklen_t
-
-import CNIOWindows
 #endif
 
 protocol Registration {


### PR DESCRIPTION
Reduce unnecessary noise in the files after previous refactoring
shuffled the use of the imported interfaces.  We can centralise most of
the imports and internal typealiases which avoids cluttering the shared
interfaces with compatibility handling for Windows.