### PR TITLE
Correct a few Musl additions from #2449 for Android, plus error if libc not found

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -68,6 +68,6 @@ Donghyeon Kim <wplong11@gmail.com> <wplong11@users.noreply.github.com>
 Guillaume Lessard <guillaume.lessard@apple.com> <glessard@users.noreply.github.com>
 Joakim Hassila <jocke@ordo.one> <hassila@users.noreply.github.com>
 Stepan Ulyanin <sulyanin@apple.com> <99296376+stepan-ulyanin@users.noreply.github.com>
-buttaface <butta@fastem.com> <repo@butta.fastem.com>
+Finagolfin <butta@fastem.com> <repo@butta.fastem.com>
 Paul Schmiedmayer <paul.schmiedmayer@tum.de> <PSchmiedmayer@users.noreply.github.com>
 John Connolly <connoljo2@gmail.com> <jconnolly@touchbistro.com>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -51,6 +51,7 @@ needs to be listed here.
 - Esteban Torres <me@estebantorr.es>
 - Eugen <eugenf78@gmail.com>
 - Fabian Fett <fabianfett@apple.com>
+- Finagolfin <butta@fastem.com>
 - Frank Kair <frankkair@gmail.com>
 - Franz Busch <f.busch@apple.com>
 - Gautier Delorme <gautier.delorme@gmail.com>
@@ -152,7 +153,6 @@ needs to be listed here.
 - Will Lisac <will@lisac.org>
 - Wilson Ding <hello@wilsonding.com>
 - akash-55 <61596874+akash-55@users.noreply.github.com>
-- buttaface <butta@fastem.com>
 - fadi-botros <botros_fadi@yahoo.com>
 - jemmons <jemmons@users.noreply.github.com>
 - pokryfka <pokryfka@gmail.com>

--- a/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
+++ b/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
@@ -16,8 +16,10 @@ import Foundation
 import AtomicCounter
 #if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#else
