### PR TITLE
Fix typo in bash variable: expections -> exceptions

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -47,7 +47,7 @@ for language in swift-or-c bash dtrace python; do
   printf "   * $language... "
   declare -a matching_files
   declare -a exceptions
-  expections=( )
+  exceptions=( )
   matching_files=( -name '*' )
   case "$language" in
       swift-or-c)


### PR DESCRIPTION
### Motivation:

There was a typo in a bash variable in `soundness.sh`. The variable, `exceptions` (misspelled `expections`) is designed to allow some files to be skipped from license checks. It seems that a later shadowing of this variable masked the issue.

### Modifications:

- Fix typo in bash variable: expections -> exceptions
 
### Result:

No unused, misspelled bash variable.