### PR TITLE
rename class Lock to struct NIOLock

### DIFF
--- a/IntegrationTests/tests_05_assertions/test_01_syscall_wrapper_fast.sh
+++ b/IntegrationTests/tests_05_assertions/test_01_syscall_wrapper_fast.sh
@@ -26,14 +26,14 @@ elif [[ "$(uname -s)" == "Linux" ]]; then
     swift_binary=$(which swiftc)
 fi
 
-cp "$here/../../Sources/NIOConcurrencyHelpers/lock.swift" "$tmp"
+cp "$here/../../Sources/NIOConcurrencyHelpers/"{lock,NIOLock}.swift "$tmp"
 cat > "$tmp/main.swift" <<"EOF"
-let l = Lock()
+let l = NIOLock()
 l.lock()
 l.lock()
 EOF
 
-"$swift_binary" -o "$tmp/test" "$tmp/main.swift" "$tmp/lock.swift"
+"$swift_binary" -o "$tmp/test" "$tmp/main.swift" "$tmp/"{lock,NIOLock}.swift
 if "$tmp/test"; then
     fail "should have crashed"
 else

--- a/Sources/NIOConcurrencyHelpers/LockedValue.swift
+++ b/Sources/NIOConcurrencyHelpers/LockedValue.swift
@@ -25,7 +25,7 @@ public struct NIOLockedValueBox<Value> {
     @usableFromInline
     internal final class _Storage {
         @usableFromInline
-        internal let _lock = Lock()
+        internal let _lock = NIOLock()
         
         @usableFromInline
         internal var _value: Value

--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -1,0 +1,148 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+#elseif os(Windows)
+import ucrt
+import WinSDK
+#else
+import Glibc
+#endif
+
+/// A threading lock based on `libpthread` instead of `libdispatch`.
+///
+/// - note: ``NIOLock`` has reference semantics.
+///
+/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
+/// of lock is safe to use with `libpthread`-based threading models, such as the
+/// one used by NIO. On Windows, the lock is based on the substantially similar
+/// `SRWLOCK` type.
+public struct NIOLock {
+    @usableFromInline
+    internal let _storage: _Storage
+
+#if os(Windows)
+    @usableFromInline
+    internal typealias LockPrimitive = SRWLOCK
+#else
+    @usableFromInline
+    internal typealias LockPrimitive = pthread_mutex_t
+#endif
+    
+    @usableFromInline
+    internal final class _Storage {
+        // TODO: We should tail-allocate the pthread_t/SRWLock.
+        @usableFromInline
+        internal let mutex: UnsafeMutablePointer<LockPrimitive> =
+        UnsafeMutablePointer.allocate(capacity: 1)
+
+        /// Create a new lock.
+        internal init() {
+#if os(Windows)
+            InitializeSRWLock(self.mutex)
+#else
+            var attr = pthread_mutexattr_t()
+            pthread_mutexattr_init(&attr)
+            debugOnly {
+                pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
+            }
+            
+            let err = pthread_mutex_init(self.mutex, &attr)
+            precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+#endif
+        }
+        
+        internal func lock() {
+#if os(Windows)
+            AcquireSRWLockExclusive(self.mutex)
+#else
+            let err = pthread_mutex_lock(self.mutex)
+            precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+#endif
+        }
+        
+        internal func unlock() {
+#if os(Windows)
+            ReleaseSRWLockExclusive(self._storage.mutex)
+#else
+            let err = pthread_mutex_unlock(self.mutex)
+            precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+#endif
+        }
+
+        internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+            return try body(self.mutex)
+        }
+        
+        deinit {
+#if os(Windows)
+            // SRWLOCK does not need to be free'd
+#else
+            let err = pthread_mutex_destroy(self.mutex)
+            precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+#endif
+            mutex.deallocate()
+        }
+    }
+    
+    /// Create a new lock.
+    public init() {
+        self._storage = _Storage()
+    }
+
+    /// Acquire the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `unlock`, to simplify lock handling.
+    public func lock() {
+        self._storage.lock()
+    }
+
+    /// Release the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `lock`, to simplify lock handling.
+    public func unlock() {
+        self._storage.unlock()
+    }
+
+    internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+        return try self._storage.withLockPrimitive(body)
+    }
+}
+
+extension NIOLock {
+    /// Acquire the lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lock` and `unlock` in
+    /// most situations, as it ensures that the lock will be released regardless
+    /// of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    public func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+}
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension NIOLock: Sendable {}
+extension NIOLock._Storage: Sendable {}
+#endif

--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -27,6 +27,7 @@ import Glibc
 /// of lock is safe to use with `libpthread`-based threading models, such as the
 /// one used by NIO. On Windows, the lock is based on the substantially similar
 /// `SRWLOCK` type.
+@available(*, deprecated, renamed: "NIOLock")
 public final class Lock {
 #if os(Windows)
     fileprivate let mutex: UnsafeMutablePointer<SRWLOCK> =
@@ -89,6 +90,7 @@ public final class Lock {
     }
 }
 
+@available(*, deprecated, renamed: "NIOLock")
 extension Lock {
     /// Acquire the lock for the duration of the given block.
     ///
@@ -120,7 +122,7 @@ extension Lock {
 /// until the state variable is set to a specific value to acquire the lock.
 public final class ConditionLock<T: Equatable> {
     private var _value: T
-    private let mutex: Lock
+    private let mutex: NIOLock
 #if os(Windows)
     private let cond: UnsafeMutablePointer<CONDITION_VARIABLE> =
         UnsafeMutablePointer.allocate(capacity: 1)
@@ -134,7 +136,7 @@ public final class ConditionLock<T: Equatable> {
     /// - Parameter value: The initial value to give the state variable.
     public init(value: T) {
         self._value = value
-        self.mutex = Lock()
+        self.mutex = NIOLock()
 #if os(Windows)
         InitializeConditionVariable(self.cond)
 #else
@@ -186,13 +188,15 @@ public final class ConditionLock<T: Equatable> {
             if self._value == wantedValue {
                 break
             }
+            self.mutex.withLockPrimitive { mutex in
 #if os(Windows)
-            let result = SleepConditionVariableSRW(self.cond, self.mutex.mutex, INFINITE, 0)
-            precondition(result, "\(#function) failed in SleepConditionVariableSRW with error \(GetLastError())")
+                let result = SleepConditionVariableSRW(self.cond, mutex, INFINITE, 0)
+                precondition(result, "\(#function) failed in SleepConditionVariableSRW with error \(GetLastError())")
 #else
-            let err = pthread_cond_wait(self.cond, self.mutex.mutex)
-            precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
+                let err = pthread_cond_wait(self.cond, mutex)
+                precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
 #endif
+            }
         }
     }
 
@@ -244,18 +248,20 @@ public final class ConditionLock<T: Equatable> {
                                   tv_nsec: Int(allNSecs % nsecPerSec))
         assert(timeoutAbs.tv_nsec >= 0 && timeoutAbs.tv_nsec < Int(nsecPerSec))
         assert(timeoutAbs.tv_sec >= curTime.tv_sec)
-        while true {
-            if self._value == wantedValue {
-                return true
-            }
-            switch pthread_cond_timedwait(self.cond, self.mutex.mutex, &timeoutAbs) {
-            case 0:
-                continue
-            case ETIMEDOUT:
-                self.unlock()
-                return false
-            case let e:
-                fatalError("caught error \(e) when calling pthread_cond_timedwait")
+        return self.mutex.withLockPrimitive { mutex -> Bool in
+            while true {
+                if self._value == wantedValue {
+                    return true
+                }
+                switch pthread_cond_timedwait(self.cond, mutex, &timeoutAbs) {
+                case 0:
+                    continue
+                case ETIMEDOUT:
+                    self.unlock()
+                    return false
+                case let e:
+                    fatalError("caught error \(e) when calling pthread_cond_timedwait")
+                }
             }
         }
 #endif
@@ -288,6 +294,7 @@ internal func debugOnly(_ body: () -> Void) {
 }
 
 #if compiler(>=5.5) && canImport(_Concurrency)
+@available(*, deprecated, renamed: "NIOLock")
 extension Lock: Sendable {
 
 }

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
@@ -395,7 +395,7 @@ extension NIOAsyncWriter {
 
         /// The lock that protects our state.
         @usableFromInline
-        /* private */ internal let _lock = Lock()
+        /* private */ internal let _lock = NIOLock()
         /// The counter used to assign an ID to all our yields.
         @usableFromInline
         /* private */ internal let _yieldIDGenerator = YieldIDGenerator()

--- a/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
@@ -304,7 +304,7 @@ extension NIOThrowingAsyncSequenceProducer {
     /* fileprivate */ internal final class Storage: @unchecked Sendable {
         /// The lock that protects our state.
         @usableFromInline
-        /* private */ internal let _lock = Lock()
+        /* private */ internal let _lock = NIOLock()
         /// The state machine.
         @usableFromInline
         /* private */ internal var _stateMachine: StateMachine

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -1186,7 +1186,7 @@ extension EventLoopGroup {
     public func syncShutdownGracefully() throws {
         self._preconditionSafeToSyncShutdown(file: #file, line: #line)
 
-        let errorStorageLock = Lock()
+        let errorStorageLock = NIOLock()
         var errorStorage: Error? = nil
         let continuation = DispatchWorkItem {}
         self.shutdownGracefully { error in

--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -194,7 +194,7 @@ public final class NIOAsyncTestingChannel: Channel {
     /*private but usableFromInline */ var channelcore: EmbeddedChannelCore!
 
     /// Guards any of the getters/setters that can be accessed from any thread.
-    private let stateLock: Lock = Lock()
+    private let stateLock: NIOLock = NIOLock()
 
     // Guarded by `stateLock`
     private var _isWritable: Bool = true
@@ -223,7 +223,7 @@ public final class NIOAsyncTestingChannel: Channel {
             return self.stateLock.withLock { self._isWritable }
         }
         set {
-            self.stateLock.withLockVoid {
+            self.stateLock.withLock { () -> Void in
                 self._isWritable = newValue
             }
         }
@@ -235,7 +235,7 @@ public final class NIOAsyncTestingChannel: Channel {
             return self.stateLock.withLock { self._localAddress }
         }
         set {
-            self.stateLock.withLockVoid {
+            self.stateLock.withLock { () -> Void in
                 self._localAddress = newValue
             }
         }
@@ -247,7 +247,7 @@ public final class NIOAsyncTestingChannel: Channel {
             return self.stateLock.withLock { self._remoteAddress }
         }
         set {
-            self.stateLock.withLockVoid {
+            self.stateLock.withLock { () -> Void in
                 self._remoteAddress = newValue
             }
         }

--- a/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
+++ b/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
@@ -353,12 +353,12 @@ public final class NIOAsyncTestingEventLoop: EventLoop, @unchecked Sendable {
 ///
 /// We use this to keep track of where promises come from in the `NIOAsyncTestingEventLoop`.
 private class PromiseCreationStore {
-    private let lock = Lock()
+    private let lock = NIOLock()
     private var promiseCreationStore: [_NIOEventLoopFutureIdentifier: (file: StaticString, line: UInt)] = [:]
 
     func promiseCreated(futureIdentifier: _NIOEventLoopFutureIdentifier, file: StaticString, line: UInt) {
         precondition(_isDebugAssertConfiguration())
-        self.lock.withLockVoid {
+        self.lock.withLock { () -> Void in
             self.promiseCreationStore[futureIdentifier] = (file: file, line: line)
         }
     }

--- a/Sources/NIOPerformanceTester/LockBenchmark.swift
+++ b/Sources/NIOPerformanceTester/LockBenchmark.swift
@@ -17,7 +17,7 @@ import NIOPosix
 import Dispatch
 import NIOConcurrencyHelpers
 
-final class LockBenchmark: Benchmark {
+final class NIOLockBenchmark: Benchmark {
     private let numberOfThreads: Int
     private let lockOperationsPerThread: Int
     private let threadPool: NIOThreadPool
@@ -27,7 +27,7 @@ final class LockBenchmark: Benchmark {
     private let sem3 = DispatchSemaphore(value: 0)
     private var opsDone = 0
 
-    private let lock = Lock()
+    private let lock = NIOLock()
     
     init(numberOfThreads: Int, lockOperationsPerThread: Int) {
         self.numberOfThreads = numberOfThreads

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -1016,7 +1016,7 @@ try measureAndPrint(
 
 try measureAndPrint(
     desc: "lock_1_thread_10M_ops",
-    benchmark: LockBenchmark(
+    benchmark: NIOLockBenchmark(
         numberOfThreads: 1,
         lockOperationsPerThread: 10_000_000
     )
@@ -1024,7 +1024,7 @@ try measureAndPrint(
 
 try measureAndPrint(
     desc: "lock_2_threads_10M_ops",
-    benchmark: LockBenchmark(
+    benchmark: NIOLockBenchmark(
         numberOfThreads: 2,
         lockOperationsPerThread: 5_000_000
     )
@@ -1032,7 +1032,7 @@ try measureAndPrint(
 
 try measureAndPrint(
     desc: "lock_4_threads_10M_ops",
-    benchmark: LockBenchmark(
+    benchmark: NIOLockBenchmark(
         numberOfThreads: 4,
         lockOperationsPerThread: 2_500_000
     )
@@ -1041,7 +1041,7 @@ try measureAndPrint(
 
 try measureAndPrint(
     desc: "lock_8_threads_10M_ops",
-    benchmark: LockBenchmark(
+    benchmark: NIOLockBenchmark(
         numberOfThreads: 8,
         lockOperationsPerThread: 1_250_000
     )

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -238,7 +238,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
     internal let socket: SocketType
     private let closePromise: EventLoopPromise<Void>
     internal let selectableEventLoop: SelectableEventLoop
-    private let _offEventLoopLock = Lock()
+    private let _offEventLoopLock = NIOLock()
     private let isActiveAtomic: ManagedAtomic<Bool> = .init(false)
     // just a thread-safe way of having something to print about the socket from any thread
     internal let socketDescription: String

--- a/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
+++ b/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
@@ -70,7 +70,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     private let myGroupID: Int
     private let index = ManagedAtomic<Int>(0)
     private var eventLoops: [SelectableEventLoop]
-    private let shutdownLock: Lock = Lock()
+    private let shutdownLock: NIOLock = NIOLock()
     private var runState: RunState = .running
 
     private static func runTheLoop(thread: NIOThread,
@@ -104,7 +104,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
                                                 parentGroup: MultiThreadedEventLoopGroup,
                                                 selectorFactory: @escaping () throws -> NIOPosix.Selector<NIORegistration>,
                                                 initializer: @escaping ThreadInitializer)  -> SelectableEventLoop {
-        let lock = Lock()
+        let lock = NIOLock()
         /* the `loopUpAndRunningGroup` is done by the calling thread when the EventLoop has been created and was written to `_loop` */
         let loopUpAndRunningGroup = DispatchGroup()
 

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -65,7 +65,7 @@ public final class NIOThreadPool {
         case running(CircularBuffer<WorkItem>)
     }
     private let semaphore = DispatchSemaphore(value: 0)
-    private let lock = Lock()
+    private let lock = NIOLock()
     private var threads: [NIOThread]? = nil // protected by `lock`
     private var state: State = .stopped
     private let numberOfThreads: Int
@@ -313,7 +313,7 @@ extension NIOThreadPool {
     #endif
 
     public func syncShutdownGracefully() throws {
-        let errorStorageLock = Lock()
+        let errorStorageLock = NIOLock()
         var errorStorage: Swift.Error? = nil
         let continuation = DispatchWorkItem {}
         self.shutdownGracefully { error in

--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -131,7 +131,7 @@ internal class Selector<R: Registration>  {
     // The rules for `self.selectorFD`, `self.eventFD`, and `self.timerFD`:
     // reads: `self.externalSelectorFDLock` OR access from the EventLoop thread
     // writes: `self.externalSelectorFDLock` AND access from the EventLoop thread
-    let externalSelectorFDLock = Lock()
+    let externalSelectorFDLock = NIOLock()
     var selectorFD: CInt = -1 // -1 == we're closed
 
     // Here we add the stored properties that are used by the specific backends

--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
@@ -461,7 +461,7 @@ class NIOConcurrencyHelpersTests: XCTestCase {
 
 
     func testLockMutualExclusion() {
-        let l = Lock()
+        let l = NIOLock()
 
         var x = 1
         let q = DispatchQueue(label: "q")
@@ -493,7 +493,7 @@ class NIOConcurrencyHelpersTests: XCTestCase {
     }
 
     func testWithLockMutualExclusion() {
-        let l = Lock()
+        let l = NIOLock()
 
         var x = 1
         let q = DispatchQueue(label: "q")

--- a/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
@@ -453,7 +453,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
             // schedule that expire "now" all run at the same time, and that any work they schedule is run
             // after all such tasks expire.
             let loop = NIOAsyncTestingEventLoop()
-            let lock = Lock()
+            let lock = NIOLock()
             var firstScheduled: Scheduled<Void>? = nil
             var secondScheduled: Scheduled<Void>? = nil
             let orderingCounter = ManagedAtomic(0)
@@ -472,7 +472,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
             //
             // To validate the ordering, we'll use a counter.
 
-            lock.withLockVoid {
+            lock.withLock { () -> Void in
                 firstScheduled = loop.scheduleTask(in: .nanoseconds(5)) {
                     let second = lock.withLock { () -> Scheduled<Void>? in
                         XCTAssertNotNil(firstScheduled)
@@ -496,7 +496,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
                 }
 
                 secondScheduled = loop.scheduleTask(in: .nanoseconds(5)) {
-                    lock.withLockVoid {
+                    lock.withLock { () -> Void in
                         secondScheduled = nil
                         XCTAssertNil(firstScheduled)
                         XCTAssertNil(secondScheduled)

--- a/Tests/NIOEmbeddedTests/TestUtils.swift
+++ b/Tests/NIOEmbeddedTests/TestUtils.swift
@@ -43,7 +43,7 @@ extension EventLoopFuture {
             }
             return fulfilled
         } else {
-            let lock = Lock()
+            let lock = NIOLock()
             let group = DispatchGroup()
             var fulfilled = false // protected by lock
 

--- a/Tests/NIOPosixTests/BootstrapTest.swift
+++ b/Tests/NIOPosixTests/BootstrapTest.swift
@@ -21,7 +21,7 @@ import XCTest
 class BootstrapTest: XCTestCase {
     var group: MultiThreadedEventLoopGroup!
     var groupBag: [MultiThreadedEventLoopGroup]? = nil // protected by `self.lock`
-    let lock = Lock()
+    let lock = NIOLock()
 
     override func setUp() {
         XCTAssertNil(self.group)

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -1164,7 +1164,7 @@ public final class EventLoopTest : XCTestCase {
     func testTakeOverThreadAndAlsoTakeItBack() {
         let currentNIOThread = NIOThread.current
         let currentNSThread = Thread.current
-        let lock = Lock()
+        let lock = NIOLock()
         var hasBeenShutdown = false
         let allDoneGroup = DispatchGroup()
         allDoneGroup.enter()

--- a/Tests/NIOPosixTests/NIOThreadPoolTest.swift
+++ b/Tests/NIOPosixTests/NIOThreadPoolTest.swift
@@ -27,7 +27,7 @@ class NIOThreadPoolTest: XCTestCase {
         }
 
         var allThreadNames: Set<String> = []
-        let lock = Lock()
+        let lock = NIOLock()
         let threadNameCollectionSem = DispatchSemaphore(value: 0)
         let threadBlockingSem = DispatchSemaphore(value: 0)
 
@@ -74,14 +74,14 @@ class NIOThreadPoolTest: XCTestCase {
 
         // The lock here is arguably redundant with the dispatchgroup, but let's make
         // this test thread-safe even if I screw up.
-        let lock = Lock()
+        let lock = NIOLock()
         var threadOne = Thread?.none
         var threadTwo = Thread?.none
 
         completionGroup.enter()
         pool.submit { s in
             precondition(s == .active)
-            lock.withLockVoid {
+            lock.withLock { () -> Void in
                 XCTAssertEqual(threadOne, nil)
                 threadOne = Thread.current
             }
@@ -93,7 +93,7 @@ class NIOThreadPoolTest: XCTestCase {
         completionGroup.enter()
         pool.submit { s in
             precondition(s == .active)
-            lock.withLockVoid {
+            lock.withLock { () -> Void in
                 XCTAssertEqual(threadTwo, nil)
                 threadTwo = Thread.current
             }
@@ -102,7 +102,7 @@ class NIOThreadPoolTest: XCTestCase {
 
         completionGroup.wait()
 
-        lock.withLockVoid {
+        lock.withLock { () -> Void in
             XCTAssertNotNil(threadOne)
             XCTAssertNotNil(threadTwo)
             XCTAssertEqual(threadOne, threadTwo)

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -496,7 +496,7 @@ func forEachActiveChannelType<T>(file: StaticString = #file,
     }
     let channelEL = group.next()
 
-    let lock = Lock()
+    let lock = NIOLock()
     var ret: [T] = []
     _ = try forEachCrossConnectedStreamChannelPair(file: (file), line: line) { (chan1: Channel, chan2: Channel) throws -> Void in
         var innerRet: [T] = [try body(chan1)]
@@ -692,7 +692,7 @@ extension EventLoopFuture {
             }
             return fulfilled
         } else {
-            let lock = Lock()
+            let lock = NIOLock()
             let group = DispatchGroup()
             var fulfilled = false // protected by lock
 

--- a/Tests/NIOPosixTests/ThreadTest.swift
+++ b/Tests/NIOPosixTests/ThreadTest.swift
@@ -260,7 +260,7 @@ class ThreadTest: XCTestCase {
             }
         }
         var globalTSVs: [ThreadSpecificVariable<SomeClass>] = []
-        let globalTSVLock = Lock()
+        let globalTSVLock = NIOLock()
         ({
             let tsv = ThreadSpecificVariable<SomeClass>()
             globalTSVLock.withLock {


### PR DESCRIPTION
### Motivation:

It's silly that we allocate _twice_ for each `Lock` because we should just tail-allocate the `pthread_mutex_t`. Unfortunately, that's impossible without changing the API for the worse (`Lock.makeLock()` or something weird and no options left for the existing `Lock.init()`).

Also `Lock` is a type that can very easily clash with another library.

### Modifications:

- deprecate `Lock`
- introduce `public struct NIOLock` (backed by a `class Storage` for now)

### Result:

- We can file a subsequent issue (easy to implement) which will tail-allocate the `pthread_mutex_t` and we can cut in half all `NIOLock` allocations.