### PR TITLE
Adopt `Sendable` for `NIOChatServer` and `MIOMulticastChat` Examples

### DIFF
--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -46,20 +46,19 @@ private final class ChatMessageEncoder: ChannelOutboundHandler {
 
 
 // We allow users to specify the interface they want to use here.
-var targetDevice: NIONetworkDevice? = nil
-if let interfaceAddress = CommandLine.arguments.dropFirst().first,
-   let targetAddress = try? SocketAddress(ipAddress: interfaceAddress, port: 0) {
-    for device in try! System.enumerateDevices() {
-        if device.address == targetAddress {
-            targetDevice = device
-            break
+let targetDevice: NIONetworkDevice? = {
+    if let interfaceAddress = CommandLine.arguments.dropFirst().first,
+       let targetAddress = try? SocketAddress(ipAddress: interfaceAddress, port: 0) {
+        for device in try! System.enumerateDevices() {
+            if device.address == targetAddress {
+                return device
+            }
         }
-    }
-
-    if targetDevice == nil {
         fatalError("Could not find device for \(interfaceAddress)")
     }
-}
+    return nil
+}()
+
 
 // For this chat protocol we temporarily squat on 224.1.0.26. This is a reserved multicast IPv4 address,
 // so your machine is unlikely to have already joined this group. That helps properly demonstrate correct


### PR DESCRIPTION
The examples already compile and don't produce sendable warnings. However, with strict concurrency checking (`-warn-concurrency`) turned on, they produce some `Sendable` warnings which are easily fixable. 
This doesn't fix all e.g. accessing `CommandLine.arguments` still produces a warnings (Reference to static property 'arguments' is not concurrency-safe because it involves shared mutable state) but it fixes the warnings which can be easily fixed today.