### PR TITLE
Add support for UDP_SEGMENT

### DIFF
--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -25,6 +25,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <netinet/ip.h>
+#include <netinet/udp.h>
 #include "liburing_nio.h"
 
 #if __has_include(<linux/mptcp.h>)
@@ -105,5 +106,7 @@ size_t CNIOLinux_CMSG_SPACE(size_t);
 // awkward time_T pain
 extern const int CNIOLinux_SO_TIMESTAMP;
 extern const int CNIOLinux_SO_RCVTIMEO;
+
+int CNIOLinux_supports_udp_segment();
 #endif
 #endif

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -150,4 +150,21 @@ size_t CNIOLinux_CMSG_SPACE(size_t payloadSizeBytes) {
 
 const int CNIOLinux_SO_TIMESTAMP = SO_TIMESTAMP;
 const int CNIOLinux_SO_RCVTIMEO = SO_RCVTIMEO;
+
+int CNIOLinux_supports_udp_segment() {
+    #ifndef UDP_SEGMENT
+    return -1;
+    #else
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd == -1) {
+        return -1;
+    }
+
+    int gso_size = 512;
+    int rc = setsockopt(fd, IPPROTO_UDP, UDP_SEGMENT, &gso_size, sizeof(gso_size));
+    close(fd);
+    return rc;
+    #endif
+}
+
 #endif

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -245,6 +245,15 @@ extension NIOBSDSocket.OptionLevel {
     /// Socket options that apply to all sockets.
     public static let socket: NIOBSDSocket.OptionLevel =
             NIOBSDSocket.OptionLevel(rawValue: SOL_SOCKET)
+
+    /// Socket options that apply only to UDP sockets.
+    #if os(Linux) || os(Android)
+    public static let udp: NIOBSDSocket.OptionLevel =
+            NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_UDP))
+    #else
+    public static let udp: NIOBSDSocket.OptionLevel =
+            NIOBSDSocket.OptionLevel(rawValue: IPPROTO_UDP)
+    #endif
 }
 
 // IPv4 Options
@@ -325,6 +334,15 @@ extension NIOBSDSocket.Option {
     /// Get information about the TCP connection.
     public static let tcp_connection_info: NIOBSDSocket.Option =
             NIOBSDSocket.Option(rawValue: TCP_CONNECTION_INFO)
+}
+#endif
+
+#if os(Linux)
+extension NIOBSDSocket.Option {
+    // Note: UDP_SEGMENT is not available on all Linux platforms so the value is hardcoded.
+
+    /// Use UDP segmentation offload (UDP_SEGMENT, or 'GSO'). Only available on Linux.
+    public static let udp_segment = NIOBSDSocket.Option(rawValue: 103)
 }
 #endif
 

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -191,6 +191,19 @@ extension ChannelOptions {
             public init() { }
         }
 
