### PR TITLE
Don't lose or delay writes before channelActive

### DIFF
--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -301,7 +301,7 @@ class BaseSocket: BaseSocketProtocol {
     ///     - level: The protocol level (see `man getsockopt`).
     ///     - name: The name of the option to set.
     /// - throws: An `IOError` if the operation failed.
-    final func getOption<T>(level: NIOBSDSocket.OptionLevel, name: NIOBSDSocket.Option) throws -> T {
+    func getOption<T>(level: NIOBSDSocket.OptionLevel, name: NIOBSDSocket.Option) throws -> T {
         return try self.withUnsafeHandle { fd in
             var length = socklen_t(MemoryLayout<T>.size)
             let storage = UnsafeMutableRawBufferPointer.allocate(byteCount: MemoryLayout<T>.stride,

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -411,7 +411,7 @@ public final class ServerBootstrap {
         }
     }
 
-    class AcceptHandler: ChannelInboundHandler {
+    final class AcceptHandler: ChannelInboundHandler {
         public typealias InboundIn = SocketChannel
 
         private let childChannelInit: ((Channel) -> EventLoopFuture<Void>)?

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -411,7 +411,7 @@ public final class ServerBootstrap {
         }
     }
 
-    private class AcceptHandler: ChannelInboundHandler {
+    class AcceptHandler: ChannelInboundHandler {
         public typealias InboundIn = SocketChannel
 
         private let childChannelInit: ((Channel) -> EventLoopFuture<Void>)?

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -2068,11 +2068,6 @@ public final class ChannelTests: XCTestCase {
             }
         }
         withChannel { channel in
-            checkThatItThrowsInappropriateOperationForState {
-                try channel.writeAndFlush("foo").wait()
-            }
-        }
-        withChannel { channel in
             XCTAssertThrowsError(try channel.triggerUserOutboundEvent("foo").wait()) { error in
                 if let error = error as? ChannelError {
                     XCTAssertEqual(ChannelError.operationUnsupported, error)
@@ -2181,7 +2176,8 @@ public final class ChannelTests: XCTestCase {
             .childChannelInitializer { channel in
                 var buffer = channel.allocator.buffer(capacity: 4)
                 buffer.writeString("foo")
-                return channel.write(NIOAny(buffer))
+                channel.writeAndFlush(NIOAny(buffer), promise: nil)
+                return channel.eventLoop.makeSucceededVoidFuture()
             }
             .bind(host: "127.0.0.1", port: 0)
             .wait())

--- a/Tests/NIOPosixTests/SALChannelTests.swift
+++ b/Tests/NIOPosixTests/SALChannelTests.swift
@@ -392,21 +392,21 @@ final class SALChannelTest: XCTestCase, SALTest {
         final class ConnectionRecorder: ChannelInboundHandler {
             typealias InboundIn = Any
             typealias InboundOut = Any
-
+            
             let readCount = ManagedAtomic(0)
-
+            
             func channelRead(context: ChannelHandlerContext, data: NIOAny) {
                 readCount.wrappingIncrement(ordering: .sequentiallyConsistent)
                 context.fireChannelRead(data)
             }
         }
-
+        
         let localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5)
         let remoteAddress = try! SocketAddress(ipAddress: "5.6.7.8", port: 10)
         let channel = try self.makeBoundServerSocketChannel(localAddress: localAddress)
-
+        
         let socket = try self.makeSocket()
-
+        
         let readRecorder = ConnectionRecorder()
         XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
             let readEvent = SelectorEvent(io: [.read],
@@ -417,16 +417,16 @@ final class SALChannelTest: XCTestCase, SALTest {
             try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, return: socket)
             try self.assertLocalAddress(address: localAddress)
             try self.assertRemoteAddress(address: remoteAddress)
-
+            
             // This accept is expected: we delay inbound channel registration by one EL tick. This one throws.
             // We throw a deliberate error here: this one hits the buggy codepath.
             try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, throwing: NIOFcntlFailedError())
-
+            
             // Then we register the inbound channel from the first accept.
             try self.assertRegister { selectable, eventSet, registration in
                 if case (.socketChannel(let channel), let registrationEventSet) =
                     (registration.channel, registration.interested) {
-
+                    
                     XCTAssertEqual(localAddress, channel.localAddress)
                     XCTAssertEqual(remoteAddress, channel.remoteAddress)
                     XCTAssertEqual(eventSet, registrationEventSet)
@@ -445,15 +445,442 @@ final class SALChannelTest: XCTestCase, SALTest {
                 XCTAssertEqual([.reset, .readEOF, .read], eventSet)
                 return true
             }
-
+            
             // Importantly, we should now be _parked_. This test is mostly testing in the absence:
             // we expect not to see a reregister that removes readable.
             try self.assertParkedRightNow()
         }) {
             channel.pipeline.addHandler(readRecorder)
         })
-
+        
         XCTAssertEqual(readRecorder.readCount.load(ordering: .sequentiallyConsistent), 1)
     }
 
+    func testWriteBeforeChannelActiveClientStreamDelayedConnect() {
+        guard let channel = try? self.makeSocketChannel() else {
+            XCTFail("couldn't make a channel")
+            return
+        }
+        let localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5)
+        let serverAddress = try! SocketAddress(ipAddress: "9.8.7.6", port: 5)
+        let firstWrite = ByteBuffer(string: "foo")
+        let secondWrite = ByteBuffer(string: "bar")
+
+        XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
+            try self.assertSetOption(expectedLevel: .tcp, expectedOption: .tcp_nodelay) { value in
+                return (value as? SocketOptionValue) == 1
+            }
+            try self.assertConnect(expectedAddress: serverAddress, result: false)
+            try self.assertLocalAddress(address: localAddress)
+            try self.assertRegister { selectable, event, Registration in
+                XCTAssertEqual([.reset], event)
+                return true
+            }
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .write], event)
+                return true
+            }
+
+            let writeEvent = SelectorEvent(io: [.write],
+                                          registration: NIORegistration(channel: .socketChannel(channel),
+                                                                        interested: [.reset, .write],
+                                                                        registrationID: .initialRegistrationID))
+            try self.assertWaitingForNotification(result: writeEvent)
+            try self.assertGetOption(expectedLevel: .socket, expectedOption: .so_error, value: CInt(0))
+            try self.assertRemoteAddress(address: serverAddress)
+
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .readEOF, .write], event)
+                return true
+            }
+            try self.assertWritev(expectedFD: .max, expectedBytes: [firstWrite, secondWrite], return: .processed(6))
+
+            try self.assertDeregister { selectable in
+                return true
+            }
+            try self.assertClose(expectedFD: .max)
+        }) {
+            ClientBootstrap(group: channel.eventLoop)
+                .channelOption(ChannelOptions.autoRead, value: false)
+                .channelInitializer { channel in
+                    channel.write(firstWrite, promise: nil)
+                    channel.write(secondWrite).whenComplete { _ in
+                        channel.close(promise: nil)
+                    }
+                    channel.flush()
+                    return channel.eventLoop.makeSucceededVoidFuture()
+                }
+                .testOnly_connect(injectedChannel: channel, to: serverAddress)
+                .flatMap {
+                    $0.closeFuture
+                }
+        }.salWait())
+    }
+
+    func testWriteBeforeChannelActiveClientStreamInstantConnect() {
+        guard let channel = try? self.makeSocketChannel() else {
+            XCTFail("couldn't make a channel")
+            return
+        }
+        let localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5)
+        let serverAddress = try! SocketAddress(ipAddress: "9.8.7.6", port: 5)
+        let firstWrite = ByteBuffer(string: "foo")
+        let secondWrite = ByteBuffer(string: "bar")
+
+        XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
+            try self.assertSetOption(expectedLevel: .tcp, expectedOption: .tcp_nodelay) { value in
+                return (value as? SocketOptionValue) == 1
+            }
+            try self.assertConnect(expectedAddress: serverAddress, result: true)
+            try self.assertLocalAddress(address: localAddress)
+            try self.assertRemoteAddress(address: serverAddress)
+            try self.assertRegister { selectable, event, Registration in
+                XCTAssertEqual([.reset], event)
+                return true
+            }
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .readEOF], event)
+                return true
+            }
+            try self.assertWritev(expectedFD: .max, expectedBytes: [firstWrite, secondWrite], return: .processed(6))
+
+            try self.assertDeregister { selectable in
+                return true
+            }
+            try self.assertClose(expectedFD: .max)
+        }) {
+            ClientBootstrap(group: channel.eventLoop)
+                .channelOption(ChannelOptions.autoRead, value: false)
+                .channelInitializer { channel in
+                    channel.write(firstWrite, promise: nil)
+                    channel.write(secondWrite).whenComplete { _ in
+                        channel.close(promise: nil)
+                    }
+                    channel.flush()
+                    return channel.eventLoop.makeSucceededVoidFuture()
+                }
+                .testOnly_connect(injectedChannel: channel, to: serverAddress)
+                .flatMap {
+                    $0.closeFuture
+                }
+        }.salWait())
+    }
+
+    func testWriteBeforeChannelActiveClientStreamInstantConnect_shortWriteLeadsToWritable() {
+        guard let channel = try? self.makeSocketChannel() else {
+            XCTFail("couldn't make a channel")
+            return
+        }
+        let localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5)
+        let serverAddress = try! SocketAddress(ipAddress: "9.8.7.6", port: 5)
+        let firstWrite = ByteBuffer(string: "foo")
+        let secondWrite = ByteBuffer(string: "bar")
+
+        XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
+            try self.assertSetOption(expectedLevel: .tcp, expectedOption: .tcp_nodelay) { value in
+                return (value as? SocketOptionValue) == 1
+            }
+            try self.assertConnect(expectedAddress: serverAddress, result: true)
+            try self.assertLocalAddress(address: localAddress)
+            try self.assertRemoteAddress(address: serverAddress)
+            try self.assertRegister { selectable, event, Registration in
+                XCTAssertEqual([.reset], event)
+                return true
+            }
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .readEOF], event)
+                return true
+            }
+            try self.assertWritev(expectedFD: .max, expectedBytes: [firstWrite, secondWrite], return: .processed(3))
+            try self.assertWrite(expectedFD: .max, expectedBytes: secondWrite, return: .wouldBlock(0))
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .readEOF, .write], event)
+                return true
+            }
+
+            try self.assertDeregister { selectable in
+                return true
+            }
+            try self.assertClose(expectedFD: .max)
+        }) {
+            ClientBootstrap(group: channel.eventLoop)
+                .channelOption(ChannelOptions.autoRead, value: false)
+                .channelOption(ChannelOptions.writeSpin, value: 1)
+                .channelInitializer { channel in
+                    channel.write(firstWrite).whenComplete { _ in
+                        // An extra EL spin here to ensure that the close doesn't
+                        // beat the writable
+                        channel.eventLoop.execute {
+                            channel.close(promise: nil)
+                        }
+                    }
+                    channel.write(secondWrite, promise: nil)
+                    channel.flush()
+                    return channel.eventLoop.makeSucceededVoidFuture()
+                }
+                .testOnly_connect(injectedChannel: channel, to: serverAddress)
+                .flatMap {
+                    $0.closeFuture
+                }
+        }.salWait())
+    }
+
+    func testWriteBeforeChannelActiveClientStreamInstantConnect_shortWriteLeadsToWritable_instantClose() {
+        guard let channel = try? self.makeSocketChannel() else {
+            XCTFail("couldn't make a channel")
+            return
+        }
+        let localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5)
+        let serverAddress = try! SocketAddress(ipAddress: "9.8.7.6", port: 5)
+        let firstWrite = ByteBuffer(string: "foo")
+        let secondWrite = ByteBuffer(string: "bar")
+
+        XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
+            try self.assertSetOption(expectedLevel: .tcp, expectedOption: .tcp_nodelay) { value in
+                return (value as? SocketOptionValue) == 1
+            }
+            try self.assertConnect(expectedAddress: serverAddress, result: true)
+            try self.assertLocalAddress(address: localAddress)
+            try self.assertRemoteAddress(address: serverAddress)
+            try self.assertRegister { selectable, event, Registration in
+                XCTAssertEqual([.reset], event)
+                return true
+            }
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .readEOF], event)
+                return true
+            }
+            try self.assertWritev(expectedFD: .max, expectedBytes: [firstWrite, secondWrite], return: .processed(3))
+
+            try self.assertDeregister { selectable in
+                return true
+            }
+            try self.assertClose(expectedFD: .max)
+        }) {
+            ClientBootstrap(group: channel.eventLoop)
+                .channelOption(ChannelOptions.autoRead, value: false)
+                .channelOption(ChannelOptions.writeSpin, value: 1)
+                .channelInitializer { channel in
+                    channel.write(firstWrite).whenComplete { _ in
+                        // No EL spin here so the close happens in the middle of the write spin.
+                        channel.close(promise: nil)
+                    }
+                    channel.write(secondWrite, promise: nil)
+                    channel.flush()
+                    return channel.eventLoop.makeSucceededVoidFuture()
+                }
+                .testOnly_connect(injectedChannel: channel, to: serverAddress)
+                .flatMap {
+                    $0.closeFuture
+                }
+        }.salWait())
+    }
+
+    func testWriteBeforeChannelActiveServerStream() throws {
+        let localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5)
+        let remoteAddress = try! SocketAddress(ipAddress: "5.6.7.8", port: 10)
+        let channel = try self.makeBoundServerSocketChannel(localAddress: localAddress)
+
+        let socket = try self.makeSocket()
+        let firstWrite = ByteBuffer(string: "foo")
+        let secondWrite = ByteBuffer(string: "bar")
+
+        XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
+            let readEvent = SelectorEvent(io: [.read],
+                                          registration: NIORegistration(channel: .serverSocketChannel(channel),
+                                                                        interested: [.read],
+                                                                        registrationID: .initialRegistrationID))
+            try self.assertWaitingForNotification(result: readEvent)
+            try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, return: socket)
+            try self.assertLocalAddress(address: localAddress)
+            try self.assertRemoteAddress(address: remoteAddress)
+
+            // This accept is expected: we delay inbound channel registration by one EL tick.
+            try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, return: nil)
+
+            // Then we register the inbound channel.
+            try self.assertRegister { selectable, eventSet, registration in
+                if case (.socketChannel(let channel), let registrationEventSet) =
+                    (registration.channel, registration.interested) {
+
+                    XCTAssertEqual(localAddress, channel.localAddress)
+                    XCTAssertEqual(remoteAddress, channel.remoteAddress)
+                    XCTAssertEqual(eventSet, registrationEventSet)
+                    XCTAssertEqual(.reset, eventSet)
+                    return true
+                } else {
+                    return false
+                }
+            }
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .readEOF], event)
+                return true
+            }
+
+            // We then get an immediate write which completes, then a close.
+            try self.assertWritev(expectedFD: .max, expectedBytes: [firstWrite, secondWrite], return: .processed(6))
+
+            try self.assertDeregister { selectable in
+                return true
+            }
+            try self.assertClose(expectedFD: .max)
+
+            try self.assertParkedRightNow()
+        }) {
+            channel.pipeline.addHandler(
+                ServerBootstrap.AcceptHandler(
+                    childChannelInitializer: { channel in
+                        channel.write(firstWrite, promise: nil)
+                        channel.write(secondWrite).whenComplete { _ in
+                            channel.close(promise: nil)
+                        }
+                        channel.flush()
+                        return channel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    childChannelOptions: .init()
+                ))
+        })
+    }
+
+    func testWriteBeforeChannelActiveServerStream_shortWriteLeadsToWritable() throws {
+        let localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5)
+        let remoteAddress = try! SocketAddress(ipAddress: "5.6.7.8", port: 10)
+        let channel = try self.makeBoundServerSocketChannel(localAddress: localAddress)
+
+        let socket = try self.makeSocket()
+        let firstWrite = ByteBuffer(string: "foo")
+        let secondWrite = ByteBuffer(string: "bar")
+        var childChannelOptions = ChannelOptions.Storage()
+        childChannelOptions.append(key: ChannelOptions.autoRead, value: false)
+
+        XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
+            let readEvent = SelectorEvent(io: [.read],
+                                          registration: NIORegistration(channel: .serverSocketChannel(channel),
+                                                                        interested: [.read],
+                                                                        registrationID: .initialRegistrationID))
+            try self.assertWaitingForNotification(result: readEvent)
+            try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, return: socket)
+            try self.assertLocalAddress(address: localAddress)
+            try self.assertRemoteAddress(address: remoteAddress)
+
+            // This accept is expected: we delay inbound channel registration by one EL tick.
+            try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, return: nil)
+
+            // Then we register the inbound channel.
+            try self.assertRegister { selectable, eventSet, registration in
+                if case (.socketChannel(let channel), let registrationEventSet) =
+                    (registration.channel, registration.interested) {
+
+                    XCTAssertEqual(localAddress, channel.localAddress)
+                    XCTAssertEqual(remoteAddress, channel.remoteAddress)
+                    XCTAssertEqual(eventSet, registrationEventSet)
+                    XCTAssertEqual(.reset, eventSet)
+                    return true
+                } else {
+                    return false
+                }
+            }
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .readEOF], event)
+                return true
+            }
+
+            try self.assertWritev(expectedFD: .max, expectedBytes: [firstWrite, secondWrite], return: .processed(3))
+            try self.assertWrite(expectedFD: .max, expectedBytes: secondWrite, return: .wouldBlock(0))
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .readEOF, .write], event)
+                return true
+            }
+
+            try self.assertDeregister { selectable in
+                return true
+            }
+            try self.assertClose(expectedFD: .max)
+
+            try self.assertParkedRightNow()
+        }) {
+            channel.pipeline.addHandler(
+                ServerBootstrap.AcceptHandler(
+                    childChannelInitializer: { channel in
+                        channel.write(firstWrite).whenComplete { _ in
+                            // An extra EL spin here to ensure that the close doesn't
+                            // beat the writable
+                            channel.eventLoop.execute {
+                                channel.close(promise: nil)
+                            }
+                        }
+                        channel.write(secondWrite, promise: nil)
+                        channel.flush()
+                        return channel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    childChannelOptions: childChannelOptions
+                ))
+        })
+    }
+
+    func testWriteBeforeChannelActiveServerStream_shortWriteLeadsToWritable_instantClose() throws {
+        let localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5)
+        let remoteAddress = try! SocketAddress(ipAddress: "5.6.7.8", port: 10)
+        let channel = try self.makeBoundServerSocketChannel(localAddress: localAddress)
+
+        let socket = try self.makeSocket()
+        let firstWrite = ByteBuffer(string: "foo")
+        let secondWrite = ByteBuffer(string: "bar")
+        var childChannelOptions = ChannelOptions.Storage()
+        childChannelOptions.append(key: ChannelOptions.autoRead, value: false)
+
+        XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
+            let readEvent = SelectorEvent(io: [.read],
+                                          registration: NIORegistration(channel: .serverSocketChannel(channel),
+                                                                        interested: [.read],
+                                                                        registrationID: .initialRegistrationID))
+            try self.assertWaitingForNotification(result: readEvent)
+            try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, return: socket)
+            try self.assertLocalAddress(address: localAddress)
+            try self.assertRemoteAddress(address: remoteAddress)
+
+            // This accept is expected: we delay inbound channel registration by one EL tick.
+            try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, return: nil)
+
+            // Then we register the inbound channel.
+            try self.assertRegister { selectable, eventSet, registration in
+                if case (.socketChannel(let channel), let registrationEventSet) =
+                    (registration.channel, registration.interested) {
+
+                    XCTAssertEqual(localAddress, channel.localAddress)
+                    XCTAssertEqual(remoteAddress, channel.remoteAddress)
+                    XCTAssertEqual(eventSet, registrationEventSet)
+                    XCTAssertEqual(.reset, eventSet)
+                    return true
+                } else {
+                    return false
+                }
+            }
+            try self.assertReregister { selectable, event in
+                XCTAssertEqual([.reset, .readEOF], event)
+                return true
+            }
+
+            try self.assertWritev(expectedFD: .max, expectedBytes: [firstWrite, secondWrite], return: .processed(3))
+            try self.assertDeregister { selectable in
+                return true
+            }
+            try self.assertClose(expectedFD: .max)
+
+            try self.assertParkedRightNow()
+        }) {
+            channel.pipeline.addHandler(
+                ServerBootstrap.AcceptHandler(
+                    childChannelInitializer: { channel in
+                        channel.write(firstWrite).whenComplete { _ in
+                            channel.close(promise: nil)
+                        }
+                        channel.write(secondWrite, promise: nil)
+                        channel.flush()
+                        return channel.eventLoop.makeSucceededVoidFuture()
+                    },
+                    childChannelOptions: childChannelOptions
+                ))
+        })
+    }
 }

