### PR TITLE
Fix test availability for tests

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -278,6 +278,7 @@ private final class RecordingHTTPHandler: ChannelInboundHandler, RemovableChanne
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 class HTTPClientUpgradeTestCase: XCTestCase {
     
     // MARK: Test basic happy path requests and responses.

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -34,6 +34,7 @@ extension ChannelPipeline {
         }
     }
 
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     fileprivate func assertContainsUpgrader() throws {
         do {
             _ = try self.context(handlerType: NIOTypedHTTPServerUpgradeHandler<Bool>.self).wait()
@@ -88,6 +89,7 @@ extension EmbeddedChannel {
 
 private typealias UpgradeCompletionHandler = @Sendable (ChannelHandlerContext) -> Void
 
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 private func serverHTTPChannelWithAutoremoval(group: EventLoopGroup,
                                               pipelining: Bool,
                                               upgraders: [any TypedAndUntypedHTTPServerProtocolUpgrader],
@@ -164,6 +166,7 @@ internal func assertResponseIs(response: String, expectedResponseLine: String, e
     XCTAssertEqual(lines.count, 0)
 }
 
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 protocol TypedAndUntypedHTTPServerProtocolUpgrader: HTTPServerProtocolUpgrader, NIOTypedHTTPServerProtocolUpgrader where UpgradeResult == Bool {}
 
 private class ExplodingUpgrader: TypedAndUntypedHTTPServerProtocolUpgrader {
@@ -407,6 +410,7 @@ private class ReentrantReadOnChannelReadCompleteHandler: ChannelInboundHandler {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 class HTTPServerUpgradeTestCase: XCTestCase {
     fileprivate func setUpTestWithAutoremoval(pipelining: Bool = false,
                                           upgraders: [any TypedAndUntypedHTTPServerProtocolUpgrader],
@@ -1554,6 +1558,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
     fileprivate override func setUpTestWithAutoremoval(
         pipelining: Bool = false,

--- a/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
@@ -527,6 +527,7 @@ class WebSocketServerEndToEndTests: XCTestCase {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedWebSocketServerEndToEndTests: WebSocketServerEndToEndTests {
     override func createTestFixtures(
         upgraders: [WebSocketServerUpgraderConfiguration]


### PR DESCRIPTION
# Motivation

Building on Darwin is currently broken since we are missing availability annotations on some of the tests.