### PR TITLE
Rebuild the channel when retrying testWriteBufferAtGSOSegmentCountLimit

### DIFF
--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -1283,6 +1283,9 @@ class DatagramChannelTests: XCTestCase {
         } catch let e as IOError where e.errnoCode == EINVAL {
             // Some older kernel versions report EINVAL with 64 segments. Tolerate that
             // failure and try again with a lower limit.
+            self.firstChannel = try self.buildChannel(group: self.group)
+            let didSet = self.firstChannel.setOption(ChannelOptions.datagramSegmentSize, value: CInt(segmentSize))
+            XCTAssertNoThrow(try didSet.wait())
             segments = 61
             try send(byteCount: segments * segmentSize)
         }


### PR DESCRIPTION
Motivation:

I (foolishly) didn't validate the test fix in #2382, instead I validated that the original test passed with 61 segments (rather than 64).

Modifications:

- Rebuild the channel before trying again if 64 segments is too many.

Result:

Test passes.