### PR TITLE
Rework the `NIOAsyncSequenceProducer` tests to rely less on timings

### DIFF
--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
@@ -16,20 +16,31 @@ import NIOCore
 import XCTest
 
 final class MockNIOElementStreamBackPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategy, @unchecked Sendable {
-    var didYieldCallCount = 0
+    enum Event {
+        case didYield
+        case didNext
+    }
+    let events: AsyncStream<Event>
+    private let eventsContinuation: AsyncStream<Event>.Continuation
+
+    init() {
+        var eventsContinuation: AsyncStream<Event>.Continuation!
+        self.events = .init() { eventsContinuation = $0 }
+        self.eventsContinuation = eventsContinuation!
+    }
+
     var didYieldHandler: ((Int) -> Bool)?
     func didYield(bufferDepth: Int) -> Bool {
-        self.didYieldCallCount += 1
+        self.eventsContinuation.yield(.didYield)
         if let didYieldHandler = self.didYieldHandler {
             return didYieldHandler(bufferDepth)
         }
         return false
     }
 
-    var didNextCallCount = 0
     var didNextHandler: ((Int) -> Bool)?
     func didConsume(bufferDepth: Int) -> Bool {
-        self.didNextCallCount += 1
+        self.eventsContinuation.yield(.didNext)
         if let didNextHandler = self.didNextHandler {
             return didNextHandler(bufferDepth)
         }
@@ -38,19 +49,30 @@ final class MockNIOElementStreamBackPressureStrategy: NIOAsyncSequenceProducerBa
 }
 
 final class MockNIOBackPressuredStreamSourceDelegate: NIOAsyncSequenceProducerDelegate, @unchecked Sendable {
-    var produceMoreCallCount = 0
+    enum Event {
+        case produceMore
+        case didTerminate
+    }
+    let events: AsyncStream<Event>
+    private let eventsContinuation: AsyncStream<Event>.Continuation
+
+    init() {
+        var eventsContinuation: AsyncStream<Event>.Continuation!
+        self.events = .init() { eventsContinuation = $0 }
+        self.eventsContinuation = eventsContinuation!
+    }
+
     var produceMoreHandler: (() -> Void)?
     func produceMore() {
-        self.produceMoreCallCount += 1
+        self.eventsContinuation.yield(.produceMore)
         if let produceMoreHandler = self.produceMoreHandler {
             return produceMoreHandler()
         }
     }
 
-    var didTerminateCallCount = 0
     var didTerminateHandler: (() -> Void)?
     func didTerminate() {
-        self.didTerminateCallCount += 1
+        self.eventsContinuation.yield(.didTerminate)
         if let didTerminateHandler = self.didTerminateHandler {
             return didTerminateHandler()
         }
@@ -109,14 +131,12 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
 
         XCTAssertEqual(self.source.yield(contentsOf: [1, 2, 3]), .produceMore)
         XCTAssertEqual(self.source.yield(contentsOf: [4, 5, 6]), .stopProducing)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 0)
         XCTAssertEqualWithoutAutoclosure(await iterator.next(), 1)
         XCTAssertEqualWithoutAutoclosure(await iterator.next(), 2)
         XCTAssertEqualWithoutAutoclosure(await iterator.next(), 3)
         XCTAssertEqualWithoutAutoclosure(await iterator.next(), 4)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 0)
         XCTAssertEqualWithoutAutoclosure(await iterator.next(), 5)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.produceMore])
         XCTAssertEqual(self.source.yield(contentsOf: [7, 8, 9, 10, 11]), .stopProducing)
     }
 
@@ -126,7 +146,7 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         self.backPressureStrategy.didYieldHandler = { _ in false }
         let result = self.source.yield(contentsOf: [1])
 
-        XCTAssertEqual(self.backPressureStrategy.didYieldCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didYield])
         XCTAssertEqual(result, .stopProducing)
     }
 
@@ -134,7 +154,7 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         self.backPressureStrategy.didYieldHandler = { _ in true }
         let result = self.source.yield(contentsOf: [1])
 
-        XCTAssertEqual(self.backPressureStrategy.didYieldCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didYield])
         XCTAssertEqual(result, .produceMore)
     }
 
@@ -145,14 +165,13 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         // sure the other child task runs when the demand is registered
         let sequence = try XCTUnwrap(self.sequence)
         async let element = sequence.first { _ in true }
-        try await Task.sleep(nanoseconds: 1_000_000)
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didNext])
 
         let result = self.source.yield(contentsOf: [1])
 
         XCTAssertEqual(result, .stopProducing)
         XCTAssertEqualWithoutAutoclosure(await element, 1)
-        XCTAssertEqual(self.backPressureStrategy.didYieldCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didYield])
     }
 
     func testYield_whenStreaming_andSuspended_andDemandMore() async throws {
@@ -162,14 +181,13 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         // sure the other child task runs when the demand is registered
         let sequence = try XCTUnwrap(self.sequence)
         async let element = sequence.first { _ in true }
-        try await Task.sleep(nanoseconds: 1_000_000)
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didNext])
 
         let result = self.source.yield(contentsOf: [1])
 
         XCTAssertEqual(result, .produceMore)
         XCTAssertEqualWithoutAutoclosure(await element, 1)
