### PR TITLE
Make System.coreCount aware of cgroup2

### DIFF
--- a/Sources/NIOCore/Linux.swift
+++ b/Sources/NIOCore/Linux.swift
@@ -61,7 +61,7 @@ enum Linux {
     }
 
     /// Get the available core count according to cgroup1 restrictions.
-    /// Round up the the next whole number.
+    /// Round up to the next whole number.
     static func coreCountCgroup1Restriction(quota quotaPath: String = Linux.cfsQuotaPath,
                                             period periodPath: String = Linux.cfsPeriodPath) -> Int? {
         guard

--- a/Sources/NIOCore/Linux.swift
+++ b/Sources/NIOCore/Linux.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -60,8 +60,10 @@ enum Linux {
         return cpuset.map(countCoreIds).reduce(0, +)
     }
 
-    // cgroup1
-    static func coreCount(quota quotaPath: String,  period periodPath: String) -> Int? {
+    /// Get the available core count according to cgroup1 restrctions.
+    /// Round up the the next whole number.
+    static func coreCountCgroup1Restriction(quota quotaPath: String = Linux.cfsQuotaPath,
+                                            period periodPath: String = Linux.cfsPeriodPath) -> Int? {
         guard
             let quota = try? Int(firstLineOfFile(path: quotaPath)),
             quota > 0
@@ -73,9 +75,10 @@ enum Linux {
         return (quota - 1 + period) / period // always round up if fractional CPU quota requested
     }
 
-    // cgroup2
-    static func coreCount(maxPath: String) -> Int? {
-        guard let maxDetails = try? firstLineOfFile(path: maxPath),
+    /// Get the available core count according to cgroup2 restrctions.
+    /// Round up the the next whole number.
+    static func coreCountCgroup2Restriction(cpuMaxPath: String = Linux.cfsCpuMaxPath) -> Int? {
+        guard let maxDetails = try? firstLineOfFile(path: cpuMaxPath),
               let spaceIndex = maxDetails.firstIndex(of: " "),
               let quota = Int(maxDetails[maxDetails.startIndex ..< spaceIndex]),
               let period = Int(maxDetails[maxDetails.index(after: spaceIndex) ..< maxDetails.endIndex])

--- a/Sources/NIOCore/Linux.swift
+++ b/Sources/NIOCore/Linux.swift
@@ -76,7 +76,7 @@ enum Linux {
     }
 
     /// Get the available core count according to cgroup2 restrictions.
-    /// Round up the the next whole number.
+    /// Round up to the next whole number.
     static func coreCountCgroup2Restriction(cpuMaxPath: String = Linux.cfsCpuMaxPath) -> Int? {
         guard let maxDetails = try? firstLineOfFile(path: cpuMaxPath),
               let spaceIndex = maxDetails.firstIndex(of: " "),

--- a/Sources/NIOCore/Linux.swift
+++ b/Sources/NIOCore/Linux.swift
@@ -75,7 +75,7 @@ enum Linux {
         return (quota - 1 + period) / period // always round up if fractional CPU quota requested
     }
 
-    /// Get the available core count according to cgroup2 restrctions.
+    /// Get the available core count according to cgroup2 restrictions.
     /// Round up the the next whole number.
     static func coreCountCgroup2Restriction(cpuMaxPath: String = Linux.cfsCpuMaxPath) -> Int? {
         guard let maxDetails = try? firstLineOfFile(path: cpuMaxPath),

--- a/Sources/NIOCore/Linux.swift
+++ b/Sources/NIOCore/Linux.swift
@@ -60,7 +60,7 @@ enum Linux {
         return cpuset.map(countCoreIds).reduce(0, +)
     }
 
-    /// Get the available core count according to cgroup1 restrctions.
+    /// Get the available core count according to cgroup1 restrictions.
     /// Round up the the next whole number.
     static func coreCountCgroup1Restriction(quota quotaPath: String = Linux.cfsQuotaPath,
                                             period periodPath: String = Linux.cfsPeriodPath) -> Int? {

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -99,7 +99,9 @@ public enum System {
             .map { $0.ProcessorMask.nonzeroBitCount }
             .reduce(0, +)
 #elseif os(Linux) || os(Android)
-        if let quota = Linux.coreCount(quota: Linux.cfsQuotaPath, period: Linux.cfsPeriodPath) {
+        if let quota2 = Linux.coreCount(maxPath: Linux.cfsCpuMaxPath) {
+            return quota2
+        } else if let quota = Linux.coreCount(quota: Linux.cfsQuotaPath, period: Linux.cfsPeriodPath) {
             return quota
         } else if let cpusetCount = Linux.coreCount(cpuset: Linux.cpuSetPath) {
             return cpusetCount

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2021-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -62,12 +62,15 @@ extension Box: Sendable where T: Sendable {}
 
 public enum System {
     /// A utility function that returns an estimate of the number of *logical* cores
-    /// on the system.
+    /// on the system available for use.
     ///
     /// This value can be used to help provide an estimate of how many threads to use with
     /// the `MultiThreadedEventLoopGroup`. The exact ratio between this number and the number
     /// of threads to use is a matter for the programmer, and can be determined based on the
     /// specific execution behaviour of the program.
+    ///
+    /// On Linux the value returned will take account of cgroup or cpuset restrictions.
+    /// The result will be rounded up to the nearest whole number where fractional CPUs have been assigned.
     ///
     /// - returns: The logical core count on the system.
     public static var coreCount: Int {
@@ -99,9 +102,9 @@ public enum System {
             .map { $0.ProcessorMask.nonzeroBitCount }
             .reduce(0, +)
 #elseif os(Linux) || os(Android)
-        if let quota2 = Linux.coreCount(maxPath: Linux.cfsCpuMaxPath) {
+        if let quota2 = Linux.coreCountCgroup2Restriction() {
             return quota2
-        } else if let quota = Linux.coreCount(quota: Linux.cfsQuotaPath, period: Linux.cfsPeriodPath) {
+        } else if let quota = Linux.coreCountCgroup1Restriction() {
             return quota
         } else if let cpusetCount = Linux.coreCount(cpuset: Linux.cpuSetPath) {
             return cpusetCount

--- a/Tests/NIOCoreTests/LinuxTest.swift
+++ b/Tests/NIOCoreTests/LinuxTest.swift
@@ -57,4 +57,18 @@ class LinuxTest: XCTestCase {
         }
         #endif
     }
+
+    func testCoreCountMax() throws {
+        #if os(Linux) || os(Android)
+        try [
+            ("max 100000", nil),
+            ("75000 100000", 1),
+            ("200000 100000", 2)
+        ].forEach { (content, count) in
+            try withTemporaryFile(content: content) { (_, path) in
+                XCTAssertEqual(Linux.coreCount(maxPath: path), count)
+            }
+        }
+        #endif
+    }
 }

--- a/Tests/NIOCoreTests/LinuxTest.swift
+++ b/Tests/NIOCoreTests/LinuxTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -33,7 +33,7 @@ class LinuxTest: XCTestCase {
         ].forEach { quota, period, count in
             try withTemporaryFile(content: quota) { (_, quotaPath) -> Void in
                 try withTemporaryFile(content: period) { (_, periodPath) -> Void in
-                    XCTAssertEqual(Linux.coreCount(quota: quotaPath, period: periodPath), count)
+                    XCTAssertEqual(Linux.coreCountCgroup1Restriction(quota: quotaPath, period: periodPath), count)
                 }
             }
         }
@@ -58,7 +58,7 @@ class LinuxTest: XCTestCase {
         #endif
     }
 
-    func testCoreCountMax() throws {
+    func testCoreCountCgoup2() throws {
         #if os(Linux) || os(Android)
         try [
             ("max 100000", nil),
@@ -66,7 +66,7 @@ class LinuxTest: XCTestCase {
             ("200000 100000", 2)
         ].forEach { (content, count) in
             try withTemporaryFile(content: content) { (_, path) in
-                XCTAssertEqual(Linux.coreCount(maxPath: path), count)
+                XCTAssertEqual(Linux.coreCountCgroup2Restriction(cpuMaxPath: path), count)
             }
         }
         #endif


### PR DESCRIPTION
Motivation:

The count already appears to be aware of cgroup1
but doesn't have logic to support cgroup2.

Modifications:

Add logic to parse /sys/fs/cgroup/cpu.max
For details see - https://stackoverflow.com/questions/65551215/get-docker-cpu-memory-limit-inside-container/65554131#65554131

Result:

Core count will adapt if constrained by a cgroup on more modern kernels.
