### PR TITLE
Add support for UDP_GRO

### DIFF
--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -22,6 +22,7 @@
 #include <sys/sysinfo.h>
 #include <sys/socket.h>
 #include <sched.h>
+#include <stdbool.h>
 #include <errno.h>
 #include <pthread.h>
 #include <netinet/ip.h>
@@ -107,7 +108,7 @@ size_t CNIOLinux_CMSG_SPACE(size_t);
 extern const int CNIOLinux_SO_TIMESTAMP;
 extern const int CNIOLinux_SO_RCVTIMEO;
 
-int CNIOLinux_supports_udp_segment();
-int CNIOLinux_supports_udp_gro();
+bool CNIOLinux_supports_udp_segment();
+bool CNIOLinux_supports_udp_gro();
 #endif
 #endif

--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -108,5 +108,6 @@ extern const int CNIOLinux_SO_TIMESTAMP;
 extern const int CNIOLinux_SO_RCVTIMEO;
 
 int CNIOLinux_supports_udp_segment();
+int CNIOLinux_supports_udp_gro();
 #endif
 #endif

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -151,19 +151,29 @@ size_t CNIOLinux_CMSG_SPACE(size_t payloadSizeBytes) {
 const int CNIOLinux_SO_TIMESTAMP = SO_TIMESTAMP;
 const int CNIOLinux_SO_RCVTIMEO = SO_RCVTIMEO;
 
-int CNIOLinux_supports_udp_segment() {
-    #ifndef UDP_SEGMENT
-    return -1;
-    #else
+int supports_udp_sockopt(int opt, int value) {
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd == -1) {
         return -1;
     }
-
-    int gso_size = 512;
-    int rc = setsockopt(fd, IPPROTO_UDP, UDP_SEGMENT, &gso_size, sizeof(gso_size));
+    int rc = setsockopt(fd, IPPROTO_UDP, opt, &value, sizeof(value));
     close(fd);
     return rc;
+}
+
+int CNIOLinux_supports_udp_segment() {
+    #ifndef UDP_SEGMENT
+    return -1;
+    #else
+    return supports_udp_sockopt(UDP_SEGMENT, 512);
+    #endif
+}
+
+int CNIOLinux_supports_udp_gro() {
+    #ifndef UDP_GRO
+    return -1;
+    #else
+    return supports_udp_sockopt(UDP_GRO, 1);
     #endif
 }
 

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -151,27 +151,27 @@ size_t CNIOLinux_CMSG_SPACE(size_t payloadSizeBytes) {
 const int CNIOLinux_SO_TIMESTAMP = SO_TIMESTAMP;
 const int CNIOLinux_SO_RCVTIMEO = SO_RCVTIMEO;
 
-int supports_udp_sockopt(int opt, int value) {
+bool supports_udp_sockopt(int opt, int value) {
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd == -1) {
-        return -1;
+        return false;
     }
     int rc = setsockopt(fd, IPPROTO_UDP, opt, &value, sizeof(value));
     close(fd);
-    return rc;
+    return rc == 0;
 }
 
-int CNIOLinux_supports_udp_segment() {
+bool CNIOLinux_supports_udp_segment() {
     #ifndef UDP_SEGMENT
-    return -1;
+    return false;
     #else
     return supports_udp_sockopt(UDP_SEGMENT, 512);
     #endif
 }
 
-int CNIOLinux_supports_udp_gro() {
+bool CNIOLinux_supports_udp_gro() {
     #ifndef UDP_GRO
-    return -1;
+    return false;
     #else
     return supports_udp_sockopt(UDP_GRO, 1);
     #endif

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -339,10 +339,14 @@ extension NIOBSDSocket.Option {
 
 #if os(Linux)
 extension NIOBSDSocket.Option {
-    // Note: UDP_SEGMENT is not available on all Linux platforms so the value is hardcoded.
+    // Note: UDP_SEGMENT and UDP_GRO are not available on all Linux platforms so values are
+    // hardcoded.
 
     /// Use UDP segmentation offload (UDP_SEGMENT, or 'GSO'). Only available on Linux.
     public static let udp_segment = NIOBSDSocket.Option(rawValue: 103)
+
+    /// Use UDP generic receive offload (GRO). Only available on Linux.
+    public static let udp_gro = NIOBSDSocket.Option(rawValue: 104)
 }
 #endif
 

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -204,6 +204,19 @@ extension ChannelOptions {
             public init() { }
         }
 
+        /// ``DatagramReceiveOffload`` sets the 'UDP_GRO' socket option which allows for datagrams to be accumulated
+        /// by the kernel (or in some cases, the NIC) and reduces traversals in the kernel's networking layer.
+        ///
+        /// This option is currently only supported on Linux (5.10 and newer). Support can be checked
+        /// using ``System/supportsUDPReceiveOffload``.
+        ///
+        /// - Note: users should ensure they use an appropriate receive buffer allocator when enabling this option.
+        ///   The default allocator for datagram channels uses fixed sized buffers of 2048 bytes.
+        public struct DatagramReceiveOffload: ChannelOption, Sendable {
+            public typealias Value = Bool
+            public init() { }
+        }
+
         /// When set to true IP level ECN information will be reported through `AddressedEnvelope.Metadata`
         public struct ExplicitCongestionNotificationsOption: ChannelOption, Sendable {
             public typealias Value = Bool
@@ -332,6 +345,9 @@ public struct ChannelOptions {
 
     /// - seealso: `DatagramSegmentSize`
     public static let datagramSegmentSize = Types.DatagramSegmentSize()
+
+    /// - seealso: `DatagramReceiveOffload`
+    public static let datagramReceiveOffload = Types.DatagramReceiveOffload()
 
     /// - seealso: `ExplicitCongestionNotificationsOption`
     public static let explicitCongestionNotification = Types.ExplicitCongestionNotificationsOption()

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -214,4 +214,16 @@ extension System {
     /// The option can be enabled by setting the ``DatagramSegmentSize`` channel option.
     public static let supportsUDPSegmentationOffload: Bool = false
     #endif
+
+    #if os(Linux)
+    /// Returns true if the platform supports 'UDP_GRO'.
+    ///
+    /// The option can be enabled by setting the ``DatagramReceiveOffload`` channel option.
+    public static let supportsUDPReceiveOffload: Bool = CNIOLinux_supports_udp_gro() == 0
+    #else
+    /// Returns true if the platform supports 'UDP_GRO'.
+    ///
+    /// The option can be enabled by setting the ``DatagramReceiveOffload`` channel option.
+    public static let supportsUDPReceiveOffload: Bool = false
+    #endif
 }

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -207,7 +207,7 @@ extension System {
     /// Returns true if the platform supports 'UDP_SEGMENT' (GSO).
     ///
     /// The option can be enabled by setting the ``DatagramSegmentSize`` channel option.
-    public static let supportsUDPSegmentationOffload: Bool = CNIOLinux_supports_udp_segment() == 0
+    public static let supportsUDPSegmentationOffload: Bool = CNIOLinux_supports_udp_segment()
     #else
     /// Returns true if the platform supports 'UDP_SEGMENT' (GSO).
     ///
@@ -219,7 +219,7 @@ extension System {
     /// Returns true if the platform supports 'UDP_GRO'.
     ///
     /// The option can be enabled by setting the ``DatagramReceiveOffload`` channel option.
-    public static let supportsUDPReceiveOffload: Bool = CNIOLinux_supports_udp_gro() == 0
+    public static let supportsUDPReceiveOffload: Bool = CNIOLinux_supports_udp_gro()
     #else
     /// Returns true if the platform supports 'UDP_GRO'.
     ///

--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -560,5 +560,13 @@ extension NIOBSDSocket {
     static func getUDPSegmentSize(socket: NIOBSDSocket.Handle) throws -> CInt {
         throw ChannelError.operationUnsupported
     }
+
+    static func setUDPReceiveOffload(_ enabled: Bool, socket: NIOBSDSocket.Handle) throws {
+        throw ChannelError.operationUnsupported
+    }
+
+    static func getUDPReceiveOffload(socket: NIOBSDSocket.Handle) throws -> Bool {
+        throw ChannelError.operationUnsupported
+    }
 }
 #endif

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -338,4 +338,18 @@ typealias IOVector = iovec
             try NIOBSDSocket.getUDPSegmentSize(socket: $0)
         }
     }
+
+    /// Sets the value for the 'UDP_GRO' socket option.
+    func setUDPReceiveOffload(_ enabled: Bool) throws {
+        try self.withUnsafeHandle {
+            try NIOBSDSocket.setUDPReceiveOffload(enabled, socket: $0)
+        }
+    }
+
+    /// Returns the value of the 'UDP_GRO' socket option.
+    func getUDPReceiveOffload() throws -> Bool {
+        return try self.withUnsafeHandle {
+            try NIOBSDSocket.getUDPReceiveOffload(socket: $0)
+        }
+    }
 }

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -514,6 +514,12 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             }
             let segmentSize = value as! ChannelOptions.Types.DatagramSegmentSize.Value
             try self.socket.setUDPSegmentSize(segmentSize)
+        case _ as ChannelOptions.Types.DatagramReceiveOffload:
+            guard System.supportsUDPReceiveOffload else {
+                throw ChannelError.operationUnsupported
+            }
+            let enable = value as! ChannelOptions.Types.DatagramReceiveOffload.Value
+            try self.socket.setUDPReceiveOffload(enable)
         default:
             try super.setOption0(option, value: value)
         }
@@ -562,6 +568,11 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                 throw ChannelError.operationUnsupported
             }
             return try self.socket.getUDPSegmentSize() as! Option.Value
+        case _ as ChannelOptions.Types.DatagramReceiveOffload:
+            guard System.supportsUDPReceiveOffload else {
+                throw ChannelError.operationUnsupported
+            }
+            return try self.socket.getUDPReceiveOffload() as! Option.Value
         default:
             return try super.getOption0(option)
         }

--- a/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests+XCTest.swift
@@ -82,6 +82,13 @@ extension DatagramChannelTests {
                 ("testLargeVectorWriteWithGSO", testLargeVectorWriteWithGSO),
                 ("testWriteBufferAtGSOSegmentCountLimit", testWriteBufferAtGSOSegmentCountLimit),
                 ("testWriteBufferAboveGSOSegmentCountLimitShouldError", testWriteBufferAboveGSOSegmentCountLimitShouldError),
+                ("testGROIsUnsupportedOnNonLinuxPlatforms", testGROIsUnsupportedOnNonLinuxPlatforms),
+                ("testSetGROOption", testSetGROOption),
+                ("testGetGROOption", testGetGROOption),
+                ("testChannelCanReceiveLargeBufferWithGROUsingScalarReads", testChannelCanReceiveLargeBufferWithGROUsingScalarReads),
+                ("testChannelCanReceiveLargeBufferWithGROUsingVectorReads", testChannelCanReceiveLargeBufferWithGROUsingVectorReads),
+                ("testChannelCanReceiveMultipleLargeBuffersWithGROUsingScalarReads", testChannelCanReceiveMultipleLargeBuffersWithGROUsingScalarReads),
+                ("testChannelCanReceiveMultipleLargeBuffersWithGROUsingVectorReads", testChannelCanReceiveMultipleLargeBuffersWithGROUsingVectorReads),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Support was added for UDP_SEGMENT in #2372 which allows for large UDP datagrams to be written to a socket by letting the kernel or NIC segment the data across multiple datagrams. This reduces traversals across the network stack which can lead to performance improvements. UDP_GRO is the receive-side counterpart allowing the kernel/NIC to aggregate datagrams and reduce network stack traversals.

Modifications:

- Add a function in CNIOLinux to check whether UDP_GRO is supported
- Add the relevant socket and channel options
- Add tests

Result:

- UDP_GRO can be enabled where supported and applications may receive large buffers.