### PR TITLE
Get NIO compiling with GM Xcode

### DIFF
--- a/Sources/_NIOBeta/TimeAmount+Duration.swift
+++ b/Sources/_NIOBeta/TimeAmount+Duration.swift
@@ -14,7 +14,7 @@
 
 import NIOCore
 
-#if swift(>=5.7)
+#if (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
 extension TimeAmount {
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     /// Creates a new `TimeAmount` for the given `Duration`, truncating and clamping if necessary.
@@ -55,4 +55,4 @@ internal extension Swift.Duration {
         return combinedNanos.partialValue
     }
 }
-#endif // swift(>=5.7)
+#endif // (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))

--- a/Tests/NIOBetaTests/TimeAmount+DurationTests.swift
+++ b/Tests/NIOBetaTests/TimeAmount+DurationTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 class TimeAmountDurationTests: XCTestCase {
     func testTimeAmountFromDurationConversion() throws {
-#if swift(>=5.7)
+#if (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
         guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
@@ -69,11 +69,11 @@ class TimeAmountDurationTests: XCTestCase {
             TimeAmount(Duration.nanoseconds(Int64.max) + .nanoseconds(1)),
             .nanoseconds(Int64.max)
         )
-#endif // swift(>=5.7)
+#endif // (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
     }
 
     func testTimeAmountToDurationLosslessRountTrip() throws {
-#if swift(>=5.7)
+#if (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
         guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
@@ -88,11 +88,11 @@ class TimeAmountDurationTests: XCTestCase {
         ] {
             XCTAssertEqual(TimeAmount(Duration(amount)), amount)
         }
-#endif // swift(>=5.7)
+#endif // (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
     }
 
     func testDurationToTimeAmountLossyRoundTrip() throws {
-#if swift(>=5.7)
+#if (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
         guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
@@ -118,6 +118,6 @@ class TimeAmountDurationTests: XCTestCase {
             let duration_ = Duration(TimeAmount(duration))
             XCTAssertEqual(duration_.nanosecondsClamped, duration.nanosecondsClamped)
         }
-#endif // swift(>=5.7)
+#endif // (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
     }
 }


### PR DESCRIPTION
Motivation

It's good if we compile with the GM Xcode.

Modifications

Guard Duration usability to at least Swift 5.7.1.

Result

NIO compiles on GM Xcode again.

Note that this is technically an API break for those using Xcode 14 Betas. As those users can (and should) update to 14.1 Beta, and we don't define API stability for Beta xcodes, this is acceptable.
Resolves #2279.
