### PR TITLE
NIOPosix: alter construction of `in_addr` on Windows

### DIFF
--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -968,7 +968,12 @@ extension DatagramChannel: MulticastChannel {
                 try self.socket.setOption(level: .ip, name: operation.optionName(level: .ip), value: multicastRequest)
             case (.v4(let groupAddress), .none):
                 // IPv4 binding without target interface.
-                let multicastRequest = ip_mreq(imr_multiaddr: groupAddress.address.sin_addr, imr_interface: in_addr(s_addr: INADDR_ANY))
+#if os(Windows)
+                let addr: in_addr = in_addr(S_un: .init(S_addr: INADDR_ANY))
+#else
+                let addr: in_addr = in_addr(s_addr: INADDR_ANY)
+#endif
+                let multicastRequest = ip_mreq(imr_multiaddr: groupAddress.address.sin_addr, imr_interface: addr)
                 try self.socket.setOption(level: .ip, name: operation.optionName(level: .ip), value: multicastRequest)
             case (.v6(let groupAddress), .some(.v6)):
                 // IPv6 binding with specific target interface.


### PR DESCRIPTION
The type structure for `in_addr` is not compatible across Windows and
non-Windows due to spelling differences.  Out-of-line the construction
of the type to properly invoke the constructor.