### PR TITLE
Add bootstrap APIs for VSOCK sockets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,7 @@ let package = Package(
             name: "NIOCore",
             dependencies: [
                 "NIOConcurrencyHelpers",
+                "CNIODarwin",
                 "CNIOLinux",
                 "CNIOWindows",
                 swiftCollections,

--- a/Sources/CNIODarwin/include/CNIODarwin.h
+++ b/Sources/CNIODarwin/include/CNIODarwin.h
@@ -16,6 +16,7 @@
 
 #ifdef __APPLE__
 #include <sys/socket.h>
+#include <sys/vsock.h>
 #include <time.h>
 
 // Darwin platforms do not have a sendmmsg implementation available to them. This C module
@@ -49,6 +50,8 @@ const void *CNIODarwin_CMSG_DATA(const struct cmsghdr *);
 void *CNIODarwin_CMSG_DATA_MUTABLE(struct cmsghdr *);
 size_t CNIODarwin_CMSG_LEN(size_t);
 size_t CNIODarwin_CMSG_SPACE(size_t);
+
+uint32_t CNIODarwin_get_local_vsock_cid(int socket);
 
 #endif  // __APPLE__
 #endif  // C_NIO_DARWIN_H

--- a/Sources/CNIODarwin/shim.c
+++ b/Sources/CNIODarwin/shim.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <netinet/ip.h>
 #include <netinet/in.h>
+#include <sys/ioctl.h>
 
 int CNIODarwin_sendmmsg(int sockfd, CNIODarwin_mmsghdr *msgvec, unsigned int vlen, int flags) {
     // Some quick error checking. If vlen can't fit into int, we bail.
@@ -90,4 +91,9 @@ const int CNIODarwin_IPTOS_ECN_CE = IPTOS_ECN_CE;
 const int CNIODarwin_IPV6_RECVPKTINFO = IPV6_RECVPKTINFO;
 const int CNIODarwin_IPV6_PKTINFO = IPV6_PKTINFO;
 
+uint32_t CNIODarwin_get_local_vsock_cid(int socket) {
+    uint32_t cid = 0;
+    int result = ioctl(socket, IOCTL_VM_SOCKETS_GET_LOCAL_CID, &cid);
+    return cid;
+}
 #endif  // __APPLE__

--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -29,6 +29,7 @@
 #include <netinet/ip.h>
 #include <netinet/udp.h>
 #include "liburing_nio.h"
+#include <linux/vm_sockets.h>
 
 #if __has_include(<linux/mptcp.h>)
 #include <linux/mptcp.h>
@@ -113,6 +114,8 @@ bool CNIOLinux_supports_udp_segment();
 bool CNIOLinux_supports_udp_gro();
 
 int CNIOLinux_system_info(struct utsname* uname_data);
+
+uint32_t CNIOLinux_get_local_vsock_cid(int socket);
 
 #endif
 #endif

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -182,4 +182,20 @@ int CNIOLinux_system_info(struct utsname* uname_data) {
     return uname(uname_data);
 }
 
+/// For consistency with Darwin API, on which this is the only way to get the local CID.
+///
+/// While Linux and Darwin both support `IOCTL_VM_SOCKETS_GET_LOCAL_CID`, they operate on different
+/// special files.
+///
+/// - On Darwin, `IOCTL_VM_SOCKETS_GET_LOCAL_CID` is called with the socket to get the local CID.
+///
+/// - On Linux, `IOCTL_VM_SOCKETS_GET_LOCAL_CID` is called with `/dev/vsock` and, while it is a
+/// supported way to get the local CID, the man page encourages the use of `VMADDR_CID_LOCAL` instead.
+///
+/// This Linux API exists solely for consistency with Darwin platforms and, as such, makes no use of
+/// the parameter and just returns `VMADDR_CID_LOCAL`.
+uint32_t CNIOLinux_get_local_vsock_cid(int __unused__) {
+    return VMADDR_CID_LOCAL;
+}
+
 #endif

--- a/Sources/NIOCore/VsockAddress.swift
+++ b/Sources/NIOCore/VsockAddress.swift
@@ -1,0 +1,221 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+#if canImport(Darwin) || os(Linux)
+
+#if canImport(Darwin)
+import Darwin
+import CNIODarwin
+fileprivate let get_local_vsock_cid: @convention(c) (CInt) -> UInt32 = CNIODarwin_get_local_vsock_cid
+#elseif os(Linux)
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+import CNIOLinux
+fileprivate let get_local_vsock_cid: @convention(c) (CInt) -> UInt32 = CNIOLinux_get_local_vsock_cid
+#else
+#error("Unable to identify your C library.")
+#endif
+
+/// A vsock socket address.
+///
+/// A socket address is defined as a combination of a Context Identifier (CID) and a port number.
+/// The CID identifies the source or destination, which is either a virtual machine or the host.
+/// The port number differentiates between multiple services running on a single machine.
+///
+/// For well-known CID values and port numbers, see ``ContextID`` and ``Port`` respectively.
+public struct VsockAddress: Sendable {
+    private let _storage: Box<sockaddr_vm>
+
+    /// The libc socket address for a vsock socket.
+    public var address: sockaddr_vm { return _storage.value }
+
+    /// Get the context ID associated with the address.
+    public var cid: Int {
+        Int(Int32(bitPattern: self.address.svm_cid))
+    }
+
+    /// Get the port associated with the address.
+    public var port: Int {
+        Int(Int32(bitPattern: self.address.svm_port))
+    }
+
+    /// Creates a new vsock address.
+    ///
+    /// - parameters:
+    ///     - address: the `sockaddr_vm` that holds the context ID and port.
+    public init(address: sockaddr_vm) {
+        self._storage = Box(address)
+    }
+
+    public init(cid: UInt32, port: UInt32) {
+        var addr = sockaddr_vm()
+        addr.svm_family = sa_family_t(NIOBSDSocket.AddressFamily.vsock.rawValue)
+        addr.svm_cid = cid
+        addr.svm_port = port
+        self.init(address: addr)
+    }
+
+    /// Creates a new vsock address.
+    ///
+    /// - parameters:
+    ///   - cid: the context ID.
+    ///   - port: the target port.
+    /// - returns: the `SocketAddress` for the given context ID and port combination.
+    public init(cid: Int, port: Int) {
+        self.init(cid: UInt32(bitPattern: Int32(truncatingIfNeeded: cid)), port: UInt32(bitPattern: Int32(truncatingIfNeeded: port)))
+    }
+
+    /// Get the local context ID for a vsock socket.
+    ///
+    /// - parameters:
+    ///   - socket: The vsock socket to get the local context ID for.
+    ///
+    /// - NOTE: On Linux, you can use `VMADDR_CID_LOCAL` to retrieve the local context ID, which does not require a socket.
+    public static func localVsockContextID(_ socket: NIOBSDSocket.Handle) -> Int {
+        Int(get_local_vsock_cid(socket))
+    }
+}
+
+extension VsockAddress {
+    /// A vsock Context Identifier (CID).
+    ///
+    /// The CID identifies the source or destination, which is either a virtual machine or the host.
+    public struct ContextID: RawRepresentable, ExpressibleByIntegerLiteral, Hashable, Sendable {
+        public var rawValue: UInt32
+
+        public init(rawValue: UInt32) {
+            self.rawValue = rawValue
+        }
+
+        public init(integerLiteral value: UInt32) {
+            self.init(rawValue: value)
+        }
+
+        /// Wildcard, matches any address.
+        ///
+        /// On all platforms, using this value with `bind(2)` means "any address".
+        ///
+        /// On Darwin platforms, the man page states this can be used with `connect(2)` to mean "this host".
+        public static let any: Self = Self(rawValue: VMADDR_CID_ANY)
+
+        /// The address of the hypervisor.
+        public static let hypervisor: Self = Self(rawValue: UInt32(VMADDR_CID_HYPERVISOR))
+
+        /// The address of the host.
+        public static let host: Self = Self(rawValue: UInt32(VMADDR_CID_HOST))
+
+#if os(Linux)
+        /// The address for local communication (loopback).
+        ///
+        /// This directs packets to the same host that generated them.  This is useful for testing
+        /// applications on a single host and for debugging.
+        ///
+        /// The local context ID obtained with ``getLocalContextID(_:)`` can be used for the same
+        /// purpose, but it is preferable to use ``local``.
+        public static let local: Self = Self(rawValue: UInt32(VMADDR_CID_LOCAL))
+#endif
+
+        /// Get the context ID of the local machine.
+        ///
+        /// On Linux, consider using ``local`` when binding instead of this function.
+        public static func getLocalContextID(_ socket: NIOBSDSocket.Handle) -> Self {
+            Self(rawValue: get_local_vsock_cid(socket))
+        }
+    }
+
+    /// A vsock port number.
+    ///
+    /// The vsock port number differentiates between multiple services running on a single machine.
+    public struct Port: RawRepresentable, ExpressibleByIntegerLiteral, Hashable, Sendable {
+        public var rawValue: UInt32
+
+        public init(rawValue: UInt32) {
+            self.rawValue = rawValue
+        }
+
+        public init(integerLiteral value: UInt32) {
+            self.init(rawValue: value)
+        }
+
+        /// Used to bind to any port number.
+        public static let any: Self = Self(rawValue: VMADDR_PORT_ANY)
+    }
+
+    /// Creates a new vsock address.
+    ///
+    /// - parameters:
+    ///   - cid: the context ID.
+    ///   - port: the target port.
+    /// - returns: the `SocketAddress` for the given context ID and port combination.
+    public init(cid: ContextID, port: Port) {
+        self.init(cid: cid.rawValue, port: port.rawValue)
+    }
+}
+
+extension VsockAddress: CustomStringConvertible {
+    public var description: String {
+        "[VSOCK]\(self.cid):\(self.port)"
+    }
+}
+
+/// Element-wise Equatable conformance using only the struct fields defined in the man page (excluding lengths).
+extension VsockAddress: Equatable {
+    public static func == (lhs: VsockAddress, rhs: VsockAddress) -> Bool {
+        (
+            lhs.address.svm_family == rhs.address.svm_family
+            && lhs.address.svm_reserved1 == rhs.address.svm_reserved1
+            && lhs.address.svm_port == rhs.address.svm_port
+            && lhs.address.svm_cid == rhs.address.svm_cid
+        )
+    }
+}
+
+/// Element-wise Hashable conformance using only the struct fields defined in the man page (excluding lengths).
+extension VsockAddress: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.address.svm_family)
+        hasher.combine(self.address.svm_reserved1)
+        hasher.combine(self.address.svm_port)
+        hasher.combine(self.address.svm_cid)
+    }
+}
+
+extension VsockAddress: SockAddrProtocol {
+    public func withSockAddr<T>(_ body: (UnsafePointer<sockaddr>, Int) throws -> T) rethrows -> T {
+        try self.address.withSockAddr({ try body($0, $1) })
+    }
+}
+
+extension NIOBSDSocket.AddressFamily {
+    /// Address for vsock.
+    public static let vsock: NIOBSDSocket.AddressFamily =
+            NIOBSDSocket.AddressFamily(rawValue: AF_VSOCK)
+}
+
+extension NIOBSDSocket.ProtocolFamily {
+    /// Vsock protocol.
+    public static let vsock: NIOBSDSocket.ProtocolFamily =
+            NIOBSDSocket.ProtocolFamily(rawValue: PF_VSOCK)
+}
+
+extension sockaddr_vm: SockAddrProtocol {
+    func withSockAddr<R>(_ body: (UnsafePointer<sockaddr>, Int) throws -> R) rethrows -> R {
+        return try withUnsafeBytes(of: self) { p in
+            try body(p.baseAddress!.assumingMemoryBound(to: sockaddr.self), p.count)
+        }
+    }
+}
+#endif  // canImport(Darwin) || os(Linux)

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -24,7 +24,7 @@ private final class EchoHandler: ChannelInboundHandler {
     private var receiveBuffer: ByteBuffer = ByteBuffer()
     
     public func channelActive(context: ChannelHandlerContext) {
-        print("Client connected to \(context.remoteAddress!)")
+        print("Client connected to \(context.remoteAddress?.description ?? "unknown")")
         
         // We are connected. It's time to send the message to the server to initialize the ping-pong sequence.
         let buffer = context.channel.allocator.buffer(string: line)
@@ -75,18 +75,22 @@ let defaultPort: Int = 9999
 enum ConnectTo {
     case ip(host: String, port: Int)
     case unixDomainSocket(path: String)
+    case vsock(cid: Int, port: Int)
 }
 
 let connectTarget: ConnectTo
 switch (arg1, arg1.flatMap(Int.init), arg2.flatMap(Int.init)) {
-case (.some(let h), _ , .some(let p)):
-    /* we got two arguments, let's interpret that as host and port */
+case (_, .some(let cid), .some(let port)):
+    /* we got two arguments (Int, Int), let's interpret that as vsock cid and port */
+    connectTarget = .vsock(cid: cid, port: port)
+case (.some(let h), .none, .some(let p)):
+    /* we got two arguments (String, Int), let's interpret that as host and port */
     connectTarget = .ip(host: h, port: p)
-case (.some(let portString), .none, _):
-    /* couldn't parse as number, expecting unix domain socket path */
+case (.some(let portString), .none, .none):
+    /* we got one argument (String), let's interpret that as unix domain socket path */
     connectTarget = .unixDomainSocket(path: portString)
 case (_, .some(let p), _):
-    /* only one argument --> port */
+    /* we got one argument (Int), let's interpret that as port on default host */
     connectTarget = .ip(host: defaultHost, port: p)
 default:
     connectTarget = .ip(host: defaultHost, port: defaultPort)
@@ -98,6 +102,8 @@ let channel = try { () -> Channel in
         return try bootstrap.connect(host: host, port: port).wait()
     case .unixDomainSocket(let path):
         return try bootstrap.connect(unixDomainSocketPath: path).wait()
+    case .vsock(let cid, let port):
+        return try bootstrap.connect(to: VsockAddress(cid: cid, port: port)).wait()
     }
 }()
 

--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -70,18 +70,22 @@ let defaultPort = 9999
 enum BindTo {
     case ip(host: String, port: Int)
     case unixDomainSocket(path: String)
+    case vsock(_: VsockAddress)
 }
 
 let bindTarget: BindTo
 switch (arg1, arg1.flatMap(Int.init), arg2.flatMap(Int.init)) {
-case (.some(let h), _ , .some(let p)):
-    /* we got two arguments, let's interpret that as host and port */
+case (_, .some(let cid), .some(let port)):
+    /* we got two arguments (Int, Int), let's interpret that as vsock cid and port */
+    bindTarget = .vsock(VsockAddress(cid: cid, port: port))
+case (.some(let h), _, .some(let p)):
+    /* we got two arguments (String, Int), let's interpret that as host and port */
     bindTarget = .ip(host: h, port: p)
-case (.some(let portString), .none, _):
-    /* couldn't parse as number, expecting unix domain socket path */
-    bindTarget = .unixDomainSocket(path: portString)
-case (_, .some(let p), _):
-    /* only one argument --> port */
+case (.some(let pathString), .none, .none):
+    /* we got one argument (String), let's interpret that unix domain socket path */
+    bindTarget = .unixDomainSocket(path: pathString)
+case (_, .some(let p), .none):
+    /* we got one argument (Int), let's interpret that as port on default host */
     bindTarget = .ip(host: defaultHost, port: p)
 default:
     bindTarget = .ip(host: defaultHost, port: defaultPort)
@@ -93,10 +97,17 @@ let channel = try { () -> Channel in
         return try bootstrap.bind(host: host, port: port).wait()
     case .unixDomainSocket(let path):
         return try bootstrap.bind(unixDomainSocketPath: path).wait()
+    case .vsock(let vsockAddress):
+        return try bootstrap.bind(to: vsockAddress).wait()
     }
 }()
 
-print("Server started and listening on \(channel.localAddress!)")
+switch bindTarget {
+case .ip, .unixDomainSocket:
+    print("Server started and listening on \(channel.localAddress!)")
+case .vsock(let vsockAddress):
+    print("Server started and listening on \(vsockAddress)")
+}
 
 // This will never unblock as we don't close the ServerChannel
 try channel.closeFuture.wait()

--- a/Sources/NIOPosix/ServerSocket.swift
+++ b/Sources/NIOPosix/ServerSocket.swift
@@ -39,6 +39,10 @@ import NIOCore
         switch protocolFamily {
         case .unix:
             cleanupOnClose = true
+        #if canImport(Darwin) || os(Linux)
+        case .vsock:
+            cleanupOnClose = true
+        #endif
         default:
             cleanupOnClose = false
         }

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -117,6 +117,17 @@ typealias IOVector = iovec
         }
     }
 
