### PR TITLE
cap read+pread POSIX read sizes at Int32.max

### DIFF
--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -435,12 +435,13 @@ public struct NonBlockingFileIO: Sendable {
 
     private func read0(fileHandle: NIOFileHandle,
                        fromOffset: Int64?, // > 2 GB offset is reasonable on 32-bit systems
-                       byteCount: Int,
+                       byteCount rawByteCount: Int,
                        allocator: ByteBufferAllocator,
                        eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
-        guard byteCount > 0 else {
+        guard rawByteCount > 0 else {
             return eventLoop.makeSucceededFuture(allocator.buffer(capacity: 0))
         }
+        let byteCount = rawByteCount < Int32.max ? rawByteCount : size_t(Int32.max)
 
         var buf = allocator.buffer(capacity: byteCount)
         return self.threadPool.runIfActive(eventLoop: eventLoop) { () -> ByteBuffer in

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -602,17 +602,15 @@ internal enum Posix {
 
     @inline(never)
     internal static func read(descriptor: CInt, pointer: UnsafeMutableRawPointer, size: size_t) throws -> IOResult<ssize_t> {
-        let cappedSize = size < Int32.max ? size : size_t(Int32.max)
         return try syscallForbiddingEINVAL {
-            sysRead(descriptor, pointer, cappedSize)
+            sysRead(descriptor, pointer, size)
         }
     }
 
     @inline(never)
     internal static func pread(descriptor: CInt, pointer: UnsafeMutableRawPointer, size: size_t, offset: off_t) throws -> IOResult<ssize_t> {
-        let cappedSize = size < Int32.max ? size : size_t(Int32.max)
         return try syscallForbiddingEINVAL {
-            sysPread(descriptor, pointer, cappedSize, offset)
+            sysPread(descriptor, pointer, size, offset)
         }
     }
 

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -602,15 +602,17 @@ internal enum Posix {
 
     @inline(never)
     internal static func read(descriptor: CInt, pointer: UnsafeMutableRawPointer, size: size_t) throws -> IOResult<ssize_t> {
+        let cappedSize = size < Int32.max ? size : size_t(Int32.max)
         return try syscallForbiddingEINVAL {
-            sysRead(descriptor, pointer, size)
+            sysRead(descriptor, pointer, cappedSize)
         }
     }
 
     @inline(never)
     internal static func pread(descriptor: CInt, pointer: UnsafeMutableRawPointer, size: size_t, offset: off_t) throws -> IOResult<ssize_t> {
+        let cappedSize = size < Int32.max ? size : size_t(Int32.max)
         return try syscallForbiddingEINVAL {
-            sysPread(descriptor, pointer, size, offset)
+            sysPread(descriptor, pointer, cappedSize, offset)
         }
     }
 

--- a/Tests/NIOPosixTests/NonBlockingFileIOTest+XCTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest+XCTest.swift
@@ -40,6 +40,7 @@ extension NonBlockingFileIOTest {
                 ("testReadingDifferentChunkSize", testReadingDifferentChunkSize),
                 ("testReadDoesNotReadShort", testReadDoesNotReadShort),
                 ("testChunkReadingWhereByteCountIsNotAChunkSizeMultiplier", testChunkReadingWhereByteCountIsNotAChunkSizeMultiplier),
+                ("testReadMoreThanIntMaxBytesDoesntThrow", testReadMoreThanIntMaxBytesDoesntThrow),
                 ("testChunkedReadDoesNotReadShort", testChunkedReadDoesNotReadShort),
                 ("testChunkSizeMoreThanTotal", testChunkSizeMoreThanTotal),
                 ("testFileRegionReadFromPipeFails", testFileRegionReadFromPipeFails),

--- a/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
@@ -283,10 +283,12 @@ class NonBlockingFileIOTest: XCTestCase {
     }
 
     func testReadMoreThanIntMaxBytesDoesntThrow() throws {
+        try XCTSkipIf(MemoryLayout<size_t>.size == MemoryLayout<UInt32>.size)
         // here we try to read way more data back from the file than it contains but it serves the purpose
         // even on a small file the OS will return EINVAL if you try to read > INT_MAX bytes
         try withTemporaryFile(content: "some-dummy-content", { (filehandle, path) -> Void in
-            _ = try self.fileIO.read(fileHandle: filehandle, byteCount:Int(Int32.max)+10, allocator: .init(), eventLoop: self.eventLoop).wait()
+            let content = try self.fileIO.read(fileHandle: filehandle, byteCount:Int(Int32.max)+10, allocator: .init(), eventLoop: self.eventLoop).wait()
+            XCTAssertEqual(String(buffer: content), "some-dummy-content")
         })
     }
 

--- a/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
@@ -282,6 +282,14 @@ class NonBlockingFileIOTest: XCTestCase {
         XCTAssertEqual(2, numCalls)
     }
 
+    func testReadMoreThanIntMaxBytesDoesntThrow() throws {
+        // here we try to read way more data back from the file than it contains but it serves the purpose
+        // even on a small file the OS will return EINVAL if you try to read > INT_MAX bytes
+        try withTemporaryFile(content: "some-dummy-content", { (filehandle, path) -> Void in
+            _ = try self.fileIO.read(fileHandle: filehandle, byteCount:Int(Int32.max)+10, allocator: .init(), eventLoop: self.eventLoop).wait()
+        })
+    }
+
     func testChunkedReadDoesNotReadShort() throws {
         var innerError: Error? = nil
         try withPipe { readFH, writeFH in


### PR DESCRIPTION
### Motivation:

According to `read`/`pread` man page, reads may return `EINVAL` if "The value provided for `nbyte` exceeds `INT_MAX`". In practice on Darwin it is observed that this happens for `>Int32.max`.

We workaround the issiue in the `NonBlockingFileIO` level to keep the lower levels as simple as possible.

### Modifications:

`NonBlockingFileIO` `read0` amends read `byteCount`s to be `Int32.max` if they are larger than that value.

### Result:

We will no longer receive `EINVAL` signals and fail preconditions for reads larger than` Int32.max`. reads larger than `Int32.max` will return up to `Int32.max` bytes.