### PR TITLE
Remove `ProtocolNegotiationHandler` protocol

### DIFF
--- a/Sources/NIOCore/ChannelHandler.swift
+++ b/Sources/NIOCore/ChannelHandler.swift
@@ -429,15 +429,3 @@ extension NIOProtocolNegotiationResult.Result: Equatable where NegotiationResult
 
 @_spi(AsyncChannel)
 extension NIOProtocolNegotiationResult.Result: Sendable where NegotiationResult: Sendable {}
-
-/// A ``ProtocolNegotiationHandler`` is a ``ChannelHandler`` that is responsible for negotiating networking protocols.
-///
-/// Typically these handlers are at the tail of the pipeline and wait until the peer indicated what protocol should be used. Once, the protocol
-/// has been negotiated the handlers allow user code to configure the pipeline.
-@_spi(AsyncChannel)
-public protocol NIOProtocolNegotiationHandler: ChannelHandler {
-    associatedtype NegotiationResult
-
-    /// The future which gets succeeded with the protocol negotiation result.
-    var protocolNegotiationResult: EventLoopFuture<NIOProtocolNegotiationResult<NegotiationResult>> { get }
-}

--- a/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
@@ -40,7 +40,7 @@
 /// promise. This allows us to construct pipelines that include protocol negotiation handlers and be able to bridge them into ``NIOAsyncChannel``
 /// based bootstraps.
 @_spi(AsyncChannel)
-public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>: ChannelInboundHandler, RemovableChannelHandler, NIOProtocolNegotiationHandler {
+public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>: ChannelInboundHandler, RemovableChannelHandler {
     @_spi(AsyncChannel)
     public typealias InboundIn = Any
 


### PR DESCRIPTION
# Motivation
When we created the first round of new async bootstrap APIs we added a `ProtocolNegotiationHandler` protocol to identify handlers that are doing protocol negotiation. Since then, we have changed the way how the async bootstraps work and we no longer need this protocol.

# Modification
Remove the `ProtocolNegotiationHandler` protocol
