### PR TITLE
NIOPosix: use typealias instead of C name

### DIFF
--- a/Sources/NIOPosix/PendingWritesManager.swift
+++ b/Sources/NIOPosix/PendingWritesManager.swift
@@ -53,7 +53,7 @@ private func doPendingWriteVectorOperation(pending: PendingStreamWritesState,
 
             buffer.withUnsafeReadableBytesWithStorageManagement { ptr, storageRef in
                 storageRefs[i] = storageRef.retain()
-                iovecs[i] = iovec(iov_base: UnsafeMutableRawPointer(mutating: ptr.baseAddress!), iov_len: numericCast(toWriteForThisBuffer))
+                iovecs[i] = IOVector(iov_base: UnsafeMutableRawPointer(mutating: ptr.baseAddress!), iov_len: numericCast(toWriteForThisBuffer))
             }
             numberOfUsedStorageSlots += 1
         case .fileRegion:

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -156,7 +156,7 @@ typealias IOVector = iovec
                  controlBytes: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
         // Dubious const casts - it should be OK as there is no reason why this should get mutated
         // just bad const declaration below us.
-        var vec = iovec(iov_base: UnsafeMutableRawPointer(mutating: pointer.baseAddress!), iov_len: numericCast(pointer.count))
+        var vec = IOVector(iov_base: UnsafeMutableRawPointer(mutating: pointer.baseAddress!), iov_len: numericCast(pointer.count))
         let notConstCorrectDestinationPtr = UnsafeMutableRawPointer(mutating: destinationPtr)
 
         return try withUnsafeHandle { handle in
@@ -213,7 +213,7 @@ typealias IOVector = iovec
                  storage: inout sockaddr_storage,
                  storageLen: inout socklen_t,
                  controlBytes: inout UnsafeReceivedControlBytes) throws -> IOResult<Int> {
-        var vec = iovec(iov_base: pointer.baseAddress, iov_len: numericCast(pointer.count))
+        var vec = IOVector(iov_base: pointer.baseAddress, iov_len: numericCast(pointer.count))
 
         return try withUnsafeMutablePointer(to: &vec) { vecPtr in
             return try storage.withMutableSockAddr { (sockaddrPtr, _) in


### PR DESCRIPTION
Switch to the typealias rather than the raw name to support Windows and
make the code homogeneous with the rest of the codebase.