### PR TITLE
Update Bootstrap.swift

### DIFF
--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -712,8 +712,13 @@ private extension Channel {
 
 /// A `ClientBootstrap` is an easy way to bootstrap a `SocketChannel` when creating network clients.
 ///
-/// Usually you re-use a `ClientBootstrap` once you set it up and called `connect` multiple times on it.
+/// You may re-use a `ClientBootstrap` once you set it up and called `connect` multiple times on it.
 /// This way you ensure that the same `EventLoop`s will be shared across all your connections.
+///
+/// Keep in mind that `ClientBoostrap` is not `Sendable` so you cannot share the same instance across
+/// multiple threads/`EventLoop`s. Creating a `ClientBootstrap` is cheap so instead of arranging
+/// synchronization to re-use a single `ClientBootstrap` instance across threads, it's advisable to
+/// just create fresh instances.
 ///
 /// Example:
 ///
@@ -731,7 +736,7 @@ private extension Channel {
 ///             // resolves to both IPv4 and IPv6 addresses, cf. Happy Eyeballs).
 ///             channel.pipeline.addHandler(MyChannelHandler())
 ///         }
-///     try! bootstrap.connect(host: "example.org", port: 12345).wait()
+///     try bootstrap.connect(host: "example.org", port: 12345).wait()
 ///     /* the Channel is now connected */
 /// ```
 ///


### PR DESCRIPTION
### Motivation:

The original `ClientBootstrap` documentation [is sometimes misunderstood](https://forums.swift.org/t/creating-many-clients-vs-wrapping-a-client-in-an-actor/67380/4) as stressing the importance to re-use.

### Modifications:

Explain that reuse is not important but permissible on the same thread/EL.

### Result:

Clearer docs.