### PR TITLE
Improve performance of `NIOAsyncChannel`

### DIFF
--- a/Benchmarks/Thresholds/5.10/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
+++ b/Benchmarks/Thresholds/5.10/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 2557298
+  "mallocCountTotal" : 1317015
 }

--- a/Benchmarks/Thresholds/5.9/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
+++ b/Benchmarks/Thresholds/5.9/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 2557305
+  "mallocCountTotal" : 1317022
 }

--- a/Benchmarks/Thresholds/main/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
+++ b/Benchmarks/Thresholds/main/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 2557298
+  "mallocCountTotal" : 1317015
 }

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -78,10 +78,21 @@ This product contains a derivation of Fabian Fett's 'Base64.swift'.
     * https://github.com/fabianfett/swift-base64-kit/blob/master/LICENSE
   * HOMEPAGE:
     * https://github.com/fabianfett/swift-base64-kit
-    
+
+---
+
 This product contains a derivation of "XCTest+AsyncAwait.swift" from AsyncHTTPClient.
 
   * LICENSE (Apache License 2.0):
     * https://www.apache.org/licenses/LICENSE-2.0
   * HOMEPAGE:
     * https://github.com/swift-server/async-http-client
+
+---
+
+This product contains a derivation of "_TinyArray.swift" from SwiftCertificates.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/apple/swift-certificates

