### PR TITLE
Add support to xrOS

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
+++ b/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
@@ -136,7 +136,7 @@ func measureAndPrint(desc: String, trackFDs: Bool, fn: () -> Int) -> Void {
     measurements.printRemainingAllocations(description: desc)
     measurements.printTotalAllocatedBytes(description: desc)
     measurements.printLeakedFDs(description: desc)
-    
+
     print("DEBUG: \(measurements)")
 }
 
@@ -146,7 +146,7 @@ public func measure(identifier: String, trackFDs: Bool = false, _ body: () -> In
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 func measureAll(trackFDs: Bool, _ fn: @escaping () async -> Int) -> [Measurement] {
     func measureOne(throwAway: Bool = false, trackFDs: Bool, _ fn: @escaping () async -> Int) -> Measurement? {
         func run(_ fn: @escaping () async -> Int) {
@@ -158,7 +158,7 @@ func measureAll(trackFDs: Bool, _ fn: @escaping () async -> Int) -> [Measurement
             }
             group.wait()
         }
-        
+
         if trackFDs {
             AtomicCounter.begin_tracking_fds()
         }
@@ -209,7 +209,7 @@ func measureAll(trackFDs: Bool, _ fn: @escaping () async -> Int) -> [Measurement
     return measurements
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 func measureAndPrint(desc: String, trackFDs: Bool, fn: @escaping () async -> Int) -> Void {
     let measurements = measureAll(trackFDs: trackFDs, fn)
     measurements.printTotalAllocations(description: desc)
@@ -218,7 +218,7 @@ func measureAndPrint(desc: String, trackFDs: Bool, fn: @escaping () async -> Int
     measurements.printLeakedFDs(description: desc)
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public func measure(identifier: String, trackFDs: Bool = false, _ body: @escaping () async -> Int) {
     measureAndPrint(desc: identifier, trackFDs: trackFDs, fn: body)
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_10000000_asyncsequenceproducer.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_10000000_asyncsequenceproducer.swift
@@ -14,10 +14,10 @@
 
 import NIOCore
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 fileprivate typealias SequenceProducer = NIOAsyncSequenceProducer<Int, NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark, Delegate>
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 fileprivate final class Delegate: NIOAsyncSequenceProducerDelegate, @unchecked Sendable {
     private let elements = Array(repeating: 1, count: 1000)
 
@@ -31,7 +31,7 @@ fileprivate final class Delegate: NIOAsyncSequenceProducerDelegate, @unchecked S
 }
 
 func run(identifier: String) {
-    guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+    guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *) else {
         return
     }
     measure(identifier: identifier) {

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000000_asyncwriter.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000000_asyncwriter.swift
@@ -15,7 +15,7 @@
 import NIOCore
 import DequeModule
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 fileprivate struct Delegate: NIOAsyncWriterSinkDelegate, Sendable {
     typealias Element = Int
 
@@ -25,7 +25,7 @@ fileprivate struct Delegate: NIOAsyncWriterSinkDelegate, Sendable {
 }
 
 func run(identifier: String) {
-    guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+    guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *) else {
         return
     }
     measure(identifier: identifier) {

--- a/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
+++ b/Sources/NIOAsyncAwaitDemo/AsyncChannelIO.swift
@@ -15,7 +15,7 @@
 import NIOCore
 import NIOHTTP1
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 struct AsyncChannelIO<Request, Response> {
     let channel: Channel
 

--- a/Sources/NIOAsyncAwaitDemo/main.swift
+++ b/Sources/NIOAsyncAwaitDemo/main.swift
@@ -16,7 +16,7 @@ import NIOPosix
 import NIOHTTP1
 import Dispatch
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 func makeHTTPChannel(host: String, port: Int, group: EventLoopGroup) async throws -> AsyncChannelIO<HTTPRequestHead, NIOHTTPClientResponseFull> {
     let channel = try await ClientBootstrap(group: group).connect(host: host, port: port).get()
     try await channel.pipeline.addHTTPClientHandlers().get()
@@ -25,7 +25,7 @@ func makeHTTPChannel(host: String, port: Int, group: EventLoopGroup) async throw
     return try await AsyncChannelIO<HTTPRequestHead, NIOHTTPClientResponseFull>(channel).start()
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 func main() async {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     do {
@@ -65,7 +65,7 @@ func main() async {
 
 let dg = DispatchGroup()
 dg.enter()
-if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *) {
     Task {
         await main()
         dg.leave()

--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -17,7 +17,7 @@ extension EventLoopFuture {
     ///
     /// This function can be used to bridge an `EventLoopFuture` into the `async` world. Ie. if you're in an `async`
     /// function and want to get the result of this future.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @inlinable
     public func get() async throws -> Value {
         return try await withUnsafeThrowingContinuation { (cont: UnsafeContinuation<UnsafeTransfer<Value>, Error>) in
@@ -35,7 +35,7 @@ extension EventLoopFuture {
 
 extension EventLoopGroup {
     /// Shuts down the event loop gracefully.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @inlinable
     public func shutdownGracefully() async throws {
         return try await withCheckedThrowingContinuation { cont in
@@ -58,7 +58,7 @@ extension EventLoopPromise {
     /// - parameters:
     ///   - body: The `async` function to run.
     /// - returns: A `Task` which was created to `await` the `body`.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @discardableResult
     @inlinable
     public func completeWithTask(_ body: @escaping @Sendable () async throws -> Value) -> Task<Void, Never> {
@@ -80,21 +80,21 @@ extension Channel {
     ///     - data: the data to write
     ///     - promise: the `EventLoopPromise` that will be notified once the `write` operation completes,
     ///                or `nil` if not interested in the outcome of the operation.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @inlinable
     public func writeAndFlush<T>(_ any: T) async throws {
         try await self.writeAndFlush(any).get()
     }
 
     /// Set `option` to `value` on this `Channel`.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @inlinable
     public func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) async throws {
         try await self.setOption(option, value: value).get()
     }
 
     /// Get the value of `option` for this `Channel`.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @inlinable
     public func getOption<Option: ChannelOption>(_ option: Option) async throws -> Option.Value {
         return try await self.getOption(option).get()
@@ -105,7 +105,7 @@ extension ChannelOutboundInvoker {
     /// Register on an `EventLoop` and so have all its IO handled.
     ///
     /// - returns: the future which will be notified once the operation completes.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func register(file: StaticString = #fileID, line: UInt = #line) async throws {
         try await self.register(file: file, line: line).get()
     }
@@ -114,7 +114,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - to: the `SocketAddress` to which we should bind the `Channel`.
     /// - returns: the future which will be notified once the operation completes.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func bind(to address: SocketAddress, file: StaticString = #fileID, line: UInt = #line) async throws {
         try await self.bind(to: address, file: file, line: line).get()
     }
@@ -123,7 +123,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - to: the `SocketAddress` to which we should connect the `Channel`.
     /// - returns: the future which will be notified once the operation completes.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func connect(to address: SocketAddress, file: StaticString = #fileID, line: UInt = #line) async throws {
         try await self.connect(to: address, file: file, line: line).get()
     }
@@ -133,7 +133,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - data: the data to write
     /// - returns: the future which will be notified once the `write` operation completes.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func writeAndFlush(_ data: NIOAny, file: StaticString = #fileID, line: UInt = #line) async throws {
         try await self.writeAndFlush(data, file: file, line: line).get()
     }
@@ -143,7 +143,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - mode: the `CloseMode` that is used
     /// - returns: the future which will be notified once the operation completes.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func close(mode: CloseMode = .all, file: StaticString = #fileID, line: UInt = #line) async throws {
         try await self.close(mode: mode, file: file, line: line).get()
     }
@@ -153,61 +153,61 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - event: the event itself.
     /// - returns: the future which will be notified once the operation completes.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func triggerUserOutboundEvent(_ event: Any, file: StaticString = #fileID, line: UInt = #line) async throws {
         try await self.triggerUserOutboundEvent(event, file: file, line: line).get()
     }
 }
 
 extension ChannelPipeline {
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func addHandler(_ handler: ChannelHandler,
                            name: String? = nil,
                            position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandler(handler, name: name, position: position).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func removeHandler(_ handler: RemovableChannelHandler) async throws {
         try await self.removeHandler(handler).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func removeHandler(name: String) async throws {
         try await self.removeHandler(name: name).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func removeHandler(context: ChannelHandlerContext) async throws {
         try await self.removeHandler(context: context).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @available(*, deprecated, message: "ChannelHandlerContext is not Sendable and it is therefore not safe to be used outside of its EventLoop")
     public func context(handler: ChannelHandler) async throws -> ChannelHandlerContext {
         return try await self.context(handler: handler).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @available(*, deprecated, message: "ChannelHandlerContext is not Sendable and it is therefore not safe to be used outside of its EventLoop")
     public func context(name: String) async throws -> ChannelHandlerContext {
         return try await self.context(name: name).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @available(*, deprecated, message: "ChannelHandlerContext is not Sendable and it is therefore not safe to be used outside of its EventLoop")
     @inlinable
     public func context<Handler: ChannelHandler>(handlerType: Handler.Type) async throws -> ChannelHandlerContext {
         return try await self.context(handlerType: handlerType).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func addHandlers(_ handlers: [ChannelHandler],
                             position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandlers(handlers, position: position).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public func addHandlers(_ handlers: ChannelHandler...,
                             position: ChannelPipeline.Position = .last) async throws {
         try await self.addHandlers(handlers, position: position)
@@ -218,7 +218,7 @@ public struct NIOTooManyBytesError: Error, Hashable {
      public init() {}
  }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension AsyncSequence where Element: RandomAccessCollection, Element.Element == UInt8 {
     /// Accumulates an ``Swift/AsyncSequence`` of ``Swift/RandomAccessCollection``s into a single `accumulationBuffer`.
     /// - Parameters:
@@ -241,7 +241,7 @@ extension AsyncSequence where Element: RandomAccessCollection, Element.Element =
             accumulationBuffer.writeBytes(fragment)
         }
     }
-    
+
     /// Accumulates an ``Swift/AsyncSequence`` of ``Swift/RandomAccessCollection``s into a single ``ByteBuffer``.
     /// - Parameters:
     ///   - maxBytes: The maximum number of bytes this method is allowed to accumulate
@@ -261,7 +261,7 @@ extension AsyncSequence where Element: RandomAccessCollection, Element.Element =
 
 // MARK: optimised methods for ByteBuffer
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension AsyncSequence where Element == ByteBuffer {
     /// Accumulates an `AsyncSequence` of ``ByteBuffer``s into a single `accumulationBuffer`.
     /// - Parameters:
@@ -284,7 +284,7 @@ extension AsyncSequence where Element == ByteBuffer {
             accumulationBuffer.writeImmutableBuffer(fragment)
         }
     }
-    
+
     /// Accumulates an `AsyncSequence` of ``ByteBuffer``s into a single ``ByteBuffer``.
     /// - Parameters:
     ///   - maxBytes: The maximum number of bytes this method is allowed to accumulate
@@ -304,7 +304,7 @@ extension AsyncSequence where Element == ByteBuffer {
         guard head.readableBytes <= maxBytes else {
             throw NIOTooManyBytesError()
         }
-        
+
         let tail = AsyncSequenceFromIterator(iterator)
         // it is guaranteed that
         // `maxBytes >= 0 && head.readableBytes >= 0 && head.readableBytes <= maxBytes`
@@ -315,23 +315,23 @@ extension AsyncSequence where Element == ByteBuffer {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @usableFromInline
 struct AsyncSequenceFromIterator<AsyncIterator: AsyncIteratorProtocol>: AsyncSequence {
     @usableFromInline typealias Element = AsyncIterator.Element
-    
+
     @usableFromInline var iterator: AsyncIterator
-    
+
     @inlinable init(_ iterator: AsyncIterator) {
         self.iterator = iterator
     }
-    
+
     @inlinable func makeAsyncIterator() -> AsyncIterator {
         self.iterator
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension EventLoop {
     @inlinable
     public func makeFutureWithTask<Return>(_ body: @Sendable @escaping () async throws -> Return) -> EventLoopFuture<Return> {

--- a/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
@@ -32,7 +32,7 @@
 /// protocol-specific logic (such as parsers and encoders) and those that implement business
 /// logic. Protocol-specific logic should be implemented as a ``ChannelHandler``, while business
 /// logic should use ``NIOAsyncChannel`` to consume and produce data to the network.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @_spi(AsyncChannel)
 public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Sendable {
     /// The underlying channel being wrapped by this ``NIOAsyncChannel``.
@@ -169,7 +169,7 @@ public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Senda
 
 extension Channel {
     // TODO: We need to remove the public and spi here once we make the AsyncChannel methods public
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @inlinable
     @_spi(AsyncChannel)
     public func _syncAddAsyncHandlers<Inbound: Sendable, Outbound: Sendable>(
@@ -191,7 +191,7 @@ extension Channel {
         return (inboundStream, writer)
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @inlinable
     @_spi(AsyncChannel)
     public func _syncAddAsyncHandlersForBootstrapBind<Inbound: Sendable, Outbound: Sendable>(
@@ -215,7 +215,7 @@ extension Channel {
         return (inboundStream, writer)
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @inlinable
     @_spi(AsyncChannel)
     public func _syncAddAsyncHandlersForBootstrapProtocolNegotiation<Inbound: Sendable, Outbound: Sendable>(

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
@@ -15,7 +15,7 @@
 /// The inbound message asynchronous sequence of a ``NIOAsyncChannel``.
 ///
 /// This is a unicast async sequence that allows a single iterator to be created.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @_spi(AsyncChannel)
 public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     @usableFromInline
@@ -117,7 +117,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncChannelInboundStream: AsyncSequence {
     @_spi(AsyncChannel)
     public typealias Element = Inbound
@@ -146,6 +146,6 @@ extension NIOAsyncChannelInboundStream: AsyncSequence {
 
 /// The ``NIOAsyncChannelInboundStream/AsyncIterator`` MUST NOT be shared across `Task`s. With marking this as
 /// unavailable we are explicitly declaring this.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @available(*, unavailable)
 extension NIOAsyncChannelInboundStream.AsyncIterator: Sendable {}

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStreamChannelHandler.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStreamChannelHandler.swift
@@ -14,7 +14,7 @@
 
 /// A ``ChannelHandler`` that is used to transform the inbound portion of a NIO
 /// ``Channel`` into an asynchronous sequence that supports back-pressure.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @usableFromInline
 internal final class NIOAsyncChannelInboundStreamChannelHandler<InboundIn: Sendable, ProducerElement: Sendable>: ChannelDuplexHandler {
     @usableFromInline
@@ -297,7 +297,7 @@ internal final class NIOAsyncChannelInboundStreamChannelHandler<InboundIn: Senda
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncChannelInboundStreamChannelHandler {
     @inlinable
     func _didTerminate() {
@@ -334,7 +334,7 @@ extension NIOAsyncChannelInboundStreamChannelHandler {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @usableFromInline
 struct NIOAsyncChannelInboundStreamChannelHandlerProducerDelegate: @unchecked Sendable, NIOAsyncSequenceProducerDelegate {
     @usableFromInline
@@ -368,6 +368,6 @@ struct NIOAsyncChannelInboundStreamChannelHandlerProducerDelegate: @unchecked Se
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @available(*, unavailable)
 extension NIOAsyncChannelInboundStreamChannelHandler: Sendable {}

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
@@ -17,7 +17,7 @@
 /// The writer acts as a bridge between the Concurrency and NIO world. It allows to write and flush messages into the
 /// underlying ``Channel``. Furthermore, it respects back-pressure of the channel by suspending the calls to write until
 /// the channel becomes writable again.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @_spi(AsyncChannel)
 public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
     @usableFromInline

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriterHandler.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriterHandler.swift
@@ -16,7 +16,7 @@ import DequeModule
 
 /// A ``ChannelHandler`` that is used to write the outbound portion of a NIO
 /// ``Channel`` from Swift Concurrency with back-pressure support.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @usableFromInline
 internal final class NIOAsyncChannelOutboundWriterHandler<OutboundOut: Sendable>: ChannelDuplexHandler {
     @usableFromInline typealias InboundIn = Any
@@ -126,7 +126,7 @@ internal final class NIOAsyncChannelOutboundWriterHandler<OutboundOut: Sendable>
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncChannelOutboundWriterHandler {
     @usableFromInline
     struct Delegate: @unchecked Sendable, NIOAsyncWriterSinkDelegate {
@@ -163,6 +163,6 @@ extension NIOAsyncChannelOutboundWriterHandler {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @available(*, unavailable)
 extension NIOAsyncChannelOutboundWriterHandler: Sendable {}

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducer.swift
@@ -27,7 +27,7 @@ import NIOConcurrencyHelpers
 ///
 /// - Important: The methods of this protocol are guaranteed to be called serially. Furthermore, the implementation of these
 /// methods **MUST NOT** do any locking or call out to any other Task/Thread.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public protocol NIOAsyncSequenceProducerBackPressureStrategy: Sendable {
     /// This method is called after new elements were yielded by the producer to the source.
     ///
@@ -53,7 +53,7 @@ public protocol NIOAsyncSequenceProducerBackPressureStrategy: Sendable {
 /// We recommend dispatching from the arbitrary thread that called ``NIOAsyncSequenceProducerDelegate/produceMore()`` and ``NIOAsyncSequenceProducerDelegate/didTerminate()``
 /// onto the thread that is calling ``NIOAsyncSequenceProducer/Source/yield(contentsOf:)``.
 /// This way you synchronize the receiving the result of a yield call and the callbacks of the delegate on the same thread.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public protocol NIOAsyncSequenceProducerDelegate: Sendable {
     /// This method is called once the back-pressure strategy of the ``NIOAsyncSequenceProducer`` determined
     /// that the producer needs to start producing more elements. Furthermore, it will also only be called if ``NIOAsyncSequenceProducer/Source/yield(_:)``
@@ -92,7 +92,7 @@ public protocol NIOAsyncSequenceProducerDelegate: Sendable {
 ///
 /// - Important: This sequence is a unicast sequence that only supports a single ``NIOAsyncSequenceProducer/AsyncIterator``.
 /// If you try to create more than one iterator it will result in a `fatalError`.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public struct NIOAsyncSequenceProducer<
     Element: Sendable,
     Strategy: NIOAsyncSequenceProducerBackPressureStrategy,
@@ -166,14 +166,14 @@ public struct NIOAsyncSequenceProducer<
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncSequenceProducer: AsyncSequence {
     public func makeAsyncIterator() -> AsyncIterator {
         AsyncIterator(throwingIterator: self._throwingSequence.makeAsyncIterator())
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncSequenceProducer {
     public struct AsyncIterator: AsyncIteratorProtocol {
         @usableFromInline
@@ -203,7 +203,7 @@ extension NIOAsyncSequenceProducer {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncSequenceProducer {
     /// A struct to interface between the synchronous code of the producer and the asynchronous consumer.
     /// This type allows the producer to synchronously `yield` new elements to the ``NIOAsyncSequenceProducer``
@@ -325,7 +325,7 @@ extension NIOAsyncSequenceProducer {
 
 /// The ``NIOAsyncSequenceProducer/AsyncIterator`` MUST NOT be shared across `Task`s. With marking this as
 /// unavailable we are explicitly declaring this.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @available(*, unavailable)
 extension NIOAsyncSequenceProducer.AsyncIterator: Sendable {}
 

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducerStrategies.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducerStrategies.swift
@@ -18,7 +18,7 @@ public enum NIOAsyncSequenceProducerBackPressureStrategies {
     /// This strategy does the following:
     /// - On yield it keeps on demanding more elements from the producer as long as the number of buffered elements hasn't reached the `highWatermark`.
     /// - On consume it starts to demand again from the producer once the number of buffered elements reach the `lowWatermark`.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     public struct HighLowWatermark: NIOAsyncSequenceProducerBackPressureStrategy {
         private let lowWatermark: Int
         private let highWatermark: Int

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
@@ -22,7 +22,7 @@ import NIOConcurrencyHelpers
 /// - Important: The methods on the delegate are called while a lock inside of the ``NIOAsyncWriter`` is held. This is done to
 /// guarantee the ordering of the writes. However, this means you **MUST NOT** call ``NIOAsyncWriter/Sink/setWritability(to:)``
 /// from within ``NIOAsyncWriterSinkDelegate/didYield(contentsOf:)`` or ``NIOAsyncWriterSinkDelegate/didTerminate(error:)``.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public protocol NIOAsyncWriterSinkDelegate: Sendable {
     /// The `Element` type of the delegate and the writer.
     associatedtype Element: Sendable
@@ -67,7 +67,7 @@ public protocol NIOAsyncWriterSinkDelegate: Sendable {
     func didTerminate(error: Error?)
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncWriterSinkDelegate {
     @inlinable
     public func didYield(_ element: Element) {
@@ -76,7 +76,7 @@ extension NIOAsyncWriterSinkDelegate {
 }
 
 /// Errors thrown by the ``NIOAsyncWriter``.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public struct NIOAsyncWriterError: Error, Hashable, CustomStringConvertible {
     @usableFromInline
     internal enum _Code: String, Hashable, Sendable {
@@ -135,7 +135,7 @@ public struct NIOAsyncWriterError: Error, Hashable, CustomStringConvertible {
 /// Moreover, having a wrapping type allows to optimize this to specialized calls if all generic types are known.
 ///
 /// - Note: This struct has reference semantics. Once all copies of a writer have been dropped ``NIOAsyncWriterSinkDelegate/didTerminate(error:)`` will be called.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public struct NIOAsyncWriter<
     Element,
     Delegate: NIOAsyncWriterSinkDelegate
@@ -301,7 +301,7 @@ public struct NIOAsyncWriter<
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncWriter {
     /// The underlying sink of the ``NIOAsyncWriter``. This type allows to set the writability of the ``NIOAsyncWriter``.
     ///
@@ -374,7 +374,7 @@ extension NIOAsyncWriter {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncWriter {
     /// This is the underlying storage of the writer. The goal of this is to synchronize the access to all state.
     @usableFromInline
@@ -641,7 +641,7 @@ extension NIOAsyncWriter {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOAsyncWriter {
     @usableFromInline
     /* private */ internal struct StateMachine {

--- a/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
@@ -28,7 +28,7 @@ import NIOConcurrencyHelpers
 ///
 /// - Important: This sequence is a unicast sequence that only supports a single ``NIOThrowingAsyncSequenceProducer/AsyncIterator``.
 /// If you try to create more than one iterator it will result in a `fatalError`.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public struct NIOThrowingAsyncSequenceProducer<
     Element: Sendable,
     Failure: Error,
@@ -114,7 +114,7 @@ public struct NIOThrowingAsyncSequenceProducer<
 
         return .init(source: source, sequence: sequence)
     }
-    
+
     /// Initializes a new ``NIOThrowingAsyncSequenceProducer`` and a ``NIOThrowingAsyncSequenceProducer/Source``.
     ///
     /// - Important: This method returns a struct containing a ``NIOThrowingAsyncSequenceProducer/Source`` and
@@ -173,14 +173,14 @@ public struct NIOThrowingAsyncSequenceProducer<
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOThrowingAsyncSequenceProducer: AsyncSequence {
     public func makeAsyncIterator() -> AsyncIterator {
         AsyncIterator(storage: self._internalClass._storage)
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOThrowingAsyncSequenceProducer {
     public struct AsyncIterator: AsyncIteratorProtocol {
         /// This class is needed to hook the deinit to observe once all references to an instance of the ``AsyncIterator`` are dropped.
@@ -221,7 +221,7 @@ extension NIOThrowingAsyncSequenceProducer {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOThrowingAsyncSequenceProducer {
     /// A struct to interface between the synchronous code of the producer and the asynchronous consumer.
     /// This type allows the producer to synchronously `yield` new elements to the ``NIOThrowingAsyncSequenceProducer``
@@ -342,7 +342,7 @@ extension NIOThrowingAsyncSequenceProducer {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOThrowingAsyncSequenceProducer {
     /// This is the underlying storage of the sequence. The goal of this is to synchronize the access to all state.
     @usableFromInline
@@ -573,7 +573,7 @@ extension NIOThrowingAsyncSequenceProducer {
                         } else {
                             continuation.resume(returning: nil)
                         }
-                        
+
                         let delegate = self._delegate
                         self._delegate = nil
 
@@ -590,7 +590,7 @@ extension NIOThrowingAsyncSequenceProducer {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 extension NIOThrowingAsyncSequenceProducer {
     @usableFromInline
     /* private */ internal struct StateMachine {
@@ -966,7 +966,7 @@ extension NIOThrowingAsyncSequenceProducer {
             switch self._state {
             case .initial(_, let iteratorInitialized):
                 // This can happen if the `Task` that calls `next()` is already cancelled.
-                
+
                 // We have deprecated the generic Failure type in the public API and Failure should
                 // now be `Swift.Error`. However, if users have not migrated to the new API they could
                 // still use a custom generic Error type and this cast might fail.
@@ -984,7 +984,7 @@ extension NIOThrowingAsyncSequenceProducer {
                 } else {
                     self._state = .finished(iteratorInitialized: iteratorInitialized)
                 }
-                
+
                 return .none
 
             case .streaming(_, _, .some(let continuation), _, let iteratorInitialized):
@@ -1167,6 +1167,6 @@ extension NIOThrowingAsyncSequenceProducer {
 
 /// The ``NIOThrowingAsyncSequenceProducer/AsyncIterator`` MUST NOT be shared across `Task`s. With marking this as
 /// unavailable we are explicitly declaring this.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 @available(*, unavailable)
 extension NIOThrowingAsyncSequenceProducer.AsyncIterator: Sendable {}

--- a/Sources/NIOCore/TimeAmount+Duration.swift
+++ b/Sources/NIOCore/TimeAmount+Duration.swift
@@ -14,7 +14,7 @@
 
 #if (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
 extension TimeAmount {
-    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, xrOS 1.0, *)
     /// Creates a new `TimeAmount` for the given `Duration`, truncating and clamping if necessary.
     ///
     /// - returns: `TimeAmount`, truncated to nanosecond precision, and clamped to `Int64.max` nanoseconds.
@@ -23,7 +23,7 @@ extension TimeAmount {
     }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, xrOS 1.0, *)
 extension Swift.Duration {
     /// Construct a `Duration` given a number of nanoseconds represented as a `TimeAmount`.
     ///
@@ -33,7 +33,7 @@ extension Swift.Duration {
     }
 }
 
-@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, xrOS 1.0, *)
 internal extension Swift.Duration {
     /// The duration represented as nanoseconds, clamped to maximum expressible value.
     var nanosecondsClamped: Int64 {

--- a/Sources/NIOCore/UniversalBootstrapSupport.swift
+++ b/Sources/NIOCore/UniversalBootstrapSupport.swift
@@ -55,7 +55,7 @@ public protocol NIOClientTCPBootstrapProtocol {
     ///     - handler: A closure that initializes the provided `Channel`.
     func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
     #endif
-    
+
     #if swift(>=5.7)
     /// Sets the protocol handlers that will be added to the front of the `ChannelPipeline` right after the
     /// `channelInitializer` has been called.
@@ -81,7 +81,7 @@ public protocol NIOClientTCPBootstrapProtocol {
     ///     - option: The option to be applied.
     ///     - value: The value for the option.
     func channelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
-    
+
     /// Apply any understood convenience options to the bootstrap, removing them from the set of options if they are consumed.
     /// Method is optional to implement and should never be directly called by users.
     /// - parameters:
@@ -147,7 +147,7 @@ public protocol NIOClientTCPBootstrapProtocol {
 ///         }
 ///
 ///         #if canImport(Network)
-///         if #available(macOS 10.14, iOS 12, tvOS 12, watchOS 3, *) {
+///         if #available(macOS 10.14, iOS 12, tvOS 12, watchOS 3, xrOS 1.0, *) {
 ///             // We run on a new-enough Darwin so we can use Network.framework
 ///
 ///             let group = NIOTSEventLoopGroup()
@@ -198,7 +198,7 @@ public struct NIOClientTCPBootstrap {
         self.underlyingBootstrap = bootstrap
         self.tlsEnablerTypeErased = tlsEnabler
     }
-    
+
     internal init(_ original : NIOClientTCPBootstrap, updating underlying : NIOClientTCPBootstrapProtocol) {
         self.underlyingBootstrap = underlying
         self.tlsEnablerTypeErased = original.tlsEnablerTypeErased

--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -82,7 +82,7 @@ import NIOCore
 /// - note: ``NIOAsyncTestingChannel`` is currently only compatible with
 ///   ``NIOAsyncTestingEventLoop``s and cannot be used with `SelectableEventLoop`s from
 ///   for example `MultiThreadedEventLoopGroup`.
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 public final class NIOAsyncTestingChannel: Channel {
     /// ``LeftOverState`` represents any left-over inbound, outbound, and pending outbound events that hit the
     /// ``NIOAsyncTestingChannel`` and were not consumed when ``finish()`` was called on the ``NIOAsyncTestingChannel``.
@@ -644,8 +644,8 @@ public final class NIOAsyncTestingChannel: Channel {
 // of this object across threads because in the overwhelming majority of cases the data types
 // in a channel pipeline _are_ `Sendable`, and because these objects only carry NIOAnys in cases
 // where the `Channel` itself no longer holds a reference to these objects.
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 extension NIOAsyncTestingChannel.LeftOverState: @unchecked Sendable { }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 extension NIOAsyncTestingChannel.BufferState: @unchecked Sendable { }

--- a/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
+++ b/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
@@ -55,7 +55,7 @@ import NIOConcurrencyHelpers
 /// event loop. Simply calling `.wait()` from the test thread will never complete. This is because
 /// `wait` calls `loop.execute` under the hood, and that callback cannot execute without calling
 /// `loop.run()`.
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 public final class NIOAsyncTestingEventLoop: EventLoop, @unchecked Sendable {
     // This type is `@unchecked Sendable` because of the use of `taskNumber`. This
     // variable is only used from within `queue`, but the compiler cannot see that.

--- a/Sources/NIOPerformanceTester/Benchmark.swift
+++ b/Sources/NIOPerformanceTester/Benchmark.swift
@@ -30,14 +30,14 @@ func measureAndPrint<B: Benchmark>(desc: String, benchmark bench: B) throws {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 protocol AsyncBenchmark: AnyObject, Sendable {
     func setUp() async throws
     func tearDown()
     func run() async throws -> Int
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 func measureAndPrint<B: AsyncBenchmark>(desc: String, benchmark bench: B) throws {
     let group = DispatchGroup()
     group.enter()

--- a/Sources/NIOPerformanceTester/NIOAsyncSequenceProducerBenchmark.swift
+++ b/Sources/NIOPerformanceTester/NIOAsyncSequenceProducerBenchmark.swift
@@ -17,7 +17,7 @@ import DequeModule
 import Atomics
 
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 final class NIOAsyncSequenceProducerBenchmark: AsyncBenchmark, NIOAsyncSequenceProducerDelegate, @unchecked Sendable {
     fileprivate typealias SequenceProducer = NIOThrowingAsyncSequenceProducer<Int, Error, NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark, NIOAsyncSequenceProducerBenchmark>
 

--- a/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
+++ b/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
@@ -28,7 +28,7 @@ fileprivate struct NoOpDelegate: NIOAsyncWriterSinkDelegate, @unchecked Sendable
 }
 
 // This is unchecked Sendable because the Sink is not Sendable but the Sink is thread safe
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 final class NIOAsyncWriterSingleWritesBenchmark: AsyncBenchmark, @unchecked Sendable {
     private let iterations: Int
     private let delegate: NoOpDelegate

--- a/Sources/NIOPerformanceTester/TCPThroughputBenchmark.swift
+++ b/Sources/NIOPerformanceTester/TCPThroughputBenchmark.swift
@@ -20,7 +20,7 @@ import NIOPosix
 /// measure the time from the very first message sent by the server
 /// to the last message received by the client.
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 final class TCPThroughputBenchmark: Benchmark {
 
     private let messages: Int

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -62,7 +62,7 @@ public func measureAndPrint(desc: String, fn: () throws -> Int) rethrows -> Void
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public func measure(_ fn: () async throws -> Int) async rethrows -> [Double] {
     func measureOne(_ fn: () async throws -> Int) async rethrows -> Double {
         let start = DispatchTime.now().uptimeNanoseconds
@@ -80,7 +80,7 @@ public func measure(_ fn: () async throws -> Int) async rethrows -> [Double] {
     return measurements
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
 public func measureAndPrint(desc: String, fn: () async throws -> Int) async rethrows -> Void {
     if limitSet.isEmpty || limitSet.contains(desc) {
         print("measuring\(warning): \(desc): ", terminator: "")
@@ -1083,7 +1083,7 @@ try measureAndPrint(
     )
 )
 
-if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) {
     try measureAndPrint(
         desc: "asyncwriter_single_writes_1M_times",
         benchmark: NIOAsyncWriterSingleWritesBenchmark(
@@ -1139,7 +1139,7 @@ try measureAndPrint(
     )
 )
 
-if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *) {
     try measureAndPrint(
         desc: "tcp_100k_messages_throughput",
         benchmark: TCPThroughputBenchmark(messages: 100_000, messageSize: 500)

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -497,7 +497,7 @@ extension ServerBootstrap {
     ///   - isChildChannelOutboundHalfClosureEnabled: Indicates if half closure is enabled on the child channels. If half closure is enabled
     ///   then finishing the ``NIOAsyncChannelWriter`` will lead to half closure.
     /// - Returns: A ``NIOAsyncChannel`` of connection ``NIOAsyncChannel``s.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<ChildChannelInbound: Sendable, ChildChannelOutbound: Sendable>(
         host: String,
@@ -528,7 +528,7 @@ extension ServerBootstrap {
     ///   - isChildChannelOutboundHalfClosureEnabled: Indicates if half closure is enabled on the child channels. If half closure is enabled
     ///   then finishing the ``NIOAsyncChannelWriter`` will lead to half closure.
     /// - Returns: A ``NIOAsyncChannel`` of connection ``NIOAsyncChannel``s.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<ChildChannelInbound: Sendable, ChildChannelOutbound: Sendable>(
         to address: SocketAddress,
@@ -558,7 +558,7 @@ extension ServerBootstrap {
     ///   - isChildChannelOutboundHalfClosureEnabled: Indicates if half closure is enabled on the child channels. If half closure is enabled
     ///   then finishing the ``NIOAsyncChannelWriter`` will lead to half closure.
     /// - Returns: A ``NIOAsyncChannel`` of connection ``NIOAsyncChannel``s.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<ChildChannelInbound: Sendable, ChildChannelOutbound: Sendable>(
         unixDomainSocketPath: String,
@@ -592,7 +592,7 @@ extension ServerBootstrap {
     ///   - isChildChannelOutboundHalfClosureEnabled: Indicates if half closure is enabled on the child channels. If half closure is enabled
     ///   then finishing the ``NIOAsyncChannelWriter`` will lead to half closure.
     /// - Returns: A ``NIOAsyncChannel`` of connection ``NIOAsyncChannel``s.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func withBoundSocket<ChildChannelInbound: Sendable, ChildChannelOutbound: Sendable>(
         _ socket: NIOBSDSocket.Handle,
@@ -620,7 +620,7 @@ extension ServerBootstrap {
         }
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func bindAsyncChannel0<ChildChannelInbound: Sendable, ChildChannelOutbound: Sendable>(
         serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         childBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
@@ -651,7 +651,7 @@ extension ServerBootstrap {
     private typealias MakeServerChannel = (_ eventLoop: SelectableEventLoop, _ childGroup: EventLoopGroup, _ enableMPTCP: Bool) throws -> ServerSocketChannel
     private typealias Register = @Sendable (EventLoop, ServerSocketChannel) -> EventLoopFuture<Void>
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func bindAsyncChannel0<ChildChannelInbound: Sendable, ChildChannelOutbound: Sendable>(
         makeServerChannel: MakeServerChannel,
         serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
@@ -724,7 +724,7 @@ extension ServerBootstrap {
     ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
     /// - Returns: A ``NIOAsyncChannel`` of  the protocol negotiation results. It is expected that the protocol negotiation handler
     /// is going to wrap the child channels into ``NIOAsyncChannel`` which are returned as part of the negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Handler: NIOProtocolNegotiationHandler>(
         host: String,
@@ -750,7 +750,7 @@ extension ServerBootstrap {
     ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
     /// - Returns: A ``NIOAsyncChannel`` of  the protocol negotiation results. It is expected that the protocol negotiation handler
     /// is going to wrap the child channels into ``NIOAsyncChannel`` which are returned as part of the negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Handler: NIOProtocolNegotiationHandler>(
         to address: SocketAddress,
@@ -775,7 +775,7 @@ extension ServerBootstrap {
     ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
     /// - Returns: A ``NIOAsyncChannel`` of  the protocol negotiation results. It is expected that the protocol negotiation handler
     /// is going to wrap the child channels into ``NIOAsyncChannel`` which are returned as part of the negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Handler: NIOProtocolNegotiationHandler>(
         unixDomainSocketPath: String,
@@ -804,7 +804,7 @@ extension ServerBootstrap {
     ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
     /// - Returns: A ``NIOAsyncChannel`` of  the protocol negotiation results. It is expected that the protocol negotiation handler
     /// is going to wrap the child channels into ``NIOAsyncChannel`` which are returned as part of the negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func withBoundSocket<Handler: NIOProtocolNegotiationHandler>(
         _ socket: NIOBSDSocket.Handle,
@@ -828,7 +828,7 @@ extension ServerBootstrap {
         }
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func bindAsyncChannelWithProtocolNegotiation0<Handler: NIOProtocolNegotiationHandler & ChannelHandler>(
         protocolNegotiationHandlerType: Handler.Type,
         serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
@@ -854,7 +854,7 @@ extension ServerBootstrap {
         }
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func bindAsyncChannelWithProtocolNegotiation0<Handler: NIOProtocolNegotiationHandler & ChannelHandler>(
         makeServerChannel: MakeServerChannel,
         protocolNegotiationHandlerType: Handler.Type,
@@ -1350,7 +1350,7 @@ extension ClientBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         host: String,
@@ -1386,7 +1386,7 @@ extension ClientBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         to address: SocketAddress,
@@ -1420,7 +1420,7 @@ extension ClientBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         unixDomainSocketPath: String,
@@ -1454,7 +1454,7 @@ extension ClientBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         _ socket: NIOBSDSocket.Handle,
@@ -1489,7 +1489,7 @@ extension ClientBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Handler: NIOProtocolNegotiationHandler>(
         host: String,
@@ -1509,7 +1509,7 @@ extension ClientBootstrap {
             }
         )
     }
-    
+
     /// Specify the `address` to connect to for the TCP `Channel` that will be established.
     ///
     /// - Parameters:
@@ -1517,7 +1517,7 @@ extension ClientBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Handler: NIOProtocolNegotiationHandler>(
         to address: SocketAddress,
@@ -1539,7 +1539,7 @@ extension ClientBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Handler: NIOProtocolNegotiationHandler>(
         unixDomainSocketPath: String,
@@ -1559,7 +1559,7 @@ extension ClientBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func withConnectedSocket<Handler: NIOProtocolNegotiationHandler>(
         _ socket: NIOBSDSocket.Handle,
@@ -1578,7 +1578,7 @@ extension ClientBootstrap {
         )
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func initializeAndRegisterNewChannel<Handler: NIOProtocolNegotiationHandler>(
         eventLoop: EventLoop,
         protocolFamily: NIOBSDSocket.ProtocolFamily,
@@ -1598,7 +1598,7 @@ extension ClientBootstrap {
         )
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func initializeAndRegisterChannel<Handler: NIOProtocolNegotiationHandler>(
         channel: SocketChannel,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Handler>,
@@ -1630,7 +1630,7 @@ extension ClientBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         host: String,
@@ -1656,7 +1656,7 @@ extension ClientBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         to address: SocketAddress,
@@ -1681,7 +1681,7 @@ extension ClientBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         unixDomainSocketPath: String,
@@ -1701,7 +1701,7 @@ extension ClientBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func withConnectedSocket<Output: Sendable>(
         _ socket: NIOBSDSocket.Handle,
@@ -1718,7 +1718,7 @@ extension ClientBootstrap {
         )
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     func connect<ChannelInitializerResult, PostRegistrationTransformationResult>(
         host: String,
         port: Int,
@@ -1751,7 +1751,7 @@ extension ClientBootstrap {
         return try await connector.resolveAndConnect().map { $0.1 }.get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func withConnectedSocket<ChannelInitializerResult, PostRegistrationTransformationResult>(
         eventLoop: EventLoop,
         socket: NIOBSDSocket.Handle,
@@ -1772,7 +1772,7 @@ extension ClientBootstrap {
         ).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func initializeAndRegisterNewChannel<ChannelInitializerResult, PostRegistrationTransformationResult>(
         eventLoop: EventLoop,
         protocolFamily: NIOBSDSocket.ProtocolFamily,
@@ -1796,7 +1796,7 @@ extension ClientBootstrap {
         ).map { (channel, $0) }
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func initializeAndRegisterChannel<ChannelInitializerResult, PostRegistrationTransformationResult>(
         channel: SocketChannel,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<ChannelInitializerResult>,
@@ -2134,7 +2134,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func withBoundSocket<Output: Sendable>(
         _ socket: NIOBSDSocket.Handle,
@@ -2165,7 +2165,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         host: String,
@@ -2190,7 +2190,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         to address: SocketAddress,
@@ -2216,7 +2216,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         unixDomainSocketPath: String,
@@ -2246,7 +2246,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         host: String,
@@ -2271,7 +2271,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         to address: SocketAddress,
@@ -2295,7 +2295,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         unixDomainSocketPath: String,
@@ -2312,7 +2312,7 @@ extension DatagramBootstrap {
         )
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func connect0<ChannelInitializerResult, PostRegistrationTransformationResult>(
         makeSocketAddress: () throws -> SocketAddress,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<ChannelInitializerResult>,
@@ -2340,7 +2340,7 @@ extension DatagramBootstrap {
         ).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func bind0<ChannelInitializerResult, PostRegistrationTransformationResult>(
         makeSocketAddress: () throws -> SocketAddress,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<ChannelInitializerResult>,
@@ -2368,7 +2368,7 @@ extension DatagramBootstrap {
         ).get()
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     private func makeConfiguredChannel<ChannelInitializerResult, PostRegistrationTransformationResult>(
         makeChannel: (_ eventLoop: SelectableEventLoop) throws -> DatagramChannel,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<ChannelInitializerResult>,
@@ -2430,7 +2430,7 @@ extension DatagramBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the bound connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func withBoundSocket<Inbound: Sendable, Outbound: Sendable>(
         _ socket: NIOBSDSocket.Handle,
@@ -2477,7 +2477,7 @@ extension DatagramBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the bound connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Inbound: Sendable, Outbound: Sendable>(
         host: String,
@@ -2514,7 +2514,7 @@ extension DatagramBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the bound connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Inbound: Sendable, Outbound: Sendable>(
         to address: SocketAddress,
@@ -2551,7 +2551,7 @@ extension DatagramBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the bound connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Inbound: Sendable, Outbound: Sendable>(
         unixDomainSocketPath: String,
@@ -2589,7 +2589,7 @@ extension DatagramBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         host: String,
@@ -2625,7 +2625,7 @@ extension DatagramBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         to address: SocketAddress,
@@ -2659,7 +2659,7 @@ extension DatagramBootstrap {
     ///   - inboundType: The channel's inbound type.
     ///   - outboundType: The channel's outbound type.
     /// - Returns: A `NIOAsyncChannel` for the established connection.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Inbound: Sendable, Outbound: Sendable>(
         unixDomainSocketPath: String,
@@ -2694,7 +2694,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func withBoundSocket<Handler: NIOProtocolNegotiationHandler>(
         _ socket: NIOBSDSocket.Handle,
@@ -2727,7 +2727,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Handler: NIOProtocolNegotiationHandler>(
         host: String,
@@ -2754,7 +2754,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Handler: NIOProtocolNegotiationHandler>(
         to address: SocketAddress,
@@ -2782,7 +2782,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func bind<Handler: NIOProtocolNegotiationHandler>(
         unixDomainSocketPath: String,
@@ -2814,7 +2814,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Handler: NIOProtocolNegotiationHandler>(
         host: String,
@@ -2841,7 +2841,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Handler: NIOProtocolNegotiationHandler>(
         to address: SocketAddress,
@@ -2867,7 +2867,7 @@ extension DatagramBootstrap {
     ///   - channelInitializer: A closure to initialize the channel which must return the handler that is used for negotiating
     ///   the protocol.
     /// - Returns: The protocol negotiation result.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @_spi(AsyncChannel)
     public func connect<Handler: NIOProtocolNegotiationHandler>(
         unixDomainSocketPath: String,
@@ -3109,7 +3109,7 @@ extension NIOProtocolNegotiationResult {
         switch result {
         case .finished(let negotiationResult):
             return eventLoop.makeSucceededFuture(negotiationResult)
-            
+
         case .deferredResult(let future):
             return future.flatMap { result in
                 return resolve(on: eventLoop, result: result)

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -18,7 +18,7 @@ import NIOConcurrencyHelpers
 
 /// Errors that may be thrown when executing work on a `NIOThreadPool`
 public enum NIOThreadPoolError {
-    
+
     /// The `NIOThreadPool` was not active.
     public struct ThreadPoolInactive: Error { }
 }
@@ -48,7 +48,7 @@ public final class NIOThreadPool {
         /// The `WorkItem` was cancelled and will not be processed by the `NIOThreadPool`.
         case cancelled
     }
-    
+
     #if swift(>=5.7)
     /// The work that should be done by the `NIOThreadPool`.
     public typealias WorkItem = @Sendable (WorkItemState) -> Void
@@ -90,7 +90,7 @@ public final class NIOThreadPool {
         self._shutdownGracefully(queue: queue, callback)
     }
     #endif
-    
+
     private func _shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {
         let g = DispatchGroup()
         let threadsToJoin = self.lock.withLock { () -> [NIOThread] in
@@ -121,8 +121,8 @@ public final class NIOThreadPool {
             callback(nil)
         }
     }
-    
-    
+
+
 
     #if swift(>=5.7)
     /// Submit a `WorkItem` to process.
@@ -162,7 +162,7 @@ public final class NIOThreadPool {
         /* if item couldn't be added run it immediately indicating that it couldn't be run */
         item.map { $0(.cancelled) }
     }
-    
+
     /// Initialize a `NIOThreadPool` thread pool with `numberOfThreads` threads.
     ///
     /// - parameters:
@@ -255,7 +255,7 @@ public final class NIOThreadPool {
 extension NIOThreadPool: @unchecked Sendable {}
 
 extension NIOThreadPool {
-    
+
     #if swift(>=5.7)
     /// Runs the submitted closure if the thread pool is still active, otherwise fails the promise.
     /// The closure will be run on the thread pool so can do blocking work.
@@ -280,7 +280,7 @@ extension NIOThreadPool {
         self._runIfActive(eventLoop: eventLoop, body)
     }
     #endif
-    
+
     private func _runIfActive<T>(eventLoop: EventLoop, _ body: @escaping () throws -> T) -> EventLoopFuture<T> {
         let promise = eventLoop.makePromise(of: T.self)
         self.submit { shouldRun in
@@ -311,7 +311,7 @@ extension NIOThreadPool {
     #endif
 
     /// Shuts down the thread pool gracefully.
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, xrOS 1.0, *)
     @inlinable
     public func shutdownGracefully() async throws {
         return try await withCheckedThrowingContinuation { cont in

--- a/Sources/NIOWebSocket/Base64.swift
+++ b/Sources/NIOWebSocket/Base64.swift
@@ -154,7 +154,7 @@ extension String {
   @inlinable
   init(customUnsafeUninitializedCapacity capacity: Int,
      initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int) rethrows {
-    if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
+    if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, xrOS 1.0, *) {
         try self.init(unsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
     } else {
         try self.init(backportUnsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 final class AsyncChannelTests: XCTestCase {
     func testAsyncChannelBasicFunctionality() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let wrapped = try await channel.testingEventLoop.executeInContext {
@@ -47,7 +47,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testAsyncChannelBasicWrites() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let wrapped = try await channel.testingEventLoop.executeInContext {
@@ -68,7 +68,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testDroppingTheWriterClosesTheWriteSideOfTheChannel() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let closeRecorder = CloseRecorder()
@@ -103,7 +103,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testDroppingTheWriterDoesntCloseTheWriteSideOfTheChannelIfHalfClosureIsDisabled() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let closeRecorder = CloseRecorder()
@@ -133,7 +133,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testDroppingTheWriterFirstLeadsToChannelClosureWhenReaderIsAlsoDropped() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let closeRecorder = CloseRecorder()
@@ -178,7 +178,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testDroppingEverythingClosesTheChannel() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let closeRecorder = CloseRecorder()
@@ -208,7 +208,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testReadsArePropagated() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let wrapped = try await channel.testingEventLoop.executeInContext {
@@ -227,7 +227,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testErrorsArePropagatedButAfterReads() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let wrapped = try await channel.testingEventLoop.executeInContext {
@@ -250,7 +250,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testChannelBecomingNonWritableDelaysWriters() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let wrapped = try await channel.testingEventLoop.executeInContext {
@@ -289,7 +289,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testBufferDropsReadsIfTheReaderIsGone() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             try await channel.pipeline.addHandler(CloseSuppressor()).get()
@@ -316,7 +316,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testManagingBackpressure() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let readCounter = ReadCounter()
@@ -424,7 +424,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testCanWrapAChannelSynchronously() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let channel = NIOAsyncTestingChannel()
             let wrapped = try await channel.testingEventLoop.executeInContext {

--- a/Tests/NIOCoreTests/AsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequenceTests.swift
@@ -27,7 +27,7 @@ fileprivate struct TestCase {
 
 final class AsyncSequenceCollectTests: XCTestCase {
     func testAsyncSequenceCollect() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let testCases = [
                 TestCase([
@@ -95,9 +95,9 @@ final class AsyncSequenceCollectTests: XCTestCase {
             ]
             for testCase in testCases {
                 let expectedBytes = testCase.buffers.flatMap({ $0 })
-                
+
                 // happy case where maxBytes is exactly the same as number of buffers received
-                
+
                 // test for the generic version
                 let accumulatedBytes1 = try await testCase.buffers
                     .asAsyncSequence()
@@ -108,7 +108,7 @@ final class AsyncSequenceCollectTests: XCTestCase {
                     file: testCase.file,
                     line: testCase.line
                 )
-                
+
                 // test for the `ByteBuffer` optimised version
                 let accumulatedBytes2 = try await testCase.buffers
                     .map(ByteBuffer.init(bytes:))
@@ -125,7 +125,7 @@ final class AsyncSequenceCollectTests: XCTestCase {
                 guard expectedBytes.count >= 1 else {
                     continue
                 }
-                
+
                 // test for the generic version
                 await XCTAssertThrowsError(
                     try await testCase.buffers
@@ -140,7 +140,7 @@ final class AsyncSequenceCollectTests: XCTestCase {
                         line: testCase.line
                     )
                 }
-                
+
                 // test for the `ByteBuffer` optimised version
                 await XCTAssertThrowsError(
                     try await testCase.buffers
@@ -161,7 +161,7 @@ final class AsyncSequenceCollectTests: XCTestCase {
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 struct AsyncSequenceFromSyncSequence<Wrapped: Sequence>: AsyncSequence {
     typealias Element = Wrapped.Element
     struct AsyncIterator: AsyncIteratorProtocol {
@@ -178,7 +178,7 @@ struct AsyncSequenceFromSyncSequence<Wrapped: Sequence>: AsyncSequence {
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 extension Sequence {
     /// Turns `self` into an `AsyncSequence` by wending each element of `self` asynchronously.
     func asAsyncSequence() -> AsyncSequenceFromSyncSequence<Self> {

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceProducer+HighLowWatermarkBackPressureStrategyTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceProducer+HighLowWatermarkBackPressureStrategyTests.swift
@@ -15,7 +15,7 @@
 import NIOCore
 import XCTest
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 final class NIOAsyncSequenceProducerBackPressureStrategiesHighLowWatermarkTests: XCTestCase {
     private var strategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark!
 

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
@@ -79,7 +79,7 @@ final class MockNIOBackPressuredStreamSourceDelegate: NIOAsyncSequenceProducerDe
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 final class NIOAsyncSequenceProducerTests: XCTestCase {
     private var backPressureStrategy: MockNIOElementStreamBackPressureStrategy!
     private var delegate: MockNIOBackPressuredStreamSourceDelegate!

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
@@ -40,7 +40,7 @@ private final class MockAsyncWriterDelegate: NIOAsyncWriterSinkDelegate, @unchec
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 final class NIOAsyncWriterTests: XCTestCase {
     private var writer: NIOAsyncWriter<String, MockAsyncWriterDelegate>!
     private var sink: NIOAsyncWriter<String, MockAsyncWriterDelegate>.Sink!

--- a/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
@@ -15,7 +15,7 @@
 import NIOCore
 import XCTest
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
     private var backPressureStrategy: MockNIOElementStreamBackPressureStrategy!
     private var delegate: MockNIOBackPressuredStreamSourceDelegate!
@@ -463,7 +463,7 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
             XCTAssertTrue(error is CancellationError)
         }
     }
-    
+
     @available(*, deprecated, message: "tests the deprecated custom generic failure type")
     func testTaskCancel_whenStreaming_andSuspended_withCustomErrorType() async throws {
         struct CustomError: Error {}
@@ -487,7 +487,7 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
         task.cancel()
         let result = await task.result
         XCTAssertEqualWithoutAutoclosure(await delegate.events.prefix(1).collect(), [.didTerminate])
-        
+
         try withExtendedLifetime(new.source) {
             XCTAssertNil(try result.get())
         }
@@ -500,7 +500,7 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
         let task: Task<Int?, Error> = Task {
             let iterator = sequence.makeAsyncIterator()
             let element = try await iterator.next()
-            
+
             // Sleeping here to give the other Task a chance to cancel this one.
             try? await Task.sleep(nanoseconds: 1_000_000)
             return element
@@ -550,7 +550,7 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
             XCTAssertTrue(error is CancellationError, "unexpected error \(error)")
         }
     }
-    
+
     @available(*, deprecated, message: "tests the deprecated custom generic failure type")
     func testTaskCancel_whenStreaming_andTaskIsAlreadyCancelled_withCustomErrorType() async throws {
         struct CustomError: Error {}
@@ -572,7 +572,7 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
         }
 
         task.cancel()
-        
+
         let result = await task.result
         try withExtendedLifetime(new.source) {
             XCTAssertNil(try result.get())

--- a/Tests/NIOCoreTests/TimeAmount+DurationTests.swift
+++ b/Tests/NIOCoreTests/TimeAmount+DurationTests.swift
@@ -17,7 +17,7 @@ import XCTest
 class TimeAmountDurationTests: XCTestCase {
     func testTimeAmountFromDurationConversion() throws {
 #if (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
-        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) else {
+        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, xrOS 1.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
         XCTAssertEqual(
@@ -73,7 +73,7 @@ class TimeAmountDurationTests: XCTestCase {
 
     func testTimeAmountToDurationLosslessRountTrip() throws {
 #if (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
-        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) else {
+        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, xrOS 1.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
         for amount in [
@@ -92,7 +92,7 @@ class TimeAmountDurationTests: XCTestCase {
 
     func testDurationToTimeAmountLossyRoundTrip() throws {
 #if (os(macOS) && swift(>=5.7.1)) || (!os(macOS) && swift(>=5.7))
-        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) else {
+        guard #available(macOS 13, iOS 16, tvOS 16, watchOS 9, xrOS 1.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
         for duration in [

--- a/Tests/NIOCoreTests/XCTest+AsyncAwait.swift
+++ b/Tests/NIOCoreTests/XCTest+AsyncAwait.swift
@@ -43,7 +43,7 @@
 import XCTest
 
 extension XCTestCase {
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
     /// Cross-platform XCTest support for async-await tests.
     ///
     /// Currently the Linux implementation of XCTest doesn't have async-await support.
@@ -74,7 +74,7 @@ extension XCTestCase {
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAssertThrowsError<T>(
     _ expression: @autoclosure () async throws -> T,
     file: StaticString = #filePath,
@@ -89,7 +89,7 @@ internal func XCTAssertThrowsError<T>(
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAssertNoThrow<T>(
     _ expression: @autoclosure () async throws -> T,
     file: StaticString = #file,
@@ -102,7 +102,7 @@ internal func XCTAssertNoThrow<T>(
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAssertNoThrowWithResult<Result>(
     _ expression: @autoclosure () async throws -> Result,
     file: StaticString = #filePath,
@@ -116,7 +116,7 @@ internal func XCTAssertNoThrowWithResult<Result>(
     return nil
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAsyncAssertNotNil(
     _ expression: @autoclosure () async throws -> Any?,
     file: StaticString = #filePath,
@@ -126,7 +126,7 @@ internal func XCTAsyncAssertNotNil(
     XCTAssertNotNil(result, file: file, line: line)
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAsyncAssertNil(
     _ expression: @autoclosure () async throws -> Any?,
     file: StaticString = #filePath,

--- a/Tests/NIOCoreTests/XCTest+Extensions.swift
+++ b/Tests/NIOCoreTests/XCTest+Extensions.swift
@@ -67,7 +67,7 @@ fileprivate var temporaryDirectory: String {
 #if os(Linux)
         return "/tmp"
 #else
-        if #available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *) {
+        if #available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, xrOS 1.0, *) {
             return FileManager.default.temporaryDirectory.path
         } else {
             return "/tmp"

--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -19,7 +19,7 @@ import NIOCore
 
 class AsyncTestingChannelTests: XCTestCase {
     func testSingleHandlerInit() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             class Handler: ChannelInboundHandler {
                 typealias InboundIn = Never
@@ -31,7 +31,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testEmptyInit() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
 
         class Handler: ChannelInboundHandler {
             typealias InboundIn = Never
@@ -45,7 +45,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testMultipleHandlerInit() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             class Handler: ChannelInboundHandler, RemovableChannelHandler {
                 typealias InboundIn = Never
@@ -71,7 +71,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWaitForInboundWrite() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             let task = Task {
@@ -88,7 +88,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWaitForMultipleInboundWritesInParallel() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             let task = Task {
@@ -110,7 +110,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWaitForOutboundWrite() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             let task = Task {
@@ -127,7 +127,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWaitForMultipleOutboundWritesInParallel() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             let task = Task {
@@ -149,7 +149,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteOutboundByteBuffer() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             var buf = channel.allocator.buffer(capacity: 1024)
@@ -172,7 +172,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteOutboundByteBufferMultipleTimes() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             var buf = channel.allocator.buffer(capacity: 1024)
@@ -195,7 +195,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteInboundByteBuffer() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             var buf = channel.allocator.buffer(capacity: 1024)
@@ -210,7 +210,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteInboundByteBufferMultipleTimes() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             var buf = channel.allocator.buffer(capacity: 1024)
@@ -233,7 +233,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteInboundByteBufferReThrow() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             XCTAssertNoThrow(try channel.pipeline.addHandler(ExceptionThrowingInboundHandler()).wait())
@@ -245,7 +245,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteOutboundByteBufferReThrow() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             XCTAssertNoThrow(try channel.pipeline.addHandler(ExceptionThrowingOutboundHandler()).wait())
@@ -257,7 +257,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testReadOutboundWrongTypeThrows() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             try await XCTAsyncAssertTrue(await channel.writeOutbound("hello").isFull)
@@ -274,7 +274,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testReadInboundWrongTypeThrows() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             try await XCTAsyncAssertTrue(await channel.writeInbound("hello").isFull)
@@ -291,7 +291,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWrongTypesWithFastpathTypes() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
 
@@ -342,7 +342,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testCloseMultipleTimesThrows() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             try await XCTAsyncAssertTrue(await channel.finish().isClean)
@@ -358,7 +358,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testCloseOnInactiveIsOk() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             let inactiveHandler = CloseInChannelInactiveHandler()
@@ -371,7 +371,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testEmbeddedLifecycle() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let handler = ChannelLifecycleHandler()
             XCTAssertEqual(handler.currentState, .unregistered)
@@ -419,7 +419,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testEmbeddedChannelAndPipelineAndChannelCoreShareTheEventLoop() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             let pipelineEventLoop = channel.pipeline.eventLoop
@@ -430,7 +430,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSendingAnythingOnEmbeddedChannel() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             let buffer = ByteBufferAllocator().buffer(capacity: 5)
@@ -451,7 +451,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             XCTAssertFalse(channel.isActive)
@@ -473,7 +473,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteWithoutFlushDoesNotWrite() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
 
@@ -489,7 +489,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSetLocalAddressAfterSuccessfulBind() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
 
         let channel = NIOAsyncTestingChannel()
         let bindPromise = channel.eventLoop.makePromise(of: Void.self)
@@ -503,7 +503,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSetRemoteAddressAfterSuccessfulConnect() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
 
         let channel = NIOAsyncTestingChannel()
         let connectPromise = channel.eventLoop.makePromise(of: Void.self)
@@ -517,7 +517,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testUnprocessedOutboundUserEventFailsOnEmbeddedChannel() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
 
         let channel = NIOAsyncTestingChannel()
         XCTAssertThrowsError(try channel.triggerUserOutboundEvent("event").wait()) { (error: Error) in
@@ -531,7 +531,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testEmbeddedChannelWritabilityIsWritable() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
 
         let channel = NIOAsyncTestingChannel()
         let opaqueChannel: Channel = channel
@@ -544,7 +544,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testFinishWithRecursivelyScheduledTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             let invocations = AtomicCounter()
@@ -564,7 +564,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSyncOptionsAreSupported() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         try channel.testingEventLoop.submit {
             let options = channel.syncOptions
@@ -576,7 +576,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testGetChannelOptionAutoReadIsSupported() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         try channel.testingEventLoop.submit {
             let options = channel.syncOptions
@@ -587,7 +587,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSetGetChannelOptionAllowRemoteHalfClosureIsSupported() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         try channel.testingEventLoop.submit {
             let options = channel.syncOptions
@@ -605,7 +605,7 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSecondFinishThrows() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let channel = NIOAsyncTestingChannel()
             _ = try await channel.finish()
@@ -614,20 +614,20 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 fileprivate func XCTAsyncAssertTrue(_ predicate: @autoclosure () async throws -> Bool, file: StaticString = #filePath, line: UInt = #line) async rethrows {
     let result = try await predicate()
     XCTAssertTrue(result, file: file, line: line)
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 fileprivate func XCTAsyncAssertEqual<Element: Equatable>(_ lhs: @autoclosure () async throws -> Element, _ rhs: @autoclosure () async throws -> Element, file: StaticString = #filePath, line: UInt = #line) async rethrows {
     let lhsResult = try await lhs()
     let rhsResult = try await rhs()
     XCTAssertEqual(lhsResult, rhsResult, file: file, line: line)
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 fileprivate func XCTAsyncAssertThrowsError<ResultType>(_ expression: @autoclosure () async throws -> ResultType, file: StaticString = #filePath, line: UInt = #line, _ callback: Optional<(Error) -> Void> = nil) async {
     do {
         let _ = try await expression()
@@ -637,13 +637,13 @@ fileprivate func XCTAsyncAssertThrowsError<ResultType>(_ expression: @autoclosur
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 fileprivate func XCTAsyncAssertNil(_ expression: @autoclosure () async throws -> Any?, file: StaticString = #filePath, line: UInt = #line) async rethrows {
     let result = try await expression()
     XCTAssertNil(result, file: file, line: line)
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 fileprivate func XCTAsyncAssertNotNil(_ expression: @autoclosure () async throws -> Any?, file: StaticString = #filePath, line: UInt = #line) async rethrows {
     let result = try await expression()
     XCTAssertNotNil(result, file: file, line: line)

--- a/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
@@ -21,7 +21,7 @@ private class EmbeddedTestError: Error { }
 
 final class NIOAsyncTestingEventLoopTests: XCTestCase {
     func testExecuteDoesNotImmediatelyRunTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let callbackRan = ManagedAtomic(false)
             let loop = NIOAsyncTestingEventLoop()
@@ -35,7 +35,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecuteWillRunAllTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let runCount = ManagedAtomic(0)
             let loop = NIOAsyncTestingEventLoop()
@@ -54,7 +54,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecuteWillRunTasksAddedRecursively() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let sentinel = ManagedAtomic(0)
             let loop = NIOAsyncTestingEventLoop()
@@ -86,7 +86,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecuteRunsImmediately() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let callbackRan = ManagedAtomic(false)
             let loop = NIOAsyncTestingEventLoop()
@@ -107,7 +107,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testTasksScheduledAfterRunDontRun() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let callbackRan = ManagedAtomic(false)
             let loop = NIOAsyncTestingEventLoop()
@@ -130,7 +130,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testSubmitRunsImmediately() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let callbackRan = ManagedAtomic(false)
             let loop = NIOAsyncTestingEventLoop()
@@ -151,7 +151,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testSyncShutdownGracefullyRunsTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let callbackRan = ManagedAtomic(false)
             let loop = NIOAsyncTestingEventLoop()
@@ -168,7 +168,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testShutdownGracefullyRunsTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let callbackRan = ManagedAtomic(false)
             let loop = NIOAsyncTestingEventLoop()
@@ -185,7 +185,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testCanControlTime() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let callbackCount = ManagedAtomic(0)
             let loop = NIOAsyncTestingEventLoop()
@@ -216,7 +216,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testCanScheduleMultipleTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let sentinel = ManagedAtomic(0)
             let loop = NIOAsyncTestingEventLoop()
@@ -239,7 +239,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecutedTasksFromScheduledOnesAreRun() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let sentinel = ManagedAtomic(0)
             let loop = NIOAsyncTestingEventLoop()
@@ -262,7 +262,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksFromScheduledTasksProperlySchedule() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let sentinel = ManagedAtomic(0)
             let loop = NIOAsyncTestingEventLoop()
@@ -304,7 +304,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksFromExecutedTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let sentinel = ManagedAtomic(0)
             let loop = NIOAsyncTestingEventLoop()
@@ -325,7 +325,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testCancellingScheduledTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let loop = NIOAsyncTestingEventLoop()
             let task = loop.scheduleTask(in: .nanoseconds(10), { XCTFail("Cancelled task ran") })
@@ -338,7 +338,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksFuturesFire() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let fired = ManagedAtomic(false)
             let loop = NIOAsyncTestingEventLoop()
@@ -353,7 +353,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksFuturesError() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let err = EmbeddedTestError()
             let fired = ManagedAtomic(false)
@@ -377,7 +377,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testTaskOrdering() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             // This test validates that the ordering of task firing on NIOAsyncTestingEventLoop via
             // advanceTime(by:) is the same as on MultiThreadedEventLoopGroup: specifically, that tasks run via
@@ -460,7 +460,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testCancelledScheduledTasksDoNotHoldOnToRunClosure() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let eventLoop = NIOAsyncTestingEventLoop()
             defer {
@@ -502,7 +502,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testDrainScheduledTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let eventLoop = NIOAsyncTestingEventLoop()
             let tasksRun = ManagedAtomic(0)
@@ -524,7 +524,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testDrainScheduledTasksDoesNotRunNewlyScheduledTasks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let eventLoop = NIOAsyncTestingEventLoop()
             let tasksRun = ManagedAtomic(0)
@@ -543,7 +543,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testAdvanceTimeToDeadline() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let eventLoop = NIOAsyncTestingEventLoop()
             let deadline = NIODeadline.uptimeNanoseconds(0) + .seconds(42)
@@ -559,7 +559,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testWeCantTimeTravelByAdvancingTimeToThePast() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let eventLoop = NIOAsyncTestingEventLoop()
 
@@ -583,7 +583,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecuteInOrder() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let eventLoop = NIOAsyncTestingEventLoop()
             let counter = ManagedAtomic(0)
@@ -609,7 +609,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksInOrder() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let eventLoop = NIOAsyncTestingEventLoop()
             let counter = ManagedAtomic(0)

--- a/Tests/NIOEmbeddedTests/XCTest+AsyncAwait.swift
+++ b/Tests/NIOEmbeddedTests/XCTest+AsyncAwait.swift
@@ -43,7 +43,7 @@
 import XCTest
 
 extension XCTestCase {
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
     /// Cross-platform XCTest support for async-await tests.
     ///
     /// Currently the Linux implementation of XCTest doesn't have async-await support.
@@ -74,7 +74,7 @@ extension XCTestCase {
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAssertThrowsError<T>(
     _ expression: @autoclosure () async throws -> T,
     file: StaticString = #filePath,
@@ -89,7 +89,7 @@ internal func XCTAssertThrowsError<T>(
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAssertNoThrowWithResult<Result>(
     _ expression: @autoclosure () async throws -> Result,
     file: StaticString = #filePath,

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -821,14 +821,14 @@ extension AsyncStream {
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 private func XCTAsyncAssertEqual<Element: Equatable>(_ lhs: @autoclosure () async throws -> Element, _ rhs: @autoclosure () async throws -> Element, file: StaticString = #filePath, line: UInt = #line) async rethrows {
     let lhsResult = try await lhs()
     let rhsResult = try await rhs()
     XCTAssertEqual(lhsResult, rhsResult, file: file, line: line)
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 private func XCTAsyncAssertThrowsError<T>(
     _ expression: @autoclosure () async throws -> T,
     _ message: @autoclosure () -> String = "",

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -1564,7 +1564,7 @@ public final class EventLoopTest : XCTestCase {
     }
 
     func testMultiThreadedEventLoopGroupSupportsStickyAnyImplementation() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 3)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
@@ -1579,7 +1579,7 @@ public final class EventLoopTest : XCTestCase {
     }
 
     func testAsyncToFutureConversionSuccess() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
@@ -1593,7 +1593,7 @@ public final class EventLoopTest : XCTestCase {
     }
 
     func testAsyncToFutureConversionFailure() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { return }
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())

--- a/Tests/NIOPosixTests/NIOThreadPoolTest.swift
+++ b/Tests/NIOPosixTests/NIOThreadPoolTest.swift
@@ -111,7 +111,7 @@ class NIOThreadPoolTest: XCTestCase {
     }
 
     func testAsyncShutdownWorks() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *) else { throw XCTSkip() }
         XCTAsyncTest {
             let threadPool = NIOThreadPool(numberOfThreads: 17)
             let eventLoop = NIOAsyncTestingEventLoop()

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -131,7 +131,7 @@ var temporaryDirectory: String {
 #if os(Linux)
         return "/tmp"
 #else
-        if #available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *) {
+        if #available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, xrOS 1.0, *) {
             return FileManager.default.temporaryDirectory.path
         } else {
             return "/tmp"

--- a/Tests/NIOPosixTests/XCTest+AsyncAwait.swift
+++ b/Tests/NIOPosixTests/XCTest+AsyncAwait.swift
@@ -43,7 +43,7 @@
 import XCTest
 
 extension XCTestCase {
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
     /// Cross-platform XCTest support for async-await tests.
     ///
     /// Currently the Linux implementation of XCTest doesn't have async-await support.
@@ -74,7 +74,7 @@ extension XCTestCase {
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAssertThrowsError<T>(
     _ expression: @autoclosure () async throws -> T,
     file: StaticString = #filePath,
@@ -89,7 +89,7 @@ internal func XCTAssertThrowsError<T>(
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAssertNoThrow<T>(
     _ expression: @autoclosure () async throws -> T,
     file: StaticString = #file,
@@ -102,7 +102,7 @@ internal func XCTAssertNoThrow<T>(
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, xrOS 1.0, *)
 internal func XCTAssertNoThrowWithResult<Result>(
     _ expression: @autoclosure () async throws -> Result,
     file: StaticString = #filePath,


### PR DESCRIPTION
This the release of visionOS Beta SDK, I made this contribution so we can start to use the SwiftNIO with full compatibility in xrOS.

### Motivation:

Some parts of the SwiftNIO codebase has conditional compilation or platform version verification. What I did here was to add the `xrOS 1.0` so the Swift compiler targeting to visionOS SDK can use the right code and not falloff to the `else` statements.

### Modifications:

From this `available(macOS x.x, iOS x.x, tvOS x.x, watchOS x.x, *)` to this `available(macOS x.x, iOS x.x, tvOS x.x, watchOS x.x, xrOS 1, *)`

### Result:

The Swift 5.9 compiles successfully and the compiled code runs great on visionOS.
