### PR TITLE
Add support for Musl libc

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -17,8 +17,10 @@ import Darwin
 #elseif os(Windows)
 import ucrt
 import WinSDK
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 #if os(Windows)

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -26,7 +26,12 @@ fileprivate func sys_sched_yield() {
   Sleep(0)
 }
 #else
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
 fileprivate func sys_sched_yield() {
     _ = sched_yield()
 }

--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -17,8 +17,10 @@ import Darwin
 #elseif os(Windows)
 import ucrt
 import WinSDK
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 /// A threading lock based on `libpthread` instead of `libdispatch`.

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -61,7 +61,11 @@ import func WinSDK.WSAGetLastError
 
 internal typealias socklen_t = ucrt.size_t
 #elseif os(Linux) || os(Android)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 import CNIOLinux
 
 private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -16,8 +16,10 @@
 import ucrt
 #elseif canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 @usableFromInline let sysMalloc: @convention(c) (size_t) -> UnsafeMutableRawPointer? = malloc

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -15,8 +15,10 @@
 import ucrt
 #elseif canImport(Darwin)
 import Darwin
-#elseif os(Linux) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 #if os(Windows)

--- a/Sources/NIOCore/FileRegion.swift
+++ b/Sources/NIOCore/FileRegion.swift
@@ -15,8 +15,10 @@
 import ucrt
 #elseif canImport(Darwin)
 import Darwin
-#elseif os(Linux) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 

--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 #if os(Linux) || os(FreeBSD) || os(Android)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 import CNIOLinux
 #elseif canImport(Darwin)
 import Darwin

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -44,7 +44,11 @@ fileprivate typealias sa_family_t = WinSDK.ADDRESS_FAMILY
 #elseif canImport(Darwin)
 import Darwin
 #elseif os(Linux) || os(FreeBSD) || os(Android)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 import CNIOLinux
 #endif
 

--- a/Sources/NIOCore/SocketOptionProvider.swift
+++ b/Sources/NIOCore/SocketOptionProvider.swift
@@ -14,7 +14,11 @@
 #if canImport(Darwin)
 import Darwin
 #elseif os(Linux) || os(Android)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 import CNIOLinux
 #elseif os(Windows)
 import WinSDK

--- a/Sources/NIOCore/SystemCallHelpers.swift
+++ b/Sources/NIOCore/SystemCallHelpers.swift
@@ -22,7 +22,11 @@
 #if canImport(Darwin)
 import Darwin.C
 #elseif os(Linux) || os(FreeBSD) || os(Android)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 #elseif os(Windows)
 import CNIOWindows
 #else

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 #if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 #elseif os(Windows)
 import let WinSDK.RelationProcessorCore
 

