### PR TITLE
NIOPosix: disable `timespec` extension on Windows

### DIFF
--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -33,6 +33,7 @@ extension Optional {
     }
 }
 
+#if !os(Windows)
 extension timespec {
     init(timeAmount amount: TimeAmount) {
         let nsecPerSec: Int64 = 1_000_000_000
@@ -41,6 +42,7 @@ extension timespec {
         self = timespec(tv_sec: Int(sec), tv_nsec: Int(ns - sec * nsecPerSec))
     }
 }
+#endif
 
 /// Represents IO events NIO might be interested in. `SelectorEventSet` is used for two purposes:
 ///  1. To express interest in a given event set and


### PR DESCRIPTION
This extension does not port cleanly to Windows as the time structures
on Windows are different.  This happens to be unused, so simply remove
the extension on Windows.