### PR TITLE
NIOThrowingAsyncSequenceProducer throws when cancelled

### DIFF
--- a/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
@@ -618,7 +618,7 @@ extension NIOThrowingAsyncSequenceProducer {
                 failure: Failure?
             )
 
-            /// The state once a call to next has been cancelled. To reach this state we must cancel the source.
+            /// The state once a call to next has been cancelled. Cancel the source when entering this state.
             case cancelled(iteratorInitialized: Bool)
 
             /// The state once there can be no outstanding demand. This can happen if:


### PR DESCRIPTION
NIOThrowingAsyncSequenceProducer throws when cancelled

### Motivation:

Currently `NIOThrowingAsyncSequenceProducer` currently does not throw a CancellationError, if the AsyncSequence is cancelled while the buffer is not empty.

### Modifications:

- Make `NIOThrowingAsyncSequenceProducer` throw when cancelled

### Result:

- Postgres queries that are cancelled throw and do not give the impression that they succeed.
