### PR TITLE
Functions passed to non-`Sendable` `ChannelHandler`s do not need to conform to `Sendable`

### DIFF
--- a/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
@@ -62,15 +62,9 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
     public typealias InboundIn = HTTPServerRequestPart
     public typealias InboundOut = HTTPServerRequestPart
     public typealias OutboundOut = HTTPServerResponsePart
-
-    #if swift(>=5.7)
-    private typealias UpgradeCompletionHandler =  @Sendable (ChannelHandlerContext) -> Void
-    #else
-    private typealias UpgradeCompletionHandler =  (ChannelHandlerContext) -> Void
-    #endif
     
     private let upgraders: [String: HTTPServerProtocolUpgrader]
-    private let upgradeCompletionHandler: UpgradeCompletionHandler
+    private let upgradeCompletionHandler: (ChannelHandlerContext) -> Void
 
     private let httpEncoder: HTTPResponseEncoder?
     private let extraHTTPHandlers: [RemovableChannelHandler]
@@ -82,7 +76,6 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
     private var upgradeState: UpgradeState = .idle
     private var receivedMessages: CircularBuffer<NIOAny> = CircularBuffer()
 
-    #if swift(>=5.7)
     /// Create a `HTTPServerUpgradeHandler`.
     ///
     /// - Parameter upgraders: All `HTTPServerProtocolUpgrader` objects that this pipeline will be able
@@ -94,42 +87,11 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
     ///     this should include the `HTTPDecoder`, but should also include any other handler that cannot tolerate
     ///     receiving non-HTTP data.
     /// - Parameter upgradeCompletionHandler: A block that will be fired when HTTP upgrade is complete.
-    @preconcurrency
-    public convenience init(
-        upgraders: [HTTPServerProtocolUpgrader],
-        httpEncoder: HTTPResponseEncoder,
-        extraHTTPHandlers: [RemovableChannelHandler],
-        upgradeCompletionHandler: @escaping @Sendable (ChannelHandlerContext) -> Void
-    ) {
-        self.init(_upgraders: upgraders, httpEncoder: httpEncoder, extraHTTPHandlers: extraHTTPHandlers, upgradeCompletionHandler: upgradeCompletionHandler)
-    }
-    #else
-    /// Create a `HTTPServerUpgradeHandler`.
-    ///
-    /// - Parameter upgraders: All `HTTPServerProtocolUpgrader` objects that this pipeline will be able
-    ///     to use to handle HTTP upgrade.
-    /// - Parameter httpEncoder: The `HTTPResponseEncoder` encoding responses from this handler and which will
-    ///     be removed from the pipeline once the upgrade response is sent. This is used to ensure
-    ///     that the pipeline will be in a clean state after upgrade.
-    /// - Parameter extraHTTPHandlers: Any other handlers that are directly related to handling HTTP. At the very least
-    ///     this should include the `HTTPDecoder`, but should also include any other handler that cannot tolerate
-    ///     receiving non-HTTP data.
-    /// - Parameter upgradeCompletionHandler: A block that will be fired when HTTP upgrade is complete.
-    public convenience init(
+    public init(
         upgraders: [HTTPServerProtocolUpgrader],
         httpEncoder: HTTPResponseEncoder,
         extraHTTPHandlers: [RemovableChannelHandler],
         upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void
-    ) {
-        self.init(_upgraders: upgraders, httpEncoder: httpEncoder, extraHTTPHandlers: extraHTTPHandlers, upgradeCompletionHandler: upgradeCompletionHandler)
-    }
-    #endif
-    
-    private init(
-        _upgraders upgraders: [HTTPServerProtocolUpgrader],
-        httpEncoder: HTTPResponseEncoder,
-        extraHTTPHandlers: [RemovableChannelHandler],
-        upgradeCompletionHandler: @escaping UpgradeCompletionHandler
     ) {
         var upgraderMap = [String: HTTPServerProtocolUpgrader]()
         for upgrader in upgraders {

--- a/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
@@ -60,26 +60,10 @@ public final class ApplicationProtocolNegotiationHandler: ChannelInboundHandler,
     public typealias InboundIn = Any
     public typealias InboundOut = Any
 
-    #if swift(>=5.7)
-    private let completionHandler: @Sendable (ALPNResult, Channel) -> EventLoopFuture<Void>
-    #else
     private let completionHandler: (ALPNResult, Channel) -> EventLoopFuture<Void>
-    #endif
     private var waitingForUser: Bool
     private var eventBuffer: [NIOAny]
 
-    #if swift(>=5.7)
-    /// Create an `ApplicationProtocolNegotiationHandler` with the given completion
-    /// callback.
-    ///
-    /// - Parameter alpnCompleteHandler: The closure that will fire when ALPN
-    ///   negotiation has completed.
-    @preconcurrency public init(alpnCompleteHandler: @Sendable @escaping (ALPNResult, Channel) -> EventLoopFuture<Void>) {
-        self.completionHandler = alpnCompleteHandler
-        self.waitingForUser = false
-        self.eventBuffer = []
-    }
-    #else
     /// Create an `ApplicationProtocolNegotiationHandler` with the given completion
     /// callback.
     ///
@@ -90,20 +74,7 @@ public final class ApplicationProtocolNegotiationHandler: ChannelInboundHandler,
         self.waitingForUser = false
         self.eventBuffer = []
     }
-    #endif
 
-    #if swift(>=5.7)
-    /// Create an `ApplicationProtocolNegotiationHandler` with the given completion
-    /// callback.
-    ///
-    /// - Parameter alpnCompleteHandler: The closure that will fire when ALPN
-    ///   negotiation has completed.
-    @preconcurrency public convenience init(alpnCompleteHandler: @Sendable @escaping (ALPNResult) -> EventLoopFuture<Void>) {
-        self.init { result, _ in
-            alpnCompleteHandler(result)
-        }
-    }
-    #else
     /// Create an `ApplicationProtocolNegotiationHandler` with the given completion
     /// callback.
     ///
@@ -114,7 +85,6 @@ public final class ApplicationProtocolNegotiationHandler: ChannelInboundHandler,
             alpnCompleteHandler(result)
         }
     }
