### PR TITLE
NIOPosix: use wrapper function for duplicating file descriptor

### DIFF
--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -1096,7 +1096,7 @@ public final class NIOPipeBootstrap {
     /// - returns: an `EventLoopFuture<Channel>` to deliver the `Channel`.
     public func withInputOutputDescriptor(_ fileDescriptor: CInt) -> EventLoopFuture<Channel> {
         let inputFD = fileDescriptor
-        let outputFD = dup(fileDescriptor)
+        let outputFD = try! Posix.dup(descriptor: fileDescriptor)
 
         return self.withPipes(inputDescriptor: inputFD, outputDescriptor: outputFD).flatMapErrorThrowing { error in
             try! Posix.close(descriptor: outputFD)


### PR DESCRIPTION
Use the wrapper function for duplicating the file descriptor.  This
allows us to swap out the implementation for different targets making
the code more portable.  It additionally adds additional error handling
and checking as the wrappers are intended to perform error handling.