### PR TITLE
Mark syncShutdownGracefully() noasync

### DIFF
--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -1234,8 +1234,20 @@ extension EventLoopGroup {
         self.shutdownGracefully(queue: .global(), callback)
     }
     #endif
-    
+
+
+    #if swift(>=5.7)
+    @available(*, noasync, message: "this can end up blocking the calling thread")
     public func syncShutdownGracefully() throws {
+        try self._syncShutdownGracefully()
+    }
+    #else
+    public func syncShutdownGracefully() throws {
+        try self._syncShutdownGracefully()
+    }
+    #endif
+
+    private func _syncShutdownGracefully() throws {
         self._preconditionSafeToSyncShutdown(file: #fileID, line: #line)
 
         let errorStorageLock = NIOLock()

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -310,7 +310,18 @@ extension NIOThreadPool {
     }
     #endif
 
+    #if swift(>=5.7)
+    @available(*, noasync, message: "this can end up blocking the calling thread")
     public func syncShutdownGracefully() throws {
+        try self._syncShutdownGracefully()
+    }
+    #else
+    public func syncShutdownGracefully() throws {
+        try self._syncShutdownGracefully()
+    }
+    #endif
+
+    private func _syncShutdownGracefully() throws {
         let errorStorageLock = NIOLock()
         var errorStorage: Swift.Error? = nil
         let continuation = DispatchWorkItem {}


### PR DESCRIPTION
Motivation:

The code as-is blocks the calling thread which shouldn't be done in an `async` content.

Modifications:

Mark `EventLoopGroup.syncShutdownGracefully()` and `NIOThreadPool.syncShutdownGracefully()` noasync on Swift > 5.7

