### PR TITLE
Add NIOAsyncChannel based connect methods to ClientBootstrap

### DIFF
--- a/Sources/NIOCore/Docs.docc/swift-concurrency.md
+++ b/Sources/NIOCore/Docs.docc/swift-concurrency.md
@@ -142,7 +142,25 @@ Afterwards, we handle each inbound connection in separate child tasks and echo t
 Normal task groups will result in a memory leak since they do not reap their child tasks automatically.
 
 #### ClientBootstrap
-> Important: Support for `ClientBootstrap` with `NIOAsyncChannel` hasn't landed yet.
+
+The client bootstrap is used to create a new TCP based client. Let's take a look at the new
+`NIOAsyncChannel` based connect methods.
+
+```swift
+let clientChannel = try await ClientBootstrap(group: eventLoopGroup)
+    .connect(
+        host: "127.0.0.1",
+        port: 0,
+        channelInboundType: ByteBuffer.self,
+        channelOutboundType: ByteBuffer.self
+    )
+
+clientChannel.outboundWriter.write(ByteBuffer(string: "hello"))
+
+for try await inboundData in clientChannel.inboundStream {
+    print(inboundData)
+}
+```
 
 #### DatagramBootstrap
 > Important: Support for `DatagramBootstrap` with `NIOAsyncChannel` hasn't landed yet.
@@ -158,7 +176,7 @@ To solve the problem of protocol negotiation, NIO introduced a new ``ChannelHand
 that is completed once the handler is finished with protocol negotiation. In the successful case,
 the future can either indicate that protocol negotiation is fully done by returning `NIOProtocolNegotiationResult/finished(_:)` or
 indicate that further protocol negotiation needs to be done by returning `NIOProtocolNegotiationResult/deferredResult(_:)`.
