### PR TITLE
Update RediStack URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ HTTP | ✅| ❌ | [swift-server/async-http-client](https://github.com/swift-serv
 gRPC | ✅| ✅ | [grpc/grpc-swift](https://github.com/grpc/grpc-swift) | `GRPC` | also offers a low-level API; SSWG community project
 APNS | ✅ | ❌ | [kylebrowning/APNSwift](https://github.com/kylebrowning/APNSwift) | `APNSwift` | SSWG community project
 PostgreSQL | ✅ | ❌ | [vapor/postgres-nio](https://github.com/vapor/postgres-nio) | `PostgresNIO` | SSWG community project
-Redis | ✅ | ❌ | [mordil/swift-redi-stack](https://gitlab.com/Mordil/swift-redi-stack) | `RediStack` | SSWG community project
+Redis | ✅ | ❌ | [swift-server/RediStack](https://github.com/swift-server/RediStack) | `RediStack` | SSWG community project
 
 ### Supported Versions
 


### PR DESCRIPTION
This should point to GitHub, not to the GitLab mirror.