### PR TITLE
Async support NIOPipeBootstrap

### DIFF
--- a/Sources/NIOCrashTester/CrashTests+System.swift
+++ b/Sources/NIOCrashTester/CrashTests+System.swift
@@ -21,7 +21,7 @@ fileprivate let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 struct SystemCrashTests {
     let testEBADFIsUnacceptable = CrashTest(
         regex: "Precondition failed: unacceptable errno \(EBADF) Bad file descriptor in", {
-            _ = try? NIOPipeBootstrap(group: group).withPipes(inputDescriptor: .max, outputDescriptor: .max - 1).wait()
+            _ = try? NIOPipeBootstrap(group: group).takingOwnershipOfInputOutputDescriptor(inputDescriptor: .max, outputDescriptor: .max - 1).wait()
         })
 }
 #endif

--- a/Sources/NIOCrashTester/CrashTests+System.swift
+++ b/Sources/NIOCrashTester/CrashTests+System.swift
@@ -21,7 +21,7 @@ fileprivate let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 struct SystemCrashTests {
     let testEBADFIsUnacceptable = CrashTest(
         regex: "Precondition failed: unacceptable errno \(EBADF) Bad file descriptor in", {
-            _ = try? NIOPipeBootstrap(group: group).takingOwnershipOfInputOutputDescriptor(inputDescriptor: .max, outputDescriptor: .max - 1).wait()
+            _ = try? NIOPipeBootstrap(group: group).takingOwnershipOfDescriptors(input: .max, output: .max - 1).wait()
         })
 }
 #endif

--- a/Sources/NIOCrashTester/OutputGrepper.swift
+++ b/Sources/NIOCrashTester/OutputGrepper.swift
@@ -34,8 +34,8 @@ internal struct OutputGrepper {
                 channel.pipeline.addHandlers([ByteToMessageHandler(NewlineFramer()),
                                               GrepHandler(promise: outputPromise)])
             }
-            .takingOwnershipOfInputOutputDescriptor(inputDescriptor: dup(processToChannel.fileHandleForReading.fileDescriptor),
-                       outputDescriptor: dup(deadPipe.fileHandleForWriting.fileDescriptor))
+            .takingOwnershipOfDescriptors(input: dup(processToChannel.fileHandleForReading.fileDescriptor),
+                       output: dup(deadPipe.fileHandleForWriting.fileDescriptor))
         let processOutputPipe = NIOFileHandle(descriptor: dup(processToChannel.fileHandleForWriting.fileDescriptor))
         processToChannel.fileHandleForReading.closeFile()
         processToChannel.fileHandleForWriting.closeFile()

--- a/Sources/NIOCrashTester/OutputGrepper.swift
+++ b/Sources/NIOCrashTester/OutputGrepper.swift
@@ -34,7 +34,7 @@ internal struct OutputGrepper {
                 channel.pipeline.addHandlers([ByteToMessageHandler(NewlineFramer()),
                                               GrepHandler(promise: outputPromise)])
             }
-            .withPipes(inputDescriptor: dup(processToChannel.fileHandleForReading.fileDescriptor),
+            .takingOwnershipOfInputOutputDescriptor(inputDescriptor: dup(processToChannel.fileHandleForReading.fileDescriptor),
                        outputDescriptor: dup(deadPipe.fileHandleForWriting.fileDescriptor))
         let processOutputPipe = NIOFileHandle(descriptor: dup(processToChannel.fileHandleForWriting.fileDescriptor))
         processToChannel.fileHandleForReading.closeFile()

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -558,7 +558,7 @@ let channel = try { () -> Channel in
     case .unixDomainSocket(let path):
         return try socketBootstrap.bind(unixDomainSocketPath: path).wait()
     case .stdio:
-        return try pipeBootstrap.takingOwnershipOfInputOutputDescriptor(inputDescriptor: STDIN_FILENO, outputDescriptor: STDOUT_FILENO).wait()
+        return try pipeBootstrap.takingOwnershipOfDescriptors(input: STDIN_FILENO, output: STDOUT_FILENO).wait()
     }
 }()
 

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -558,7 +558,7 @@ let channel = try { () -> Channel in
     case .unixDomainSocket(let path):
         return try socketBootstrap.bind(unixDomainSocketPath: path).wait()
     case .stdio:
-        return try pipeBootstrap.withPipes(inputDescriptor: STDIN_FILENO, outputDescriptor: STDOUT_FILENO).wait()
+        return try pipeBootstrap.takingOwnershipOfInputOutputDescriptor(inputDescriptor: STDIN_FILENO, outputDescriptor: STDOUT_FILENO).wait()
     }
 }()
 

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2968,7 +2968,7 @@ extension DatagramBootstrap: Sendable {}
 ///                       .channelInitializer { channel in
 ///                           channel.pipeline.addHandler(MyChannelHandler())
 ///                       }
