### PR TITLE
Add customization point for scheduling `ExecutorJob`s on `EventLoop`s

### DIFF
--- a/Benchmarks/Benchmarks/NIOPosixBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOPosixBenchmarks/Benchmarks.swift
@@ -15,7 +15,7 @@
 import Benchmark
 import NIOPosix
 
-private let eventLoop = MultiThreadedEventLoopGroup(numberOfThreads: 1).next()
+private let eventLoop = MultiThreadedEventLoopGroup.singleton.next()
 
 let benchmarks = {
     let defaultMetrics: [BenchmarkMetric] = [

--- a/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEcho.swift
+++ b/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEcho.swift
@@ -26,7 +26,7 @@ private final class EchoChannelHandler: ChannelInboundHandler {
 private final class EchoRequestChannelHandler: ChannelInboundHandler {
     fileprivate typealias InboundIn = ByteBuffer
 
-    private let bufferSize = 10000
+    private let messageSize = 10000
     private let numberOfWrites: Int
     private var batchCount = 0
     private let data: NIOAny
@@ -36,7 +36,7 @@ private final class EchoRequestChannelHandler: ChannelInboundHandler {
     init(numberOfWrites: Int, readsCompletePromise: EventLoopPromise<Void>) {
         self.numberOfWrites = numberOfWrites
         self.readsCompletePromise = readsCompletePromise
-        self.data = NIOAny(ByteBuffer(repeating: 0, count: self.bufferSize))
+        self.data = NIOAny(ByteBuffer(repeating: 0, count: self.messageSize))
     }
 
     func channelActive(context: ChannelHandlerContext) {
@@ -49,7 +49,7 @@ private final class EchoRequestChannelHandler: ChannelInboundHandler {
         let buffer = self.unwrapInboundIn(data)
         self.receivedData += buffer.readableBytes
 
-        if self.receivedData == self.numberOfWrites * self.bufferSize {
+        if self.receivedData == self.numberOfWrites * self.messageSize {
             self.readsCompletePromise.succeed()
         }
     }

--- a/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEchoAsyncChannel.swift
+++ b/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEchoAsyncChannel.swift
@@ -48,7 +48,7 @@ func runTCPEchoAsyncChannel(numberOfWrites: Int, eventLoop: EventLoop) async thr
             }
         }
 
-    let bufferSize = 10000
+    let messageSize = 10000
 
     try await withThrowingTaskGroup(of: Void.self) { group in
         // This child task is echoing back the data on the server.
@@ -66,14 +66,14 @@ func runTCPEchoAsyncChannel(numberOfWrites: Int, eventLoop: EventLoop) async thr
             for try await inboundData in clientChannel.inboundStream  {
                 receivedData += inboundData.readableBytes
 
-                if receivedData == numberOfWrites * bufferSize {
+                if receivedData == numberOfWrites * messageSize {
                     return
                 }
             }
         }
 
         // Let's start sending data.
-        let data = ByteBuffer(repeating: 0, count: bufferSize)
+        let data = ByteBuffer(repeating: 0, count: messageSize)
         for _ in 0..<numberOfWrites {
             try await clientChannel.outboundWriter.write(data)
         }

--- a/Benchmarks/Thresholds/5.10/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
+++ b/Benchmarks/Thresholds/5.10/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 5554895
+  "mallocCountTotal" : 2557298
 }

--- a/Benchmarks/Thresholds/5.9/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
+++ b/Benchmarks/Thresholds/5.9/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 5636901
+  "mallocCountTotal" : 2557305
 }

--- a/Benchmarks/Thresholds/main/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
+++ b/Benchmarks/Thresholds/main/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 5554895
+  "mallocCountTotal" : 2557298
 }

--- a/Sources/NIOCore/EventLoop+SerialExecutor.swift
+++ b/Sources/NIOCore/EventLoop+SerialExecutor.swift
@@ -25,6 +25,9 @@ public protocol NIOSerialEventLoopExecutor: EventLoop, SerialExecutor { }
 extension NIOSerialEventLoopExecutor {
     @inlinable
     public func enqueue(_ job: consuming ExecutorJob) {
+        // By default we are just going to use execute to run the job
+        // this is quite heavy since it allocates the closure for
+        // every single job.
         let unownedJob = UnownedJob(job)
         self.execute {
             unownedJob.runSynchronously(on: self.asUnownedSerialExecutor())
@@ -62,10 +65,7 @@ final class NIODefaultSerialEventLoopExecutor {
 extension NIODefaultSerialEventLoopExecutor: SerialExecutor {
     @inlinable
     public func enqueue(_ job: consuming ExecutorJob) {
-        let unownedJob = UnownedJob(job)
-        self.loop.execute {
-            unownedJob.runSynchronously(on: self.asUnownedSerialExecutor())
-        }
+        self.loop.enqueue(job)
     }
 
     @inlinable

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -299,6 +299,20 @@ Further information:
         }, .now()))
     }
 
+    #if swift(>=5.9)
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    @usableFromInline
+    func enqueue(_ job: consuming ExecutorJob) {
+        let scheduledTask = ScheduledTask(
+            id: self.scheduledTaskCounter.loadThenWrappingIncrement(ordering: .relaxed),
+            job: job,
+            readyTime: .now()
+        )
+        // nothing we can do if we fail enqueuing here.
+        try? self._schedule0(scheduledTask)
+    }
+    #endif
+
     /// Add the `ScheduledTask` to be executed.
     @usableFromInline
     internal func _schedule0(_ task: ScheduledTask) throws {
@@ -515,7 +529,19 @@ Further information:
                 for task in self.tasksCopy {
                     /* for macOS: in case any calls we make to Foundation put objects into an autoreleasepool */
                     withAutoReleasePool {
-                        task.task()
+                        switch task.task {
+                        case .function(let function):
+                            function()
+
+                        #if swift(>=5.9)
+                        case .unownedJob(let erasedUnownedJob):
+                            if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+                                erasedUnownedJob.unownedJob.runSynchronously(on: self.asUnownedSerialExecutor())
+                            } else {
+                                fatalError("Tried to run an UnownedJob without runtime support")
+                            }
+                        #endif
+                        }
                     }
                 }
                 // Drop everything (but keep the capacity) so we can fill it again on the next iteration.


### PR DESCRIPTION
# Motivation
Currently, the NIO's EventLoop conformance to the `SerialExecutor` protocol always uses `execute` to schedule the actual job. However, the closure for `execute` has to close over the job and the `EventLoop` itself; hence, it always allocates. Since jobs are a very fine grained object in Concurrency that are created a lot this lead to millions of allocations in even small benchmarks.

# Modification
This PR provides a customization point for `EventLoop`s to execute `ExecutorJob`s directly. For `SelectableEventLoop` we store a type erased `UnownedJob` in our `ScheduledTask` and just run it right away.

# Result
No more allocations when NIO's EL is used as a `SerialExecutor`.