+#error("The integration test scaffolding was unable to identify your C library.")
 #endif
 
 func waitForThreadsToQuiesce(shouldReachZero: Bool) {

--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -21,6 +21,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#else
+#error("The concurrency NIOLock module was unable to identify your C library.")
 #endif
 
 #if os(Windows)

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -30,6 +30,8 @@ fileprivate func sys_sched_yield() {
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#else
+#error("The concurrency atomics module was unable to identify your C library.")
 #endif
 
 fileprivate func sys_sched_yield() {

--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -21,6 +21,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#else
+#error("The concurrency lock module was unable to identify your C library.")
 #endif
 
 /// A threading lock based on `libpthread` instead of `libdispatch`.

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -75,6 +75,8 @@ import Darwin
 
 private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
 private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> CInt = inet_pton
+#else
+#error("The BSD Socket module was unable to identify your C library.")
 #endif
 
 #if os(Android)

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -20,6 +20,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#else
+#error("The Byte Buffer module was unable to identify your C library.")
 #endif
 
 @usableFromInline let sysMalloc: @convention(c) (size_t) -> UnsafeMutableRawPointer? = malloc

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -19,6 +19,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#else
+#error("The File Handle module was unable to identify your C library.")
 #endif
 
 #if os(Windows)

--- a/Sources/NIOCore/FileRegion.swift
+++ b/Sources/NIOCore/FileRegion.swift
@@ -19,6 +19,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#else
+#error("The File Region module was unable to identify your C library.")
 #endif
 
 

--- a/Sources/NIOCore/IO.swift
+++ b/Sources/NIOCore/IO.swift
@@ -32,6 +32,8 @@ internal func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
 import Glibc
 #elseif canImport(Darwin)
 import Darwin
+#else
+#error("The IO module was unable to identify your C library.")
 #endif
 
 /// An `Error` for an IO operation.

--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -38,6 +38,8 @@ import struct WinSDK.sockaddr_storage
 import struct WinSDK.sockaddr_un
 
 import typealias WinSDK.UINT8
+#else
+#error("The Core interfaces module was unable to identify your C library.")
 #endif
 
 #if !os(Windows)

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -50,6 +50,8 @@ import Glibc
 import Musl
 #endif
 import CNIOLinux
+#else
+#error("The Socket Addresses module was unable to identify your C library.")
 #endif
 
 /// Special `Error` that may be thrown if we fail to create a `SocketAddress`.

--- a/Sources/NIOCore/SocketOptionProvider.swift
+++ b/Sources/NIOCore/SocketOptionProvider.swift
@@ -22,6 +22,8 @@ import Musl
 import CNIOLinux
 #elseif os(Windows)
 import WinSDK
+#else
+#error("The Socket Option provider module was unable to identify your C library.")
 #endif
 
 /// This protocol defines an object, most commonly a `Channel`, that supports

--- a/Sources/NIOCore/SystemCallHelpers.swift
+++ b/Sources/NIOCore/SystemCallHelpers.swift
@@ -21,16 +21,14 @@
 // know about system calls into the core API (looking at you, FileHandle). As a result we need support for a small number of system calls.
 #if canImport(Darwin)
 import Darwin.C
-#elseif os(Linux) || os(FreeBSD) || os(Android)
-#if canImport(Glibc)
+#elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#endif
 #elseif os(Windows)
 import CNIOWindows
 #else
-#error("bad os")
+#error("The system call helpers module was unable to identify your C library.")
 #endif
 
 #if os(Windows)

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -36,6 +36,8 @@ import struct WinSDK.ULONG
 import typealias WinSDK.DWORD
 #elseif canImport(Darwin)
 import Darwin
+#else
+#error("The Core utilities module was unable to identify your C library.")
 #endif
 
 /// A utility function that runs the body code only in debug builds, without

--- a/Sources/NIOPosix/BSDSocketAPICommon.swift
+++ b/Sources/NIOPosix/BSDSocketAPICommon.swift
@@ -66,7 +66,7 @@ extension NIOBSDSocket.SocketType: Hashable {
 extension NIOBSDSocket.SocketType {
     /// Supports datagrams, which are connectionless, unreliable messages of a
     /// fixed (typically small) maximum length.
-    #if canImport(Glibc)
+    #if os(Linux) && !canImport(Musl)
         internal static let datagram: NIOBSDSocket.SocketType =
                 NIOBSDSocket.SocketType(rawValue: CInt(SOCK_DGRAM.rawValue))
     #else
@@ -76,7 +76,7 @@ extension NIOBSDSocket.SocketType {
 
     /// Supports reliable, two-way, connection-based byte streams without
     /// duplication of data and without preservation of boundaries.
-    #if canImport(Glibc)
+    #if os(Linux) && !canImport(Musl)
         internal static let stream: NIOBSDSocket.SocketType =
                 NIOBSDSocket.SocketType(rawValue: CInt(SOCK_STREAM.rawValue))
     #else

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -37,7 +37,7 @@ import CNIOWindows
 
 internal typealias MMsgHdr = CNIOWindows_mmsghdr
 #else
-let badOS = { fatalError("unsupported OS") }()
+#error("The POSIX system module was unable to identify your C library.")
 #endif
 
 #if os(Android)
@@ -111,7 +111,7 @@ private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsigne
 private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>?) -> CInt = socketpair
 #endif
 
-#if canImport(Glibc)
+#if os(Linux) && !canImport(Musl)
 private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>) -> CInt = fstat
 private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat
 private let sysLstat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = lstat

--- a/Sources/_NIODataStructures/Heap.swift
+++ b/Sources/_NIODataStructures/Heap.swift
@@ -19,6 +19,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#else
+#error("The Heap module was unable to identify your C library.")
 #endif
 
 @usableFromInline

--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
@@ -13,8 +13,10 @@
 //===----------------------------------------------------------------------===//
 #if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#else
+#error("The Concurrency helpers test module was unable to identify your C library.")
 #endif
 import Dispatch
 import XCTest

--- a/Tests/NIOPosixTests/HappyEyeballsTest.swift
+++ b/Tests/NIOPosixTests/HappyEyeballsTest.swift
@@ -14,8 +14,10 @@
 
 #if canImport(Darwin)
     import Darwin
-#else
+#elseif canImport(Glibc)
     import Glibc
+#else
+    #error("The Happy Eyeballs test module was unable to identify your C library.")
 #endif
 import XCTest
 @testable import NIOCore


### PR DESCRIPTION
### Motivation:

Fix build errors on Android

### Modifications:

- Fix previous Musl modifications that assumed Glibc wasn't imported on Android
- Add errors for all libc imports, so new platform ports error out early
- Update my github username

### Result:

NIO builds natively on Android again, with all the same tests passing