### PR TITLE
add easier async to future conversion

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -330,3 +330,13 @@ struct AsyncSequenceFromIterator<AsyncIterator: AsyncIteratorProtocol>: AsyncSeq
         self.iterator
     }
 }
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension EventLoop {
+    @inlinable
+    public func makeFutureWithTask<Return>(_ body: @Sendable @escaping () async throws -> Return) -> EventLoopFuture<Return> {
+        let promise = self.makePromise(of: Return.self)
+        promise.completeWithTask(body)
+        return promise.futureResult
+    }
+}

--- a/Tests/NIOPosixTests/EventLoopTest+XCTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest+XCTest.swift
@@ -89,6 +89,8 @@ extension EventLoopTest {
                 ("testEventLoopGroupsWithoutAnyImplementationAreValid", testEventLoopGroupsWithoutAnyImplementationAreValid),
                 ("testCallingAnyOnAnMTELGThatIsNotSelfDoesNotReturnItself", testCallingAnyOnAnMTELGThatIsNotSelfDoesNotReturnItself),
                 ("testMultiThreadedEventLoopGroupSupportsStickyAnyImplementation", testMultiThreadedEventLoopGroupSupportsStickyAnyImplementation),
+                ("testAsyncToFutureConversionSuccess", testAsyncToFutureConversionSuccess),
+                ("testAsyncToFutureConversionFailure", testAsyncToFutureConversionFailure),
            ]
    }
 }


### PR DESCRIPTION
### Motivation:

During the migration we unfortunately do need async -> future conversions from time to time. Currently, we do this with `EventLoopPromise.completeWithTask` which is great but also inconvenient in many cases.

### Modifications:

Add `EventLoop.makeFutureWithTask` which allows a direct `EventLoopFuture` -> `async throws` conversion.

### Result:

Less code, better code, fewer bugs.