### PR TITLE
Improve diagnostics for depracted `Lock`.

### DIFF
--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -88,10 +88,7 @@ public final class Lock {
         precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
 #endif
     }
-}
 
-@available(*, deprecated, renamed: "NIOLock")
-extension Lock {
     /// Acquire the lock for the duration of the given block.
     ///
     /// This convenience method should be preferred to `lock` and `unlock` in
@@ -294,7 +291,7 @@ internal func debugOnly(_ body: () -> Void) {
 }
 
 #if compiler(>=5.5) && canImport(_Concurrency)
-@available(*, deprecated, renamed: "NIOLock")
+@available(*, deprecated)
 extension Lock: Sendable {
 
 }


### PR DESCRIPTION
Improve diagnostics for depracted `Lock`.

### Motivation:

When using a `Lock` instance handed by another library and calling `withLock` or `withLockVoid` on it, the compiler will issue an incorrect fix-it warning that `withLock` (or `withLockVoid`) was renamed to `NIOLock` and by applying it will incorrectly change the method signature to `NIOLock`.

For example when using [Vapor](https://www.vapor.codes), there is a property called `locks` on Vapor's `Application` class. Vapors hands out locks to users here. However, creating these locks isn't done by the users of Vapor, but by Vapor itself. Thus, users cannot fix the deprecation themselves.

### Modifications:

The warning results from annotating the extension that adds `withLock` and `withLockVoid` with `@available(*, deprecated, renamed: "NIOLock")`. This removes the annotation and moves these two methods into the main declaration of `Lock`.

### Result:

The fix-it warning no longer appears when using `withLock` or `withLockVoid`.
