### PR TITLE
Throw SocketAddressError (cf. fatalError) in SocketAddress.convert for unknown address family

### DIFF
--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -382,6 +382,10 @@ func __testOnly_convertSockAddr(_ addr: sockaddr_storage) -> sockaddr_un {
     return addr.convert()
 }
 
+func __testOnly_convertSockAddr(_ addr: sockaddr_storage) throws -> SocketAddress {
+    return try addr.convert()
+}
+
 func __testOnly_withMutableSockAddr<ReturnType>(
     _ addr: inout sockaddr_storage, _ body: (UnsafeMutablePointer<sockaddr>, Int) throws -> ReturnType
 ) rethrows -> ReturnType {

--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -74,7 +74,7 @@ extension sockaddr_storage {
     }
 
     /// Converts the `socketaddr_storage` to a `SocketAddress`.
-    func convert() -> SocketAddress {
+    func convert() throws -> SocketAddress {
         switch NIOBSDSocket.AddressFamily(rawValue: CInt(self.ss_family)) {
         case .inet:
             let sockAddr: sockaddr_in = self.convert()
@@ -85,7 +85,7 @@ extension sockaddr_storage {
         case .unix:
             return SocketAddress(self.convert() as sockaddr_un)
         default:
-            fatalError("unknown sockaddr family \(self.ss_family)")
+            throw SocketAddressError.unsupported
         }
     }
 }
@@ -154,7 +154,7 @@ class BaseSocket: BaseSocketProtocol {
                 try body($0, addressPtr, &size)
             }
         }
-        return addr.convert()
+        return try addr.convert()
     }
 
     /// Create a new socket and return the file descriptor of it.

--- a/Sources/NIOPosix/DatagramVectorReadManager.swift
+++ b/Sources/NIOPosix/DatagramVectorReadManager.swift
@@ -178,7 +178,9 @@ struct DatagramVectorReadManager {
 #else
             precondition(self.messageVector[i].msg_hdr.msg_namelen != 0, "Unexpected zero length peer name")
 #endif
-            let address: SocketAddress = self.sockaddrVector[i].convert()
+            let address: SocketAddress
+            do { address = try self.sockaddrVector[i].convert() }
+            catch { fatalError("Socket address conversion failed.") }
             
             // Extract congestion information if requested.
             let metadata: AddressedEnvelope<ByteBuffer>.Metadata?

--- a/Sources/NIOPosix/DatagramVectorReadManager.swift
+++ b/Sources/NIOPosix/DatagramVectorReadManager.swift
@@ -136,10 +136,10 @@ struct DatagramVectorReadManager {
             return .none
         case .processed(let messagesProcessed):
             buffer.moveWriterIndex(to: messageSize * messagesProcessed)
-            return self.buildMessages(messageCount: messagesProcessed,
-                                      sliceSize: messageSize,
-                                      buffer: &buffer,
-                                      parseControlMessages: parseControlMessages)
+            return try self.buildMessages(messageCount: messagesProcessed,
+                                          sliceSize: messageSize,
+                                          buffer: &buffer,
+                                          parseControlMessages: parseControlMessages)
         }
     }
 
