### PR TITLE
Added test for BufferView custom contains function

### DIFF
--- a/Tests/NIOCoreTests/ByteBufferTest+XCTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest+XCTest.swift
@@ -158,6 +158,7 @@ extension ByteBufferTest {
                 ("testBufferViewEmpty", testBufferViewEmpty),
                 ("testBufferViewFirstIndex", testBufferViewFirstIndex),
                 ("testBufferViewLastIndex", testBufferViewLastIndex),
+                ("testBufferViewContains", testBufferViewContains),
                 ("testByteBuffersCanBeInitializedFromByteBufferViews", testByteBuffersCanBeInitializedFromByteBufferViews),
                 ("testReserveCapacityWhenOversize", testReserveCapacityWhenOversize),
                 ("testReserveCapacitySameCapacity", testReserveCapacitySameCapacity),

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -2071,6 +2071,16 @@ class ByteBufferTest: XCTestCase {
         XCTAssertNil(view?.lastIndex(of: UInt8(0x3F)))
     }
 
+    func testBufferViewContains() {
+        self.buf.clear()
+        self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
+        self.buf.setBytes([UInt8(0x59)], at: 1000)
+        let view: ByteBufferView?  = self.buf.viewBytes(at: 5, length: 1010)
+        XCTAssertTrue(view?.contains(UInt8(0x4E)))
+        XCTAssertTrue(view?.contains(UInt8(0x59)))
+        XCTAssertFalse(view?.contains(UInt8(0x3F)))
+    }
+
     func testByteBuffersCanBeInitializedFromByteBufferViews() throws {
         self.buf.writeString("hello")
 

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -2075,10 +2075,10 @@ class ByteBufferTest: XCTestCase {
         self.buf.clear()
         self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
         self.buf.setBytes([UInt8(0x59)], at: 1000)
-        let view = self.buf.viewBytes(at: 5, length: 1010)
-        XCTAssertTrue(view.contains(UInt8(0x4E)))
-        XCTAssertTrue(view.contains(UInt8(0x59)))
-        XCTAssertFalse(view.contains(UInt8(0x3F)))
+        let view: ByteBufferView?  = self.buf.viewBytes(at: 5, length: 1010)
+        XCTAssertTrue(view?.contains(UInt8(0x4E)) == true)
+        XCTAssertTrue(view?.contains(UInt8(0x59)) == true)
+        XCTAssertTrue(view?.contains(UInt8(0x3F)) == false)
     }
 
     func testByteBuffersCanBeInitializedFromByteBufferViews() throws {

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -2075,10 +2075,10 @@ class ByteBufferTest: XCTestCase {
         self.buf.clear()
         self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
         self.buf.setBytes([UInt8(0x59)], at: 1000)
-        let view: ByteBufferView?  = self.buf.viewBytes(at: 5, length: 1010)
-        XCTAssertTrue(view?.contains(UInt8(0x4E)))
-        XCTAssertTrue(view?.contains(UInt8(0x59)))
-        XCTAssertFalse(view?.contains(UInt8(0x3F)))
+        let view = self.buf.viewBytes(at: 5, length: 1010)
+        XCTAssertTrue(view.contains(UInt8(0x4E)))
+        XCTAssertTrue(view.contains(UInt8(0x59)))
+        XCTAssertFalse(view.contains(UInt8(0x3F)))
     }
 
     func testByteBuffersCanBeInitializedFromByteBufferViews() throws {


### PR DESCRIPTION
Added test for BufferView custom contains function

### Motivation:

This adds a test for  BufferView custom contains function

### Modifications:

Added `testBufferViewContains()` to `ByteBufferTest` 


### Result:

Doesn't affect any endpoint, only a testing improvement 