--- a/Tests/NIOPosixTests/SALChannelTests.swift
+++ b/Tests/NIOPosixTests/SALChannelTests.swift
@@ -392,21 +392,21 @@ final class SALChannelTest: XCTestCase, SALTest {
         final class ConnectionRecorder: ChannelInboundHandler {
             typealias InboundIn = Any
             typealias InboundOut = Any
-            
+
             let readCount = ManagedAtomic(0)
-            
+
             func channelRead(context: ChannelHandlerContext, data: NIOAny) {
                 readCount.wrappingIncrement(ordering: .sequentiallyConsistent)
                 context.fireChannelRead(data)
             }
         }
-        
+
         let localAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5)
         let remoteAddress = try! SocketAddress(ipAddress: "5.6.7.8", port: 10)
         let channel = try self.makeBoundServerSocketChannel(localAddress: localAddress)
-        
+
         let socket = try self.makeSocket()
-        
+
         let readRecorder = ConnectionRecorder()
         XCTAssertNoThrow(try channel.eventLoop.runSAL(syscallAssertions: {
             let readEvent = SelectorEvent(io: [.read],
@@ -417,16 +417,16 @@ final class SALChannelTest: XCTestCase, SALTest {
             try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, return: socket)
             try self.assertLocalAddress(address: localAddress)
             try self.assertRemoteAddress(address: remoteAddress)
-            
+
             // This accept is expected: we delay inbound channel registration by one EL tick. This one throws.
             // We throw a deliberate error here: this one hits the buggy codepath.
             try self.assertAccept(expectedFD: .max, expectedNonBlocking: true, throwing: NIOFcntlFailedError())
-            
+
             // Then we register the inbound channel from the first accept.
             try self.assertRegister { selectable, eventSet, registration in
                 if case (.socketChannel(let channel), let registrationEventSet) =
                     (registration.channel, registration.interested) {
-                    
+
                     XCTAssertEqual(localAddress, channel.localAddress)
                     XCTAssertEqual(remoteAddress, channel.remoteAddress)
                     XCTAssertEqual(eventSet, registrationEventSet)
@@ -445,14 +445,14 @@ final class SALChannelTest: XCTestCase, SALTest {
                 XCTAssertEqual([.reset, .readEOF, .read], eventSet)
                 return true
             }
-            
+
             // Importantly, we should now be _parked_. This test is mostly testing in the absence:
             // we expect not to see a reregister that removes readable.
             try self.assertParkedRightNow()
         }) {
             channel.pipeline.addHandler(readRecorder)
         })
-        
+
         XCTAssertEqual(readRecorder.readCount.load(ordering: .sequentiallyConsistent), 1)
     }
 


### PR DESCRIPTION
Motivation:

In rare circumstances, some users have reported hangs, delays, or lost writes when writing network proxies. These proxies have typically been derived from our TLSify example:
https://github.com/apple/swift-nio-examples/tree/main/TLSify

This proxy makes its outbound connections in handlerAdded. Generally this works without issue, as the connection takes long enough to set up that channelActive fires before the outbound connection has been made.

However, in some rare circumstances it is possible to both make an outbound connection, have it succeed, _and_ read from the network on that connection before NIO activates the inbound channel. This would cause users to lose writes.

This violates a cardinal NIO rule: writes should never be lost. If it is practical for us to delay them and apply them later, we should. This patch addresses several holes in this area to correctly handle these outbound writes.

The first hole is that we would fail writes if the Channel wasn't yet active. This constraint was unnecessary: it was added in a refactor to use an internal state machine, and while we had a test that this happened, it didn't protect us from anything. We can safely buffer a write at this point: and indeed, we _do_ buffer flushes at this point. So the check was unneeded.

The second hole was that, even if we buffered the writes, we frequently wouldn't unbuffer them again until a flush happened after channelActive. This didn't happen on _every_ path: in the rare case that connect() succeeded immediately, we would flush the writes. But in all other cases, including listening connections, we needed _another_ flush to happen to get the writes out.

This fix patches up both issues and reconciles the flows. Now we _always_ try to push out flushed writes when we activate the Channel, just as we always try to read.

Modifications:

- Remove a check that failed writes if we weren't active.
- Remove a test that validated that we did that.
- Attempt to emit flushed writes on channelActive.
- Make sure we mark ourselves writable if we couldn't write it all.
- Make `BaseSocket.getOption` non-final so we can hook it in the SAL.
- Make `AcceptHandler` non-private so we can use it in tests.
- Extend the SAL to support `getOption`
- Write several SAL tests to ensure we manage our writes.

Result:

No lost writes.
