### PR TITLE
NIOPosix: shuffle typealias location

### DIFF
--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -108,6 +108,7 @@ import typealias WinSDK.LPFN_WSARECVMSG
 internal typealias in_addr = IN_ADDR
 internal typealias in_port_t = USHORT
 internal typealias sa_family_t = ADDRESS_FAMILY
+internal typealias sockaddr = SOCKADDR
 internal typealias sockaddr_in = SOCKADDR_IN
 internal typealias sockaddr_in6 = SOCKADDR_IN6
 internal typealias sockaddr_un = SOCKADDR_UN

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -31,7 +31,6 @@ internal typealias in6_pktinfo = CNIOLinux_in6_pktinfo
 
 import CNIOWindows
 
-internal typealias sockaddr = WinSDK.SOCKADDR
 internal typealias MMsgHdr = CNIOWindows_mmsghdr
 #else
 let badOS = { fatalError("unsupported OS") }()


### PR DESCRIPTION
Move the `sockaddr` typealias for Windows into the `BSDSocketAPIWindows`
file which is a better home for the platform specific typealias.