### PR TITLE
Fix compilation with Swift 5.5.0 and 5.5.1

### DIFF
--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -75,7 +75,7 @@ extension SocketAddressError {
 public enum SocketAddress: CustomStringConvertible, NIOSendable {
 
     /// A single IPv4 address for `SocketAddress`.
-    public struct IPv4Address: NIOSendable {
+    public struct IPv4Address {
         private let _storage: Box<(address: sockaddr_in, host: String)>
 
         /// The libc socket address for an IPv4 address.
@@ -90,7 +90,7 @@ public enum SocketAddress: CustomStringConvertible, NIOSendable {
     }
 
     /// A single IPv6 address for `SocketAddress`.
-    public struct IPv6Address: NIOSendable {
+    public struct IPv6Address {
         private let _storage: Box<(address: sockaddr_in6, host: String)>
 
         /// The libc socket address for an IPv6 address.
@@ -559,6 +559,16 @@ extension SocketAddress: Equatable {
         }
     }
 }
+
+#if compiler(>=5.5.2)
+extension SocketAddress.IPv4Address: Sendable {}
+extension SocketAddress.IPv6Address: Sendable {}
+#elseif compiler(>=5.5)
+// Implicit conformance of tuples to Sendable interacts poorly with conditional conformance of Sendable in Swift <=5.5.1
+// https://github.com/apple/swift/issues/57346
+extension SocketAddress.IPv4Address: @unchecked Sendable {}
+extension SocketAddress.IPv6Address: @unchecked Sendable {}
+#endif
 
 /// We define an extension on `SocketAddress` that gives it an elementwise hashable conformance, using
 /// only the elements defined on the structure in their man pages (excluding lengths).

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -298,7 +298,7 @@ extension HTTPHeaders {
 /// field when needed. It also supports recomposing headers to a maximally joined
 /// or split representation, such that header fields that are able to be repeated
 /// can be represented appropriately.
-public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiteral, NIOSendable {
+public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiteral {
     @usableFromInline
     internal var headers: [(String, String)]
     internal var keepAliveState: KeepAliveState = .unknown
@@ -496,6 +496,14 @@ public struct HTTPHeaders: CustomStringConvertible, ExpressibleByDictionaryLiter
         return result.flatMap { $0.split(separator: ",").map { $0.trimWhitespace() } }
     }
 }
+
+#if compiler(>=5.5.2)
+extension HTTPHeaders: Sendable {}
+#elseif compiler(>=5.5)
+// Implicit conformance of tuples to Sendable interacts poorly with conditional conformance of Sendable in Swift <=5.5.1
+// https://github.com/apple/swift/issues/57346
+extension HTTPHeaders: @unchecked Sendable {}
+#endif
 
 extension HTTPHeaders {
 


### PR DESCRIPTION
### Motivation:

`swift-nio` does not compile with Swift 5.5.0 and Swift 5.5.1 as described in this issue: https://github.com/apple/swift-nio/issues/2233
The underlying issue is described here https://github.com/apple/swift/issues/57346

### Modifications:

- use `@unchecked Sendable` in Swift 5.5.0 and 5.5.1

### Result:

`swift-nio` compiles again with Swift 5.5.0 and 5.5.1