--- a/Sources/NIOPosix/BSDSocketAPICommon.swift
+++ b/Sources/NIOPosix/BSDSocketAPICommon.swift
@@ -66,7 +66,7 @@ extension NIOBSDSocket.SocketType: Hashable {
 extension NIOBSDSocket.SocketType {
     /// Supports datagrams, which are connectionless, unreliable messages of a
     /// fixed (typically small) maximum length.
-    #if os(Linux)
+    #if canImport(Glibc)
         internal static let datagram: NIOBSDSocket.SocketType =
                 NIOBSDSocket.SocketType(rawValue: CInt(SOCK_DGRAM.rawValue))
     #else
@@ -76,7 +76,7 @@ extension NIOBSDSocket.SocketType {
 
     /// Supports reliable, two-way, connection-based byte streams without
     /// duplication of data and without preservation of boundaries.
-    #if os(Linux)
+    #if canImport(Glibc)
         internal static let stream: NIOBSDSocket.SocketType =
                 NIOBSDSocket.SocketType(rawValue: CInt(SOCK_STREAM.rawValue))
     #else

--- a/Sources/NIOPosix/DatagramVectorReadManager.swift
+++ b/Sources/NIOPosix/DatagramVectorReadManager.swift
@@ -112,7 +112,7 @@ struct DatagramVectorReadManager {
                 }
 
                 // Next we set up the msghdr structure. This points into the other vectors.
-                let msgHdr = msghdr()
+                var msgHdr = msghdr()
                 msgHdr.msg_name = self.sockaddrVector.baseAddress! + i
                 msgHdr.msg_namelen = socklen_t(MemoryLayout<sockaddr_storage>.size)
                 msgHdr.msg_iov = self.ioVector.baseAddress! + i

--- a/Sources/NIOPosix/DatagramVectorReadManager.swift
+++ b/Sources/NIOPosix/DatagramVectorReadManager.swift
@@ -113,7 +113,7 @@ struct DatagramVectorReadManager {
 
                 // Next we set up the msghdr structure. This points into the other vectors.
                 var msgHdr = msghdr()
-                msgHdr.msg_name = self.sockaddrVector.baseAddress! + i
+                msgHdr.msg_name = .init(self.sockaddrVector.baseAddress! + i)
                 msgHdr.msg_namelen = socklen_t(MemoryLayout<sockaddr_storage>.size)
                 msgHdr.msg_iov = self.ioVector.baseAddress! + i
                 msgHdr.msg_iovlen = 1  // This is weird, but each message gets only one array. Duh

--- a/Sources/NIOPosix/DatagramVectorReadManager.swift
+++ b/Sources/NIOPosix/DatagramVectorReadManager.swift
@@ -113,13 +113,13 @@ struct DatagramVectorReadManager {
 
                 // Next we set up the msghdr structure. This points into the other vectors.
                 let msgHdr = msghdr()
-                msg_name = self.sockaddrVector.baseAddress! + i
-                msg_namelen = socklen_t(MemoryLayout<sockaddr_storage>.size)
-                msg_iov = self.ioVector.baseAddress! + i
-                msg_iovlen = 1  // This is weird, but each message gets only one array. Duh
-                msg_control = controlBytes.baseAddress
-                msg_controllen = .init(controlBytes.count)
-                msg_flags = 0
+                msgHdr.msg_name = self.sockaddrVector.baseAddress! + i
+                msgHdr.msg_namelen = socklen_t(MemoryLayout<sockaddr_storage>.size)
+                msgHdr.msg_iov = self.ioVector.baseAddress! + i
+                msgHdr.msg_iovlen = 1  // This is weird, but each message gets only one array. Duh
+                msgHdr.msg_control = controlBytes.baseAddress
+                msgHdr.msg_controllen = .init(controlBytes.count)
+                msgHdr.msg_flags = 0
                 self.messageVector[i] = MMsgHdr(msg_hdr: msgHdr, msg_len: 0)
 
                 // Note that we don't set up the sockaddr vector: that's because it needs no initialization,

--- a/Sources/NIOPosix/DatagramVectorReadManager.swift
+++ b/Sources/NIOPosix/DatagramVectorReadManager.swift
@@ -112,13 +112,14 @@ struct DatagramVectorReadManager {
                 }
 
                 // Next we set up the msghdr structure. This points into the other vectors.
-                let msgHdr = msghdr(msg_name: self.sockaddrVector.baseAddress! + i ,
-                                    msg_namelen: socklen_t(MemoryLayout<sockaddr_storage>.size),
-                                    msg_iov: self.ioVector.baseAddress! + i,
-                                    msg_iovlen: 1,  // This is weird, but each message gets only one array. Duh.
-                                    msg_control: controlBytes.baseAddress,
-                                    msg_controllen: .init(controlBytes.count),
-                                    msg_flags: 0)
+                let msgHdr = msghdr()
+                msg_name = self.sockaddrVector.baseAddress! + i
+                msg_namelen = socklen_t(MemoryLayout<sockaddr_storage>.size)
+                msg_iov = self.ioVector.baseAddress! + i
+                msg_iovlen = 1  // This is weird, but each message gets only one array. Duh
+                msg_control = controlBytes.baseAddress
+                msg_controllen = .init(controlBytes.count)
+                msg_flags = 0
                 self.messageVector[i] = MMsgHdr(msg_hdr: msgHdr, msg_len: 0)
 
                 // Note that we don't set up the sockaddr vector: that's because it needs no initialization,

--- a/Sources/NIOPosix/Linux.swift
+++ b/Sources/NIOPosix/Linux.swift
@@ -82,6 +82,13 @@ internal enum Epoll {
     internal static let EPOLLRDHUP: CUnsignedInt = 8192 //numericCast(CNIOLinux.EPOLLRDHUP)
     internal static let EPOLLHUP: CUnsignedInt = 16 //numericCast(CNIOLinux.EPOLLHUP)
     internal static let EPOLLET: CUnsignedInt = 2147483648 //numericCast(CNIOLinux.EPOLLET)
+    #elseif canImport(Musl)
+    internal static let EPOLLIN: CUnsignedInt = numericCast(CNIOLinux.EPOLLIN)
+    internal static let EPOLLOUT: CUnsignedInt = numericCast(CNIOLinux.EPOLLOUT)
+    internal static let EPOLLERR: CUnsignedInt = numericCast(CNIOLinux.EPOLLERR)
+    internal static let EPOLLRDHUP: CUnsignedInt = numericCast(CNIOLinux.EPOLLRDHUP)
+    internal static let EPOLLHUP: CUnsignedInt = numericCast(CNIOLinux.EPOLLHUP)
+    internal static let EPOLLET: CUnsignedInt = numericCast(CNIOLinux.EPOLLET)
     #else
     internal static let EPOLLIN: CUnsignedInt = numericCast(CNIOLinux.EPOLLIN.rawValue)
     internal static let EPOLLOUT: CUnsignedInt = numericCast(CNIOLinux.EPOLLOUT.rawValue)
@@ -121,6 +128,9 @@ internal enum Linux {
 #if os(Android)
     static let SOCK_CLOEXEC = Glibc.SOCK_CLOEXEC
     static let SOCK_NONBLOCK = Glibc.SOCK_NONBLOCK
+#elseif canImport(Musl)
+    static let SOCK_CLOEXEC = Musl.SOCK_CLOEXEC
+    static let SOCK_NONBLOCK = Musl.SOCK_NONBLOCK
 #else
     static let SOCK_CLOEXEC = CInt(bitPattern: Glibc.SOCK_CLOEXEC.rawValue)
     static let SOCK_NONBLOCK = CInt(bitPattern: Glibc.SOCK_NONBLOCK.rawValue)

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -135,7 +135,7 @@ private func doPendingDatagramWriteVectorOperation(pending: PendingDatagramWrite
                 controlBytes.appendExplicitCongestionState(metadata: p.metadata, protocolFamily: protocolFamily)
                 let controlMessageBytePointer = controlBytes.validControlBytes
 
-                let msg = msghdr()
+                var msg = msghdr()
                 msg.msg_name = address
                 msg.msg_namelen = addressLen
                 msg.msg_iov = iovecs.baseAddress! + c

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -136,13 +136,13 @@ private func doPendingDatagramWriteVectorOperation(pending: PendingDatagramWrite
                 let controlMessageBytePointer = controlBytes.validControlBytes
 
                 let msg = msghdr()
-                msg_name = address
-                msg_namelen = addressLen
-                msg_iov = iovecs.baseAddress! + c
-                msg_iovlen = 1
-                msg_control = controlMessageBytePointer.baseAddress
-                msg_controllen = .init(controlMessageBytePointer.count)
-                msg_flags = 0
+                msg.msg_name = address
+                msg.msg_namelen = addressLen
+                msg.msg_iov = iovecs.baseAddress! + c
+                msg.msg_iovlen = 1
+                msg.msg_control = controlMessageBytePointer.baseAddress
+                msg.msg_controllen = .init(controlMessageBytePointer.count)
+                msg.msg_flags = 0
                 msgs[c] = MMsgHdr(msg_hdr: msg, msg_len: 0)
             }
             c += 1

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -136,7 +136,7 @@ private func doPendingDatagramWriteVectorOperation(pending: PendingDatagramWrite
                 let controlMessageBytePointer = controlBytes.validControlBytes
 
                 var msg = msghdr()
-                msg.msg_name = address
+                msg.msg_name = .init(address)
                 msg.msg_namelen = addressLen
                 msg.msg_iov = iovecs.baseAddress! + c
                 msg.msg_iovlen = 1

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -135,13 +135,14 @@ private func doPendingDatagramWriteVectorOperation(pending: PendingDatagramWrite
                 controlBytes.appendExplicitCongestionState(metadata: p.metadata, protocolFamily: protocolFamily)
                 let controlMessageBytePointer = controlBytes.validControlBytes
 
-                let msg = msghdr(msg_name: address,
-                                 msg_namelen: addressLen,
-                                 msg_iov: iovecs.baseAddress! + c,
-                                 msg_iovlen: 1,
-                                 msg_control: controlMessageBytePointer.baseAddress,
-                                 msg_controllen: .init(controlMessageBytePointer.count),
-                                 msg_flags: 0)
+                let msg = msghdr()
+                msg_name = address
+                msg_namelen = addressLen
+                msg_iov = iovecs.baseAddress! + c
+                msg_iovlen = 1
+                msg_control = controlMessageBytePointer.baseAddress
+                msg_controllen = .init(controlMessageBytePointer.count)
+                msg_flags = 0
                 msgs[c] = MMsgHdr(msg_hdr: msg, msg_len: 0)
             }
             c += 1

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -186,13 +186,14 @@ typealias IOVector = iovec
                                                                 capacity: controlBytes.count)),
                            dwFlags: 0)
 #else
-                var messageHeader = msghdr(msg_name: notConstCorrectDestinationPtr,
-                                           msg_namelen: destinationSize,
-                                           msg_iov: vecPtr,
-                                           msg_iovlen: 1,
-                                           msg_control: controlBytes.baseAddress,
-                                           msg_controllen: .init(controlBytes.count),
-                                           msg_flags: 0)
+                var messageHeader = msghdr()
+                messageHeader.msg_name = notConstCorrectDestinationPtr
+                messageHeader.msg_namelen = destinationSize
+                messageHeader.msg_iov = vecPtr
+                messageHeader.msg_iovlen = 1
+                messageHeader.msg_control = controlBytes.baseAddress
+                messageHeader.msg_controllen = .init(controlBytes.count)
+                messageHeader.msg_flags = 0
 #endif
                 return try NIOBSDSocket.sendmsg(socket: handle, msgHdr: &messageHeader, flags: 0)
             }
@@ -243,13 +244,14 @@ typealias IOVector = iovec
                     storageLen = messageHeader.namelen
                 }
 #else
-                var messageHeader = msghdr(msg_name: sockaddrPtr,
-                                           msg_namelen: storageLen,
-                                           msg_iov: vecPtr,
-                                           msg_iovlen: 1,
-                                           msg_control: controlBytes.controlBytesBuffer.baseAddress,
-                                           msg_controllen: .init(controlBytes.controlBytesBuffer.count),
-                                           msg_flags: 0)
+                var messageHeader = msghdr()
+                messageHeader.msg_name = sockaddrPtr
+                messageHeader.msg_namelen = storageLen
+                messageHeader.msg_iov = vecPtr
+                messageHeader.msg_iovlen = 1
+                messageHeader.msg_control = controlBytes.controlBytesBuffer.baseAddress
+                messageHeader.msg_controllen = .init(controlBytes.controlBytesBuffer.count)
+                messageHeader.msg_flags = 0
                 defer {
                     // We need to write back the length of the message.
                     storageLen = messageHeader.msg_namelen

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -245,7 +245,7 @@ typealias IOVector = iovec
                 }
 #else
                 var messageHeader = msghdr()
-                messageHeader.msg_name = sockaddrPtr
+                messageHeader.msg_name = .init(sockaddrPtr)
                 messageHeader.msg_namelen = storageLen
                 messageHeader.msg_iov = vecPtr
                 messageHeader.msg_iovlen = 1

--- a/Sources/NIOPosix/ThreadPosix.swift
+++ b/Sources/NIOPosix/ThreadPosix.swift
@@ -39,16 +39,23 @@ private func sysPthread_create(handle: UnsafeMutablePointer<pthread_t?>,
     #if canImport(Darwin)
     return pthread_create(handle, nil, destructor, args)
     #else
+    #if canImport(Musl)
+    var handleLinux: OpaquePointer? = nil
+    let result = pthread_create(&handleLinux,
+                                nil,
+                                destructor,
+                                args)
+    #else
     var handleLinux = pthread_t()
     let result = pthread_create(&handleLinux,
                                 nil,
                                 destructor,
                                 args)
+    #endif
     handle.pointee = handleLinux
     return result
     #endif
 }
-
 
 typealias ThreadOpsSystem = ThreadOpsPosix
 

--- a/Sources/_NIODataStructures/Heap.swift
+++ b/Sources/_NIODataStructures/Heap.swift
@@ -13,8 +13,10 @@
 //===----------------------------------------------------------------------===//
 #if canImport(Darwin)
 import Darwin.C
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import ucrt
 #endif


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires a different import, which now should be applied to files that have `import Glibc` in them.
