### PR TITLE
Close accepted FDs if we fail to create Socket

### DIFF
--- a/Sources/NIOPosix/ServerSocket.swift
+++ b/Sources/NIOPosix/ServerSocket.swift
@@ -106,7 +106,16 @@ import NIOCore
             guard let fd = result else {
                 return nil
             }
-            let sock = try Socket(socket: fd)
+
+            let sock: Socket
+            do {
+                sock = try Socket(socket: fd)
+            } catch {
+                // best effort
+                try? Posix.close(descriptor: fd)
+                throw error
+            }
+
             #if !os(Linux)
             if setNonBlocking {
                 do {


### PR DESCRIPTION
Motivation:

In some circumstances we can accept a socket for a connection that is already closed. In those cases, creating the underlying Socket type will fail, as attempting to ignore SIGPIPE will fail. On Apple platforms, this causes us to leak the accepted socket, and can lead to file descriptor exhaustion.

Modifications:

- Close the accepted socket if we fail to create a Socket class

Result:

No FD leaks


An important caveat on this PR is that I have no tests for this. To add a test, I'll need to refactor the way the ServerSocket class works to allow me to customise how we handle this error, so I can observe we're hitting the error handling code, or to be able to hook the call into `close`. No other change works: we cannot easily observe the closure of this FD in full generality. I'd like opinions on how important it is that we test this change.