### PR TITLE
Allow writing and reading empty datagrams

### DIFF
--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -625,7 +625,6 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             }
             switch result {
             case .processed(let bytesRead):
-                assert(bytesRead > 0)
                 assert(self.isOpen)
                 let mayGrow = recvAllocator.record(actualReadBytes: bytesRead)
                 readPending = false
@@ -792,10 +791,6 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     override func writeToSocket() throws -> OverallWriteResult {
         let result = try self.pendingWrites.triggerAppropriateWriteOperations(
             scalarWriteOperation: { (ptr, destinationPtr, destinationSize, metadata) in
-                guard ptr.count > 0 else {
-                    // No need to call write if the buffer is empty.
-                    return .processed(0)
-                }
                 // normal write
                 // Control bytes must not escape current stack.
                 var controlBytes = UnsafeOutboundControlBytes(

--- a/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2018-2022 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2018-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -28,6 +28,7 @@ extension DatagramChannelTests {
    static var allTests : [(String, (DatagramChannelTests) -> () throws -> Void)] {
       return [
                 ("testBasicChannelCommunication", testBasicChannelCommunication),
+                ("testEmptyDatagram", testEmptyDatagram),
                 ("testManyWrites", testManyWrites),
                 ("testDatagramChannelHasWatermark", testDatagramChannelHasWatermark),
                 ("testWriteFuturesFailWhenChannelClosed", testWriteFuturesFailWhenChannelClosed),

--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -154,6 +154,18 @@ class DatagramChannelTests: XCTestCase {
         XCTAssertEqual(read.remoteAddress, self.firstChannel.localAddress!)
     }
 
+    func testEmptyDatagram() throws {
+        let buffer = self.firstChannel.allocator.buffer(capacity: 0)
+        let writeData = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
+        XCTAssertNoThrow(try self.firstChannel.writeAndFlush(NIOAny(writeData)).wait())
+
+        let reads = try self.secondChannel.waitForDatagrams(count: 1)
+        XCTAssertEqual(reads.count, 1)
+        let read = reads.first!
+        XCTAssertEqual(read.data, buffer)
+        XCTAssertEqual(read.remoteAddress, self.firstChannel.localAddress!)
+    }
+
     func testManyWrites() throws {
         var buffer = firstChannel.allocator.buffer(capacity: 256)
         buffer.writeStaticString("hello, world!")


### PR DESCRIPTION
Motivation:

Empty UDP datagrams could be used to have a meaning. Empty datagrams were being silently dropped on write. Receiving an empty diagram causes an assertion failure (possible DDoS).

Modifications:

Remove early exit when writing empty datagrams and non-empty assertion when reading them.

Result:

We can now write and read empty datagrams.