-        XCTAssertEqual(self.backPressureStrategy.didYieldCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didYield])
     }
 
     func testYieldEmptySequence_whenStreaming_andSuspended_andStopDemanding() async throws {
@@ -182,13 +200,11 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
             // Would prefer to use async let _ here but that is not allowed yet
             _ = await sequence.first { _ in true }
         }
-        try await Task.sleep(nanoseconds: 1_000_000)
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didNext])
 
         let result = self.source.yield(contentsOf: [])
 
         XCTAssertEqual(result, .stopProducing)
-        XCTAssertEqual(self.backPressureStrategy.didYieldCallCount, 0)
     }
 
     func testYieldEmptySequence_whenStreaming_andSuspended_andDemandMore() async throws {
@@ -201,13 +217,11 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
             // Would prefer to use async let _ here but that is not allowed yet
             _ = await sequence.first { _ in true }
         }
-        try await Task.sleep(nanoseconds: 1_000_000)
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didNext])
 
         let result = self.source.yield(contentsOf: [])
 
         XCTAssertEqual(result, .stopProducing)
-        XCTAssertEqual(self.backPressureStrategy.didYieldCallCount, 0)
     }
 
     func testYield_whenStreaming_andNotSuspended_andStopDemanding() async throws {
@@ -218,7 +232,7 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         let result = self.source.yield(contentsOf: [1])
 
         XCTAssertEqual(result, .stopProducing)
-        XCTAssertEqual(self.backPressureStrategy.didYieldCallCount, 2)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(2).collect(), [.didYield, .didYield])
     }
 
     func testYield_whenStreaming_andNotSuspended_andDemandMore() async throws {
@@ -229,7 +243,7 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         let result = self.source.yield(contentsOf: [1])
 
         XCTAssertEqual(result, .produceMore)
-        XCTAssertEqual(self.backPressureStrategy.didYieldCallCount, 2)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(2).collect(), [.didYield, .didYield])
     }
 
     func testYield_whenSourceFinished() async throws {
@@ -238,15 +252,12 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         let result = self.source.yield(contentsOf: [1])
 
         XCTAssertEqual(result, .dropped)
-        XCTAssertEqual(self.backPressureStrategy.didYieldCallCount, 0)
     }
 
     // MARK: - Finish
 
     func testFinish_whenInitial() async {
         self.source.finish()
-
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
     }
 
     func testFinish_whenStreaming_andSuspended() async throws {
@@ -259,7 +270,7 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         self.source.finish()
 
         XCTAssertEqualWithoutAutoclosure(await element, nil)
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 
     func testFinish_whenStreaming_andNotSuspended_andBufferEmpty() async throws {
@@ -269,7 +280,7 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
 
         let element = await self.sequence.first { _ in true }
         XCTAssertNil(element)
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 
     func testFinish_whenStreaming_andNotSuspended_andBufferNotEmpty() async throws {
@@ -277,34 +288,26 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
 
         self.source.finish()
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
-
         let element = await self.sequence.first { _ in true }
         XCTAssertEqual(element, 1)
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 
     func testFinish_whenFinished() async throws {
         self.source.finish()
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
-
         _ = await self.sequence.first { _ in true }
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
 
         self.source.finish()
-
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
     }
 
     // MARK: - Source Deinited
 
     func testSourceDeinited_whenInitial() async {
         self.source = nil
-
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
     }
 
     func testSourceDeinited_whenStreaming_andSuspended() async throws {
@@ -325,7 +328,7 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         }
 
         XCTAssertEqual(element, nil)
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 
     func testSourceDeinited_whenStreaming_andNotSuspended_andBufferEmpty() async throws {
@@ -343,15 +346,13 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         }
 
         XCTAssertNil(element)
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 
     func testSourceDeinited_whenStreaming_andNotSuspended_andBufferNotEmpty() async throws {
         _ = self.source.yield(contentsOf: [1])
 
         self.source = nil
-
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
 
         let sequence = try XCTUnwrap(self.sequence)
         let element: Int? = try await withThrowingTaskGroup(of: Int?.self) { group in
@@ -364,7 +365,7 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
 
         XCTAssertEqual(element, 1)
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 
     // MARK: - Task cancel
@@ -379,10 +380,9 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         }
         try await Task.sleep(nanoseconds: 1_000_000)
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
         task.cancel()
         let value = await task.value
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
         XCTAssertNil(value)
     }
 
@@ -405,10 +405,9 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
 
         _ = self.source.yield(contentsOf: [1])
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
         task.cancel()
         let value = await task.value
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
         XCTAssertEqual(value, 1)
     }
 
@@ -422,12 +421,10 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         }
         try await Task.sleep(nanoseconds: 1_000_000)
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
         self.source.finish()
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
         task.cancel()
         let value = await task.value
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
         XCTAssertNil(value)
     }
 
