### PR TITLE
Fixup docs for the `NIOAsyncWriter`

### DIFF
--- a/Sources/NIOConcurrencyHelpers/LockedValue.swift
+++ b/Sources/NIOConcurrencyHelpers/LockedValue.swift
@@ -14,7 +14,7 @@
 
 /// Provides locked access to `Value`.
 ///
-/// - note: ``NIOLockedValueBox`` has reference semantics and holds the ``Value``
+/// - note: ``NIOLockedValueBox`` has reference semantics and holds the `Value`
 ///         alongside a lock behind a reference.
 ///
 /// This is no different than creating a ``Lock`` and protecting all


### PR DESCRIPTION
# Motivation
We went through a lot of changes for the API of the `NIOAsyncWriter` and some doc comments suffered from this.

# Modification
Update doc comments for the `NIOAsyncWriter`.

Small fixup for the docs of the `NIOLockedValueBox`

# Result
More accurate docs.
