### PR TITLE
perf tests: reset BB indices after every iteration

### DIFF
--- a/Sources/NIOPerformanceTester/ByteBufferWriteMultipleBenchmarks.swift
+++ b/Sources/NIOPerformanceTester/ByteBufferWriteMultipleBenchmarks.swift
@@ -34,6 +34,7 @@ final class ByteBufferReadWriteMultipleIntegersBenchmark<I: FixedWidthInteger>: 
     func run() throws -> Int {
         var result: I = 0
         for _ in 0..<self.iterations {
+            self.buffer.clear()
             for i in I(0)..<I(10) {
                 self.buffer.writeInteger(i)
             }
@@ -64,6 +65,7 @@ final class ByteBufferMultiReadWriteTenIntegersBenchmark<I: FixedWidthInteger>: 
     func run() throws -> Int {
         var result: I = 0
         for _ in 0..<self.iterations {
+            self.buffer.clear()
             self.buffer.writeMultipleIntegers(
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                 as: (I, I, I, I, I, I, I, I, I, I).self


### PR DESCRIPTION
### Motivation:

The performance tests are assumed to be run with the same number of iterations, so we didn't reset indices. That however means if one were to increase the iterations by a few orders of magnitude, the perf tests may crash.

### Modifications:

Reset the indices every iteration

### Result:

Robustness against more iterations.