### PR TITLE
Adopt `noasync` for `Lock.lock()` and `Lock.unlock()`

### DIFF
--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -62,11 +62,26 @@ public final class Lock {
         mutex.deallocate()
     }
 
+    #if swift(>=5.7)
+    /// Acquire the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `unlock`, to simplify lock handling.
+    @available(*, noasync, message: "use 'withLock(_:)' if you do not cross suspension points")
+    public func lock() {
+        self._lock()
+    }
+    #else
     /// Acquire the lock.
     ///
     /// Whenever possible, consider using `withLock` instead of this method and
     /// `unlock`, to simplify lock handling.
     public func lock() {
+        self._lock()
+    }
+    #endif
+    
+    private func _lock() {
 #if os(Windows)
         AcquireSRWLockExclusive(self.mutex)
 #else
@@ -75,11 +90,26 @@ public final class Lock {
 #endif
     }
 
+    #if swift(>=5.7)
+    /// Release the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `lock`, to simplify lock handling.
+    @available(*, noasync, message: "use 'withLock(_:)' if you do not cross suspension points")
+    public func unlock() {
+        self._unlock()
+    }
+    #else
     /// Release the lock.
     ///
     /// Whenever possible, consider using `withLock` instead of this method and
     /// `lock`, to simplify lock handling.
     public func unlock() {
+        self._unlock()
+    }
+    #endif
+    
+    private func _unlock() {
 #if os(Windows)
         ReleaseSRWLockExclusive(self.mutex)
 #else


### PR DESCRIPTION
Mark `Lock.lock()` and `Lock.unlock()` as not available from asynchronous context.

### Motivation:
From [SE-0340 (Unavailable From Async Attribute)](https://github.com/apple/swift-evolution/blob/main/proposals/0340-swift-noasync.md#introduction):
> The Swift concurrency model allows tasks to resume on different threads from the one they were suspended on. For this reason, API that relies on thread-local storage, locks, mutexes, and semaphores, should not be used across suspension points.

### Modifications:

add `@available(*, noasync)` to  `Lock.lock()` and `Lock.unlock()` in Swift 5.7+

### Result:

Prevent accidental misuse of `Lock`

Note: The `noasync` diagnostics in the latest Swift 5.7 nightly compiler emits errors instead of warnings but this is already fixed and will be part of the next 5.7 nightly toolchain. https://github.com/apple/swift/issues/59748
