### PR TITLE
Add `withLockVoid(_:)` to `NIOLock`

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -140,6 +140,12 @@ extension NIOLock {
         }
         return try body()
     }
+
+    // specialise Void return (for performance)
+    @inlinable
+    public func withLockVoid(_ body: () throws -> Void) rethrows -> Void {
+        try self.withLock(body)
+    }
 }
 
 #if compiler(>=5.5) && canImport(_Concurrency)


### PR DESCRIPTION
### Motivation:

`Lock` has recently been deprecated in favor of `NIOLock`.
The warnings claim that this is supposed to be a mere rename, but the API of `NIOLock` misses `withLockVoid(_:)` compared to `Lock`, which is unexpected to some users.

### Modifications:

`NIOLock` now has the `withLockVoid(_:)` too.

### Result:

`Lock` and `NIOLock` will have a more similar API and users can move to `NIOLock` easier.
This will also resolve https://github.com/apple/swift-nio/issues/2275.