### PR TITLE
Lift alloc counter Package.swift to 5.1 and add platforms

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
+++ b/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
@@ -40,11 +40,17 @@ function hooked_package_swift_start() {
     shift 2
 
     cat <<"EOF"
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
     name: "allocation-counter-tests",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+    ],
     products: [
 EOF
     for f in "$@"; do


### PR DESCRIPTION
Motivation:

Our allocation counter tests still build for 5.0 by default. This isn't great, but we've been getting away with it because building for 5.7 requires changing the way we express our dependencies. Doing that is a big breaking pain in the neck that requires changes in multiple repos.

As a shorter-term goal, however, to enable testing in at least one more repo (swift-nio-ssh), this PR lifts the version to 5.1, which is the last release compatible with the Package.swift dependency structure we use but that supports the Platforms we need to express.

Modifications:

- Move allocation counter to 5.1
- Add platforms from swift-nio-ssh

Result:

We can write allocation counter tests for swift-nio-ssh.
