### PR TITLE
NIOSingletons: Use NIO in easy mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -393,5 +393,9 @@ let package = Package(
             name: "NIOTests",
             dependencies: ["NIO"]
         ),
+        .testTarget(
+            name: "NIOSingletonsTests",
+            dependencies: ["NIOCore", "NIOPosix"]
+        ),
     ]
 )

--- a/Sources/NIOCore/GlobalSingletons.swift
+++ b/Sources/NIOCore/GlobalSingletons.swift
@@ -1,0 +1,180 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Atomics
+#if canImport(Darwin)
+import Darwin
+#elseif os(Windows)
+import ucrt
+import WinSDK
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported C library")
+#endif
+
+/// SwiftNIO provided singleton resources for programs & libraries that don't need full control over all operating
+/// system resources. This type holds sizing (how many loops/threads) suggestions.
+///
+/// Users who need very tight control about the exact threads and resources created may decide to set
+/// `NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false`. All singleton-creating facilities should check
+/// this setting and if `false` restrain from creating any global singleton resources. Please note that disabling the
+/// global singletons will lead to a crash if _any_ code attempts to use any of the singletons.
+public enum NIOGlobalSingletons {
+}
+
+extension NIOGlobalSingletons {
+    /// A suggestion of how many ``EventLoop``s the global singleton ``EventLoopGroup``s are supposed to consist of.
+    ///
+    /// The thread count is ``System/coreCount`` unless the environment variable `NIO_SINGLETON_GROUP_LOOP_COUNT`
+    /// is set or this value was set manually by the user.
+    ///
+    /// - note: This value must be set _before_ any singletons are used and must only be set once.
+    public static var suggestedGlobalSingletonGroupLoopCount: Int {
+        set {
+            Self.userSetSingletonThreadCount(rawStorage: globalRawSuggestedLoopCount, userValue: newValue)
+        }
+
+        get {
+            return Self.getTrustworthyThreadCount(rawStorage: globalRawSuggestedLoopCount,
+                                                  environmentVariable: "NIO_SINGLETON_GROUP_LOOP_COUNT")
+        }
+    }
+
+    /// A suggestion of how many threads the global singleton thread pools that can be used for synchronous, blocking
+    /// functions (such as ``NIOThreadPool``) are supposed to consist of
+    ///
+    /// The thread count is ``System/coreCount`` unless the environment variable
+    /// `NIO_SINGLETON_BLOCKING_POOL_THREAD_COUNT` is set or this value was set manually by the user.
+    ///
+    /// - note: This value must be set _before_ any singletons are used and must only be set once.
+    public static var suggestedBlockingPoolThreadCount: Int {
+        set {
+            Self.userSetSingletonThreadCount(rawStorage: globalRawSuggestedBlockingThreadCount, userValue: newValue)
+        }
+
+        get {
+            return Self.getTrustworthyThreadCount(rawStorage: globalRawSuggestedBlockingThreadCount,
+                                                  environmentVariable: "NIO_SINGLETON_BLOCKING_POOL_THREAD_COUNT")
+        }
+    }
+
+    /// A suggestion for whether the global singletons should be enabled. This is `true` unless changed by the user.
+    ///
+    /// This value cannot be changed using an environment variable.
+    ///
+    /// - note: This value must be set _before_ any singletons are used and must only be set once.
+    public static var globalSingletonsEnabledSuggestion: Bool {
+        get {
+            let (exchanged, original) = globalRawSingletonsEnabled.compareExchange(expected: 0,
+                                                                                   desired: 1,
+                                                                                   ordering: .relaxed)
+            if exchanged {
+                // Never been set, we're committing to the default (enabled).
+                assert(original == 0)
+                return true
+            } else {
+                // This has been set before, 1: enabled; -1 disabled.
+                assert(original != 0)
+                assert(original == -1 || original == 1)
+                return original > 0
+            }
+        }
+
+        set {
+            let intRepresentation = newValue ? 1 : -1
+            let (exchanged, original) = globalRawSingletonsEnabled.compareExchange(expected: 0,
+                                                                                   desired: intRepresentation,
+                                                                                   ordering: .relaxed)
+            guard exchanged else {
+                fatalError("""
+                           Bug in user code: Global singleton enabled suggestion has been changed after \
+                           user or has been changed more than once. Either is an error, you must set this value very \
+                           early and only once.
+                           """)
+            }
+        }
+    }
+}
+
+// DO NOT TOUCH THESE DIRECTLY, use `userSetSingletonThreadCount` and `getTrustworthyThreadCount`.
+private let globalRawSuggestedLoopCount = ManagedAtomic(0)
+private let globalRawSuggestedBlockingThreadCount = ManagedAtomic(0)
+private let globalRawSingletonsEnabled = ManagedAtomic(0)
+
+extension NIOGlobalSingletons {
+    private static func userSetSingletonThreadCount(rawStorage: ManagedAtomic<Int>, userValue: Int) {
+        precondition(userValue > 0, "illegal value: needs to be strictly positive")
+
+        // The user is trying to set it. We can only do this if the value is at 0 and we will set the
+        // negative value. So if the user wants `5`, we will set `-5`. Once it's used (set getter), it'll be upped
+        // to 5.
+        let (exchanged, _) = rawStorage.compareExchange(expected: 0, desired: -userValue, ordering: .relaxed)
+        guard exchanged else {
+            fatalError("""
+                       Bug in user code: Global singleton suggested loop/thread count has been changed after \
+                       user or has been changed more than once. Either is an error, you must set this value very early \
+                       and only once.
+                       """)
+        }
+    }
+
+    private static func validateTrustedThreadCount(_ threadCount: Int) {
+        assert(threadCount > 0,
+               "BUG IN NIO, please report: negative suggested loop/thread count: \(threadCount)")
+        assert(threadCount <= 1024,
+               "BUG IN NIO, please report: overly big suggested loop/thread count: \(threadCount)")
+    }
+
+    private static func getTrustworthyThreadCount(rawStorage: ManagedAtomic<Int>, environmentVariable: String) -> Int {
+        let returnedValueUnchecked: Int
+
+        let rawSuggestion = rawStorage.load(ordering: .relaxed)
+        switch rawSuggestion {
+        case 0: // == 0
+            // Not set by user, not yet finalised, let's try to get it from the env var and fall back to
+            // `System.coreCount`.
+            let envVarString = getenv(environmentVariable).map { String(cString: $0) }
+            returnedValueUnchecked = envVarString.flatMap(Int.init) ?? System.coreCount
+        case .min ..< 0: // < 0
+            // Untrusted and unchecked user value. Let's invert and then sanitise/check.
+            returnedValueUnchecked = -rawSuggestion
+        case 1 ... .max: // > 0
+            // Trustworthy value that has been evaluated and sanitised before.
+            let returnValue = rawSuggestion
+            Self.validateTrustedThreadCount(returnValue)
+            return returnValue
+        default:
+            // Unreachable
+            preconditionFailure()
+        }
+
+        // Can't have fewer than 1, don't want more than 1024.
+        let returnValue = max(1, min(1024, returnedValueUnchecked))
+        Self.validateTrustedThreadCount(returnValue)
+
+        // Store it for next time.
+        let (exchanged, _) = rawStorage.compareExchange(expected: rawSuggestion,
+                                                        desired: returnValue,
+                                                        ordering: .relaxed)
+        if !exchanged {
+            // We lost the race, this must mean it has been concurrently set correctly so we can safely recurse
+            // and try again.
+            return Self.getTrustworthyThreadCount(rawStorage: rawStorage, environmentVariable: environmentVariable)
+        }
+        return returnValue
+    }
+}

