### PR TITLE
Work around the SwiftPM layout change.

### DIFF
--- a/IntegrationTests/tests_02_syscall_wrappers/defines.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/defines.sh
@@ -16,6 +16,11 @@
 set -eu
 
 function make_package() {
+    if [[ ! -d "$tmpdir/syscallwrapper/Sources/syscallwrapper/" ]]; then
+        mkdir "$tmpdir/syscallwrapper/Sources/syscallwrapper/"
+        mv "$tmpdir"/syscallwrapper/Sources/*.swift "$tmpdir/syscallwrapper/Sources/syscallwrapper/"
+    fi
+
     cat > "$tmpdir/syscallwrapper/Package.swift" <<"EOF"
 // swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.

--- a/IntegrationTests/tests_02_syscall_wrappers/test_01_syscall_wrapper_fast.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_01_syscall_wrapper_fast.sh
@@ -30,7 +30,13 @@ tmpdir=$(mktemp -d /tmp/.swift-nio-syscall-wrappers-sh-test_XXXXXX)
 mkdir "$tmpdir/syscallwrapper"
 cd "$tmpdir/syscallwrapper"
 swift package init --type=executable
-cat > "$tmpdir/syscallwrapper/Sources/syscallwrapper/main.swift" <<EOF
+
+main_path="$tmpdir/syscallwrapper/Sources/main.swift"
+if [[ -d "$tmpdir/syscallwrapper/Sources/syscallwrapper/" ]]; then
+    main_path="$tmpdir/syscallwrapper/Sources/syscallwrapper/main.swift"
+fi
+
+cat > "$main_path" <<EOF
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
 #else

--- a/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
@@ -30,7 +30,13 @@ tmpdir=$(mktemp -d /tmp/.swift-nio-syscall-wrappers-sh-test_XXXXXX)
 mkdir "$tmpdir/syscallwrapper"
 cd "$tmpdir/syscallwrapper"
 swift package init --type=executable
-cat > "$tmpdir/syscallwrapper/Sources/syscallwrapper/main.swift" <<EOF
+
+main_path="$tmpdir/syscallwrapper/Sources/main.swift"
+if [[ -d "$tmpdir/syscallwrapper/Sources/syscallwrapper/" ]]; then
+    main_path="$tmpdir/syscallwrapper/Sources/syscallwrapper/main.swift"
+fi
+
+cat > "$main_path" <<EOF
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
 #else

--- a/IntegrationTests/tests_02_syscall_wrappers/test_03_unacceptable_read_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_03_unacceptable_read_errnos.sh
@@ -30,7 +30,13 @@ tmpdir=$(mktemp -d /tmp/.swift-nio-syscall-wrappers-sh-test_XXXXXX)
 mkdir "$tmpdir/syscallwrapper"
 cd "$tmpdir/syscallwrapper"
 swift package init --type=executable
-cat > "$tmpdir/syscallwrapper/Sources/syscallwrapper/main.swift" <<EOF
+
+main_path="$tmpdir/syscallwrapper/Sources/main.swift"
+if [[ -d "$tmpdir/syscallwrapper/Sources/syscallwrapper/" ]]; then
+    main_path="$tmpdir/syscallwrapper/Sources/syscallwrapper/main.swift"
+fi
+
+cat > "$main_path" <<EOF
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
 #else


### PR DESCRIPTION
Motivation:

SwiftPM has changed its default layout for packages in apple/swift-package-manager#6144. This breaks our CI, which assumes the prior layout. We should work around this.

Modifications:

Enhance the code to tolerate both layouts.

Result:

Integration tests run on all platforms
