### PR TITLE
Avoid integer literals that won't fit.

### DIFF
--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1756,9 +1756,9 @@ class ByteBufferTest: XCTestCase {
 
         // This allocator assumes that we'll never call realloc.
         let fakeAllocator = ByteBufferAllocator(
-            hookedMalloc: { _ in .init(bitPattern: 0xdeadbeef) },
+            hookedMalloc: { _ in .init(bitPattern: 0xdedbeef) },
             hookedRealloc: { _, _ in fatalError() },
-            hookedFree: { precondition($0 == .init(bitPattern: 0xdeadbeef)!) },
+            hookedFree: { precondition($0 == .init(bitPattern: 0xdedbeef)!) },
             hookedMemcpy: {_, _, _ in }
         )
 


### PR DESCRIPTION
Motivation:

While the "giant buffer" test doesn't run on 32-bit systems, it does need to compile. That means we can't set a pointer to a value that won't fit into an Int.

Modifications:

Smaller pointers!

Result:

The compile should work again.