### PR TITLE
Fix failed c++ compile of CNIOAtomics.h

### DIFF
--- a/Sources/CNIOAtomics/include/CNIOAtomics.h
+++ b/Sources/CNIOAtomics/include/CNIOAtomics.h
@@ -39,7 +39,11 @@
   type catmc_nio_atomic_ ## name ## _load(struct catmc_nio_atomic_ ## name * _Nonnull);                                               \
   void catmc_nio_atomic_ ## name ## _store(struct catmc_nio_atomic_ ## name * _Nonnull, type value);                                  \
 
+#ifdef __cplusplus
+DECLARE_ATOMIC_OPERATIONS(bool, _Bool)
+#else
 DECLARE_ATOMIC_OPERATIONS(_Bool, _Bool)
+#endif
 DECLARE_ATOMIC_OPERATIONS(char, char)
 DECLARE_ATOMIC_OPERATIONS(short, short)
 DECLARE_ATOMIC_OPERATIONS(int, int)


### PR DESCRIPTION
Motivation:

    On c++ compile, we get 'error: unknown type name '_Bool' DECLARE_ATOMIC_OPERATIONS(_Bool, _Bool)'

    The c++ compile is happening when SwiftPM builds a module
    with swiftSettings: [.interoperabilityMode(.Cxx)] set and
    where nio is a dependency.

Modifications:

* Sources/CNIOAtomics/include/CNIOAtomics.h

 Conditionally, if __cplusplus, use bool type instead of
 _Bool (a c-type only) for booleans.

Result:

 Compiles where previous it error'd.

After your change, what will change.

 No change other than now it compiles under c++.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
