### PR TITLE
Simplify header separator and crlf

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -517,9 +517,9 @@ extension ByteBuffer {
     mutating func write(headers: HTTPHeaders) {
         for header in headers.headers {
             self.writeString(header.0)
-            self.writeStaticString(": ")
+            self.writeStaticString(headerSeparator)
             self.writeString(header.1)
-            self.writeStaticString("\r\n")
+            self.writeStaticString(crlf)
         }
         self.writeStaticString(crlf)
     }


### PR DESCRIPTION
Everywhere else in the file uses `crlf` and `headerSeperator` when writing those static strings, we shouldn't be using string literals here

### Motivation:

Code cleanliness

### Modifications:

Swapped the string literals of `\r\n` and `: ` for their already defined constants

### Result:

No functional changes