-///                       .takingOwnershipOfInputOutputDescriptor(inputDescriptor: STDIN_FILENO, outputDescriptor: STDOUT_FILENO)
+///                       .takingOwnershipOfDescriptors(input: STDIN_FILENO, output: STDOUT_FILENO)
 ///
 public final class NIOPipeBootstrap {
     private let group: EventLoopGroup

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -3334,7 +3334,7 @@ extension NIOPipeBootstrap {
         output: CInt,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Handler>
     ) async throws -> Handler.NegotiationResult {
-        try await self.takingOwnershipOfDescriptors(
+        try await self._takingOwnershipOfDescriptors(
             input: input,
             output: output,
             channelInitializer: channelInitializer,
@@ -3410,7 +3410,7 @@ extension NIOPipeBootstrap {
         output: CInt,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
     ) async throws -> Output {
-        try await self.takingOwnershipOfDescriptors(
+        try await self._takingOwnershipOfDescriptors(
             input: input,
             output: output,
             channelInitializer: channelInitializer,
@@ -3420,7 +3420,7 @@ extension NIOPipeBootstrap {
     
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @_spi(AsyncChannel) // Should become private
-    public func takingOwnershipOfDescriptors<ChannelInitializerResult, PostRegistrationTransformationResult: Sendable>(
+    public func _takingOwnershipOfDescriptors<ChannelInitializerResult, PostRegistrationTransformationResult: Sendable>(
         input: CInt,
         output: CInt,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<ChannelInitializerResult>,

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -598,7 +598,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
         
         do {
             channel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .withPipes(
+                .takingOwnershipOfInputOutputDescriptor(
                     inputDescriptor: pipe1ReadFH,
                     outputDescriptor: pipe2WriteFH
                 )
@@ -633,7 +633,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             group.addTask {
                 do {
                     return try await NIOPipeBootstrap(group: eventLoopGroup)
-                        .withPipes(
+                        .takingOwnershipOfInputOutputDescriptor(
                             inputDescriptor: pipe1ReadFH,
                             outputDescriptor: pipe2WriteFH
                         ) { channel -> EventLoopFuture<NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>> in

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -598,9 +598,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
         
         do {
             channel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .takingOwnershipOfInputOutputDescriptor(
-                    inputDescriptor: pipe1ReadFH,
-                    outputDescriptor: pipe2WriteFH
+                .takingOwnershipOfDescriptors(
+                    input: pipe1ReadFH,
+                    output: pipe2WriteFH
                 )
         } catch {
             [pipe1ReadFH, pipe1WriteFH, pipe2ReadFH, pipe2WriteFH].forEach { try? SystemCalls.close(descriptor: $0) }
@@ -633,9 +633,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             group.addTask {
                 do {
                     return try await NIOPipeBootstrap(group: eventLoopGroup)
-                        .takingOwnershipOfInputOutputDescriptor(
-                            inputDescriptor: pipe1ReadFH,
-                            outputDescriptor: pipe2WriteFH
+                        .takingOwnershipOfDescriptors(
+                            input: pipe1ReadFH,
+                            output: pipe2WriteFH
                         ) { channel -> EventLoopFuture<NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>> in
                             return channel.eventLoop.makeCompletedFuture {
                                 return try self.configureProtocolNegotiationHandlers(channel: channel)

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOConcurrencyHelpers
-@_spi(AsyncChannel) import NIOCore
+@_spi(AsyncChannel) @testable import NIOCore
 @_spi(AsyncChannel) @testable import NIOPosix
 import XCTest
 @_spi(AsyncChannel) import NIOTLS
@@ -586,8 +586,104 @@ final class AsyncChannelBootstrapTests: XCTestCase {
             }
         }
     }
+    
+    // MARK: - Pipe Bootstrap
+    
+    func testPipeBootstrap() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let (pipe1ReadFH, pipe1WriteFH, pipe2ReadFH, pipe2WriteFH) = self.makePipeFileDescriptors()
+        let toChannel = FileHandle(fileDescriptor: pipe1WriteFH, closeOnDealloc: false)
+        let fromChannel = FileHandle(fileDescriptor: pipe2ReadFH, closeOnDealloc: false)
+        let channel: NIOAsyncChannel<ByteBuffer, ByteBuffer>
+        
+        do {
+            channel = try await NIOPipeBootstrap(group: eventLoopGroup)
+                .withPipes(
+                    inputDescriptor: pipe1ReadFH,
+                    outputDescriptor: pipe2WriteFH
+                )
+        } catch {
+            [pipe1ReadFH, pipe1WriteFH, pipe2ReadFH, pipe2WriteFH].forEach { try? SystemCalls.close(descriptor: $0) }
+            throw error
+        }
+        
+        var inboundIterator = channel.inboundStream.makeAsyncIterator()
+        
+        do {
+            try toChannel.writeBytes(.init(string: "Request"))
+            try await XCTAsyncAssertEqual(try await inboundIterator.next(), ByteBuffer(string: "Request"))
+            
+            let response = ByteBuffer(string: "Response")
+            try await channel.outboundWriter.write(response)
+            XCTAssertEqual(try fromChannel.readBytes(ofExactLength: response.readableBytes), Array(buffer: response))
+        } catch {
+            // We only got to close the FDs that are not owned by the PipeChannel
+            [pipe1WriteFH, pipe2ReadFH].forEach { try? SystemCalls.close(descriptor: $0) }
+            throw error
+        }
+    }
+    
+    func testPipeBootstrap_withProtocolNegotiation() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let (pipe1ReadFH, pipe1WriteFH, pipe2ReadFH, pipe2WriteFH) = self.makePipeFileDescriptors()
+        let toChannel = FileHandle(fileDescriptor: pipe1WriteFH, closeOnDealloc: false)
+        let fromChannel = FileHandle(fileDescriptor: pipe2ReadFH, closeOnDealloc: false)
+        
+        try await withThrowingTaskGroup(of: NegotiationResult.self) { group in
+            group.addTask {
+                do {
+                    return try await NIOPipeBootstrap(group: eventLoopGroup)
+                        .withPipes(
+                            inputDescriptor: pipe1ReadFH,
+                            outputDescriptor: pipe2WriteFH
+                        ) { channel -> EventLoopFuture<NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>> in
+                            return channel.eventLoop.makeCompletedFuture {
+                                return try self.configureProtocolNegotiationHandlers(channel: channel)
+                            }
+                        }
+                } catch {
+                    [pipe1ReadFH, pipe1WriteFH, pipe2ReadFH, pipe2WriteFH].forEach { try? SystemCalls.close(descriptor: $0) }
+                    throw error
+                }
+            }
+            
+            
+            try toChannel.writeBytes(.init(string: "alpn:string\nHello\n"))
+            let negotiationResult = try await group.next()
+            switch negotiationResult {
+            case .string(let channel):
+                var inboundIterator = channel.inboundStream.makeAsyncIterator()
+                do {
+                    try await XCTAsyncAssertEqual(try await inboundIterator.next(), "Hello")
+                    
+                    let response = ByteBuffer(string: "Response")
+                    try await channel.outboundWriter.write("Response")
+                    XCTAssertEqual(try fromChannel.readBytes(ofExactLength: response.readableBytes), Array(buffer: response))
+                } catch {
+                    // We only got to close the FDs that are not owned by the PipeChannel
+                    [pipe1WriteFH, pipe2ReadFH].forEach { try? SystemCalls.close(descriptor: $0) }
+                    throw error
+                }
+                
+            case .byte, nil:
+                fatalError()
+            }
+        }
+    }
 
     // MARK: - Test Helpers
+    
+    private func makePipeFileDescriptors() -> (pipe1ReadFH: Int32, pipe1WriteFH: Int32, pipe2ReadFH: Int32, pipe2WriteFH: Int32) {
+        var pipe1FDs: [Int32] = [-1, -1]
+        pipe1FDs.withUnsafeMutableBufferPointer { ptr in
+            XCTAssertEqual(0, pipe(ptr.baseAddress!))
+        }
+        var pipe2FDs: [Int32] = [-1, -1]
+        pipe2FDs.withUnsafeMutableBufferPointer { ptr in
+            XCTAssertEqual(0, pipe(ptr.baseAddress!))
+        }
+        return (pipe1FDs[0], pipe1FDs[1], pipe2FDs[0], pipe2FDs[1])
+    }
 
     private func makeClientChannel(eventLoopGroup: EventLoopGroup, port: Int) async throws -> NIOAsyncChannel<String, String> {
         return try await ClientBootstrap(group: eventLoopGroup)

--- a/Tests/NIOPosixTests/BootstrapTest.swift
+++ b/Tests/NIOPosixTests/BootstrapTest.swift
@@ -381,7 +381,7 @@ class BootstrapTest: XCTestCase {
                     }
                     return channel.pipeline.addHandler(MakeSureAutoReadIsOffInChannelInitializer())
             }
-            .takingOwnershipOfInputOutputDescriptor(inputDescriptor: inFD, outputDescriptor: outFD)
+            .takingOwnershipOfDescriptors(input: inFD, output: outFD)
             .wait())
             XCTAssertNotNil(channel)
             XCTAssertNoThrow(try channel?.close().wait())
@@ -401,7 +401,7 @@ class BootstrapTest: XCTestCase {
                 let readHandle = NIOFileHandle(descriptor: pipe.fileHandleForReading.fileDescriptor)
                 let writeHandle = NIOFileHandle(descriptor: pipe.fileHandleForWriting.fileDescriptor)
                 _ = NIOPipeBootstrap(group: self.group)
-                    .takingOwnershipOfInputOutputDescriptor(inputDescriptor: try readHandle.takeDescriptorOwnership(), outputDescriptor: try writeHandle.takeDescriptorOwnership())
+                    .takingOwnershipOfDescriptors(input: try readHandle.takeDescriptorOwnership(), output: try writeHandle.takeDescriptorOwnership())
                     .flatMap({ channel in
                         channel.close()
                     }).always({ _ in

--- a/Tests/NIOPosixTests/BootstrapTest.swift
+++ b/Tests/NIOPosixTests/BootstrapTest.swift
@@ -381,7 +381,7 @@ class BootstrapTest: XCTestCase {
                     }
                     return channel.pipeline.addHandler(MakeSureAutoReadIsOffInChannelInitializer())
             }
-            .withPipes(inputDescriptor: inFD, outputDescriptor: outFD)
+            .takingOwnershipOfInputOutputDescriptor(inputDescriptor: inFD, outputDescriptor: outFD)
             .wait())
             XCTAssertNotNil(channel)
             XCTAssertNoThrow(try channel?.close().wait())
@@ -401,7 +401,7 @@ class BootstrapTest: XCTestCase {
                 let readHandle = NIOFileHandle(descriptor: pipe.fileHandleForReading.fileDescriptor)
                 let writeHandle = NIOFileHandle(descriptor: pipe.fileHandleForWriting.fileDescriptor)
                 _ = NIOPipeBootstrap(group: self.group)
-                    .withPipes(inputDescriptor: try readHandle.takeDescriptorOwnership(), outputDescriptor: try writeHandle.takeDescriptorOwnership())
+                    .takingOwnershipOfInputOutputDescriptor(inputDescriptor: try readHandle.takeDescriptorOwnership(), outputDescriptor: try writeHandle.takeDescriptorOwnership())
                     .flatMap({ channel in
                         channel.close()
                     }).always({ _ in

--- a/Tests/NIOPosixTests/PipeChannelTest.swift
+++ b/Tests/NIOPosixTests/PipeChannelTest.swift
@@ -43,7 +43,7 @@ final class PipeChannelTest: XCTestCase {
                 try pipe1Read.withUnsafeFileDescriptor { channelIn in
                     try pipe2Write.withUnsafeFileDescriptor { channelOut in
                         let channel = NIOPipeBootstrap(group: self.group)
-                            .withPipes(inputDescriptor: channelIn,
+                            .takingOwnershipOfInputOutputDescriptor(inputDescriptor: channelIn,
                                        outputDescriptor: channelOut)
                         XCTAssertNoThrow(self.channel = try channel.wait())
                     }
@@ -114,12 +114,12 @@ final class PipeChannelTest: XCTestCase {
                     try pipeIn.withUnsafeFileDescriptor { pipeInDescriptor in
                         try pipeOut.withUnsafeFileDescriptor { pipeOutDescriptor in
                             XCTAssertThrowsError(try NIOPipeBootstrap(group: self.group)
-                                .withPipes(inputDescriptor: fileFHDescriptor,
+                                .takingOwnershipOfInputOutputDescriptor(inputDescriptor: fileFHDescriptor,
                                            outputDescriptor: pipeOutDescriptor).wait()) { error in
                                     XCTAssertEqual(ChannelError.operationUnsupported, error as? ChannelError)
                             }
                             XCTAssertThrowsError(try NIOPipeBootstrap(group: self.group)
-                                .withPipes(inputDescriptor: pipeInDescriptor,
+                                .takingOwnershipOfInputOutputDescriptor(inputDescriptor: pipeInDescriptor,
                                            outputDescriptor: fileFHDescriptor).wait()) { error in
                                     XCTAssertEqual(ChannelError.operationUnsupported, error as? ChannelError)
                             }
@@ -161,7 +161,7 @@ final class PipeChannelTest: XCTestCase {
             .channelInitializer { channel in
                 channel.pipeline.addHandler(EchoHandler())
             }
-            .withInputOutputDescriptor(dup(socketPair[0]))
+            .takingOwnershipOfInputOutputDescriptor(dup(socketPair[0]))
             .wait())
         defer {
             XCTAssertNoThrow(try maybeChannel?.close().wait())

--- a/Tests/NIOPosixTests/PipeChannelTest.swift
+++ b/Tests/NIOPosixTests/PipeChannelTest.swift
@@ -43,8 +43,8 @@ final class PipeChannelTest: XCTestCase {
                 try pipe1Read.withUnsafeFileDescriptor { channelIn in
                     try pipe2Write.withUnsafeFileDescriptor { channelOut in
                         let channel = NIOPipeBootstrap(group: self.group)
-                            .takingOwnershipOfInputOutputDescriptor(inputDescriptor: channelIn,
-                                       outputDescriptor: channelOut)
+                            .takingOwnershipOfDescriptors(input: channelIn,
+                                       output: channelOut)
                         XCTAssertNoThrow(self.channel = try channel.wait())
                     }
                 }
@@ -114,13 +114,13 @@ final class PipeChannelTest: XCTestCase {
                     try pipeIn.withUnsafeFileDescriptor { pipeInDescriptor in
                         try pipeOut.withUnsafeFileDescriptor { pipeOutDescriptor in
                             XCTAssertThrowsError(try NIOPipeBootstrap(group: self.group)
-                                .takingOwnershipOfInputOutputDescriptor(inputDescriptor: fileFHDescriptor,
-                                           outputDescriptor: pipeOutDescriptor).wait()) { error in
+                                .takingOwnershipOfDescriptors(input: fileFHDescriptor,
+                                           output: pipeOutDescriptor).wait()) { error in
                                     XCTAssertEqual(ChannelError.operationUnsupported, error as? ChannelError)
                             }
                             XCTAssertThrowsError(try NIOPipeBootstrap(group: self.group)
-                                .takingOwnershipOfInputOutputDescriptor(inputDescriptor: pipeInDescriptor,
-                                           outputDescriptor: fileFHDescriptor).wait()) { error in
+                                .takingOwnershipOfDescriptors(input: pipeInDescriptor,
+                                           output: fileFHDescriptor).wait()) { error in
                                     XCTAssertEqual(ChannelError.operationUnsupported, error as? ChannelError)
                             }
                         }
@@ -161,7 +161,7 @@ final class PipeChannelTest: XCTestCase {
             .channelInitializer { channel in
                 channel.pipeline.addHandler(EchoHandler())
             }
-            .takingOwnershipOfInputOutputDescriptor(dup(socketPair[0]))
+            .takingOwnershipOfDescriptor(inputOutput: dup(socketPair[0]))
             .wait())
         defer {
             XCTAssertNoThrow(try maybeChannel?.close().wait())

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -644,13 +644,13 @@ func withCrossConnectedPipeChannels<R>(forceSeparateEventLoops: Bool = false,
                     try pipe2Read.withUnsafeFileDescriptor { pipe2Read in
                         try pipe2Write.withUnsafeFileDescriptor { pipe2Write in
                             let channel1 = try NIOPipeBootstrap(group: channel1Group)
-                                .takingOwnershipOfInputOutputDescriptor(inputDescriptor: pipe1Read, outputDescriptor: pipe2Write)
+                                .takingOwnershipOfDescriptors(input: pipe1Read, output: pipe2Write)
                                 .wait()
                             defer {
                                 XCTAssertNoThrow(try channel1.syncCloseAcceptingAlreadyClosed())
                             }
                             let channel2 = try NIOPipeBootstrap(group: channel2Group)
-                                .takingOwnershipOfInputOutputDescriptor(inputDescriptor: pipe2Read, outputDescriptor: pipe1Write)
+                                .takingOwnershipOfDescriptors(input: pipe2Read, output: pipe1Write)
                                 .wait()
                             defer {
                                 XCTAssertNoThrow(try channel2.syncCloseAcceptingAlreadyClosed())

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -644,13 +644,13 @@ func withCrossConnectedPipeChannels<R>(forceSeparateEventLoops: Bool = false,
                     try pipe2Read.withUnsafeFileDescriptor { pipe2Read in
                         try pipe2Write.withUnsafeFileDescriptor { pipe2Write in
                             let channel1 = try NIOPipeBootstrap(group: channel1Group)
-                                .withPipes(inputDescriptor: pipe1Read, outputDescriptor: pipe2Write)
+                                .takingOwnershipOfInputOutputDescriptor(inputDescriptor: pipe1Read, outputDescriptor: pipe2Write)
                                 .wait()
                             defer {
                                 XCTAssertNoThrow(try channel1.syncCloseAcceptingAlreadyClosed())
                             }
                             let channel2 = try NIOPipeBootstrap(group: channel2Group)
-                                .withPipes(inputDescriptor: pipe2Read, outputDescriptor: pipe1Write)
+                                .takingOwnershipOfInputOutputDescriptor(inputDescriptor: pipe2Read, outputDescriptor: pipe1Write)
                                 .wait()
                             defer {
                                 XCTAssertNoThrow(try channel2.syncCloseAcceptingAlreadyClosed())


### PR DESCRIPTION
# Motivation
We want to support async bootstrapping with all our bootstraps.

# Modification
This PR adds support for the `NIOPipeBootstrap` and adds the three variants of methods to it (abstract output, `NIOAsyncChannel` based and protocol negotiation based)

# Result
We now support asynchronous interaction with the `NIOPipeBootstrap`