### PR TITLE
Move ISSUE_TEMPLATE.md to ISSUE_TEMPLATE/bug-report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,3 +1,8 @@
+---
+name: Bug Report
+about: File a bug report to help us improve
+---
+
 ### Expected behavior
 _[what you expected to happen]_
 


### PR DESCRIPTION
Motivation:

If the "New issue" button is clicked on GitHub it takes you straight to the NIO bug report template. This makes it slightly too easy to accidentally file a security vulnerability in public.

Modifications:

Move the ISSUE_TEMPLATE.md to ISSUE_TEMPLATE/bug-report.md, doing so means the "New issue" will take users to a page where they can select from filing a bug report or reporting a security vulnerability.

Result:

It's clearer when filing an issue that security vulnerabilities are handled differently.