### PR TITLE
Skip TCP_NODELAY on sockets that NIO doesn't explicitly support

### DIFF
--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -2770,9 +2770,9 @@ public final class ChannelTests: XCTestCase {
         XCTAssertEqual(1, counter.errorCaughtCalls)
     }
 
-    func _testTCP_NODELAYis(
-        enabledByDefault: Bool,
-        for socketAddress: SocketAddress,
+    func _testTCP_NODELAYDefaultValue(
+        value: Bool,
+        _ socketAddress: SocketAddress,
         file: StaticString = #file,
         line: UInt = #line
     ) throws {
@@ -2808,31 +2808,31 @@ public final class ChannelTests: XCTestCase {
         XCTAssertNoThrow(
             XCTAssertEqual(
                 try getBoolSocketOption(channel: accepted, level: .tcp, name: .tcp_nodelay),
-                enabledByDefault,
+                value,
                 file: file, line: line),
             file: file, line: line
         )
         XCTAssertNoThrow(
             XCTAssertEqual(
                 try getBoolSocketOption(channel: client, level: .tcp, name: .tcp_nodelay),
-                enabledByDefault,
+                value,
                 file: file, line: line),
             file: file, line: line
         )
     }
 
     func testTCP_NODELAYisOnByDefaultForInetSockets() throws {
-        try _testTCP_NODELAYis(enabledByDefault: true, for: SocketAddress(ipAddress: "127.0.0.1", port: 0))
+        try _testTCP_NODELAYDefaultValue(value: true, SocketAddress(ipAddress: "127.0.0.1", port: 0))
     }
 
     func testTCP_NODELAYisOnByDefaultForInet6Sockets() throws {
         try XCTSkipUnless(System.supportsIPv6)
-        try _testTCP_NODELAYis(enabledByDefault: true, for: SocketAddress(ipAddress: "::1", port: 0))
+        try _testTCP_NODELAYDefaultValue(value: true, SocketAddress(ipAddress: "::1", port: 0))
     }
 
     func testTCP_NODELAYisOffByDefaultForUnixSockets() throws {
         try withTemporaryUnixDomainSocketPathName { udsPath in
-            try _testTCP_NODELAYis(enabledByDefault: false, for: SocketAddress(unixDomainSocketPath: udsPath))
+            try _testTCP_NODELAYDefaultValue(value: false, SocketAddress(unixDomainSocketPath: udsPath))
         }
     }
 

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -2770,39 +2770,66 @@ public final class ChannelTests: XCTestCase {
         XCTAssertEqual(1, counter.errorCaughtCalls)
     }
 
-    func testTCP_NODELAYisOnByDefault() throws {
+    func _testTCP_NODELAYis(
+        enabledByDefault: Bool,
+        for socketAddress: SocketAddress,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
         let singleThreadedELG = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
-            XCTAssertNoThrow(try singleThreadedELG.syncShutdownGracefully())
+            XCTAssertNoThrow(try singleThreadedELG.syncShutdownGracefully(), file: file, line: line)
         }
         let acceptedChannel = singleThreadedELG.next().makePromise(of: Channel.self)
-        let server = try assertNoThrowWithValue(ServerBootstrap(group: singleThreadedELG)
+        let server = try assertNoThrowWithValue(
+            ServerBootstrap(group: singleThreadedELG)
             .childChannelInitializer { channel in
                 acceptedChannel.succeed(channel)
                 return channel.eventLoop.makeSucceededFuture(())
             }
-            .bind(host: "127.0.0.1", port: 0)
-            .wait())
+            .bind(to: socketAddress)
+            .wait(),
+            file: file, line: line
+        )
         defer {
-            XCTAssertNoThrow(try server.close().wait())
+            XCTAssertNoThrow(try server.close().wait(), file: file, line: line)
         }
-        XCTAssertNoThrow(XCTAssertTrue(try getBoolSocketOption(channel: server,
-                                                               level: .tcp,
-                                                               name: .tcp_nodelay)))
 
-        let client = try assertNoThrowWithValue(ClientBootstrap(group: singleThreadedELG)
+        let client = try assertNoThrowWithValue(
+            ClientBootstrap(group: singleThreadedELG)
             .connect(to: server.localAddress!)
-            .wait())
-        let accepted = try assertNoThrowWithValue(acceptedChannel.futureResult.wait())
+            .wait(),
+            file: file, line: line
+        )
+        let accepted = try assertNoThrowWithValue(acceptedChannel.futureResult.wait(), file: file, line: line)
         defer {
-            XCTAssertNoThrow(try client.close().wait())
+            XCTAssertNoThrow(try client.close().wait(), file: file, line: line)
         }
-        XCTAssertNoThrow(XCTAssertTrue(try getBoolSocketOption(channel: accepted,
-                                                               level: .tcp,
-                                                               name: .tcp_nodelay)))
-        XCTAssertNoThrow(XCTAssertTrue(try getBoolSocketOption(channel: client,
-                                                               level: .tcp,
-                                                               name: .tcp_nodelay)))
+        XCTAssertNoThrow(
+            XCTAssertEqual(
+                try getBoolSocketOption(channel: accepted, level: .tcp, name: .tcp_nodelay),
+                enabledByDefault,
+                file: file, line: line),
+            file: file, line: line
+        )
+        XCTAssertNoThrow(
+            XCTAssertEqual(
+                try getBoolSocketOption(channel: client, level: .tcp, name: .tcp_nodelay),
+                enabledByDefault,
+                file: file, line: line),
+            file: file, line: line
+        )
+    }
+
+    func testTCP_NODELAYisOnByDefaultForInetSockets() throws {
+        try _testTCP_NODELAYis(enabledByDefault: true, for: SocketAddress(ipAddress: "127.0.0.1", port: 0))
+        try _testTCP_NODELAYis(enabledByDefault: true, for: SocketAddress(ipAddress: "::1", port: 0))
+    }
+
+    func testTCP_NODELAYisOffByDefaultForUnixSockets() throws {
+        try withTemporaryUnixDomainSocketPathName { udsPath in
+            try _testTCP_NODELAYis(enabledByDefault: false, for: SocketAddress(unixDomainSocketPath: udsPath))
+        }
     }
 
     func testDescriptionCanBeCalledFromNonEventLoopThreads() {

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -2830,12 +2830,6 @@ public final class ChannelTests: XCTestCase {
         try _testTCP_NODELAYDefaultValue(value: true, SocketAddress(ipAddress: "::1", port: 0))
     }
 
-    func testTCP_NODELAYisOffByDefaultForUnixSockets() throws {
-        try withTemporaryUnixDomainSocketPathName { udsPath in
-            try _testTCP_NODELAYDefaultValue(value: false, SocketAddress(unixDomainSocketPath: udsPath))
-        }
-    }
-
     func testDescriptionCanBeCalledFromNonEventLoopThreads() {
         // regression test for https://github.com/apple/swift-nio/issues/1141
         let q = DispatchQueue(label: "elsewhere")

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -2823,6 +2823,10 @@ public final class ChannelTests: XCTestCase {
 
     func testTCP_NODELAYisOnByDefaultForInetSockets() throws {
         try _testTCP_NODELAYis(enabledByDefault: true, for: SocketAddress(ipAddress: "127.0.0.1", port: 0))
+    }
+
+    func testTCP_NODELAYisOnByDefaultForInet6Sockets() throws {
+        try XCTSkipUnless(System.supportsIPv6)
         try _testTCP_NODELAYis(enabledByDefault: true, for: SocketAddress(ipAddress: "::1", port: 0))
     }
 


### PR DESCRIPTION
### Motivation:

NIO automatically calls `setsockopt` with `TCP_NODELAY` unless the protocol family is `PF_UNIX`. However, since NIO offers API that allows users to create sockets out of band (`withConnectedSocket(_:)` and `withBoundSocket(_:)`), it cannot know whether the socket supports this option or not.

### Modifications:

This PR inverts the filter so that it is only added for `PF_INET` and `PF_INET6`. Any other socket, e.g. `PF_UNIX`, or any socket that NIO doesn't explicitly handle.

### Result:

`TCP_NODELAY` is skipped for sockets that NIO doesn't know about.