-    #endif
 
     public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         guard let tlsEvent = event as? TLSUserEvent else {

--- a/Sources/NIOTLS/SNIHandler.swift
+++ b/Sources/NIOTLS/SNIHandler.swift
@@ -98,26 +98,15 @@ public final class SNIHandler: ByteToMessageDecoder {
     public var cumulationBuffer: Optional<ByteBuffer>
     public typealias InboundIn = ByteBuffer
     public typealias InboundOut = ByteBuffer
-    #if swift(>=5.7)
-    private let completionHandler: @Sendable (SNIResult) -> EventLoopFuture<Void>
-    #else
+
     private let completionHandler: (SNIResult) -> EventLoopFuture<Void>
-    #endif
     private var waitingForUser: Bool
     
-    #if swift(>=5.7)
-    @preconcurrency public init(sniCompleteHandler: @Sendable @escaping (SNIResult) -> EventLoopFuture<Void>) {
-        self.cumulationBuffer = nil
-        self.completionHandler = sniCompleteHandler
-        self.waitingForUser = false
-    }
-    #else
     public init(sniCompleteHandler: @escaping (SNIResult) -> EventLoopFuture<Void>) {
         self.cumulationBuffer = nil
         self.completionHandler = sniCompleteHandler
         self.waitingForUser = false
     }
-    #endif
 
     public func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
         context.fireChannelRead(NIOAny(buffer))

--- a/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
@@ -62,13 +62,6 @@ fileprivate extension HTTPHeaders {
 /// This upgrader assumes that the `HTTPServerUpgradeHandler` will appropriately mutate the pipeline to
 /// remove the HTTP `ChannelHandler`s.
 public final class NIOWebSocketServerUpgrader: HTTPServerProtocolUpgrader {
-    #if swift(>=5.7)
-    private typealias ShouldUpgrade = @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>
-    private typealias UpgradePipelineHandler = @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<Void>
-    #else
-    private typealias ShouldUpgrade = (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>
-    private typealias UpgradePipelineHandler = (Channel, HTTPRequestHead) -> EventLoopFuture<Void>
-    #endif
     /// RFC 6455 specs this as the required entry in the Upgrade header.
     public let supportedProtocol: String = "websocket"
 
@@ -77,8 +70,8 @@ public final class NIOWebSocketServerUpgrader: HTTPServerProtocolUpgrader {
     /// which NIO requires. We check for these manually.
     public let requiredUpgradeHeaders: [String] = []
 
-    private let shouldUpgrade: ShouldUpgrade
-    private let upgradePipelineHandler: UpgradePipelineHandler
+    private let shouldUpgrade: (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>
+    private let upgradePipelineHandler: (Channel, HTTPRequestHead) -> EventLoopFuture<Void>
     private let maxFrameSize: Int
     private let automaticErrorHandling: Bool
 
@@ -135,7 +128,6 @@ public final class NIOWebSocketServerUpgrader: HTTPServerProtocolUpgrader {
     }
     #endif
 
-    #if swift(>=5.7)
     /// Create a new `NIOWebSocketServerUpgrader`.
     ///
     /// - parameters:
@@ -156,61 +148,11 @@ public final class NIOWebSocketServerUpgrader: HTTPServerProtocolUpgrader {
     ///         websocket protocol. This only needs to add the user handlers: the
     ///         `WebSocketFrameEncoder` and `WebSocketFrameDecoder` will have been added to the
     ///         pipeline automatically.
-    @preconcurrency
-    public convenience init(
-        maxFrameSize: Int,
-        automaticErrorHandling: Bool = true,
-        shouldUpgrade: @escaping @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>,
-        upgradePipelineHandler: @escaping @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<Void>
-    ) {
-        self.init(
-            _maxFrameSize: maxFrameSize,
-            automaticErrorHandling: automaticErrorHandling,
-            shouldUpgrade: shouldUpgrade,
-            upgradePipelineHandler: upgradePipelineHandler
-        )
-    }
-    #else
-    /// Create a new `NIOWebSocketServerUpgrader`.
-    ///
-    /// - parameters:
-    ///     - maxFrameSize: The maximum frame size the decoder is willing to tolerate from the
-    ///         remote peer. WebSockets in principle allows frame sizes up to `2**64` bytes, but
-    ///         this is an objectively unreasonable maximum value (on AMD64 systems it is not
-    ///         possible to even. Users may set this to any value up to `UInt32.max`.
-    ///     - automaticErrorHandling: Whether the pipeline should automatically handle protocol
-    ///         errors by sending error responses and closing the connection. Defaults to `true`,
-    ///         may be set to `false` if the user wishes to handle their own errors.
-    ///     - shouldUpgrade: A callback that determines whether the websocket request should be
-    ///         upgraded. This callback is responsible for creating a `HTTPHeaders` object with
-    ///         any headers that it needs on the response *except for* the `Upgrade`, `Connection`,
-    ///         and `Sec-WebSocket-Accept` headers, which this upgrader will handle. Should return
-    ///         an `EventLoopFuture` containing `nil` if the upgrade should be refused.
-    ///     - upgradePipelineHandler: A function that will be called once the upgrade response is
-    ///         flushed, and that is expected to mutate the `Channel` appropriately to handle the
-    ///         websocket protocol. This only needs to add the user handlers: the
-    ///         `WebSocketFrameEncoder` and `WebSocketFrameDecoder` will have been added to the
-    ///         pipeline automatically.
-    public convenience init(
+    public init(
         maxFrameSize: Int,
         automaticErrorHandling: Bool = true,
         shouldUpgrade: @escaping (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>,
         upgradePipelineHandler: @escaping (Channel, HTTPRequestHead) -> EventLoopFuture<Void>
-    ) {
-        self.init(
-            _maxFrameSize: maxFrameSize,
-            automaticErrorHandling: automaticErrorHandling,
-            shouldUpgrade: shouldUpgrade,
-            upgradePipelineHandler: upgradePipelineHandler
-        )
-    }
-    #endif
-    
-    private init(
-        _maxFrameSize maxFrameSize: Int,
-        automaticErrorHandling: Bool,
-        shouldUpgrade: @escaping ShouldUpgrade,
-        upgradePipelineHandler: @escaping UpgradePipelineHandler
     ) {
         precondition(maxFrameSize <= UInt32.max, "invalid overlarge max frame size")
         self.shouldUpgrade = shouldUpgrade


### PR DESCRIPTION
### Motivation
A non-`Sendable` `ChannelHandler` can *not* be transfered to a different isolation domain. If it wants to be added to a `Channel` it need to be initialized on the `EventLoop` of the `Channel`. The functions modified in this PR are guaranteed to be called on the `EventLoop` of their `Channel`. They therefore do not need to be `Sendable`.

### Modification
Remove `Sendable` conformance requirement for functions passed to non-`Sendable` `ChannelHandler`s

### Result
Correct semantics and less code duplication. 

This is an API stable change because we only relax requirements for types passed into `ChannelHandler`s and they are luckily not expose as properties.