### PR TITLE
Fix happy eyeballs races with custom resolver

### DIFF
--- a/Sources/NIOPosix/HappyEyeballs.swift
+++ b/Sources/NIOPosix/HappyEyeballs.swift
@@ -433,8 +433,14 @@ internal class HappyEyeballsConnector {
         // The two queries SHOULD be made as soon after one another as possible,
         // with the AAAA query made first and immediately followed by the A
         // query.
-        whenAAAALookupComplete(future: resolver.initiateAAAAQuery(host: host, port: port))
-        whenALookupComplete(future: resolver.initiateAQuery(host: host, port: port))
+        //
+        // We hop back to `self.loop` because there's no guarantee the resolver runs
+        // on our event loop.
+        let aaaaLookup = self.resolver.initiateAAAAQuery(host: self.host, port: self.port).hop(to: self.loop)
+        self.whenAAAALookupComplete(future: aaaaLookup)
+
+        let aLookup = self.resolver.initiateAQuery(host: self.host, port: self.port).hop(to: self.loop)
+        self.whenALookupComplete(future: aLookup)
     }
 
     /// Called when the A query has completed before the AAAA query.


### PR DESCRIPTION
Motivation:

The HappyEyeballs connector synchronises state on an event loop but calls out to a 'Resolver' to do DNS lookups. The resolver returns results as a future which may be on a different loop than the connector. The connector does not hop back to its own event loop before processing the results.

For client bootstraps, if no resolver is specified then the default resolver uses the same event loop as the connector so in many cases this is not an issue. However, if a custom resolver is used this guarantee is lost and data races are much more likely.

Modifications:

- Hop back to the connector's event loop after calling the resolver.
- Add a test.

Result:

Fewer data races.