### PR TITLE
NIOPosix: add import for `stderr` on Windows

### DIFF
--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -17,6 +17,10 @@ import NIOCore
 import NIOConcurrencyHelpers
 import _NIODataStructures
 
+#if os(Windows)
+import CRT
+#endif
+
 /// Execute the given closure and ensure we release all auto pools if needed.
 @inlinable
 internal func withAutoReleasePool<T>(_ execute: () throws -> T) rethrows -> T {


### PR DESCRIPTION
Windows cannot directly access the standard error stream due to it being
a "complex" macro according to the clang importer.  This requires us to
use the CRT Swift overlay wrappers to access the stream.  Add the
appropriate import.