### PR TITLE
NIOCore: Implemented all three variants of _failEarlyRangeCheck methods for ByteBufferView

### DIFF
--- a/Sources/NIOCore/ByteBuffer-views.swift
+++ b/Sources/NIOCore/ByteBuffer-views.swift
@@ -138,20 +138,15 @@ public struct ByteBufferView: RandomAccessCollection, NIOSendable {
         return (iterator, bytesToWrite)
     }
 
+    // These are implemented as no-ops for performance reasons.
     @inlinable
-    public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
-        precondition(bounds.lowerBound <= index && index < bounds.upperBound)
-    }
+    public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {}
     
     @inlinable
-    public func _failEarlyRangeCheck(_ index: Index, bounds: ClosedRange<Index>) {
-        precondition(bounds.lowerBound <= index && index <= bounds.upperBound)
-    }
+    public func _failEarlyRangeCheck(_ index: Index, bounds: ClosedRange<Index>) {}
     
     @inlinable
-    public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {
-        precondition(bounds.lowerBound <= range.lowerBound && range.upperBound <= bounds.upperBound)
-    }
+    public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {}
 }
 
 extension ByteBufferView: MutableCollection {}

--- a/Sources/NIOCore/ByteBuffer-views.swift
+++ b/Sources/NIOCore/ByteBuffer-views.swift
@@ -137,6 +137,21 @@ public struct ByteBufferView: RandomAccessCollection, NIOSendable {
         let iterator = self[self.endIndex..<self.endIndex].makeIterator()
         return (iterator, bytesToWrite)
     }
+
+    @inlinable
+    public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
+        precondition(bounds.lowerBound <= index && index < bounds.upperBound)
+    }
+    
+    @inlinable
+    public func _failEarlyRangeCheck(_ index: Index, bounds: ClosedRange<Index>) {
+        precondition(bounds.lowerBound <= index && index <= bounds.upperBound)
+    }
+    
+    @inlinable
+    public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {
+        precondition(bounds.lowerBound <= range.lowerBound && range.upperBound <= bounds.upperBound)
+    }
 }
 
 extension ByteBufferView: MutableCollection {}


### PR DESCRIPTION
Implements all versions of the `_failEarlyRangeCheck(_:bounds:)`  for `ByteBufferView`

### Motivation:

#1385 specifies the missing Collection customization points that we would like to customize.

### Modifications:

Adds three methods to the `ByteBufferView` conforming to Collection

### Result:

The default implementations of the `_failEarlyRangeCheck` methods are going to be customized according to needs in the `ByteBufferView`.