### PR TITLE
Add jitter support to recurring tasks

### DIFF
--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -906,7 +906,6 @@ extension EventLoop {
     ///     - task: The closure that will be executed.
     /// - return: `RepeatedTask`
     @discardableResult
-    @preconcurrency
     public func scheduleRepeatedTask(
         initialDelay: TimeAmount,
         delay: TimeAmount,
@@ -982,7 +981,6 @@ extension EventLoop {
     ///
     /// - return: `RepeatedTask`
     @discardableResult
-    @preconcurrency
     public func scheduleRepeatedAsyncTask(
         initialDelay: TimeAmount,
         delay: TimeAmount,

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -770,7 +770,7 @@ extension EventLoop {
     ///
     /// - parameters:
     ///     - delay: The delay between the end of one task and the start of the next.
-    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` paramether.
+    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` parameter.
     ///     - task: The asynchronous task to run. As everything that runs on the `EventLoop`, it must not block.
     /// - returns: A `Scheduled` object which may be used to cancel the task if it has not yet run, or to wait
     ///            on the full execution of the task, including its returned `EventLoopFuture`.
@@ -909,7 +909,7 @@ extension EventLoop {
     /// - parameters:
     ///     - initialDelay: The delay after which the first task is executed.
     ///     - delay: The delay between the end of one task and the start of the next.
-    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` paramether.
+    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` parameter.
     ///     - promise: If non-nil, a promise to fulfill when the task is cancelled and all execution is complete.
     ///     - task: The closure that will be executed.
     /// - return: `RepeatedTask`
@@ -982,7 +982,7 @@ extension EventLoop {
     /// - parameters:
     ///     - initialDelay: The delay after which the first task is executed.
     ///     - delay: The delay between the end of one task and the start of the next.
-    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` paramether.
+    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` parameter.
     ///     - promise: If non-nil, a promise to fulfill when the task is cancelled and all execution is complete.
     ///     - task: The closure that will be executed. Task will keep repeating regardless of whether the future
     ///             gets fulfilled with success or error.

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -877,6 +877,29 @@ extension EventLoop {
     ) -> RepeatedTask {
         self._scheduleRepeatedTask(initialDelay: initialDelay, delay: delay, notifying: promise, task)
     }
+    
+    /// Overload `scheduleRepeatedTask` function with jitter support.
+    ///
+    /// - parameters:
+    ///     - initialDelay: The delay after which the first task is executed.
+    ///     - delay: The delay between the end of one task and the start of the next.
+    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` paramether.
+    ///     - promise: If non-nil, a promise to fulfill when the task is cancelled and all execution is complete.
+    ///     - task: The closure that will be executed.
+    /// - return: `RepeatedTask`
+    @discardableResult
+    @preconcurrency
+    public func scheduleRepeatedTask(
+        initialDelay: TimeAmount,
+        delay: TimeAmount,
+        maximumAllowableJitter: TimeAmount,
+        notifying promise: EventLoopPromise<Void>? = nil,
+        _ task: @escaping @Sendable (RepeatedTask) throws -> Void
+    ) -> RepeatedTask {
+        let jitter = Int64.random(in: .zero..<maximumAllowableJitter.nanoseconds)
+        let jitteredDelay = delay + .microseconds(jitter)
+        return self.scheduleRepeatedTask(initialDelay: initialDelay, delay: jitteredDelay, notifying: promise, task)
+    }
     typealias ScheduleRepeatedTaskCallback = @Sendable (RepeatedTask) throws -> Void
 
     func _scheduleRepeatedTask(

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -770,7 +770,7 @@ extension EventLoop {
     ///
     /// - parameters:
     ///     - delay: The delay between the end of one task and the start of the next.
-    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` parameter.
+    ///     - maximumAllowableJitter: Exclusive upper bound of jitter range added to the `delay` parameter.
     ///     - task: The asynchronous task to run. As everything that runs on the `EventLoop`, it must not block.
     /// - returns: A `Scheduled` object which may be used to cancel the task if it has not yet run, or to wait
     ///            on the full execution of the task, including its returned `EventLoopFuture`.
@@ -909,7 +909,7 @@ extension EventLoop {
     /// - parameters:
     ///     - initialDelay: The delay after which the first task is executed.
     ///     - delay: The delay between the end of one task and the start of the next.
-    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` parameter.
+    ///     - maximumAllowableJitter: Exclusive upper bound of jitter range added to the `delay` parameter.
     ///     - promise: If non-nil, a promise to fulfill when the task is cancelled and all execution is complete.
     ///     - task: The closure that will be executed.
     /// - return: `RepeatedTask`
@@ -982,7 +982,7 @@ extension EventLoop {
     /// - parameters:
     ///     - initialDelay: The delay after which the first task is executed.
     ///     - delay: The delay between the end of one task and the start of the next.
-    ///     - maximumAllowableJitter: Upper exlusive bound of jitter range added to the `delay` parameter.
+    ///     - maximumAllowableJitter: Exclusive upper bound of jitter range added to the `delay` parameter.
     ///     - promise: If non-nil, a promise to fulfill when the task is cancelled and all execution is complete.
     ///     - task: The closure that will be executed. Task will keep repeating regardless of whether the future
     ///             gets fulfilled with success or error.

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -382,7 +382,38 @@ public final class EventLoopTest : XCTestCase {
         eventLoop.advanceTime(by: .hours(10))
         XCTAssertEqual(5, counter)
     }
+    
+    func testScheduledRepeatedAsyncTaskIsJittered() throws {
+        let initialDelay = TimeAmount.minutes(5)
+        let delay = TimeAmount.minutes(2)
+        let maximumAllowableJitter = TimeAmount.minutes(1)
+        var sentinel: Int64 = 0
+        let loop = EmbeddedEventLoop()
 
+        _ = loop.scheduleRepeatedAsyncTask(initialDelay: initialDelay, delay: delay, maximumAllowableJitter: maximumAllowableJitter, { RepeatedTask in
+            sentinel += 1
+            let p = loop.makePromise(of: Void.self)
+            loop.scheduleTask(in: .milliseconds(10)) {
+                p.succeed(())
+            }
+            return p.futureResult
+        })
+        
+        for _ in 0..<10 {
+            // just running shouldn't do anything
+            loop.run()
+        }
+
+        let timeRange = TimeAmount.hours(1)
+        // Due to jittered delays is not possible to exactly know how many tasks will be executed in a given time range,
+        // instead calculate a range representing an estimate of the number of tasks executed during that given time range.
+        let minNumberOfExecutedTasks = (timeRange.nanoseconds - initialDelay.nanoseconds) / (delay.nanoseconds + maximumAllowableJitter.nanoseconds)
+        let maxNumberOfExecutedTasks = (timeRange.nanoseconds - initialDelay.nanoseconds) / delay.nanoseconds + 1
+
+        loop.advanceTime(by: timeRange)
+        XCTAssertTrue((minNumberOfExecutedTasks...maxNumberOfExecutedTasks).contains(sentinel))
+    }
+    
     public func testEventLoopGroupMakeIterator() throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         defer {
@@ -802,6 +833,27 @@ public final class EventLoopTest : XCTestCase {
         XCTAssertEqual(XCTWaiter.wait(for: [expectFail1, expectFail2], timeout: 0.5), .timedOut)
         semaphore.signal()
         XCTAssertEqual(XCTWaiter.wait(for: [expect1, expect2], timeout: 0.5), .completed)
+    }
+    
+    func testRepeatedTaskIsJittered() throws {
+        let initialDelay = TimeAmount.minutes(5)
+        let delay = TimeAmount.minutes(2)
+        let maximumAllowableJitter = TimeAmount.minutes(1)
+        var sentinel: Int64 = 0
+        let loop = EmbeddedEventLoop()
+
+        _ = loop.scheduleRepeatedTask(initialDelay: initialDelay, delay: delay, maximumAllowableJitter: maximumAllowableJitter, { RepeatedTask in
+            sentinel += 1
+        })
+
+        let timeRange = TimeAmount.hours(1)
+        // Due to jittered delays is not possible to exactly know how many tasks will be executed in a given time range,
+        // instead calculate a range representing an estimate of the number of tasks executed during that given time range.
+        let minNumberOfExecutedTasks = (timeRange.nanoseconds - initialDelay.nanoseconds) / (delay.nanoseconds + maximumAllowableJitter.nanoseconds)
+        let maxNumberOfExecutedTasks = (timeRange.nanoseconds - initialDelay.nanoseconds) / delay.nanoseconds + 1
+
+        loop.advanceTime(by: timeRange)
+        XCTAssertTrue((minNumberOfExecutedTasks...maxNumberOfExecutedTasks).contains(sentinel))
     }
 
     func testCancelledScheduledTasksDoNotHoldOnToRunClosure() {


### PR DESCRIPTION
Add jitter support to functions managing recurring tasks.

### Motivation:

Closes https://github.com/apple/swift-nio/issues/2505.

### Modifications:

Overloaded the following `EventLoop` functions that might need jitter support:
- `flatScheduleTask`
- `scheduleRepeatedTask`
- `scheduleRepeatedAsyncTask`

with the following new parameter: `maximumAllowableJitter: TimeAmount`, which is the exclusive upper bound of the jitter range that will be added to the `delay` and `initialDelay` parameters.

### Result:

If jitter is needed when scheduling a repeated task with one of the functions listed above, it will be possible to add it by using the `maximumAllowableJitter` parameter.
