### PR TITLE
Add availability requirements to TCPThroughputBenchmark

### DIFF
--- a/Sources/NIOPerformanceTester/TCPThroughputBenchmark.swift
+++ b/Sources/NIOPerformanceTester/TCPThroughputBenchmark.swift
@@ -20,6 +20,7 @@ import NIOPosix
 /// measure the time from the very first message sent by the server
 /// to the last message received by the client.
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class TCPThroughputBenchmark: Benchmark {
 
     private let messages: Int

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -1139,7 +1139,9 @@ try measureAndPrint(
     )
 )
 
-try measureAndPrint(
-    desc: "tcp_100k_messages_throughput",
-    benchmark: TCPThroughputBenchmark(messages: 100_000, messageSize: 500)
-)
+if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+    try measureAndPrint(
+        desc: "tcp_100k_messages_throughput",
+        benchmark: TCPThroughputBenchmark(messages: 100_000, messageSize: 500)
+    )
+}


### PR DESCRIPTION
Motivation:

- Uses Concurrency but missing availability requirements; does not build on macOS.

Modifications:

- Add availability requirements/guards

Result:

Compiles on macOS