--- a/Sources/NIOCore/GlobalSingletons.swift
+++ b/Sources/NIOCore/GlobalSingletons.swift
@@ -55,7 +55,7 @@ extension NIOSingletons {
     }
 
     /// A suggestion of how many threads the global singleton thread pools that can be used for synchronous, blocking
-    /// functions (such as ``NIOThreadPool``) are supposed to consist of
+    /// functions (such as `NIOThreadPool`) are supposed to consist of
     ///
     /// The thread count is ``System/coreCount`` unless the environment variable
     /// `NIO_SINGLETON_BLOCKING_POOL_THREAD_COUNT` is set or this value was set manually by the user.

--- a/Sources/NIOCrashTester/CrashTests+EventLoop.swift
+++ b/Sources/NIOCrashTester/CrashTests+EventLoop.swift
@@ -109,8 +109,8 @@ struct EventLoopCrashTests {
     let testUsingTheSingletonGroupWhenDisabled = CrashTest(
         regex: #"Fatal error: Cannot create global singleton MultiThreadedEventLoopGroup because the global singletons"#
     ) {
-        NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false
-        try? NIOGlobalSingletons.posixEventLoopGroup.next().submit {}.wait()
+        NIOSingletons.singletonsEnabledSuggestion = false
+        try? NIOSingletons.posixEventLoopGroup.next().submit {}.wait()
     }
 
     let testUsingTheSingletonBlockingPoolWhenDisabled = CrashTest(
@@ -120,62 +120,62 @@ struct EventLoopCrashTests {
         defer {
             try? group.syncShutdownGracefully()
         }
-        NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false
-        try? NIOGlobalSingletons.posixBlockingThreadPool.runIfActive(eventLoop: group.next(), {}).wait()
+        NIOSingletons.singletonsEnabledSuggestion = false
+        try? NIOSingletons.posixBlockingThreadPool.runIfActive(eventLoop: group.next(), {}).wait()
     }
 
-    let testDisablingGlobalSingletonsEnabledValueTwice = CrashTest(
+    let testDisablingSingletonsEnabledValueTwice = CrashTest(
         regex: #"Fatal error: Bug in user code: Global singleton enabled suggestion has been changed after"#
     ) {
-        NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false
-        NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false
+        NIOSingletons.singletonsEnabledSuggestion = false
+        NIOSingletons.singletonsEnabledSuggestion = false
     }
 
-    let testEnablingGlobalSingletonsEnabledValueTwice = CrashTest(
+    let testEnablingSingletonsEnabledValueTwice = CrashTest(
         regex: #"Fatal error: Bug in user code: Global singleton enabled suggestion has been changed after"#
     ) {
-        NIOGlobalSingletons.globalSingletonsEnabledSuggestion = true
-        NIOGlobalSingletons.globalSingletonsEnabledSuggestion = true
+        NIOSingletons.singletonsEnabledSuggestion = true
+        NIOSingletons.singletonsEnabledSuggestion = true
     }
 
-    let testEnablingThenDisablingGlobalSingletonsEnabledValue = CrashTest(
+    let testEnablingThenDisablingSingletonsEnabledValue = CrashTest(
         regex: #"Fatal error: Bug in user code: Global singleton enabled suggestion has been changed after"#
     ) {
-        NIOGlobalSingletons.globalSingletonsEnabledSuggestion = true
-        NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false
+        NIOSingletons.singletonsEnabledSuggestion = true
+        NIOSingletons.singletonsEnabledSuggestion = false
     }
 
-    let testSettingTheGlobalSingletonEnabledValueAfterUse = CrashTest(
+    let testSettingTheSingletonEnabledValueAfterUse = CrashTest(
         regex: #"Fatal error: Bug in user code: Global singleton enabled suggestion has been changed after"#
     ) {
-        try? MultiThreadedEventLoopGroup.globalSingleton.next().submit({}).wait()
-        NIOGlobalSingletons.globalSingletonsEnabledSuggestion = true
+        try? MultiThreadedEventLoopGroup.singleton.next().submit({}).wait()
+        NIOSingletons.singletonsEnabledSuggestion = true
     }
 
     let testSettingTheSuggestedSingletonGroupCountTwice = CrashTest(
         regex: #"Fatal error: Bug in user code: Global singleton suggested loop/thread count has been changed after"#
     ) {
-        NIOGlobalSingletons.suggestedGlobalSingletonGroupLoopCount = 17
-        NIOGlobalSingletons.suggestedGlobalSingletonGroupLoopCount = 17
+        NIOSingletons.groupLoopCountSuggestion = 17
+        NIOSingletons.groupLoopCountSuggestion = 17
     }
 
     let testSettingTheSuggestedSingletonGroupChangeAfterUse = CrashTest(
         regex: #"Fatal error: Bug in user code: Global singleton suggested loop/thread count has been changed after"#
     ) {
-        try? MultiThreadedEventLoopGroup.globalSingleton.next().submit({}).wait()
-        NIOGlobalSingletons.suggestedGlobalSingletonGroupLoopCount = 17
+        try? MultiThreadedEventLoopGroup.singleton.next().submit({}).wait()
+        NIOSingletons.groupLoopCountSuggestion = 17
     }
 
     let testSettingTheSuggestedSingletonGroupLoopCountToZero = CrashTest(
         regex: #"Precondition failed: illegal value: needs to be strictly positive"#
     ) {
-        NIOGlobalSingletons.suggestedGlobalSingletonGroupLoopCount = 0
+        NIOSingletons.groupLoopCountSuggestion = 0
     }
 
     let testSettingTheSuggestedSingletonGroupLoopCountToANegativeValue = CrashTest(
         regex: #"Precondition failed: illegal value: needs to be strictly positive"#
     ) {
-        NIOGlobalSingletons.suggestedGlobalSingletonGroupLoopCount = -1
+        NIOSingletons.groupLoopCountSuggestion = -1
     }
 }
 #endif

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -514,18 +514,14 @@ default:
     bindTarget = BindTo.ip(host: defaultHost, port: defaultPort)
 }
 
-let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-let threadPool = NIOThreadPool(numberOfThreads: 6)
-threadPool.start()
-
 func childChannelInitializer(channel: Channel) -> EventLoopFuture<Void> {
     return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
         channel.pipeline.addHandler(HTTPHandler(fileIO: fileIO, htdocsPath: htdocs))
     }
 }
 
-let fileIO = NonBlockingFileIO(threadPool: threadPool)
-let socketBootstrap = ServerBootstrap(group: group)
+let fileIO = NonBlockingFileIO(threadPool: .globalSingleton)
+let socketBootstrap = ServerBootstrap(group: MultiThreadedEventLoopGroup.globalSingleton)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)
     .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -537,18 +533,12 @@ let socketBootstrap = ServerBootstrap(group: group)
     .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
     .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: allowHalfClosure)
-let pipeBootstrap = NIOPipeBootstrap(group: group)
+let pipeBootstrap = NIOPipeBootstrap(group: MultiThreadedEventLoopGroup.globalSingleton)
     // Set the handlers that are applied to the accepted Channels
     .channelInitializer(childChannelInitializer(channel:))
 
     .channelOption(ChannelOptions.maxMessagesPerRead, value: 1)
     .channelOption(ChannelOptions.allowRemoteHalfClosure, value: allowHalfClosure)
-
-defer {
-    try! group.syncShutdownGracefully()
-    try! threadPool.syncShutdownGracefully()
-}
-
 print("htdocs = \(htdocs)")
 
 let channel = try { () -> Channel in

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -520,8 +520,8 @@ func childChannelInitializer(channel: Channel) -> EventLoopFuture<Void> {
     }
 }
 
-let fileIO = NonBlockingFileIO(threadPool: .globalSingleton)
-let socketBootstrap = ServerBootstrap(group: MultiThreadedEventLoopGroup.globalSingleton)
+let fileIO = NonBlockingFileIO(threadPool: .singleton)
+let socketBootstrap = ServerBootstrap(group: MultiThreadedEventLoopGroup.singleton)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)
     .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -533,7 +533,7 @@ let socketBootstrap = ServerBootstrap(group: MultiThreadedEventLoopGroup.globalS
     .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
     .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
     .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: allowHalfClosure)
