### PR TITLE
NIOPosix: use internal enumeration for GAI resolver

### DIFF
--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -582,7 +582,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         let loop = self.group.next()
         let resolver = self.resolver ?? GetaddrinfoResolver(loop: loop,
                                                             aiSocktype: .stream,
-                                                            aiProtocol: CInt(IPPROTO_TCP))
+                                                            aiProtocol: .tcp)
         let connector = HappyEyeballsConnector(resolver: resolver,
                                                loop: loop,
                                                host: host,

--- a/Sources/NIOPosix/GetaddrinfoResolver.swift
+++ b/Sources/NIOPosix/GetaddrinfoResolver.swift
@@ -52,7 +52,7 @@ internal class GetaddrinfoResolver: Resolver {
     private let v4Future: EventLoopPromise<[SocketAddress]>
     private let v6Future: EventLoopPromise<[SocketAddress]>
     private let aiSocktype: NIOBSDSocket.SocketType
-    private let aiProtocol: CInt
+    private let aiProtocol: NIOBSDSocket.OptionLevel
 
     /// Create a new resolver.
     ///
@@ -60,7 +60,8 @@ internal class GetaddrinfoResolver: Resolver {
     ///     - loop: The `EventLoop` whose thread this resolver will block.
     ///     - aiSocktype: The sock type to use as hint when calling getaddrinfo.
     ///     - aiProtocol: the protocol to use as hint when calling getaddrinfo.
-    init(loop: EventLoop, aiSocktype: NIOBSDSocket.SocketType, aiProtocol: CInt) {
+    init(loop: EventLoop, aiSocktype: NIOBSDSocket.SocketType,
+         aiProtocol: NIOBSDSocket.OptionLevel) {
         self.v4Future = loop.makePromise()
         self.v6Future = loop.makePromise()
         self.aiSocktype = aiSocktype
@@ -134,7 +135,7 @@ internal class GetaddrinfoResolver: Resolver {
 
                 var aiHints: ADDRINFOW = ADDRINFOW()
                 aiHints.ai_socktype = self.aiSocktype.rawValue
-                aiHints.ai_protocol = self.aiProtocol
+                aiHints.ai_protocol = self.aiProtocol.rawValue
 
                 let iResult = GetAddrInfoW(wszHost, wszPort, &aiHints, &pResult)
                 guard iResult == 0 else {
@@ -155,7 +156,7 @@ internal class GetaddrinfoResolver: Resolver {
 
         var hint = addrinfo()
         hint.ai_socktype = self.aiSocktype.rawValue
-        hint.ai_protocol = self.aiProtocol
+        hint.ai_protocol = self.aiProtocol.rawValue
         guard getaddrinfo(host, String(port), &hint, &info) == 0 else {
             self.fail(SocketAddressError.unknown(host: host, port: port))
             return

--- a/Tests/NIOPosixTests/GetAddrInfoResolverTest.swift
+++ b/Tests/NIOPosixTests/GetAddrInfoResolverTest.swift
@@ -24,7 +24,7 @@ class GetaddrinfoResolverTest: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let resolver = GetaddrinfoResolver(loop: group.next(), aiSocktype: .stream, aiProtocol: CInt(IPPROTO_TCP))
+        let resolver = GetaddrinfoResolver(loop: group.next(), aiSocktype: .stream, aiProtocol: .tcp)
         let v4Future = resolver.initiateAQuery(host: "127.0.0.1", port: 12345)
         let v6Future = resolver.initiateAAAAQuery(host: "127.0.0.1", port: 12345)
 
@@ -41,7 +41,7 @@ class GetaddrinfoResolverTest: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let resolver = GetaddrinfoResolver(loop: group.next(), aiSocktype: .stream, aiProtocol: CInt(IPPROTO_TCP))
+        let resolver = GetaddrinfoResolver(loop: group.next(), aiSocktype: .stream, aiProtocol: .tcp)
         let v4Future = resolver.initiateAQuery(host: "::1", port: 12345)
         let v6Future = resolver.initiateAAAAQuery(host: "::1", port: 12345)
 

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -278,7 +278,7 @@ func resolverDebugInformation(eventLoop: EventLoop, host: String, previouslyRece
             return __testOnly_addressDescription(sa.address)
         }
     }
-    let res = GetaddrinfoResolver(loop: eventLoop, aiSocktype: .stream, aiProtocol: CInt(IPPROTO_TCP))
+    let res = GetaddrinfoResolver(loop: eventLoop, aiSocktype: .stream, aiProtocol: .tcp)
     let ipv6Results = try assertNoThrowWithValue(res.initiateAAAAQuery(host: host, port: 0).wait()).map(printSocketAddress)
     let ipv4Results = try assertNoThrowWithValue(res.initiateAQuery(host: host, port: 0).wait()).map(printSocketAddress)
 


### PR DESCRIPTION
Replace the use of raw constants with the internal enumeration.  This
ensures that the constant names are uniform and don't leak structural
information from the underlying information.