### PR TITLE
Fixed compile errors on windows

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -75,7 +75,7 @@ public struct NIOLock {
         
         internal func unlock() {
 #if os(Windows)
-            ReleaseSRWLockExclusive(self._storage.mutex)
+            ReleaseSRWLockExclusive(self.mutex)
 #else
             let err = pthread_mutex_unlock(self.mutex)
             precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")

--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -221,7 +221,7 @@ public final class ConditionLock<T: Equatable> {
             }
 
             let dwWaitStart = timeGetTime()
-            if !SleepConditionVariableSRW(self.cond, self.mutex.mutex,
+            if !SleepConditionVariableSRW(self.cond, self.mutex._storage.mutex,
                                           dwMilliseconds, 0) {
                 let dwError = GetLastError()
                 if (dwError == ERROR_TIMEOUT) {


### PR DESCRIPTION
Fixed compile error that seems to be caused by https://github.com/apple/swift-nio/pull/2266/

### Motivation:

Fixed compilation errors on Windows.

### Modifications:

Fixed typos

### Result:

Devs should be able to compile on Windows
