### PR TITLE
SPI(AsyncChannel): Make `NIOAsyncChannel` a struct

### DIFF
--- a/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
@@ -34,7 +34,7 @@
 /// logic should use ``NIOAsyncChannel`` to consume and produce data to the network.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @_spi(AsyncChannel)
-public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Sendable {
+public struct NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Sendable {
     @_spi(AsyncChannel)
     public struct Configuration: Sendable {
         /// The backpressure strategy of the ``NIOAsyncChannel/inboundStream``.
@@ -76,6 +76,8 @@ public final class NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Senda
     @_spi(AsyncChannel)
     public let channel: Channel
     /// The stream of inbound messages.
+    ///
+    /// - Important: The `inboundStream` is a unicast `AsyncSequence` and only one iterator can be created.
     @_spi(AsyncChannel)
     public let inboundStream: NIOAsyncChannelInboundStream<Inbound>
     /// The writer for writing outbound messages.


### PR DESCRIPTION
# Motivation
To reduce allocations when wrapping a channel into a `NIOAsyncChannel` we should make the `NIOAsyncChannel` a struct instead of a class.

# Modification
This PR changes the `NIOAsyncChannel` to a struct.
