### PR TITLE
NIOPosix: remove unused alias for function

### DIFF
--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -102,7 +102,7 @@ private let sysDup: @convention(c) (CInt) -> CInt = dup
 private let sysGetpeername: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = getpeername
 private let sysGetsockname: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = getsockname
 #endif
-private let sysFreeifaddrs: @convention(c) (UnsafeMutablePointer<ifaddrs>?) -> Void = freeifaddrs
+
 private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsignedInt = if_nametoindex
 #if !os(Windows)
 private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>?) -> CInt = socketpair


### PR DESCRIPTION
This cleans up a reference to `freeifaddrs` as that is no longer
referenced in the code base.  This avoids an error on Windows as
a side-effect.