### PR TITLE
POC output with URring

### DIFF
--- a/Sources/NIOPosix/LinuxUring.swift
+++ b/Sources/NIOPosix/LinuxUring.swift
@@ -12,15 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if SWIFTNIO_USE_IO_URING
-#if os(Linux)
+#if SWIFTNIO_USE_IO_URING && os(Linux)
 
 import CNIOLinux
 import NIOCore
 
 @usableFromInline
 enum CQEEventType: UInt8 {
-    case poll = 1, pollModify, pollDelete // start with 1 to not get zero bit patterns for stdin
+    case poll = 1, // start with 1 to not get zero bit patterns for stdin
+    pollModify,
+    pollDelete,
+    write
 }
 
 internal enum URingError: Error {
@@ -38,84 +40,135 @@ internal extension TimeAmount {
     }
 }
 
-// URingUserData supports (un)packing into an `UInt64` as io_uring has a user_data 64-bit payload which is set in the SQE
-// and returned in the CQE. We're using 56 of those 64 bits, 32 for the file descriptor, 16 for a "registration ID" and 8
-// for the type of event issued (poll/modify/delete).
-@usableFromInline struct URingUserData {
-    @usableFromInline var fileDescriptor: CInt
-    @usableFromInline var registrationID: UInt16 // SelectorRegistrationID truncated, only have room for bottom 16 bits (could be expanded to 24 if required)
-    @usableFromInline var eventType: CQEEventType
-    @usableFromInline var padding: Int8 // reserved for future use
-
-    @inlinable init(registrationID: SelectorRegistrationID, fileDescriptor: CInt, eventType: CQEEventType) {
-        assert(MemoryLayout<UInt64>.size == MemoryLayout<URingUserData>.size)
-        self.registrationID = UInt16(truncatingIfNeeded: registrationID.rawValue)
-        self.fileDescriptor = fileDescriptor
-        self.eventType = eventType
-        self.padding = 0
-    }
-
-    @inlinable init(rawValue: UInt64) {
-        let unpacked = IntegerBitPacking.unpackUInt32UInt16UInt8(rawValue)
-        self = .init(registrationID: SelectorRegistrationID(rawValue: UInt32(unpacked.1)),
-                     fileDescriptor: CInt(unpacked.0),
-                     eventType: CQEEventType(rawValue:unpacked.2)!)
-    }
-}
-
-extension UInt64 {
-    init(_ uringUserData: URingUserData) {
-        let fd = uringUserData.fileDescriptor
-        let eventType = uringUserData.eventType.rawValue
-        assert(fd >= 0, "\(fd) is not a valid file descriptor")
-        assert(eventType >= 0, "\(eventType) is not a valid eventType")
-
-        self = IntegerBitPacking.packUInt32UInt16UInt8(UInt32(truncatingIfNeeded: fd),
-                                                       uringUserData.registrationID,
-                                                       eventType)
-    }
-}
-
 // These are the events returned up to the selector
 internal struct URingEvent {
+    enum EventType {
+        case _none
+        case poll(UInt32, Bool) // poll mask, poll cancelled
+        case write(Int32)
+    }
+
     var fd: CInt
-    var pollMask: UInt32
     var registrationID: UInt16 // we just have the truncated lower 16 bits of the registrationID
-    var pollCancelled: Bool
-    init () {
-        self.fd = -1
-        self.pollMask = 0
-        self.registrationID = 0
-        self.pollCancelled = false
+    var type: EventType
+
+    init() {
+        fd = 0
+        registrationID = 0
+        type = ._none
+    }
+
+    init(_ fd: CInt, _ registrationID: UInt16, _ type: EventType) {
+        self.fd = fd
+        self.registrationID = registrationID
+        self.type = type
     }
 }
 
 // This is the key we use for merging events in our internal hashtable
-struct FDEventKey: Hashable {
-    var fileDescriptor: CInt
-    var registrationID: UInt16 // we just have the truncated lower 16 bits of the registrationID
+private struct EventKey: Hashable {
+    let fileDescriptor: CInt
+    let registrationID: UInt16 // we just have the truncated lower 16 bits of the registrationID
 
-    init(_ f: CInt, _ s: UInt16) {
-        self.fileDescriptor = f
-        self.registrationID = s
+    init(_ fileDescriptor: CInt, _ registrationID: UInt16) {
+        self.fileDescriptor = fileDescriptor
+        self.registrationID = registrationID
     }
 }
 
+private func _debugPrint(_ s: @autoclosure () -> String) {
+    #if SWIFTNIO_IO_URING_DEBUG
+    print("L \(s())")
+    #endif
+}
+
 final internal class URing {
+
+    // a user_data 64-bit payload which is set in the SQE and returned in the CQE.
+    // We're using 56 of those 64 bits, 32 for the file descriptor, 16 for a "registration ID" and 8
+    // for the type of event issued (poll/modify/delete).
+    private struct UserData {
+        let fileDescriptor: CInt
+        let registrationID: UInt16 // SelectorRegistrationID truncated, only have room for bottom 16 bits (could be expanded to 24 if required)
+        let eventType: CQEEventType
+        let padding: Int8 // reserved for future use
+
+        @inlinable init(_ fileDescriptor: CInt, _ registrationID: SelectorRegistrationID, _ eventType: CQEEventType) {
+            assert(MemoryLayout<UInt64>.size == MemoryLayout<UserData>.size)
+            self.fileDescriptor = fileDescriptor
+            self.registrationID = UInt16(truncatingIfNeeded: registrationID.rawValue)
+            self.eventType = eventType
+            self.padding = 0
+        }
+
+        @inlinable init(rawValue: UInt64) {
+            let unpacked = IntegerBitPacking.unpackUInt32UInt16UInt8(rawValue >> 1)
+            self = .init(CInt(unpacked.0),
+                        SelectorRegistrationID(rawValue: UInt32(unpacked.1)),
+                        CQEEventType(rawValue:unpacked.2)!)
+        }
+
+        @inlinable func asUInt64() -> UInt64 {
+            let rawValue = IntegerBitPacking.packUInt32UInt16UInt8(
+                UInt32(truncatingIfNeeded: self.fileDescriptor),
+                self.registrationID,
+                self.eventType.rawValue)
+            return ((rawValue << 1) + 1)
+        }
+    }
+
+    private class SendFileRequest {
+        let fileDescriptor: CInt
+        let src: CInt
+        let registrationID: UInt16
+        let bytes: UInt32
+        let pipe: Pipe
+        var opsDone: Int
+
+        init(_ fileDescriptor: CInt, _ src: CInt, _ registrationID: SelectorRegistrationID, _ bytes: UInt32, _ pipe: Pipe) {
+            self.fileDescriptor = fileDescriptor
+            self.src = src
+            self.registrationID = UInt16(truncatingIfNeeded: registrationID.rawValue)
+            self.pipe = pipe
+            self.bytes = bytes
+            self.opsDone = 0
+        }
+
+        deinit {
+            pipe.release()
+        }
+
+        func opDone() -> Bool {
+            opsDone += 1
+            assert(opsDone <= 2)
+            return (opsDone == 2)
+        }
+    }
+
+    private struct SendFileUserData {
+        let request: SendFileRequest
+        var offs: Int64
+        var bytesProcessed: UInt32
+
+        init(_ request: SendFileRequest, _ offs: Int64) {
+            self.request = request
+            self.offs = offs
+            self.bytesProcessed = 0
+        }
+    }
+
     internal static let POLLIN: CUnsignedInt = numericCast(CNIOLinux.POLLIN)
     internal static let POLLOUT: CUnsignedInt = numericCast(CNIOLinux.POLLOUT)
     internal static let POLLERR: CUnsignedInt = numericCast(CNIOLinux.POLLERR)
     internal static let POLLRDHUP: CUnsignedInt = CNIOLinux_POLLRDHUP() // numericCast(CNIOLinux.POLLRDHUP) 
     internal static let POLLHUP: CUnsignedInt = numericCast(CNIOLinux.POLLHUP)
-    internal static let POLLCANCEL: CUnsignedInt = 0xF0000000 // Poll cancelled, need to reregister for singleshot polls
 
     private var ring = io_uring()
     private let ringEntries: CUnsignedInt = 8192
     private let cqeMaxCount: UInt32 = 8192 // this is the max chunk of CQE we take.
 
-    var cqes: UnsafeMutablePointer<UnsafeMutablePointer<io_uring_cqe>?>
-    var fdEvents = [FDEventKey : UInt32]() // fd, sequence_identifier : merged event_poll_return
-    var emptyCqe = io_uring_cqe()
+    private var cqes: UnsafeMutablePointer<UnsafeMutablePointer<io_uring_cqe>?>
+    private var pollIdx = [EventKey : Int]()
 
     var fd: CInt {
         return ring.ring_fd
@@ -129,56 +182,33 @@ final internal class URing {
         #endif
     }
 
-    func _dumpCqes(_ header:String, count: Int = 1) {
-        #if SWIFTNIO_IO_URING_DEBUG_DUMP_CQE
-        func _debugPrintCQE(_ s: String) {
-            print("Q [\(NIOThread.current)] " + s)
-        }
-
-        if count < 0 {
-            return
-        }
-
-        _debugPrintCQE(header + " CQE:s [\(cqes)] - ring flags are [\(ring.flags)]")
-        for i in 0..<count {
-            let c = cqes[i]!.pointee
-
-            let bitPattern = UInt(bitPattern:io_uring_cqe_get_data(cqes[i]))
-            let uringUserData = URingUserData(rawValue: UInt64(bitPattern))
-
-            _debugPrintCQE("\(i) = fd[\(uringUserData.fileDescriptor)] eventType[\(String(describing:uringUserData.eventType))] registrationID[\(uringUserData.registrationID)] res [\(c.res)] flags [\(c.flags)]")
-        }
-        #endif
-    }
-
     init() {
         cqes = UnsafeMutablePointer<UnsafeMutablePointer<io_uring_cqe>?>.allocate(capacity: Int(cqeMaxCount))
-        cqes.initialize(repeating:&emptyCqe, count:Int(cqeMaxCount))
+        var emptyCqe = io_uring_cqe()
+        cqes.initialize(repeating: &emptyCqe, count: Int(cqeMaxCount))
     }
 
     deinit {
         cqes.deallocate()
     }
 
-    internal func io_uring_queue_init() throws -> () {
-        if (CNIOLinux.io_uring_queue_init(ringEntries, &ring, 0 ) != 0)
-         {
-             throw URingError.uringSetupFailure
-         }
+    internal func queue_init() throws -> () {
+        if (io_uring_queue_init(ringEntries, &ring, 0 ) != 0) {
+            throw URingError.uringSetupFailure
+        }
+        _debugPrint("URing.queue_init: \(self.ring.ring_fd)")
+    }
 
-        _debugPrint("io_uring_queue_init \(self.ring.ring_fd)")
-     }
-
-    internal func io_uring_queue_exit() {
-        _debugPrint("io_uring_queue_exit \(self.ring.ring_fd)")
-        CNIOLinux.io_uring_queue_exit(&ring)
+    internal func queue_exit() {
+        _debugPrint("URing.queue_exit: \(self.ring.ring_fd)")
+        io_uring_queue_exit(&ring)
     }
 
     // Adopting some retry code from queue.c from liburing with slight
     // modifications - we never want to have to handle retries of
     // SQE allocation in all places it could possibly occur.
     // If the SQ ring is full, we may need to submit IO first
-    func withSQE<R>(_ body: (UnsafeMutablePointer<io_uring_sqe>?) throws -> R) rethrows -> R
+    private func withSQE<R>(_ body: (UnsafeMutablePointer<io_uring_sqe>?) throws -> R) rethrows -> R
     {
         // io_uring_submit can fail here due to backpressure from kernel for not reaping CQE:s.
         //
@@ -190,10 +220,10 @@ final internal class URing {
         // This is a slight design issue with SwiftNIO in general that should be discussed.
         //
         while true {
-            if let sqe = CNIOLinux.io_uring_get_sqe(&ring) {
+            if let sqe = io_uring_get_sqe(&ring) {
                return try body(sqe)
             }
-            self.io_uring_flush()
+            self.flush()
         }
     }
 
@@ -202,16 +232,13 @@ final internal class URing {
     // has gone down and we are re-registering polls this means we will silently lose any
     // entries after the failed fd. Ouch. Proper approach is to use io_uring_sq_ready() in a loop.
     // See: https://github.com/axboe/liburing/issues/309
-    internal func io_uring_flush() {         // When using SQPOLL this is basically a NOP
-        var waitingSubmissions: UInt32 = 0
+    func flush() {         // When using SQPOLL this is basically a NOP
         var submissionCount = 0
-        var retval: CInt
-
-        waitingSubmissions = CNIOLinux.io_uring_sq_ready(&ring)
+        var waitingSubmissions = io_uring_sq_ready(&ring)
 
         loop: while (waitingSubmissions > 0)
         {
-            retval = CNIOLinux.io_uring_submit(&ring)
+            let retval = io_uring_submit(&ring)
             submissionCount += 1
 
             switch retval {
@@ -225,84 +252,80 @@ final internal class URing {
             // trying to get new SQE if the actual SQE queue is full, but
             // that would be due to user error in usage IMHO and we should fatalError there.
             case -EAGAIN, -EBUSY:
-                _debugPrint("io_uring_flush io_uring_submit -EBUSY/-EAGAIN waitingSubmissions[\(waitingSubmissions)] submissionCount[\(submissionCount)]. Breaking out and resubmitting later (whenReady() end).")
+                _debugPrint("URing.flush: io_uring_submit -EBUSY/-EAGAIN waitingSubmissions[\(waitingSubmissions)] submissionCount[\(submissionCount)]. Breaking out and resubmitting later (whenReady() end).")
                 break loop
             // -ENOMEM when there is not enough memory to do internal allocations on the kernel side.
             // Right nog we just loop with a sleep trying to buy time, but could also possibly fatalError here.
             // See: https://github.com/axboe/liburing/issues/309
             case -ENOMEM:
                 usleep(10_000) // let's not busy loop to give the kernel some time to recover if possible
-                _debugPrint("io_uring_flush io_uring_submit -ENOMEM \(submissionCount)")
+                _debugPrint("URing.flush: io_uring_submit -ENOMEM \(submissionCount)")
             case 0:
-                _debugPrint("io_uring_flush io_uring_submit submitted 0, so far needed submissionCount[\(submissionCount)] waitingSubmissions[\(waitingSubmissions)] submitted [\(retval)] SQE:s this iteration")
+                _debugPrint("URing.flush: io_uring_submit submitted 0, so far needed submissionCount[\(submissionCount)] waitingSubmissions[\(waitingSubmissions)] submitted [\(retval)] SQE:s this iteration")
                 break
             case 1...:
-                _debugPrint("io_uring_flush io_uring_submit needed [\(submissionCount)] submission(s), submitted [\(retval)] SQE:s out of [\(waitingSubmissions)] possible")
+                _debugPrint("URing.flush: io_uring_submit needed [\(submissionCount)] submission(s), submitted [\(retval)] SQE:s out of [\(waitingSubmissions)] possible")
                 break
             default: // other errors
                 fatalError("Unexpected error [\(retval)] from io_uring_submit ")
             }
 
-            waitingSubmissions = CNIOLinux.io_uring_sq_ready(&ring)
+            waitingSubmissions = io_uring_sq_ready(&ring)
         }
     }
 
     // we stuff event type into the upper byte, the next 3 bytes gives us the sequence number (16M before wrap) and final 4 bytes are fd.
-    internal func io_uring_prep_poll_add(fileDescriptor: CInt, pollMask: UInt32, registrationID: SelectorRegistrationID, submitNow: Bool = true, multishot: Bool = true) -> () {
-        let bitPattern = UInt64(URingUserData(registrationID: registrationID, fileDescriptor: fileDescriptor, eventType:CQEEventType.poll))
-        let bitpatternAsPointer = UnsafeMutableRawPointer.init(bitPattern: UInt(bitPattern))
+    func prep_poll_add(fileDescriptor: CInt, pollMask: UInt32, registrationID: SelectorRegistrationID, multishot: Bool = true) -> () {
+        let userData = UserData(fileDescriptor, registrationID, CQEEventType.poll).asUInt64()
 
-        _debugPrint("io_uring_prep_poll_add fileDescriptor[\(fileDescriptor)] pollMask[\(pollMask)] bitpatternAsPointer[\(String(describing:bitpatternAsPointer))] submitNow[\(submitNow)] multishot[\(multishot)]")
+        _debugPrint("URing.prep_poll_add: " +
+            "fd[\(fileDescriptor)] " +
+            "pollMask[0x\(String(pollMask, radix: 16))] " +
+            "userData[0x\(String(userData>>1, radix: 16))] " +
+            "multishot[\(multishot)]")
 
         self.withSQE { sqe in
-            CNIOLinux.io_uring_prep_poll_add(sqe, fileDescriptor, pollMask)
-            CNIOLinux.io_uring_sqe_set_data(sqe, bitpatternAsPointer) // must be done after prep_poll_add, otherwise zeroed out.
+            io_uring_prep_poll_add(sqe, fileDescriptor, pollMask)
+            io_uring_sqe_set_data64(sqe, userData) // must be done after prep_poll_add, otherwise zeroed out.
 
             if multishot {
                 sqe!.pointee.len |= IORING_POLL_ADD_MULTI; // turn on multishots, set through environment variable
             }
         }
-        
-        if submitNow {
-            self.io_uring_flush()
-        }
     }
 
-    internal func io_uring_prep_poll_remove(fileDescriptor: CInt, pollMask: UInt32, registrationID: SelectorRegistrationID, submitNow: Bool = true, link: Bool = false) -> () {
-        let bitPattern = UInt64(URingUserData(registrationID: registrationID,
-                                              fileDescriptor: fileDescriptor,
-                                              eventType:CQEEventType.poll))
-        let userbitPattern = UInt64(URingUserData(registrationID: registrationID,
-                                                  fileDescriptor: fileDescriptor,
-                                                  eventType:CQEEventType.pollDelete))
+    func prep_poll_remove(fileDescriptor: CInt, pollMask: UInt32, registrationID: SelectorRegistrationID, link: Bool = false) -> () {
+        let pollUserData = UserData(fileDescriptor, registrationID, CQEEventType.poll).asUInt64()
+        let reqUserData = UserData(fileDescriptor,  registrationID, CQEEventType.pollDelete).asUInt64()
 
-        _debugPrint("io_uring_prep_poll_remove fileDescriptor[\(fileDescriptor)] pollMask[\(pollMask)] bitpatternAsPointer[\(String(describing: bitPattern))] userBitpatternAsPointer[\(String(describing: userbitPattern))] submitNow[\(submitNow)] link[\(link)]")
+        _debugPrint("URing.prep_poll_remove: " +
+            "fd[\(fileDescriptor)] " +
+            "pollMask[0x\(String(pollMask, radix: 16))] " +
+            "pollUserData[0x\(String(pollUserData>>1, radix: 16))] " +
+            "reqUserData[0x\(String(reqUserData>>1, radix: 16))] " +
+            "link[\(link)]")
 
         self.withSQE { sqe in
-            CNIOLinux.io_uring_prep_poll_remove(sqe, .init(userData: bitPattern))
-            CNIOLinux.io_uring_sqe_set_data(sqe, .init(userData: userbitPattern)) // must be done after prep_poll_add, otherwise zeroed out.
+            io_uring_prep_poll_remove(sqe, pollUserData)
+            io_uring_sqe_set_data64(sqe, reqUserData) // must be done after prep_poll_add, otherwise zeroed out.
 
             if link {
                 CNIOLinux_io_uring_set_link_flag(sqe)
             }
         }
-        
-        if submitNow {
-            self.io_uring_flush()
-        }
     }
-    
-    // the update/multishot polls are
-    internal func io_uring_poll_update(fileDescriptor: CInt, newPollmask: UInt32, oldPollmask: UInt32, registrationID: SelectorRegistrationID, submitNow: Bool = true, multishot: Bool = true) -> () {
-        
-        let bitpattern = UInt64(URingUserData(registrationID: registrationID,
-                                              fileDescriptor: fileDescriptor,
-                                              eventType:CQEEventType.poll))
-        let userbitPattern = UInt64(URingUserData(registrationID: registrationID,
-                                              fileDescriptor: fileDescriptor,
-                                              eventType:CQEEventType.pollModify))
 
-        _debugPrint("io_uring_poll_update fileDescriptor[\(fileDescriptor)] oldPollmask[\(oldPollmask)] newPollmask[\(newPollmask)]  userBitpatternAsPointer[\(String(describing: userbitPattern))]")
+    // the update/multishot polls are
+    func poll_update(fileDescriptor: CInt, newPollMask: UInt32, oldPollMask: UInt32, registrationID: SelectorRegistrationID, multishot: Bool = true) {
+        
+        let oldUserData = UserData(fileDescriptor, registrationID, CQEEventType.poll).asUInt64()
+        let newUserData = UserData(fileDescriptor, registrationID, CQEEventType.pollModify).asUInt64()
+
+        _debugPrint("URing.poll_update: " +
+            "fd[\(fileDescriptor)] " +
+            "newPollMask[\(newPollMask)] " +
+            "oldUserData[0x\(String(oldUserData>>1, radix: 16)))] " +
+            "newUserData[0x\(String(newUserData>>1, radix: 16))]")
 
         self.withSQE { sqe in
             // "Documentation" for multishot polls and updates here:
@@ -312,174 +335,285 @@ final internal class URing {
                 flags |= IORING_POLL_ADD_MULTI       // ask for multiple updates
             }
 
-            CNIOLinux.io_uring_prep_poll_update(sqe, .init(userData: bitpattern), .init(userData: bitpattern), newPollmask, flags)
-            CNIOLinux.io_uring_sqe_set_data(sqe, .init(userData: userbitPattern))
-        }
-        
-        if submitNow {
-            self.io_uring_flush()
+            CNIOLinux.io_uring_prep_poll_update(sqe, oldUserData, newUserData, newPollMask, flags)
+            //CNIOLinux.io_uring_sqe_set_data64(sqe, newUserData) ??
         }
     }
 
-    internal func _debugPrint(_ s: @autoclosure () -> String)
-    {
-        #if SWIFTNIO_IO_URING_DEBUG_URING
-        print("L [\(NIOThread.current)] " + s())
-        #endif
+    func prep_write(fileDescriptor: CInt, pointer: UnsafeRawBufferPointer, registrationID: SelectorRegistrationID) {
+        let userData = UserData(fileDescriptor, registrationID, CQEEventType.write).asUInt64()
+
+        _debugPrint("URing.prep_write: " +
+            "fd[\(fileDescriptor)] " +
+            "pointer[\(pointer)] " +
+            "userData=[0x\(String(userData>>1, radix: 16))]")
+
+        assert(pointer.count > 0)
+
+        self.withSQE { sqe in
+            io_uring_prep_write(sqe, fileDescriptor, pointer.baseAddress, UInt32(pointer.count), 0)
+            io_uring_sqe_set_data64(sqe, userData)
+        }
     }
 
-    // We merge results into fdEvents on (fd, registrationID) for the given CQE
-    // this minimizes amount of events propagating up and allows Selector to discard
-    // events with an old sequence identifier.
-    internal func _process_cqe(events: UnsafeMutablePointer<URingEvent>, cqeIndex: Int, multishot: Bool) {
-        let bitPattern = UInt(bitPattern:io_uring_cqe_get_data(cqes[cqeIndex]))
-        let uringUserData = URingUserData(rawValue: UInt64(bitPattern))
-        let result = cqes[cqeIndex]!.pointee.res
+    func prep_writev(fileDescriptor: CInt, iovecs: UnsafeBufferPointer<IOVector>, registrationID: SelectorRegistrationID) {
+        let userData = UserData(fileDescriptor, registrationID, CQEEventType.write).asUInt64()
 
-        switch uringUserData.eventType {
-        case .poll:
-            switch result {
-            case -ECANCELED:
-                var pollError: UInt32 = 0
-                assert(uringUserData.fileDescriptor >= 0, "fd must be zero or greater")
-                if multishot { // -ECANCELED for streaming polls, should signal error
-                    pollError = URing.POLLERR | URing.POLLHUP
-                } else {       // this just signals that Selector just should resubmit a new fresh poll
-                    pollError = URing.POLLCANCEL
-                }
-                if let current = fdEvents[FDEventKey(uringUserData.fileDescriptor, uringUserData.registrationID)] {
-                    fdEvents[FDEventKey(uringUserData.fileDescriptor, uringUserData.registrationID)] = current | pollError
-                } else {
-                    fdEvents[FDEventKey(uringUserData.fileDescriptor, uringUserData.registrationID)] = pollError
-                }
-                break
-            // We can validly receive an EBADF as a close() can race vis-a-vis pending SQE:s
-            // with polls / pollModifications - in that case, we should just discard the result.
-            // This is similar to the assert in BaseSocketChannel and is due to the lack
-            // of implicit synchronization with regard to registration changes for io_uring
-            // - we simply can't know when the kernel will process our SQE without
-            // heavy-handed synchronization which would dump performance.
-            // Discussion here:
-            // https://github.com/apple/swift-nio/pull/1804#discussion_r621304055
-            // including clarifications from @isilence (one of the io_uring developers)
-            case -EBADF:
-                _debugPrint("Failed poll with -EBADF for cqeIndex[\(cqeIndex)]")
-                break
-            case ..<0: // other errors
-                fatalError("Failed poll with unexpected error (\(result) for cqeIndex[\(cqeIndex)]")
-                break
-            case 0: // successfull chained add for singleshots, not an event
-                break
-            default: // positive success
-                assert(uringUserData.fileDescriptor >= 0, "fd must be zero or greater")
-                let uresult = UInt32(result)
+        func bytesToWrite(_ iovecs: UnsafeBufferPointer<IOVector>) -> Int {
+            var bytes = 0
+            for idx in 0..<iovecs.count {
+                bytes += iovecs[idx].iov_len
+            }
+            return bytes
+        }
 
-                if let current = fdEvents[FDEventKey(uringUserData.fileDescriptor, uringUserData.registrationID)] {
-                    fdEvents[FDEventKey(uringUserData.fileDescriptor, uringUserData.registrationID)] =  current | uresult
-                } else {
-                    fdEvents[FDEventKey(uringUserData.fileDescriptor, uringUserData.registrationID)] = uresult
+        _debugPrint("URing.prep_writev: " +
+            "fd[\(fileDescriptor)] " +
+            "iovecs[\(iovecs)] " +
+            "bytesToWrite[\(bytesToWrite(iovecs))] " +
+            "userData=[0x\(String(userData>>1, radix: 16))]")
+
+        assert(bytesToWrite(iovecs) > 0)
+
+        self.withSQE { sqe in
+            io_uring_prep_writev(sqe, fileDescriptor, iovecs.baseAddress, UInt32(iovecs.count), 0)
+            io_uring_sqe_set_data64(sqe, userData)
+        }
+    }
+
+    func prep_splice(_ fdIn: CInt, _ offsIn: Int64, _ fdOut: CInt, _ offsOut: Int64, _ count: UInt32, _ flags: UInt32) {
+        _debugPrint("URing.prep_splice: " +
+            "in[fd=\(fdIn), offs=\(offsIn)] " +
+            "out[fd=\(fdOut), offs=\(offsOut)] " +
+            "count=\(count)")
+
+        //let _offs = UnsafeMutablePointer<Int64>.allocate(capacity: 1)
+        //_offs.pointee = offsIn
+        self.withSQE { sqe in
+            io_uring_prep_splice(sqe, fdIn, offsIn, fdOut, offsOut, count, flags)
+        }
+    }
+
+    func prep_sendfile(_ fileDescriptor: CInt, _ src: CInt, _ offs: Int64, _ count: UInt32, _ registrationID: SelectorRegistrationID, _ pipe: Pipe) {
+
+        _debugPrint("URing.prep_sendfile: fileDescriptor=\(fileDescriptor) src[\(src)] offs[\(offs)] count[\(count)]")
+        let request = SendFileRequest(fileDescriptor, src, registrationID, count, pipe)
+
+        self.withSQE { sqe in
+            let userData = UnsafeMutablePointer<SendFileUserData>.allocate(capacity: 1)
+            userData.initialize(to: SendFileUserData(request, offs))
+            io_uring_prep_splice(sqe, src, offs, pipe.write, -1, count, 0)
+            io_uring_sqe_set_data(sqe, userData)
+        }
+
+        self.withSQE { sqe in
+            let userData = UnsafeMutablePointer<SendFileUserData>.allocate(capacity: 1)
+            userData.initialize(to: SendFileUserData(request, -1))
+            io_uring_prep_splice(sqe, pipe.read, -1, fileDescriptor, -1, count, 0)
+            io_uring_sqe_set_data(sqe, userData)
+        }
+    }
+
+    func prep_sendmsg(_ fileDescriptor: CInt, _ msghdr: UnsafePointer<msghdr>, _ registrationID: SelectorRegistrationID) {
+        let userData = UserData(fileDescriptor, registrationID, CQEEventType.write).asUInt64()
+
+        _debugPrint("URing.prep_sendmsg: " +
+            "fd[\(fileDescriptor)] msghdr[\(msghdr)] " +
+            "msg_iovlen[\(msghdr.pointee.msg_iovlen)] iovlen[\(msghdr.pointee.msg_iov[0].iov_len)] " +
+            "userData[0x\(String(userData>>1, radix: 16))]")
+
+        self.withSQE { sqe in
+            io_uring_prep_sendmsg(sqe, fileDescriptor, msghdr, 0)
+            io_uring_sqe_set_data64(sqe, userData)
+        }
+    }
+
+    private func _processPollCQE(_ events: UnsafeMutablePointer<URingEvent>, _ count: inout Int, _ eventKey: EventKey, _ pollMask: UInt32, _ pollCancelled: Bool) {
+        if let idx = pollIdx[eventKey] {
+            switch events[idx].type {
+                case .poll(let current, let pollCancelled):
+                    let pollMask = (current | pollMask)
+                    events[idx].type = .poll(pollMask, pollCancelled)
+                default:
+                    assert(false)
+            }
+        }
+        else {
+            let idx = count
+            count += 1
+            events[idx] = URingEvent(eventKey.fileDescriptor, eventKey.registrationID, .poll(pollMask, pollCancelled))
+            pollIdx[eventKey] = idx
+        }
+    }
+
+    private func _processCQE(events: UnsafeMutablePointer<URingEvent>, count: inout Int, pendingSQEs: inout Int, multishot: Bool, cqe: UnsafeMutablePointer<io_uring_cqe>) {
+        let userData64 : UInt64 = io_uring_cqe_get_data64(cqe)
+        let result = cqe.pointee.res
+        if (userData64 & 1) != 0 {
+            let userData = UserData(rawValue: userData64)
+
+            switch userData.eventType {
+            case .poll:
+                _debugPrint("URing: CQE/poll, fd[\(userData.fileDescriptor)] userData[0x\(String(userData64, radix: 16))] result[\(result)]")
+                switch result {
+                case -ECANCELED:
+                    var pollError: UInt32 = 0
+                    assert(userData.fileDescriptor >= 0, "fd must be zero or greater")
+                    var pollCancelled = false
+                    if multishot { // -ECANCELED for streaming polls, should signal error
+                        pollError = URing.POLLERR | URing.POLLHUP
+                    } else {       // this just signals that Selector just should resubmit a new fresh poll
+                        pollCancelled = true
+                    }
+                    let eventKey = EventKey(userData.fileDescriptor, userData.registrationID)
+                    _processPollCQE(events, &count, eventKey, pollError, pollCancelled)
+                // We can validly receive an EBADF as a close() can race vis-a-vis pending SQE:s
+                // with polls / pollModifications - in that case, we should just discard the result.
+                // This is similar to the assert in BaseSocketChannel and is due to the lack
+                // of implicit synchronization with regard to registration changes for io_uring
+                // - we simply can't know when the kernel will process our SQE without
+                // heavy-handed synchronization which would dump performance.
+                // Discussion here:
+                // https://github.com/apple/swift-nio/pull/1804#discussion_r621304055
+                // including clarifications from @isilence (one of the io_uring developers)
+                case -EBADF:
+                    _debugPrint("Failed poll with -EBADF for cqe[\(cqe)]")
+                case ..<0: // other errors
+                    fatalError("Failed poll with unexpected error (\(result) for cqe[\(cqe)]")
+                case 0: // successfull chained add for singleshots, not an event
+                    break
+                default: // positive success
+                    assert(userData.fileDescriptor >= 0, "fd must be zero or greater")
+                    let eventKey = EventKey(userData.fileDescriptor, userData.registrationID)
+                    _processPollCQE(events, &count, eventKey, UInt32(result), false)
+                }
+
+            case .pollModify: // we only get this for multishot modifications
+                _debugPrint("URing: CQE/pollModify, fd[\(userData.fileDescriptor)] userData=[0x\(String(userData64, radix: 16))] result[\(result)]")
+                switch result {
+                case -ECANCELED: // -ECANCELED for streaming polls, should signal error
+                    assert(userData.fileDescriptor >= 0, "fd must be zero or greater")
+                    let eventKey = EventKey(userData.fileDescriptor, userData.registrationID)
+                    _processPollCQE(events, &count, eventKey, URing.POLLERR, false)
+                case -EALREADY:
+                    _debugPrint("Failed pollModify with -EALREADY for cqe[\(cqe)]")
+                case -ENOENT:
+                    _debugPrint("Failed pollModify with -ENOENT for cqe[\(cqe)]")
+                // See the description for EBADF handling above in the poll case for rationale of allowing EBADF.
+                case -EBADF:
+                    _debugPrint("Failed pollModify with -EBADF for cqe[\(cqe)]")
+                case ..<0: // other errors
+                    fatalError("Failed pollModify with unexpected error (\(result) for cqe[\(cqe)]")
+                case 0: // successfull chained add, not an event
+                    break
+                default: // positive success
+                    fatalError("pollModify returned > 0")
+                }
+
+            case .write:
+                _debugPrint("URing: CQE/write, fd[\(userData.fileDescriptor)] result[\(result)]")
+                let idx = count
+                count += 1
+                events[idx] = URingEvent(userData.fileDescriptor, userData.registrationID, .write(result))
+
+            default:
+                break
+            }
+        }
+        else {
+            let userData = UnsafeMutablePointer<SendFileUserData>(bitPattern: Int(userData64))!
+            let request = userData.pointee.request
+            if result > 0 {
+                userData.pointee.bytesProcessed += UInt32(result)
+                assert(userData.pointee.bytesProcessed <= request.bytes)
+                if userData.pointee.bytesProcessed >= request.bytes {
+                    request.opsDone += 1
+                    let opsDone = request.opsDone
+                    _debugPrint("URing: CQE/sendFile, result[\(result)] offs[\(userData.pointee.offs)] opsDone[\(opsDone)]")
+                    if opsDone == 2 {
+                        let idx = count
+                        count += 1
+                        events[idx] = URingEvent(request.fileDescriptor, request.registrationID, .write(Int32(request.bytes)))
+                    }
+                    userData.deallocate()
+                }
+                else {
+                    let pipe = request.pipe
+                    var offs = userData.pointee.offs
+                    let bytes = (request.bytes - userData.pointee.bytesProcessed)
+                    _debugPrint("URing: CQE/sendFile, result[\(result)] offs[\(userData.pointee.offs)] bytes[\(bytes)]")
+                    if offs >= 0 {
+                        // source file -> write side of the pipe
+                        offs += Int64(userData.pointee.bytesProcessed)
+                        self.withSQE { sqe in
+                            io_uring_prep_splice(sqe, request.src, offs, pipe.write, -1, bytes, 0)
+                            io_uring_sqe_set_data(sqe, userData)
+                        }
+                    }
+                    else {
+                        // read side of the pipe -> destination socket
+                        self.withSQE { sqe in
+                            io_uring_prep_splice(sqe, pipe.read, -1, request.fileDescriptor, -1, bytes, 0)
+                            io_uring_sqe_set_data(sqe, userData)
+                        }
+                    }
+                    pendingSQEs += 1
                 }
             }
-        case .pollModify: // we only get this for multishot modifications
-            switch result {
-            case -ECANCELED: // -ECANCELED for streaming polls, should signal error
-                assert(uringUserData.fileDescriptor >= 0, "fd must be zero or greater")
-
-                let pollError = URing.POLLERR // URing.POLLERR // (URing.POLLHUP | URing.POLLERR)
-                if let current = fdEvents[FDEventKey(uringUserData.fileDescriptor, uringUserData.registrationID)] {
-                    fdEvents[FDEventKey(uringUserData.fileDescriptor, uringUserData.registrationID)] = current | pollError
-                } else {
-                    fdEvents[FDEventKey(uringUserData.fileDescriptor, uringUserData.registrationID)] = pollError
+            else {
+                request.opsDone += 1
+                if request.opsDone == 2 {
+                    let idx = count
+                    count += 1
+                    events[idx] = URingEvent(request.fileDescriptor, request.registrationID, .write(Int32(request.bytes)))
                 }
-                break
-            case -EALREADY:
-                _debugPrint("Failed pollModify with -EALREADY for cqeIndex[\(cqeIndex)]")
-                break
-            case -ENOENT:
-                _debugPrint("Failed pollModify with -ENOENT for cqeIndex [\(cqeIndex)]")
-                break
-            // See the description for EBADF handling above in the poll case for rationale of allowing EBADF.
-            case -EBADF:
-                _debugPrint("Failed pollModify with -EBADF for cqeIndex[\(cqeIndex)]")
-                break
-            case ..<0: // other errors
-                fatalError("Failed pollModify with unexpected error (\(result) for cqeIndex[\(cqeIndex)]")
-                break
-            case 0: // successfull chained add, not an event
-                break
-            default: // positive success
-                fatalError("pollModify returned > 0")
+                userData.deallocate()
             }
-            break
-        case .pollDelete:
-            break
         }
     }
 
-    internal func io_uring_peek_batch_cqe(events: UnsafeMutablePointer<URingEvent>, maxevents: UInt32, multishot: Bool = true) -> Int {
-        var eventCount = 0
-        var currentCqeCount = CNIOLinux.io_uring_peek_batch_cqe(&ring, cqes, cqeMaxCount)
+    func peekBatchCQE(events: UnsafeMutablePointer<URingEvent>, maxEvents: Int, pendingSQEs: inout Int, multishot: Bool) -> Int {
+        assert(maxEvents > 0, "maxEvents should be a positive number")
 
+        let currentCqeCount = io_uring_peek_batch_cqe(&ring, cqes, cqeMaxCount)
         if currentCqeCount == 0 {
-            _debugPrint("io_uring_peek_batch_cqe found zero events, breaking out")
+            _debugPrint("URing.peekBatchCQE: found zero events, breaking out")
             return 0
         }
-
-        _debugPrint("io_uring_peek_batch_cqe found [\(currentCqeCount)] events")
-
-        self._dumpCqes("io_uring_peek_batch_cqe", count: Int(currentCqeCount))
-
         assert(currentCqeCount >= 0, "currentCqeCount should never be negative")
-        assert(maxevents > 0, "maxevents should be a positive number")
 
-        for cqeIndex in 0 ..< currentCqeCount
-        {
-            self._process_cqe(events: events, cqeIndex: Int(cqeIndex), multishot:multishot)
+        _debugPrint("URing.peekBatchCQE: found [\(currentCqeCount)] events")
 
-            if (fdEvents.count == maxevents) // ensure we don't generate more events than maxevents
-            {
-                _debugPrint("io_uring_peek_batch_cqe breaking loop early, currentCqeCount [\(currentCqeCount)] maxevents [\(maxevents)]")
-                currentCqeCount = maxevents // to make sure we only cq_advance the correct amount
+        var eventCount : Int = 0
+        for cqeIndex in 0 ..< Int(currentCqeCount) {
+            let cqe = cqes[cqeIndex]!
+            self._processCQE(events: events, count: &eventCount, pendingSQEs: &pendingSQEs, multishot: multishot, cqe: cqe)
+
+            if (eventCount == maxEvents) {
+                _debugPrint("io_uring_peek_batch_cqe: breaking loop early, currentCqeCount=\(currentCqeCount) maxEvents=\(maxEvents)")
                 break
             }
         }
 
         io_uring_cq_advance(&ring, currentCqeCount) // bulk variant of io_uring_cqe_seen(&ring, dataPointer)
+        pollIdx.removeAll(keepingCapacity: true)
 
-        //  we just return single event per fd, sequencenumber pair
-        eventCount = 0
-        for (eventKey, pollMask) in fdEvents {
-            assert(eventCount < maxevents)
-            assert(eventKey.fileDescriptor >= 0)
-
-            events[eventCount].fd = eventKey.fileDescriptor
-            events[eventCount].pollMask = pollMask
-            events[eventCount].registrationID = eventKey.registrationID
-            if (pollMask & URing.POLLCANCEL) != 0 {
-                events[eventCount].pollMask &= ~URing.POLLCANCEL
-                events[eventCount].pollCancelled = true
-            }
-            eventCount += 1
-        }
-
-        fdEvents.removeAll(keepingCapacity: true) // reused for next batch
-
-        _debugPrint("io_uring_peek_batch_cqe returning [\(eventCount)] events, fdEvents.count [\(fdEvents.count)]")
+        _debugPrint("URing.peekBatchCQE: [\(eventCount)] events")
 
         return eventCount
     }
 
-    internal func _io_uring_wait_cqe_shared(events: UnsafeMutablePointer<URingEvent>, error: Int32, multishot: Bool) throws -> Int {
+    private func _waitCQE(_ events: UnsafeMutablePointer<URingEvent>, _ error: Int32, _ multishot: Bool) throws -> Int {
         var eventCount = 0
 
         switch error {
         case 0:
             break
         case -CNIOLinux.EINTR:
-            _debugPrint("_io_uring_wait_cqe_shared got CNIOLinux.EINTR")
+            _debugPrint("_io_uring_wait_cqe_shared: EINTR")
             return eventCount
         case -CNIOLinux.ETIME:
-            _debugPrint("_io_uring_wait_cqe_shared timed out with -CNIOLinux.ETIME")
+            _debugPrint("_io_uring_wait_cqe_shared: ETIME")
             CNIOLinux.io_uring_cqe_seen(&ring, cqes[0])
             return eventCount
         default:
@@ -487,64 +621,28 @@ final internal class URing {
             throw URingError.uringWaitCqeFailure
         }
 
-        self._dumpCqes("_io_uring_wait_cqe_shared")
+        let cqe = cqes[0]!
+        var pendingSQEs = 0
+        self._processCQE(events: events, count: &eventCount, pendingSQEs: &pendingSQEs, multishot: multishot, cqe: cqe)
 
-        self._process_cqe(events: events, cqeIndex: 0, multishot:multishot)
-
-        CNIOLinux.io_uring_cqe_seen(&ring, cqes[0])
-
-        if let firstEvent = fdEvents.first {
-            events[0].fd = firstEvent.key.fileDescriptor
-            events[0].pollMask = firstEvent.value
-            events[0].registrationID = firstEvent.key.registrationID
-            eventCount = 1
-        } else {
-            _debugPrint("_io_uring_wait_cqe_shared if let firstEvent = fdEvents.first failed")
-        }
-
-        fdEvents.removeAll(keepingCapacity: true) // reused for next batch
+        io_uring_cqe_seen(&ring, cqes[0])
+        pollIdx.removeAll(keepingCapacity: true) // reused for next batch
 
         return eventCount
     }
 
-    internal func io_uring_wait_cqe(events: UnsafeMutablePointer<URingEvent>, maxevents: UInt32, multishot: Bool = true) throws -> Int {
-        _debugPrint("io_uring_wait_cqe")
-
-        let error = CNIOLinux.io_uring_wait_cqe(&ring, cqes)
-
-        return try self._io_uring_wait_cqe_shared(events: events, error: error, multishot:multishot)
+    func waitCQE(events: UnsafeMutablePointer<URingEvent>, multishot: Bool) throws -> Int {
+        _debugPrint("URing.wait_cqe")
+        let error = io_uring_wait_cqe(&ring, cqes)
+        return try self._waitCQE(events, error, multishot)
     }
 
-    internal func io_uring_wait_cqe_timeout(events: UnsafeMutablePointer<URingEvent>, maxevents: UInt32, timeout: TimeAmount, multishot: Bool = true) throws -> Int {
+    func waitCQE(events: UnsafeMutablePointer<URingEvent>, timeout: TimeAmount, multishot: Bool = true) throws -> Int {
         var ts = timeout.kernelTimespec()
-
-        _debugPrint("io_uring_wait_cqe_timeout.ETIME milliseconds \(ts)")
-
-        let error = CNIOLinux.io_uring_wait_cqe_timeout(&ring, cqes, &ts)
-
-        return try self._io_uring_wait_cqe_shared(events: events, error: error, multishot:multishot)
+        _debugPrint("URing.wait_cqe_timeout: \(ts)ms")
+        let error = io_uring_wait_cqe_timeout(&ring, cqes, &ts)
+        return try self._waitCQE(events, error, multishot)
     }
 }
-
-// MARK: Conversion helpers
-// Newer versions of liburing changed one of the method arguments from UnsafeMutableRawPointer
-// to UInt64 in order to allow 32-bit systems to work properly. We therefore need a way to
-// transform a UInt64 into either of these types. These two initializers help us do that in
-// a way that supports both the old and new format in source.
-extension UInt64 {
-    init(userData: UInt64) {
-        self = userData
-    }
-}
-
-extension Optional where Wrapped == UnsafeMutableRawPointer {
-    init(userData: UInt64) {
-        // This will crash on 32-bit systems: that's fine, our liburing support
-        // never worked on 32-bit for older libraries anyway.
-        self = .init(bitPattern: UInt(userData))
-    }
-}
-
-#endif
 
 #endif

--- a/Sources/NIOPosix/PendingWritesManager.swift
+++ b/Sources/NIOPosix/PendingWritesManager.swift
@@ -180,6 +180,117 @@ private struct PendingStreamWritesState {
         self.pendingWrites.mark()
     }
 
+#if SWIFTNIO_USE_IO_URING && os(Linux)
+
+    mutating func didAsyncWrite(_ written: Int, _ storageRefs: UnsafeMutableBufferPointer<Unmanaged<AnyObject>>) -> (EventLoopPromise<Void>?, Bool) {
+        var promise0: EventLoopPromise<Void>?
+        var unaccountedWrites = written
+        var idx: Int = 0
+
+        while unaccountedWrites > 0 {
+            let pw = self.pendingWrites.first!
+            let headItemReadableBytes = pw.data.readableBytes
+
+            if headItemReadableBytes > 0 {
+                if unaccountedWrites < headItemReadableBytes {
+                    self.partiallyWrittenFirst(bytes: unaccountedWrites)
+                    return (promise0, self.pendingWrites.hasMark)
+                }
+                unaccountedWrites -= headItemReadableBytes
+
+                if case .byteBuffer = pw.data {
+                    storageRefs[idx].release()
+                    idx += 1
+                }
+            }
+
+            if let promise = self.fullyWrittenFirst() {
+                if let p = promise0 {
+                    p.futureResult.cascade(to: promise)
+                } else {
+                    promise0 = promise
+                }
+            }
+        }
+
+        let flushedChunks = self.flushedChunks
+        for _ in 0..<flushedChunks {
+            let pw = self.pendingWrites.first!
+            let headItemReadableBytes = pw.data.readableBytes
+            if headItemReadableBytes > 0 {
+                break
+            }
+
+            if let promise = self.fullyWrittenFirst() {
+                if let p = promise0 {
+                    p.futureResult.cascade(to: promise)
+                } else {
+                    promise0 = promise
+                }
+            }
+        }
+        return (promise0, self.pendingWrites.hasMark)
+    }
+
+    func releaseData(_ iovecs: UnsafeMutableBufferPointer<IOVector>,
+                     _ storageRefs: UnsafeMutableBufferPointer<Unmanaged<AnyObject>>) {
+        let count = min(iovecs.count, storageRefs.count)
+        for idx in 0..<count {
+            if iovecs[idx].iov_len == 0 {
+                break
+            }
+            storageRefs[idx].release()
+        }
+    }
+
+    func prepareIOVectors(_ iovecs: UnsafeMutableBufferPointer<IOVector>,
+                          _ storageRefs: UnsafeMutableBufferPointer<Unmanaged<AnyObject>>) -> UnsafeBufferPointer<IOVector> {
+        var count = min(Socket.writevLimitIOVectors, iovecs.count)
+        count = min(count, storageRefs.count)
+        count = min(count, self.flushedChunks)
+
+        // the numbers of storage refs that we need to decrease later.
+        var numberOfUsedSlots = 0
+        var toWrite: Int = 0
+
+        loop: for idx in 0..<count {
+            let p = self[idx]
+            switch p.data {
+            case .byteBuffer(let buffer):
+                // Must not write more than Int32.max in one go.
+                /* FIXME: pronably worth to split that buffer
+                guard (numberOfUsedStorageSlots == 0) || (Socket.writevLimitBytes - toWrite >= buffer.readableBytes) else {
+                    break loop
+                }
+                */
+                let toWriteForThisBuffer = min(Socket.writevLimitBytes, buffer.readableBytes)
+                if toWriteForThisBuffer > 0 {
+                    toWrite += numericCast(toWriteForThisBuffer)
+                    buffer.withUnsafeReadableBytesWithStorageManagement { ptr, storageRef in
+                        iovecs[numberOfUsedSlots] = IOVector(
+                            iov_base: UnsafeMutableRawPointer(mutating: ptr.baseAddress!),
+                            iov_len: numericCast(toWriteForThisBuffer))
+                        storageRefs[numberOfUsedSlots] = storageRef.retain()
+                    }
+                    numberOfUsedSlots += 1
+                }
+            case .fileRegion:
+                assert(numberOfUsedSlots != 0, "first item in doPendingWriteVectorOperation was a FileRegion")
+                // We found a FileRegion so stop collecting
+                break loop
+            }
+        }
+
+        count = min(iovecs.count, storageRefs.count)
+        if numberOfUsedSlots < count {
+            iovecs[numberOfUsedSlots].iov_len = 0
+        }
+
+        return UnsafeBufferPointer(start: iovecs.baseAddress!, count: numberOfUsedSlots)
+    }
+
+#endif
+
     /// Indicate that a write has happened, this may be a write of multiple outstanding writes (using for example `writev`).
     ///
     /// - warning: The promises will be returned in order. If one of those promises does for example close the `Channel` we might see subsequent writes fail out of order. Example: Imagine the user issues three writes: `A`, `B` and `C`. Imagine that `A` and `B` both get successfully written in one write operation but the user closes the `Channel` in `A`'s callback. Then overall the promises will be fulfilled in this order: 1) `A`: success 2) `C`: error 3) `B`: success. Note how `B` and `C` get fulfilled out of order.
@@ -189,7 +300,7 @@ private struct PendingStreamWritesState {
     /// - returns: A tuple of a promise and a `OneWriteResult`. The promise is the first promise that needs to be notified of the write result.
     ///            This promise will cascade the result to all other promises that need notifying. If no promises need to be notified, will be `nil`.
     ///            The write result will indicate whether we were able to write everything or not.
-    public mutating func didWrite(itemCount: Int, result writeResult: IOResult<Int>) -> (EventLoopPromise<Void>?, OneWriteOperationResult) {
+    mutating func didWrite(itemCount: Int, result writeResult: IOResult<Int>) -> (EventLoopPromise<Void>?, OneWriteOperationResult) {
         switch writeResult {
         case .wouldBlock(0):
             return (nil, .wouldBlock)
@@ -329,6 +440,81 @@ final class PendingStreamWritesManager: PendingWritesManager {
         return self.state.currentBestWriteMechanism
     }
 
+#if SWIFTNIO_USE_IO_URING && os(Linux)
+
+    func triggerAppropriateAsyncWriteOperations(scalarBufferAsyncWriteOperation: (UnsafeRawBufferPointer) throws -> Void,
+                                                vectorBufferAsyncWriteOperation: (UnsafeBufferPointer<IOVector>) throws -> Void,
+                                                scalarFileAsyncWriteOperation: (CInt, Int, Int) throws -> Void) throws {
+        let writeMechanism = self.currentBestWriteMechanism
+        switch writeMechanism {
+        case .scalarBufferWrite:
+            switch self.state[0].data {
+            case .byteBuffer(let buffer):
+                let toWrite = min(Socket.writevLimitBytes, buffer.readableBytes)
+                if toWrite > 0 {
+                    try buffer.withUnsafeReadableBytesWithStorageManagement { ptr, storageRef in
+                        self.storageRefs[0] = storageRef.retain()
+                        try scalarBufferAsyncWriteOperation(ptr)
+                    }
+                }
+                else {
+                    // can happen if empty buffer sent
+                    let (promise, flushAgain) = self.state.didAsyncWrite(0, self.storageRefs)
+                    assert(!flushAgain)
+                    promise?.succeed(())
+                }
+            case .fileRegion:
+                preconditionFailure("called \(#function) but first item to write was a FileRegion")
+            }
+        case .vectorBufferWrite:
+            let iovecs = self.state.prepareIOVectors(self.iovecs, self.storageRefs)
+            try vectorBufferAsyncWriteOperation(iovecs)
+        case .scalarFileWrite:
+            switch self.state[0].data {
+            case .byteBuffer:
+                preconditionFailure("called \(#function) but first item to write was a FileRegion")
+            case .fileRegion(let file):
+                let toWrite = min(Socket.writevLimitBytes, file.readableBytes)
+                if toWrite > 0 {
+                    let readerIndex = file.readerIndex
+                    let endIndex = file.endIndex
+                    try file.fileHandle.withUnsafeFileDescriptor { fd in
+                        try scalarFileAsyncWriteOperation(fd, readerIndex, endIndex)
+                    }
+                }
+                else {
+                    let (promise, flushAgain) = self.state.didAsyncWrite(0, self.storageRefs)
+                    assert(!flushAgain)
+                    promise?.succeed(())
+                }
+            }
+        case .nothingToBeWritten:
+            // can happen,
+            // if for example writeAndFlush() has been called for the closed channel
+            break
+        }
+    }
+
+    func didAsyncWrite(written: Int) -> (Bool, Bool) {
+        let (promise, flushAgain) = self.state.didAsyncWrite(written, self.storageRefs)
+
+        var writabilityChange = false
+        if self.state.bytes < waterMark.low {
+            if self.channelWritabilityFlag.compareExchange(expected: false, desired: true, ordering: .relaxed).exchanged {
+                writabilityChange = true
+            }
+        }
+
+        promise?.succeed(())
+        return (writabilityChange, flushAgain)
+    }
+
+    func releaseData() {
+        self.state.releaseData(self.iovecs, self.storageRefs)
+    }
+
+#endif
+
     /// Triggers the appropriate write operation. This is a fancy way of saying trigger either `write`, `writev` or
     /// `sendfile`.
     ///
@@ -434,10 +620,17 @@ final class PendingStreamWritesManager: PendingWritesManager {
         assert(self.state.isEmpty)
     }
 
-    /// Initialize with a pre-allocated array of IO vectors and storage references. We pass in these pre-allocated
+    func flushedChunks() -> Int {
+        return self.state.flushedChunks
+    }
+
+    /// Initialize with a pre-allocated array of IO vectors and storage references.
+    /// With default demultiplexor (like epoll) we pass in these pre-allocated
     /// objects to save allocations. They can be safely be re-used for all `Channel`s on a given `EventLoop` as an
     /// `EventLoop` always runs on one and the same thread. That means that there can't be any writes of more than
     /// one `Channel` on the same `EventLoop` at the same time.
+    /// With URing the data stored in the 'iovecs' and 'storageRefs' is required while the write operation
+    /// will not complete, so each PendingWritesManager has own vector becoming an owner of the provided.
     ///
     /// - parameters:
     ///     - iovecs: A pre-allocated array of `IOVector` elements
@@ -446,6 +639,15 @@ final class PendingStreamWritesManager: PendingWritesManager {
         self.iovecs = iovecs
         self.storageRefs = storageRefs
     }
+
+#if SWIFTNIO_USE_IO_URING && os(Linux)
+
+    deinit {
+        self.iovecs.deallocate()
+        self.storageRefs.deallocate()
+    }
+
+#endif
 }
 
 internal enum WriteMechanism {

--- a/Sources/NIOPosix/PipeChannel.swift
+++ b/Sources/NIOPosix/PipeChannel.swift
@@ -109,6 +109,18 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
         }
         try super.shutdownSocket(mode: mode)
     }
+
+#if SWIFTNIO_USE_IO_URING && os(Linux)
+
+    override func writeAsync(selector: Selector<NIORegistration>, pointer: UnsafeRawBufferPointer) throws {
+        try selector.writeAsync(selectable: self.pipePair.outputFD, pointer: pointer)
+    }
+
+    override func writeAsync(selector: Selector<NIORegistration>, iovecs: UnsafeBufferPointer<IOVector>) throws {
+        try selector.writeAsync(selectable: self.pipePair.outputFD, iovecs: iovecs)
+    }
+
+#endif
 }
 
 extension PipeChannel: CustomStringConvertible {

--- a/Sources/NIOPosix/SelectableChannel.swift
+++ b/Sources/NIOPosix/SelectableChannel.swift
@@ -49,4 +49,10 @@ internal protocol SelectableChannel: Channel {
     func deregister(selector: Selector<NIORegistration>, mode: CloseMode) throws
 
     func reregister(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws
+
+#if SWIFTNIO_USE_IO_URING && os(Linux)
+    func writeAsync(selector: Selector<NIORegistration>, pointer: UnsafeRawBufferPointer) throws
+    func writeAsync(selector: Selector<NIORegistration>, iovecs: UnsafeBufferPointer<IOVector>) throws
+    func sendFileAsync(selector: Selector<NIORegistration>, src: CInt, offset: Int64, count: UInt32) throws
+#endif
 }

--- a/Sources/NIOPosix/SelectorEpoll.swift
+++ b/Sources/NIOPosix/SelectorEpoll.swift
@@ -249,7 +249,7 @@ extension Selector: _SelectorBackendProtocol {
                         continue
                     }
 
-                    try body((SelectorEvent(io: selectorEvent, registration: registration)))
+                    try body(SelectorEvent(registration: registration, io: selectorEvent))
                 }
             }
         }

--- a/Tests/NIOPosixTests/ChannelTests+XCTest.swift
+++ b/Tests/NIOPosixTests/ChannelTests+XCTest.swift
@@ -29,6 +29,7 @@ extension ChannelTests {
       return [
                 ("testBasicLifecycle", testBasicLifecycle),
                 ("testManyManyWrites", testManyManyWrites),
+                ("testEmtyWrite", testEmptyWrite),
                 ("testWritevLotsOfData", testWritevLotsOfData),
                 ("testParentsOfSocketChannels", testParentsOfSocketChannels),
                 ("testPendingWritesEmptyWritesWorkAndWeDontWriteUnflushedThings", testPendingWritesEmptyWritesWorkAndWeDontWriteUnflushedThings),

--- a/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
@@ -48,42 +48,50 @@ private extension SocketAddress {
 class PendingDatagramWritesManagerTests: XCTestCase {
     private func withPendingDatagramWritesManager(_ body: (PendingDatagramWritesManager) throws -> Void) rethrows {
         try withExtendedLifetime(NSObject()) { o in
-            var iovecs: [IOVector] = Array(repeating: iovec(), count: Socket.writevLimitIOVectors + 1)
-            var managed: [Unmanaged<AnyObject>] = Array(repeating: Unmanaged.passUnretained(o), count: Socket.writevLimitIOVectors + 1)
-            var msgs: [MMsgHdr] = Array(repeating: MMsgHdr(), count: Socket.writevLimitIOVectors + 1)
-            var addresses: [sockaddr_storage] = Array(repeating: sockaddr_storage(), count: Socket.writevLimitIOVectors + 1)
-            var controlMessageStorage = UnsafeControlMessageStorage.allocate(msghdrCount: Socket.writevLimitIOVectors)
+
+            let count = (Socket.writevLimitIOVectors + 1)
+            let msgs = UnsafeMutableBufferPointer<MMsgHdr>.allocate(capacity: count)
+            let iovecs = UnsafeMutableBufferPointer<IOVector>.allocate(capacity: count)
+            let addresses = UnsafeMutableBufferPointer<sockaddr_storage>.allocate(capacity: count)
+            let managed = UnsafeMutableBufferPointer<Unmanaged<AnyObject>>.allocate(capacity: count)
+            let controlMessageStorage = UnsafeControlMessageStorage.allocate(msghdrCount: Socket.writevLimitIOVectors)
+
+#if SWIFTNIO_USE_IO_URING && os(Linux)
+            // With Uring the PendingDatagramWritesManager suppose 'msgs', 'iovecs', 'addresses', 'managed'
+            // and 'controlMessageStorage' are allocated by the caller and PendingDatagramWritesManager become an owner
+#else
             defer {
+                msgs.deallocate()
+                iovecs.deallocate()
+                addresses.deallocate()
+                managed.deallocate()
                 controlMessageStorage.deallocate()
             }
+#endif
+
             /* put a canary value at the end */
-            iovecs[iovecs.count - 1] = iovec(iov_base: UnsafeMutableRawPointer(bitPattern: 0xdeadbee)!, iov_len: 0xdeadbee)
-            try iovecs.withUnsafeMutableBufferPointer { iovecs in
-                try managed.withUnsafeMutableBufferPointer { managed in
-                    try msgs.withUnsafeMutableBufferPointer { msgs in
-                        try addresses.withUnsafeMutableBufferPointer { addresses in
-                            let pwm = NIOPosix.PendingDatagramWritesManager(msgs: msgs,
-                                                                            iovecs: iovecs,
-                                                                            addresses: addresses,
-                                                                            storageRefs: managed,
-                                                                            controlMessageStorage: controlMessageStorage)
-                            XCTAssertTrue(pwm.isEmpty)
-                            XCTAssertTrue(pwm.isOpen)
-                            XCTAssertFalse(pwm.isFlushPending)
-                            XCTAssertTrue(pwm.isWritable)
+            iovecs[count - 1] = iovec(iov_base: UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)!, iov_len: 0xdeadbeef)
+            managed.assign(repeating: Unmanaged.passUnretained(o))
 
-                            try body(pwm)
+            let pwm = NIOPosix.PendingDatagramWritesManager(msgs: msgs,
+                                                            iovecs: iovecs,
+                                                            addresses: addresses,
+                                                            storageRefs: managed,
+                                                            controlMessageStorage: controlMessageStorage)
+            XCTAssertTrue(pwm.isEmpty)
+            XCTAssertTrue(pwm.isOpen)
+            XCTAssertFalse(pwm.isFlushPending)
+            XCTAssertTrue(pwm.isWritable)
 
-                            XCTAssertTrue(pwm.isEmpty)
-                            XCTAssertFalse(pwm.isFlushPending)
-                        }
-                    }
-                }
-            }
+            try body(pwm)
+
+            XCTAssertTrue(pwm.isEmpty)
+            XCTAssertFalse(pwm.isFlushPending)
+
             /* assert that the canary values are still okay, we should definitely have never written those */
             XCTAssertEqual(managed.last!.toOpaque(), Unmanaged.passUnretained(o).toOpaque())
-            XCTAssertEqual(0xdeadbee, Int(bitPattern: iovecs.last!.iov_base))
-            XCTAssertEqual(0xdeadbee, iovecs.last!.iov_len)
+            XCTAssertEqual(0xdeadbeef, Int(bitPattern: iovecs.last!.iov_base))
+            XCTAssertEqual(0xdeadbeef, iovecs.last!.iov_len)
         }
     }
 

--- a/Tests/NIOPosixTests/StreamChannelsTest.swift
+++ b/Tests/NIOPosixTests/StreamChannelsTest.swift
@@ -912,7 +912,7 @@ private func assertNoSelectorChanges(fd: CInt, selector: NIOPosix.Selector<NIORe
     #else
     let events: UnsafeMutablePointer<URingEvent> = UnsafeMutablePointer.allocate(capacity: 1)
     events.initialize(to: URingEvent())
-    let numberOfEvents = try selector.ring.io_uring_wait_cqe_timeout(events: events, maxevents: 1, timeout: TimeAmount.seconds(0))
+    let numberOfEvents = try selector.ring.waitCQE(events: events, timeout: TimeAmount.seconds(0))
     events.deinitialize(count: 1)
     events.deallocate()
     guard numberOfEvents == 0 else {


### PR DESCRIPTION
Use URing on Linux.

URing on Linux provides an API to demultiplex events and perform socket operations.
NIO originally designed to demultiplex events and perform all IO in a single thread, while URing socket operations are asynchronous. It requires more significant changes in the NIO taking into account the requirement to additionally manage memory buffers for pending read and write operations.

The one idea was to try to minimise PR as possible, so that PR send outbound data using URing, but still read inbound data using base socket API. Reading inbound data with URing is a next step.

Some highlights regarding changes in the PR

1) The URing API using on Linux can be enabled by the conditional compilation.
In some places I saw '#if defined(SWIFTNIO_USE_IO_URING) && (os(Linux) || os(Android))
As of now we have no possibility even to compile it for Android, not saying to test, so all URing related code is under just os(Linux). Let's decide later what can we do with Android.

2) NIO used some buffers stored in the EventLoop (iovecs, storageRefs etc) which are shared across all channels registered in the event loop. That approach does not work with URing because of its asynchronous nature. There are not too many ways to workaround it for URing, so I moved them to the channel, so with URing each channel has own iovecs and storageRefs buffers. Probably we could cache them... not clear what is better... let's discuss...

3) URing has no analogue for the sendfile() system call.
Instead they suggest to splice() the file via intermediate pipe. It works, but requires an intermediate pipe. There are not too many options how to manage intermediate pipes, but I can't see a good one. So, as of now we just cache intermediate pipes and reuse them...

4) URing has no analogue for sendmmsg() system call.
Unfortunately did not found a good way to workaround that. Currently just send messages one by one. One possible optimisation here is to collect all messages with the same destination address and same ancillary data and send them with one sendmsg(), but did not found such obvious optimisation in the NIO, so probably it is not a case.

5) I had to disable few tests which checks the order of system calls. Have no idea how we could make them work for URing, because URing is asynchronous. Let's discuss them later. All other tests works on my environment, but I will not be surprised if they will not work somewhere else.

Will add some information later within comments to PR if will recall something important.