-Additionally, the various bootstraps provide another set of `bind()` methods that handle protocol negotiation.
+Additionally, the various bootstraps provide another set of `bind()`/`connect()` methods that handle protocol negotiation.
 Let's walk through how to setup a `ServerBootstrap` with protocol negotiation.
 
 First, we have to define our negotiation result. For this example, we are negotiating between a

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -1344,7 +1344,7 @@ extension ClientBootstrap {
     /// - Parameters:
     ///   - host: The host to connect to.
     ///   - port: The port to connect to.
-    ///   - channelBackpressureStrategy: The back pressure strategy used by the channel.
+    ///   - backpressureStrategy: The back pressure strategy used by the channel.
     ///   - isOutboundHalfClosureEnabled: Indicates if half closure is enabled on the channel. If half closure is enabled
     ///   then finishing the `NIOAsyncChannelWriter` will lead to half closure.
     ///   - inboundType: The channel's inbound type.
@@ -1380,7 +1380,7 @@ extension ClientBootstrap {
     ///
     /// - Parameters:
     ///   - address: The address to connect to.
-    ///   - channelBackpressureStrategy: The back pressure strategy used by the channel.
+    ///   - backpressureStrategy: The back pressure strategy used by the channel.
     ///   - isOutboundHalfClosureEnabled: Indicates if half closure is enabled on the channel. If half closure is enabled
     ///   then finishing the `NIOAsyncChannelWriter` will lead to half closure.
     ///   - inboundType: The channel's inbound type.
@@ -1414,7 +1414,7 @@ extension ClientBootstrap {
     ///
     /// - Parameters:
     ///   - unixDomainSocketPath: The _Unix domain socket_ path to connect to.
-    ///   - channelBackpressureStrategy: The back pressure strategy used by the channel.
+    ///   - backpressureStrategy: The back pressure strategy used by the channel.
     ///   - isOutboundHalfClosureEnabled: Indicates if half closure is enabled on the channel. If half closure is enabled
     ///   then finishing the `NIOAsyncChannelWriter` will lead to half closure.
     ///   - inboundType: The channel's inbound type.
@@ -1448,7 +1448,7 @@ extension ClientBootstrap {
     ///
     /// - Parameters:
     ///   - descriptor: The _Unix file descriptor_ representing the connected stream socket.
-    ///   - channelBackpressureStrategy: The back pressure strategy used by the channel.
+    ///   - backpressureStrategy: The back pressure strategy used by the channel.
     ///   - isOutboundHalfClosureEnabled: Indicates if half closure is enabled on the channel. If half closure is enabled
     ///   then finishing the `NIOAsyncChannelWriter` will lead to half closure.
     ///   - inboundType: The channel's inbound type.
@@ -1628,8 +1628,8 @@ extension ClientBootstrap {
     /// - Parameters:
     ///   - host: The host to connect to.
     ///   - port: The port to connect to.
-    ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
-    ///   the protocol.
+    ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
+    ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
@@ -1654,8 +1654,8 @@ extension ClientBootstrap {
     ///
     /// - Parameters:
     ///   - address: The address to connect to.
-    ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
-    ///   the protocol.
+    ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
+    ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
@@ -1679,8 +1679,8 @@ extension ClientBootstrap {
     ///
     /// - Parameters:
     ///   - unixDomainSocketPath: The _Unix domain socket_ path to connect to.
-    ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
-    ///   the protocol.
+    ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
+    ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)
@@ -1699,8 +1699,8 @@ extension ClientBootstrap {
     ///
     /// - Parameters:
     ///   - descriptor: The _Unix file descriptor_ representing the connected stream socket.
-    ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
-    ///   the protocol.
+    ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
+    ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel)

--- a/Sources/NIOPosix/HappyEyeballs.swift
+++ b/Sources/NIOPosix/HappyEyeballs.swift
@@ -141,6 +141,9 @@ private struct TargetIterator: IteratorProtocol {
 ///
 /// This class's private API is *not* thread-safe, and expects to be called from the
 /// event loop thread of the `loop` it is passed.
+///
+/// The `ChannelBuilderResult` generic type can used to tunnel an arbitrary type
+/// from the `channelBuilderCallback` to the `resolve` methods return value.
 internal final class HappyEyeballsConnector<ChannelBuilderResult> {
     /// An enum for keeping track of connection state.
     private enum ConnectionState {

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -35,8 +35,7 @@ private final class LineDelimiterCoder: ByteToMessageDecoder, MessageToByteEncod
     }
 
     func encode(data: ByteBuffer, out: inout ByteBuffer) throws {
-        var data = data
-        out.writeBuffer(&data)
+        out.writeImmutableBuffer(data)
         out.writeString("\n")
     }
 }
@@ -484,8 +483,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             }
             .connect(
                 to: .init(ipAddress: "127.0.0.1", port: port),
-                channelInboundType: String.self,
-                channelOutboundType: String.self
+                inboundType: String.self,
+                outboundType: String.self
             )
     }
 

--- a/Tests/NIOPosixTests/HappyEyeballsTest.swift
+++ b/Tests/NIOPosixTests/HappyEyeballsTest.swift
@@ -226,10 +226,12 @@ private func defaultChannelBuilder(loop: EventLoop, family: NIOBSDSocket.Protoco
     return loop.makeSucceededFuture(channel)
 }
 
-private func buildEyeballer(host: String,
-                            port: Int,
-                            connectTimeout: TimeAmount = .seconds(10),
-                            channelBuilderCallback: @escaping (EventLoop, NIOBSDSocket.ProtocolFamily) -> EventLoopFuture<Channel> = defaultChannelBuilder) -> (eyeballer: HappyEyeballsConnector, resolver: DummyResolver, loop: EmbeddedEventLoop) {
+private func buildEyeballer(
+    host: String,
+    port: Int,
+    connectTimeout: TimeAmount = .seconds(10),
+    channelBuilderCallback: @escaping (EventLoop, NIOBSDSocket.ProtocolFamily) -> EventLoopFuture<Channel> = defaultChannelBuilder
+) -> (eyeballer: HappyEyeballsConnector<Void>, resolver: DummyResolver, loop: EmbeddedEventLoop) {
     let loop = EmbeddedEventLoop()
     let resolver = DummyResolver(loop: loop)
     let eyeballer = HappyEyeballsConnector(resolver: resolver,


### PR DESCRIPTION
# Motivation
In my previous PR, I added new `bind` methods to `ServerBootstrap` that vend `NIOAsyncChannel` or support an async protocol negotiation. This PR focuses on adding new `connect` methods to `ClientBootstrap` which offer the same functionality.

# Modification
This PR adds new `connect` methods that either vend a `NIOAsyncChannel` or an asynchronous protocol negotiation result. To make this work I had to change the `HappyEyeballs` resolver so that it can return a generic value on resolving. Lastly, I adapted the bootstrap tests to use the new `ClientBootstrap` capabilities which now demonstrate a client/server protocol negotiation dance.

# Result
We can now bootstrap TCP clients with `NIOAsyncChannel`s
