### PR TITLE
Adopt `Sendable` for closures in `HTTPClientUpgradeHandler.swift` and `HTTPServerUpgradeHandler.swift`

### DIFF
--- a/Sources/NIOCore/NIOSendable.swift
+++ b/Sources/NIOCore/NIOSendable.swift
@@ -24,12 +24,11 @@ public typealias NIOSendable = Any
 public protocol NIOPreconcurrencySendable {}
 #endif
 
-#if swift(>=5.5) && canImport(_Concurrency)
 /// ``UnsafeTransfer`` can be used to make non-`Sendable` values `Sendable`.
 /// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler.
 /// It can be used similar to `@unsafe Sendable` but for values instead of types.
 @usableFromInline
-struct UnsafeTransfer<Wrapped>: @unchecked Sendable {
+struct UnsafeTransfer<Wrapped> {
     @usableFromInline
     var wrappedValue: Wrapped
     
@@ -38,26 +37,14 @@ struct UnsafeTransfer<Wrapped>: @unchecked Sendable {
         self.wrappedValue = wrappedValue
     }
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension UnsafeTransfer: @unchecked Sendable {}
+#endif
 
 extension UnsafeTransfer: Equatable where Wrapped: Equatable {}
 extension UnsafeTransfer: Hashable where Wrapped: Hashable {}
-#endif
 
-#if swift(>=5.5) && canImport(_Concurrency)
-/// ``UnsafeMutableTransferBox`` can be used to make non-`Sendable` values `Sendable` and mutable.
-/// It can be used to capture local mutable values in a `@Sendable` closure and mutate them from within the closure.
-/// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler and does not add any synchronisation.
-@usableFromInline
-final class UnsafeMutableTransferBox<Wrapped>: @unchecked Sendable {
-    @usableFromInline
-    var wrappedValue: Wrapped
-    
-    @inlinable
-    init(_ wrappedValue: Wrapped) {
-        self.wrappedValue = wrappedValue
-    }
-}
-#else
 /// ``UnsafeMutableTransferBox`` can be used to make non-`Sendable` values `Sendable` and mutable.
 /// It can be used to capture local mutable values in a `@Sendable` closure and mutate them from within the closure.
 /// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler and does not add any synchronisation.
@@ -71,4 +58,6 @@ final class UnsafeMutableTransferBox<Wrapped> {
         self.wrappedValue = wrappedValue
     }
 }
+#if swift(>=5.5) && canImport(_Concurrency)
+extension UnsafeMutableTransferBox: @unchecked Sendable {}
 #endif

--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -14,11 +14,19 @@
 
 import NIOCore
 
+#if swift(>=5.7)
+/// Configuration required to configure a HTTP client pipeline for upgrade.
+///
+/// See the documentation for `HTTPClientUpgradeHandler` for details on these
+/// properties.
+public typealias NIOHTTPClientUpgradeConfiguration = (upgraders: [NIOHTTPClientProtocolUpgrader], completionHandler: @Sendable (ChannelHandlerContext) -> Void)
+#else
 /// Configuration required to configure a HTTP client pipeline for upgrade.
 ///
 /// See the documentation for `HTTPClientUpgradeHandler` for details on these
 /// properties.
 public typealias NIOHTTPClientUpgradeConfiguration = (upgraders: [NIOHTTPClientProtocolUpgrader], completionHandler: (ChannelHandlerContext) -> Void)
+#endif
 
 /// Configuration required to configure a HTTP server pipeline for upgrade.
 ///
@@ -27,7 +35,11 @@ public typealias NIOHTTPClientUpgradeConfiguration = (upgraders: [NIOHTTPClientP
 @available(*, deprecated, renamed: "NIOHTTPServerUpgradeConfiguration")
 public typealias HTTPUpgradeConfiguration = NIOHTTPServerUpgradeConfiguration
 
+#if swift(>=5.7)
+public typealias NIOHTTPServerUpgradeConfiguration = (upgraders: [HTTPServerProtocolUpgrader], completionHandler: @Sendable (ChannelHandlerContext) -> Void)
+#else
 public typealias NIOHTTPServerUpgradeConfiguration = (upgraders: [HTTPServerProtocolUpgrader], completionHandler: (ChannelHandlerContext) -> Void)
+#endif
 
 extension ChannelPipeline {
     /// Configure a `ChannelPipeline` for use as a HTTP client.
@@ -44,6 +56,42 @@ extension ChannelPipeline {
                                           withClientUpgrade: nil)
     }
 
+    #if swift(>=5.7)
+    /// Configure a `ChannelPipeline` for use as a HTTP client with a client upgrader configuration.
+    ///
+    /// - parameters:
+    ///     - position: The position in the `ChannelPipeline` where to add the HTTP client handlers. Defaults to `.last`.
+    ///     - leftOverBytesStrategy: The strategy to use when dealing with leftover bytes after removing the `HTTPDecoder`
+    ///         from the pipeline.
+    ///     - upgrade: Add a `HTTPClientUpgradeHandler` to the pipeline, configured for
+    ///         HTTP upgrade. Should be a tuple of an array of `HTTPClientProtocolUpgrader` and
+    ///         the upgrade completion handler. See the documentation on `HTTPClientUpgradeHandler`
+    ///         for more details.
+    /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    @preconcurrency
+    public func addHTTPClientHandlers(position: Position = .last,
+                                      leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
+                                      withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration?) -> EventLoopFuture<Void> {
+        let future: EventLoopFuture<Void>
+
+        if self.eventLoop.inEventLoop {
+            let result = Result<Void, Error> {
+                try self.syncOperations.addHTTPClientHandlers(position: position,
+                                                              leftOverBytesStrategy: leftOverBytesStrategy,
+                                                              withClientUpgrade: upgrade)
+            }
+            future = self.eventLoop.makeCompletedFuture(result)
+        } else {
+            future = self.eventLoop.submit {
+                return try self.syncOperations.addHTTPClientHandlers(position: position,
+                                                                     leftOverBytesStrategy: leftOverBytesStrategy,
+                                                                     withClientUpgrade: upgrade)
+            }
+        }
+
+        return future
+    }
+    #else
     /// Configure a `ChannelPipeline` for use as a HTTP client with a client upgrader configuration.
     ///
     /// - parameters:
@@ -77,7 +125,70 @@ extension ChannelPipeline {
 
         return future
     }
+    #endif
+    
+    private func _addHTTPClientHandlers(position: Position = .last,
+                                        leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
+                                        withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration?) -> EventLoopFuture<Void> {
+        let future: EventLoopFuture<Void>
 
+        if self.eventLoop.inEventLoop {
+            let result = Result<Void, Error> {
+                try self.syncOperations.addHTTPClientHandlers(position: position,
+                                                              leftOverBytesStrategy: leftOverBytesStrategy,
+                                                              withClientUpgrade: upgrade)
+            }
+            future = self.eventLoop.makeCompletedFuture(result)
+        } else {
+            future = self.eventLoop.submit {
+                return try self.syncOperations.addHTTPClientHandlers(position: position,
+                                                                     leftOverBytesStrategy: leftOverBytesStrategy,
+                                                                     withClientUpgrade: upgrade)
+            }
+        }
+
+        return future
+    }
+    
+    #if swift(>=5.7)
+    /// Configure a `ChannelPipeline` for use as a HTTP server.
+    ///
+    /// This function knows how to set up all first-party HTTP channel handlers appropriately
+    /// for server use. It supports the following features:
+    ///
+    /// 1. Providing assistance handling clients that pipeline HTTP requests, using the
+    ///     `HTTPServerPipelineHandler`.
+    /// 2. Supporting HTTP upgrade, using the `HTTPServerUpgradeHandler`.
+    ///
+    /// This method will likely be extended in future with more support for other first-party
+    /// features.
+    ///
+    /// - parameters:
+    ///     - position: Where in the pipeline to add the HTTP server handlers, defaults to `.last`.
+    ///     - pipelining: Whether to provide assistance handling HTTP clients that pipeline
+    ///         their requests. Defaults to `true`. If `false`, users will need to handle
+    ///         clients that pipeline themselves.
+    ///     - upgrade: Whether to add a `HTTPServerUpgradeHandler` to the pipeline, configured for
+    ///         HTTP upgrade. Defaults to `nil`, which will not add the handler to the pipeline. If
+    ///         provided should be a tuple of an array of `HTTPServerProtocolUpgrader` and the upgrade
+    ///         completion handler. See the documentation on `HTTPServerUpgradeHandler` for more
+    ///         details.
+    ///     - errorHandling: Whether to provide assistance handling protocol errors (e.g.
+    ///         failure to parse the HTTP request) by sending 400 errors. Defaults to `true`.
+    /// - returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    @preconcurrency
+    public func configureHTTPServerPipeline(position: ChannelPipeline.Position = .last,
+                                            withPipeliningAssistance pipelining: Bool = true,
+                                            withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
+                                            withErrorHandling errorHandling: Bool = true) -> EventLoopFuture<Void> {
+        self._configureHTTPServerPipeline(
+            position: position,
+            withPipeliningAssistance: pipelining,
+            withServerUpgrade: upgrade,
+            withErrorHandling: errorHandling
+        )
+    }
+    #else
     /// Configure a `ChannelPipeline` for use as a HTTP server.
     ///
     /// This function knows how to set up all first-party HTTP channel handlers appropriately
@@ -107,6 +218,19 @@ extension ChannelPipeline {
                                             withPipeliningAssistance pipelining: Bool = true,
                                             withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
                                             withErrorHandling errorHandling: Bool = true) -> EventLoopFuture<Void> {
+        self._configureHTTPServerPipeline(
+            position: position,
+            withPipeliningAssistance: pipelining,
+            withServerUpgrade: upgrade,
+            withErrorHandling: errorHandling
+        )
+    }
+    #endif
+    
+    private func _configureHTTPServerPipeline(position: ChannelPipeline.Position = .last,
+                                              withPipeliningAssistance pipelining: Bool = true,
+                                              withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
+                                              withErrorHandling errorHandling: Bool = true) -> EventLoopFuture<Void> {
         let future: EventLoopFuture<Void>
 
         if self.eventLoop.inEventLoop {
@@ -131,6 +255,30 @@ extension ChannelPipeline {
 }
 
 extension ChannelPipeline.SynchronousOperations {
+    #if swift(>=5.7)
+    /// Configure a `ChannelPipeline` for use as a HTTP client with a client upgrader configuration.
+    ///
+    /// - important: This **must** be called on the Channel's event loop.
+    /// - parameters:
+    ///     - position: The position in the `ChannelPipeline` where to add the HTTP client handlers. Defaults to `.last`.
+    ///     - leftOverBytesStrategy: The strategy to use when dealing with leftover bytes after removing the `HTTPDecoder`
+    ///         from the pipeline.
+    ///     - upgrade: Add a `HTTPClientUpgradeHandler` to the pipeline, configured for
+    ///         HTTP upgrade. Should be a tuple of an array of `HTTPClientProtocolUpgrader` and
+    ///         the upgrade completion handler. See the documentation on `HTTPClientUpgradeHandler`
+    ///         for more details.
+    /// - throws: If the pipeline could not be configured.
+    @preconcurrency
+    public func addHTTPClientHandlers(position: ChannelPipeline.Position = .last,
+                                      leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
+                                      withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration? = nil) throws {
+        try self._addHTTPClientHandlers(
+            position: position,
+            leftOverBytesStrategy: leftOverBytesStrategy,
+            withClientUpgrade: upgrade
+        )
+    }
+    #else
     /// Configure a `ChannelPipeline` for use as a HTTP client with a client upgrader configuration.
     ///
     /// - important: This **must** be called on the Channel's event loop.
@@ -144,6 +292,17 @@ extension ChannelPipeline.SynchronousOperations {
     ///         for more details.
     /// - throws: If the pipeline could not be configured.
     public func addHTTPClientHandlers(position: ChannelPipeline.Position = .last,
+                                      leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
+                                      withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration? = nil) throws {
+        try self._addHTTPClientHandlers(
+            position: position,
+            leftOverBytesStrategy: leftOverBytesStrategy,
+            withClientUpgrade: upgrade
+        )
+    }
+    #endif
+    
+    private func _addHTTPClientHandlers(position: ChannelPipeline.Position = .last,
                                       leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
                                       withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration? = nil) throws {
         // Why two separate functions? When creating the array of handlers to add to the pipeline, when we don't have
@@ -183,7 +342,46 @@ extension ChannelPipeline.SynchronousOperations {
 
         try self.addHandlers(handlers, position: position)
     }
-
+    #if swift(>=5.7)
+    /// Configure a `ChannelPipeline` for use as a HTTP server.
+    ///
+    /// This function knows how to set up all first-party HTTP channel handlers appropriately
+    /// for server use. It supports the following features:
+    ///
+    /// 1. Providing assistance handling clients that pipeline HTTP requests, using the
+    ///     `HTTPServerPipelineHandler`.
+    /// 2. Supporting HTTP upgrade, using the `HTTPServerUpgradeHandler`.
+    ///
+    /// This method will likely be extended in future with more support for other first-party
+    /// features.
+    ///
+    /// - important: This **must** be called on the Channel's event loop.
+    /// - parameters:
+    ///     - position: Where in the pipeline to add the HTTP server handlers, defaults to `.last`.
+    ///     - pipelining: Whether to provide assistance handling HTTP clients that pipeline
+    ///         their requests. Defaults to `true`. If `false`, users will need to handle
+    ///         clients that pipeline themselves.
+    ///     - upgrade: Whether to add a `HTTPServerUpgradeHandler` to the pipeline, configured for
+    ///         HTTP upgrade. Defaults to `nil`, which will not add the handler to the pipeline. If
+    ///         provided should be a tuple of an array of `HTTPServerProtocolUpgrader` and the upgrade
+    ///         completion handler. See the documentation on `HTTPServerUpgradeHandler` for more
+    ///         details.
+    ///     - errorHandling: Whether to provide assistance handling protocol errors (e.g.
+    ///         failure to parse the HTTP request) by sending 400 errors. Defaults to `true`.
+    /// - throws: If the pipeline could not be configured.
+    @preconcurrency
+    public func configureHTTPServerPipeline(position: ChannelPipeline.Position = .last,
+                                            withPipeliningAssistance pipelining: Bool = true,
+                                            withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
+                                            withErrorHandling errorHandling: Bool = true) throws {
+        try self._configureHTTPServerPipeline(
+            position: position,
+            withPipeliningAssistance: pipelining,
+            withServerUpgrade: upgrade,
+            withErrorHandling: errorHandling
+        )
+    }
+    #else
     /// Configure a `ChannelPipeline` for use as a HTTP server.
     ///
     /// This function knows how to set up all first-party HTTP channel handlers appropriately
@@ -214,6 +412,19 @@ extension ChannelPipeline.SynchronousOperations {
                                             withPipeliningAssistance pipelining: Bool = true,
                                             withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
                                             withErrorHandling errorHandling: Bool = true) throws {
+        try self._configureHTTPServerPipeline(
+            position: position,
+            withPipeliningAssistance: pipelining,
+            withServerUpgrade: upgrade,
+            withErrorHandling: errorHandling
+        )
+    }
+    #endif
+    
+    private func _configureHTTPServerPipeline(position: ChannelPipeline.Position = .last,
+                                              withPipeliningAssistance pipelining: Bool = true,
+                                              withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
+                                              withErrorHandling errorHandling: Bool = true) throws {
         self.eventLoop.assertInEventLoop()
 
         let responseEncoder = HTTPResponseEncoder()

--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -72,24 +72,11 @@ extension ChannelPipeline {
     public func addHTTPClientHandlers(position: Position = .last,
                                       leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
                                       withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration?) -> EventLoopFuture<Void> {
-        let future: EventLoopFuture<Void>
-
-        if self.eventLoop.inEventLoop {
-            let result = Result<Void, Error> {
-                try self.syncOperations.addHTTPClientHandlers(position: position,
-                                                              leftOverBytesStrategy: leftOverBytesStrategy,
-                                                              withClientUpgrade: upgrade)
-            }
-            future = self.eventLoop.makeCompletedFuture(result)
-        } else {
-            future = self.eventLoop.submit {
-                return try self.syncOperations.addHTTPClientHandlers(position: position,
-                                                                     leftOverBytesStrategy: leftOverBytesStrategy,
-                                                                     withClientUpgrade: upgrade)
-            }
-        }
-
-        return future
+        self._addHTTPClientHandlers(
+            position: position,
+            leftOverBytesStrategy: leftOverBytesStrategy,
+            withClientUpgrade: upgrade
+        )
     }
     #else
     /// Configure a `ChannelPipeline` for use as a HTTP client with a client upgrader configuration.
@@ -106,24 +93,11 @@ extension ChannelPipeline {
     public func addHTTPClientHandlers(position: Position = .last,
                                       leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
                                       withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration?) -> EventLoopFuture<Void> {
-        let future: EventLoopFuture<Void>
-
-        if self.eventLoop.inEventLoop {
-            let result = Result<Void, Error> {
-                try self.syncOperations.addHTTPClientHandlers(position: position,
-                                                              leftOverBytesStrategy: leftOverBytesStrategy,
-                                                              withClientUpgrade: upgrade)
-            }
-            future = self.eventLoop.makeCompletedFuture(result)
-        } else {
-            future = self.eventLoop.submit {
-                return try self.syncOperations.addHTTPClientHandlers(position: position,
-                                                                     leftOverBytesStrategy: leftOverBytesStrategy,
-                                                                     withClientUpgrade: upgrade)
-            }
-        }
-
-        return future
+        self._addHTTPClientHandlers(
+            position: position,
+            leftOverBytesStrategy: leftOverBytesStrategy,
+            withClientUpgrade: upgrade
+        )
     }
     #endif
     

--- a/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
@@ -63,8 +63,14 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
     public typealias InboundOut = HTTPServerRequestPart
     public typealias OutboundOut = HTTPServerResponsePart
 
+    #if swift(>=5.7)
+    private typealias UpgradeCompletionHandler =  @Sendable (ChannelHandlerContext) -> Void
+    #else
+    private typealias UpgradeCompletionHandler =  (ChannelHandlerContext) -> Void
+    #endif
+    
     private let upgraders: [String: HTTPServerProtocolUpgrader]
-    private let upgradeCompletionHandler: (ChannelHandlerContext) -> Void
+    private let upgradeCompletionHandler: UpgradeCompletionHandler
 
     private let httpEncoder: HTTPResponseEncoder?
     private let extraHTTPHandlers: [RemovableChannelHandler]
@@ -76,6 +82,7 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
     private var upgradeState: UpgradeState = .idle
     private var receivedMessages: CircularBuffer<NIOAny> = CircularBuffer()
 
+    #if swift(>=5.7)
     /// Create a `HTTPServerUpgradeHandler`.
     ///
     /// - Parameter upgraders: All `HTTPServerProtocolUpgrader` objects that this pipeline will be able
@@ -87,7 +94,43 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
     ///     this should include the `HTTPDecoder`, but should also include any other handler that cannot tolerate
     ///     receiving non-HTTP data.
     /// - Parameter upgradeCompletionHandler: A block that will be fired when HTTP upgrade is complete.
-    public init(upgraders: [HTTPServerProtocolUpgrader], httpEncoder: HTTPResponseEncoder, extraHTTPHandlers: [RemovableChannelHandler], upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) {
+    @preconcurrency
+    public convenience init(
+        upgraders: [HTTPServerProtocolUpgrader],
+        httpEncoder: HTTPResponseEncoder,
+        extraHTTPHandlers: [RemovableChannelHandler],
+        upgradeCompletionHandler: @escaping @Sendable (ChannelHandlerContext) -> Void
+    ) {
+        self.init(_upgraders: upgraders, httpEncoder: httpEncoder, extraHTTPHandlers: extraHTTPHandlers, upgradeCompletionHandler: upgradeCompletionHandler)
+    }
+    #else
+    /// Create a `HTTPServerUpgradeHandler`.
+    ///
+    /// - Parameter upgraders: All `HTTPServerProtocolUpgrader` objects that this pipeline will be able
+    ///     to use to handle HTTP upgrade.
+    /// - Parameter httpEncoder: The `HTTPResponseEncoder` encoding responses from this handler and which will
+    ///     be removed from the pipeline once the upgrade response is sent. This is used to ensure
+    ///     that the pipeline will be in a clean state after upgrade.
+    /// - Parameter extraHTTPHandlers: Any other handlers that are directly related to handling HTTP. At the very least
+    ///     this should include the `HTTPDecoder`, but should also include any other handler that cannot tolerate
+    ///     receiving non-HTTP data.
+    /// - Parameter upgradeCompletionHandler: A block that will be fired when HTTP upgrade is complete.
+    public convenience init(
+        upgraders: [HTTPServerProtocolUpgrader],
+        httpEncoder: HTTPResponseEncoder,
+        extraHTTPHandlers: [RemovableChannelHandler],
+        upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void
+    ) {
+        self.init(_upgraders: upgraders, httpEncoder: httpEncoder, extraHTTPHandlers: extraHTTPHandlers, upgradeCompletionHandler: upgradeCompletionHandler)
+    }
+    #endif
+    
+    private init(
+        _upgraders upgraders: [HTTPServerProtocolUpgrader],
+        httpEncoder: HTTPResponseEncoder,
+        extraHTTPHandlers: [RemovableChannelHandler],
+        upgradeCompletionHandler: @escaping UpgradeCompletionHandler
+    ) {
         var upgraderMap = [String: HTTPServerProtocolUpgrader]()
         for upgrader in upgraders {
             upgraderMap[upgrader.supportedProtocol.lowercased()] = upgrader

--- a/Sources/NIOHTTP1/NIOHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOHTTPClientUpgradeHandler.swift
@@ -92,9 +92,15 @@ public final class NIOHTTPClientUpgradeHandler: ChannelDuplexHandler, RemovableC
     public typealias InboundIn = HTTPClientResponsePart
     public typealias InboundOut = HTTPClientResponsePart
     
+    #if swift(>=5.7)
+    private typealias UpgradeCompletionHandler = @Sendable (ChannelHandlerContext) -> Void
+    #else
+    private typealias UpgradeCompletionHandler = (ChannelHandlerContext) -> Void
+    #endif
+    
     private var upgraders: [NIOHTTPClientProtocolUpgrader]
     private let httpHandlers: [RemovableChannelHandler]
-    private let upgradeCompletionHandler: (ChannelHandlerContext) -> Void
+    private let upgradeCompletionHandler: UpgradeCompletionHandler
     
     /// Whether we've already seen the first response from our initial upgrade request.
     private var seenFirstResponse = false
@@ -103,6 +109,7 @@ public final class NIOHTTPClientUpgradeHandler: ChannelDuplexHandler, RemovableC
     
     private var receivedMessages: CircularBuffer<NIOAny> = CircularBuffer()
     
+    #if swift(>=5.7)
     /// Create a `HTTPClientUpgradeHandler`.
     ///
     /// - Parameter upgraders: All `HTTPClientProtocolUpgrader` objects that will add their upgrade request
@@ -114,10 +121,40 @@ public final class NIOHTTPClientUpgradeHandler: ChannelDuplexHandler, RemovableC
     ///     At the very least this should include the `HTTPEncoder` and `HTTPDecoder`, but should also include
     ///     any other handler that cannot tolerate receiving non-HTTP data.
     /// - Parameter upgradeCompletionHandler: A closure that will be fired when HTTP upgrade is complete.
-    public init(upgraders: [NIOHTTPClientProtocolUpgrader],
-                httpHandlers: [RemovableChannelHandler],
-                upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void) {
-
+    @preconcurrency
+    public convenience init(
+        upgraders: [NIOHTTPClientProtocolUpgrader],
+        httpHandlers: [RemovableChannelHandler],
+        upgradeCompletionHandler: @escaping @Sendable (ChannelHandlerContext) -> Void
+    ) {
+        self.init(_upgraders: upgraders, httpHandlers: httpHandlers, upgradeCompletionHandler: upgradeCompletionHandler)
+    }
+    #else
+    /// Create a `HTTPClientUpgradeHandler`.
+    ///
+    /// - Parameter upgraders: All `HTTPClientProtocolUpgrader` objects that will add their upgrade request
+    ///     headers and handle the upgrade if there is a response for their protocol. They should be placed in
+    ///     order of the preference for the upgrade.
+    /// - Parameter httpHandlers: All `RemovableChannelHandler` objects which will be removed from the pipeline
+    ///     once the upgrade response is sent. This is used to ensure that the pipeline will be in a clean state
+    ///     after the upgrade. It should include any handlers that are directly related to handling HTTP.
+    ///     At the very least this should include the `HTTPEncoder` and `HTTPDecoder`, but should also include
+    ///     any other handler that cannot tolerate receiving non-HTTP data.
+    /// - Parameter upgradeCompletionHandler: A closure that will be fired when HTTP upgrade is complete.
+    public convenience init(
+        upgraders: [NIOHTTPClientProtocolUpgrader],
+        httpHandlers: [RemovableChannelHandler],
+        upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void
+    ) {
+        self.init(_upgraders: upgraders, httpHandlers: httpHandlers, upgradeCompletionHandler: upgradeCompletionHandler)
+    }
+    #endif
+    
+    private init(
+        _upgraders upgraders: [NIOHTTPClientProtocolUpgrader],
+        httpHandlers: [RemovableChannelHandler],
+        upgradeCompletionHandler: @escaping UpgradeCompletionHandler
+    ) {
         precondition(upgraders.count > 0, "A minimum of one protocol upgrader must be specified.")
 
         self.upgraders = upgraders

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 import Dispatch
-@testable import NIOCore
+import NIOCore
 import NIOEmbedded
 @testable import NIOPosix
 @testable import NIOHTTP1

--- a/Tests/NIOHTTP1Tests/UnsafeTransfer.swift
+++ b/Tests/NIOHTTP1Tests/UnsafeTransfer.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// ``UnsafeTransfer`` can be used to make non-`Sendable` values `Sendable`.
+/// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler.
+/// It can be used similar to `@unsafe Sendable` but for values instead of types.
+@usableFromInline
+struct UnsafeTransfer<Wrapped> {
+    @usableFromInline
+    var wrappedValue: Wrapped
+    
+    @inlinable
+    init(_ wrappedValue: Wrapped) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension UnsafeTransfer: @unchecked Sendable {}
+#endif
+
+extension UnsafeTransfer: Equatable where Wrapped: Equatable {}
+extension UnsafeTransfer: Hashable where Wrapped: Hashable {}
+
+/// ``UnsafeMutableTransferBox`` can be used to make non-`Sendable` values `Sendable` and mutable.
+/// It can be used to capture local mutable values in a `@Sendable` closure and mutate them from within the closure.
+/// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler and does not add any synchronisation.
+@usableFromInline
+final class UnsafeMutableTransferBox<Wrapped> {
+    @usableFromInline
+    var wrappedValue: Wrapped
+    
+    @inlinable
+    init(_ wrappedValue: Wrapped) {
+        self.wrappedValue = wrappedValue
+    }
+}
+#if swift(>=5.5) && canImport(_Concurrency)
+extension UnsafeMutableTransferBox: @unchecked Sendable {}
+#endif

--- a/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
@@ -116,8 +116,9 @@ class WebSocketServerEndToEndTests: XCTestCase {
     private func createTestFixtures(upgraders: [NIOWebSocketServerUpgrader]) -> (loop: EmbeddedEventLoop, serverChannel: EmbeddedChannel, clientChannel: EmbeddedChannel) {
         let loop = EmbeddedEventLoop()
         let serverChannel = EmbeddedChannel(loop: loop)
-        let upgradeConfig = (upgraders: upgraders as [HTTPServerProtocolUpgrader], completionHandler: { (context: ChannelHandlerContext) in } )
-        XCTAssertNoThrow(try serverChannel.pipeline.configureHTTPServerPipeline(withServerUpgrade: upgradeConfig).wait())
+        XCTAssertNoThrow(try serverChannel.pipeline.configureHTTPServerPipeline(
+            withServerUpgrade: (upgraders: upgraders as [HTTPServerProtocolUpgrader], completionHandler: { (context: ChannelHandlerContext) in } )
+        ).wait())
         let clientChannel = EmbeddedChannel(loop: loop)
         return (loop: loop, serverChannel: serverChannel, clientChannel: clientChannel)
     }


### PR DESCRIPTION
Depends and includes changes from https://github.com/apple/swift-nio/pull/2214.
The correct diff can be seen here: https://github.com/dnadoba/swift-nio/compare/dn-sendable-http1-pipeline-closures...dnadoba:swift-nio:dn-sendable-upgrade-handler-closures
