### PR TITLE
Workaround `Sendable` warning from Swift 5.7

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPTest.swift
@@ -146,7 +146,7 @@ class HTTPTest: XCTestCase {
                 var buf = chan.allocator.buffer(capacity: 1024)
 
                 buf.writeString("\(c)")
-                writeFutures.append(chan.eventLoop.makeSucceededFuture(()).flatMapThrowing {
+                writeFutures.append(chan.eventLoop.makeSucceededFuture(()).flatMapThrowing { [buf] in
                     try chan.writeInbound(buf)
                 })
             }


### PR DESCRIPTION
Workaround for https://github.com/apple/swift/issues/59911
```swift
/src/Tests/NIOHTTP1Tests/HTTPTest.swift:148:21: warning: 'buf' mutated after capture by sendable closure
                buf.writeString("\(c)")
```
The variable `buf` is mutated but only before being capture by the sendable closure. We now capture a copy explicitly which suppress this warning.

All other Sendable warnings/errors are fixed with the latest Swift 5.7 toolchain
