### PR TITLE
Replace `NIOSendable` with `Sendable`

### DIFF
--- a/Sources/NIOCore/AddressedEnvelope.swift
+++ b/Sources/NIOCore/AddressedEnvelope.swift
@@ -35,7 +35,7 @@ public struct AddressedEnvelope<DataType> {
     }
     
     /// Any metadata associated with an `AddressedEnvelope`
-    public struct Metadata: Hashable, NIOSendable {
+    public struct Metadata: Hashable, Sendable {
         /// Details of any congestion state.
         public var ecnState: NIOExplicitCongestionNotificationState
         public var packetInfo: NIOPacketInfo?
@@ -62,10 +62,10 @@ extension AddressedEnvelope: Equatable where DataType: Equatable {}
 
 extension AddressedEnvelope: Hashable where DataType: Hashable {}
 
-extension AddressedEnvelope: NIOSendable where DataType: NIOSendable {}
+extension AddressedEnvelope: Sendable where DataType: Sendable {}
 
 /// Possible Explicit Congestion Notification States
-public enum NIOExplicitCongestionNotificationState: Hashable, NIOSendable {
+public enum NIOExplicitCongestionNotificationState: Hashable, Sendable {
     /// Non-ECN Capable Transport.
     case transportNotCapable
     /// ECN Capable Transport (flag 0).
@@ -76,7 +76,7 @@ public enum NIOExplicitCongestionNotificationState: Hashable, NIOSendable {
     case congestionExperienced
 }
 
-public struct NIOPacketInfo: Hashable, NIOSendable {
+public struct NIOPacketInfo: Hashable, Sendable {
     public var destinationAddress: SocketAddress
     public var interfaceIndex: Int
 

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -96,7 +96,7 @@ public enum NIOBSDSocket {
 
 extension NIOBSDSocket {
     /// Specifies the addressing scheme that the socket can use.
-    public struct AddressFamily: RawRepresentable, NIOSendable {
+    public struct AddressFamily: RawRepresentable, Sendable {
         public typealias RawValue = CInt
         public var rawValue: RawValue
         public init(rawValue: RawValue) {
@@ -113,7 +113,7 @@ extension NIOBSDSocket.AddressFamily: Hashable {
 
 extension NIOBSDSocket {
     /// Specifies the type of protocol that the socket can use.
-    public struct ProtocolFamily: RawRepresentable, NIOSendable {
+    public struct ProtocolFamily: RawRepresentable, Sendable {
         public typealias RawValue = CInt
         public var rawValue: RawValue
         public init(rawValue: RawValue) {
@@ -130,7 +130,7 @@ extension NIOBSDSocket.ProtocolFamily: Hashable {
 
 extension NIOBSDSocket {
     /// Defines socket option levels.
-    public struct OptionLevel: RawRepresentable, NIOSendable {
+    public struct OptionLevel: RawRepresentable, Sendable {
         public typealias RawValue = CInt
         public var rawValue: RawValue
         public init(rawValue: RawValue) {
@@ -147,7 +147,7 @@ extension NIOBSDSocket.OptionLevel: Hashable {
 
 extension NIOBSDSocket {
     /// Defines configuration option names.
-    public struct Option: RawRepresentable, NIOSendable {
+    public struct Option: RawRepresentable, Sendable {
         public typealias RawValue = CInt
         public var rawValue: RawValue
         public init(rawValue: RawValue) {

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -34,7 +34,7 @@ extension _ByteBufferSlice: Equatable {}
 /// 24 bits (the upper bound is still 32). Before constructing, you need to make sure the lower bound actually
 /// fits within 24 bits, otherwise the behaviour is undefined.
 @usableFromInline
-struct _ByteBufferSlice: NIOSendable {
+struct _ByteBufferSlice: Sendable {
     @usableFromInline private(set) var upperBound: ByteBuffer._Index
     @usableFromInline private(set) var _begin: _UInt24
     @inlinable var lowerBound: ByteBuffer._Index {
@@ -72,7 +72,7 @@ extension _ByteBufferSlice: CustomStringConvertible {
 /// `malloc`, `realloc` and `free`.
 ///
 /// - note: `ByteBufferAllocator` is thread-safe.
-public struct ByteBufferAllocator: NIOSendable {
+public struct ByteBufferAllocator: Sendable {
 
     /// Create a fresh `ByteBufferAllocator`. In the future the allocator might use for example allocation pools and
     /// therefore it's recommended to reuse `ByteBufferAllocators` where possible instead of creating fresh ones in

--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -159,7 +159,7 @@ extension UInt32 {
 
 /// Endianness refers to the sequential order in which bytes are arranged into larger numerical values when stored in
 /// memory or when transmitted over digital links.
-public enum Endianness: NIOSendable {
+public enum Endianness: Sendable {
     /// The endianness of the machine running this program.
     public static let host: Endianness = hostEndianness0()
 

--- a/Sources/NIOCore/ByteBuffer-views.swift
+++ b/Sources/NIOCore/ByteBuffer-views.swift
@@ -16,7 +16,7 @@
 ///
 /// A `ByteBufferView` is useful whenever a `Collection where Element == UInt8` representing a portion of a
 /// `ByteBuffer` is needed.
-public struct ByteBufferView: RandomAccessCollection, NIOSendable {
+public struct ByteBufferView: RandomAccessCollection, Sendable {
     public typealias Element = UInt8
     public typealias Index = Int
     public typealias SubSequence = ByteBufferView

--- a/Sources/NIOCore/Channel.swift
+++ b/Sources/NIOCore/Channel.swift
@@ -398,7 +398,7 @@ public enum DatagramChannelError {
 }
 
 /// An `Channel` related event that is passed through the `ChannelPipeline` to notify the user.
-public enum ChannelEvent: Equatable, NIOSendable {
+public enum ChannelEvent: Equatable, Sendable {
     /// `ChannelOptions.allowRemoteHalfClosure` is `true` and input portion of the `Channel` was closed.
     case inputClosed
     /// Output portion of the `Channel` was closed.
@@ -410,7 +410,7 @@ public enum ChannelEvent: Equatable, NIOSendable {
 /// The action(s) that should be taken after receiving this event are both application and protocol dependent. If the
 /// protocol supports a notion of requests and responses, it might make sense to stop accepting new requests but finish
 /// processing the request currently in flight.
-public struct ChannelShouldQuiesceEvent: NIOSendable {
+public struct ChannelShouldQuiesceEvent: Sendable {
     public init() {
     }
 }

--- a/Sources/NIOCore/ChannelHandlers.swift
+++ b/Sources/NIOCore/ChannelHandlers.swift
@@ -170,7 +170,7 @@ public final class IdleStateHandler: ChannelDuplexHandler, RemovableChannelHandl
     public typealias OutboundOut = NIOAny
 
     ///A user event triggered by IdleStateHandler when a Channel is idle.
-    public enum IdleStateEvent: NIOSendable {
+    public enum IdleStateEvent: Sendable {
         /// Will be triggered when no write was performed for the specified amount of time
         case write
         /// Will be triggered when no read was performed for the specified amount of time

--- a/Sources/NIOCore/ChannelInvoker.swift
+++ b/Sources/NIOCore/ChannelInvoker.swift
@@ -231,7 +231,7 @@ public protocol ChannelInboundInvoker {
 public protocol ChannelInvoker: ChannelOutboundInvoker, ChannelInboundInvoker { }
 
 /// Specify what kind of close operation is requested.
-public enum CloseMode: NIOSendable {
+public enum CloseMode: Sendable {
     /// Close the output (writing) side of the `Channel` without closing the actual file descriptor.
     /// This is an optional mode which means it may not be supported by all `Channel` implementations.
     case output

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -69,7 +69,7 @@ extension ChannelOptions {
         /// `SocketOption` allows users to specify configuration settings that are directly applied to the underlying socket file descriptor.
         ///
         /// Valid options are typically found in the various man pages like `man 4 tcp`.
-        public struct SocketOption: ChannelOption, Equatable, NIOSendable {
+        public struct SocketOption: ChannelOption, Equatable, Sendable {
             public typealias Value = (SocketOptionValue)
 
             public var optionLevel: NIOBSDSocket.OptionLevel
@@ -116,14 +116,14 @@ extension ChannelOptions {
         }
 
         /// `AllocatorOption` allows to specify the `ByteBufferAllocator` to use.
-        public struct AllocatorOption: ChannelOption, NIOSendable {
+        public struct AllocatorOption: ChannelOption, Sendable {
             public typealias Value = ByteBufferAllocator
 
             public init() {}
         }
 
         /// `RecvAllocatorOption` allows users to specify the `RecvByteBufferAllocator` to use.
-        public struct RecvAllocatorOption: ChannelOption, NIOSendable {
+        public struct RecvAllocatorOption: ChannelOption, Sendable {
             public typealias Value = RecvByteBufferAllocator
 
             public init() {}
@@ -131,7 +131,7 @@ extension ChannelOptions {
 
         /// `AutoReadOption` allows users to configure if a `Channel` should automatically call `Channel.read` again once all data was read from the transport or
         /// if the user is responsible to call `Channel.read` manually.
-        public struct AutoReadOption: ChannelOption, NIOSendable {
+        public struct AutoReadOption: ChannelOption, Sendable {
             public typealias Value = Bool
 
             public init() {}
@@ -140,7 +140,7 @@ extension ChannelOptions {
         /// `WriteSpinOption` allows users to configure the number of repetitions of a only partially successful write call before considering the `Channel` not writable.
         /// Setting this option to `0` means that we only issue one write call and if that call does not write all the bytes,
         /// we consider the `Channel` not writable.
-        public struct WriteSpinOption: ChannelOption, NIOSendable {
+        public struct WriteSpinOption: ChannelOption, Sendable {
             public typealias Value = UInt
 
             public init() {}
@@ -148,14 +148,14 @@ extension ChannelOptions {
 
         /// `MaxMessagesPerReadOption` allows users to configure the maximum number of read calls to the underlying transport are performed before wait again until
         /// there is more to read and be notified.
-        public struct MaxMessagesPerReadOption: ChannelOption, NIOSendable {
+        public struct MaxMessagesPerReadOption: ChannelOption, Sendable {
             public typealias Value = UInt
 
             public init() {}
         }
 
         /// `BacklogOption` allows users to configure the `backlog` value as specified in `man 2 listen`. This is only useful for `ServerSocketChannel`s.
-        public struct BacklogOption: ChannelOption, NIOSendable {
+        public struct BacklogOption: ChannelOption, Sendable {
             public typealias Value = Int32
 
             public init() {}
@@ -185,20 +185,20 @@ extension ChannelOptions {
         /// On all other platforms, setting it has no effect.
         ///
         /// Set this option to 0 to disable vector reads and to use serial reads instead.
-        public struct DatagramVectorReadMessageCountOption: ChannelOption, NIOSendable {
+        public struct DatagramVectorReadMessageCountOption: ChannelOption, Sendable {
             public typealias Value = Int
 
             public init() { }
         }
         
         /// When set to true IP level ECN information will be reported through `AddressedEnvelope.Metadata`
-        public struct ExplicitCongestionNotificationsOption: ChannelOption, NIOSendable {
+        public struct ExplicitCongestionNotificationsOption: ChannelOption, Sendable {
             public typealias Value = Bool
             public init() {}
         }
 
         /// The watermark used to detect when `Channel.isWritable` returns `true` or `false`.
-        public struct WriteBufferWaterMark: NIOSendable {
+        public struct WriteBufferWaterMark: Sendable {
             /// The low mark setting for a `Channel`.
             ///
             /// When the amount of buffered bytes in the `Channel`s outbound buffer drops below this value the `Channel` will be
@@ -231,7 +231,7 @@ extension ChannelOptions {
         /// `Channel.isWritable` will return `false`. Once we were able to write some data out of the outbound buffer and the amount of bytes queued
         /// falls below `WriteBufferWaterMark.low` the `Channel` will become writable again. Once this happens `Channel.writable` will return
         /// `true` again. These writability changes are also propagated through the `ChannelPipeline` and so can be intercepted via `ChannelInboundHandler.channelWritabilityChanged`.
-        public struct WriteBufferWaterMarkOption: ChannelOption, NIOSendable {
+        public struct WriteBufferWaterMarkOption: ChannelOption, Sendable {
             public typealias Value = WriteBufferWaterMark
 
             public init() {}
@@ -239,7 +239,7 @@ extension ChannelOptions {
 
         /// `ConnectTimeoutOption` allows users to configure the `TimeAmount` after which a connect will fail if it was not established in the meantime. May be
         /// `nil`, in which case the connection attempt will never time out.
-        public struct ConnectTimeoutOption: ChannelOption, NIOSendable {
+        public struct ConnectTimeoutOption: ChannelOption, Sendable {
             public typealias Value = TimeAmount?
 
             public init() {}
@@ -250,14 +250,14 @@ extension ChannelOptions {
         /// will be closed automatically if the remote peer shuts down its send stream. If set to true, the `Channel` will
         /// not be closed: instead, a `ChannelEvent.inboundClosed` user event will be sent on the `ChannelPipeline`,
         /// and no more data will be received.
-        public struct AllowRemoteHalfClosureOption: ChannelOption, NIOSendable {
+        public struct AllowRemoteHalfClosureOption: ChannelOption, Sendable {
             public typealias Value = Bool
 
             public init() {}
         }
 
         /// When set to true IP level Packet Info information will be reported through `AddressedEnvelope.Metadata` for UDP packets.
-        public struct ReceivePacketInfo: ChannelOption, NIOSendable {
+        public struct ReceivePacketInfo: ChannelOption, Sendable {
             public typealias Value = Bool
             public init() {}
         }

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -1862,7 +1862,7 @@ extension ChannelHandlerContext {
     /// A `RemovalToken` is handed to a `RemovableChannelHandler` when its `removeHandler` function is invoked. A
     /// `RemovableChannelHandler` is then required to remove itself from the `ChannelPipeline`. The removal process
     /// is finalized by handing the `RemovalToken` to the `ChannelHandlerContext.leavePipeline` function.
-    public struct RemovalToken: NIOSendable {
+    public struct RemovalToken: Sendable {
         internal let promise: EventLoopPromise<Void>?
     }
 

--- a/Sources/NIOCore/CircularBuffer.swift
+++ b/Sources/NIOCore/CircularBuffer.swift
@@ -62,7 +62,7 @@ public struct CircularBuffer<Element>: CustomStringConvertible {
     ///
     /// - note: Every index is invalidated as soon as you perform a length-changing operating on the `CircularBuffer`
     ///         but remains valid when you replace one item by another using the subscript.
-    public struct Index: Comparable, NIOSendable {
+    public struct Index: Comparable, Sendable {
         @usableFromInline private(set) var _backingIndex: UInt32
         @usableFromInline private(set) var _backingCheck: _UInt24
         @usableFromInline private(set) var isIndexGEQHeadIndex: Bool
@@ -825,7 +825,7 @@ extension CircularBuffer: Hashable where Element: Hashable {
     }
 }
 
-extension CircularBuffer: NIOSendable where Element: NIOSendable {}
+extension CircularBuffer: Sendable where Element: Sendable {}
 
 extension CircularBuffer: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: Element...) {

--- a/Sources/NIOCore/Codec.swift
+++ b/Sources/NIOCore/Codec.swift
@@ -14,7 +14,7 @@
 
 
 /// State of the current decoding process.
-public enum DecodingState: NIOSendable {
+public enum DecodingState: Sendable {
     /// Continue decoding.
     case `continue`
 

--- a/Sources/NIOCore/ConvenienceOptionSupport.swift
+++ b/Sources/NIOCore/ConvenienceOptionSupport.swift
@@ -82,7 +82,7 @@ extension ChannelOptions.Types.ConvenienceOptionValue where ValueType == () {
 // MARK: TCP - data
 extension ChannelOptions {
     /// A TCP channel option which can be applied to a bootstrap using convenience notation.
-    public struct TCPConvenienceOption: Hashable, NIOSendable {
+    public struct TCPConvenienceOption: Hashable, Sendable {
         fileprivate var data: ConvenienceOption
         
         private init(_ data: ConvenienceOption) {
@@ -116,7 +116,7 @@ extension ChannelOptions.TCPConvenienceOption {
 
 extension ChannelOptions {
     /// A set of `TCPConvenienceOption`s
-    public struct TCPConvenienceOptions: ExpressibleByArrayLiteral, Hashable, NIOSendable {
+    public struct TCPConvenienceOptions: ExpressibleByArrayLiteral, Hashable, Sendable {
         var allowLocalEndpointReuse = false
         var disableAutoRead = false
         var allowRemoteHalfClosure = false

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -420,7 +420,7 @@ extension EventLoopGroup {
 /// Represents a time _interval_.
 ///
 /// - note: `TimeAmount` should not be used to represent a point in time.
-public struct TimeAmount: Hashable, NIOSendable {
+public struct TimeAmount: Hashable, Sendable {
     @available(*, deprecated, message: "This typealias doesn't serve any purpose. Please use Int64 directly.")
     public typealias Value = Int64
 
@@ -540,7 +540,7 @@ extension TimeAmount: AdditiveArithmetic {
 /// ```
 ///
 /// - note: `NIODeadline` should not be used to represent a time interval
-public struct NIODeadline: Equatable, Hashable, NIOSendable {
+public struct NIODeadline: Equatable, Hashable, Sendable {
     @available(*, deprecated, message: "This typealias doesn't serve any purpose, please use UInt64 directly.")
     public typealias Value = UInt64
 

--- a/Sources/NIOCore/EventLoopFuture.swift
+++ b/Sources/NIOCore/EventLoopFuture.swift
@@ -2165,7 +2165,7 @@ extension EventLoopFuture {
 /// This is used only when attempting to provide high-fidelity diagnostics of leaked
 /// `EventLoopFuture`s. It is entirely opaque and can only be stored in a simple
 /// tracking data structure.
-public struct _NIOEventLoopFutureIdentifier: Hashable, NIOSendable {
+public struct _NIOEventLoopFutureIdentifier: Hashable, Sendable {
     private var opaqueID: UInt
 
     @usableFromInline
@@ -2184,9 +2184,9 @@ public struct _NIOEventLoopFutureIdentifier: Hashable, NIOSendable {
 }
 
 // EventLoopPromise is a reference type, but by its very nature is Sendable.
-extension EventLoopPromise: NIOSendable { }
+extension EventLoopPromise: Sendable { }
 
 // EventLoopFuture is a reference type, but it is Sendable. However, we enforce
 // that by way of the guarantees of the EventLoop protocol, so the compiler cannot
 // check it.
-extension EventLoopFuture: @unchecked NIOSendable { }
+extension EventLoopFuture: @unchecked Sendable { }

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -95,7 +95,7 @@ public final class NIOFileHandle: FileDescriptor {
 
 extension NIOFileHandle {
     /// `Mode` represents file access modes.
-    public struct Mode: OptionSet, NIOSendable {
+    public struct Mode: OptionSet, Sendable {
         public let rawValue: UInt8
 
         public init(rawValue: UInt8) {
@@ -122,7 +122,7 @@ extension NIOFileHandle {
     }
 
     /// `Flags` allows to specify additional flags to `Mode`, such as permission for file creation.
-    public struct Flags: NIOSendable {
+    public struct Flags: Sendable {
         internal var posixMode: NIOPOSIXFileMode
         internal var posixFlags: CInt
 

--- a/Sources/NIOCore/IntegerTypes.swift
+++ b/Sources/NIOCore/IntegerTypes.swift
@@ -18,7 +18,7 @@
 
 /// A 24-bit unsigned integer value type.
 @usableFromInline
-struct _UInt24: NIOSendable {
+struct _UInt24: Sendable {
     @usableFromInline var _backing: (UInt16, UInt8)
 
     @inlinable
@@ -68,7 +68,7 @@ extension _UInt24: CustomStringConvertible {
 // MARK: _UInt56
 
 /// A 56-bit unsigned integer value type.
-struct _UInt56: NIOSendable {
+struct _UInt56: Sendable {
     @usableFromInline var _backing: (UInt32, UInt16, UInt8)
 
     @inlinable init(_ value: UInt64) {

--- a/Sources/NIOCore/MarkedCircularBuffer.swift
+++ b/Sources/NIOCore/MarkedCircularBuffer.swift
@@ -191,4 +191,4 @@ extension MarkedCircularBuffer: RandomAccessCollection {
 
 }
 
-extension MarkedCircularBuffer: NIOSendable where Element: NIOSendable {}
+extension MarkedCircularBuffer: Sendable where Element: Sendable {}

--- a/Sources/NIOCore/NIOCloseOnErrorHandler.swift
+++ b/Sources/NIOCore/NIOCloseOnErrorHandler.swift
@@ -14,7 +14,7 @@
 
 
 /// A `ChannelInboundHandler` that closes the channel when an error is caught
-public final class NIOCloseOnErrorHandler: ChannelInboundHandler, NIOSendable {
+public final class NIOCloseOnErrorHandler: ChannelInboundHandler, Sendable {
 
     public typealias InboundIn = NIOAny
     

--- a/Sources/NIOCore/NIOSendable.swift
+++ b/Sources/NIOCore/NIOSendable.swift
@@ -12,11 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5) && canImport(_Concurrency)
+@available(*, deprecated, renamed: "Sendable")
 public typealias NIOSendable = Swift.Sendable
-#else
-public typealias NIOSendable = Any
-#endif
 
 #if swift(>=5.6)
 @preconcurrency public protocol NIOPreconcurrencySendable: Sendable {}

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -72,7 +72,7 @@ extension SocketAddressError {
 }
 
 /// Represent a socket address to which we may want to connect or bind.
-public enum SocketAddress: CustomStringConvertible, NIOSendable {
+public enum SocketAddress: CustomStringConvertible, Sendable {
 
     /// A single IPv4 address for `SocketAddress`.
     public struct IPv4Address {
@@ -105,7 +105,7 @@ public enum SocketAddress: CustomStringConvertible, NIOSendable {
     }
 
     /// A single Unix socket address for `SocketAddress`.
-    public struct UnixSocketAddress: NIOSendable {
+    public struct UnixSocketAddress: Sendable {
         private let _storage: Box<sockaddr_un>
 
         /// The libc socket address for a Unix Domain Socket.

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -52,7 +52,7 @@ final class Box<T> {
     init(_ value: T) { self.value = value }
 }
 
-extension Box: NIOSendable where T: NIOSendable {}
+extension Box: Sendable where T: Sendable {}
 
 public enum System {
     /// A utility function that returns an estimate of the number of *logical* cores

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -39,7 +39,7 @@ public enum ByteBufferFoundationError: Error {
 
 extension ByteBuffer {
     /// Controls how bytes are transferred between `ByteBuffer` and other storage types.
-    public enum ByteTransferStrategy: NIOSendable {
+    public enum ByteTransferStrategy: Sendable {
         /// Force a copy of the bytes.
         case copy
 

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -479,7 +479,7 @@ public typealias HTTPResponseDecoder = HTTPDecoder<HTTPClientResponsePart, HTTPC
 /// Rather than set this up manually, consider using `ChannelPipeline.configureHTTPServerPipeline`.
 public typealias HTTPRequestDecoder = HTTPDecoder<HTTPServerRequestPart, HTTPServerResponsePart>
 
-public enum HTTPDecoderKind: NIOSendable {
+public enum HTTPDecoderKind: Sendable {
     case request
     case response
 }
@@ -750,7 +750,7 @@ extension HTTPDecoder: Sendable {}
 #endif
 
 /// Strategy to use when a HTTPDecoder is removed from a pipeline after a HTTP upgrade was detected.
-public enum RemoveAfterUpgradeStrategy: NIOSendable {
+public enum RemoveAfterUpgradeStrategy: Sendable {
     /// Forward all the remaining bytes that are currently buffered in the deccoder to the next handler in the pipeline.
     case forwardBytes
     /// Fires a `ByteToMessageDecoder.leftoverDataWhenDone` error through the pipeline
@@ -760,7 +760,7 @@ public enum RemoveAfterUpgradeStrategy: NIOSendable {
 }
 
 /// Strategy to use when a HTTPDecoder receives an informational HTTP response (1xx except 101)
-public struct NIOInformationalResponseStrategy: Hashable, NIOSendable {
+public struct NIOInformationalResponseStrategy: Hashable, Sendable {
     enum Base {
         case drop
         case forward

--- a/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
@@ -19,7 +19,7 @@ public enum HTTPServerUpgradeErrors: Error {
 }
 
 /// User events that may be fired by the `HTTPServerProtocolUpgrader`.
-public enum HTTPServerUpgradeEvents: NIOSendable {
+public enum HTTPServerUpgradeEvents: Sendable {
     /// Fired when HTTP upgrade has completed and the
     /// `HTTPServerProtocolUpgrader` is about to remove itself from the
     /// `ChannelPipeline`.

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -609,7 +609,7 @@ extension HTTPHeaders: Equatable {
     }
 }
 
-public enum HTTPMethod: Equatable, NIOSendable {
+public enum HTTPMethod: Equatable, Sendable {
     internal enum HasBody {
         case yes
         case no
@@ -668,7 +668,7 @@ public enum HTTPMethod: Equatable, NIOSendable {
 }
 
 /// A structure representing a HTTP version.
-public struct HTTPVersion: Equatable, NIOSendable {
+public struct HTTPVersion: Equatable, Sendable {
     /// Create a HTTP version.
     ///
     /// - Parameter major: The major version number.
@@ -1074,7 +1074,7 @@ extension HTTPResponseStatus {
 }
 
 /// A HTTP response status code.
-public enum HTTPResponseStatus: NIOSendable {
+public enum HTTPResponseStatus: Sendable {
     /* use custom if you want to use a non-standard response code or
      have it available in a (UInt, String) pair from a higher-level web framework. */
     case custom(code: UInt, reasonPhrase: String)

--- a/Sources/NIOHTTP1/NIOHTTPObjectAggregator.swift
+++ b/Sources/NIOHTTP1/NIOHTTPObjectAggregator.swift
@@ -17,7 +17,7 @@ import NIOCore
 ///
 /// A full HTTP request is made up of a response header encoded by `.head`
 /// and an optional `.body`.
-public struct NIOHTTPServerRequestFull: NIOSendable {
+public struct NIOHTTPServerRequestFull: Sendable {
     public var head: HTTPRequestHead
     public var body: ByteBuffer?
 
@@ -33,7 +33,7 @@ extension NIOHTTPServerRequestFull: Equatable {}
 ///
 /// A full HTTP response is made up of a response header encoded by `.head`
 /// and an optional `.body`.
-public struct NIOHTTPClientResponseFull: NIOSendable {
+public struct NIOHTTPClientResponseFull: Sendable {
     public var head: HTTPResponseHead
     public var body: ByteBuffer?
 
@@ -69,7 +69,7 @@ public struct NIOHTTPObjectAggregatorError: Error, Equatable {
     public static let unexpectedMessageEnd = NIOHTTPObjectAggregatorError(base: .unexpectedMessageEnd)
 }
 
-public struct NIOHTTPObjectAggregatorEvent: Hashable, NIOSendable {
+public struct NIOHTTPObjectAggregatorEvent: Hashable, Sendable {
     private enum Base {
         case httpExpectationFailed
         case httpFrameTooLong

--- a/Sources/NIOPosix/HappyEyeballs.swift
+++ b/Sources/NIOPosix/HappyEyeballs.swift
@@ -38,7 +38,7 @@ private extension Array where Element == EventLoopFuture<Channel> {
 }
 
 /// An error that occurred during connection to a given target.
-public struct SingleConnectionFailure: NIOSendable {
+public struct SingleConnectionFailure: Sendable {
     /// The target we were trying to connect to when we encountered the error.
     public let target: SocketAddress
 

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -42,7 +42,7 @@ public enum NIOThreadPoolError {
 public final class NIOThreadPool {
 
     /// The state of the `WorkItem`.
-    public enum WorkItemState: NIOSendable {
+    public enum WorkItemState: Sendable {
         /// The `WorkItem` is active now and in process by the `NIOThreadPool`.
         case active
         /// The `WorkItem` was cancelled and will not be processed by the `NIOThreadPool`.

--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -28,7 +28,7 @@ import NIOConcurrencyHelpers
 /// `NonBlockingFileIO` helps to work around this issue by maintaining its own thread pool that is used to read the data
 /// from the files into memory. It will then hand the (in-memory) data back which makes it available without the possibility
 /// of blocking.
-public struct NonBlockingFileIO: NIOSendable {
+public struct NonBlockingFileIO: Sendable {
     /// The default and recommended size for `NonBlockingFileIO`'s thread pool.
     public static let defaultThreadPoolSize = 2
 

--- a/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
@@ -26,7 +26,7 @@ import NIOCore
 ///
 /// Exactly what to do when falling back is the responsibility of a specific
 /// implementation.
-public enum ALPNResult: Equatable, NIOSendable {
+public enum ALPNResult: Equatable, Sendable {
     /// ALPN negotiation succeeded. The associated value is the ALPN token that
     /// was negotiated.
     case negotiated(String)

--- a/Sources/NIOTLS/SNIHandler.swift
+++ b/Sources/NIOTLS/SNIHandler.swift
@@ -33,7 +33,7 @@ private let sniHostNameType: UInt8 = 0
 /// contains the hostname received in the SNI extension. If `fallback`,
 /// then either we could not parse the SNI extension or it was not there
 /// at all.
-public enum SNIResult: Equatable, NIOSendable {
+public enum SNIResult: Equatable, Sendable {
     case fallback
     case hostname(String)
 }

--- a/Sources/NIOTLS/TLSEvents.swift
+++ b/Sources/NIOTLS/TLSEvents.swift
@@ -15,7 +15,7 @@
 import NIOCore
 
 /// Common user events sent by all TLS implementations.
-public enum TLSUserEvent: Equatable, NIOSendable {
+public enum TLSUserEvent: Equatable, Sendable {
     /// The TLS handshake has completed. If ALPN or NPN were used,
     /// the negotiated protocol is provided as `negotiatedProtocol`.
     case handshakeCompleted(negotiatedProtocol: String?)

--- a/Sources/NIOTestUtils/EventCounterHandler.swift
+++ b/Sources/NIOTestUtils/EventCounterHandler.swift
@@ -372,7 +372,7 @@ extension EventCounterHandler: ChannelDuplexHandler {
 
 #if compiler(>=5.6) && canImport(_Concurrency)
 // This is a workaround before ManagedAtomic gets Sendable conformance. Once the support
-// is ready, we should remove '@preconcurrency import' and declare NIOSendable directly.
+// is ready, we should remove '@preconcurrency import' and declare Sendable directly.
 extension EventCounterHandler: Sendable {
 
 }

--- a/Sources/NIOWebSocket/WebSocketErrorCodes.swift
+++ b/Sources/NIOWebSocket/WebSocketErrorCodes.swift
@@ -19,7 +19,7 @@ import NIOCore
 /// This enum provides names to all non-reserved code numbers,
 /// to avoid users needing to remember the specific numerical values
 /// of those codes.
-public enum WebSocketErrorCode: NIOSendable {
+public enum WebSocketErrorCode: Sendable {
     /// Indicates a normal closure, meaning that the purpose for
     /// which the connection was established has been fulfilled.
     /// Corresponds to code 1000.

--- a/Sources/NIOWebSocket/WebSocketFrame.swift
+++ b/Sources/NIOWebSocket/WebSocketFrame.swift
@@ -34,7 +34,7 @@ private extension UInt8 {
 /// predictable binary sequences into websocket data streams. This structure provides
 /// a more convenient method of interacting with a masking key than simply by passing
 /// around a four-tuple.
-public struct WebSocketMaskingKey: NIOSendable {
+public struct WebSocketMaskingKey: Sendable {
     @usableFromInline internal let _key: (UInt8, UInt8, UInt8, UInt8)
 
     public init?<T: Collection>(_ buffer: T) where T.Element == UInt8 {

--- a/Sources/NIOWebSocket/WebSocketOpcode.swift
+++ b/Sources/NIOWebSocket/WebSocketOpcode.swift
@@ -15,7 +15,7 @@
 import NIOCore
 
 /// An operation code for a websocket frame.
-public struct WebSocketOpcode: NIOSendable {
+public struct WebSocketOpcode: Sendable {
     fileprivate let networkRepresentation: UInt8
 
     public static let continuation = WebSocketOpcode(rawValue: 0x0)


### PR DESCRIPTION
We now require Swift 5.5.2 which includes `Sendable` so we no longer require the `NIOSendable` workaround.
`NIOSendable` is just a `typealias` of `Sendable` so this is a non source breaking change.

We have already replaced the usages of `NIOSendable` in all of our packages and we can now deprecate `NIOSendable` altogether.