### PR TITLE
Add CustomDebugStringConvertible conformance to ByteBuffer

### DIFF
--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -863,7 +863,7 @@ public struct ByteBuffer {
     }
 }
 
-extension ByteBuffer: CustomStringConvertible {
+extension ByteBuffer: CustomStringConvertible, CustomDebugStringConvertible {
     /// A `String` describing this `ByteBuffer`. Example:
     ///
     ///     ByteBuffer { readerIndex: 0, writerIndex: 4, readableBytes: 4, capacity: 512, storageCapacity: 1024, slice: 256..<768, storage: 0x0000000103001000 (1024 bytes)}


### PR DESCRIPTION
Declare `CustomDebugStringConvertible` conformance for `ByteBuffer`, which already implements the conformance requirement.

### Motivation:

`ByteBuffer` implements both `description` and `debugDescription`, but conforms only to `CustomStringConvertible`. As a result, `String(describing: ByteBuffer())` and `String(reflecting: ByteBuffer())` yield the same output, when it would be expected that the latter would include the additional "readable bytes (max 1k)" debug output returned by invoking `debugDescription` directly. To my knowledge, there is no drawback to adding this conformance.

### Modifications:

Added `CustomDebugStringConvertible` to the list of protocol conformances on the extension which declares the `description` and `debugDescription` properties and the existing `CustomStringConvertible` conformance.

### Result:

Given:
```swift
print(ByteBuffer().description)
print(String(describing: ByteBuffer()))
print(ByteBuffer().debugDescription)
print(String(reflecting: ByteBuffer()))
```

Before (slightly edited for brevity):
```
ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, ... }
ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, ... }
ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, ... }
readable bytes (max 1k): [ ]
ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, ... }
```

After (slightly edited for brevity):
```
ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, ... }
ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, ... }
ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, ... }
readable bytes (max 1k): [ ]
ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, ... }
readable bytes (max 1k): [ ]
```