### PR TITLE
Restructure `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,110 +18,6 @@ import PackageDescription
 let swiftAtomics: PackageDescription.Target.Dependency = .product(name: "Atomics", package: "swift-atomics")
 let swiftCollections: PackageDescription.Target.Dependency = .product(name: "DequeModule", package: "swift-collections")
 
-var targets: [PackageDescription.Target] = [
-    .target(name: "NIOCore",
-            dependencies: ["NIOConcurrencyHelpers", "CNIOLinux", "CNIOWindows", swiftCollections, swiftAtomics]),
-    .target(name: "_NIODataStructures"),
-    .target(name: "NIOEmbedded",
-            dependencies: ["NIOCore",
-                           "NIOConcurrencyHelpers",
-                           "_NIODataStructures",
-                           swiftAtomics,
-                           swiftCollections]),
-    .target(name: "NIOPosix",
-            dependencies: ["CNIOLinux",
-                           "CNIODarwin",
-                           "CNIOWindows",
-                           "NIOConcurrencyHelpers",
-                           "NIOCore",
-                           "_NIODataStructures",
-                           swiftAtomics]),
-    .target(name: "NIO",
-            dependencies: ["NIOCore",
-                           "NIOEmbedded",
-                           "NIOPosix"]),
-    .target(name: "_NIOConcurrency",
-            dependencies: ["NIO", "NIOCore"]),
-    .target(name: "NIOFoundationCompat", dependencies: ["NIO", "NIOCore"]),
-    .target(name: "CNIOAtomics", dependencies: []),
-    .target(name: "CNIOSHA1", dependencies: []),
-    .target(name: "CNIOLinux", dependencies: []),
-    .target(name: "CNIODarwin", dependencies: [], cSettings: [.define("__APPLE_USE_RFC_3542")]),
-    .target(name: "CNIOWindows", dependencies: []),
-    .target(name: "NIOConcurrencyHelpers",
-            dependencies: ["CNIOAtomics"]),
-    .target(name: "NIOHTTP1",
-            dependencies: ["NIO", "NIOCore", "NIOConcurrencyHelpers", "CNIOLLHTTP"]),
-    .executableTarget(name: "NIOEchoServer",
-                      dependencies: ["NIOPosix", "NIOCore", "NIOConcurrencyHelpers"],
-                      exclude: ["README.md"]),
-    .executableTarget(name: "NIOEchoClient",
-                      dependencies: ["NIOPosix", "NIOCore", "NIOConcurrencyHelpers"],
-                      exclude: ["README.md"]),
-    .executableTarget(name: "NIOHTTP1Server",
-                      dependencies: ["NIOPosix", "NIOCore", "NIOHTTP1", "NIOConcurrencyHelpers"],
-                      exclude: ["README.md"]),
-    .executableTarget(name: "NIOHTTP1Client",
-                      dependencies: ["NIOPosix", "NIOCore", "NIOHTTP1", "NIOConcurrencyHelpers"],
-                      exclude: ["README.md"]),
-    .target(
-        name: "CNIOLLHTTP",
-        cSettings: [.define("LLHTTP_STRICT_MODE")]
-    ),
-    .target(name: "NIOTLS", dependencies: ["NIO", "NIOCore", swiftCollections]),
-    .executableTarget(name: "NIOChatServer",
-                      dependencies: ["NIOPosix", "NIOCore", "NIOConcurrencyHelpers"],
-                      exclude: ["README.md"]),
-    .executableTarget(name: "NIOChatClient",
-                      dependencies: ["NIOPosix", "NIOCore", "NIOConcurrencyHelpers"],
-                      exclude: ["README.md"]),
-    .target(name: "NIOWebSocket",
-            dependencies: ["NIO", "NIOCore", "NIOHTTP1", "CNIOSHA1"]),
-    .executableTarget(name: "NIOWebSocketServer",
-                      dependencies: ["NIOPosix", "NIOCore", "NIOHTTP1", "NIOWebSocket"],
-                      exclude: ["README.md"]),
-    .executableTarget(name: "NIOWebSocketClient",
-                      dependencies: ["NIOPosix", "NIOCore", "NIOHTTP1", "NIOWebSocket"],
-                      exclude: ["README.md"]),
-    .executableTarget(name: "NIOPerformanceTester",
-            dependencies: ["NIOPosix", "NIOCore", "NIOEmbedded", "NIOHTTP1", "NIOFoundationCompat", "NIOWebSocket"]),
-    .executableTarget(name: "NIOMulticastChat",
-            dependencies: ["NIOPosix", "NIOCore"]),
-    .executableTarget(name: "NIOUDPEchoServer",
-                      dependencies: ["NIOPosix", "NIOCore"],
-                      exclude: ["README.md"]),
-    .executableTarget(name: "NIOUDPEchoClient",
-                      dependencies: ["NIOPosix", "NIOCore"],
-                      exclude: ["README.md"]),
-    .target(name: "NIOTestUtils",
-            dependencies: ["NIOPosix", "NIOCore", "NIOEmbedded", "NIOHTTP1", swiftAtomics]),
-    .executableTarget(name: "NIOCrashTester",
-            dependencies: ["NIOPosix", "NIOCore", "NIOEmbedded", "NIOHTTP1", "NIOWebSocket", "NIOFoundationCompat"]),
-    .executableTarget(name: "NIOAsyncAwaitDemo",
-            dependencies: ["NIOPosix", "NIOCore", "NIOHTTP1"]),
-    .testTarget(name: "NIOCoreTests",
-                dependencies: ["NIOCore", "NIOEmbedded", "NIOFoundationCompat", swiftAtomics]),
-    .testTarget(name: "NIOEmbeddedTests",
-                dependencies: ["NIOConcurrencyHelpers", "NIOCore", "NIOEmbedded"]),
-    .testTarget(name: "NIOPosixTests",
-                dependencies: ["NIOPosix", "NIOCore", "NIOFoundationCompat", "NIOTestUtils", "NIOConcurrencyHelpers", "NIOEmbedded", "CNIOLinux", "NIOTLS"]),
-    .testTarget(name: "NIOConcurrencyHelpersTests",
-                dependencies: ["NIOConcurrencyHelpers", "NIOCore"]),
-    .testTarget(name: "NIODataStructuresTests",
-                dependencies: ["_NIODataStructures"]),
-    .testTarget(name: "NIOHTTP1Tests",
-                dependencies: ["NIOCore", "NIOEmbedded", "NIOPosix", "NIOHTTP1", "NIOFoundationCompat", "NIOTestUtils"]),
-    .testTarget(name: "NIOTLSTests",
-                dependencies: ["NIOCore", "NIOEmbedded", "NIOTLS", "NIOFoundationCompat", "NIOTestUtils"]),
-    .testTarget(name: "NIOWebSocketTests",
-                dependencies: ["NIOCore", "NIOEmbedded", "NIOWebSocket"]),
-    .testTarget(name: "NIOTestUtilsTests",
-                dependencies: ["NIOTestUtils", "NIOCore", "NIOEmbedded", "NIOPosix"]),
-    .testTarget(name: "NIOFoundationCompatTests",
-                dependencies: ["NIOCore", "NIOFoundationCompat"]),
-    .testTarget(name: "NIOTests",
-                dependencies: ["NIO"]),
-]
 
 let package = Package(
     name: "swift-nio",
@@ -143,5 +39,359 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
-    targets: targets
+    targets: [
+        // MARK: - Targets
+
+        .target(
+            name: "NIOCore",
+            dependencies: [
+                "NIOConcurrencyHelpers",
+                "CNIOLinux",
+                "CNIOWindows",
+                swiftCollections,
+                swiftAtomics,
+            ]
+        ),
+        .target(
+            name: "_NIODataStructures"
+        ),
+        .target(
+            name: "NIOEmbedded",
+            dependencies: [
+                "NIOCore",
+                "NIOConcurrencyHelpers",
+                "_NIODataStructures",
+                swiftAtomics,
+                swiftCollections,
+            ]
+        ),
+        .target(
+            name: "NIOPosix",
+            dependencies: [
+                "CNIOLinux",
+                "CNIODarwin",
+                "CNIOWindows",
+                "NIOConcurrencyHelpers",
+                "NIOCore",
+                "_NIODataStructures",
+                swiftAtomics,
+            ]
+        ),
+        .target(
+            name: "NIO",
+            dependencies: [
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOPosix",
+            ]
+        ),
+        .target(
+            name: "_NIOConcurrency",
+            dependencies: [
+                "NIO",
+                "NIOCore",
+            ]
+        ),
+        .target(
+            name: "NIOFoundationCompat",
+            dependencies: [
+                "NIO",
+                "NIOCore",
+            ]
+        ),
+        .target(
+            name: "CNIOAtomics",
+            dependencies: []
+        ),
+        .target(
+            name: "CNIOSHA1",
+            dependencies: []
+        ),
+        .target(
+            name: "CNIOLinux",
+            dependencies: []
+        ),
+        .target(
+            name: "CNIODarwin",
+            dependencies: [],
+            cSettings: [
+                .define("__APPLE_USE_RFC_3542"),
+            ]
+        ),
+        .target(
+            name: "CNIOWindows",
+            dependencies: []
+        ),
+        .target(
+            name: "NIOConcurrencyHelpers",
+            dependencies: [
+                "CNIOAtomics",
+            ]
+        ),
+        .target(
+            name: "NIOHTTP1",
+            dependencies: [
+                "NIO",
+                "NIOCore",
+                "NIOConcurrencyHelpers",
+                "CNIOLLHTTP",
+            ]
+        ),
+        .target(
+            name: "NIOWebSocket",
+            dependencies: [
+                "NIO",
+                "NIOCore",
+                "NIOHTTP1",
+                "CNIOSHA1",
+            ]
+        ),
+        .target(
+            name: "CNIOLLHTTP",
+            cSettings: [.define("LLHTTP_STRICT_MODE")]
+        ),
+        .target(
+            name: "NIOTLS",
+            dependencies: [
+                "NIO",
+                "NIOCore",
+                swiftCollections,
+            ]
+        ),
+        .target(
+            name: "NIOTestUtils",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOHTTP1",
+                swiftAtomics,
+            ]
+        ),
+
+        // MARK: - Examples
+
+        .executableTarget(
+            name: "NIOEchoServer",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOConcurrencyHelpers",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOEchoClient",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOConcurrencyHelpers",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOHTTP1Server",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOHTTP1",
+                "NIOConcurrencyHelpers",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOHTTP1Client",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOHTTP1",
+                "NIOConcurrencyHelpers",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOChatServer",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOConcurrencyHelpers",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOChatClient",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOConcurrencyHelpers",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOWebSocketServer",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOHTTP1",
+                "NIOWebSocket",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOWebSocketClient",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOHTTP1",
+                "NIOWebSocket",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOMulticastChat",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+            ]
+        ),
+        .executableTarget(
+            name: "NIOUDPEchoServer",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOUDPEchoClient",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+            ],
+            exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "NIOAsyncAwaitDemo",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOHTTP1",
+            ]
+        ),
+
+        // MARK: - Tests
+
+        .executableTarget(
+            name: "NIOPerformanceTester",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOHTTP1",
+                "NIOFoundationCompat",
+                "NIOWebSocket",
+            ]
+        ),
+        .executableTarget(
+            name: "NIOCrashTester",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOHTTP1",
+                "NIOWebSocket",
+                "NIOFoundationCompat",
+            ]
+        ),
+        .testTarget(
+            name: "NIOCoreTests",
+            dependencies: [
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOFoundationCompat",
+                swiftAtomics,
+            ]
+        ),
+        .testTarget(
+            name: "NIOEmbeddedTests",
+            dependencies: [
+                "NIOConcurrencyHelpers",
+                "NIOCore",
+                "NIOEmbedded",
+            ]
+        ),
+        .testTarget(
+            name: "NIOPosixTests",
+            dependencies: [
+                "NIOPosix",
+                "NIOCore",
+                "NIOFoundationCompat",
+                "NIOTestUtils",
+                "NIOConcurrencyHelpers",
+                "NIOEmbedded",
+                "CNIOLinux",
+                "NIOTLS",
+            ]
+        ),
+        .testTarget(
+            name: "NIOConcurrencyHelpersTests",
+            dependencies: [
+                "NIOConcurrencyHelpers",
+                "NIOCore",
+            ]
+        ),
+        .testTarget(
+            name: "NIODataStructuresTests",
+            dependencies: ["_NIODataStructures"]
+        ),
+        .testTarget(
+            name: "NIOHTTP1Tests",
+            dependencies: [
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOPosix",
+                "NIOHTTP1",
+                "NIOFoundationCompat",
+                "NIOTestUtils",
+            ]
+        ),
+        .testTarget(
+            name: "NIOTLSTests",
+            dependencies: [
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOTLS",
+                "NIOFoundationCompat",
+                "NIOTestUtils",
+            ]
+        ),
+        .testTarget(
+            name: "NIOWebSocketTests",
+            dependencies: [
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOWebSocket",
+            ]
+        ),
+        .testTarget(
+            name: "NIOTestUtilsTests",
+            dependencies: [
+                "NIOTestUtils",
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOPosix",
+            ]
+        ),
+        .testTarget(
+            name: "NIOFoundationCompatTests",
+            dependencies: [
+                "NIOCore",
+                "NIOFoundationCompat",
+            ]
+        ),
+        .testTarget(
+            name: "NIOTests",
+            dependencies: ["NIO"]
+        ),
+    ]
 )


### PR DESCRIPTION
This might be a controversial PR! 🍿

# Motivation
It always bothered me how our `Package.swift` is structured. First, we had a huge list of `targets` at the top that distracted from the `products`. The `products` are the important part for our adopters since those are the actual modules they can use. Secondly, the formatting of the targets made it hard to follow and resulted in unnecessary merge conflicts.

# Modification
This PR moves the targets back to the bottom and splits all the various array elements into separate elements.

# Result
Easier to understand `Package.swift` and less merge conflicts.