### PR TITLE
Adopt `noasync` for `ThreadSpecificVariable`

### DIFF
--- a/Sources/NIOPosix/Thread.swift
+++ b/Sources/NIOPosix/Thread.swift
@@ -191,20 +191,20 @@ public final class ThreadSpecificVariable<Value: AnyObject> {
     @available(*, noasync, message: "threads can change between suspension points and therefore the thread specific value too")
     public var currentValue: Value? {
         get {
-            get()
+            self.get()
         }
         set {
-            set(newValue)
+            self.set(newValue)
         }
     }
     #else
     /// The value for the current thread.
     public var currentValue: Value? {
         get {
-            get()
+            self.get()
         }
         set {
-            set(newValue)
+            self.set(newValue)
         }
     }
     #endif

--- a/Sources/NIOPosix/Thread.swift
+++ b/Sources/NIOPosix/Thread.swift
@@ -214,9 +214,9 @@ public final class ThreadSpecificVariable<Value: AnyObject> {
         guard let raw = self.key.get() else { return nil }
         // parenthesize the return value to silence the cast warning
         return (Unmanaged<BoxedType>
-            .fromOpaque(raw)
-            .takeUnretainedValue()
-            .value.1 as! Value)
+                 .fromOpaque(raw)
+                 .takeUnretainedValue()
+                 .value.1 as! Value)
     }
     
     /// Set the current value for the calling threads. The `currentValue` for all other threads remains unchanged.

--- a/Sources/NIOPosix/Thread.swift
+++ b/Sources/NIOPosix/Thread.swift
@@ -185,25 +185,46 @@ public final class ThreadSpecificVariable<Value: AnyObject> {
         self.currentValue = value
     }
 
+    
+    #if swift(>=5.7)
+    /// The value for the current thread.
+    @available(*, noasync, message: "threads can change between suspension points and therefore the thread specific value too")
+    public var currentValue: Value? {
+        get {
+            get()
+        }
+        set {
+            set(newValue)
+        }
+    }
+    #else
     /// The value for the current thread.
     public var currentValue: Value? {
-        /// Get the current value for the calling thread.
         get {
-            guard let raw = self.key.get() else { return nil }
-          // parenthesize the return value to silence the cast warning
-          return (Unmanaged<BoxedType>
-                   .fromOpaque(raw)
-                   .takeUnretainedValue()
-                   .value.1 as! Value)
+            get()
         }
-
-        /// Set the current value for the calling threads. The `currentValue` for all other threads remains unchanged.
         set {
-            if let raw = self.key.get() {
-                Unmanaged<BoxedType>.fromOpaque(raw).release()
-            }
-            self.key.set(value: newValue.map { Unmanaged.passRetained(Box((self, $0))).toOpaque() })
+            set(newValue)
         }
+    }
+    #endif
+    
+    /// Get the current value for the calling thread.
+    func get() -> Value? {
+        guard let raw = self.key.get() else { return nil }
+        // parenthesize the return value to silence the cast warning
+        return (Unmanaged<BoxedType>
+            .fromOpaque(raw)
+            .takeUnretainedValue()
+            .value.1 as! Value)
+    }
+    
+    /// Set the current value for the calling threads. The `currentValue` for all other threads remains unchanged.
+    func set(_ newValue: Value?) {
+        if let raw = self.key.get() {
+            Unmanaged<BoxedType>.fromOpaque(raw).release()
+        }
+        self.key.set(value: newValue.map { Unmanaged.passRetained(Box((self, $0))).toOpaque() })
     }
 }
 


### PR DESCRIPTION
Mark `ThreadSpecificVariable.currentValue` as not available from asynchronous context.

### Motivation:
From [SE-0340 (Unavailable From Async Attribute)](https://github.com/apple/swift-evolution/blob/main/proposals/0340-swift-noasync.md#introduction):
> The Swift concurrency model allows tasks to resume on different threads from the one they were suspended on. For this reason, API that relies on thread-local storage, locks, mutexes, and semaphores, should not be used across suspension points.

### Modifications:

add `@available(*, noasync)` to  `ThreadSpecificVariable.currentValue` in Swift 5.7+

### Result:

Prevent accidental misuse of `ThreadSpecificVariable`

Note: The `noasync` diagnostics in the latest Swift 5.7 nightly compiler emits errors instead of warnings but this is already fixed and will be part of the next 5.7 nightly toolchain. https://github.com/apple/swift/issues/59748
