### PR TITLE
Correctly manage Content-Length on HEAD responses

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -113,6 +113,9 @@ private class BetterHTTPParser {
         }
         self.settings.pointee.on_message_complete = { opaque in
             BetterHTTPParser.fromOpaque(opaque).didReceiveMessageCompleteNotification()
+            // Temporary workaround for https://github.com/nodejs/llhttp/issues/202, should be removed
+            // when that issue is fixed.
+            opaque?.pointee.content_length = 0
             return 0
         }
         self.withExclusiveHTTPParser { parserPtr in

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -114,7 +114,7 @@ private class BetterHTTPParser {
         self.settings.pointee.on_message_complete = { opaque in
             BetterHTTPParser.fromOpaque(opaque).didReceiveMessageCompleteNotification()
             // Temporary workaround for https://github.com/nodejs/llhttp/issues/202, should be removed
-            // when that issue is fixed.
+            // when that issue is fixed. We're tracking the work in https://github.com/apple/swift-nio/issues/2274.
             opaque?.pointee.content_length = 0
             return 0
         }

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -66,6 +66,8 @@ extension HTTPDecoderTest {
                 ("testDecodingInvalidTrailerFieldNames", testDecodingInvalidTrailerFieldNames),
                 ("testDecodingInvalidHeaderFieldValues", testDecodingInvalidHeaderFieldValues),
                 ("testDecodingInvalidTrailerFieldValues", testDecodingInvalidTrailerFieldValues),
+                ("testDecodeAfterHEADResponse", testDecodeAfterHEADResponse),
+                ("testDecodeAfterHEADResponseChunked", testDecodeAfterHEADResponseChunked),
            ]
    }
 }


### PR DESCRIPTION
Motivation

When we receive a HEAD response, it's possible that the response contains a content-length. llhttp has a bug
(https://github.com/nodejs/llhttp/issues/202) that prevents it from properly managing that issue, which causes us to incorrectly parse responses.

Modifications

Forcibly set llhttp's content-length value to 0.

Result

Correctly handle HTTP framing around llhttp's issues.
