### PR TITLE
Backport: "Correctly manage Content-Length on HEAD responses (#2277)"

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -113,6 +113,9 @@ private class BetterHTTPParser {
         }
         self.settings.pointee.on_message_complete = { opaque in
             BetterHTTPParser.fromOpaque(opaque).didReceiveMessageCompleteNotification()
+            // Temporary workaround for https://github.com/nodejs/llhttp/issues/202, should be removed
+            // when that issue is fixed. We're tracking the work in https://github.com/apple/swift-nio/issues/2274.
+            opaque?.pointee.content_length = 0
             return 0
         }
         self.withExclusiveHTTPParser { parserPtr in

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -66,6 +66,8 @@ extension HTTPDecoderTest {
                 ("testDecodingInvalidTrailerFieldNames", testDecodingInvalidTrailerFieldNames),
                 ("testDecodingInvalidHeaderFieldValues", testDecodingInvalidHeaderFieldValues),
                 ("testDecodingInvalidTrailerFieldValues", testDecodingInvalidTrailerFieldValues),
+                ("testDecodeAfterHEADResponse", testDecodeAfterHEADResponse),
+                ("testDecodeAfterHEADResponseChunked", testDecodeAfterHEADResponseChunked),
            ]
    }
 }


### PR DESCRIPTION
This is a backport of the fix from #2277 to 2.42.