### PR TITLE
Update `update-alloc-limits-...` script

### DIFF
--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -22,7 +22,7 @@ url_prefix=${1-"https://ci.swiftserver.group/job/swift-nio2-swift"}
 target_repo=${2-"$here/.."}
 tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
 
-for f in 55 56 57 58 -nightly; do
+for f in 56 57 58 59 -nightly; do
     echo "swift$f"
     url="$url_prefix$f-prb/lastCompletedBuild/consoleFull"
     echo "$url"


### PR DESCRIPTION
### Motivation

Running the `update-alloc-limits-...` script failed as it looked for a CI build for Swift 5.5, which is no longer run by our CI.

### Modifications

* Don't look for CI builds for Swift 5.5
* Instead, look for CI build for Swift 5.9
