### PR TITLE
Breaking SPI(AsyncChannel): Align back pressure naming

### DIFF
--- a/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
@@ -19,14 +19,14 @@
 /// the following functionality:
 ///
 /// - reads are presented as an `AsyncSequence`
-/// - writes can be written to with async functions on a writer, providing backpressure
+/// - writes can be written to with async functions on a writer, providing back pressure
 /// - channels can be closed seamlessly
 ///
 /// This type does not replace the full complexity of NIO's ``Channel``. In particular, it
 /// does not expose the following functionality:
 ///
 /// - user events
-/// - traditional NIO backpressure such as writability signals and the ``Channel/read()`` call
+/// - traditional NIO back pressure such as writability signals and the ``Channel/read()`` call
 ///
 /// Users are encouraged to separate their ``ChannelHandler``s into those that implement
 /// protocol-specific logic (such as parsers and encoders) and those that implement business
@@ -37,8 +37,8 @@
 public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Sendable {
     @_spi(AsyncChannel)
     public struct Configuration: Sendable {
-        /// The backpressure strategy of the ``NIOAsyncChannel/inboundStream``.
-        public var backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark
+        /// The back pressure strategy of the ``NIOAsyncChannel/inboundStream``.
+        public var backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark
 
         /// If outbound half closure should be enabled. Outbound half closure is triggered once
         /// the ``NIOAsyncChannelWriter`` is either finished or deinitialized.
@@ -53,19 +53,19 @@ public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Senda
         /// Initializes a new ``NIOAsyncChannel/Configuration``.
         ///
         /// - Parameters:
-        ///   - backpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel/inboundStream``. Defaults
+        ///   - backPressureStrategy: The back pressure strategy of the ``NIOAsyncChannel/inboundStream``. Defaults
         ///     to a watermarked strategy (lowWatermark: 2, highWatermark: 10).
         ///   - isOutboundHalfClosureEnabled: If outbound half closure should be enabled. Outbound half closure is triggered once
         ///     the ``NIOAsyncChannelWriter`` is either finished or deinitialized. Defaults to `false`.
         ///   - inboundType: The ``NIOAsyncChannel/inboundStream`` message's type.
         ///   - outboundType: The ``NIOAsyncChannel/outboundWriter`` message's type.
         public init(
-            backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark = .init(lowWatermark: 2, highWatermark: 10),
+            backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark = .init(lowWatermark: 2, highWatermark: 10),
             isOutboundHalfClosureEnabled: Bool = false,
             inboundType: Inbound.Type = Inbound.self,
             outboundType: Outbound.Type = Outbound.self
         ) {
-            self.backpressureStrategy = backpressureStrategy
+            self.backPressureStrategy = backPressureStrategy
             self.isOutboundHalfClosureEnabled = isOutboundHalfClosureEnabled
             self.inboundType = inboundType
             self.outboundType = outboundType
@@ -99,7 +99,7 @@ public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Senda
         channel.eventLoop.preconditionInEventLoop()
         self.channel = channel
         (self.inboundStream, self.outboundWriter) = try channel._syncAddAsyncHandlers(
-            backpressureStrategy: configuration.backpressureStrategy,
+            backPressureStrategy: configuration.backPressureStrategy,
             isOutboundHalfClosureEnabled: configuration.isOutboundHalfClosureEnabled
         )
     }
@@ -123,7 +123,7 @@ public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Senda
         channel.eventLoop.preconditionInEventLoop()
         self.channel = channel
         (self.inboundStream, self.outboundWriter) = try channel._syncAddAsyncHandlers(
-            backpressureStrategy: configuration.backpressureStrategy,
+            backPressureStrategy: configuration.backPressureStrategy,
             isOutboundHalfClosureEnabled: configuration.isOutboundHalfClosureEnabled
         )
 
@@ -147,13 +147,13 @@ public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Senda
     @_spi(AsyncChannel)
     public static func wrapAsyncChannelWithTransformations(
         synchronouslyWrapping channel: Channel,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isOutboundHalfClosureEnabled: Bool = false,
         channelReadTransformation: @Sendable @escaping (Channel) -> EventLoopFuture<Inbound>
     ) throws -> NIOAsyncChannel<Inbound, Outbound> where Outbound == Never {
         channel.eventLoop.preconditionInEventLoop()
         let (inboundStream, outboundWriter): (NIOAsyncChannelInboundStream<Inbound>, NIOAsyncChannelOutboundWriter<Outbound>) = try channel._syncAddAsyncHandlersWithTransformations(
-            backpressureStrategy: backpressureStrategy,
+            backPressureStrategy: backPressureStrategy,
             isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled,
             channelReadTransformation: channelReadTransformation
         )
@@ -174,7 +174,7 @@ extension Channel {
     @inlinable
     @_spi(AsyncChannel)
     public func _syncAddAsyncHandlers<Inbound: Sendable, Outbound: Sendable>(
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
+        backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         isOutboundHalfClosureEnabled: Bool
     ) throws -> (NIOAsyncChannelInboundStream<Inbound>, NIOAsyncChannelOutboundWriter<Outbound>) {
         self.eventLoop.assertInEventLoop()
@@ -182,7 +182,7 @@ extension Channel {
         let closeRatchet = CloseRatchet(isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled)
         let inboundStream = try NIOAsyncChannelInboundStream<Inbound>.makeWrappingHandler(
             channel: self,
-            backpressureStrategy: backpressureStrategy,
+            backPressureStrategy: backPressureStrategy,
             closeRatchet: closeRatchet
         )
         let writer = try NIOAsyncChannelOutboundWriter<Outbound>(
@@ -196,7 +196,7 @@ extension Channel {
     @inlinable
     @_spi(AsyncChannel)
     public func _syncAddAsyncHandlersWithTransformations<ChannelReadResult>(
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
+        backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         isOutboundHalfClosureEnabled: Bool,
         channelReadTransformation: @Sendable @escaping (Channel) -> EventLoopFuture<ChannelReadResult>
     ) throws -> (NIOAsyncChannelInboundStream<ChannelReadResult>, NIOAsyncChannelOutboundWriter<Never>) {
@@ -205,7 +205,7 @@ extension Channel {
         let closeRatchet = CloseRatchet(isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled)
         let inboundStream = try NIOAsyncChannelInboundStream<ChannelReadResult>.makeTransformationHandler(
             channel: self,
-            backpressureStrategy: backpressureStrategy,
+            backPressureStrategy: backPressureStrategy,
             closeRatchet: closeRatchet,
             channelReadTransformation: channelReadTransformation
         )

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
@@ -80,14 +80,14 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     @inlinable
     init<HandlerInbound: Sendable>(
         channel: Channel,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
+        backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         closeRatchet: CloseRatchet,
         handler: NIOAsyncChannelInboundStreamChannelHandler<HandlerInbound, Inbound>
     ) throws {
         channel.eventLoop.preconditionInEventLoop()
         let strategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark
 
-        if let userProvided = backpressureStrategy {
+        if let userProvided = backPressureStrategy {
             strategy = userProvided
         } else {
             // Default strategy. These numbers are fairly arbitrary, but they line up with the default value of
@@ -108,7 +108,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     @inlinable
     static func makeWrappingHandler(
         channel: Channel,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
+        backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         closeRatchet: CloseRatchet
     ) throws -> NIOAsyncChannelInboundStream {
         let handler = NIOAsyncChannelInboundStreamChannelHandler<Inbound, Inbound>.makeHandler(
@@ -118,7 +118,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
 
         return try .init(
             channel: channel,
-            backpressureStrategy: backpressureStrategy,
+            backPressureStrategy: backPressureStrategy,
             closeRatchet: closeRatchet,
             handler: handler
         )
@@ -128,7 +128,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     @inlinable
     static func makeTransformationHandler(
         channel: Channel,
-        backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
+        backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         closeRatchet: CloseRatchet,
         channelReadTransformation: @Sendable @escaping (Channel) -> EventLoopFuture<Inbound>
     ) throws -> NIOAsyncChannelInboundStream {
@@ -140,7 +140,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
 
         return try .init(
             channel: channel,
-            backpressureStrategy: backpressureStrategy,
+            backPressureStrategy: backPressureStrategy,
             closeRatchet: closeRatchet,
             handler: handler
         )

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -469,7 +469,7 @@ extension ServerBootstrap {
     /// - Parameters:
     ///   - host: The host to bind on.
     ///   - port: The port to bind on.
-    ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
+    ///   - serverBackPressureStrategy: The back pressure strategy used by the server socket channel.
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
@@ -478,14 +478,14 @@ extension ServerBootstrap {
     public func bind<Output: Sendable>(
         host: String,
         port: Int,
-        serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        serverBackPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         childChannelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
     ) async throws -> NIOAsyncChannel<Output, Never> {
         let address = try SocketAddress.makeAddressResolvingHost(host, port: port)
 
         return try await bind(
             to: address,
-            serverBackpressureStrategy: serverBackpressureStrategy,
+            serverBackPressureStrategy: serverBackPressureStrategy,
             childChannelInitializer: childChannelInitializer
         )
     }
@@ -494,7 +494,7 @@ extension ServerBootstrap {
     ///
     /// - Parameters:
     ///   - address: The `SocketAddress` to bind on.
-    ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
+    ///   - serverBackPressureStrategy: The back pressure strategy used by the server socket channel.
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
@@ -502,7 +502,7 @@ extension ServerBootstrap {
     @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         to address: SocketAddress,
-        serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        serverBackPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         childChannelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
     ) async throws -> NIOAsyncChannel<Output, Never> {
         return try await bind0(
@@ -514,7 +514,7 @@ extension ServerBootstrap {
                     enableMPTCP: enableMPTCP
                 )
             },
-            serverBackpressureStrategy: serverBackpressureStrategy,
+            serverBackPressureStrategy: serverBackPressureStrategy,
             childChannelInitializer: childChannelInitializer,
             registration: { serverChannel in
                 serverChannel.registerAndDoSynchronously { serverChannel in
@@ -530,7 +530,7 @@ extension ServerBootstrap {
     ///   - unixDomainSocketPath: The path of the UNIX Domain Socket to bind on. The`unixDomainSocketPath` must not exist,
     ///     unless `cleanupExistingSocketFile`is set to `true`.
     ///   - cleanupExistingSocketFile: Whether to cleanup an existing socket file at `unixDomainSocketPath`.
-    ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
+    ///   - serverBackPressureStrategy: The back pressure strategy used by the server socket channel.
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
@@ -539,7 +539,7 @@ extension ServerBootstrap {
     public func bind<Output: Sendable>(
         unixDomainSocketPath: String,
         cleanupExistingSocketFile: Bool = false,
-        serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        serverBackPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         childChannelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
     ) async throws -> NIOAsyncChannel<Output, Never> {
         if cleanupExistingSocketFile {
@@ -550,7 +550,7 @@ extension ServerBootstrap {
 
         return try await self.bind(
             to: address,
-            serverBackpressureStrategy: serverBackpressureStrategy,
+            serverBackPressureStrategy: serverBackPressureStrategy,
             childChannelInitializer: childChannelInitializer
         )
     }
@@ -559,7 +559,7 @@ extension ServerBootstrap {
     ///
     /// - Parameters:
     ///   - socket: The _Unix file descriptor_ representing the bound stream socket.
-    ///   - serverBackpressureStrategy: The back pressure strategy used by the server socket channel.
+    ///   - serverBackPressureStrategy: The back pressure strategy used by the server socket channel.
     ///   - channelInitializer: A closure to initialize the channel. The return value of this closure is returned from the `connect`
     ///   method.
     /// - Returns: The result of the channel initializer.
@@ -568,7 +568,7 @@ extension ServerBootstrap {
     public func bind<Output: Sendable>(
         _ socket: NIOBSDSocket.Handle,
         cleanupExistingSocketFile: Bool = false,
-        serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        serverBackPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         childChannelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
     ) async throws -> NIOAsyncChannel<Output, Never> {
         return try await bind0(
@@ -582,7 +582,7 @@ extension ServerBootstrap {
                     group: childEventLoopGroup
                 )
             },
-            serverBackpressureStrategy: serverBackpressureStrategy,
+            serverBackPressureStrategy: serverBackPressureStrategy,
             childChannelInitializer: childChannelInitializer,
             registration: { serverChannel in
                 let promise = serverChannel.eventLoop.makePromise(of: Void.self)
@@ -595,7 +595,7 @@ extension ServerBootstrap {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     private func bind0<ChannelInitializerResult>(
         makeServerChannel: @escaping (SelectableEventLoop, EventLoopGroup, Bool) throws -> ServerSocketChannel,
-        serverBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
+        serverBackPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
         childChannelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<ChannelInitializerResult>,
         registration: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
     ) -> EventLoopFuture<NIOAsyncChannel<ChannelInitializerResult, Never>>  {
@@ -625,7 +625,7 @@ extension ServerBootstrap {
                     let asyncChannel = try NIOAsyncChannel<ChannelInitializerResult, Never>
                         .wrapAsyncChannelWithTransformations(
                             synchronouslyWrapping: serverChannel,
-                            backpressureStrategy: serverBackpressureStrategy,
+                            backPressureStrategy: serverBackPressureStrategy,
                             channelReadTransformation: { channel -> EventLoopFuture<ChannelInitializerResult> in
                                 // The channelReadTransformation is run on the EL of the server channel
                                 // We have to make sure that we execute child channel initializer on the

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -317,7 +317,7 @@ final class AsyncChannelTests: XCTestCase {
         try await channel.closeIgnoringSuppression()
     }
 
-    func testManagingBackpressure() async throws {
+    func testManagingBackPressure() async throws {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let readCounter = ReadCounter()
@@ -326,7 +326,7 @@ final class AsyncChannelTests: XCTestCase {
             try NIOAsyncChannel(
                 synchronouslyWrapping: channel,
                 configuration: .init(
-                    backpressureStrategy: .init(lowWatermark: 2, highWatermark: 4),
+                    backPressureStrategy: .init(lowWatermark: 2, highWatermark: 4),
                     inboundType: Void.self,
                     outboundType: Never.self
                 )


### PR DESCRIPTION
# Motivation
We spelled back pressure a few different ways throughout our async interfaces.

# Modification
This PR aligns to `backPressure` everywhere and uses `back pressure` in comments.
