### PR TITLE
Move 5.7 beta APIs to NIOCore

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -102,8 +102,6 @@ var targets: [PackageDescription.Target] = [
             dependencies: ["NIOPosix", "NIOCore", "NIOHTTP1"]),
     .testTarget(name: "NIOCoreTests",
                 dependencies: ["NIOCore", "NIOEmbedded", "NIOFoundationCompat"]),
-    .testTarget(name: "NIOBetaTests",
-                dependencies: ["_NIOBeta"]),
     .testTarget(name: "NIOEmbeddedTests",
                 dependencies: ["NIOConcurrencyHelpers", "NIOCore", "NIOEmbedded"]),
     .testTarget(name: "NIOPosixTests",

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -102,8 +102,6 @@ var targets: [PackageDescription.Target] = [
             dependencies: ["NIOPosix", "NIOCore", "NIOHTTP1"]),
     .testTarget(name: "NIOCoreTests",
                 dependencies: ["NIOCore", "NIOEmbedded", "NIOFoundationCompat"]),
-    .testTarget(name: "NIOBetaTests",
-                dependencies: ["_NIOBeta"]),
     .testTarget(name: "NIOEmbeddedTests",
                 dependencies: ["NIOConcurrencyHelpers", "NIOCore", "NIOEmbedded"]),
     .testTarget(name: "NIOPosixTests",

--- a/Sources/NIOCore/TimeAmount+Duration.swift
+++ b/Sources/NIOCore/TimeAmount+Duration.swift
@@ -12,12 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOCore
-
 #if (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
 extension TimeAmount {
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    @available(*, deprecated, message: "This API has been moved to NIOCore and will be removed in a future update.")
     /// Creates a new `TimeAmount` for the given `Duration`, truncating and clamping if necessary.
     ///
     /// - returns: `TimeAmount`, truncated to nanosecond precision, and clamped to `Int64.max` nanoseconds.
@@ -31,7 +28,6 @@ extension Swift.Duration {
     /// Construct a `Duration` given a number of nanoseconds represented as a `TimeAmount`.
     ///
     /// - returns: A `Duration` representing a given number of nanoseconds.
-    @available(*, deprecated, message: "This API has been moved to NIOCore and will be removed in a future update.")
     public init(_ timeAmount: TimeAmount) {
         self = .nanoseconds(timeAmount.nanoseconds)
     }
@@ -40,7 +36,6 @@ extension Swift.Duration {
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 internal extension Swift.Duration {
     /// The duration represented as nanoseconds, clamped to maximum expressible value.
-    @available(*, deprecated, message: "This API has been moved to NIOCore and will be removed in a future update.")
     var nanosecondsClamped: Int64 {
         let components = self.components
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -24,7 +24,6 @@ import XCTest
 
 #if !compiler(>=5.5)
 #if os(Linux) || os(FreeBSD) || os(Android)
-   @testable import NIOBetaTests
    @testable import NIOConcurrencyHelpersTests
    @testable import NIOCoreTests
    @testable import NIODataStructuresTests

--- a/Tests/NIOCoreTests/TimeAmount+DurationTests+XCTest.swift
+++ b/Tests/NIOCoreTests/TimeAmount+DurationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/NIOCoreTests/TimeAmount+DurationTests+XCTest.swift
+++ b/Tests/NIOCoreTests/TimeAmount+DurationTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/NIOCoreTests/TimeAmount+DurationTests.swift
+++ b/Tests/NIOCoreTests/TimeAmount+DurationTests.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import NIOCore
+@testable import NIOCore
 import XCTest
 
 class TimeAmountDurationTests: XCTestCase {

--- a/Tests/NIOCoreTests/TimeAmount+DurationTests.swift
+++ b/Tests/NIOCoreTests/TimeAmount+DurationTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 import NIOCore
-@testable import _NIOBeta
 import XCTest
 
 class TimeAmountDurationTests: XCTestCase {


### PR DESCRIPTION
Motivation:

As 5.7 has shipped we no longer need to keep these APIs in _NIOBeta. We're going to do a two-stage removal: first we're going to move the APIs to NIOCore and keep them in _NIOBeta with deprecations on them. In a later release, we'll remove the APIs from _NIOBeta entirely.

Modifications:

- Move the TimeAmount + Duration APIs to NIOCore
- Deprecate the APIs in _NIOBeta.

Result:

We're on a path to remove _NIOBeta