### PR TITLE
NIOPosix: remove use of `setNonBlockingIO` on Windows pipes

### DIFF
--- a/Sources/NIOPosix/PipePair.swift
+++ b/Sources/NIOPosix/PipePair.swift
@@ -45,11 +45,16 @@ final class PipePair: SocketProtocol {
         self.inputFD = SelectableFileHandle(inputFD)
         self.outputFD = SelectableFileHandle(outputFD)
         try self.ignoreSIGPIPE()
+        // FIXME: there are underdocumented, ill-convcieved ways to emulate this
+        // vaugely, but, it might just not be worth it and be better to always
+        // just use overlapped IO on Winodws.
+#if !os(Windows)
         for fileHandle in [inputFD, outputFD] {
             try fileHandle.withUnsafeFileDescriptor {
                 try NIOFileHandle.setNonBlocking(fileDescriptor: $0)
             }
         }
+#endif
     }
 
     func ignoreSIGPIPE() throws {


### PR DESCRIPTION
On Windows anonymous pipes are not easy to make non-blocking.
Furthermore, doing so in any reasonably useful manner requires using
undocumented tricks which makes it vaguely but not entirely similar to
Unix semantics.  Prevent this operation on Windows for the time being.