### PR TITLE
Convert `NIOAsyncSequenceProducer.Source` to a class

### DIFF
--- a/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducer.swift
@@ -197,10 +197,13 @@ extension NIOAsyncSequenceProducer {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension NIOAsyncSequenceProducer {
-    /// A struct to interface between the synchronous code of the producer and the asynchronous consumer.
+    /// A class to interface between the synchronous code of the producer and the asynchronous consumer.
     /// This type allows the producer to synchronously `yield` new elements to the ``NIOThrowingAsyncSequenceProducer``
     /// and to `finish` the sequence.
-    public struct Source {
+    ///
+    /// - Important: When a ``Source`` gets deinitilized it calls ``Source/finish()``. This will resume any
+    /// suspended continuation.
+    public final class Source {
         @usableFromInline
         /* fileprivate */ internal let _throwingSource: NIOThrowingAsyncSequenceProducer<
             Element,

--- a/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
@@ -185,13 +185,20 @@ extension NIOThrowingAsyncSequenceProducer {
     /// A struct to interface between the synchronous code of the producer and the asynchronous consumer.
     /// This type allows the producer to synchronously `yield` new elements to the ``NIOThrowingAsyncSequenceProducer``
     /// and to `finish` the sequence.
-    public struct Source {
+    ///
+    /// - Important: When a ``Source`` gets deinitilized it calls ``Source/finish()``. This will resume any
+    /// suspended continuation. 
+    public final class Source: Sendable {
         @usableFromInline
         /* fileprivate */ internal let _storage: Storage
 
         @usableFromInline
         /* fileprivate */ internal init(storage: Storage) {
             self._storage = storage
+        }
+
+        deinit {
+            self.finish()
         }
 
         /// The result of a call to ``NIOThrowingAsyncSequenceProducer/Source/yield(_:)``.

--- a/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
@@ -403,6 +403,74 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
         XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
     }
 
+    // MARK: - Source Deinited
+
+    func testSourceDeinited_whenInitial() async {
+        self.source = nil
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
+    }
+
+    func testSourceDeinited_whenStreaming_andSuspended() async throws {
+        // We are registering our demand and sleeping a bit to make
+        // sure the other child task runs when the demand is registered
+        let sequence = try XCTUnwrap(self.sequence)
+        let element: Int? = try await withThrowingTaskGroup(of: Int?.self) { group in
+            group.addTask {
+                let element = try await sequence.first { _ in true }
+                return element
+            }
+
+            try await Task.sleep(nanoseconds: 1_000_000)
+
+            self.source = nil
+
+            return try await group.next() ?? nil
+        }
+
+        XCTAssertEqual(element, nil)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    func testSourceDeinited_whenStreaming_andNotSuspended_andBufferEmpty() async throws {
+        _ = self.source.yield(contentsOf: [])
+
+        self.source = nil
+
+        let sequence = try XCTUnwrap(self.sequence)
+        let element: Int? = try await withThrowingTaskGroup(of: Int?.self) { group in
+            group.addTask {
+                return try await sequence.first { _ in true }
+            }
+
+            return try await group.next() ?? nil
+        }
+
+        XCTAssertNil(element)
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
+    func testSourceDeinited_whenStreaming_andNotSuspended_andBufferNotEmpty() async throws {
+        _ = self.source.yield(contentsOf: [1])
+
+        self.source = nil
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
+
+        let sequence = try XCTUnwrap(self.sequence)
+        let element: Int? = try await withThrowingTaskGroup(of: Int?.self) { group in
+            group.addTask {
+                return try await sequence.first { _ in true }
+            }
+
+            return try await group.next() ?? nil
+        }
+
+        XCTAssertEqual(element, 1)
+
+        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+    }
+
     // MARK: - Task cancel
 
     func testTaskCancel_whenStreaming_andSuspended() async throws {


### PR DESCRIPTION
# Motivation
@fabianfett took another look at the implementation of the `NIOAsyncSequenceProducer` and correctly spotted that the `Source` should have reference semantics. Furthermore, we came to the conclusion that it **MUST** call `finish()` when it deinits otherwise we can have a suspended continuation that never gets resumed.

# Modification
Make the `NIOAsyncSequenceProducer.Source` and its throwing variant `final class` and call `finish()` in their `deinit`s.

# Result
We now have reference semantics for the `Source` and are resuming all continuations.
