### PR TITLE
Tail allocate mutex and a generic value using ManagedBuffer

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -29,6 +29,7 @@ typealias LockPrimitive = SRWLOCK
 typealias LockPrimitive = pthread_mutex_t
 #endif
 
+@usableFromInline
 enum LockOperations { }
 
 extension LockOperations {
@@ -82,6 +83,7 @@ extension LockOperations {
 // Tail allocate both the mutex and a generic value using ManagedBuffer.
 // Both the header pointer and the elements pointer are stable for
 // the class's entire lifetime.
+@usableFromInline
 final class LockStorage<Value>: ManagedBuffer<LockPrimitive, Value> {
     
     @inlinable

--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -21,6 +21,125 @@ import WinSDK
 import Glibc
 #endif
 
+#if os(Windows)
+@usableFromInline
+typealias LockPrimitive = SRWLOCK
+#else
+@usableFromInline
+typealias LockPrimitive = pthread_mutex_t
+#endif
+
+enum LockOperations { }
+
+extension LockOperations {
+    @inlinable
+    static func create(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+#if os(Windows)
+        InitializeSRWLock(mutex)
+#else
+        var attr = pthread_mutexattr_t()
+        pthread_mutexattr_init(&attr)
+        debugOnly {
+            pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
+        }
+        
+        let err = pthread_mutex_init(mutex, &attr)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+#endif
+    }
+    
+    @inlinable
+    static func destroy(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+#if os(Windows)
+        // SRWLOCK does not need to be free'd
+#else
+        let err = pthread_mutex_destroy(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+#endif
+    }
+    
+    @inlinable
+    static func lock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+#if os(Windows)
+        AcquireSRWLockExclusive(mutex)
+#else
+        let err = pthread_mutex_lock(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+#endif
+    }
+    
+    @inlinable
+    static func unlock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+#if os(Windows)
+        ReleaseSRWLockExclusive(mutex)
+#else
+        let err = pthread_mutex_unlock(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+#endif
+    }
+}
+
+// Tail allocate both the mutex and a generic value using ManagedBuffer.
+// Both the header pointer and the elements pointer are stable for
+// the class's entire lifetime.
+final class LockStorage<Value>: ManagedBuffer<LockPrimitive, Value> {
+    
+    @inlinable
+    static func create(value: Value) -> Self {
+        let buffer = Self.create(minimumCapacity: 1) { _ in
+            return LockPrimitive()
+        }
+        let storage = unsafeDowncast(buffer, to: Self.self)
+        
+        storage.withUnsafeMutablePointers { lockPtr, valuePtr in
+            LockOperations.create(lockPtr)
+            valuePtr.initialize(to: value)
+        }
+        
+        return storage
+    }
+    
+    @inlinable
+    func lock() {
+        self.withUnsafeMutablePointerToHeader { lockPtr in
+            LockOperations.lock(lockPtr)
+        }
+    }
+    
+    @inlinable
+    func unlock() {
+        self.withUnsafeMutablePointerToHeader { lockPtr in
+            LockOperations.unlock(lockPtr)
+        }
+    }
+    
+    @inlinable
+    deinit {
+        self.withUnsafeMutablePointers { lockPtr, valuePtr in
+            LockOperations.destroy(lockPtr)
+            valuePtr.deinitialize(count: 1)
+        }
+    }
+    
+    @inlinable
+    func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+        try self.withUnsafeMutablePointerToHeader { lockPtr in
+            return try body(lockPtr)
+        }
+    }
+    
+    @inlinable
+    func withLockedValue<T>(_ mutate: (inout Value) throws -> T) rethrows -> T {
+        try self.withUnsafeMutablePointers { lockPtr, valuePtr in
+            LockOperations.lock(lockPtr)
+            defer { LockOperations.unlock(lockPtr) }
+            return try mutate(&valuePtr.pointee)
+        }
+    }
+}
+
+extension LockStorage: @unchecked Sendable { }
+
 /// A threading lock based on `libpthread` instead of `libdispatch`.
 ///
 /// - note: ``NIOLock`` has reference semantics.
@@ -31,81 +150,19 @@ import Glibc
 /// `SRWLOCK` type.
 public struct NIOLock {
     @usableFromInline
-    internal let _storage: _Storage
-
-#if os(Windows)
-    @usableFromInline
-    internal typealias LockPrimitive = SRWLOCK
-#else
-    @usableFromInline
-    internal typealias LockPrimitive = pthread_mutex_t
-#endif
-    
-    @usableFromInline
-    internal final class _Storage {
-        // TODO: We should tail-allocate the pthread_t/SRWLock.
-        @usableFromInline
-        internal let mutex: UnsafeMutablePointer<LockPrimitive> =
-        UnsafeMutablePointer.allocate(capacity: 1)
-
-        /// Create a new lock.
-        internal init() {
-#if os(Windows)
-            InitializeSRWLock(self.mutex)
-#else
-            var attr = pthread_mutexattr_t()
-            pthread_mutexattr_init(&attr)
-            debugOnly {
-                pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
-            }
-            
-            let err = pthread_mutex_init(self.mutex, &attr)
-            precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-#endif
-        }
-        
-        internal func lock() {
-#if os(Windows)
-            AcquireSRWLockExclusive(self.mutex)
-#else
-            let err = pthread_mutex_lock(self.mutex)
-            precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-#endif
-        }
-        
-        internal func unlock() {
-#if os(Windows)
-            ReleaseSRWLockExclusive(self.mutex)
-#else
-            let err = pthread_mutex_unlock(self.mutex)
-            precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-#endif
-        }
-
-        internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
-            return try body(self.mutex)
-        }
-        
-        deinit {
-#if os(Windows)
-            // SRWLOCK does not need to be free'd
-#else
-            let err = pthread_mutex_destroy(self.mutex)
-            precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-#endif
-            mutex.deallocate()
-        }
-    }
+    internal let _storage: LockStorage<Void>
     
     /// Create a new lock.
+    @inlinable
     public init() {
-        self._storage = _Storage()
+        self._storage = .create(value: ())
     }
 
     /// Acquire the lock.
     ///
     /// Whenever possible, consider using `withLock` instead of this method and
     /// `unlock`, to simplify lock handling.
+    @inlinable
     public func lock() {
         self._storage.lock()
     }
@@ -114,10 +171,12 @@ public struct NIOLock {
     ///
     /// Whenever possible, consider using `withLock` instead of this method and
     /// `lock`, to simplify lock handling.
+    @inlinable
     public func unlock() {
         self._storage.unlock()
     }
 
+    @inlinable
     internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
         return try self._storage.withLockPrimitive(body)
     }
@@ -148,4 +207,3 @@ extension NIOLock {
 }
 
 extension NIOLock: Sendable {}
-extension NIOLock._Storage: Sendable {}

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=155050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=81850
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=82000
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=407000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -18,26 +18,26 @@ services:
   test:
     image: swift-nio:20.04-5.5
     environment:
-      - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=25
+      - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=24
       - MAX_ALLOCS_ALLOWED_1000000_asyncwriter=1000050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=21050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=44050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=8050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=8050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=8050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=19050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_copying_circularbuffer_to_array=1050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=158050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=155050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=84050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=415000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=81850
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=407000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -51,20 +51,20 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space_with_mask=5050
       - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=56050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=54050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=2050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4400
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=4350
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=170050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=98
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=168050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=89
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=162050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=151050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=78950
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=79000
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=404000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
@@ -63,7 +63,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=88
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12100
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=160050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -18,26 +18,26 @@ services:
   test:
     image: swift-nio:20.04-5.6
     environment:
-      - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=23
+      - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=22
       - MAX_ALLOCS_ALLOWED_1000000_asyncwriter=1000050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=20050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=44050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=8050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=8050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=8050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=18050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_copying_circularbuffer_to_array=1050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=151050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=412050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=78950
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=404000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -51,7 +51,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space_with_mask=5050
       - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=55050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=53050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
@@ -62,9 +62,9 @@ services:
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=140050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=88
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=160050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -63,7 +63,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=60100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=60050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=88
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12100
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=160050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -17,26 +17,26 @@ services:
   test:
     image: swift-nio:20.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=23
+      - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=22
       - MAX_ALLOCS_ALLOWED_1000000_asyncwriter=1000050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=39050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=20050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=44050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=37050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=8050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=8050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=8050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=18050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_copying_circularbuffer_to_array=1050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=153050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=150050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12000
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=409000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=78700
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=401000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -50,7 +50,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space_with_mask=5050
       - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=55050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=53050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
@@ -61,9 +61,9 @@ services:
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=140050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=87
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=160050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -33,10 +33,10 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=150050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12000
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=78700
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=401000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=79000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=401050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -18,26 +18,26 @@ services:
   test:
     image: swift-nio:22.04-5.7
     environment:
-      - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=23
+      - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=22
       - MAX_ALLOCS_ALLOWED_1000000_asyncwriter=1000050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=47050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=40050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=9050
-      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=9050
-      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=20050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=44050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=8050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=8050
+      - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=8050
+      - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet=18050
       - MAX_ALLOCS_ALLOWED_1000_autoReadGetAndSet_sync=0
       - MAX_ALLOCS_ALLOWED_1000_copying_bytebufferview_to_array=1050
       - MAX_ALLOCS_ALLOWED_1000_copying_circularbuffer_to_array=1050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers=9050
-      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=37
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
+      - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=35
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=153050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=150050
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=11950
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=81050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=410000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=78850
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=402000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -51,7 +51,7 @@ services:
       - MAX_ALLOCS_ALLOWED_encode_1000_ws_frames_new_buffer_with_space_with_mask=5050
       - MAX_ALLOCS_ALLOWED_execute_hop_10000_tasks=0
       - MAX_ALLOCS_ALLOWED_future_erase_result=4050
-      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=55050
+      - MAX_ALLOCS_ALLOWED_future_lots_of_callbacks=53050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=700050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=700050
@@ -62,9 +62,9 @@ services:
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=140050
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
-      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=97
-      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=166050
+      - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=87
+      - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=12150
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=160050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -34,9 +34,9 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=30400
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=150050
-      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=11950
+      - MAX_ALLOCS_ALLOWED_1000_udp_reqs=12050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=78850
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=79000
       - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=402000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0


### PR DESCRIPTION
### Motivation:

Currently, NIOLock and NIOLockedValueBox incur unnecessary allocation and indirection costs.

### Modifications:

- Create namespace `LockOperations` for organization
- Create `LockStorage<Value>`, a subclass of `ManagedBuffer<LockPrimitive, Value>`
- Store the mutex as the header and the generic value as the first and only element
- Update NIOLock and NIOLockedValueBox to use LockStorage

### Result:

- Optimal lock and value memory layout
- Fewer allocations and less indirection
- Code generation is excellent (screenshot attached)

<img width="1168" alt="Screenshot 2023-01-13 at 11 35 49 AM" src="https://user-images.githubusercontent.com/122590765/212387701-2dc3ac37-7822-4cd4-ac84-93a4796483ec.png">

