### PR TITLE
Add unprocessedBytes property on NIOSingleStepByteToMessageProcessor

### DIFF
--- a/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
+++ b/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
@@ -281,6 +281,12 @@ extension NIOSingleStepByteToMessageProcessor: Sendable {}
 
 // MARK: NIOSingleStepByteToMessageProcessor Public API
 extension NIOSingleStepByteToMessageProcessor {
+    /// The number of bytes that are currently not processed by the ``process(buffer:_:)`` method. Having unprocessed
+    /// bytes may result from receiving only partial messages or from receiving multiple messages at once.
+    public var unprocessedBytes: Int {
+        self._buffer?.readableBytes ?? 0
+    }
+
     /// Feed data into the `NIOSingleStepByteToMessageProcessor`
     ///
     /// - parameters:


### PR DESCRIPTION
Add unprocessedBytes property on NIOSingleStepByteToMessageProcessor

### Motivation:

Some protocols require no messages to be in the incoming buffer after a certain message was received. For example if both endpoints agree on an upgrade to TLS no remaining bytes should be in the incoming buffer (as those would have been sent unencrypted or those may have been injected by a man in the middle). We should allow to ask the `NIOSingleStepByteToMessageProcessor` if there are bytes remaining in its incoming buffer.

### Modifications:

- Add unprocessedBytes property on NIOSingleStepByteToMessageProcessor

### Result:

- Safer network communication
