### PR TITLE
Widen the tolerance on testSystemCallWrapperPerformance in debug mode

### DIFF
--- a/Tests/NIOPosixTests/SystemCallWrapperHelpers.swift
+++ b/Tests/NIOPosixTests/SystemCallWrapperHelpers.swift
@@ -114,7 +114,7 @@ func runSystemCallWrapperPerformanceTest(testAssertFunction: (@autoclosure () ->
         return preventCompilerOptimisation
     }
 
-    let allowedOverheadPercent: Int = isDebugMode ? 1000 : 20
+    let allowedOverheadPercent: Int = isDebugMode ? 2000 : 20
     if allowedOverheadPercent > 100 {
         precondition(isDebugMode)
         print("WARNING: Syscall wrapper test: Over 100% overhead allowed. Running in debug assert configuration which allows \(allowedOverheadPercent)% overhead :(. Consider running in Release mode.")


### PR DESCRIPTION
Motivation:

We have downstream CI systems testing us that can't meet this
performance requirement. Given that the debug mode tests are only
checking correctness, not perf, we can widen the buffer.

Modifications:

Double the tolerance of testSystemCallWrapperPerformance in debug mode.

Result:

Downstream CI should be more reliable