### PR TITLE
Implement `remoteAddress0` and `localAddress0` on `EmbeddedChannel`

### DIFF
--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -300,15 +300,29 @@ class EmbeddedChannelCore: ChannelCore {
     var inboundBufferConsumer: Deque<(NIOAny) -> Void> = []
 
     @usableFromInline
+    var localAddress: SocketAddress?
+
+    @usableFromInline
+    var remoteAddress: SocketAddress?
+
+    @usableFromInline
     func localAddress0() throws -> SocketAddress {
         self.eventLoop.preconditionInEventLoop()
-        throw ChannelError.operationUnsupported
+        if let localAddress = self.localAddress {
+            return localAddress
+        } else {
+            throw ChannelError.operationUnsupported
+        }
     }
 
     @usableFromInline
     func remoteAddress0() throws -> SocketAddress {
         self.eventLoop.preconditionInEventLoop()
-        throw ChannelError.operationUnsupported
+        if let remoteAddress = self.remoteAddress {
+            return remoteAddress
+        } else {
+            throw ChannelError.operationUnsupported
+        }
     }
 
     @usableFromInline
@@ -615,10 +629,24 @@ public final class EmbeddedChannel: Channel {
     public var embeddedEventLoop: EmbeddedEventLoop = EmbeddedEventLoop()
 
     /// - see: `Channel.localAddress`
-    public var localAddress: SocketAddress? = nil
+    public var localAddress: SocketAddress? {
+        get {
+            self.channelcore.localAddress
+        }
+        set {
+            self.channelcore.localAddress = newValue
+        }
+    }
 
     /// - see: `Channel.remoteAddress`
-    public var remoteAddress: SocketAddress? = nil
+    public var remoteAddress: SocketAddress? {
+        get {
+            self.channelcore.remoteAddress
+        }
+        set {
+            self.channelcore.remoteAddress = newValue
+        }
+    }
 
     /// `nil` because `EmbeddedChannel`s don't have parents.
     public let parent: Channel? = nil

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest+XCTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -52,6 +52,8 @@ extension EmbeddedChannelTest {
                 ("testEmbeddedChannelWritabilityIsWritable", testEmbeddedChannelWritabilityIsWritable),
                 ("testFinishWithRecursivelyScheduledTasks", testFinishWithRecursivelyScheduledTasks),
                 ("testSyncOptionsAreSupported", testSyncOptionsAreSupported),
+                ("testLocalAddress0", testLocalAddress0),
+                ("testRemoteAddress0", testRemoteAddress0),
            ]
    }
 }

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
@@ -489,4 +489,30 @@ class EmbeddedChannelTest: XCTestCase {
         XCTAssertEqual(try options?.getOption(ChannelOptions.autoRead), true)
         // (Setting options isn't supported.)
     }
+
+    func testLocalAddress0() throws {
+        let channel = EmbeddedChannel()
+
+        XCTAssertThrowsError(try channel._channelCore.localAddress0()) { error in
+            XCTAssertEqual(error as? ChannelError, ChannelError.operationUnsupported)
+        }
+
+        let localAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 1234)
+        channel.localAddress = localAddress
+
+        XCTAssertEqual(try channel._channelCore.localAddress0(), localAddress)
+    }
+
+    func testRemoteAddress0() throws {
+        let channel = EmbeddedChannel()
+
+        XCTAssertThrowsError(try channel._channelCore.remoteAddress0()) { error in
+            XCTAssertEqual(error as? ChannelError, ChannelError.operationUnsupported)
+        }
+
+        let remoteAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 1234)
+        channel.remoteAddress = remoteAddress
+
+        XCTAssertEqual(try channel._channelCore.remoteAddress0(), remoteAddress)
+    }
 }


### PR DESCRIPTION
# Motivation
`EmbeddedChannel` is often used in testing and currently any code under testing that uses `context.localAddress` cannot be mocked, since `EmbeddedChannelCore` is always throwing.

# Modification
Use the same values for `localAddress` in `localAddress0()`. Same for `remoteAddress`

# Result
We can now properly test code that needs local/remote addresses with `EmbeddedChannel`