--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,7 @@ let package = Package(
                 "CNIODarwin",
                 "CNIOLinux",
                 "CNIOWindows",
+                "_NIODataStructures",
                 swiftCollections,
                 swiftAtomics,
             ]

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStreamChannelHandler.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStreamChannelHandler.swift
@@ -326,15 +326,23 @@ struct NIOAsyncChannelInboundStreamChannelHandlerProducerDelegate: @unchecked Se
 
     @inlinable
     func didTerminate() {
-        self.eventLoop.execute {
+        if self.eventLoop.inEventLoop {
             self._didTerminate()
+        } else {
+            self.eventLoop.execute {
+                self._didTerminate()
+            }
         }
     }
 
     @inlinable
     func produceMore() {
-        self.eventLoop.execute {
+        if self.eventLoop.inEventLoop {
             self._produceMore()
+        } else {
+            self.eventLoop.execute {
+                self._produceMore()
+            }
         }
     }
 }

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
@@ -455,7 +455,7 @@ extension NIOAsyncWriter {
                 let action = self._stateMachine.setWritability(to: writability)
 
                 switch action {
-                case .callDidYieldAndResumeContinuations(let delegate, var elements, let suspendedYields):
+                case .callDidYieldAndResumeContinuations(let delegate, let elements, let suspendedYields):
                     // We are calling the delegate while holding lock. This can lead to potential crashes
                     // if the delegate calls `setWritability` reentrantly. However, we call this
                     // out in the docs of the delegate

--- a/Sources/_NIODataStructures/_TinyArray.swift
+++ b/Sources/_NIODataStructures/_TinyArray.swift
@@ -1,0 +1,356 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// ``TinyArray`` is a ``RandomAccessCollection`` optimised to store zero or one ``Element``.
+/// It supports arbitrary many elements but if only up to one ``Element`` is stored it does **not** allocate separate storage on the heap
+/// and instead stores the ``Element`` inline.
+public struct _TinyArray<Element> {
+    @usableFromInline
+    enum Storage {
+        case one(Element)
+        case arbitrary([Element])
+    }
+
+    @usableFromInline
+    var storage: Storage
+}
+
+// MARK: - TinyArray "public" interface
+
+extension _TinyArray: Equatable where Element: Equatable {}
+extension _TinyArray: Hashable where Element: Hashable {}
+extension _TinyArray: Sendable where Element: Sendable {}
+
+extension _TinyArray: RandomAccessCollection {
+    public typealias Element = Element
+
+    public typealias Index = Int
+
+    @inlinable
+    public func makeIterator() -> Iterator {
+        return Iterator(storage: self.storage)
+    }
+
+    public struct Iterator: IteratorProtocol {
+        @usableFromInline
+        let _storage: Storage
+        @usableFromInline
+        var _index: Index
+
+        @usableFromInline
+        init(storage: Storage) {
+            self._storage = storage
+            self._index = storage.startIndex
+        }
+
+        @inlinable
+        public mutating func next() -> Element? {
+            if self._index == self._storage.endIndex {
+                return nil
+            }
+
+            defer {
+                self._index &+= 1
+            }
+
+            return self._storage[self._index]
+        }
+    }
+
+    @inlinable
+    public subscript(position: Int) -> Element {
+        get {
+            self.storage[position]
+        }
+    }
+
+    @inlinable
+    public var startIndex: Int {
+        self.storage.startIndex
+    }
+
+    @inlinable
+    public var endIndex: Int {
+        self.storage.endIndex
+    }
+}
+
+extension _TinyArray {
+    @inlinable
+    public init(_ elements: some Sequence<Element>) {
+        self.storage = .init(elements)
+    }
+
+    @inlinable
+    public init(_ elements: some Sequence<Result<Element, some Error>>) throws {
+        self.storage = try .init(elements)
+    }
+
+    @inlinable
+    public init() {
+        self.storage = .init()
+    }
+
+    @inlinable
+    public mutating func append(_ newElement: Element) {
+        self.storage.append(newElement)
+    }
+
+    @inlinable
+    public mutating func append(contentsOf newElements: some Sequence<Element>) {
+        self.storage.append(contentsOf: newElements)
+    }
+
+    @discardableResult
+    @inlinable
+    public mutating func remove(at index: Int) -> Element {
+        self.storage.remove(at: index)
+    }
+
+    @inlinable
+    public mutating func removeAll(where shouldBeRemoved: (Element) throws -> Bool) rethrows {
+        try self.storage.removeAll(where: shouldBeRemoved)
+    }
+
+    @inlinable
+    public mutating func sort(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows {
+        try self.storage.sort(by: areInIncreasingOrder)
+    }
+}
+
+// MARK: - TinyArray.Storage "private" implementation
+
+extension _TinyArray.Storage: Equatable where Element: Equatable {
+    @inlinable
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.one(let lhs), .one(let rhs)):
+            return lhs == rhs
+        case (.arbitrary(let lhs), .arbitrary(let rhs)):
+            // we don't use lhs.elementsEqual(rhs) so we can hit the fast path from Array
+            // if both arrays share the same underlying storage: https://github.com/apple/swift/blob/b42019005988b2d13398025883e285a81d323efa/stdlib/public/core/Array.swift#L1775
+            return lhs == rhs
+
+        case (.one(let element), .arbitrary(let array)),
+            (.arbitrary(let array), .one(let element)):
+            guard array.count == 1 else {
+                return false
+            }
+            return element == array[0]
+
+        }
+    }
+}
+extension _TinyArray.Storage: Hashable where Element: Hashable {
+    @inlinable
+    func hash(into hasher: inout Hasher) {
+        // same strategy as Array: https://github.com/apple/swift/blob/b42019005988b2d13398025883e285a81d323efa/stdlib/public/core/Array.swift#L1801
+        hasher.combine(count)
+        for element in self {
+            hasher.combine(element)
+        }
+    }
+}
+extension _TinyArray.Storage: Sendable where Element: Sendable {}
+
+extension _TinyArray.Storage: RandomAccessCollection {
+    @inlinable
+    subscript(position: Int) -> Element {
+        get {
+            switch self {
+            case .one(let element):
+                guard position == 0 else {
+                    fatalError("index \(position) out of bounds")
+                }
+                return element
+            case .arbitrary(let elements):
+                return elements[position]
+            }
+        }
+    }
+
+    @inlinable
+    var startIndex: Int {
+        0
+    }
+
+    @inlinable
+    var endIndex: Int {
+        switch self {
+        case .one: return 1
+        case .arbitrary(let elements): return elements.endIndex
+        }
+    }
+}
+
+extension _TinyArray.Storage {
+    @inlinable
+    init(_ elements: some Sequence<Element>) {
+        self = .arbitrary([])
+        self.append(contentsOf: elements)
+    }
+
+    @inlinable
+    init(_ newElements: some Sequence<Result<Element, some Error>>) throws {
+        var iterator = newElements.makeIterator()
+        guard let firstElement = try iterator.next()?.get() else {
+            self = .arbitrary([])
+            return
+        }
+        guard let secondElement = try iterator.next()?.get() else {
+            // newElements just contains a single element
+            // and we hit the fast path
+            self = .one(firstElement)
+            return
+        }
+
+        var elements: [Element] = []
+        elements.reserveCapacity(newElements.underestimatedCount)
+        elements.append(firstElement)
+        elements.append(secondElement)
+        while let nextElement = try iterator.next()?.get() {
+            elements.append(nextElement)
+        }
+        self = .arbitrary(elements)
+    }
+
+    @inlinable
+    init() {
+        self = .arbitrary([])
+    }
+
+    @inlinable
+    mutating func append(_ newElement: Element) {
+        self.append(contentsOf: CollectionOfOne(newElement))
+    }
+
+    @inlinable
+    mutating func append(contentsOf newElements: some Sequence<Element>) {
+        switch self {
+        case .one(let firstElement):
+            var iterator = newElements.makeIterator()
+            guard let secondElement = iterator.next() else {
+                // newElements is empty, nothing to do
+                return
+            }
+            var elements: [Element] = []
+            elements.reserveCapacity(1 + newElements.underestimatedCount)
+            elements.append(firstElement)
+            elements.append(secondElement)
+            elements.appendRemainingElements(from: &iterator)
+            self = .arbitrary(elements)
+
+        case .arbitrary(var elements):
+            if elements.isEmpty {
+                // if `self` is currently empty and `newElements` just contains a single
+                // element, we skip allocating an array and set `self` to `.one(firstElement)`
+                var iterator = newElements.makeIterator()
+                guard let firstElement = iterator.next() else {
+                    // newElements is empty, nothing to do
+                    return
+                }
+                guard let secondElement = iterator.next() else {
+                    // newElements just contains a single element
+                    // and we hit the fast path
+                    self = .one(firstElement)
+                    return
+                }
+                elements.reserveCapacity(elements.count + newElements.underestimatedCount)
+                elements.append(firstElement)
+                elements.append(secondElement)
+                elements.appendRemainingElements(from: &iterator)
+                self = .arbitrary(elements)
+
+            } else {
+                elements.append(contentsOf: newElements)
+                self = .arbitrary(elements)
+            }
+
+        }
+    }
+
+    @discardableResult
+    @inlinable
+    mutating func remove(at index: Int) -> Element {
+        switch self {
+        case .one(let oldElement):
+            guard index == 0 else {
+                fatalError("index \(index) out of bounds")
+            }
+            self = .arbitrary([])
+            return oldElement
+
+        case .arbitrary(var elements):
+            defer {
+                self = .arbitrary(elements)
+            }
+            return elements.remove(at: index)
+
+        }
+    }
+
+    @inlinable
+    mutating func removeAll(where shouldBeRemoved: (Element) throws -> Bool) rethrows {
+        switch self {
+        case .one(let oldElement):
+            if try shouldBeRemoved(oldElement) {
+                self = .arbitrary([])
+            }
+
+        case .arbitrary(var elements):
+            defer {
+                self = .arbitrary(elements)
+            }
+            return try elements.removeAll(where: shouldBeRemoved)
+
+        }
+    }
+
+    @inlinable
+    mutating func sort(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows {
+        switch self {
+        case .one:
+            // a collection of just one element is always sorted, nothing to do
+            break
+        case .arbitrary(var elements):
+            defer {
+                self = .arbitrary(elements)
+            }
+
+            try elements.sort(by: areInIncreasingOrder)
+        }
+    }
+}
+
+extension Array {
+    @inlinable
+    mutating func appendRemainingElements(from iterator: inout some IteratorProtocol<Element>) {
+        while let nextElement = iterator.next() {
+            append(nextElement)
+        }
+    }
+}


### PR DESCRIPTION
### Motivation:

There were a couple of easy performance wins in `NIOAsyncChannel` which cut the allocations in half again. Those performance wins are mostly around the underlying `NIOAsyncWriter` and `NIOAsyncSequenceProducer`.

### Modifications:

This PR contains a few changes which split up into separate commits to make reviewing easier:
1. I added a fast path to the `NIOAsyncChannelInboundStreamChannelHandlerProducerDelegate` which allows it to skip the thread hop when we are already on the correct `EventLoop`.
2. I copied over the `_TinyArray` implementation from `swift-certificates` to optimise the fast path of having just a single producer suspended in the `NIOAsyncWriter`.
3. I implemented the `NIOAsyncWriterSinkDelegate` customization point for single element writes in the `NIOAsyncChannelOutboundWriterHandler`. This avoids allocating a `Deque` for single element writes.
4. I made sure that we call the single element customization point more often in `NIOAsyncWriter` and I moved the storage of the `suspendedYield`s to the `_TinyArray` which optimises for the single producer case.

### Result:

Halved the allocations for the `NIOAsyncChannel` benchmark again.
