### PR TITLE
Fix 5.9 and nightly allocation limits (#2485)

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
@@ -130,7 +130,9 @@ func doRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> I
 
     clientChannel.write(NIOAny(HTTPClientRequestPart.head(RepeatedRequests.requestHead)), promise: nil)
     try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
-    return try repeatedRequestsHandler.wait()
+    let result = try repeatedRequestsHandler.wait()
+    try clientChannel.closeFuture.wait()
+    return result
 }
 
 func withAutoReleasePool<T>(_ execute: () throws -> T) rethrows -> T {

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=398000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=404000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=400000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -41,7 +41,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=399000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=405000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -40,7 +40,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=401000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=405050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -40,7 +40,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
       - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=401000
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=398000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050


### PR DESCRIPTION
# Motivation
Our 5.9 and nightly CI has been failing for some time now due to flaky allocation tests.

# Modification
This PR slightly changes some shared infra for how we ran some of our allocation tests. We are now waiting for the client and server channel to close so that allocations are more stable.

# Results
Green CI again
