### PR TITLE
Fix `CNIOSHA1.h` to support C++ interoperability

### DIFF
--- a/Sources/CNIOSHA1/include/CNIOSHA1.h
+++ b/Sources/CNIOSHA1/include/CNIOSHA1.h
@@ -49,6 +49,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct sha1_ctxt {
 	union {
 		uint8_t		b8[20];
@@ -68,7 +72,12 @@ typedef struct sha1_ctxt SHA1_CTX;
 
 #define	SHA1_RESULTLEN	(160/8)
 
+#ifdef __cplusplus
+#define __min_size(x)	(x)
+#else
 #define __min_size(x)	static (x)
+#endif
+
 extern void c_nio_sha1_init(struct sha1_ctxt *);
 extern void c_nio_sha1_pad(struct sha1_ctxt *);
 extern void c_nio_sha1_loop(struct sha1_ctxt *, const uint8_t *, size_t);
@@ -79,5 +88,8 @@ extern void c_nio_sha1_result(struct sha1_ctxt *, char[__min_size(SHA1_RESULTLEN
 #define SHA1Update(x, y, z)	c_nio_sha1_loop((x), (y), (z))
 #define SHA1Final(x, y)		c_nio_sha1_result((y), (x))
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /*_CRYPTO_SHA1_H_*/


### PR DESCRIPTION
Fixes C++ interoperability by removing `static` from the array definition when compiling with C++ compiler.

### Motivation:

To be able to compile packages with C++ interoperability enabled.

### Modifications:

- Removes `static` when `__cplusplus` is defined.
- Adds `extern "C"` just in case.

### Result:

NIO fully compiles with C++ interoperability enabled.