+    #if canImport(Darwin) || os(Linux)
+    func connect(to address: VsockAddress) throws -> Bool {
+        return try withUnsafeHandle { fd in
+            return try address.withSockAddr { (ptr, size) in
+                return try NIOBSDSocket.connect(socket: fd, address: ptr,
+                                                address_len: socklen_t(size))
+            }
+        }
+    }
+    #endif
+
     /// Finish a previous non-blocking `connect` operation.
     ///
     /// - throws: An `IOError` if the operation failed.

--- a/Tests/NIOPosixTests/EchoServerClientTest.swift
+++ b/Tests/NIOPosixTests/EchoServerClientTest.swift
@@ -211,6 +211,52 @@ class EchoServerClientTest : XCTestCase {
         }
     }
 
+    #if canImport(Darwin) || os(Linux)
+    func testEchoVsock() throws {
+        try XCTSkipUnless(System.supportsVsock, "No vsock transport available")
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        let numBytes = 16 * 1024
+        let port = VsockAddress.Port(1234)
+        let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
+        let serverChannel = try assertNoThrowWithValue(ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.addHandler(countingHandler)
+            }
+            .bind(to: VsockAddress(cid: .any, port: port)))
+            .wait()
+
+        defer {
+            XCTAssertNoThrow(try serverChannel.close().wait())
+        }
+
+        #if canImport(Darwin)
+        let connectAddress = VsockAddress(cid: .any, port: port)
+        #elseif os(Linux)
+        let connectAddress = VsockAddress(cid: .local, port: port)
+        #endif
+        let clientChannel = try assertNoThrowWithValue(ClientBootstrap(group: group).connect(to: connectAddress).wait())
+
+        defer {
+            XCTAssertNoThrow(try clientChannel.syncCloseAcceptingAlreadyClosed())
+        }
+
+        var buffer = clientChannel.allocator.buffer(capacity: numBytes)
+
+        for i in 0..<numBytes {
+            buffer.writeInteger(UInt8(i % 256))
+        }
+
+        try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+
+        try countingHandler.assertReceived(buffer: buffer)
+    }
+    #endif
+
     func testChannelActiveOnConnect() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -26,6 +26,14 @@ extension System {
             return false
         }
     }
