### PR TITLE
NTRIP support

### DIFF
--- a/Sources/CNIOHTTPParser/c_nio_http_parser.c
+++ b/Sources/CNIOHTTPParser/c_nio_http_parser.c
@@ -289,16 +289,16 @@ enum state
   , s_res_HT
   , s_res_HTT
   , s_res_HTTP
-    , s_res_S
-    , s_res_SO
-    , s_res_SOU
-    , s_res_SOUR
-    , s_res_SOURC
-    , s_res_SOURCE
-    , s_res_SOURCET
-    , s_res_SOURCETA
-    , s_res_SOURCETAB
-    , s_res_SOURCETABL
+  , s_res_S
+  , s_res_SO
+  , s_res_SOU
+  , s_res_SOUR
+  , s_res_SOURC
+  , s_res_SOURCE
+  , s_res_SOURCET
+  , s_res_SOURCETA
+  , s_res_SOURCETAB
+  , s_res_SOURCETABL
   , s_res_http_major
   , s_res_http_dot
   , s_res_http_minor

--- a/Sources/CNIOHTTPParser/c_nio_http_parser.c
+++ b/Sources/CNIOHTTPParser/c_nio_http_parser.c
@@ -299,6 +299,9 @@ enum state
   , s_res_SOURCETA
   , s_res_SOURCETAB
   , s_res_SOURCETABL
+  , s_res_I
+  , s_res_IC
+    
   , s_res_http_major
   , s_res_http_dot
   , s_res_http_minor
