### PR TITLE
Allow UDP GRO tests to fail in some circumstances

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,7 +104,7 @@ var targets: [PackageDescription.Target] = [
     .testTarget(name: "NIOEmbeddedTests",
                 dependencies: ["NIOConcurrencyHelpers", "NIOCore", "NIOEmbedded"]),
     .testTarget(name: "NIOPosixTests",
-                dependencies: ["NIOPosix", "NIOCore", "NIOFoundationCompat", "NIOTestUtils", "NIOConcurrencyHelpers", "NIOEmbedded"]),
+                dependencies: ["NIOPosix", "NIOCore", "NIOFoundationCompat", "NIOTestUtils", "NIOConcurrencyHelpers", "NIOEmbedded", "CNIOLinux"]),
     .testTarget(name: "NIOConcurrencyHelpersTests",
                 dependencies: ["NIOConcurrencyHelpers", "NIOCore"]),
     .testTarget(name: "NIODataStructuresTests",

--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -21,6 +21,7 @@
 #include <sys/timerfd.h>
 #include <sys/sysinfo.h>
 #include <sys/socket.h>
+#include <sys/utsname.h>
 #include <sched.h>
 #include <stdbool.h>
 #include <errno.h>
@@ -110,5 +111,8 @@ extern const int CNIOLinux_SO_RCVTIMEO;
 
 bool CNIOLinux_supports_udp_segment();
 bool CNIOLinux_supports_udp_gro();
+
+int CNIOLinux_system_info(struct utsname* uname_data);
+
 #endif
 #endif

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -24,6 +24,7 @@ void CNIOLinux_i_do_nothing_just_working_around_a_darwin_toolchain_bug(void) {}
 #include <sched.h>
 #include <stdio.h>
 #include <sys/prctl.h>
+#include <sys/utsname.h>
 #include <unistd.h>
 #include <assert.h>
 #include <time.h>
@@ -175,6 +176,10 @@ bool CNIOLinux_supports_udp_gro() {
     #else
     return supports_udp_sockopt(UDP_GRO, 1);
     #endif
+}
+
+int CNIOLinux_system_info(struct utsname* uname_data) {
+    return uname(uname_data);
 }
 
 #endif


### PR DESCRIPTION
Motivation:

The recently added UDP GRO tests fail on some older Linux Kernel versions. We believe that UDP GRO support on loopback was limited in early versions so we should tolerate those failures.

However, we've verified that on 5.15 and newer that GRO is supported so we should not tolerate failure in those cases.

Modifications:

- Add shims to CNIOLinux to get system info via uname
- Verify GRO works before running GRO tests and if it doesn't then validate the kernel version isn't greater than 5.15.

Results:

Less flaky tests.