### PR TITLE
Adopt `Sendable` in `NIOEmbedded`

### DIFF
--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -761,3 +761,8 @@ extension EmbeddedChannel {
         return SynchronousOptions(channel: self)
     }
 }
+
+#if swift(>=5.5)
+@available(*, unavailable)
+extension EmbeddedChannel.SynchronousOptions: Sendable {}
+#endif

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -762,7 +762,7 @@ extension EmbeddedChannel {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.6)
 @available(*, unavailable)
 extension EmbeddedChannel.SynchronousOptions: Sendable {}
 #endif


### PR DESCRIPTION
Incremental `Sendable` adoption.

`EmbeddedChannel` and `EmbeddedEventLoop` should not be `Sendable`. However, they inherit from `Channel` and `EventLoop` respectively. Therefore, they need to be `Sendable` and are already implicitly `Sendable`. Given these constraints, we can’t mark `EmbeddedChannel` and `EmbeddedEventLoop` as non-Sendable.