@@ -154,7 +154,7 @@ struct DatagramVectorReadManager {
     private func buildMessages(messageCount: Int,
                                sliceSize: Int,
                                buffer: inout ByteBuffer,
-                               parseControlMessages: Bool) -> ReadResult {
+                               parseControlMessages: Bool) throws -> ReadResult {
         var sliceOffset = buffer.readerIndex
         var totalReadSize = 0
 
@@ -178,7 +178,7 @@ struct DatagramVectorReadManager {
 #else
             precondition(self.messageVector[i].msg_hdr.msg_namelen != 0, "Unexpected zero length peer name")
 #endif
-            let address: SocketAddress = try! self.sockaddrVector[i].convert()
+            let address: SocketAddress = try self.sockaddrVector[i].convert()
             
             // Extract congestion information if requested.
             let metadata: AddressedEnvelope<ByteBuffer>.Metadata?

--- a/Sources/NIOPosix/DatagramVectorReadManager.swift
+++ b/Sources/NIOPosix/DatagramVectorReadManager.swift
@@ -178,9 +178,7 @@ struct DatagramVectorReadManager {
 #else
             precondition(self.messageVector[i].msg_hdr.msg_namelen != 0, "Unexpected zero length peer name")
 #endif
-            let address: SocketAddress
-            do { address = try self.sockaddrVector[i].convert() }
-            catch { fatalError("Socket address conversion failed.") }
+            let address: SocketAddress = try! self.sockaddrVector[i].convert()
             
             // Extract congestion information if requested.
             let metadata: AddressedEnvelope<ByteBuffer>.Metadata?

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -651,7 +651,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                     metadata = nil
                 }
 
-                let msg = AddressedEnvelope(remoteAddress: rawAddress.convert(),
+                let msg = AddressedEnvelope(remoteAddress: try rawAddress.convert(),
                                             data: buffer,
                                             metadata: metadata)
                 assert(self.isActive)

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -640,6 +640,8 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
             switch result {
             case .processed(let bytesRead):
                 assert(self.isOpen)
+                let remoteAddress: SocketAddress = try rawAddress.convert()
+
                 self.recvBufferPool.record(actualReadBytes: bytesRead)
                 readPending = false
 
@@ -651,7 +653,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                     metadata = nil
                 }
 
-                let msg = AddressedEnvelope(remoteAddress: try rawAddress.convert(),
+                let msg = AddressedEnvelope(remoteAddress: remoteAddress,
                                             data: buffer,
                                             metadata: metadata)
                 assert(self.isActive)

--- a/Tests/NIOPosixTests/SocketAddressTest.swift
+++ b/Tests/NIOPosixTests/SocketAddressTest.swift
@@ -203,9 +203,9 @@ class SocketAddressTest: XCTestCase {
         XCTAssertEqual(memcmp(&thirdIPAddress, &thirdCopy, MemoryLayout<sockaddr_un>.size), 0)
 
         // Test unsupported socket address family.
-        var sysAddr = sockaddr_storage()
-        sysAddr.ss_family = sa_family_t(AF_SYSTEM)
-        XCTAssertThrowsError(try sysAddr.convert() as SocketAddress) { error in
+        var unspecAddr = sockaddr_storage()
+        unspecAddr.ss_family = sa_family_t(AF_UNSPEC)
+        XCTAssertThrowsError(try unspecAddr.convert() as SocketAddress) { error in
             guard case .unsupported = error as? SocketAddressError else {
                 XCTFail("Expected error \(SocketAddressError.unsupported), got error \(error).")
                 return

--- a/Tests/NIOPosixTests/SocketAddressTest.swift
+++ b/Tests/NIOPosixTests/SocketAddressTest.swift
@@ -205,7 +205,7 @@ class SocketAddressTest: XCTestCase {
         // Test unsupported socket address family.
         var unspecAddr = sockaddr_storage()
         unspecAddr.ss_family = sa_family_t(AF_UNSPEC)
-        XCTAssertThrowsError(try unspecAddr.convert() as SocketAddress) { error in
+        XCTAssertThrowsError(try __testOnly_convertSockAddr(unspecAddr) as SocketAddress) { error in
             guard case .unsupported = error as? SocketAddressError else {
                 XCTFail("Expected error \(SocketAddressError.unsupported), got error \(error).")
                 return

--- a/Tests/NIOPosixTests/SocketAddressTest.swift
+++ b/Tests/NIOPosixTests/SocketAddressTest.swift
@@ -201,6 +201,16 @@ class SocketAddressTest: XCTestCase {
         XCTAssertEqual(memcmp(&firstIPAddress, &firstCopy, MemoryLayout<sockaddr_in>.size), 0)
         XCTAssertEqual(memcmp(&secondIPAddress, &secondCopy, MemoryLayout<sockaddr_in6>.size), 0)
         XCTAssertEqual(memcmp(&thirdIPAddress, &thirdCopy, MemoryLayout<sockaddr_un>.size), 0)
+
+        // Test unsupported socket address family.
+        var sysAddr = sockaddr_storage()
+        sysAddr.ss_family = sa_family_t(AF_SYSTEM)
+        XCTAssertThrowsError(try sysAddr.convert() as SocketAddress) { error in
+            guard case .unsupported = error as? SocketAddressError else {
+                XCTFail("Expected error \(SocketAddressError.unsupported), got error \(error).")
+                return
+            }
+        }
     }
 
     func testComparingSockaddrs() throws {


### PR DESCRIPTION
### Motivation:

NIO currently fails with `fatalError` when converting a `sockaddr_storage` if it is not one of the socket addresses that NIO explicitly supports (`AF_UNIX`, `AF_INET`, or `AF_INET6`). However, since NIO offers API that allows users to create sockets out of band (`withConnectedSocket(_:)` and `withBoundSocket(_:)`), it's possible a user has provided a socket of a different family.

### Modifications:

Instead of crashing, `SocketAddress.convert()` now throws `SocketAddressError.unsupported`, and whether to crash (or just propagate the error) is moved up the stack.

### Result:

It's possible to bootstrap clients and servers with other kinds of sockets, even if NIO cannot convert them to one of the `SocketAddress` cases it knows about.