+        /// ``DatagramSegmentSize`` controls the 'UDP_SEGMENT' socket option (sometimes reffered to as 'GSO') which allows for
+        /// large writes to be sent via `sendmsg` and `sendmmsg` and segmented into separate datagrams by the kernel (or in some cases, the NIC).
+        /// The size of segments the large write is split into is controlled by the value of this option (note that writes do not need to be a
+        /// multiple of this option).
+        ///
+        /// This option is currently only supported on Linux (4.18 and newer). Support can be checked using ``System/supportsUDPSegmentationOffload``.
+        ///
+        /// Setting this option to zero disables segmentation offload.
+        public struct DatagramSegmentSize: ChannelOption, Sendable {
+            public typealias Value = CInt
+            public init() { }
+        }
+
         /// When set to true IP level ECN information will be reported through `AddressedEnvelope.Metadata`
         public struct ExplicitCongestionNotificationsOption: ChannelOption, Sendable {
             public typealias Value = Bool
@@ -276,7 +289,7 @@ public struct ChannelOptions {
     public static let socketOption = { (name: NIOBSDSocket.Option) -> Types.SocketOption in
         .init(level: .socket, name: name)
     }
-    
+
     /// - seealso: `SocketOption`.
     public static let ipOption = { (name: NIOBSDSocket.Option) -> Types.SocketOption in
         .init(level: .ip, name: name)
@@ -316,6 +329,9 @@ public struct ChannelOptions {
 
     /// - seealso: `DatagramVectorReadMessageCountOption`
     public static let datagramVectorReadMessageCount = Types.DatagramVectorReadMessageCountOption()
+
+    /// - seealso: `DatagramSegmentSize`
+    public static let datagramSegmentSize = Types.DatagramSegmentSize()
 
     /// - seealso: `ExplicitCongestionNotificationsOption`
     public static let explicitCongestionNotification = Types.ExplicitCongestionNotificationsOption()

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -202,3 +202,16 @@ public enum System {
     }
 }
 
+extension System {
+    #if os(Linux)
+    /// Returns true if the platform supports 'UDP_SEGMENT' (GSO).
+    ///
+    /// The option can be enabled by setting the ``DatagramSegmentSize`` channel option.
+    public static let supportsUDPSegmentationOffload: Bool = CNIOLinux_supports_udp_segment() == 0
+    #else
+    /// Returns true if the platform supports 'UDP_SEGMENT' (GSO).
+    ///
+    /// The option can be enabled by setting the ``DatagramSegmentSize`` channel option.
+    public static let supportsUDPSegmentationOffload: Bool = false
+    #endif
+}

--- a/Sources/NIOPosix/BSDSocketAPIPosix.swift
+++ b/Sources/NIOPosix/BSDSocketAPIPosix.swift
@@ -267,4 +267,35 @@ extension NIOBSDSocketControlMessage {
     }
 }
 
+extension NIOBSDSocket {
+    static func setUDPSegmentSize(_ segmentSize: CInt, socket: NIOBSDSocket.Handle) throws {
+        #if os(Linux)
+        var segmentSize = segmentSize
+        try Self.setsockopt(socket: socket,
+                            level: .udp,
+                            option_name: .udp_segment,
+                            option_value: &segmentSize,
+                            option_len: socklen_t(MemoryLayout<CInt>.size))
+        #else
+        throw ChannelError.operationUnsupported
+        #endif
+    }
+
+    static func getUDPSegmentSize(socket: NIOBSDSocket.Handle) throws -> CInt {
+        #if os(Linux)
+        var segmentSize: CInt = 0
+        var optionLength = socklen_t(MemoryLayout<CInt>.size)
+        try withUnsafeMutablePointer(to: &segmentSize) { segmentSizeBytes in
+            try Self.getsockopt(socket: socket,
+                                level: .udp,
+                                option_name: .udp_segment,
+                                option_value: segmentSizeBytes,
+                                option_len: &optionLength)
+        }
+        return segmentSize
+        #else
+        throw ChannelError.operationUnsupported
+        #endif
+    }
+}
 #endif

--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -551,4 +551,14 @@ extension NIOBSDSocketControlMessage {
         return CNIOWindows_CMSG_SPACE(payloadSize)
     }
 }
+
+extension NIOBSDSocket {
+    static func setUDPSegmentSize(_ segmentSize: CInt, socket: NIOBSDSocket.Handle) throws {
+        throw ChannelError.operationUnsupported
+    }
+
+    static func getUDPSegmentSize(socket: NIOBSDSocket.Handle) throws -> CInt {
+        throw ChannelError.operationUnsupported
+    }
+}
 #endif

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -324,4 +324,18 @@ typealias IOVector = iovec
             try NIOBSDSocket.shutdown(socket: $0, how: how)
         }
     }
