### PR TITLE
Initial PoC of Custom Actor Executor support

### DIFF
--- a/Sources/NIOCore/ActorExecutor.swift
+++ b/Sources/NIOCore/ActorExecutor.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.9)
+#if compiler(>=5.9)
 /// A helper protocol that can be mixed in to a NIO ``EventLoop`` to provide an
 /// automatic conformance to `SerialExecutor`.
 ///

--- a/Sources/NIOCore/ActorExecutor.swift
+++ b/Sources/NIOCore/ActorExecutor.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.9)
+/// A helper protocol that can be mixed in to a NIO ``EventLoop`` to provide an
+/// automatic conformance to `SerialExecutor`.
+///
+/// Implementers of `EventLoop` should consider conforming to this protocol as
+/// well on Swift 5.9 and later.
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+public protocol NIOSerialEventLoopExecutor: EventLoop, SerialExecutor { }
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension NIOSerialEventLoopExecutor {
+    @inlinable
+    public func enqueue(_ job: consuming ExecutorJob) {
+        let unownedJob = UnownedJob(job)
+        self.execute {
+            unownedJob.runSynchronously(on: self.asUnownedSerialExecutor())
+        }
+    }
+
+    @inlinable
+    public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+        UnownedSerialExecutor(ordinary: self)
+    }
+
+    @inlinable
+    public var executor: any SerialExecutor {
+        self
+    }
+}
+
+/// A type that wraps a NIO ``EventLoop`` into a `SerialExecutor`
+/// for use with Swift concurrency.
+///
+/// This type is not recommended for use because it risks problems with unowned
+/// executors. Adopters are recommended to conform their own event loop
+/// types to `SerialExecutor`.
+final class NIODefaultSerialEventLoopExecutor {
+    @usableFromInline
+    let loop: EventLoop
+
+    @inlinable
+    init(_ loop: EventLoop) {
+        self.loop = loop
+    }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension NIODefaultSerialEventLoopExecutor: SerialExecutor {
+    @inlinable
+    public func enqueue(_ job: consuming ExecutorJob) {
+        let unownedJob = UnownedJob(job)
+        self.loop.execute {
+            unownedJob.runSynchronously(on: self.asUnownedSerialExecutor())
+        }
+    }
+
+    @inlinable
+    public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+        UnownedSerialExecutor(complexEquality: self)
+
+    }
+
+    @inlinable
+    public func isSameExclusiveExecutionContext(other: NIODefaultSerialEventLoopExecutor) -> Bool {
+        self.loop === other.loop
+    }
+}
+#endif

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -373,6 +373,17 @@ public protocol EventLoop: EventLoopGroup {
     /// allows `EventLoop`s to cache a pre-succeeded `Void` future to prevent superfluous allocations.
     func makeSucceededVoidFuture() -> EventLoopFuture<Void>
 
+    #if swift(>=5.9)
+    /// Returns a `SerialExecutor` corresponding to this ``EventLoop``.
+    ///
+    /// This executor can be used to isolate an actor to a given ``EventLoop``. Implementers are encouraged to customise
+    /// this implementation by conforming their ``EventLoop`` to ``NIOSerialEventLoopExecutor`` which will provide an
+    /// optimised implementation of this method, and will conform their type to `SerialExecutor`. The default
+    /// implementation returns a ``NIODefaultSerialEventLoopExecutor`` instead, which provides suboptimal performance.
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    var executor: any SerialExecutor { get }
+    #endif
+
     /// Must crash if it is not safe to call `wait()` on an `EventLoopFuture`.
     ///
     /// This method is a debugging hook that can be used to override the behaviour of `EventLoopFuture.wait()` when called.
@@ -427,6 +438,15 @@ extension EventLoop {
     public func _promiseCompleted(futureIdentifier: _NIOEventLoopFutureIdentifier) -> (file: StaticString, line: UInt)? {
         return nil
     }
+}
+
+extension EventLoop {
+    #if swift(>=5.9)
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    public var executor: any SerialExecutor {
+        NIODefaultSerialEventLoopExecutor(self)
+    }
+    #endif
 }
 
 extension EventLoopGroup {

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -373,7 +373,7 @@ public protocol EventLoop: EventLoopGroup {
     /// allows `EventLoop`s to cache a pre-succeeded `Void` future to prevent superfluous allocations.
     func makeSucceededVoidFuture() -> EventLoopFuture<Void>
 
-    #if swift(>=5.9)
+    #if compiler(>=5.9)
     /// Returns a `SerialExecutor` corresponding to this ``EventLoop``.
     ///
     /// This executor can be used to isolate an actor to a given ``EventLoop``. Implementers are encouraged to customise
@@ -441,7 +441,7 @@ extension EventLoop {
 }
 
 extension EventLoop {
-    #if swift(>=5.9)
+    #if compiler(>=5.9)
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     public var executor: any SerialExecutor {
         NIODefaultSerialEventLoopExecutor(self)

--- a/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
+++ b/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
@@ -350,7 +350,7 @@ public final class NIOAsyncTestingEventLoop: EventLoop, @unchecked Sendable {
 }
 
 // MARK: SerialExecutor conformance
-#if swift(>=5.9)
+#if compiler(>=5.9)
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension NIOAsyncTestingEventLoop: NIOSerialEventLoopExecutor { }
 #endif

--- a/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
+++ b/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
@@ -349,6 +349,12 @@ public final class NIOAsyncTestingEventLoop: EventLoop, @unchecked Sendable {
     }
 }
 
+// MARK: SerialExecutor conformance
+#if swift(>=5.9)
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension NIOAsyncTestingEventLoop: NIOSerialEventLoopExecutor { }
+#endif
+
 /// This is a thread-safe promise creation store.
 ///
 /// We use this to keep track of where promises come from in the `NIOAsyncTestingEventLoop`.

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -233,6 +233,13 @@ public final class EmbeddedEventLoop: EventLoop {
     deinit {
         precondition(scheduledTasks.isEmpty, "Embedded event loop freed with unexecuted scheduled tasks!")
     }
+
+    #if swift(>=5.9)
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    public var executor: any SerialExecutor {
+        fatalError("EmbeddedEventLoop is not thread safe and cannot be used as a SerialExecutor. Use NIOAsyncTestingEventLoop instead.")
+    }
+    #endif
 }
 
 @usableFromInline

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -234,7 +234,7 @@ public final class EmbeddedEventLoop: EventLoop {
         precondition(scheduledTasks.isEmpty, "Embedded event loop freed with unexecuted scheduled tasks!")
     }
 
-    #if swift(>=5.9)
+    #if compiler(>=5.9)
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     public var executor: any SerialExecutor {
         fatalError("EmbeddedEventLoop is not thread safe and cannot be used as a SerialExecutor. Use NIOAsyncTestingEventLoop instead.")

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -663,7 +663,7 @@ extension SelectableEventLoop: CustomStringConvertible, CustomDebugStringConvert
 }
 
 // MARK: SerialExecutor conformance
-#if swift(>=5.9)
+#if compiler(>=5.9)
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension SelectableEventLoop: NIOSerialEventLoopExecutor { }
 #endif

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -661,3 +661,9 @@ extension SelectableEventLoop: CustomStringConvertible, CustomDebugStringConvert
         }
     }
 }
+
+// MARK: SerialExecutor conformance
+#if swift(>=5.9)
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension SelectableEventLoop: NIOSerialEventLoopExecutor { }
+#endif

--- a/Tests/NIOPosixTests/SerialExecutorTests.swift
+++ b/Tests/NIOPosixTests/SerialExecutorTests.swift
@@ -16,7 +16,7 @@ import NIOEmbedded
 import NIOPosix
 import XCTest
 
-#if swift(>=5.9)
+#if compiler(>=5.9)
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 actor EventLoopBoundActor {
     nonisolated let unownedExecutor: UnownedSerialExecutor
@@ -39,7 +39,7 @@ actor EventLoopBoundActor {
 
 final class SerialExecutorTests: XCTestCase {
     private func _testBasicExecutorFitsOnEventLoop(loop1: EventLoop, loop2: EventLoop) async throws {
-        #if swift(<5.9)
+        #if compiler(<5.9)
         throw XCTSkip("Custom executors are only supported in 5.9")
         #else
         guard #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) else {

--- a/Tests/NIOPosixTests/SerialExecutorTests.swift
+++ b/Tests/NIOPosixTests/SerialExecutorTests.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOCore
+import NIOEmbedded
+import NIOPosix
+import XCTest
+
+#if swift(>=5.9)
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+actor EventLoopBoundActor {
+    nonisolated let unownedExecutor: UnownedSerialExecutor
+
+    init(loop: EventLoop) {
+        self.unownedExecutor = loop.executor.asUnownedSerialExecutor()
+    }
+
+    func assertInLoop(_ loop: EventLoop) {
+        loop.assertInEventLoop()
+        XCTAssertTrue(loop.inEventLoop)
+    }
+
+    func assertNotInLoop(_ loop: EventLoop) {
+        loop.assertNotInEventLoop()
+        XCTAssertFalse(loop.inEventLoop)
+    }
+}
+#endif
+
+final class SerialExecutorTests: XCTestCase {
+    private func _testBasicExecutorFitsOnEventLoop(loop1: EventLoop, loop2: EventLoop) async throws {
+        #if swift(<5.9)
+        throw XCTSkip("Custom executors are only supported in 5.9")
+        #else
+        guard #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) else {
+            throw XCTSkip("Custom executors not available on this platform")
+        }
+
+        let testActor = EventLoopBoundActor(loop: loop1)
+        await testActor.assertInLoop(loop1)
+        await testActor.assertNotInLoop(loop2)
+        #endif
+    }
+
+    func testBasicExecutorFitsOnEventLoop_MTELG() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        defer {
+            try! group.syncShutdownGracefully()
+        }
+        let loops = Array(group.makeIterator())
+        try await self._testBasicExecutorFitsOnEventLoop(loop1: loops[0], loop2: loops[1])
+    }
+
+    func testBasicExecutorFitsOnEventLoop_AsyncTestingEventLoop() async throws {
+        let loop1 = NIOAsyncTestingEventLoop()
+        let loop2 = NIOAsyncTestingEventLoop()
+        defer {
+            try? loop1.syncShutdownGracefully()
+            try? loop2.syncShutdownGracefully()
+        }
+
+        try await self._testBasicExecutorFitsOnEventLoop(loop1: loop1, loop2: loop2)
+    }
+}
+


### PR DESCRIPTION
This PR tracks an example of custom actor executor support, as well as updating our AsyncAwait example to clearly annotate (via `precondition[Not]OnEventLoop`) whether the code in question is executing on the event loop or not.

The initial conclusion here is that this demonstrates the strengths _and_ limitations of custom actor executors for the NIO model. Actors running on an event loop executor clearly run _on_ the event loop, such that the NIO fast-path successfully fires. However, free functions and non-actor types do not inherit this execution context, which limits the utility of our existing async sequences (which are not actors and cannot be EL bound).