### PR TITLE
Correctly include netinet/in.h

### DIFF
--- a/Sources/CNIODarwin/shim.c
+++ b/Sources/CNIODarwin/shim.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <netinet/ip.h>
+#include <netinet/in.h>
 
 int CNIODarwin_sendmmsg(int sockfd, CNIODarwin_mmsghdr *msgvec, unsigned int vlen, int flags) {
     // Some quick error checking. If vlen can't fit into int, we bail.


### PR DESCRIPTION
Motivation:

IPV6_RECVPKTINFO and IPV6_PKTINFO are not currently directly included. On Apple platforms, these are found by including netinet/in.h, so we should include that header directly.

Modifications:

- Add the correct include to shims.c

Result:

Better macOS builds