### PR TITLE
NIOCore: add missing import on Windows

### DIFF
--- a/Sources/NIOCore/SocketOptionProvider.swift
+++ b/Sources/NIOCore/SocketOptionProvider.swift
@@ -15,6 +15,8 @@
 import Darwin
 #elseif os(Linux) || os(Android)
 import Glibc
+#elseif os(Windows)
+import WinSDK
 #endif
 
 /// This protocol defines an object, most commonly a `Channel`, that supports


### PR DESCRIPTION
We did not import `WinSDK` which provides the socketing interfaces.
This allows building `NIOCore` on Windows again.
