### PR TITLE
Fix flaky testTaskCancel_whenStreaming_andNotSuspended

### DIFF
--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
@@ -391,9 +391,16 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         let sequence = try XCTUnwrap(self.sequence)
         let task: Task<Int?, Never> = Task {
             let iterator = sequence.makeAsyncIterator()
-            return await iterator.next()
+            let value = await iterator.next()
+
+            // Sleeping here a bit to make sure we hit the case where
+            // we are streaming and still retain the iterator.
+            try? await Task.sleep(nanoseconds: 1_000_000)
+
+            return value
         }
-        try await Task.sleep(nanoseconds: 1_000_000)
+
+        try await Task.sleep(nanoseconds: 2_000_000)
 
         _ = self.source.yield(contentsOf: [1])
 


### PR DESCRIPTION
# Motivation
Currently `testTaskCancel_whenStreaming_andNotSuspended` is flaky since `didTerminate` can be called after the iterator is dropped. Fixes https://github.com/apple/swift-nio/issues/2354

# Modification
Let's modify that slightly so we hight the condition we want to hit.

# Result
No more flaky tests.