@@ -791,6 +794,8 @@ reexecute:
           UPDATE_STATE(s_res_H);
         } else if (ch == 'S') {
             UPDATE_STATE(s_res_S);
+        } else if (ch == 'I') {
+            UPDATE_STATE(s_res_I);
         } else {
           SET_ERRNO(HPE_INVALID_CONSTANT);
           goto error;
@@ -867,6 +872,18 @@ reexecute:
         
       case s_res_SOURCETABL:
         STRICT_CHECK(ch != 'E');
+        parser->http_major = 1;
+        parser->http_minor = 1;
+        UPDATE_STATE(s_res_http_end);
+        break;
+
+      case s_res_I:
+        STRICT_CHECK(ch != 'C');
+        UPDATE_STATE(s_res_IC);
+        break;
+            
+      case s_res_IC:
+        STRICT_CHECK(ch != 'Y');
         parser->http_major = 1;
         parser->http_minor = 1;
         UPDATE_STATE(s_res_http_end);

--- a/Sources/CNIOHTTPParser/c_nio_http_parser.c
+++ b/Sources/CNIOHTTPParser/c_nio_http_parser.c
@@ -289,6 +289,16 @@ enum state
   , s_res_HT
   , s_res_HTT
   , s_res_HTTP
+    , s_res_S
+    , s_res_SO
+    , s_res_SOU
+    , s_res_SOUR
+    , s_res_SOURC
+    , s_res_SOURCE
+    , s_res_SOURCET
+    , s_res_SOURCETA
+    , s_res_SOURCETAB
+    , s_res_SOURCETABL
   , s_res_http_major
   , s_res_http_dot
   , s_res_http_minor
@@ -779,6 +789,8 @@ reexecute:
 
         if (ch == 'H') {
           UPDATE_STATE(s_res_H);
+        } else if (ch == 'S') {
+            UPDATE_STATE(s_res_S);
         } else {
           SET_ERRNO(HPE_INVALID_CONSTANT);
           goto error;
@@ -806,6 +818,58 @@ reexecute:
       case s_res_HTTP:
         STRICT_CHECK(ch != '/');
         UPDATE_STATE(s_res_http_major);
+        break;
+            
+      case s_res_S:
+        STRICT_CHECK(ch != 'O');
+        UPDATE_STATE(s_res_SO);
+        break;
+
+      case s_res_SO:
+        STRICT_CHECK(ch != 'U');
+        UPDATE_STATE(s_res_SOU);
+        break;
+        
+      case s_res_SOU:
+        STRICT_CHECK(ch != 'R');
+        UPDATE_STATE(s_res_SOUR);
+        break;
+        
+      case s_res_SOUR:
+        STRICT_CHECK(ch != 'C');
+        UPDATE_STATE(s_res_SOURC);
+        break;
+        
+      case s_res_SOURC:
+        STRICT_CHECK(ch != 'E');
+        UPDATE_STATE(s_res_SOURCE);
+        break;
+        
+      case s_res_SOURCE:
+        STRICT_CHECK(ch != 'T');
+        UPDATE_STATE(s_res_SOURCET);
+        break;
+        
+      case s_res_SOURCET:
+        STRICT_CHECK(ch != 'A');
+        UPDATE_STATE(s_res_SOURCETA);
+        break;
+        
+      case s_res_SOURCETA:
+        STRICT_CHECK(ch != 'B');
+        UPDATE_STATE(s_res_SOURCETAB);
+        break;
+        
+      case s_res_SOURCETAB:
+        STRICT_CHECK(ch != 'L');
+        UPDATE_STATE(s_res_SOURCETABL);
+        break;
+        
+      case s_res_SOURCETABL:
+        STRICT_CHECK(ch != 'E');
+        parser->http_major = 1;
+        parser->http_minor = 1;
+        UPDATE_STATE(s_res_http_end);
         break;
 
       case s_res_http_major:

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -35,6 +35,8 @@ extension HTTPDecoderTest {
                 ("testDoesNotDecodeFakeHTTP09Response", testDoesNotDecodeFakeHTTP09Response),
                 ("testDoesNotDecodeHTTP2XResponse", testDoesNotDecodeHTTP2XResponse),
                 ("testToleratesHTTP13Response", testToleratesHTTP13Response),
+                ("testToleratesSourcetableResponse", testToleratesSourcetableResponse),
+                ("testToleratesIcyResponse", testToleratesIcyResponse),
                 ("testCorrectlyMaintainIndicesWhenDiscardReadBytes", testCorrectlyMaintainIndicesWhenDiscardReadBytes),
                 ("testDropExtraBytes", testDropExtraBytes),
                 ("testDontDropExtraBytesRequest", testDontDropExtraBytesRequest),

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -177,6 +177,22 @@ class HTTPDecoderTest: XCTestCase {
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.finish())
     }
+    
+    func testToleratesIcyResponse() throws {
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(ByteToMessageHandler(HTTPResponseDecoder())).wait())
+
+        // We need to prime the decoder by seeing a GET request.
+        try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .http2, method: .GET, uri: "/")))
+
+        // We tolerate SOURCETABLE responses due to NTRIP revision 1.
+        // says that these should be treated like HTTP/1.1 by our users.
+        var buffer = channel.allocator.buffer(capacity: 64)
+        buffer.writeStaticString("ICY 200 OK\r\n\r\n")
+
+        XCTAssertNoThrow(try channel.writeInbound(buffer))
+        XCTAssertNoThrow(try channel.finish())
+    }
 
     func testCorrectlyMaintainIndicesWhenDiscardReadBytes() throws {
         class Receiver: ChannelInboundHandler {

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -161,6 +161,22 @@ class HTTPDecoderTest: XCTestCase {
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         XCTAssertNoThrow(try channel.finish())
     }
+    
+    func testToleratesSourcetableResponse() throws {
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPRequestEncoder()).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(ByteToMessageHandler(HTTPResponseDecoder())).wait())
+
+        // We need to prime the decoder by seeing a GET request.
+        try channel.writeOutbound(HTTPClientRequestPart.head(HTTPRequestHead(version: .http2, method: .GET, uri: "/")))
+
+        // We tolerate SOURCETABLE responses due to NTRIP revision 1.
+        // says that these should be treated like HTTP/1.1 by our users.
+        var buffer = channel.allocator.buffer(capacity: 64)
+        buffer.writeStaticString("SOURCETABLE 200 OK\r\nServer: whatever\r\n\r\n")
+
+        XCTAssertNoThrow(try channel.writeInbound(buffer))
+        XCTAssertNoThrow(try channel.finish())
+    }
 
     func testCorrectlyMaintainIndicesWhenDiscardReadBytes() throws {
         class Receiver: ChannelInboundHandler {


### PR DESCRIPTION
Reinterprets NTRIP SOURCETABLE and ICY responses as HTTP/1.1 responses.

### Motivation:

My goal is to use these changes to develop an NTRIP client (like a web browser) for iOS. These changes are being contributed in the hopes that other NTRIP developers use them to create more stable, safe and reliable NTRIP applications.

In the past I would accomplish this by manually encoding and decoding NTRIP requests and responses. This was error-prone, difficult to maintain, often lacked support (such as redirects, proxies and TLS), and was reinventing what many HTTP clients had already done.

#### What is NTRIP

> Ntrip is a generic, stateless protocol based on the Hypertext Transfer Protocol HTTP/1.1.

It is intended for streaming real-time, high-accuracy positioning data over the internet.

At this time, no Swift-based HTTP package supports NTRIP. A similar pull request was proposed and accepted for OkHTTP (https://github.com/square/okhttp/pull/7320), which I am using on Android.

The next major version of NTRIP (revision 2) is fully HTTP-compliant but is not yet widely supported by a majority of NTRIP servers (called casters).

### Modifications:

The http-parser (CNIOHTTPParser) main loop was modified to interpret messages starting with SOURCETABLE or ICY as HTTP responses with a major and minor version of 1.1.

Tests where added for both SOURCETABLE and ICY.

#### Future changes

Node.js, the apparent authors of the http-parser, no longer maintain it. It will no longer receive updates and the included update_and_patch_http_parser.sh script should be redirected to a forked repository, or modified to avoid overwriting these changes.

Another pull request is being worked on and will be necessary to support a wider range of older NTRIP casters. Some casters produce responses that are not fully HTTP compliant. Most of these errors are tolerated.
One error results in the body of the response being interpreted as a header, causing the execution to never produce a result or to produce an incorrect result (infinite loop, timeout, or invalid header and cut off body).
In practice, this only ever appears to occur when the body contains RTCM data. This data always starts with a D3 hex character. To resolve this I am modifying the http-parser to look for this character at the start of a header and if found, reverse the parsing process and set the state to `s_headers_almost_done`.

### Result:

This results in NTRIP responses being properly interpreted as HTTP responses in tests. Addition improvements can be made directly by users (e.g. NTRIP suggests setting the Connection header to "close").
