### PR TITLE
Fix strict concurrency checking diagnostics in `NonBlockingFileIO`

### DIFF
--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -442,8 +442,9 @@ public struct NonBlockingFileIO: NIOSendable {
             return eventLoop.makeSucceededFuture(allocator.buffer(capacity: 0))
         }
 
-        var buf = allocator.buffer(capacity: byteCount)
+        
         return self.threadPool.runIfActive(eventLoop: eventLoop) { () -> ByteBuffer in
+            var buf = allocator.buffer(capacity: byteCount)
             var bytesRead = 0
             while bytesRead < byteCount {
                 let n = try buf.writeWithUnsafeMutableBytes(minimumWritableBytes: byteCount - bytesRead) { ptr in


### PR DESCRIPTION
### Motivation:

We want to incrementally comply with the strict sendability checking rules.

### Modifications:
Move `ByteBuffer` allocation to thread modifying buffer by moving the mutable variable into the sendable and escaping closure 

### Result:

less warnings/errors in strict concurrency mode

### Alternatives considered
`ByteBuffer` is `Sendable` and we could therefore allocate a non-mutable buffer outside the closure, capture it by value and create a local mutable copy in the closure. However, I fear that we might trigger CoW as I'm not sure if the compiler eagerly release the initial buffer instance.