### PR TITLE
Fix Sendable warning in `NIOPipeBoostrap`

### DIFF
--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2142,6 +2142,7 @@ extension NIOPipeBootstrap {
                      "illegal file descriptor pair. The file descriptors \(input), \(output) " +
                      "must be distinct and both positive integers.")
         let eventLoop = group.next()
+        let channelOptions = self._channelOptions
         try self.validateFileDescriptorIsNotAFile(input)
         try self.validateFileDescriptorIsNotAFile(output)
 
@@ -2161,7 +2162,7 @@ extension NIOPipeBootstrap {
         @Sendable
         func setupChannel() -> EventLoopFuture<PostRegistrationTransformationResult> {
             eventLoop.assertInEventLoop()
-            return self._channelOptions.applyAllChannelOptions(to: channel).flatMap { _ -> EventLoopFuture<ChannelInitializerResult> in
+            return channelOptions.applyAllChannelOptions(to: channel).flatMap { _ -> EventLoopFuture<ChannelInitializerResult> in
                 channelInitializer(channel)
             }.flatMap { result in
                 eventLoop.assertInEventLoop()


### PR DESCRIPTION
# Motivation
We were accessing `self` in a `@Sendable` function in the `NIOPipeBoostrap`. The 5.10 compiler correctly diagnoses this as a Sendable violation since the bootstrap is in-fact not Sendable.

# Modification
Store the `channelOptions` in a local variable outside of the `@Sendable` function.

# Result
No more Sendable warnings on 5.10