+
+    /// Sets the value for the 'UDP_SEGMENT' socket option.
+    func setUDPSegmentSize(_ segmentSize: CInt) throws {
+        try self.withUnsafeHandle {
+            try NIOBSDSocket.setUDPSegmentSize(segmentSize, socket: $0)
+        }
+    }
+
+    /// Returns the value of the 'UDP_SEGMENT' socket option.
+    func getUDPSegmentSize() throws -> CInt {
+        return try self.withUnsafeHandle {
+            try NIOBSDSocket.getUDPSegmentSize(socket: $0)
+        }
+    }
 }

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -508,7 +508,12 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                 // Receiving packet info is only supported for IP
                 throw ChannelError.operationUnsupported
             }
-            break
+        case _ as ChannelOptions.Types.DatagramSegmentSize:
+            guard System.supportsUDPSegmentationOffload else {
+                throw ChannelError.operationUnsupported
+            }
+            let segmentSize = value as! ChannelOptions.Types.DatagramSegmentSize.Value
+            try self.socket.setUDPSegmentSize(segmentSize)
         default:
             try super.setOption0(option, value: value)
         }
@@ -552,6 +557,11 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                 // Receiving packet info is only supported for IP
                 throw ChannelError.operationUnsupported
             }
+        case _ as ChannelOptions.Types.DatagramSegmentSize:
+            guard System.supportsUDPSegmentationOffload else {
+                throw ChannelError.operationUnsupported
+            }
+            return try self.socket.getUDPSegmentSize() as! Option.Value
         default:
             return try super.getOption0(option)
         }

--- a/Sources/NIOPosix/SocketProtocols.swift
+++ b/Sources/NIOPosix/SocketProtocols.swift
@@ -52,7 +52,7 @@ protocol SocketProtocol: BaseSocketProtocol {
                  storage: inout sockaddr_storage,
                  storageLen: inout socklen_t,
                  controlBytes: inout UnsafeReceivedControlBytes) throws -> IOResult<Int>
-    
+
     func sendmsg(pointer: UnsafeRawBufferPointer,
                  destinationPtr: UnsafePointer<sockaddr>?,
                  destinationSize: socklen_t,

--- a/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
@@ -75,6 +75,13 @@ extension DatagramChannelTests {
                 ("testConnectingSocketAfterFlushingExistingMessages", testConnectingSocketAfterFlushingExistingMessages),
                 ("testConnectingSocketFailsBufferedWrites", testConnectingSocketFailsBufferedWrites),
                 ("testReconnectingSocketFailsBufferedWrites", testReconnectingSocketFailsBufferedWrites),
+                ("testGSOIsUnsupportedOnNonLinuxPlatforms", testGSOIsUnsupportedOnNonLinuxPlatforms),
+                ("testSetGSOOption", testSetGSOOption),
+                ("testGetGSOOption", testGetGSOOption),
+                ("testLargeScalarWriteWithGSO", testLargeScalarWriteWithGSO),
+                ("testLargeVectorWriteWithGSO", testLargeVectorWriteWithGSO),
+                ("testWriteBufferAtGSOSegmentCountLimit", testWriteBufferAtGSOSegmentCountLimit),
+                ("testWriteBufferAboveGSOSegmentCountLimitShouldError", testWriteBufferAboveGSOSegmentCountLimitShouldError),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

On Linux, the UDP_SEGMENT socket option allows for large buffers to be written to the kernel and segmented by the kernel (or in some cases the NIC) into smaller datagrams. This can substantially decrease the number of syscalls.

This can be set on a per message basis on a per socket basis. This change adds per socket configuration.

Modifications:

- Add a CNIOLinux function to check whether UDP_SEGMENT is supported on that particular Linux.
- Add a helper to `System` to check whether UDP_SEGMENT is supported on the current platform.
- On Linux only:
  - add the sol_udp socket option level
  - add the udp_gso socket option
- Add the `DatagramGenericSegmentationOffload` channel option.
- Get/Set the option in `DatagramChannel`

Results:

UDP GSO is supported on Linux.