### PR TITLE
EventLoopFuture/Promise: only Sendable if Value is Sendable

### DIFF
--- a/Sources/NIOCore/EventLoopFuture.swift
+++ b/Sources/NIOCore/EventLoopFuture.swift
@@ -2293,13 +2293,13 @@ public struct _NIOEventLoopFutureIdentifier: Hashable, Sendable {
     }
 }
 
-// EventLoopPromise is a reference type, but by its very nature is Sendable.
-extension EventLoopPromise: Sendable { }
+// EventLoopPromise is a reference type, but by its very nature is Sendable (if its Value is).
+extension EventLoopPromise: Sendable where Value: Sendable { }
 
-// EventLoopFuture is a reference type, but it is Sendable. However, we enforce
+// EventLoopFuture is a reference type, but it is Sendable (if its Value is). However, we enforce
 // that by way of the guarantees of the EventLoop protocol, so the compiler cannot
 // check it.
-extension EventLoopFuture: @unchecked Sendable { }
+extension EventLoopFuture: @unchecked Sendable where Value: Sendable { }
 
 extension EventLoopPromise where Value == Void {
     // Deliver a successful result to the associated `EventLoopFuture<Void>` object.


### PR DESCRIPTION
### Motivation:

`EventLoopFuture/Promise` are (incorrectly) marked as unconditionally `Sendable`. But this allows to send non-`Sendable` values which isn't right.

### Modifications:

Mark `EventLoopFuture/Promise` as conditionally `Sendable` if `Value` is `Sendable`.

This is technically API breaking but given the nature of the `Sendable` protocol should only result in warnings in the very most cases. The NIO release tools will assess compatibility.

### Result:

- More correctness
- More warnings for users (sorry NIO users)