### PR TITLE
Conform `NIOTooManyBytesError` to `Hashable`

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -216,7 +216,7 @@ extension ChannelPipeline {
     }
 }
 
-public struct NIOTooManyBytesError: Error {
+public struct NIOTooManyBytesError: Error, Hashable {
      public init() {}
  }
 


### PR DESCRIPTION
Makes it easier to use in tests.