### PR TITLE
Define `Array` element type explicitly to fix nightly CI

### DIFF
--- a/Tests/NIOPosixTests/ChannelPipelineTest.swift
+++ b/Tests/NIOPosixTests/ChannelPipelineTest.swift
@@ -373,7 +373,7 @@ class ChannelPipelineTest: XCTestCase {
         try channel.pipeline.addHandler(MarkingInboundHandler(number: 6)).wait()
         try channel.pipeline.addHandler(WriteOnReadHandler()).wait()
 
-        try channel.writeInbound([])
+        try channel.writeInbound([Int]())
         loop.run()
         XCTAssertNoThrow(XCTAssertEqual([2, 6], try channel.readInbound()!))
 


### PR DESCRIPTION
Fixes a new warning with the swift `main` toolchain: 
```
/src/Tests/NIOPosixTests/ChannelPipelineTest.swift:376:34: warning: empty collection literal requires an explicit type
        try channel.writeInbound([])
                                 ^~
```