### PR TITLE
Remove redundant availability guards

### DIFF
--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -19,7 +19,6 @@ import Atomics
 import Dispatch
 import NIOConcurrencyHelpers
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public final class EventLoopTest : XCTestCase {
 
     public func testSchedule() throws {
@@ -813,7 +812,7 @@ public final class EventLoopTest : XCTestCase {
 
         class Thing: @unchecked Sendable {
             private let deallocated: ConditionLock<Int>
-            
+
             init(_ deallocated: ConditionLock<Int>) {
                 self.deallocated = deallocated
             }


### PR DESCRIPTION
Motivation:

EventLoopTest has an availability annotation for the various Darwin platforms. This availability check is repeated in a few tests which yields warnings.

Modifications:

Remove the additional test-level availability guards.

Result:

Warning free.