### PR TITLE
Fix main nightly CI

### DIFF
--- a/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
@@ -69,8 +69,9 @@ for mode in debug release; do
             fail "exited successfully but was supposed to fail"
         else
             exit_code=$?
-            # expecting illegal instruction as it should fail with an unacceptable errno
-            assert_equal $(( 128 + 4 )) $exit_code  # 4 == SIGILL
+            # expecting irrecoverable error as process should be terminated through fatalError/precondition/assert
+            assert_greater_than_or_equal $exit_code $(( 128 + 4 ))  # 4 == SIGILL aka illegal instruction, expected on x86
+            assert_less_than_or_equal $exit_code $(( 128 + 5 ))  # 5 == SIGTRAP aka trace trap, expected on arm64
             if [[ "$mode" == "debug" ]]; then
                 grep -q unacceptable\ errno "$temp_file"
             fi

--- a/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
@@ -69,9 +69,17 @@ for mode in debug release; do
             fail "exited successfully but was supposed to fail"
         else
             exit_code=$?
+            
             # expecting irrecoverable error as process should be terminated through fatalError/precondition/assert
-            assert_greater_than_or_equal $exit_code $(( 128 + 4 ))  # 4 == SIGILL aka illegal instruction, expected on x86
-            assert_less_than_or_equal $exit_code $(( 128 + 5 ))  # 5 == SIGTRAP aka trace trap, expected on arm64
+            architecture=$(uname -m)
+            if [[ $architecture =~ ^(arm|aarch) ]]; then
+                assert_equal $exit_code $(( 128 + 5 )) # 5 == SIGTRAP aka trace trap, expected on ARM
+            elif [[ $architecture =~ ^(x86|i386) ]]; then
+                assert_equal $exit_code $(( 128 + 4 ))  # 4 == SIGILL aka illegal instruction, expected on x86
+            else
+                fail "unknown CPU architecture for which we don't know the expected signal for a crash"
+            fi
+            
             if [[ "$mode" == "debug" ]]; then
                 grep -q unacceptable\ errno "$temp_file"
             fi

--- a/IntegrationTests/tests_02_syscall_wrappers/test_03_unacceptable_read_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_03_unacceptable_read_errnos.sh
@@ -87,8 +87,9 @@ for mode in debug release; do
             fail "exited successfully but was supposed to fail"
         else
             exit_code=$?
-            # expecting illegal instruction as it should fail with an unacceptable errno
-            assert_equal $(( 128 + 4 )) $exit_code  # 4 == SIGILL
+            # expecting irrecoverable error as process should be terminated through fatalError/precondition/assert
+            assert_greater_than_or_equal $exit_code $(( 128 + 4 ))  # 4 == SIGILL aka illegal instruction, expected on x86
+            assert_less_than_or_equal $exit_code $(( 128 + 5 ))  # 5 == SIGTRAP aka trace trap, expected on arm64
             if [[ "$mode" == "debug" ]]; then
                 grep -q unacceptable\ errno "$temp_file"
             fi

--- a/IntegrationTests/tests_02_syscall_wrappers/test_03_unacceptable_read_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_03_unacceptable_read_errnos.sh
@@ -87,9 +87,17 @@ for mode in debug release; do
             fail "exited successfully but was supposed to fail"
         else
             exit_code=$?
+            
             # expecting irrecoverable error as process should be terminated through fatalError/precondition/assert
-            assert_greater_than_or_equal $exit_code $(( 128 + 4 ))  # 4 == SIGILL aka illegal instruction, expected on x86
-            assert_less_than_or_equal $exit_code $(( 128 + 5 ))  # 5 == SIGTRAP aka trace trap, expected on arm64
+            architecture=$(uname -m)
+            if [[ $architecture =~ ^(arm|aarch) ]]; then
+                assert_equal $exit_code $(( 128 + 5 )) # 5 == SIGTRAP aka trace trap, expected on ARM
+            elif [[ $architecture =~ ^(x86|i386) ]]; then
+                assert_equal $exit_code $(( 128 + 4 ))  # 4 == SIGILL aka illegal instruction, expected on x86
+            else
+                fail "unknown CPU architecture for which we don't know the expected signal for a crash"
+            fi
+            
             if [[ "$mode" == "debug" ]]; then
                 grep -q unacceptable\ errno "$temp_file"
             fi

--- a/IntegrationTests/tests_05_assertions/test_01_syscall_wrapper_fast.sh
+++ b/IntegrationTests/tests_05_assertions/test_01_syscall_wrapper_fast.sh
@@ -38,7 +38,14 @@ if "$tmp/test"; then
     fail "should have crashed"
 else
     exit_code=$?
+    
     # expecting irrecoverable error as process should be terminated through fatalError/precondition/assert
-    assert_greater_than_or_equal $exit_code $(( 128 + 4 ))  # 4 == SIGILL aka illegal instruction, expected on x86
-    assert_less_than_or_equal $exit_code $(( 128 + 5 ))  # 5 == SIGTRAP aka trace trap, expected on arm64
+    architecture=$(uname -m)
+    if [[ $architecture =~ ^(arm|aarch) ]]; then
+        assert_equal $exit_code $(( 128 + 5 )) # 5 == SIGTRAP aka trace trap, expected on ARM
+    elif [[ $architecture =~ ^(x86|i386) ]]; then
+        assert_equal $exit_code $(( 128 + 4 ))  # 4 == SIGILL aka illegal instruction, expected on x86
+    else
+        fail "unknown CPU architecture for which we don't know the expected signal for a crash"
+    fi
 fi

--- a/IntegrationTests/tests_05_assertions/test_01_syscall_wrapper_fast.sh
+++ b/IntegrationTests/tests_05_assertions/test_01_syscall_wrapper_fast.sh
@@ -38,5 +38,7 @@ if "$tmp/test"; then
     fail "should have crashed"
 else
     exit_code=$?
-    assert_equal $(( 128 + 4 )) $exit_code  # 4 == SIGILL
+    # expecting irrecoverable error as process should be terminated through fatalError/precondition/assert
+    assert_greater_than_or_equal $exit_code $(( 128 + 4 ))  # 4 == SIGILL aka illegal instruction, expected on x86
+    assert_less_than_or_equal $exit_code $(( 128 + 5 ))  # 5 == SIGTRAP aka trace trap, expected on arm64
 fi

--- a/Sources/NIOCrashTester/main.swift
+++ b/Sources/NIOCrashTester/main.swift
@@ -99,7 +99,11 @@ func main() throws {
                          runResult: RunResult) throws -> InterpretedRunResult {
         struct NoOutputFound: Error {}
 
-        guard case .signal(Int(SIGILL)) = runResult else {
+        guard case .signal(let signal) = runResult,
+              // SIGILL aka illegal instruction, expected on x86
+              // SIGTRAP aka trace trap, expected on arm64
+              [Int(SIGILL), Int(SIGTRAP)].contains(signal)
+        else {
             return .unexpectedRunResult(runResult)
         }
 

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=405000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050


### PR DESCRIPTION
- Allow `SIGILL` and `SIGTRAP`. `SIGTRAP` is the signal on arm64 for fatalError/precondition/assert
- allocations `1_reqs_1000_conn` have regressed but only to the same numbers as Swift 5.7. not yet investigated