### PR TITLE
Add support for removing channel options

### DIFF
--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -190,7 +190,7 @@ extension ChannelOptions {
 
             public init() { }
         }
-        
+
         /// When set to true IP level ECN information will be reported through `AddressedEnvelope.Metadata`
         public struct ExplicitCongestionNotificationsOption: ChannelOption, Sendable {
             public typealias Value = Bool
@@ -311,7 +311,7 @@ public struct ChannelOptions {
 
     /// - seealso: `DatagramVectorReadMessageCountOption`
     public static let datagramVectorReadMessageCount = Types.DatagramVectorReadMessageCountOption()
-    
+
     /// - seealso: `ExplicitCongestionNotificationsOption`
     public static let explicitCongestionNotification = Types.ExplicitCongestionNotificationsOption()
 
@@ -382,6 +382,20 @@ extension ChannelOptions {
             applyNext()
 
             return applyPromise.futureResult
+        }
+
+        /// Remove all options with the given `key`.
+        ///
+        /// Calling this function has the effect of removing all instances of a ``ChannelOption``
+        /// from the ``ChannelOptions/Storage``, as if none had been added. This is useful in rare
+        /// cases where a bootstrap knows that some configuration must purge options of a certain kind.
+        ///
+        /// - parameters:
+        ///     - key: The ``ChannelOption`` to remove.
+        public mutating func remove<Option: ChannelOption>(key: Option) {
+            self._storage.removeAll(where: { existingKey, _ in
+                (existingKey as? Option) == key
+            })
         }
     }
 }

--- a/Tests/NIOCoreTests/ChannelOptionStorageTest+XCTest.swift
+++ b/Tests/NIOCoreTests/ChannelOptionStorageTest+XCTest.swift
@@ -31,6 +31,7 @@ extension ChannelOptionStorageTest {
                 ("testSetTwoOptionsOfDifferentType", testSetTwoOptionsOfDifferentType),
                 ("testSetTwoOptionsOfSameType", testSetTwoOptionsOfSameType),
                 ("testSetOneOptionTwice", testSetOneOptionTwice),
+                ("testClearingOptions", testClearingOptions),
            ]
    }
 }

--- a/Tests/NIOCoreTests/ChannelOptionStorageTest.swift
+++ b/Tests/NIOCoreTests/ChannelOptionStorageTest.swift
@@ -69,6 +69,29 @@ class ChannelOptionStorageTest: XCTestCase {
                            return option.1 as! SocketOptionValue
                        })
     }
+
+    func testClearingOptions() throws {
+        var cos = ChannelOptions.Storage()
+        let optionsCollector = OptionsCollectingChannel()
+        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 2)
+        cos.append(key: ChannelOptions.socketOption(.so_keepalive), value: 3)
+        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 4)
+        cos.append(key: ChannelOptions.socketOption(.so_rcvbuf), value: 5)
+        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 6)
+        cos.remove(key: ChannelOptions.socketOption(.so_reuseaddr))
+        XCTAssertNoThrow(try cos.applyAllChannelOptions(to: optionsCollector).wait())
+        XCTAssertEqual(2, optionsCollector.allOptions.count)
+        XCTAssertEqual([ChannelOptions.socketOption(.so_keepalive),
+                        ChannelOptions.socketOption(.so_rcvbuf)],
+                       optionsCollector.allOptions.map { option in
+                           return option.0 as! ChannelOptions.Types.SocketOption
+                       })
+        XCTAssertEqual([SocketOptionValue(3), SocketOptionValue(5)],
+                       optionsCollector.allOptions.map { option in
+                           return option.1 as! SocketOptionValue
+                       })
+    }
 }
 
 class OptionsCollectingChannel: Channel {


### PR DESCRIPTION
Motivation

Some bootstraps may require the ability to remove
Channel options from the ChannelOption storage in
cases where setting a higher-level flag makes those options unusable. This patch adds that functionality.

Modifications

Add ChannelOptions.Storage.remove

Result

Users can remove channel options from storage