-let pipeBootstrap = NIOPipeBootstrap(group: MultiThreadedEventLoopGroup.globalSingleton)
+let pipeBootstrap = NIOPipeBootstrap(group: MultiThreadedEventLoopGroup.singleton)
     // Set the handlers that are applied to the accepted Channels
     .channelInitializer(childChannelInitializer(channel:))
 

--- a/Sources/NIOPosix/PosixSingletons.swift
+++ b/Sources/NIOPosix/PosixSingletons.swift
@@ -35,9 +35,9 @@ extension MultiThreadedEventLoopGroup {
     /// A globally shared, singleton ``MultiThreadedEventLoopGroup``.
     ///
     /// SwiftNIO allows and encourages the precise management of all operating system resources such as threads and file descriptors.
-    /// Certain resources (such as the main ``EventLoopGroup``) however are usually globally shared across the program. This means
-    /// that many programs have to carry around an ``EventLoopGroup`` despite the fact they don't require the ability to fully return
-    /// all the operating resources which would imply shutting down the ``EventLoopGroup``. This type is the global handle for singleton
+    /// Certain resources (such as the main `EventLoopGroup`) however are usually globally shared across the program. This means
+    /// that many programs have to carry around an `EventLoopGroup` despite the fact they don't require the ability to fully return
+    /// all the operating resources which would imply shutting down the `EventLoopGroup`. This type is the global handle for singleton
     /// resources that applications (and some libraries) can use to obtain never-shut-down singleton resources.
     ///
     /// Programs and libraries that do not use these singletons will not incur extra resource usage, these resources are lazily initialized on

--- a/Sources/NIOPosix/PosixSingletons.swift
+++ b/Sources/NIOPosix/PosixSingletons.swift
@@ -78,7 +78,7 @@ extension NIOThreadPool {
     /// The thread count of this pool is determined by `NIOSingletons/suggestedBlockingPoolThreadCount`.
     ///
     /// - note: Users who do not want any code to spawn global singleton resources may set
-    ///         ``NIOSingletons/singletonsEnabledSuggestion`` to `false` which will lead to a forced crash
+    ///         `NIOSingletons/singletonsEnabledSuggestion` to `false` which will lead to a forced crash
     ///         if any code attempts to use the global singletons.
     public static var singleton: NIOThreadPool {
         return NIOSingletons.posixBlockingThreadPool

--- a/Sources/NIOPosix/PosixSingletons.swift
+++ b/Sources/NIOPosix/PosixSingletons.swift
@@ -14,18 +14,18 @@
 
 import NIOCore
 
-extension NIOGlobalSingletons {
+extension NIOSingletons {
     /// A globally shared, lazily initialized ``MultiThreadedEventLoopGroup``  that uses `epoll`/`kqueue` as the
     /// selector mechanism.
     ///
-    /// The number of threads is determined by ``NIOGlobalSingletons/suggestedGlobalSingletonGroupLoopCount``.
+    /// The number of threads is determined by ``NIOSingletons/groupLoopCountSuggestion``.
     public static var posixEventLoopGroup: MultiThreadedEventLoopGroup {
-        return globalSingletonMTELG
+        return singletonMTELG
     }
 
     /// A globally shared, lazily initialized ``NIOThreadPool`` that can be used for blocking I/O and other blocking operations.
     ///
-    /// The number of threads is determined by ``NIOGlobalSingletons/suggestedBlockingPoolThreadCount``.
+    /// The number of threads is determined by ``NIOSingletons/blockingPoolThreadCountSuggestion``.
     public static var posixBlockingThreadPool: NIOThreadPool {
         return globalPosixBlockingPool
     }
@@ -43,23 +43,23 @@ extension MultiThreadedEventLoopGroup {
     /// Programs and libraries that do not use these singletons will not incur extra resource usage, these resources are lazily initialized on
     /// first use.
     ///
-    /// The loop count of this group is determined by ``NIOGlobalSingletons/suggestedGlobalSingletonGroupLoopCount``.
+    /// The loop count of this group is determined by ``NIOSingletons/groupLoopCountSuggestion``.
     ///
     /// - note: Users who do not want any code to spawn global singleton resources may set
-    ///         ``NIOGlobalSingletons/globalSingletonsEnabledSuggestion`` to `false` which will lead to a forced crash
+    ///         ``NIOSingletons/singletonsEnabledSuggestion`` to `false` which will lead to a forced crash
     ///         if any code attempts to use the global singletons.
     ///
-    public static var globalSingleton: MultiThreadedEventLoopGroup {
-        return NIOGlobalSingletons.posixEventLoopGroup
+    public static var singleton: MultiThreadedEventLoopGroup {
+        return NIOSingletons.posixEventLoopGroup
     }
 }
 
 extension EventLoopGroup where Self == MultiThreadedEventLoopGroup {
     /// A globally shared, singleton ``MultiThreadedEventLoopGroup``.
     ///
-    /// This provides the same object as ``MultiThreadedEventLoopGroup/globalSingletonMultiThreadedEventLoopGroup``.
-    public static var globalSingletonMultiThreadedEventLoopGroup: Self {
-        return MultiThreadedEventLoopGroup.globalSingleton
+    /// This provides the same object as ``MultiThreadedEventLoopGroup/singleton``.
+    public static var singletonMultiThreadedEventLoopGroup: Self {
+        return MultiThreadedEventLoopGroup.singleton
     }
 }
 
@@ -75,24 +75,24 @@ extension NIOThreadPool {
     /// Programs and libraries that do not use these singletons will not incur extra resource usage, these resources are lazily initialized on
     /// first use.
     ///
-    /// The thread count of this pool is determined by ``NIOGlobalSingletons/suggestedBlockingPoolThreadCount``.
+    /// The thread count of this pool is determined by ``NIOSingletons/suggestedBlockingPoolThreadCount``.
     ///
     /// - note: Users who do not want any code to spawn global singleton resources may set
-    ///         ``NIOGlobalSingletons/globalSingletonsEnabledSuggestion`` to `false` which will lead to a forced crash
+    ///         ``NIOSingletons/singletonsEnabledSuggestion`` to `false` which will lead to a forced crash
     ///         if any code attempts to use the global singletons.
-    public static var globalSingleton: NIOThreadPool {
-        return NIOGlobalSingletons.posixBlockingThreadPool
+    public static var singleton: NIOThreadPool {
+        return NIOSingletons.posixBlockingThreadPool
     }
 }
 
-private let globalSingletonMTELG: MultiThreadedEventLoopGroup = {
-    guard NIOGlobalSingletons.globalSingletonsEnabledSuggestion else {
+private let singletonMTELG: MultiThreadedEventLoopGroup = {
+    guard NIOSingletons.singletonsEnabledSuggestion else {
         fatalError("""
                    Cannot create global singleton MultiThreadedEventLoopGroup because the global singletons have been \
-                   disabled by setting  `NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false`
+                   disabled by setting  `NIOSingletons.singletonsEnabledSuggestion = false`
                    """)
     }
-    let threadCount = NIOGlobalSingletons.suggestedGlobalSingletonGroupLoopCount
+    let threadCount = NIOSingletons.groupLoopCountSuggestion
     let group = MultiThreadedEventLoopGroup._makePerpetualGroup(threadNamePrefix: "NIO-SGLTN-",
                                                                 numberOfThreads: threadCount)
     _ = Unmanaged.passUnretained(group).retain() // Never gonna give you up,
@@ -100,14 +100,14 @@ private let globalSingletonMTELG: MultiThreadedEventLoopGroup = {
 }()
 
 private let globalPosixBlockingPool: NIOThreadPool = {
-    guard NIOGlobalSingletons.globalSingletonsEnabledSuggestion else {
+    guard NIOSingletons.singletonsEnabledSuggestion else {
         fatalError("""
                    Cannot create global singleton NIOThreadPool because the global singletons have been \
-                   disabled by setting `NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false`
+                   disabled by setting `NIOSingletons.singletonsEnabledSuggestion = false`
                    """)
     }
     let pool = NIOThreadPool._makePerpetualStartedPool(
-        numberOfThreads: NIOGlobalSingletons.suggestedBlockingPoolThreadCount,
+        numberOfThreads: NIOSingletons.blockingPoolThreadCountSuggestion,
         threadNamePrefix: "SGLTN-TP-#"
     )
     _ = Unmanaged.passUnretained(pool).retain() // never gonna let you down.

--- a/Sources/NIOPosix/PosixSingletons.swift
+++ b/Sources/NIOPosix/PosixSingletons.swift
@@ -18,14 +18,14 @@ extension NIOSingletons {
     /// A globally shared, lazily initialized ``MultiThreadedEventLoopGroup``  that uses `epoll`/`kqueue` as the
     /// selector mechanism.
     ///
-    /// The number of threads is determined by ``NIOSingletons/groupLoopCountSuggestion``.
+    /// The number of threads is determined by `NIOSingletons/groupLoopCountSuggestion`.
     public static var posixEventLoopGroup: MultiThreadedEventLoopGroup {
         return singletonMTELG
     }
 
     /// A globally shared, lazily initialized ``NIOThreadPool`` that can be used for blocking I/O and other blocking operations.
     ///
-    /// The number of threads is determined by ``NIOSingletons/blockingPoolThreadCountSuggestion``.
+    /// The number of threads is determined by `NIOSingletons/blockingPoolThreadCountSuggestion`.
     public static var posixBlockingThreadPool: NIOThreadPool {
         return globalPosixBlockingPool
     }
@@ -43,10 +43,10 @@ extension MultiThreadedEventLoopGroup {
     /// Programs and libraries that do not use these singletons will not incur extra resource usage, these resources are lazily initialized on
     /// first use.
     ///
-    /// The loop count of this group is determined by ``NIOSingletons/groupLoopCountSuggestion``.
+    /// The loop count of this group is determined by `NIOSingletons/groupLoopCountSuggestion`.
     ///
     /// - note: Users who do not want any code to spawn global singleton resources may set
-    ///         ``NIOSingletons/singletonsEnabledSuggestion`` to `false` which will lead to a forced crash
+    ///         `NIOSingletons/singletonsEnabledSuggestion` to `false` which will lead to a forced crash
     ///         if any code attempts to use the global singletons.
     ///
     public static var singleton: MultiThreadedEventLoopGroup {
@@ -75,7 +75,7 @@ extension NIOThreadPool {
     /// Programs and libraries that do not use these singletons will not incur extra resource usage, these resources are lazily initialized on
     /// first use.
     ///
-    /// The thread count of this pool is determined by ``NIOSingletons/suggestedBlockingPoolThreadCount``.
+    /// The thread count of this pool is determined by `NIOSingletons/suggestedBlockingPoolThreadCount`.
     ///
     /// - note: Users who do not want any code to spawn global singleton resources may set
     ///         ``NIOSingletons/singletonsEnabledSuggestion`` to `false` which will lead to a forced crash

--- a/Sources/NIOPosix/PosixSingletons.swift
+++ b/Sources/NIOPosix/PosixSingletons.swift
@@ -1,0 +1,117 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+extension NIOGlobalSingletons {
+    /// A globally shared, lazily initialized ``MultiThreadedEventLoopGroup``  that uses `epoll`/`kqueue` as the
+    /// selector mechanism.
+    ///
+    /// The number of threads is determined by ``NIOGlobalSingletons/suggestedGlobalSingletonGroupLoopCount``.
+    public static var posixEventLoopGroup: MultiThreadedEventLoopGroup {
+        return globalSingletonMTELG
+    }
+
+    /// A globally shared, lazily initialized ``NIOThreadPool`` that can be used for blocking I/O and other blocking operations.
+    ///
+    /// The number of threads is determined by ``NIOGlobalSingletons/suggestedBlockingPoolThreadCount``.
+    public static var posixBlockingThreadPool: NIOThreadPool {
+        return globalPosixBlockingPool
+    }
+}
+
+extension MultiThreadedEventLoopGroup {
+    /// A globally shared, singleton ``MultiThreadedEventLoopGroup``.
+    ///
+    /// SwiftNIO allows and encourages the precise management of all operating system resources such as threads and file descriptors.
+    /// Certain resources (such as the main ``EventLoopGroup``) however are usually globally shared across the program. This means
+    /// that many programs have to carry around an ``EventLoopGroup`` despite the fact they don't require the ability to fully return
+    /// all the operating resources which would imply shutting down the ``EventLoopGroup``. This type is the global handle for singleton
+    /// resources that applications (and some libraries) can use to obtain never-shut-down singleton resources.
+    ///
+    /// Programs and libraries that do not use these singletons will not incur extra resource usage, these resources are lazily initialized on
+    /// first use.
+    ///
+    /// The loop count of this group is determined by ``NIOGlobalSingletons/suggestedGlobalSingletonGroupLoopCount``.
+    ///
+    /// - note: Users who do not want any code to spawn global singleton resources may set
+    ///         ``NIOGlobalSingletons/globalSingletonsEnabledSuggestion`` to `false` which will lead to a forced crash
+    ///         if any code attempts to use the global singletons.
+    ///
+    public static var globalSingleton: MultiThreadedEventLoopGroup {
+        return NIOGlobalSingletons.posixEventLoopGroup
+    }
+}
+
+extension EventLoopGroup where Self == MultiThreadedEventLoopGroup {
+    /// A globally shared, singleton ``MultiThreadedEventLoopGroup``.
+    ///
+    /// This provides the same object as ``MultiThreadedEventLoopGroup/globalSingletonMultiThreadedEventLoopGroup``.
+    public static var globalSingletonMultiThreadedEventLoopGroup: Self {
+        return MultiThreadedEventLoopGroup.globalSingleton
+    }
+}
+
+extension NIOThreadPool {
+    /// A globally shared, singleton ``NIOThreadPool``.
+    ///
+    /// SwiftNIO allows and encourages the precise management of all operating system resources such as threads and file descriptors.
+    /// Certain resources (such as the main ``NIOThreadPool``) however are usually globally shared across the program. This means
+    /// that many programs have to carry around an ``NIOThreadPool`` despite the fact they don't require the ability to fully return
+    /// all the operating resources which would imply shutting down the ``NIOThreadPool``. This type is the global handle for singleton
+    /// resources that applications (and some libraries) can use to obtain never-shut-down singleton resources.
+    ///
+    /// Programs and libraries that do not use these singletons will not incur extra resource usage, these resources are lazily initialized on
+    /// first use.
+    ///
+    /// The thread count of this pool is determined by ``NIOGlobalSingletons/suggestedBlockingPoolThreadCount``.
+    ///
+    /// - note: Users who do not want any code to spawn global singleton resources may set
+    ///         ``NIOGlobalSingletons/globalSingletonsEnabledSuggestion`` to `false` which will lead to a forced crash
+    ///         if any code attempts to use the global singletons.
+    public static var globalSingleton: NIOThreadPool {
+        return NIOGlobalSingletons.posixBlockingThreadPool
+    }
+}
+
+private let globalSingletonMTELG: MultiThreadedEventLoopGroup = {
+    guard NIOGlobalSingletons.globalSingletonsEnabledSuggestion else {
+        fatalError("""
+                   Cannot create global singleton MultiThreadedEventLoopGroup because the global singletons have been \
+                   disabled by setting  `NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false`
+                   """)
+    }
+    let threadCount = NIOGlobalSingletons.suggestedGlobalSingletonGroupLoopCount
+    let group = MultiThreadedEventLoopGroup._makePerpetualGroup(threadNamePrefix: "NIO-SGLTN-",
+                                                                numberOfThreads: threadCount)
+    _ = Unmanaged.passUnretained(group).retain() // Never gonna give you up,
+    return group
+}()
+
+private let globalPosixBlockingPool: NIOThreadPool = {
+    guard NIOGlobalSingletons.globalSingletonsEnabledSuggestion else {
+        fatalError("""
+                   Cannot create global singleton NIOThreadPool because the global singletons have been \
+                   disabled by setting `NIOGlobalSingletons.globalSingletonsEnabledSuggestion = false`
+                   """)
+    }
+    let pool = NIOThreadPool._makePerpetualStartedPool(
+        numberOfThreads: NIOGlobalSingletons.suggestedBlockingPoolThreadCount,
+        threadNamePrefix: "SGLTN-TP-#"
+    )
+    _ = Unmanaged.passUnretained(pool).retain() // never gonna let you down.
+    return pool
+}()
+
+

--- a/Tests/NIOSingletonsTests/GlobalSingletonsTests.swift
+++ b/Tests/NIOSingletonsTests/GlobalSingletonsTests.swift
@@ -17,15 +17,15 @@ import NIOCore
 import NIOPosix
 import Foundation
 
-final class NIOGlobalSingletonsTests: XCTestCase {
+final class NIOSingletonsTests: XCTestCase {
     func testSingletonMultiThreadedEventLoopWorks() async throws {
-        let works = try await MultiThreadedEventLoopGroup.globalSingleton.any().submit { "yes" }.get()
+        let works = try await MultiThreadedEventLoopGroup.singleton.any().submit { "yes" }.get()
         XCTAssertEqual(works, "yes")
     }
 
     func testSingletonBlockingPoolWorks() async throws {
-        let works = try await NIOThreadPool.globalSingleton.runIfActive(
-            eventLoop: MultiThreadedEventLoopGroup.globalSingleton.any()
+        let works = try await NIOThreadPool.singleton.runIfActive(
+            eventLoop: MultiThreadedEventLoopGroup.singleton.any()
         ) {
             "yes"
         }.get()
@@ -33,34 +33,34 @@ final class NIOGlobalSingletonsTests: XCTestCase {
     }
 
     func testCannotShutdownMultiGroup() {
-        XCTAssertThrowsError(try MultiThreadedEventLoopGroup.globalSingleton.syncShutdownGracefully()) { error in
+        XCTAssertThrowsError(try MultiThreadedEventLoopGroup.singleton.syncShutdownGracefully()) { error in
             XCTAssertEqual(.unsupportedOperation, error as? EventLoopError)
         }
     }
 
     func testCannotShutdownBlockingPool() {
-        XCTAssertThrowsError(try NIOThreadPool.globalSingleton.syncShutdownGracefully()) { error in
+        XCTAssertThrowsError(try NIOThreadPool.singleton.syncShutdownGracefully()) { error in
             XCTAssert(error is NIOThreadPoolError.UnsupportedOperation)
         }
     }
 
     func testMultiGroupThreadPrefix() {
-        XCTAssert(MultiThreadedEventLoopGroup.globalSingleton.description.contains("NIO-SGLTN-"),
-                  "\(MultiThreadedEventLoopGroup.globalSingleton.description)")
+        XCTAssert(MultiThreadedEventLoopGroup.singleton.description.contains("NIO-SGLTN-"),
+                  "\(MultiThreadedEventLoopGroup.singleton.description)")
 
         for _ in 0..<100 {
-            let someEL = MultiThreadedEventLoopGroup.globalSingleton.next()
+            let someEL = MultiThreadedEventLoopGroup.singleton.next()
             XCTAssert(someEL.description.contains("NIO-SGLTN-"), "\(someEL.description)")
         }
     }
 
     func testSingletonsAreEnabledAndCanBeReadMoreThanOnce() {
-        XCTAssertTrue(NIOGlobalSingletons.globalSingletonsEnabledSuggestion)
-        XCTAssertTrue(NIOGlobalSingletons.globalSingletonsEnabledSuggestion)
-        XCTAssertTrue(NIOGlobalSingletons.globalSingletonsEnabledSuggestion)
+        XCTAssertTrue(NIOSingletons.singletonsEnabledSuggestion)
+        XCTAssertTrue(NIOSingletons.singletonsEnabledSuggestion)
+        XCTAssertTrue(NIOSingletons.singletonsEnabledSuggestion)
     }
 
     func testCanCreateClientBootstrapWithoutSpecifyingTypeName() {
-        _ = ClientBootstrap(group: .globalSingletonMultiThreadedEventLoopGroup)
+        _ = ClientBootstrap(group: .singletonMultiThreadedEventLoopGroup)
     }
 }

--- a/Tests/NIOSingletonsTests/GlobalSingletonsTests.swift
+++ b/Tests/NIOSingletonsTests/GlobalSingletonsTests.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import NIOCore
+import NIOPosix
+import Foundation
+
+final class NIOGlobalSingletonsTests: XCTestCase {
+    func testSingletonMultiThreadedEventLoopWorks() async throws {
+        let works = try await MultiThreadedEventLoopGroup.globalSingleton.any().submit { "yes" }.get()
+        XCTAssertEqual(works, "yes")
+    }
+
+    func testSingletonBlockingPoolWorks() async throws {
+        let works = try await NIOThreadPool.globalSingleton.runIfActive(
+            eventLoop: MultiThreadedEventLoopGroup.globalSingleton.any()
+        ) {
+            "yes"
+        }.get()
+        XCTAssertEqual(works, "yes")
+    }
+
+    func testCannotShutdownMultiGroup() {
+        XCTAssertThrowsError(try MultiThreadedEventLoopGroup.globalSingleton.syncShutdownGracefully()) { error in
+            XCTAssertEqual(.unsupportedOperation, error as? EventLoopError)
+        }
+    }
+
+    func testCannotShutdownBlockingPool() {
+        XCTAssertThrowsError(try NIOThreadPool.globalSingleton.syncShutdownGracefully()) { error in
+            XCTAssert(error is NIOThreadPoolError.UnsupportedOperation)
+        }
+    }
+
+    func testMultiGroupThreadPrefix() {
+        XCTAssert(MultiThreadedEventLoopGroup.globalSingleton.description.contains("NIO-SGLTN-"),
+                  "\(MultiThreadedEventLoopGroup.globalSingleton.description)")
+
+        for _ in 0..<100 {
+            let someEL = MultiThreadedEventLoopGroup.globalSingleton.next()
+            XCTAssert(someEL.description.contains("NIO-SGLTN-"), "\(someEL.description)")
+        }
+    }
+
+    func testSingletonsAreEnabledAndCanBeReadMoreThanOnce() {
+        XCTAssertTrue(NIOGlobalSingletons.globalSingletonsEnabledSuggestion)
+        XCTAssertTrue(NIOGlobalSingletons.globalSingletonsEnabledSuggestion)
+        XCTAssertTrue(NIOGlobalSingletons.globalSingletonsEnabledSuggestion)
+    }
+
+    func testCanCreateClientBootstrapWithoutSpecifyingTypeName() {
+        _ = ClientBootstrap(group: .globalSingletonMultiThreadedEventLoopGroup)
+    }
+}


### PR DESCRIPTION
### Motivation:

SwiftNIO allows and encourages to precisely manage all operating system resources like file descriptors & threads. That is a very important property of the system but in many places -- especially since Swift Concurrency arrived -- many simpler SwiftNIO programs only require a single, globally shared EventLoopGroup. Often even with just one thread.

Long story short: Many, probably most users would happily trade precise control over the threads for not having to pass around `EventLoopGroup`s. Today, many of those users resort to creating (and often leaking) threads because it's simpler. Adding a `.globalSingle` static var which _lazily_ provides singleton `EventLoopGroup`s and `NIOThreadPool`s is IMHO a much better answer.

Finally, this aligns SwiftNIO a little more with Apple's SDKs which have a lot of global singletons that hold onto system resources (`Dispatch`'s thread pool, `URLSession.shared`, ...). At least in `Dispatch`'s case the Apple SDKs actually make it impossible to manage the resources, there can only ever be one global pool of threads. That's fine for app development but wouldn't be good enough for certain server use cases, therefore I propose to add `NIOSingleton`s as an _option_ to the user. Confident programmers (especially in libraries) are still free and encouraged to manage all the resources deterministically and explicitly.

Companion PRs: 
 - https://github.com/apple/swift-nio-transport-services/pull/180
 - https://github.com/swift-server/async-http-client/pull/697

### Modifications:

- Add the `NIOSingletons` type
- Add `MultiThreadedEventLoopGroup.singleton`
- Add `NIOThreadPool.singleton`

### Result:

- Easier use of NIO that requires fewer parameters for users who don't require full control.
- Helps with #2142
- Fixes #2472
- Partially addresses #2473 