### PR TITLE
Fix overflow

### DIFF
--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -420,9 +420,12 @@ public struct TimeAmount: Hashable, Sendable {
     /// - parameters:
     ///     - amount: the amount of microseconds this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
+    ///
+    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
     @inlinable
     public static func microseconds(_ amount: Int64) -> TimeAmount {
-        return TimeAmount(amount * 1000)
+        let nanoseconds = amount &* 1000
+        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
     }
 
     /// Creates a new `TimeAmount` for the given amount of milliseconds.
@@ -430,9 +433,12 @@ public struct TimeAmount: Hashable, Sendable {
     /// - parameters:
     ///     - amount: the amount of milliseconds this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
+    ///
+    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
     @inlinable
     public static func milliseconds(_ amount: Int64) -> TimeAmount {
-        return TimeAmount(amount * (1000 * 1000))
+        let nanoseconds = amount &* (1000 * 1000)
+        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
     }
 
     /// Creates a new `TimeAmount` for the given amount of seconds.
@@ -440,9 +446,12 @@ public struct TimeAmount: Hashable, Sendable {
     /// - parameters:
     ///     - amount: the amount of seconds this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
+    ///
+    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
     @inlinable
     public static func seconds(_ amount: Int64) -> TimeAmount {
-        return TimeAmount(amount * (1000 * 1000 * 1000))
+        let nanoseconds = amount &* (1000 * 1000 * 1000)
+        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
     }
 
     /// Creates a new `TimeAmount` for the given amount of minutes.
@@ -450,9 +459,12 @@ public struct TimeAmount: Hashable, Sendable {
     /// - parameters:
     ///     - amount: the amount of minutes this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
+    ///
+    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
     @inlinable
     public static func minutes(_ amount: Int64) -> TimeAmount {
-        return TimeAmount(amount * (1000 * 1000 * 1000 * 60))
+        let nanoseconds = amount &* (1000 * 1000 * 1000 * 60)
+        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
     }
 
     /// Creates a new `TimeAmount` for the given amount of hours.
@@ -460,9 +472,12 @@ public struct TimeAmount: Hashable, Sendable {
     /// - parameters:
     ///     - amount: the amount of hours this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
+    ///
+    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
     @inlinable
     public static func hours(_ amount: Int64) -> TimeAmount {
-        return TimeAmount(amount * (1000 * 1000 * 1000 * 60 * 60))
+        let nanoseconds = amount &* (1000 * 1000 * 1000 * 60 * 60)
+        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
     }
 }
 

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -437,11 +437,10 @@ public struct TimeAmount: Hashable, Sendable {
     ///     - amount: the amount of microseconds this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
     ///
-    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
+    /// - note: returns `TimeAmount(.max)` if the amount overflows when converted to nanoseconds and `TimeAmount(.min)` if it underflows.
     @inlinable
     public static func microseconds(_ amount: Int64) -> TimeAmount {
-        let nanoseconds = amount &* 1000
-        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
+        return TimeAmount(_cappedNanoseconds(amount: amount, multiplier: 1000))
     }
 
     /// Creates a new `TimeAmount` for the given amount of milliseconds.
@@ -450,11 +449,10 @@ public struct TimeAmount: Hashable, Sendable {
     ///     - amount: the amount of milliseconds this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
     ///
-    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
+    /// - note: returns `TimeAmount(.max)` if the amount overflows when converted to nanoseconds and `TimeAmount(.min)` if it underflows.
     @inlinable
     public static func milliseconds(_ amount: Int64) -> TimeAmount {
-        let nanoseconds = amount &* (1000 * 1000)
-        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
+        return TimeAmount(_cappedNanoseconds(amount: amount, multiplier: 1000 * 1000))
     }
 
     /// Creates a new `TimeAmount` for the given amount of seconds.
@@ -463,11 +461,10 @@ public struct TimeAmount: Hashable, Sendable {
     ///     - amount: the amount of seconds this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
     ///
-    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
+    /// - note: returns `TimeAmount(.max)` if the amount overflows when converted to nanoseconds and `TimeAmount(.min)` if it underflows.
     @inlinable
     public static func seconds(_ amount: Int64) -> TimeAmount {
-        let nanoseconds = amount &* (1000 * 1000 * 1000)
-        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
+        return TimeAmount(_cappedNanoseconds(amount: amount, multiplier: 1000 * 1000 * 1000))
     }
 
     /// Creates a new `TimeAmount` for the given amount of minutes.
@@ -476,11 +473,10 @@ public struct TimeAmount: Hashable, Sendable {
     ///     - amount: the amount of minutes this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
     ///
-    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
+    /// - note: returns `TimeAmount(.max)` if the amount overflows when converted to nanoseconds and `TimeAmount(.min)` if it underflows.
     @inlinable
     public static func minutes(_ amount: Int64) -> TimeAmount {
-        let nanoseconds = amount &* (1000 * 1000 * 1000 * 60)
-        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
+        return TimeAmount(_cappedNanoseconds(amount: amount, multiplier: 1000 * 1000 * 1000 * 60))
     }
 
     /// Creates a new `TimeAmount` for the given amount of hours.
@@ -489,11 +485,26 @@ public struct TimeAmount: Hashable, Sendable {
     ///     - amount: the amount of hours this `TimeAmount` represents.
     /// - returns: the `TimeAmount` for the given amount.
     ///
-    /// - note: returns `TimeAmount(.max)` if the amount, once converted to nanoseconds, exceeds `Int64.max`.
+    /// - note: returns `TimeAmount(.max)` if the amount overflows when converted to nanoseconds and `TimeAmount(.min)` if it underflows.
     @inlinable
     public static func hours(_ amount: Int64) -> TimeAmount {
-        let nanoseconds = amount &* (1000 * 1000 * 1000 * 60 * 60)
-        return nanoseconds >= 0 ? TimeAmount(nanoseconds) : TimeAmount(.max)
+        return TimeAmount(_cappedNanoseconds(amount: amount, multiplier: 1000 * 1000 * 1000 * 60 * 60))
+    }
+    
+    /// Converts `amount` to nanoseconds multiplying it by `multiplier`. The return value is capped to `Int64.max` if the multiplication overflows and `Int64.min` if it underflows.
+    ///
+    ///  - parameters:
+    ///     - amount: the amount to be converted to nanoseconds.
+    ///     - multiplier: the multiplier that converts the given amount to nanoseconds.
+    ///  - returns: the amount converted to nanoseconds within [Int64.min, Int64.max].
+    @inlinable
+    static func _cappedNanoseconds(amount: Int64, multiplier: Int64) -> Int64 {
+        let nanosecondsMultiplication = amount.multipliedReportingOverflow(by: multiplier)
+        if nanosecondsMultiplication.overflow {
+            return amount >= 0 ? .max : .min
+        } else {
+            return nanosecondsMultiplication.partialValue
+        }
     }
 }
 

--- a/Tests/NIOCoreTests/TimeAmountTests.swift
+++ b/Tests/NIOCoreTests/TimeAmountTests.swift
@@ -43,4 +43,22 @@ class TimeAmountTests: XCTestCase {
         lhs -= rhs
         XCTAssertEqual(lhs, .nanoseconds(0))
     }
+    
+    func testTimeAmountCappedOverflow() {
+        let overflowCap = TimeAmount.nanoseconds(Int64.max)
+        XCTAssertEqual(TimeAmount.microseconds(.max), overflowCap)
+        XCTAssertEqual(TimeAmount.milliseconds(.max), overflowCap)
+        XCTAssertEqual(TimeAmount.seconds(.max), overflowCap)
+        XCTAssertEqual(TimeAmount.minutes(.max), overflowCap)
+        XCTAssertEqual(TimeAmount.hours(.max), overflowCap)
+    }
+    
+    func testTimeAmountCappedUnderflow() {
+        let underflowCap = TimeAmount.nanoseconds(.min)
+        XCTAssertEqual(TimeAmount.microseconds(.min), underflowCap)
+        XCTAssertEqual(TimeAmount.milliseconds(.min), underflowCap)
+        XCTAssertEqual(TimeAmount.seconds(.min), underflowCap)
+        XCTAssertEqual(TimeAmount.minutes(.min), underflowCap)
+        XCTAssertEqual(TimeAmount.hours(.min), underflowCap)
+    }
 }

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -1608,6 +1608,24 @@ public final class EventLoopTest : XCTestCase {
             XCTAssert(error is DummyError)
         }
     }
+    
+    func testTimeAmountCappedOverflow() {
+        let overflowCap = TimeAmount(Int64.max)
+        XCTAssertEqual(TimeAmount.microseconds(.max), overflowCap)
+        XCTAssertEqual(TimeAmount.milliseconds(.max), overflowCap)
+        XCTAssertEqual(TimeAmount.seconds(.max), overflowCap)
+        XCTAssertEqual(TimeAmount.minutes(.max), overflowCap)
+        XCTAssertEqual(TimeAmount.hours(.max), overflowCap)
+    }
+    
+    func testTimeAmountCappedUnderflow() {
+        let underflowCap = TimeAmount(.min)
+        XCTAssertEqual(TimeAmount.microseconds(.min), underflowCap)
+        XCTAssertEqual(TimeAmount.milliseconds(.min), underflowCap)
+        XCTAssertEqual(TimeAmount.seconds(.min), underflowCap)
+        XCTAssertEqual(TimeAmount.minutes(.min), underflowCap)
+        XCTAssertEqual(TimeAmount.hours(.min), underflowCap)
+    }
 }
 
 fileprivate class EventLoopWithPreSucceededFuture: EventLoop {

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -1608,24 +1608,6 @@ public final class EventLoopTest : XCTestCase {
             XCTAssert(error is DummyError)
         }
     }
-    
-    func testTimeAmountCappedOverflow() {
-        let overflowCap = TimeAmount(Int64.max)
-        XCTAssertEqual(TimeAmount.microseconds(.max), overflowCap)
-        XCTAssertEqual(TimeAmount.milliseconds(.max), overflowCap)
-        XCTAssertEqual(TimeAmount.seconds(.max), overflowCap)
-        XCTAssertEqual(TimeAmount.minutes(.max), overflowCap)
-        XCTAssertEqual(TimeAmount.hours(.max), overflowCap)
-    }
-    
-    func testTimeAmountCappedUnderflow() {
-        let underflowCap = TimeAmount(.min)
-        XCTAssertEqual(TimeAmount.microseconds(.min), underflowCap)
-        XCTAssertEqual(TimeAmount.milliseconds(.min), underflowCap)
-        XCTAssertEqual(TimeAmount.seconds(.min), underflowCap)
-        XCTAssertEqual(TimeAmount.minutes(.min), underflowCap)
-        XCTAssertEqual(TimeAmount.hours(.min), underflowCap)
-    }
 }
 
 fileprivate class EventLoopWithPreSucceededFuture: EventLoop {


### PR DESCRIPTION
Fixes overflow when initializing any `TimeAmount` other than `TimeAmount.nanoseconds` to `Int64.max`.

### Motivation:

Closes https://github.com/apple/swift-nio/issues/2532

### Modifications:

Added a check to the amount calculated in nanoseconds. If it overflows, `TimeAmount(.max)` is returned, otherwise `TimeAmount(nanoseconds)`.

### Result:
Program doesn't crash when setting a `TimeAmount` to be `Int64.max`. Instead, `TimeAmount(.max)` is returned.
