### PR TITLE
Make the initializers of NIOThreadPoolError public

### DIFF
--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -20,10 +20,14 @@ import NIOConcurrencyHelpers
 public enum NIOThreadPoolError {
     
     /// The `NIOThreadPool` was not active.
-    public struct ThreadPoolInactive: Error { }
+    public struct ThreadPoolInactive: Error { 
+        public init() {}
+    }
 
     /// The `NIOThreadPool` operation is unsupported (e.g. shutdown of a perpetual pool).
-    public struct UnsupportedOperation: Error { }
+    public struct UnsupportedOperation: Error { 
+        public init() {}
+    }
 }
 
 


### PR DESCRIPTION
I tried to implement the following methods in my project to make the `NIOThreadPool` more user-friendly in a Swift Concurrency environment. 

```swift
extension NIOThreadPool {
    public func runIfActive<T>(_ body: @escaping @Sendable () throws -> T) async throws -> T {
        return try await withCheckedThrowingContinuation { (continuation) in
            self.submit { shouldRun in
                guard case shouldRun = NIOThreadPool.WorkItemState.active else {
                    continuation.resume(throwing: NIOThreadPoolError.ThreadPoolInactive())
                    return
                }
                
                do {
                    continuation.resume(returning: try body())
                } catch {
                    continuation.resume(throwing: error)
                }
            }
        }
    }
}
```

However, I was unable to do so because the `init` of `NIOThreadPoolError.ThreadPoolInactive` is `internal`. 
It would be desirable for users to be able to use it conveniently in such cases by making the `init` of the error `public`.