### PR TITLE
Implement a `NIOAsyncWriter`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let swiftCollections: PackageDescription.Target.Dependency = .product(name: "Deq
 
 var targets: [PackageDescription.Target] = [
     .target(name: "NIOCore",
-            dependencies: ["NIOConcurrencyHelpers", "CNIOLinux", "CNIOWindows", swiftCollections]),
+            dependencies: ["NIOConcurrencyHelpers", "CNIOLinux", "CNIOWindows", swiftCollections, swiftAtomics]),
     .target(name: "_NIODataStructures"),
     .target(name: "NIOEmbedded",
             dependencies: ["NIOCore",

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -20,7 +20,7 @@ let swiftCollections: PackageDescription.Target.Dependency = .product(name: "Deq
 
 var targets: [PackageDescription.Target] = [
     .target(name: "NIOCore",
-            dependencies: ["NIOConcurrencyHelpers", "CNIOLinux", "CNIOWindows", swiftCollections]),
+            dependencies: ["NIOConcurrencyHelpers", "CNIOLinux", "CNIOWindows", swiftCollections, swiftAtomics]),
     .target(name: "_NIODataStructures"),
     .target(name: "NIOEmbedded",
             dependencies: ["NIOCore",

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -20,7 +20,7 @@ let swiftCollections: PackageDescription.Target.Dependency = .product(name: "Deq
 
 var targets: [PackageDescription.Target] = [
     .target(name: "NIOCore",
-            dependencies: ["NIOConcurrencyHelpers", "CNIOLinux", "CNIOWindows", swiftCollections]),
+            dependencies: ["NIOConcurrencyHelpers", "CNIOLinux", "CNIOWindows", swiftCollections, swiftAtomics]),
     .target(name: "_NIODataStructures"),
     .target(name: "NIOEmbedded",
             dependencies: ["NIOCore",

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
@@ -274,22 +274,22 @@ extension NIOAsyncWriter {
 
         @inlinable
         /* fileprivate */ internal func writerDeinitialized() {
-            let _delegate: Delegate? = self._lock.withLock {
+            let delegate: Delegate? = self._lock.withLock {
                 let action = self._stateMachine.writerDeinitialized()
 
                 switch action {
                 case .callDidTerminate:
-                    let _delegate = self._delegate
+                    let delegate = self._delegate
                     self._delegate = nil
 
-                    return _delegate
+                    return delegate
 
                 case .none:
                     return nil
                 }
             }
 
-            _delegate?.didTerminate(failure: nil)
+            delegate?.didTerminate(failure: nil)
         }
 
         @inlinable
@@ -301,10 +301,10 @@ extension NIOAsyncWriter {
 
             switch action {
             case .callDidYieldAndResumeContinuations(let suspendedYields):
-                let _delegate = self._delegate
+                let delegate = self._delegate
                 self._lock.unlock()
 
-                _delegate?.didYield(contentsOf: suspendedYields.lazy.map { $0.elements }.flatMap { $0 })
+                delegate?.didYield(contentsOf: suspendedYields.lazy.map { $0.elements }.flatMap { $0 })
                 suspendedYields.forEach { $0.continuation.resume() }
 
             case .none:
@@ -327,9 +327,9 @@ extension NIOAsyncWriter {
 
                 switch action {
                 case .callDidYield:
-                    let _delegate = self._delegate
+                    let delegate = self._delegate
                     self._lock.unlock()
-                    _delegate?.didYield(contentsOf: sequence)
+                    delegate?.didYield(contentsOf: sequence)
 
                 case .throwError(let error):
                     self._lock.unlock()
@@ -361,32 +361,32 @@ extension NIOAsyncWriter {
 
         @inlinable
         /* fileprivate */ internal func finish(with failure: Failure?) {
-            let _delegate: Delegate? = self._lock.withLock {
+            let delegate: Delegate? = self._lock.withLock {
                 let action = self._stateMachine.finish()
 
                 switch action {
                 case .callDidTerminate:
-                    let _delegate = self._delegate
+                    let delegate = self._delegate
                     self._delegate = nil
 
-                    return _delegate
+                    return delegate
 
                 case .resumeContinuationsWithErrorAndCallDidTerminate(let suspendedYields, let error):
-                    let _delegate = self._delegate
+                    let delegate = self._delegate
                     self._delegate = nil
                     // It is safe to resume the continuation while holding the lock
                     // since the task will get enqueued on its executor and the resume method
                     // is returning immediately
                     suspendedYields.forEach { $0.continuation.resume(throwing: error) }
 
-                    return _delegate
+                    return delegate
 
                 case .none:
                     return nil
                 }
             }
 
-            _delegate?.didTerminate(failure: failure)
+            delegate?.didTerminate(failure: failure)
         }
     }
 }

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
@@ -1,0 +1,750 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Atomics
+import NIOConcurrencyHelpers
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+/// The delegate of the ``NIOAsyncWriter``.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol NIOAsyncWriterDelegate: Sendable {
+    /// The `Element` type of the delegate and the writer.
+    associatedtype Element: Sendable
+    /// The `Failure` type of the delegate and the writer.
+    associatedtype Failure: Error = Never
+
+    /// This method is called once a sequence was yielded to the ``NIOAsyncWriter``.
+    ///
+    /// If the ``NIOAsyncWriter`` was writable when the sequence was yielded, the sequence will be forwarded
+    /// right away to the delegate. If the ``NIOAsyncWriter`` was _NOT_ writable then the sequence will be buffered
+    /// until the ``NIOAsyncWriter`` becomes writable again.
+    func didYield<S: Sequence>(contentsOf sequence: S) where S.Element == Element
+
+    /// This method is called once the ``NIOAsyncWriter`` is terminated.
+    ///
+    /// Termination happens if:
+    /// - The ``NIOAsyncWriter`` is deinited.
+    /// - ``NIOAsyncWriter/finish(completion:)`` is called.
+    func didTerminate(completion: NIOAsyncWriterCompletion<Failure>)
+}
+
+/// The signal that the writer doesn’t produce additional elements, either due to normal completion or an error.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public enum NIOAsyncWriterCompletion<Failure: Error>: Sendable {
+    /// The writer finished normally.
+    case finished
+    /// The writer stopped publishing due to the indicated error.
+    case failure(Failure)
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+/// Errors thrown by the ``NIOAsyncWriter``.
+public struct NIOAsyncWriterError: Error, Hashable {
+    @usableFromInline
+    internal enum _Code: Hashable, Sendable {
+        case alreadyFinished
+    }
+
+    @usableFromInline
+    let _code: _Code
+
+    public static let alreadyFinished: Self = .init(_code: .alreadyFinished)
+}
+
+/// A ``NIOAsyncWriter`` is a type used to bridge elements from the Swift Concurrency domain into
+/// a synchronous world. The `Task`s that are yielding to the ``NIOAsyncWriter`` are the producers.
+/// Whereas the ``NIOAsyncWriterDelegate`` is the consumer.
+///
+/// Additionally, the ``NIOAsyncWriter`` allows the consumer to toggle the writability by calling ``NIOAsyncWriter/Sink/toggleWritability()``.
+/// This allows the implementation of flow control on the consumer side. Any call to ``NIOAsyncWriter/yield(contentsOf:)`` or ``NIOAsyncWriter/yield(_:)``
+/// will suspend if the ``NIOAsyncWriter`` is not writable and only be resumed after the ``NIOAsyncWriter`` becomes writable again.
+///
+/// - Note: It is recommended to never directly expose this type from APIs, but rather wrap it. This is due to the fact that
+/// this type has three generic parameters where at least two should be known statically and it is really awkward to spell out this type.
+/// Moreover, having a wrapping type allows to optimize this to specialized calls if all generic types are known.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public struct NIOAsyncWriter<
+    Element,
+    Failure,
+    Delegate: NIOAsyncWriterDelegate
+>: Sendable where Delegate.Element == Element, Delegate.Failure == Failure {
+    /// Simple struct for the return type of ``NIOAsyncWriter/makeWriter(elementType:failureType:isWritable:delegate:)``.
+    ///
+    /// This struct contains two properties:
+    /// 1. The ``sink`` which should be retained by the consumer and is used to toggle the writability.
+    /// 2. The ``writer`` which is the actual ``NIOAsyncWriter`` and should be passed to the producer.
+    public struct NewWriter {
+        public let sink: Sink
+        public let writer: NIOAsyncWriter
+
+        @usableFromInline
+        /* fileprivate */ internal init(
+            sink: Sink,
+            writer: NIOAsyncWriter
+        ) {
+            self.sink = sink
+            self.writer = writer
+        }
+    }
+
+    /// This class is needed to hook the deinit to observe once all references to the ``NIOAsyncWriter`` are dropped.
+    ///
+    /// If we get move-only types we should be able to drop this class and use the `deinit` of the ``NIOAsyncWriter`` struct itself.
+    ///
+    /// - Important: This is safe to be unchecked ``Sendable`` since the `storage` is ``Sendable`` and `immutable`.
+    @usableFromInline
+    /* fileprivate */ internal final class InternalClass: @unchecked Sendable {
+        @usableFromInline
+        internal let storage: Storage
+
+        @inlinable
+        init(storage: Storage) {
+            self.storage = storage
+        }
+
+        @inlinable
+        deinit {
+            storage.writerDeinitialized()
+        }
+    }
+
+    @usableFromInline
+    /* private */ internal let internalClass: InternalClass
+
+    @usableFromInline
+    /* private */ internal var storage: Storage {
+        self.internalClass.storage
+    }
+
+    /// Initializes a new ``NIOAsyncWriter`` and a ``NIOAsyncWriter/Sink``.
+    ///
+    /// - Important: This method returns a struct containing a ``NIOAsyncWriter/Sink`` and
+    /// a ``NIOAsyncWriter``. The sink MUST be held by the caller and is used to toggle the writability.
+    /// The writer MUST be passed to the actual producer and MUST NOT be held by the
+    /// caller. This is due to the fact that deiniting the sequence is used as part of a trigger to terminate the underlying sink.
+    ///
+    /// - Parameters:
+    ///   - elementType: The element type of the sequence.
+    ///   - failureType: The failure type of the sequence.
+    ///   - isWritable: The initial writability state of the writer.
+    ///   - delegate: The delegate of the writer.
+    /// - Returns: A ``NIOAsyncWriter/NewWriter``.
+    public static func makeWriter(
+        elementType: Element.Type = Element.self,
+        failureType: Failure.Type = Failure.self,
+        isWritable: Bool,
+        delegate: Delegate
+    ) -> NewWriter {
+        let writer = Self(
+            isWritable: isWritable,
+            delegate: delegate
+        )
+        let sink = Sink(storage: writer.storage)
+
+        return .init(sink: sink, writer: writer)
+    }
+
+    private init(
+        isWritable: Bool,
+        delegate: Delegate
+    ) {
+        let storage = Storage(
+            isWritable: isWritable,
+            delegate: delegate
+        )
+        self.internalClass = .init(storage: storage)
+    }
+
+    /// Yields a sequence of new elements to the ``NIOAsyncWriter``.
+    ///
+    /// If the ``NIOAsyncWriter`` is writable the sequence will get forwarded to the ``NIOAsyncWriterDelegate`` immediately.
+    /// Otherwise, the call to ``NIOAsyncWriter/yield(contentsOf:)`` will get suspended until the ``NIOAsyncWriter``
+    /// becomes writable again.
+    ///
+    /// If the ``NIOAsyncWriter`` is finished while a call to ``NIOAsyncWriter/yield(contentsOf:)`` is suspended the
+    /// call will throw a ``NIOAsyncWriterError/alreadyFinished`` error.
+    ///
+    /// This can be called more than once and from multiple `Task`s at the same time.
+    ///
+    /// - Parameter contentsOf: The sequence to yield.
+    @inlinable
+    public func yield<S: Sequence>(contentsOf sequence: S) async throws where S.Element == Element {
+        try await self.storage.yield(contentsOf: sequence)
+    }
+
+    /// Yields an element to the ``NIOAsyncWriter``.
+    ///
+    /// If the ``NIOAsyncWriter`` is writable the element will get forwarded to the ``NIOAsyncWriterDelegate`` immediately.
+    /// Otherwise, the call to ``NIOAsyncWriter/yield(contentsOf:)`` will get suspended until the ``NIOAsyncWriter``
+    /// becomes writable again.
+    ///
+    /// If the ``NIOAsyncWriter`` is finished while a call to ``NIOAsyncWriter/yield(contentsOf:)`` is suspended the
+    /// call will throw a ``NIOAsyncWriterError/alreadyFinished`` error.
+    ///
+    /// This can be called more than once and from multiple `Task`s at the same time.
+    ///
+    /// - Parameter element: The element to yield.
+    @inlinable
+    public func yield(_ element: Element) async throws {
+        try await self.yield(contentsOf: CollectionOfOne(element))
+    }
+
+    /// Finishes the writer.
+    ///
+    /// Calling this function signals the writer that any suspended or subsequent calls to ``NIOAsyncWriter/yield(contentsOf:)``
+    /// or ``NIOAsyncWriter/yield(_:)`` will return a ``NIOAsyncWriterError/alreadyFinished`` error.
+    ///
+    /// - Note: Calling this function more than once has no effect.
+    /// - Parameter completion: A ``NIOAsyncWriterCompletion`` which indicates whether publishing has finished normally
+    /// or failed with an error.
+    @inlinable
+    public func finish(completion: NIOAsyncWriterCompletion<Failure>) {
+        self.storage.finish(completion: completion)
+    }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension NIOAsyncWriter {
+    /// The underlying sink of the ``NIOAsyncWriter``. This type allows to toggle the writability of the ``NIOAsyncWriter``.
+    public struct Sink {
+        @usableFromInline
+        /* private */ internal var storage: Storage
+
+        @inlinable
+        init(storage: Storage) {
+            self.storage = storage
+        }
+
+        /// Toggles the writability of the ``NIOAsyncWriter``.
+        ///
+        /// If the writer becomes writable again all suspended yields will be resumed and the produced elements will be forwarded via
+        /// the ``NIOAsyncWriterDelegate/didYield(contentsOf:)`` method.
+        public func toggleWritability() {
+            self.storage.toggleWritability()
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension NIOAsyncWriter {
+    /// This is the underlying storage of the writer. The goal of this is to synchronize the access to all state.
+    @usableFromInline
+    /* fileprivate */ internal final class Storage: @unchecked Sendable {
+        /// The lock that protects our state.
+        @usableFromInline
+        /* private */ internal let lock = Lock()
+        /// The counter used to assign an ID to all our yields.
+        @usableFromInline
+        /* private */ internal let yieldIDCounter = ManagedAtomic<UInt64>(0)
+        /// The state machine.
+        @usableFromInline
+        /* private */ internal var stateMachine: StateMachine
+        /// The delegate.
+        @usableFromInline
+        /* private */ internal var delegate: Delegate?
+
+        @usableFromInline
+        /* fileprivate */ internal init(
+            isWritable: Bool,
+            delegate: Delegate
+        ) {
+            self.stateMachine = .init(isWritable: isWritable)
+            self.delegate = delegate
+        }
+
+        @inlinable
+        /* fileprivate */ internal func writerDeinitialized() {
+            let delegate: Delegate? = self.lock.withLock {
+                let action = self.stateMachine.writerDeinitialized()
+
+                switch action {
+                case .callDidTerminate:
+                    let delegate = self.delegate
+                    self.delegate = nil
+
+                    return delegate
+
+                case .none:
+                    return nil
+                }
+            }
+
+            delegate?.didTerminate(completion: .finished)
+        }
+
+        @inlinable
+        /* fileprivate */ internal func toggleWritability() {
+            // We are manually locking here since we need to use both the delegate and the
+            // suspendedYields. Doing this with a withLock becomes very unhandy.
+            self.lock.lock()
+            let action = self.stateMachine.toggleWritability()
+
+            switch action {
+            case .callDidYieldAndResumeContinuations(let suspendedYields):
+                let delegate = self.delegate
+                self.lock.unlock()
+
+                delegate?.didYield(contentsOf: suspendedYields.lazy.map { $0.elements }.flatMap { $0 })
+                suspendedYields.forEach { $0.continuation.resume() }
+
+            case .none:
+                self.lock.unlock()
+                return
+            }
+        }
+
+        @inlinable
+        /* fileprivate */ internal func yield<S: Sequence>(contentsOf sequence: S) async throws where S.Element == Element {
+            // Using relaxed is fine here since we do not need any strict ordering just a
+            // unique ID for every yield.
+            let yieldID = self.yieldIDCounter.loadThenWrappingIncrement(ordering: .relaxed)
+
+            try await withTaskCancellationHandler {
+                // We are manually locking here to hold the lock across the withCheckedContinuation call
+                self.lock.lock()
+
+                let action = self.stateMachine.yield(yieldID: yieldID)
+
+                switch action {
+                case .callDidYield:
+                    let delegate = self.delegate
+                    self.lock.unlock()
+                    delegate?.didYield(contentsOf: sequence)
+
+                case .throwError(let error):
+                    self.lock.unlock()
+                    throw error
+
+                case .suspendTask:
+                    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                        self.stateMachine.yield(
+                            contentsOf: sequence,
+                            continuation: continuation,
+                            yieldID: yieldID
+                        )
+
+                        self.lock.unlock()
+                    }
+                }
+            } onCancel: {
+                let action = self.lock.withLock { self.stateMachine.cancel(yieldID: yieldID) }
+
+                switch action {
+                case .resumeContinuationWithError(let continuation, let error):
+                    continuation.resume(throwing: error)
+
+                case .none:
+                    break
+                }
+            }
+        }
+
+        @inlinable
+        /* fileprivate */ internal func finish(completion: NIOAsyncWriterCompletion<Failure>) {
+            let delegate: Delegate? = self.lock.withLock {
+                let action = self.stateMachine.finish()
+
+                switch action {
+                case .callDidTerminate:
+                    let delegate = self.delegate
+                    self.delegate = nil
+
+                    return delegate
+
+                case .resumeContinuationsWithErrorAndCallDidTerminate(let suspendedYields, let error):
+                    let delegate = self.delegate
+                    self.delegate = nil
+                    // It is safe to resume the continuation while holding the lock
+                    // since the task will get enqueued on its executor and the resume method
+                    // is returning immediately
+                    suspendedYields.forEach { $0.continuation.resume(throwing: error) }
+
+                    return delegate
+
+                case .none:
+                    return nil
+                }
+            }
+
+            delegate?.didTerminate(completion: completion)
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension NIOAsyncWriter {
+    @usableFromInline
+    /* private */ internal struct StateMachine {
+        /// This is a small helper struct to encapsulate the three different values for a suspended yield.
+        @usableFromInline
+        /* private */ internal struct SuspendedYield {
+            /// The yield's ID.
+            @usableFromInline
+            var yieldID: UInt64
+            /// The yield's produced sequence of elements.
+            @usableFromInline
+            var elements: AnySequence<Element>
+            /// The yield's continuation.
+            @usableFromInline
+            var continuation: CheckedContinuation<Void, Error>
+
+            @usableFromInline
+            init(yieldID: UInt64, elements: AnySequence<Element>, continuation: CheckedContinuation<Void, Error>) {
+                self.yieldID = yieldID
+                self.elements = elements
+                self.continuation = continuation
+            }
+        }
+
+        /// The current state of our ``NIOAsyncWriter``.
+        @usableFromInline
+        /* private */ internal enum State {
+            /// The initial state before either a call to ``NIOAsyncWriter/yield(contentsOf:)`` or
+            /// ``NIOAsyncWriter/finish(completion:)`` happened.
+            case initial(isWritable: Bool)
+
+            /// The state after a call to ``NIOAsyncWriter/yield(contentsOf:)``.
+            case streaming(
+                isWritable: Bool,
+                cancelledYields: [UInt64],
+                suspendedYields: [SuspendedYield]
+            )
+
+            /// The state once the writer finished. This can happen if:
+            /// 1. The ``NIOAsyncWriter`` was deinited
+            /// 2. ``NIOAsyncWriter/finish(completion:)`` was called.
+            case finished
+
+            /// Internal state to avoid CoW.
+            case modifying
+        }
+
+        /// The state machine's current state.
+        @usableFromInline
+        /* private */ internal var state: State
+
+        init(isWritable: Bool) {
+            self.state = .initial(isWritable: isWritable)
+        }
+
+        /// Actions returned by `writerDeinitialized()`.
+        @usableFromInline
+        enum WriterDeinitializedAction {
+            /// Indicates that ``NIOAsyncWriterDelegate/didTerminate(completion:)`` should be called.
+            case callDidTerminate
+            /// Indicates that nothing should be done.
+            case none
+        }
+
+        @inlinable
+        /* fileprivate */ internal mutating func writerDeinitialized() -> WriterDeinitializedAction {
+            switch self.state {
+            case .initial:
+                // The writer deinited before writing anything.
+                // We can transition to finished and inform our delegate
+                self.state = .finished
+
+                return .callDidTerminate
+
+            case .streaming(_, _, let suspendedYields):
+                // The writer got deinited after we started streaming.
+                // This is normal and we need to transition to finished
+                // and call the delegate. However, we should not have
+                // any suspended yields because they MUST strongly retain
+                // the writer.
+                precondition(suspendedYields.isEmpty, "We have outstanding suspended yields")
+
+                self.state = .finished
+
+                return .callDidTerminate
+
+            case .finished:
+                // We are already finished nothing to do here
+                return .none
+
+            case .modifying:
+                preconditionFailure("Invalid state")
+            }
+        }
+
+        /// Actions returned by `toggleWritability()`.
+        @usableFromInline
+        enum ToggleWritabilityAction {
+            /// Indicates that ``NIOAsyncWriterDelegate/didYield(contentsOf:)`` should be called
+            /// and all continuations should be resumed.
+            case callDidYieldAndResumeContinuations([SuspendedYield])
+            /// Indicates that nothing should be done.
+            case none
+        }
+
+        @inlinable
+        /* fileprivate */ internal mutating func toggleWritability() -> ToggleWritabilityAction {
+            switch self.state {
+            case .initial(let isWritable):
+                // We just need to store the new writability state
+                self.state = .initial(isWritable: !isWritable)
+
+                return .none
+
+            case .streaming(let isWritable, let cancelledYields, let suspendedYields):
+                if isWritable {
+                    // We became unwritable nothing really to do here
+                    precondition(suspendedYields.isEmpty, "No yield should be suspended at this point")
+
+                    self.state = .streaming(
+                        isWritable: !isWritable,
+                        cancelledYields: cancelledYields,
+                        suspendedYields: suspendedYields
+                    )
+                    return .none
+
+                } else {
+                    // We became writable again. This means we have to resume all the continuations
+                    // and yield the values
+
+                    // We are taking the whole array of suspended yields and allocate a new empty one
+                    // As a performance optimization we could always keep to arrays and switch between
+                    // them but I don't think this is the performance critical part
+                    let yields = suspendedYields
+
+                    self.state = .streaming(
+                        isWritable: !isWritable,
+                        cancelledYields: cancelledYields,
+                        suspendedYields: []
+                    )
+                    return .callDidYieldAndResumeContinuations(yields)
+                }
+
+            case .finished:
+                // We are already finished nothing to do here
+                return .none
+
+            case .modifying:
+                preconditionFailure("Invalid state")
+            }
+        }
+
+        /// Actions returned by `yield()`.
+        @usableFromInline
+        enum YieldAction {
+            /// Indicates that ``NIOAsyncWriterDelegate/didYield(contentsOf:)`` should be called.
+            case callDidYield
+            /// Indicates that the calling `Task` should get suspended.
+            case suspendTask
+            /// Indicates the given error should be thrown.
+            case throwError(Error)
+
+            @usableFromInline
+            init(isWritable: Bool) {
+                if isWritable {
+                    self = .callDidYield
+                } else {
+                    self = .suspendTask
+                }
+            }
+        }
+
+        @inlinable
+        /* fileprivate */ internal mutating func yield(
+            yieldID: UInt64
+        ) -> YieldAction {
+            switch self.state {
+            case .initial(let isWritable):
+                // We can transition to streaming now
+
+                self.state = .streaming(
+                    isWritable: isWritable,
+                    cancelledYields: [],
+                    suspendedYields: []
+                )
+
+                return .init(isWritable: isWritable)
+
+            case .streaming(let isWritable, var cancelledYields, let suspendedYields):
+                if let index = cancelledYields.firstIndex(of: yieldID) {
+                    // We already marked the yield as cancelled. We have to remove it and
+                    // throw an error.
+                    self.state = .modifying
+
+                    cancelledYields.remove(at: index)
+
+                    self.state = .streaming(
+                        isWritable: isWritable,
+                        cancelledYields: cancelledYields,
+                        suspendedYields: suspendedYields
+                    )
+                    return .throwError(CancellationError())
+
+                } else {
+                    // Yield hasn't been marked as cancelled.
+                    // This means we can either call the delegate or suspend
+                    return .init(isWritable: isWritable)
+                }
+
+            case .finished:
+                // We are already finished and still tried to write something
+                return .throwError(NIOAsyncWriterError.alreadyFinished)
+
+            case .modifying:
+                preconditionFailure("Invalid state")
+            }
+        }
+
+        @inlinable
+        /* fileprivate */ internal mutating func yield<S: Sequence>(
+            contentsOf sequence: S,
+            continuation: CheckedContinuation<Void, Error>,
+            yieldID: UInt64
+        ) where S.Element == Element {
+            switch self.state {
+            case .streaming(let isWritable, let cancelledYields, var suspendedYields):
+                // We have a suspended yield at this point that hasn't been cancelled yet.
+                // We need to store the yield now.
+
+                self.state = .modifying
+
+                let suspendedYield = SuspendedYield(
+                    yieldID: yieldID,
+                    elements: AnySequence(sequence),
+                    continuation: continuation
+                )
+                suspendedYields.append(suspendedYield)
+
+                self.state = .streaming(
+                    isWritable: isWritable,
+                    cancelledYields: cancelledYields,
+                    suspendedYields: suspendedYields
+                )
+
+            case .initial, .finished:
+                preconditionFailure("This should have already been handled by `yield()`")
+
+            case .modifying:
+                preconditionFailure("Invalid state")
+            }
+        }
+
+        /// Actions returned by `cancel()`.
+        @usableFromInline
+        enum CancelAction {
+            case resumeContinuationWithError(CheckedContinuation<Void, Error>, Error)
+            /// Indicates that nothing should be done.
+            case none
+        }
+
+        @inlinable
+        /* fileprivate */ internal mutating func cancel(
+            yieldID: UInt64
+        ) -> CancelAction {
+            switch self.state {
+            case .initial(let isWritable):
+                // We got a cancel before the yield happened. This means we
+                // need to transition to streaming and store our cancelled state.
+
+                self.state = .streaming(
+                    isWritable: isWritable,
+                    cancelledYields: [yieldID],
+                    suspendedYields: []
+                )
+
+                return .none
+
+            case .streaming(let isWritable, var cancelledYields, var suspendedYields):
+                if let index = suspendedYields.firstIndex(where: { $0.yieldID == yieldID }) {
+                    self.state = .modifying
+                    // We have a suspended yield for the id. We need to resume the continuation with
+                    // an error now.
+
+                    // Removing can be quite expensive if it produces a gap in the array.
+                    // Since we are not expected a lot of elements in this array it should be fine
+                    // to just remove. If this turns out to be a performance pitfall, we can
+                    // swap the elements before removing. So that we always remove the last element.
+                    let suspendedYield = suspendedYields.remove(at: index)
+                    self.state = .streaming(
+                        isWritable: isWritable,
+                        cancelledYields: cancelledYields,
+                        suspendedYields: suspendedYields
+                    )
+
+                    return .resumeContinuationWithError(
+                        suspendedYield.continuation,
+                        CancellationError()
+                    )
+
+                } else {
+                    // There is no suspended yield. This can mean that we either already yielded
+                    // or that the call to `yield` is coming afterwards. We need to store
+                    // the ID here. However, if the yield already happened we will never remove the
+                    // stored ID. The only way to avoid doing this would be storing every ID
+                    cancelledYields.append(yieldID)
+                    self.state = .streaming(
+                        isWritable: isWritable,
+                        cancelledYields: cancelledYields,
+                        suspendedYields: suspendedYields
+                    )
+
+                    return .none
+                }
+
+            case .finished:
+                // We are already finished and there is nothing to do
+                return .none
+
+            case .modifying:
+                preconditionFailure("Invalid state")
+            }
+        }
+
+        /// Actions returned by `finish()`.
+        @usableFromInline
+        enum FinishAction {
+            /// Indicates that ``NIOAsyncWriterDelegate/didTerminate(completion:)`` should be called.
+            case callDidTerminate
+            /// Indicates that ``NIOAsyncWriterDelegate/didTerminate(completion:)`` should be called and all
+            /// continuations should be resumed with the given error.
+            case resumeContinuationsWithErrorAndCallDidTerminate([SuspendedYield], Error)
+            /// Indicates that nothing should be done.
+            case none
+        }
+
+        @inlinable
+        /* fileprivate */ internal mutating func finish() -> FinishAction {
+            switch self.state {
+            case .initial:
+                // Nothing was ever written so we can transition to finished
+                self.state = .finished
+
+                return .callDidTerminate
+
+            case .streaming(_, _, let suspendedYields):
+                // We are currently streaming and the writer got finished.
+                // We can transition to finished and need to resume all continuations.
+                self.state = .finished
+
+                return .resumeContinuationsWithErrorAndCallDidTerminate(
+                    suspendedYields,
+                    CancellationError()
+                )
+
+            case .finished:
+                // We are already finished and there is nothing to do
+                return .none
+
+            case .modifying:
+                preconditionFailure("Invalid state")
+            }
+        }
+    }
+}
+#endif

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
@@ -20,7 +20,7 @@ import NIOConcurrencyHelpers
 /// Furthermore, the delegate gets informed when the ``NIOAsyncWriter`` terminated.
 ///
 /// - Important: The methods on the delegate are called while a lock inside of the ``NIOAsyncWriter`` is held. This is done to
-/// guarantee that the ordering of the writes. However, this means you **MUST** avoid calling ``NIOAsyncWriter/Sink/setWritability(to:)``
+/// guarantee the ordering of the writes. However, this means you **MUST** avoid calling ``NIOAsyncWriter/Sink/setWritability(to:)``
 /// from within ``NIOAsyncWriterDelegate/didYield(contentsOf:)`` or ``NIOAsyncWriterDelegate/didTerminate(failure:)``.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol NIOAsyncWriterDelegate: Sendable {
@@ -34,6 +34,8 @@ public protocol NIOAsyncWriterDelegate: Sendable {
     /// If the ``NIOAsyncWriter`` was writable when the sequence was yielded, the sequence will be forwarded
     /// right away to the delegate. If the ``NIOAsyncWriter`` was _NOT_ writable then the sequence will be buffered
     /// until the ``NIOAsyncWriter`` becomes writable again.
+    ///
+    /// - Important: You **MUST** avoid calling ``NIOAsyncWriter/Sink/setWritability(to:)`` from within this method.
     func didYield<S: Sequence>(contentsOf sequence: S) where S.Element == Element
 
     /// This method is called once the ``NIOAsyncWriter`` is terminated.
@@ -47,6 +49,8 @@ public protocol NIOAsyncWriterDelegate: Sendable {
     ///
     /// - Parameter failure: The failure that terminated the ``NIOAsyncWriter``. If the writer was terminated without an
     /// error this value is `nil`.
+    ///
+    /// - Important: You **MUST** avoid calling ``NIOAsyncWriter/Sink/setWritability(to:)`` from within this method.
     func didTerminate(failure: Failure?)
 }
 

--- a/Sources/NIOPerformanceTester/Benchmark.swift
+++ b/Sources/NIOPerformanceTester/Benchmark.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
+
 protocol Benchmark: AnyObject {
     func setUp() throws
     func tearDown()
@@ -27,3 +29,32 @@ func measureAndPrint<B: Benchmark>(desc: String, benchmark bench: B) throws {
         return try bench.run()
     }
 }
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+protocol AsyncBenchmark: AnyObject {
+    func setUp() async throws
+    func tearDown()
+    func run() async throws -> Int
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+func measureAndPrint<B: AsyncBenchmark>(desc: String, benchmark bench: B) throws {
+    let group = DispatchGroup()
+    group.enter()
+    Task {
+        do {
+            try await bench.setUp()
+            defer {
+                bench.tearDown()
+            }
+            try await measureAndPrint(desc: desc) {
+                return try await bench.run()
+            }
+        }
+        group.leave()
+    }
+
+    group.wait()
+}
+#endif

--- a/Sources/NIOPerformanceTester/Benchmark.swift
+++ b/Sources/NIOPerformanceTester/Benchmark.swift
@@ -32,7 +32,7 @@ func measureAndPrint<B: Benchmark>(desc: String, benchmark bench: B) throws {
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-protocol AsyncBenchmark: AnyObject {
+protocol AsyncBenchmark: AnyObject, Sendable {
     func setUp() async throws
     func tearDown()
     func run() async throws -> Int

--- a/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
+++ b/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
@@ -28,27 +28,24 @@ struct NoOpDelegate: NIOAsyncWriterSinkDelegate, @unchecked Sendable {
     func didTerminate(error: Never?) {}
 }
 
+// This is unchecked Sendable because the Sink is not Sendable but the Sink is thread safe
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-final class NIOAsyncWriterSingleWritesBenchmark: AsyncBenchmark {
+final class NIOAsyncWriterSingleWritesBenchmark: AsyncBenchmark, @unchecked Sendable {
     private let iterations: Int
-    private var delegate: NoOpDelegate!
-    private var writer: NIOAsyncWriter<Int, Never, NoOpDelegate>!
-    private var sink: NIOAsyncWriter<Int, Never, NoOpDelegate>.Sink!
+    private let delegate: NoOpDelegate
+    private let writer: NIOAsyncWriter<Int, Never, NoOpDelegate>
+    private let sink: NIOAsyncWriter<Int, Never, NoOpDelegate>.Sink
 
     init(iterations: Int) {
         self.iterations = iterations
-    }
-
-    func setUp() async throws {
         self.delegate = .init()
         let newWriter = NIOAsyncWriter<Int, Never, NoOpDelegate>.makeWriter(isWritable: true, delegate: self.delegate)
         self.writer = newWriter.writer
         self.sink = newWriter.sink
     }
 
-    func tearDown() {
-        self.writer = nil
-    }
+    func setUp() async throws {}
+    func tearDown() {}
 
     func run() async throws -> Int {
         for i in 0..<self.iterations {

--- a/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
+++ b/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
@@ -22,10 +22,10 @@ struct NoOpDelegate: NIOAsyncWriterSinkDelegate, @unchecked Sendable {
     let counter = ManagedAtomic(0)
 
     func didYield(contentsOf sequence: Deque<Int>) {
-        counter.wrappingIncrement(by: sequence.count, ordering: .sequentiallyConsistent)
+        counter.wrappingIncrement(by: sequence.count, ordering: .relaxed)
     }
 
-    func didTerminate(failure: Never?) {}
+    func didTerminate(error: Never?) {}
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)

--- a/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
+++ b/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
@@ -25,7 +25,7 @@ struct NoOpDelegate: NIOAsyncWriterSinkDelegate, @unchecked Sendable {
         counter.wrappingIncrement(by: sequence.count, ordering: .relaxed)
     }
 
-    func didTerminate(error: Never?) {}
+    func didTerminate(error: Error?) {}
 }
 
 // This is unchecked Sendable because the Sink is not Sendable but the Sink is thread safe
@@ -33,13 +33,13 @@ struct NoOpDelegate: NIOAsyncWriterSinkDelegate, @unchecked Sendable {
 final class NIOAsyncWriterSingleWritesBenchmark: AsyncBenchmark, @unchecked Sendable {
     private let iterations: Int
     private let delegate: NoOpDelegate
-    private let writer: NIOAsyncWriter<Int, Never, NoOpDelegate>
-    private let sink: NIOAsyncWriter<Int, Never, NoOpDelegate>.Sink
+    private let writer: NIOAsyncWriter<Int, NoOpDelegate>
+    private let sink: NIOAsyncWriter<Int, NoOpDelegate>.Sink
 
     init(iterations: Int) {
         self.iterations = iterations
         self.delegate = .init()
-        let newWriter = NIOAsyncWriter<Int, Never, NoOpDelegate>.makeWriter(isWritable: true, delegate: self.delegate)
+        let newWriter = NIOAsyncWriter<Int, NoOpDelegate>.makeWriter(isWritable: true, delegate: self.delegate)
         self.writer = newWriter.writer
         self.sink = newWriter.sink
     }

--- a/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
+++ b/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import NIOCore
+import DequeModule
+import Atomics
+
+struct NoOpDelegate: NIOAsyncWriterSinkDelegate, @unchecked Sendable {
+    typealias Element = Int
+    let counter = ManagedAtomic(0)
+
+    func didYield(contentsOf sequence: Deque<Int>) {
+        counter.wrappingIncrement(by: sequence.count, ordering: .sequentiallyConsistent)
+    }
+
+    func didTerminate(failure: Never?) {}
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+final class NIOAsyncWriterSingleWritesBenchmark: AsyncBenchmark {
+    private let iterations: Int
+    private var delegate: NoOpDelegate!
+    private var writer: NIOAsyncWriter<Int, Never, NoOpDelegate>!
+    private var sink: NIOAsyncWriter<Int, Never, NoOpDelegate>.Sink!
+
+    init(iterations: Int) {
+        self.iterations = iterations
+    }
+
+    func setUp() async throws {
+        self.delegate = .init()
+        let newWriter = NIOAsyncWriter<Int, Never, NoOpDelegate>.makeWriter(isWritable: true, delegate: self.delegate)
+        self.writer = newWriter.writer
+        self.sink = newWriter.sink
+    }
+
+    func tearDown() {
+        self.writer = nil
+    }
+
+    func run() async throws -> Int {
+        for i in 0..<self.iterations {
+            try await self.writer.yield(i)
+        }
+        return self.delegate.counter.load(ordering: .sequentiallyConsistent)
+    }
+}
+#endif

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
@@ -269,7 +269,7 @@ final class NIOAsyncWriterTests: XCTestCase {
         self.writer.finish()
 
         await XCTAssertThrowsError(try await self.writer.yield("message1")) { error in
-            XCTAssertEqual(error as? NIOAsyncWriterError, .alreadyFinished)
+            XCTAssertEqual(error as? NIOAsyncWriterError, .alreadyFinished())
         }
         XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
     }
@@ -359,7 +359,7 @@ final class NIOAsyncWriterTests: XCTestCase {
 
         XCTAssertEqual(self.delegate.didYieldCallCount, 0)
         await XCTAssertThrowsError(try await task.value) { error in
-            XCTAssertEqual(error as? NIOAsyncWriterError, .alreadyFinished)
+            XCTAssertEqual(error as? NIOAsyncWriterError, .alreadyFinished())
         }
     }
 

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
@@ -122,6 +122,36 @@ final class NIOAsyncWriterTests: XCTestCase {
         XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
     }
 
+    // MARK: - SinkDeinitialized
+
+    func testSinkDeinitialized_whenInitial() async throws {
+        self.sink = nil
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    func testSinkDeinitialized_whenStreaming() async throws {
+        Task { [writer] in
+            try await writer!.yield("message1")
+        }
+
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        self.sink = nil
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    func testSinkDeinitialized_whenFinished() async throws {
+        self.writer.finish()
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+
+        self.sink = nil
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
     // MARK: - ToggleWritability
 
     func testSetWritability_whenInitial() async throws {

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
@@ -34,10 +34,10 @@ private final class MockAsyncWriterDelegate: NIOAsyncWriterSinkDelegate, @unchec
 
     var didTerminateCallCount = 0
     var didTerminateHandler: ((Failure?) -> Void)?
-    func didTerminate(failure: Failure?) {
+    func didTerminate(error: Failure?) {
         self.didTerminateCallCount += 1
         if let didTerminateHandler = self.didTerminateHandler {
-            didTerminateHandler(failure)
+            didTerminateHandler(error)
         }
     }
 }
@@ -429,7 +429,7 @@ final class NIOAsyncWriterTests: XCTestCase {
     }
 
     func testFinish_whenInitial_andFailure() async throws {
-        self.writer.finish(with: SomeError())
+        self.writer.finish(error: SomeError())
 
         XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
     }

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
@@ -1,0 +1,391 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import XCTest
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+private struct SomeError: Error, Hashable {}
+
+private final class MockAsyncWriterDelegate: NIOAsyncWriterDelegate, @unchecked Sendable {
+    typealias Element = String
+    typealias Failure = SomeError
+
+    var didYieldCallCount = 0
+    var didYieldHandler: ((AnySequence<String>) -> Void)?
+    func didYield<S: Sequence>(contentsOf sequence: S) where S.Element == String {
+        self.didYieldCallCount += 1
+        if let didYieldHandler = self.didYieldHandler {
+            didYieldHandler(AnySequence(sequence))
+        }
+    }
+
+    var didTerminateCallCount = 0
+    var didTerminateHandler: ((NIOAsyncWriterCompletion<Failure>) -> Void)?
+    func didTerminate(completion: NIOAsyncWriterCompletion<Failure>) {
+        self.didTerminateCallCount += 1
+        if let didTerminateHandler = self.didTerminateHandler {
+            didTerminateHandler(completion)
+        }
+    }
+}
+
+final class NIOAsyncWriterTests: XCTestCase {
+    private var writer: NIOAsyncWriter<String, SomeError, MockAsyncWriterDelegate>!
+    private var sink: NIOAsyncWriter<String, SomeError, MockAsyncWriterDelegate>.Sink!
+    private var delegate: MockAsyncWriterDelegate!
+
+    override func setUp() {
+        super.setUp()
+
+        self.delegate = .init()
+        let newWriter = NIOAsyncWriter.makeWriter(
+            elementType: String.self,
+            failureType: SomeError.self,
+            isWritable: true,
+            delegate: self.delegate
+        )
+        self.writer = newWriter.writer
+        self.sink = newWriter.sink
+    }
+
+    override func tearDown() {
+        self.delegate = nil
+        self.writer = nil
+        self.sink = nil
+
+        super.tearDown()
+    }
+
+    func testMultipleConcurrentWrites() async throws {
+        let task1 = Task { [writer] in
+            for i in 0...9 {
+                try await writer!.yield("message\(i)")
+            }
+        }
+        let task2 = Task { [writer] in
+            for i in 10...19 {
+                try await writer!.yield("message\(i)")
+            }
+        }
+        let task3 = Task { [writer] in
+            for i in 20...29 {
+                try await writer!.yield("message\(i)")
+            }
+        }
+
+        try await task1.value
+        try await task2.value
+        try await task3.value
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 30)
+    }
+
+    // MARK: - WriterDeinitialized
+
+    func testWriterDeinitialized_whenInitial() async throws {
+        self.writer = nil
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    func testWriterDeinitialized_whenStreaming() async throws {
+        Task { [writer] in
+            try await writer!.yield("message1")
+        }
+
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        self.writer = nil
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    func testWriterDeinitialized_whenFinished() async throws {
+        self.writer.finish(completion: .finished)
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+
+        self.writer = nil
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    // MARK: - ToggleWritability
+
+    func testToggleWritability_whenInitial() async throws {
+        self.sink.toggleWritability()
+
+        Task { [writer] in
+            try await writer!.yield("message1")
+        }
+
+        // Sleep a bit so that the other Task suspends on the yield
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 0)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
+    }
+
+    func testToggleWritability_whenStreaming_andBecomingUnwritable() async throws {
+        try await self.writer.yield("message1")
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+
+        self.sink.toggleWritability()
+
+        Task { [writer] in
+            try await writer!.yield("message2")
+        }
+
+        // Sleep a bit so that the other Task suspends on the yield
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
+    }
+
+    func testToggleWritability_whenStreaming_andBecomingWritable() async throws {
+        self.sink.toggleWritability()
+
+        Task { [writer] in
+            try await writer!.yield("message2")
+        }
+
+        // Sleep a bit so that the other Task suspends on the yield
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        self.sink.toggleWritability()
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
+    }
+
+    func testToggleWritability_whenFinished() async throws {
+        self.writer.finish(completion: .finished)
+
+        self.sink.toggleWritability()
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    // MARK: - Yield
+
+    func testYield_whenInitial_andWritable() async throws {
+        try await self.writer.yield("message1")
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+    }
+
+    func testYield_whenInitial_andNotWritable() async throws {
+        self.sink.toggleWritability()
+
+        Task { [writer] in
+            try await writer!.yield("message2")
+        }
+
+        // Sleep a bit so that the other Task suspends on the yield
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 0)
+    }
+
+    func testYield_whenStreaming_andWritable() async throws {
+        try await self.writer.yield("message1")
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+
+        try await self.writer.yield("message2")
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 2)
+    }
+
+    func testYield_whenStreaming_andNotWritable() async throws {
+        try await self.writer.yield("message1")
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+
+        self.sink.toggleWritability()
+
+        Task { [writer] in
+            try await writer!.yield("message2")
+        }
+
+        // Sleep a bit so that the other Task suspends on the yield
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+    }
+
+    func testYield_whenStreaming_andYieldCancelled() async throws {
+        try await self.writer.yield("message1")
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+
+        let task = Task { [writer] in
+            // Sleeping here a bit to delay the call to yield
+            // The idea is that we call yield once the Task is
+            // already cancelled
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            try await writer!.yield("message2")
+        }
+
+        task.cancel()
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+        await XCTAssertThrowsError(try await task.value) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
+    func testYield_whenFinished() async throws {
+        self.writer.finish(completion: .finished)
+
+        await XCTAssertThrowsError(try await self.writer.yield("message1")) { error in
+            XCTAssertEqual(error as? NIOAsyncWriterError, .alreadyFinished)
+        }
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    // MARK: - Cancel
+
+    func testCancel_whenInitial() async throws {
+        let task = Task { [writer] in
+            // Sleeping here a bit to delay the call to yield
+            // The idea is that we call yield once the Task is
+            // already cancelled
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            try await writer!.yield("message1")
+        }
+
+        task.cancel()
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 0)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
+        await XCTAssertThrowsError(try await task.value) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
+    func testCancel_whenStreaming_andCancelBeforeYield() async throws {
+        try await self.writer.yield("message1")
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+
+        let task = Task { [writer] in
+            // Sleeping here a bit to delay the call to yield
+            // The idea is that we call yield once the Task is
+            // already cancelled
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            try await writer!.yield("message2")
+        }
+
+        task.cancel()
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
+        await XCTAssertThrowsError(try await task.value) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
+    func testCancel_whenStreaming_andCancelAfterSuspendedYield() async throws {
+        try await self.writer.yield("message1")
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+
+        self.sink.toggleWritability()
+
+        let task = Task { [writer] in
+            try await writer!.yield("message2")
+        }
+
+        // Sleeping here to give the task enough time to suspend on the yield
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        task.cancel()
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 1)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
+        await XCTAssertThrowsError(try await task.value) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
+    func testCancel_whenFinished() async throws {
+        self.writer.finish(completion: .finished)
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+
+        let task = Task { [writer] in
+            // Sleeping here a bit to delay the call to yield
+            // The idea is that we call yield once the Task is
+            // already cancelled
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            try await writer!.yield("message1")
+        }
+
+        // Sleeping here to give the task enough time to suspend on the yield
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        task.cancel()
+
+        XCTAssertEqual(self.delegate.didYieldCallCount, 0)
+        await XCTAssertThrowsError(try await task.value) { error in
+            XCTAssertEqual(error as? NIOAsyncWriterError, .alreadyFinished)
+        }
+    }
+
+    // MARK: - Finish
+
+    func testFinish_whenInitial() async throws {
+        self.writer.finish(completion: .finished)
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    func testFinish_whenInitial_andFailure() async throws {
+        self.writer.finish(completion: .failure(SomeError()))
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    func testFinish_whenStreaming() async throws {
+        // We are setting up a suspended yield here to check that it gets resumed
+        self.sink.toggleWritability()
+
+        let task = Task { [writer] in
+            try await writer!.yield("message1")
+        }
+
+        // Sleeping here to give the task enough time to suspend on the yield
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        self.writer.finish(completion: .finished)
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        await XCTAssertThrowsError(try await task.value) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
+    func testFinish_whenFinished() {
+        // This tests just checks that finishing again is a no-op
+        self.writer.finish(completion: .finished)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+
+        self.writer.finish(completion: .finished)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+}
+#endif

--- a/Tests/NIOCoreTests/XCTest+AsyncAwait.swift
+++ b/Tests/NIOCoreTests/XCTest+AsyncAwait.swift
@@ -90,6 +90,19 @@ internal func XCTAssertThrowsError<T>(
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+internal func XCTAssertNoThrow<T>(
+    _ expression: @autoclosure () async throws -> T,
+    file: StaticString = #file,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+    } catch {
+        XCTFail("Expression did throw error", file: file, line: line)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal func XCTAssertNoThrowWithResult<Result>(
     _ expression: @autoclosure () async throws -> Result,
     file: StaticString = #file,


### PR DESCRIPTION
# Motivation
We previously added the `NIOAsyncSequenceProducer` to bridge between the NIO channel pipeline and the asynchronous world. However, we still need something to bridge writes from the asynchronous world back to the NIO channel pipeline.

# Modification
This PR adds a new `NIOAsyncWriter` type that allows us to asynchronously `yield` elements to it. On the other side, we can register a `NIOAsyncWriterDelegate` which will get informed about any written elements. Furthermore, the synchronous side can toggle the writability of the `AsyncWriter` which allows it to implement flow control.
A main goal of this type is to be as performant as possible. To achieve this I did the following things:
- Make everything generic and inlinable
- Use a class with a lock instead of an actor
- Provide methods to yield a sequence of things which allows users to reduce the amount of times the lock gets acquired.

# Result
We now have the means to bridge writes from the asynchronous world to the synchronous
