### PR TITLE
Handle reentrant reads in ALPNHandler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,7 @@ var targets: [PackageDescription.Target] = [
         name: "CNIOLLHTTP",
         cSettings: [.define("LLHTTP_STRICT_MODE")]
     ),
-    .target(name: "NIOTLS", dependencies: ["NIO", "NIOCore"]),
+    .target(name: "NIOTLS", dependencies: ["NIO", "NIOCore", swiftCollections]),
     .executableTarget(name: "NIOChatServer",
                       dependencies: ["NIOPosix", "NIOCore", "NIOConcurrencyHelpers"],
                       exclude: ["README.md"]),
@@ -112,7 +112,7 @@ var targets: [PackageDescription.Target] = [
     .testTarget(name: "NIOHTTP1Tests",
                 dependencies: ["NIOCore", "NIOEmbedded", "NIOPosix", "NIOHTTP1", "NIOFoundationCompat", "NIOTestUtils"]),
     .testTarget(name: "NIOTLSTests",
-                dependencies: ["NIOCore", "NIOEmbedded", "NIOTLS", "NIOFoundationCompat"]),
+                dependencies: ["NIOCore", "NIOEmbedded", "NIOTLS", "NIOFoundationCompat", "NIOTestUtils"]),
     .testTarget(name: "NIOWebSocketTests",
                 dependencies: ["NIOCore", "NIOEmbedded", "NIOWebSocket"]),
     .testTarget(name: "NIOTestUtilsTests",

--- a/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests+XCTest.swift
+++ b/Tests/NIOTLSTests/ApplicationProtocolNegotiationHandlerTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -35,6 +35,7 @@ extension ApplicationProtocolNegotiationHandlerTests {
                 ("testBufferingWhileWaitingForFuture", testBufferingWhileWaitingForFuture),
                 ("testNothingBufferedDoesNotFireReadCompleted", testNothingBufferedDoesNotFireReadCompleted),
                 ("testUnbufferingFiresReadCompleted", testUnbufferingFiresReadCompleted),
+                ("testUnbufferingHandlesReentrantReads", testUnbufferingHandlesReentrantReads),
            ]
    }
 }


### PR DESCRIPTION
# Motivation
I spotted a bug in the ALPNHandler where it doesn't properly unbuffer reentrant reads. This can lead to dropped reads.

# Modification
Instead of buffering into an array we are now buffering into a Deque and unbuffer as long as there are reads in the Deque.

# Result
No more dropped reads.