+
+    #if canImport(Darwin) || os(Linux)
+    static var supportsVsock: Bool {
+        guard let socket = try? Socket(protocolFamily: .vsock, type: .stream) else { return false }
+        XCTAssertNoThrow(try socket.close())
+        return true
+    }
+    #endif
 }
 
 func withPipe(_ body: (NIOCore.NIOFileHandle, NIOCore.NIOFileHandle) throws -> [NIOCore.NIOFileHandle]) throws {

--- a/Tests/NIOPosixTests/VsockAddressTest.swift
+++ b/Tests/NIOPosixTests/VsockAddressTest.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import NIOCore
+@testable import NIOPosix
+
+class VsockAddressTest: XCTestCase {
+
+    func testDescriptionWorks() throws {
+        XCTAssertEqual(VsockAddress(cid: .host, port: 12345).description, "[VSOCK]2:12345")
+        XCTAssertEqual(VsockAddress(cid: .any, port: 12345).description, "[VSOCK]-1:12345")
+    }
+
+    func testSocketAddressEqualitySpecialValues() throws {
+        XCTAssertEqual(VsockAddress(cid: .any, port: 12345), .init(cid: UInt32(bitPattern: -1), port: 12345))
+        XCTAssertEqual(VsockAddress(cid: .hypervisor, port: 12345), .init(cid: 0, port: 12345))
+        XCTAssertEqual(VsockAddress(cid: .host, port: 12345), .init(cid: 2, port: 12345))
+    }
+
+    func testSocketAddressEquality() throws {
+        XCTAssertEqual(VsockAddress(cid: 0, port: 0), .init(cid: 0, port: 0))
+        XCTAssertEqual(VsockAddress(cid: 1, port: 0), .init(cid: 1, port: 0))
+        XCTAssertEqual(VsockAddress(cid: 0, port: 1), .init(cid: 0, port: 1))
+
+        XCTAssertNotEqual(VsockAddress(cid: 0, port: 0), .init(cid: 1, port: 0))
+        XCTAssertNotEqual(VsockAddress(cid: 0, port: 0), .init(cid: 0, port: 1))
+    }
+}
+


### PR DESCRIPTION
### Motivation:

The VSOCK address family facilitates communication between virtual machines and the host they are running that need a communications channel that is independent of virtual machine network configuration.

While NIO has support for building channels using sockets that were created out of band (`withConnectedSocket(_:)` and `withBoundSocket(_:)`, there are no APIs that facilitate the creation of VSOCK-based channels.

### Modifications:

Given `AF_VSOCK` is just another address family, extending `enum SocketAddress` with a new case would be the most natural approach. However this is a breaking API change, so this pull request introduces a new type, `VsockAddress`, and some bootstrap APIs.

Note that this depends on #2477 and #2476, which make NIO more tolerant of channels backed by sockets other than those represented by `SocketAddress`.

Linux and Darwin man pages differ in both API and behaviour:

- Support for `SOCK_DGRAM`: only supported on Linux.
- Getting the local CID via `ioctl(2)`: Called with `/dev/vsock` on Linux and with the socket on Darwin.
- Use of `VMADDR_CID_LOCAL`: only present on Linux.
- Use of `VMADDR_CID_ANY` with `connect(2)`: documented only on Darwin

To accommodate these, this change only covers `SOCK_STREAM` and provides a consistent API for getting the local context ID for a socket (but discourage its use on Linux in the documentation).

This change also includes some tweaks to `NIOEchoClient` and `NIOEchoServer`—when run with two integer parameters, these are considered to be the VSOCK context ID and port number.

### Result:

It's now possible to bootstrap clients and servers using `VsockAddress`. For example, you can do the following to run `NIOEchoServer` and `NIOEchoClient` in the same Linux container over loopback (note `VMADDR_CID_LOCAL = 1` on Linux in the following example): 

```console
[root@3255e403fa47 code]# $(swift build --show-bin-path)/NIOEchoServer -1 12345
Server started and listening on nil
```

...then, exec'ing into the same container:

```console
[root@3255e403fa47 code]# $(swift build --show-bin-path)/NIOEchoClient 1 12345
Please enter line to send to the server
Hello!
Client connected to nil
Received: 'Hello!' back from the server, closing channel.
Client closed
```

It's important to callout that these binaries used to rely on `localAddress` and `remoteAddress` being non-nil. When working with sockets that are not handled by `enum SocketAddress` these _will_ be nil, so it's worth calling out because it seems common that people make the non-nil assumption.