### PR TITLE
Fix huge compile time of setUUIDBytes

### DIFF
--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -315,23 +315,23 @@ extension ByteBuffer {
         let bytes = uuid.uuid
 
         // Pack the bytes into two 'UInt64's and set them.
-        let chunk1 = UInt64(bytes.0) << 56
-            | UInt64(bytes.1) << 48
-            | UInt64(bytes.2) << 40
-            | UInt64(bytes.3) << 32
-            | UInt64(bytes.4) << 24
-            | UInt64(bytes.5) << 16
-            | UInt64(bytes.6) << 8
-            | UInt64(bytes.7)
+        var chunk1 = UInt64(bytes.0) << 56
+        chunk1 |= UInt64(bytes.1) << 48
+        chunk1 |= UInt64(bytes.2) << 40
+        chunk1 |= UInt64(bytes.3) << 32
+        chunk1 |= UInt64(bytes.4) << 24
+        chunk1 |= UInt64(bytes.5) << 16
+        chunk1 |= UInt64(bytes.6) << 8
+        chunk1 |= UInt64(bytes.7)
 
-        let chunk2 = UInt64(bytes.8) << 56
-            | UInt64(bytes.9) << 48
-            | UInt64(bytes.10) << 40
-            | UInt64(bytes.11) << 32
-            | UInt64(bytes.12) << 24
-            | UInt64(bytes.13) << 16
-            | UInt64(bytes.14) << 8
-            | UInt64(bytes.15)
+        var chunk2 = UInt64(bytes.8) << 56
+        chunk2 |= UInt64(bytes.9) << 48
+        chunk2 |= UInt64(bytes.10) << 40
+        chunk2 |= UInt64(bytes.11) << 32
+        chunk2 |= UInt64(bytes.12) << 24
+        chunk2 |= UInt64(bytes.13) << 16
+        chunk2 |= UInt64(bytes.14) << 8
+        chunk2 |= UInt64(bytes.15)
 
         var written = self.setInteger(chunk1, at: index)
         written &+= self.setInteger(chunk2, at: index &+ written)


### PR DESCRIPTION
Fix huge compile time of `ByteBuffer.setUUIDBytes`

### Motivation:

`ByteBuffer.setUUIDBytes` takes a lot of compile time.

```shell
$ swift package clean && swift build --target NIOFoundationCompat -Xswiftc -debug-time-function-bodies | grep "ByteBuffer-foundation"
0.24ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:215:26	instance method writeContiguousBytes(_:)
0.35ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:229:26	instance method setContiguousBytes(_:at:)
0.15ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:242:26	instance method writeData(_:)
2.38ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:256:26	instance method setData(_:at:)
[174/175] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
0.15ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:65:26	instance method readData(length:)
0.26ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:78:26	instance method readData(length:byteTransferStrategy:)
0.07ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:97:17	instance method getData(at:length:)
7.06ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:110:17	instance method getData(at:length:byteTransferStrategy:)
1.24ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:149:17	instance method getString(at:length:encoding:)
0.29ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:163:26	instance method readString(length:encoding:)
0.15ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:182:26	instance method writeString(_:encoding:)
1.05ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:196:26	instance method setString(_:encoding:at:)
0.25ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:203:12	initializer init(data:)
0.13ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:215:26	instance method writeContiguousBytes(_:)
0.18ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:229:26	instance method setContiguousBytes(_:at:)
0.11ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:242:26	instance method writeData(_:)
1.03ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:256:26	instance method setData(_:at:)
5.74ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:278:17	instance method getUUIDBytes(at:)
8023.77ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:314:26	instance method setUUIDBytes(_:at:)
0.26ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:345:26	instance method readUUIDBytes()
0.11ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:358:26	instance method writeUUIDBytes(_:)
0.32ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:370:17	instance method buffer(data:)
0.23ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:383:57	getter regions
0.09ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:395:12	initializer init(buffer:byteTransferStrategy:)
```

It takes 8000ms and it is 110000x slower than the minimum one.

### Modifications:

It is assumed that the compile time is increasing exponentially due to the increase in the number of undetermined type variables in the type inference process.
So use `|=` operator instead of `|` to reduce undetermined type variables.

### Result:

```shell
$ swift package clean && swift build --target NIOFoundationCompat -Xswiftc -debug-time-function-bodies | grep "ByteBuffer-foundation"
0.24ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:215:26	instance method writeContiguousBytes(_:)
0.25ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:229:26	instance method setContiguousBytes(_:at:)
0.13ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:242:26	instance method writeData(_:)
2.23ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:256:26	instance method setData(_:at:)
[175/175] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
0.17ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:65:26	instance method readData(length:)
0.27ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:78:26	instance method readData(length:byteTransferStrategy:)
0.07ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:97:17	instance method getData(at:length:)
6.95ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:110:17	instance method getData(at:length:byteTransferStrategy:)
1.37ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:149:17	instance method getString(at:length:encoding:)
0.27ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:163:26	instance method readString(length:encoding:)
0.14ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:182:26	instance method writeString(_:encoding:)
0.85ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:196:26	instance method setString(_:encoding:at:)
0.28ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:203:12	initializer init(data:)
0.12ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:215:26	instance method writeContiguousBytes(_:)
0.17ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:229:26	instance method setContiguousBytes(_:at:)
0.11ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:242:26	instance method writeData(_:)
1.05ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:256:26	instance method setData(_:at:)
5.63ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:278:17	instance method getUUIDBytes(at:)
17.57ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:314:26	instance method setUUIDBytes(_:at:)
0.21ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:345:26	instance method readUUIDBytes()
0.10ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:358:26	instance method writeUUIDBytes(_:)
0.27ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:370:17	instance method buffer(data:)
0.08ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:383:57	getter regions
0.08ms	/Users/iceman/github/swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift:395:12	initializer init(buffer:byteTransferStrategy:)
```

450x faster build time!

### env

macOS 13.4.1 (c)

```shell
$ swift --version                                                                                                                    
swift-driver version: 1.75.2 Apple Swift version 5.8 (swiftlang-5.8.0.124.2 clang-1403.0.22.11.100)
Target: arm64-apple-macosx13.0
```