### PR TITLE
Implement additional file operation in NonBlockingFileIO

### DIFF
--- a/Tests/NIOPosixTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest+XCTest.swift
@@ -70,6 +70,11 @@ extension NonBlockingFileIOTest {
                 ("testReadChunkedFromOffsetFileRegion", testReadChunkedFromOffsetFileRegion),
                 ("testReadManyChunks", testReadManyChunks),
                 ("testThrowsErrorOnUnstartedPool", testThrowsErrorOnUnstartedPool),
+                ("testLStat", testLStat),
+                ("testSymlink", testSymlink),
+                ("testListDirectory", testListDirectory),
+                ("testRename", testRename),
+                ("testRemove", testRemove),
            ]
    }
 }


### PR DESCRIPTION
Motivation:
Basic set of function that NonBlockingFileIO provides is enough to read and write files, but as we get more and more into fully asynchronous world we need other non-blocking file-related function.

Modifications:
 - Adds support for getting file information using `lstat`
 - Adds ability to create a symlink, delete symlink and read it's destination
 - Adds ability to list directories
 - Adds ability to rename and remove files