### PR TITLE
Align ServerBootstrap bind methods with the initializer style

### DIFF
--- a/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
@@ -120,12 +120,12 @@ public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Senda
 
     @inlinable
     @_spi(AsyncChannel)
-    public static func wrapAsyncChannelWithTransformations<ChannelReadResult>(
+    public static func wrapAsyncChannelWithTransformations<ChannelReadResult: Sendable>(
         synchronouslyWrapping channel: Channel,
         backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isOutboundHalfClosureEnabled: Bool = false,
-        channelReadTransformation: @escaping (Channel) -> EventLoopFuture<ChannelReadResult>,
-        postFireChannelReadTransformation: @escaping (ChannelReadResult) -> EventLoopFuture<Inbound>
+        channelReadTransformation: @Sendable @escaping (Channel) -> EventLoopFuture<ChannelReadResult>,
+        postFireChannelReadTransformation: @Sendable  @escaping (ChannelReadResult) -> EventLoopFuture<Inbound>
     ) throws -> NIOAsyncChannel<Inbound, Outbound> where Outbound == Never {
         channel.eventLoop.preconditionInEventLoop()
         let (inboundStream, outboundWriter): (NIOAsyncChannelInboundStream<Inbound>, NIOAsyncChannelOutboundWriter<Outbound>) = try channel._syncAddAsyncHandlersWithTransformations(
@@ -175,8 +175,8 @@ extension Channel {
     public func _syncAddAsyncHandlersWithTransformations<ChannelReadResult, PostFireChannelReadResult>(
         backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         isOutboundHalfClosureEnabled: Bool,
-        channelReadTransformation: @escaping (Channel) -> EventLoopFuture<ChannelReadResult>,
-        postFireChannelReadTransformation: @escaping (ChannelReadResult) -> EventLoopFuture<PostFireChannelReadResult>
+        channelReadTransformation: @Sendable @escaping (Channel) -> EventLoopFuture<ChannelReadResult>,
+        postFireChannelReadTransformation: @Sendable @escaping (ChannelReadResult) -> EventLoopFuture<PostFireChannelReadResult>
     ) throws -> (NIOAsyncChannelInboundStream<PostFireChannelReadResult>, NIOAsyncChannelOutboundWriter<Never>) {
         self.eventLoop.assertInEventLoop()
 

--- a/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
@@ -120,41 +120,19 @@ public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Senda
 
     @inlinable
     @_spi(AsyncChannel)
-    public static func wrapAsyncChannelForBootstrapBind(
+    public static func wrapAsyncChannelWithTransformations<ChannelReadResult>(
         synchronouslyWrapping channel: Channel,
         backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isOutboundHalfClosureEnabled: Bool = false,
-        transformationClosure: @escaping (Channel) -> EventLoopFuture<Inbound>
+        channelReadTransformation: @escaping (Channel) -> EventLoopFuture<ChannelReadResult>,
+        postFireChannelReadTransformation: @escaping (ChannelReadResult) -> EventLoopFuture<Inbound>
     ) throws -> NIOAsyncChannel<Inbound, Outbound> where Outbound == Never {
         channel.eventLoop.preconditionInEventLoop()
-        let (inboundStream, outboundWriter): (NIOAsyncChannelInboundStream<Inbound>, NIOAsyncChannelOutboundWriter<Outbound>) = try channel._syncAddAsyncHandlersForBootstrapBind(
+        let (inboundStream, outboundWriter): (NIOAsyncChannelInboundStream<Inbound>, NIOAsyncChannelOutboundWriter<Outbound>) = try channel._syncAddAsyncHandlersWithTransformations(
             backpressureStrategy: backpressureStrategy,
             isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled,
-            transformationClosure: transformationClosure
-        )
-
-        outboundWriter.finish()
-
-        return .init(
-            channel: channel,
-            inboundStream: inboundStream,
-            outboundWriter: outboundWriter
-        )
-    }
-
-    @inlinable
-    @_spi(AsyncChannel)
-    public static func wrapAsyncChannelForBootstrapBindWithProtocolNegotiation(
-        synchronouslyWrapping channel: Channel,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        isOutboundHalfClosureEnabled: Bool = false,
-        transformationClosure: @escaping (Channel) -> EventLoopFuture<Inbound>
-    ) throws -> NIOAsyncChannel<Inbound, Outbound> where Outbound == Never {
-        channel.eventLoop.preconditionInEventLoop()
-        let (inboundStream, outboundWriter): (NIOAsyncChannelInboundStream<Inbound>, NIOAsyncChannelOutboundWriter<Outbound>) = try channel._syncAddAsyncHandlersForBootstrapProtocolNegotiation(
-            backpressureStrategy: backpressureStrategy,
-            isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled,
-            transformationClosure: transformationClosure
+            channelReadTransformation: channelReadTransformation,
+            postFireChannelReadTransformation: postFireChannelReadTransformation
         )
 
         outboundWriter.finish()
@@ -194,45 +172,23 @@ extension Channel {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @inlinable
     @_spi(AsyncChannel)
-    public func _syncAddAsyncHandlersForBootstrapBind<Inbound: Sendable, Outbound: Sendable>(
+    public func _syncAddAsyncHandlersWithTransformations<ChannelReadResult, PostFireChannelReadResult>(
         backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         isOutboundHalfClosureEnabled: Bool,
-        transformationClosure: @escaping (Channel) -> EventLoopFuture<Inbound>
-    ) throws -> (NIOAsyncChannelInboundStream<Inbound>, NIOAsyncChannelOutboundWriter<Outbound>) {
+        channelReadTransformation: @escaping (Channel) -> EventLoopFuture<ChannelReadResult>,
+        postFireChannelReadTransformation: @escaping (ChannelReadResult) -> EventLoopFuture<PostFireChannelReadResult>
+    ) throws -> (NIOAsyncChannelInboundStream<PostFireChannelReadResult>, NIOAsyncChannelOutboundWriter<Never>) {
         self.eventLoop.assertInEventLoop()
 
         let closeRatchet = CloseRatchet(isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled)
-        let inboundStream = try NIOAsyncChannelInboundStream<Inbound>.makeBindingHandler(
+        let inboundStream = try NIOAsyncChannelInboundStream<PostFireChannelReadResult>.makeTransformationHandler(
             channel: self,
             backpressureStrategy: backpressureStrategy,
             closeRatchet: closeRatchet,
-            transformationClosure: transformationClosure
+            channelReadTransformation: channelReadTransformation,
+            postFireChannelReadTransformation: postFireChannelReadTransformation
         )
-        let writer = try NIOAsyncChannelOutboundWriter<Outbound>(
-            channel: self,
-            closeRatchet: closeRatchet
-        )
-        return (inboundStream, writer)
-    }
-
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @inlinable
-    @_spi(AsyncChannel)
-    public func _syncAddAsyncHandlersForBootstrapProtocolNegotiation<Inbound: Sendable, Outbound: Sendable>(
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
-        isOutboundHalfClosureEnabled: Bool,
-        transformationClosure: @escaping (Channel) -> EventLoopFuture<Inbound>
-    ) throws -> (NIOAsyncChannelInboundStream<Inbound>, NIOAsyncChannelOutboundWriter<Outbound>) {
-        self.eventLoop.assertInEventLoop()
-
-        let closeRatchet = CloseRatchet(isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled)
-        let inboundStream = try NIOAsyncChannelInboundStream<Inbound>.makeProtocolNegotiationHandler(
-            channel: self,
-            backpressureStrategy: backpressureStrategy,
-            closeRatchet: closeRatchet,
-            transformationClosure: transformationClosure
-        )
-        let writer = try NIOAsyncChannelOutboundWriter<Outbound>(
+        let writer = try NIOAsyncChannelOutboundWriter<Never>(
             channel: self,
             closeRatchet: closeRatchet
         )

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
@@ -77,8 +77,8 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
         channel: Channel,
         backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         closeRatchet: CloseRatchet,
-        channelReadTransformation: @escaping (Channel) -> EventLoopFuture<ChannelReadResult>,
-        postFireChannelReadTransformation: @escaping (ChannelReadResult) -> EventLoopFuture<Inbound>
+        channelReadTransformation: @Sendable @escaping (Channel) -> EventLoopFuture<ChannelReadResult>,
+        postFireChannelReadTransformation: @Sendable @escaping (ChannelReadResult) -> EventLoopFuture<Inbound>
     ) throws -> NIOAsyncChannelInboundStream {
         let handler = NIOAsyncChannelInboundStreamChannelHandler<Channel, ChannelReadResult, Inbound>.makeHandlerWithTransformations(
             eventLoop: channel.eventLoop,

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
@@ -25,11 +25,11 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     @usableFromInline let _producer: Producer
 
     @inlinable
-    init<HandlerInbound: Sendable>(
+    init<HandlerInbound: Sendable, ReadTransformationResult: Sendable>(
         channel: Channel,
         backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         closeRatchet: CloseRatchet,
-        handler: NIOAsyncChannelInboundStreamChannelHandler<HandlerInbound, Inbound>
+        handler: NIOAsyncChannelInboundStreamChannelHandler<HandlerInbound, ReadTransformationResult, Inbound>
     ) throws {
         channel.eventLoop.preconditionInEventLoop()
         let strategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark
@@ -58,7 +58,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
         backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         closeRatchet: CloseRatchet
     ) throws -> NIOAsyncChannelInboundStream {
-        let handler = NIOAsyncChannelInboundStreamChannelHandler<Inbound, Inbound>.makeWrappingHandler(
+        let handler = NIOAsyncChannelInboundStreamChannelHandler<Inbound, Inbound, Inbound>.makeHandler(
             eventLoop: channel.eventLoop,
             closeRatchet: closeRatchet
         )
@@ -71,41 +71,20 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
         )
     }
 
-    /// Creates a new ``NIOAsyncChannelInboundStreamChannelHandler`` which is used in the bootstrap for the ServerChannel.
+    /// Creates a new ``NIOAsyncChannelInboundStream`` which has hooks for transformations.
     @inlinable
-    static func makeBindingHandler(
+    static func makeTransformationHandler<ChannelReadResult>(
         channel: Channel,
         backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         closeRatchet: CloseRatchet,
-        transformationClosure: @escaping (Channel) -> EventLoopFuture<Inbound>
+        channelReadTransformation: @escaping (Channel) -> EventLoopFuture<ChannelReadResult>,
+        postFireChannelReadTransformation: @escaping (ChannelReadResult) -> EventLoopFuture<Inbound>
     ) throws -> NIOAsyncChannelInboundStream {
-        let handler = NIOAsyncChannelInboundStreamChannelHandler<Channel, Inbound>.makeBindingHandler(
+        let handler = NIOAsyncChannelInboundStreamChannelHandler<Channel, ChannelReadResult, Inbound>.makeHandlerWithTransformations(
             eventLoop: channel.eventLoop,
             closeRatchet: closeRatchet,
-            transformationClosure: transformationClosure
-        )
-
-        return try .init(
-            channel: channel,
-            backpressureStrategy: backpressureStrategy,
-            closeRatchet: closeRatchet,
-            handler: handler
-        )
-    }
-
-    /// Creates a new ``NIOAsyncChannelInboundStreamChannelHandler`` which is used in the bootstrap for the ServerChannel when the child
-    /// channel does protocol negotiation.
-    @inlinable
-    static func makeProtocolNegotiationHandler(
-        channel: Channel,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
-        closeRatchet: CloseRatchet,
-        transformationClosure: @escaping (Channel) -> EventLoopFuture<Inbound>
-    ) throws -> NIOAsyncChannelInboundStream {
-        let handler = NIOAsyncChannelInboundStreamChannelHandler<Channel, Inbound>.makeProtocolNegotiationHandler(
-            eventLoop: channel.eventLoop,
-            closeRatchet: closeRatchet,
-            transformationClosure: transformationClosure
+            channelReadTransformation: channelReadTransformation,
+            postFireChannelReadTransformation: postFireChannelReadTransformation
         )
 
         return try .init(

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStreamChannelHandler.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStreamChannelHandler.swift
@@ -16,7 +16,7 @@
 /// ``Channel`` into an asynchronous sequence that supports back-pressure.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
-internal final class NIOAsyncChannelInboundStreamChannelHandler<InboundIn: Sendable, ProducerElement: Sendable>: ChannelDuplexHandler {
+internal final class NIOAsyncChannelInboundStreamChannelHandler<InboundIn: Sendable, ReadTransformationResult: Sendable, ProducerElement: Sendable>: ChannelDuplexHandler {
     @usableFromInline
     enum _ProducingState {
         // Not .stopProducing
@@ -72,11 +72,10 @@ internal final class NIOAsyncChannelInboundStreamChannelHandler<InboundIn: Senda
     enum Transformation {
         /// A synchronous transformation is applied to incoming reads. This is used when sync wrapping a channel.
         case syncWrapping((InboundIn) -> ProducerElement)
-        /// This is used in the ServerBootstrap since we require to wrap the child channel on it's event loop but yield it on the parent's loop.
-        case bind((InboundIn) -> EventLoopFuture<ProducerElement>)
-        /// In the case of protocol negotiation we are applying a future based transformation where we wait for the transformation
-        /// to finish before we yield it to the source.
-        case protocolNegotiation((InboundIn) -> EventLoopFuture<ProducerElement>)
+        case transformation(
+            channelReadTransformation: (InboundIn) -> EventLoopFuture<ReadTransformationResult>,
+            postFireChannelReadTransformation: (ReadTransformationResult) -> EventLoopFuture<ProducerElement>
+        )
     }
 
     /// The transformation applied to incoming reads.
@@ -96,7 +95,7 @@ internal final class NIOAsyncChannelInboundStreamChannelHandler<InboundIn: Senda
 
     /// Creates a new ``NIOAsyncChannelInboundStreamChannelHandler`` which is used when the pipeline got synchronously wrapped.
     @inlinable
-    static func makeWrappingHandler(
+    static func makeHandler(
         eventLoop: EventLoop,
         closeRatchet: CloseRatchet
     ) -> NIOAsyncChannelInboundStreamChannelHandler where InboundIn == ProducerElement {
@@ -107,32 +106,21 @@ internal final class NIOAsyncChannelInboundStreamChannelHandler<InboundIn: Senda
         )
     }
 
-    /// Creates a new ``NIOAsyncChannelInboundStreamChannelHandler`` which is used in the bootstrap for the ServerChannel.
+    /// Creates a new ``NIOAsyncChannelInboundStreamChannelHandler`` which has hooks for transformations.
     @inlinable
-    static func makeBindingHandler(
+    static func makeHandlerWithTransformations(
         eventLoop: EventLoop,
         closeRatchet: CloseRatchet,
-        transformationClosure: @escaping (Channel) -> EventLoopFuture<ProducerElement>
+        channelReadTransformation: @escaping (InboundIn) -> EventLoopFuture<ReadTransformationResult>,
+        postFireChannelReadTransformation: @escaping (ReadTransformationResult) -> EventLoopFuture<ProducerElement>
     ) -> NIOAsyncChannelInboundStreamChannelHandler where InboundIn == Channel {
         return .init(
             eventLoop: eventLoop,
             closeRatchet: closeRatchet,
-            transformation: .bind(transformationClosure)
-        )
-    }
-
-    /// Creates a new ``NIOAsyncChannelInboundStreamChannelHandler`` which is used in the bootstrap for the ServerChannel when the child
-    /// channel does protocol negotiation.
-    @inlinable
-    static func makeProtocolNegotiationHandler(
-        eventLoop: EventLoop,
-        closeRatchet: CloseRatchet,
-        transformationClosure: @escaping (Channel) -> EventLoopFuture<ProducerElement>
-    ) -> NIOAsyncChannelInboundStreamChannelHandler where InboundIn == Channel {
-        return .init(
-            eventLoop: eventLoop,
-            closeRatchet: closeRatchet,
-            transformation: .protocolNegotiation(transformationClosure)
+            transformation: .transformation(
+                channelReadTransformation: channelReadTransformation,
+                postFireChannelReadTransformation: postFireChannelReadTransformation
+            )
         )
     }
 
@@ -157,38 +145,27 @@ internal final class NIOAsyncChannelInboundStreamChannelHandler<InboundIn: Senda
             // We forward on reads here to enable better channel composition.
             context.fireChannelRead(data)
 
-        case .bind(let transformation):
+        case .transformation(let channelReadTransformation, let postFireChannelReadTransformation):
             // The unsafe transfers here are required because we need to use self in whenComplete
             // We are making sure to be on our event loop so we can safely use self in whenComplete
             let unsafeSelf = NIOLoopBound(self, eventLoop: context.eventLoop)
             let unsafeContext = NIOLoopBound(context, eventLoop: context.eventLoop)
-            transformation(unwrapped)
+            channelReadTransformation(unwrapped)
                 .hop(to: context.eventLoop)
-                .whenComplete { result in
-                    unsafeSelf.value._transformationCompleted(context: unsafeContext.value, result: result)
-
-                    // We forward the read only after the transformation has been completed. This is super important
-                    // since we are setting up the NIOAsyncChannel handlers in the transformation and
-                    // we must make sure to only generate reads once they are setup. Reads can only
-                    // happen after the child channels hit `channelRead0` that's why we are holding the read here.
+                .map { result -> ReadTransformationResult in
+                    // We have to fire through the original data now. Since our channelReadTransformation
+                    // is the channel initializer. Once that's done we need to fire the channel as a read
+                    // so that it hits channelRead0 in the base socket channel.
                     context.fireChannelRead(data)
+                    return result
                 }
-
-        case .protocolNegotiation(let protocolNegotiation):
-            // The unsafe transfers here are required because we need to use self in whenComplete
-            // We are making sure to be on our event loop so we can safely use self in whenComplete
-            let unsafeSelf = NIOLoopBound(self, eventLoop: context.eventLoop)
-            let unsafeContext = NIOLoopBound(context, eventLoop: context.eventLoop)
-            protocolNegotiation(unwrapped)
+                .flatMap { result -> EventLoopFuture<ProducerElement> in
+                    postFireChannelReadTransformation(result)
+                }
                 .hop(to: context.eventLoop)
                 .whenComplete { result in
                     unsafeSelf.value._transformationCompleted(context: unsafeContext.value, result: result)
                 }
-
-            // We forwarding the read here right away since protocol negotiation often needs reads to progress.
-            // In this case, we expect the user to synchronously wrap the child channel into a NIOAsyncChannel
-            // hence we don't have the timing issue as in the `.bind` case.
-            context.fireChannelRead(data)
         }
     }
 
@@ -347,7 +324,7 @@ struct NIOAsyncChannelInboundStreamChannelHandlerProducerDelegate: @unchecked Se
     let _produceMore: () -> Void
 
     @inlinable
-    init<InboundIn, ProducerElement>(handler: NIOAsyncChannelInboundStreamChannelHandler<InboundIn, ProducerElement>) {
+    init<InboundIn, ReadTransformationResult, ProducerElement>(handler: NIOAsyncChannelInboundStreamChannelHandler<InboundIn, ReadTransformationResult, ProducerElement>) {
         self.eventLoop = handler.eventLoop
         self._didTerminate = handler._didTerminate
         self._produceMore = handler._produceMore

--- a/Sources/NIOCore/ChannelHandler.swift
+++ b/Sources/NIOCore/ChannelHandler.swift
@@ -346,7 +346,7 @@ extension RemovableChannelHandler {
 
 /// The result of protocol negotiation.
 @_spi(AsyncChannel)
-public enum NIOProtocolNegotiationResult<NegotiationResult> {
+public enum NIOProtocolNegotiationResult<NegotiationResult: Sendable> {
     /// Indicates that the protocol negotiation finished.
     case finished(NegotiationResult)
     /// Indicates that protocol negotiation has been deferred to the next handler.

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -954,7 +954,7 @@ extension ServerBootstrap {
                         .wrapAsyncChannelWithTransformations(
                             synchronouslyWrapping: serverChannel,
                             backpressureStrategy: serverBackpressureStrategy,
-                            channelReadTransformation: { channel -> EventLoopFuture<(ChannelInitializerResult, any EventLoop)> in
+                            channelReadTransformation: { channel -> EventLoopFuture<(ChannelInitializerResult, EventLoop)> in
                                 // The channelReadTransformation is run on the EL of the server channel
                                 // We have to make sure that we execute child channel initializer on the
                                 // EL of the child channel.

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -304,7 +304,7 @@ final class AsyncChannelTests: XCTestCase {
             do {
                 let strongSentinel: Sentinel? = Sentinel()
                 sentinel = strongSentinel!
-                try await XCTAsyncAssertNotNil(await channel.pipeline.handler(type: NIOAsyncChannelInboundStreamChannelHandler<Sentinel, Sentinel>.self).get())
+                try await XCTAsyncAssertNotNil(await channel.pipeline.handler(type: NIOAsyncChannelInboundStreamChannelHandler<Sentinel, Sentinel, Sentinel>.self).get())
                 try await channel.writeInbound(strongSentinel!)
                 _ = try await channel.readInbound(as: Sentinel.self)
             }

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -228,16 +228,14 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             let channel: NIOAsyncChannel<NegotiationResult, Never> = try await ServerBootstrap(group: eventLoopGroup)
                 .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
                 .childChannelOption(ChannelOptions.autoRead, value: true)
-                .childChannelInitializer { channel in
+                .bind(
+                    host: "127.0.0.1",
+                    port: 0
+                ) { channel in
                     channel.eventLoop.makeCompletedFuture {
                         try self.configureProtocolNegotiationHandlers(channel: channel)
                     }
                 }
-                .bind(
-                    host: "127.0.0.1",
-                    port: 0,
-                    protocolNegotiationHandlerType: NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>.self
-                )
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 let (stream, continuation) = AsyncStream<StringOrByte>.makeStream()
@@ -276,7 +274,6 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     preconditionFailure()
                 }
 
-
                 let byteNegotiationResult = try await self.makeClientChannelWithProtocolNegotiation(
                     eventLoopGroup: eventLoopGroup,
                     port: channel.channel.localAddress!.port!,
@@ -306,16 +303,14 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             let channel: NIOAsyncChannel<NegotiationResult, Never> = try await ServerBootstrap(group: eventLoopGroup)
                 .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
                 .childChannelOption(ChannelOptions.autoRead, value: true)
-                .childChannelInitializer { channel in
+                .bind(
+                    host: "127.0.0.1",
+                    port: 0
+                ) { channel in
                     channel.eventLoop.makeCompletedFuture {
                         try self.configureNestedProtocolNegotiationHandlers(channel: channel)
                     }
                 }
-                .bind(
-                    host: "127.0.0.1",
-                    port: 0,
-                    protocolNegotiationHandlerType: NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>.self
-                )
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 let (stream, continuation) = AsyncStream<StringOrByte>.makeStream()
@@ -438,16 +433,14 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     }
                 }
                 .childChannelOption(ChannelOptions.autoRead, value: true)
-                .childChannelInitializer { channel in
+                .bind(
+                    host: "127.0.0.1",
+                    port: 0
+                ) { channel in
                     channel.eventLoop.makeCompletedFuture {
                         try self.configureProtocolNegotiationHandlers(channel: channel)
                     }
                 }
-                .bind(
-                    host: "127.0.0.1",
-                    port: 0,
-                    protocolNegotiationHandlerType: NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>.self
-                )
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 let (stream, continuation) = AsyncStream<StringOrByte>.makeStream()

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -34,7 +34,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=148000
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=148050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=155050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050


### PR DESCRIPTION
# Motivation

After experimenting with the bind/connect APIs of the other bootstraps, we realized that passing the type of the handler is not working very well and choose to add an initializer closure to all the bind/connect methods which returns a concrete result.

# Modification

This PR aligns the `ServerBootstrap` APIs with the new initializer based approach. To make this work I had to refactor the `NIOAsyncChannel` SPIs a bit. Overall, this is a net reduction in code.

# Result

We now have aligned bootstrap APIs.