### PR TITLE
Fix `testTaskCancel_whenStreaming_andNotSuspended` flakiness

### DIFF
--- a/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
@@ -495,7 +495,11 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
         let sequence = try XCTUnwrap(self.sequence)
         let task: Task<Int?, Error> = Task {
             let iterator = sequence.makeAsyncIterator()
-            return try await iterator.next()
+            let element = try await iterator.next()
+            
+            // Sleeping here to give the other Task a chance to cancel this one.
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            return element
         }
         try await Task.sleep(nanoseconds: 1_000_000)
 


### PR DESCRIPTION
# Motivation
This test has been flaky for some time. This was due to the fact that the consuming Task could have deinited the iterator which has resulted in a call to `didTerminate`.

# Modification
This PR, adds a small sleep in the consuming task to avoid this race.

# Result
No more flakiness in this test.
