### PR TITLE
Add test coverage of WebSocketMaskingKey.random()

### DIFF
--- a/Tests/NIOWebSocketTests/WebSocketMaskingKeyTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketMaskingKeyTests.swift
@@ -32,10 +32,9 @@ final class WebSocketMaskingKeyTests: XCTestCase {
         }, "at least 1 of 1000 random masking keys should not be all zeros")
     }
     
-    func testRandomMaskingKeyWithDefaultGenerator() {
-        let key1 = WebSocketMaskingKey.random()
-        let key2 = WebSocketMaskingKey.random()
-        
-        XCTAssertNotEqual(key1, key2)
+    func testRandomMaskingKeyIsNotAlwaysZeroWithDefaultGenerator() {
+        XCTAssertTrue((0..<1000).contains { _ in
+            WebSocketMaskingKey.random() != [0, 0, 0, 0]
+        }, "at least 1 of 1000 random masking keys with default generator should not be all zeros")
     }
 }

--- a/Tests/NIOWebSocketTests/WebSocketMaskingKeyTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketMaskingKeyTests.swift
@@ -31,4 +31,11 @@ final class WebSocketMaskingKeyTests: XCTestCase {
             WebSocketMaskingKey.random(using: &generator) != [0, 0, 0, 0]
         }, "at least 1 of 1000 random masking keys should not be all zeros")
     }
+    
+    func testRandomMaskingKeyWithDefaultGenerator() {
+        let key1 = WebSocketMaskingKey.random()
+        let key2 = WebSocketMaskingKey.random()
+        
+        XCTAssertNotEqual(key1, key2)
+    }
 }


### PR DESCRIPTION
This solves the NIO side of #2432.

### Motivation:

There is currently no test coverage of the `WebSocketMaskingKey.random()` convenience wrapper for `WebSocketMaskingKey.random(using:)`, which aside from simply being incomplete also has the somewhat ironic effect of masking apple/swift#66099.

### Modifications:

Added a test which exercises the code.

### Result:

The code coverage is increased by a fraction of a percent and an apparently rather obscure Thread Sanitizer issue is less hidden.
