### PR TITLE
Don't have channels stop reading on errors they tolerate.

### DIFF
--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -1091,36 +1091,40 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
             // peer closed / shutdown the connection.
             if let channelErr = err as? ChannelError, channelErr == ChannelError.eof {
                 readStreamState = .eof
-                // Directly call getOption0 as we are already on the EventLoop and so not need to create an extra future.
 
-                // getOption0 can only fail if the channel is not active anymore but we assert further up that it is. If
-                // that's not the case this is a precondition failure and we would like to know.
-                if self.lifecycleManager.isActive, try! self.getOption0(ChannelOptions.allowRemoteHalfClosure) {
-                    // If we want to allow half closure we will just mark the input side of the Channel
-                    // as closed.
-                    assert(self.lifecycleManager.isActive)
+                if self.lifecycleManager.isActive {
+                    // Directly call getOption0 as we are already on the EventLoop and so not need to create an extra future.
+                    //
+                    // getOption0 can only fail if the channel is not active anymore but we assert further up that it is. If
+                    // that's not the case this is a precondition failure and we would like to know.
+                    let allowRemoteHalfClosure = try! self.getOption0(ChannelOptions.allowRemoteHalfClosure)
+
+                    // For EOF, we always fire read complete.
                     self.pipeline.syncOperations.fireChannelReadComplete()
-                    if self.shouldCloseOnReadError(err) {
-                        self.close0(error: err, mode: .input, promise: nil)
+
+                    if allowRemoteHalfClosure {
+                        // If we want to allow half closure we will just mark the input side of the Channel
+                        // as closed.
+                        if self.shouldCloseOnReadError(err) {
+                            self.close0(error: err, mode: .input, promise: nil)
+                        }
+                        self.readPending = false
+                        return .eof
                     }
-                    self.readPending = false
-                    return .eof
                 }
             } else {
                 readStreamState = .error
                 self.pipeline.syncOperations.fireErrorCaught(err)
             }
 
-            // Call before triggering the close of the Channel.
-            if readStreamState != .error, self.lifecycleManager.isActive {
-                self.pipeline.syncOperations.fireChannelReadComplete()
-            }
-
             if self.shouldCloseOnReadError(err) {
                 self.close0(error: err, mode: .all, promise: nil)
+                return readStreamState
+            } else {
+                // This is non-fatal, so continue as normal.
+                // This constitutes "some" as we did get at least an error from the socket.
+                readResult = .some
             }
-
-            return readStreamState
         }
         // This assert needs to be disabled for io_uring, as the io_uring backend does not have the implicit synchronisation between
         // modifications to the poll mask and the actual returned events on the completion queue that kqueue and epoll has.

--- a/Tests/NIOPosixTests/SocketChannelTest.swift
+++ b/Tests/NIOPosixTests/SocketChannelTest.swift
@@ -717,7 +717,8 @@ public final class SocketChannelTest : XCTestCase {
         XCTAssertNoThrow(try serverChan.eventLoop.submit {
             serverChan.readable()
         }.wait())
-        XCTAssertEqual(["errorCaught"], eventCounter.allTriggeredEvents())
+        XCTAssertEqual(["channelReadComplete", "errorCaught"], eventCounter.allTriggeredEvents())
+        XCTAssertEqual(1, eventCounter.channelReadCompleteCalls)
         XCTAssertEqual(1, eventCounter.errorCaughtCalls)
 
         serverSock.shouldAcceptsFail.store(false, ordering: .relaxed)
@@ -729,7 +730,7 @@ public final class SocketChannelTest : XCTestCase {
                        eventCounter.allTriggeredEvents())
         XCTAssertEqual(1, eventCounter.errorCaughtCalls)
         XCTAssertEqual(1, eventCounter.channelReadCalls)
-        XCTAssertEqual(1, eventCounter.channelReadCompleteCalls)
+        XCTAssertEqual(2, eventCounter.channelReadCompleteCalls)
     }
 
     func testWeAreInterestedInReadEOFWhenChannelIsConnectedOnTheServerSide() throws {


### PR DESCRIPTION
Motivation:

When an error is hit during a read loop, a channel is able to tolerate that error without closing. This is done for a number of reasons, but the most important one is accepting sockets for already-closed connections, which can trigger all kinds of errors on the read path.

Unfortunately, there was an edge-case in the code for handling this case. If one or more reads in the loop had succeeded before the error was caught, the inner code would be expecting a call to readIfNeeded, but the outer code wouldn't make it. This would lead to autoRead channels being wedged open.

Modifications:

This patch extends the Syscall Abstraction Layer to add support for server sockets. It adds two tests: one for the basic accept flow, and then one for the case discussed above.

This patch also refactors the code in BaseSocketChannel.readable0 to more clearly show the path through the error case. There were a number of early returns and partial conditionals that led to us checking the same condition in a number of places. This refactor makes it clearer that it is possible to exit this code in the happy path, with a tolerated error, which should be considered the same as reading _something_.

Result:

Harder to wedge a channel open.