@@ -459,10 +456,9 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
             // Would prefer to use async let _ here but that is not allowed yet
             _ = await sequence.first { _ in true }
         }
-        try await Task.sleep(nanoseconds: 1_000_000)
 
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didNext])
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.produceMore])
     }
 
     func testNext_whenInitial_whenNoDemand() async throws {
@@ -474,10 +470,8 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
             // Would prefer to use async let _ here but that is not allowed yet
             _ = await sequence.first { _ in true }
         }
-        try await Task.sleep(nanoseconds: 1_000_000)
 
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 0)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(1).collect(), [.didNext])
     }
 
     func testNext_whenStreaming_whenEmptyBuffer_whenDemand() async throws {
@@ -491,10 +485,9 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
             // Would prefer to use async let _ here but that is not allowed yet
             _ = await sequence.first { _ in true }
         }
-        try await Task.sleep(nanoseconds: 1_000_000)
 
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(2).collect(), [.didYield, .didNext])
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.produceMore])
     }
 
     func testNext_whenStreaming_whenEmptyBuffer_whenNoDemand() async throws {
@@ -508,10 +501,8 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
             // Would prefer to use async let _ here but that is not allowed yet
             _ = await sequence.first { _ in true }
         }
-        try await Task.sleep(nanoseconds: 1_000_000)
 
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 0)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(2).collect(), [.didYield, .didNext])
     }
 
     func testNext_whenStreaming_whenNotEmptyBuffer_whenNoDemand() async throws {
@@ -521,8 +512,7 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         let element = await self.sequence.first { _ in true }
 
         XCTAssertEqual(element, 1)
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 0)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(2).collect(), [.didYield, .didNext])
     }
 
     func testNext_whenStreaming_whenNotEmptyBuffer_whenNewDemand() async throws {
@@ -532,8 +522,8 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         let element = await self.sequence.first { _ in true }
 
         XCTAssertEqual(element, 1)
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(2).collect(), [.didYield, .didNext])
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.produceMore])
     }
 
     func testNext_whenStreaming_whenNotEmptyBuffer_whenNewAndOutstandingDemand() async throws {
@@ -541,13 +531,11 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         self.backPressureStrategy.didYieldHandler = { _ in true }
 
         _ = self.source.yield(contentsOf: [1])
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 0)
 
         let element = await self.sequence.first { _ in true }
 
         XCTAssertEqual(element, 1)
-        XCTAssertEqual(self.backPressureStrategy.didNextCallCount, 1)
-        XCTAssertEqual(self.delegate.produceMoreCallCount, 0)
+        XCTAssertEqualWithoutAutoclosure(await self.backPressureStrategy.events.prefix(2).collect(), [.didYield, .didNext])
     }
 
     func testNext_whenSourceFinished() async throws {
@@ -568,18 +556,17 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
     func testSequenceDeinitialized() async {
         self.sequence = nil
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 
     func testSequenceDeinitialized_whenIteratorReferenced() async {
         var iterator = self.sequence?.makeAsyncIterator()
 
         self.sequence = nil
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
 
         XCTAssertNotNil(iterator)
         iterator = nil
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 
     // MARK: - IteratorDeinitialized
@@ -589,32 +576,30 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
 
         XCTAssertNotNil(iterator)
         iterator = nil
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
 
         self.sequence = nil
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
     }
 
-    func testIteratorDeinitialized_whenSequenceFinished() {
+    func testIteratorDeinitialized_whenSequenceFinished() async {
         self.source.finish()
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 0)
 
         var iterator = self.sequence?.makeAsyncIterator()
 
         XCTAssertNotNil(iterator)
         iterator = nil
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 
-    func testIteratorDeinitialized_whenStreaming() {
+    func testIteratorDeinitialized_whenStreaming() async {
         _ = self.source.yield(contentsOf: [1])
         var iterator = self.sequence?.makeAsyncIterator()
 
         XCTAssertNotNil(iterator)
         iterator = nil
 
-        XCTAssertEqual(self.delegate.didTerminateCallCount, 1)
+        XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
     }
 }
 
@@ -626,6 +611,14 @@ fileprivate func XCTAssertEqualWithoutAutoclosure<T>(
     file: StaticString = #filePath,
     line: UInt = #line
 ) where T: Equatable {
-    let result = expression1 == expression2
-    XCTAssertTrue(result, message(), file: file, line: line)
+    XCTAssertEqual(expression1, expression2, message(), file: file, line: line)
+}
+
+extension AsyncSequence {
+    /// Collect all elements in the sequence into an array.
+    fileprivate func collect() async rethrows -> [Element] {
+        try await self.reduce(into: []) { accumulated, next in
+            accumulated.append(next)
+        }
+    }
 }


### PR DESCRIPTION
# Motivation
We see a bunch of flaky tests for the `NIOAsyncSequenceProducer` where we rely on specific timings to hit our assertions.

# Modification
This PR inverts the control of the assertions to use an event stream and await the events on the stream. This makes the tests way more reliable and gets rid of a bunch of sleeps.

# Result
Less flaky tests.