### PR TITLE
Mark types explicitly non sendable

### DIFF
--- a/Sources/NIOCore/FileRegion.swift
+++ b/Sources/NIOCore/FileRegion.swift
@@ -82,6 +82,11 @@ public struct FileRegion {
     }
 }
 
+#if swift(>=5.6)
+@available(*, unavailable)
+extension FileRegion: Sendable {}
+#endif
+
 extension FileRegion {
     /// Create a new `FileRegion` forming a complete file.
     ///

--- a/Sources/NIOCore/IOData.swift
+++ b/Sources/NIOCore/IOData.swift
@@ -30,6 +30,11 @@ public enum IOData {
 /// `IOData` objects are comparable just like the values they wrap.
 extension IOData: Equatable {}
 
+#if swift(>=5.6)
+@available(*, unavailable)
+extension IOData: Sendable {}
+#endif
+
 /// `IOData` provide a number of readable bytes.
 extension IOData {
     /// Returns the number of readable bytes in this `IOData`.

--- a/Sources/NIOCore/NIOAny.swift
+++ b/Sources/NIOCore/NIOAny.swift
@@ -257,6 +257,11 @@ public struct NIOAny {
     }
 }
 
+#if swift(>=5.6)
+@available(*, unavailable)
+extension NIOAny: Sendable {}
+#endif
+
 extension NIOAny: CustomStringConvertible {
     public var description: String {
         return "NIOAny { \(self.asAny()) }"


### PR DESCRIPTION
### Motivation:
If we do not mark types explicitly non sendable and users import `NIOCore` with `@preconcurrency` they will not get a warning. E.g. the following code compiles without warnings:
```swift
@preconcurrency import NIOCore
struct Foo: Sendable {
    var any: NIOAny
}
```

### Modifications:

Mark `FileRegion`, `IOData` and `NIOAny` as non-sendable.

### Result:

Users will get a warning if they use non-sendable types e.g.:
```
Stored property 'any' of 'Sendable'-conforming struct 'Foo' has non-sendable type 'NIOAny'
```
