### PR TITLE
Throw `CancellationError` if `NIOThrowingAsyncSequenceProducer.AsyncIterator.next()` is cancelled instead of returning `nil`

### DIFF
--- a/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducer.swift
@@ -198,7 +198,8 @@ extension NIOAsyncSequenceProducer {
 
         @inlinable
         public func next() async -> Element? {
-            return try! await self._throwingIterator.next()
+            // this call will only throw if cancelled and we want to just return nil in that case
+            return try? await self._throwingIterator.next()
         }
     }
 }

--- a/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
@@ -868,7 +868,7 @@ extension NIOThrowingAsyncSequenceProducer {
         enum CancelledAction {
             /// Indicates that ``NIOAsyncSequenceProducerDelegate/didTerminate()`` should be called.
             case callDidTerminate
-            /// Indicates that the continuation should be resumed with a `CancelationError` and
+            /// Indicates that the continuation should be resumed with a `CancellationError` and
             /// that ``NIOAsyncSequenceProducerDelegate/didTerminate()`` should be called.
             case resumeContinuationWithCancellationErrorAndCallDidTerminate(CheckedContinuation<Element?, Error>)
             /// Indicates that nothing should be done.

--- a/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
@@ -498,8 +498,8 @@ extension NIOThrowingAsyncSequenceProducer {
 
                         return delegate
 
-                    case .resumeContinuationWithNilAndCallDidTerminate(let continuation):
-                        continuation.resume(returning: nil)
+                    case .resumeContinuationWithCancellationErrorAndCallDidTerminate(let continuation):
+                        continuation.resume(throwing: CancellationError())
                         let delegate = self._delegate
                         self._delegate = nil
 
@@ -870,7 +870,7 @@ extension NIOThrowingAsyncSequenceProducer {
             case callDidTerminate
             /// Indicates that the continuation should be resumed with `nil` and
             /// that ``NIOAsyncSequenceProducerDelegate/didTerminate()`` should be called.
-            case resumeContinuationWithNilAndCallDidTerminate(CheckedContinuation<Element?, Error>)
+            case resumeContinuationWithCancellationErrorAndCallDidTerminate(CheckedContinuation<Element?, Error>)
             /// Indicates that nothing should be done.
             case none
         }
@@ -889,7 +889,7 @@ extension NIOThrowingAsyncSequenceProducer {
                 // and we can transition to finished here and inform the delegate
                 self._state = .finished(iteratorInitialized: iteratorInitialized)
 
-                return .resumeContinuationWithNilAndCallDidTerminate(continuation)
+                return .resumeContinuationWithCancellationErrorAndCallDidTerminate(continuation)
 
             case .streaming(_, _, continuation: .none, _, let iteratorInitialized):
                 self._state = .finished(iteratorInitialized: iteratorInitialized)

--- a/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
@@ -868,7 +868,7 @@ extension NIOThrowingAsyncSequenceProducer {
         enum CancelledAction {
             /// Indicates that ``NIOAsyncSequenceProducerDelegate/didTerminate()`` should be called.
             case callDidTerminate
-            /// Indicates that the continuation should be resumed with `nil` and
+            /// Indicates that the continuation should be resumed with a `CancelationError` and
             /// that ``NIOAsyncSequenceProducerDelegate/didTerminate()`` should be called.
             case resumeContinuationWithCancellationErrorAndCallDidTerminate(CheckedContinuation<Element?, Error>)
             /// Indicates that nothing should be done.

--- a/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
@@ -457,9 +457,11 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
         try await Task.sleep(nanoseconds: 1_000_000)
 
         task.cancel()
-        let value = try await task.value
+        let result = await task.result
         XCTAssertEqualWithoutAutoclosure(await self.delegate.events.prefix(1).collect(), [.didTerminate])
-        XCTAssertNil(value)
+        await XCTAssertThrowsError(try result.get()) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
     }
 
     func testTaskCancel_whenStreaming_andNotSuspended() async throws {


### PR DESCRIPTION
Fixes https://github.com/apple/swift-nio/issues/2398
### Motivation:

`NIOThrowingAsyncSequenceProducer.AsyncIterator.next()` currently returns nil if the current `Task` is canceled. This behaviour is undesirable. For example `AsyncSequence<ByteBuffer>.collect(upTo:)` would return an incomplete buffer instead of throwing an error which will very likely result in corrupted data or parsing errors down the line.

### Modifications:

Throw `CancellationError` if task is cancelled.

### Result:

`NIOThrowingAsyncSequenceProducer.AsyncIterator.next()` correctly signals that it was prematurely terminated through cancellation.

For the non-throwing version `NIOAsyncSequenceProducer` we should think about not returning `nil` as well and instead waiting until the source finishes the `AsyncSequence`.