### PR TITLE
Avoid using deinit to fulfil the protocol negotiation promise

### DIFF
--- a/Sources/NIOTLS/ProtocolNegotiationHandlerStateMachine.swift
+++ b/Sources/NIOTLS/ProtocolNegotiationHandlerStateMachine.swift
@@ -30,20 +30,15 @@ struct ProtocolNegotiationHandlerStateMachine<NegotiationResult> {
     private var state = State.initial
 
     @usableFromInline
-    enum DeinitHandlerAction {
+    enum HandlerRemovedAction {
         case failPromise
     }
 
     @inlinable
-    mutating func deinitHandler() -> DeinitHandlerAction? {
+    mutating func handlerRemoved() -> HandlerRemovedAction? {
         switch self.state {
-        case .initial:
+        case .initial, .waitingForUser, .unbuffering:
             return .failPromise
-
-        case .waitingForUser, .unbuffering:
-            // We are retaining the handler strongly while waiting and unbuffering
-            // so we should never hit the deinit.
-            fatalError("Unexpected state")
 
         case .finished:
             return .none

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -989,7 +989,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
         try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
         try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
         try channel.pipeline.syncOperations.addHandler(TLSUserEventHandler(proposedALPN: proposedOuterALPN))
-        let negotiationHandler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: channel.eventLoop) { alpnResult, channel in
+        let negotiationHandler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { alpnResult, channel in
             switch alpnResult {
             case .negotiated(let alpn):
                 switch alpn {
@@ -1020,7 +1020,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
     @discardableResult
     private func addTypedApplicationProtocolNegotiationHandler(to channel: Channel) throws -> EventLoopFuture<NIOProtocolNegotiationResult<NegotiationResult>> {
-        let negotiationHandler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: channel.eventLoop) { alpnResult, channel in
+        let negotiationHandler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { alpnResult, channel in
             switch alpnResult {
             case .negotiated(let alpn):
                 switch alpn {

--- a/Tests/NIOTLSTests/NIOTypedApplicationProtocolNegotiationHandlerTests.swift
+++ b/Tests/NIOTLSTests/NIOTypedApplicationProtocolNegotiationHandlerTests.swift
@@ -27,16 +27,15 @@ final class NIOTypedApplicationProtocolNegotiationHandlerTests: XCTestCase {
     private let negotiatedEvent: TLSUserEvent = .handshakeCompleted(negotiatedProtocol: "h2")
     private let negotiatedResult: ALPNResult = .negotiated("h2")
 
-    func testPromiseIsCompleted() {
+    func testPromiseIsCompleted() throws {
         let channel = EmbeddedChannel()
-        let eventLoop = channel.embeddedEventLoop
 
-        var handler: NIOTypedApplicationProtocolNegotiationHandler? = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: eventLoop) { result, channel in
+        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { result, channel in
             return channel.eventLoop.makeSucceededFuture(.init(result: (.negotiated(result))))
         }
-        let future = handler!.protocolNegotiationResult
-        handler = nil
-        XCTAssertThrowsError(try future.wait()) { error in
+        try channel.pipeline.addHandler(handler).wait()
+        try channel.pipeline.removeHandler(handler).wait()
+        XCTAssertThrowsError(try handler.protocolNegotiationResult.wait()) { error in
             XCTAssertEqual(error as? ChannelError, .inappropriateOperationForState)
         }
     }
@@ -46,7 +45,7 @@ final class NIOTypedApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let loop = emChannel.eventLoop as! EmbeddedEventLoop
         var called = false
 
-        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: loop) { result, channel in
+        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { result, channel in
             called = true
             XCTAssertEqual(result, self.negotiatedResult)
             XCTAssertTrue(emChannel === channel)
@@ -64,7 +63,7 @@ final class NIOTypedApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
 
-        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: loop) { result in
+        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { result in
             XCTFail("Negotiation fired")
             return loop.makeSucceededFuture(.init(result: (.failed)))
         }
@@ -85,7 +84,7 @@ final class NIOTypedApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let channel = EmbeddedChannel()
         let loop = channel.eventLoop as! EmbeddedEventLoop
 
-        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: loop) { result in
+        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { result in
             XCTFail("Should not be called")
             return loop.makeSucceededFuture(.init(result: (.failed)))
         }
@@ -104,7 +103,7 @@ final class NIOTypedApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let loop = channel.eventLoop as! EmbeddedEventLoop
         let continuePromise = loop.makePromise(of: NIOProtocolNegotiationResult<NegotiationResult>.self)
 
-        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: loop) { result in
+        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { result in
             return continuePromise.futureResult
         }
 
@@ -135,7 +134,7 @@ final class NIOTypedApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let loop = channel.eventLoop as! EmbeddedEventLoop
         let continuePromise = loop.makePromise(of: NIOProtocolNegotiationResult<NegotiationResult>.self)
 
-        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: loop) { result in
+        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { result in
             continuePromise.futureResult
         }
         let eventCounterHandler = EventCounterHandler()
@@ -162,7 +161,7 @@ final class NIOTypedApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let loop = channel.eventLoop as! EmbeddedEventLoop
         let continuePromise = loop.makePromise(of: NIOProtocolNegotiationResult<NegotiationResult>.self)
 
-        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: loop) { result in
+        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { result in
             continuePromise.futureResult
         }
         let eventCounterHandler = EventCounterHandler()
@@ -193,7 +192,7 @@ final class NIOTypedApplicationProtocolNegotiationHandlerTests: XCTestCase {
         let loop = channel.eventLoop as! EmbeddedEventLoop
         let continuePromise = loop.makePromise(of: NIOProtocolNegotiationResult<NegotiationResult>.self)
 
-        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>(eventLoop: loop) { result in
+        let handler = NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult> { result in
             continuePromise.futureResult
         }
         let eventCounterHandler = EventCounterHandler()


### PR DESCRIPTION
# Motivation

Fixes https://github.com/apple/swift-nio/issues/2494

# Modification
This PR avoids using `deinit` to fulfil the protocol negotiation promise and opts to trap instead when it is being accessed before the handler is added. This allows us to use `handlerAdded` and `handlerRemoved`.

# Result
No more `deinit` usage that can be observed.
