### PR TITLE
Remove SPI from `NIOAsyncChannel` and new bootstrap methods

### DIFF
--- a/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEchoAsyncChannel.swift
+++ b/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEchoAsyncChannel.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(AsyncChannel) import NIOCore
-@_spi(AsyncChannel) import NIOPosix
+import NIOCore
+import NIOPosix
 
 func runTCPEchoAsyncChannel(numberOfWrites: Int, eventLoop: EventLoop) async throws {
     let serverChannel = try await ServerBootstrap(group: eventLoop)

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
@@ -16,7 +16,6 @@
 ///
 /// This is a unicast async sequence that allows a single iterator to be created.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-@_spi(AsyncChannel)
 public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     @usableFromInline
     typealias Producer = NIOThrowingAsyncSequenceProducer<Inbound, Error, NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark, NIOAsyncChannelInboundStreamChannelHandlerProducerDelegate>
@@ -149,10 +148,8 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension NIOAsyncChannelInboundStream: AsyncSequence {
-    @_spi(AsyncChannel)
     public typealias Element = Inbound
 
-    @_spi(AsyncChannel)
     public struct AsyncIterator: AsyncIteratorProtocol {
         @usableFromInline
         enum _Backing {
@@ -172,7 +169,7 @@ extension NIOAsyncChannelInboundStream: AsyncSequence {
             }
         }
 
-        @inlinable @_spi(AsyncChannel)
+        @inlinable
         public mutating func next() async throws -> Element? {
             switch self._backing {
             case .asyncStream(var iterator):
@@ -189,7 +186,6 @@ extension NIOAsyncChannelInboundStream: AsyncSequence {
     }
 
     @inlinable
-    @_spi(AsyncChannel)
     public func makeAsyncIterator() -> AsyncIterator {
         return AsyncIterator(self._backing)
     }

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
@@ -12,13 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A ``NIOAsyncChannelWriter`` is used to write and flush new outbound messages in a channel.
+/// A ``NIOAsyncChannelOutboundWriter`` is used to write and flush new outbound messages in a channel.
 ///
 /// The writer acts as a bridge between the Concurrency and NIO world. It allows to write and flush messages into the
 /// underlying ``Channel``. Furthermore, it respects back-pressure of the channel by suspending the calls to write until
 /// the channel becomes writable again.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-@_spi(AsyncChannel)
 public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
     @usableFromInline
     typealias _Writer = NIOAsyncChannelOutboundWriterHandler<OutboundOut>.Writer
@@ -112,7 +111,6 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
     ///
     /// This method suspends if the underlying channel is not writable and will resume once the it becomes writable again.
     @inlinable
-    @_spi(AsyncChannel)
     public func write(_ data: OutboundOut) async throws {
         switch self._backing {
         case .asyncStream(let continuation):
@@ -126,7 +124,6 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
     ///
     /// This method suspends if the underlying channel is not writable and will resume once the it becomes writable again.
     @inlinable
-    @_spi(AsyncChannel)
     public func write<Writes: Sequence>(contentsOf sequence: Writes) async throws where Writes.Element == OutboundOut {
         switch self._backing {
         case .asyncStream(let continuation):
@@ -144,7 +141,6 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
     ///
     /// This method suspends if the underlying channel is not writable and will resume once the it becomes writable again.
     @inlinable
-    @_spi(AsyncChannel)
     public func write<Writes: AsyncSequence>(contentsOf sequence: Writes) async throws where Writes.Element == OutboundOut {
         for try await data in sequence {
             try await self.write(data)
@@ -154,7 +150,6 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
     /// Finishes the writer.
     ///
     /// This might trigger a half closure if the ``NIOAsyncChannel`` was configured to support it.
-    @_spi(AsyncChannel)
     public func finish() {
         switch self._backing {
         case .asyncStream(let continuation):

--- a/Sources/NIOCore/Docs.docc/swift-concurrency.md
+++ b/Sources/NIOCore/Docs.docc/swift-concurrency.md
@@ -46,7 +46,7 @@ bi-directional streaming pipeline. To bridge such a pipeline into Concurrency
 required new types. Importantly, these types need to uphold the channel's
 back pressure and writability guarantees. NIO introduced the
 ``NIOThrowingAsyncSequenceProducer``, ``NIOAsyncSequenceProducer`` and the
-``NIOAsyncWriter`` which form the foundation to bridge a ``Channel``. On top of
+``NIOAsyncChannelOutboundWriter`` which form the foundation to bridge a ``Channel``. On top of
 these foundational types, NIO provides the `NIOAsyncChannel` which is used to
 wrap a ``Channel`` to produce an interface that can be consumed directly from
 Swift Concurrency. The following sections cover the details of the foundational
@@ -65,7 +65,7 @@ sequence.
 
 #### NIOAsyncWriter
 
-The ``NIOAsyncWriter`` is used for bridging from an asynchronous producer to a
+The ``NIOAsyncChannelOutboundWriter`` is used for bridging from an asynchronous producer to a
 synchronous consumer. It also has back pressure support which allows the
 consumer to stop the producer by suspending the
 ``NIOAsyncWriter/yield(contentsOf:)`` method.

--- a/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
@@ -11,13 +11,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-@_spi(AsyncChannel) import NIOCore
+import NIOCore
 
 // MARK: - Server pipeline configuration
 
 /// Configuration for an upgradable HTTP pipeline.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@_spi(AsyncChannel)
 public struct NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult: Sendable> {
     /// Whether to provide assistance handling HTTP clients that pipeline
     /// their requests. Defaults to `true`. If `false`, users will need to handle clients that pipeline themselves.
@@ -58,7 +57,6 @@ extension ChannelPipeline {
     /// - Returns: An `EventLoopFuture` that will fire when the pipeline is configured. The future contains an `EventLoopFuture`
     /// that is fired once the pipeline has been upgraded or not and contains the `UpgradeResult`.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    @_spi(AsyncChannel)
     public func configureUpgradableHTTPServerPipeline<UpgradeResult: Sendable>(
         configuration: NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult>
     ) -> EventLoopFuture<EventLoopFuture<UpgradeResult>> {
@@ -99,7 +97,6 @@ extension ChannelPipeline.SynchronousOperations {
     ///   - configuration: The HTTP pipeline's configuration.
     /// - Returns: An `EventLoopFuture` that is fired once the pipeline has been upgraded or not and contains the `UpgradeResult`.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    @_spi(AsyncChannel)
     public func configureUpgradableHTTPServerPipeline<UpgradeResult: Sendable>(
         configuration: NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult>
     ) throws -> EventLoopFuture<UpgradeResult> {
@@ -148,7 +145,6 @@ extension ChannelPipeline.SynchronousOperations {
 
 /// Configuration for an upgradable HTTP pipeline.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@_spi(AsyncChannel)
 public struct NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult: Sendable> {
     /// The strategy to use when dealing with leftover bytes after removing the ``HTTPDecoder`` from the pipeline.
     public var leftOverBytesStrategy = RemoveAfterUpgradeStrategy.dropBytes
@@ -182,7 +178,6 @@ extension ChannelPipeline {
     /// - Returns: An `EventLoopFuture` that will fire when the pipeline is configured. The future contains an `EventLoopFuture`
     /// that is fired once the pipeline has been upgraded or not and contains the `UpgradeResult`.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    @_spi(AsyncChannel)
     public func configureUpgradableHTTPClientPipeline<UpgradeResult: Sendable>(
         configuration: NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult>
     ) -> EventLoopFuture<EventLoopFuture<UpgradeResult>> {
@@ -221,7 +216,6 @@ extension ChannelPipeline.SynchronousOperations {
     ///   - configuration: The HTTP pipeline's configuration.
     /// - Returns: An `EventLoopFuture` that is fired once the pipeline has been upgraded or not and contains the `UpgradeResult`.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    @_spi(AsyncChannel)
     public func configureUpgradableHTTPClientPipeline<UpgradeResult: Sendable>(
         configuration: NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult>
     ) throws -> EventLoopFuture<UpgradeResult> {

--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
@@ -16,7 +16,6 @@ import NIOCore
 /// An object that implements `NIOTypedHTTPClientProtocolUpgrader` knows how to handle HTTP upgrade to
 /// a protocol on a client-side channel.
 /// It has the option of denying this upgrade based upon the server response.
-@_spi(AsyncChannel)
 public protocol NIOTypedHTTPClientProtocolUpgrader<UpgradeResult> {
     associatedtype UpgradeResult: Sendable
 
@@ -42,7 +41,6 @@ public protocol NIOTypedHTTPClientProtocolUpgrader<UpgradeResult> {
 
 /// The upgrade configuration for the ``NIOTypedHTTPClientUpgradeHandler``.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@_spi(AsyncChannel)
 public struct NIOTypedHTTPClientUpgradeConfiguration<UpgradeResult: Sendable> {
     /// The initial request head that is sent out once the channel becomes active.
     public var upgradeRequestHead: HTTPRequestHead
@@ -76,7 +74,6 @@ public struct NIOTypedHTTPClientUpgradeConfiguration<UpgradeResult: Sendable> {
 /// It will only upgrade to the protocol that is returned first in the list and does not currently
 /// have the capability to upgrade to multiple simultaneous layered protocols.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@_spi(AsyncChannel)
 public final class NIOTypedHTTPClientUpgradeHandler<UpgradeResult: Sendable>: ChannelDuplexHandler, RemovableChannelHandler {
     public typealias OutboundIn = HTTPClientRequestPart
     public typealias OutboundOut = HTTPClientRequestPart

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -11,11 +11,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-@_spi(AsyncChannel) import NIOCore
+import NIOCore
 
 /// An object that implements `NIOTypedHTTPServerProtocolUpgrader` knows how to handle HTTP upgrade to
 /// a protocol on a server-side channel.
-@_spi(AsyncChannel)
 public protocol NIOTypedHTTPServerProtocolUpgrader<UpgradeResult> {
     associatedtype UpgradeResult: Sendable
 
@@ -47,7 +46,6 @@ public protocol NIOTypedHTTPServerProtocolUpgrader<UpgradeResult> {
 
 /// The upgrade configuration for the ``NIOTypedHTTPServerUpgradeHandler``.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@_spi(AsyncChannel)
 public struct NIOTypedHTTPServerUpgradeConfiguration<UpgradeResult: Sendable> {
     /// The array of potential upgraders.
     public var upgraders: [any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>]
@@ -76,7 +74,6 @@ public struct NIOTypedHTTPServerUpgradeConfiguration<UpgradeResult: Sendable> {
 /// requests that we choose to punt on it entirely and not allow it. As it happens this is mostly fine:
 /// the odds of someone needing to upgrade midway through the lifetime of a connection are very low.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@_spi(AsyncChannel)
 public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: ChannelInboundHandler, RemovableChannelHandler {
     public typealias InboundIn = HTTPServerRequestPart
     public typealias InboundOut = HTTPServerRequestPart

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-@_spi(AsyncChannel) import NIOCore
+import NIOCore
 
 #if os(Windows)
 import ucrt
@@ -474,7 +474,6 @@ extension ServerBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         host: String,
         port: Int,
@@ -499,7 +498,6 @@ extension ServerBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         to address: SocketAddress,
         serverBackPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
@@ -535,7 +533,6 @@ extension ServerBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         unixDomainSocketPath: String,
         cleanupExistingSocketFile: Bool = false,
@@ -564,7 +561,6 @@ extension ServerBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         _ socket: NIOBSDSocket.Handle,
         cleanupExistingSocketFile: Bool = false,
@@ -623,7 +619,7 @@ extension ServerBootstrap {
                         name: "AcceptHandler"
                     )
                     let asyncChannel = try NIOAsyncChannel<ChannelInitializerResult, Never>
-                        .wrapAsyncChannelWithTransformations(
+                        ._wrapAsyncChannelWithTransformations(
                             synchronouslyWrapping: serverChannel,
                             backPressureStrategy: serverBackPressureStrategy,
                             channelReadTransformation: { channel -> EventLoopFuture<ChannelInitializerResult> in
@@ -1067,7 +1063,6 @@ extension ClientBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         host: String,
         port: Int,
@@ -1093,7 +1088,6 @@ extension ClientBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         to address: SocketAddress,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
@@ -1118,7 +1112,6 @@ extension ClientBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         unixDomainSocketPath: String,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
@@ -1138,7 +1131,6 @@ extension ClientBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func withConnectedSocket<Output: Sendable>(
         _ socket: NIOBSDSocket.Handle,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
@@ -1567,7 +1559,6 @@ extension DatagramBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func withBoundSocket<Output: Sendable>(
         _ socket: NIOBSDSocket.Handle,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
@@ -1598,7 +1589,6 @@ extension DatagramBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         host: String,
         port: Int,
@@ -1623,7 +1613,6 @@ extension DatagramBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         to address: SocketAddress,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
@@ -1649,7 +1638,6 @@ extension DatagramBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         unixDomainSocketPath: String,
         cleanupExistingSocketFile: Bool = false,
@@ -1679,7 +1667,6 @@ extension DatagramBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         host: String,
         port: Int,
@@ -1704,7 +1691,6 @@ extension DatagramBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         to address: SocketAddress,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
@@ -1728,7 +1714,6 @@ extension DatagramBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         unixDomainSocketPath: String,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
@@ -2077,7 +2062,6 @@ extension NIOPipeBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func takingOwnershipOfDescriptor<Output: Sendable>(
         inputOutput: CInt,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
@@ -2116,7 +2100,6 @@ extension NIOPipeBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func takingOwnershipOfDescriptors<Output: Sendable>(
         input: CInt,
         output: CInt,
@@ -2131,8 +2114,7 @@ extension NIOPipeBootstrap {
     }
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel) // Should become private
-    public func _takingOwnershipOfDescriptors<ChannelInitializerResult, PostRegistrationTransformationResult: Sendable>(
+    func _takingOwnershipOfDescriptors<ChannelInitializerResult, PostRegistrationTransformationResult: Sendable>(
         input: CInt,
         output: CInt,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<ChannelInitializerResult>,

--- a/Sources/NIOPosix/RawSocketBootstrap.swift
+++ b/Sources/NIOPosix/RawSocketBootstrap.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-@_spi(AsyncChannel) import NIOCore
+import NIOCore
 
 /// A `RawSocketBootstrap` is an easy way to interact with IP based protocols other then TCP and UDP.
 ///
@@ -204,7 +204,6 @@ extension NIORawSocketBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func bind<Output: Sendable>(
         host: String,
         ipProtocol: NIOIPProtocol,
@@ -227,7 +226,6 @@ extension NIORawSocketBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @_spi(AsyncChannel)
     public func connect<Output: Sendable>(
         host: String,
         ipProtocol: NIOIPProtocol,

--- a/Sources/NIOTCPEchoClient/Client.swift
+++ b/Sources/NIOTCPEchoClient/Client.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 #if swift(>=5.9)
-@_spi(AsyncChannel) import NIOCore
-@_spi(AsyncChannel) import NIOPosix
+import NIOCore
+import NIOPosix
 
 @available(macOS 14, *)
 @main

--- a/Sources/NIOTCPEchoServer/Server.swift
+++ b/Sources/NIOTCPEchoServer/Server.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 #if swift(>=5.9)
-@_spi(AsyncChannel) import NIOCore
-@_spi(AsyncChannel) import NIOPosix
+import NIOCore
+import NIOPosix
 
 @available(macOS 14, *)
 @main

--- a/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(AsyncChannel) import NIOCore
+import NIOCore
 
-/// A helper ``ChannelInboundHandler`` that makes it easy to swap channel pipelines
+/// A helper `ChannelInboundHandler` that makes it easy to swap channel pipelines
 /// based on the result of an ALPN negotiation.
 ///
 /// The standard pattern used by applications that want to use ALPN is to select
@@ -26,28 +26,24 @@
 ///
 /// The user of this channel handler provides a single closure that is called with
 /// an ``ALPNResult`` when the ALPN negotiation is complete. Based on that result
-/// the user is free to reconfigure the ``ChannelPipeline`` as required, and should
-/// return an ``EventLoopFuture`` that will complete when the pipeline is reconfigured.
+/// the user is free to reconfigure the `ChannelPipeline` as required, and should
+/// return an `EventLoopFuture` that will complete when the pipeline is reconfigured.
 ///
-/// Until the ``EventLoopFuture`` completes, this channel handler will buffer inbound
-/// data. When the ``EventLoopFuture`` completes, the buffered data will be replayed
+/// Until the `EventLoopFuture` completes, this channel handler will buffer inbound
+/// data. When the `EventLoopFuture` completes, the buffered data will be replayed
 /// down the channel. Then, finally, this channel handler will automatically remove
 /// itself from the channel pipeline, leaving the pipeline in its final
 /// configuration.
 ///
 /// Importantly, this is a typed variant of the ``ApplicationProtocolNegotiationHandler`` and allows the user to
 /// specify a type that must be returned from the supplied closure. The result will then be used to succeed the ``NIOTypedApplicationProtocolNegotiationHandler/protocolNegotiationResult``
-/// promise. This allows us to construct pipelines that include protocol negotiation handlers and be able to bridge them into ``NIOAsyncChannel``
+/// promise. This allows us to construct pipelines that include protocol negotiation handlers and be able to bridge them into `NIOAsyncChannel`
 /// based bootstraps.
-@_spi(AsyncChannel)
 public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>: ChannelInboundHandler, RemovableChannelHandler {
-    @_spi(AsyncChannel)
     public typealias InboundIn = Any
 
-    @_spi(AsyncChannel)
     public typealias InboundOut = Any
 
-    @_spi(AsyncChannel)
     public var protocolNegotiationResult: EventLoopFuture<NegotiationResult> {
         return self.negotiatedPromise.futureResult
     }
@@ -66,7 +62,6 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
     ///
     /// - Parameter alpnCompleteHandler: The closure that will fire when ALPN
     ///   negotiation has completed.
-    @_spi(AsyncChannel)
     public init(alpnCompleteHandler: @escaping (ALPNResult, Channel) -> EventLoopFuture<NegotiationResult>) {
         self.completionHandler = alpnCompleteHandler
     }
@@ -76,7 +71,6 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
     ///
     /// - Parameter alpnCompleteHandler: The closure that will fire when ALPN
     ///   negotiation has completed.
-    @_spi(AsyncChannel)
     public convenience init(alpnCompleteHandler: @escaping (ALPNResult) -> EventLoopFuture<NegotiationResult>) {
         self.init { result, _ in
             alpnCompleteHandler(result)
@@ -97,7 +91,6 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
         }
     }
 
-    @_spi(AsyncChannel)
     public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         switch self.stateMachine.userInboundEventTriggered(event: event) {
         case .fireUserInboundEventTriggered:
@@ -108,7 +101,6 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
         }
     }
 
-    @_spi(AsyncChannel)
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         switch self.stateMachine.channelRead(data: data) {
         case .fireChannelRead:
@@ -119,7 +111,6 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
         }
     }
 
-    @_spi(AsyncChannel)
     public func channelInactive(context: ChannelHandlerContext) {
         self.stateMachine.channelInactive()
         

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-@_spi(AsyncChannel) import NIOHTTP1
+import NIOHTTP1
 import _NIOBase64
 
 @available(*, deprecated, renamed: "NIOWebSocketClientUpgrader")
@@ -80,7 +80,6 @@ public final class NIOWebSocketClientUpgrader: NIOHTTPClientProtocolUpgrader {
 /// This upgrader also assumes that the `HTTPClientUpgradeHandler` will appropriately mutate the
 /// pipeline to remove the HTTP `ChannelHandler`s.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@_spi(AsyncChannel)
 public final class NIOTypedWebSocketClientUpgrader<UpgradeResult: Sendable>: NIOTypedHTTPClientProtocolUpgrader {
     /// RFC 6455 specs this as the required entry in the Upgrade header.
     public let supportedProtocol: String = "websocket"

--- a/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
@@ -13,8 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import CNIOSHA1
-@_spi(AsyncChannel) import NIOCore
-@_spi(AsyncChannel) import NIOHTTP1
+import NIOCore
+import NIOHTTP1
 
 let magicWebSocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
@@ -185,7 +185,6 @@ public final class NIOWebSocketServerUpgrader: HTTPServerProtocolUpgrader, @unch
 ///
 /// This upgrader assumes that the `HTTPServerUpgradeHandler` will appropriately mutate the pipeline to
 /// remove the HTTP `ChannelHandler`s.
-@_spi(AsyncChannel)
 public final class NIOTypedWebSocketServerUpgrader<UpgradeResult: Sendable>: NIOTypedHTTPServerProtocolUpgrader, Sendable {
     private typealias ShouldUpgrade = @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>
     private typealias UpgradePipelineHandler = @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<UpgradeResult>

--- a/Sources/NIOWebSocketClient/Client.swift
+++ b/Sources/NIOWebSocketClient/Client.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 #if swift(>=5.9)
-@_spi(AsyncChannel) import NIOCore
-@_spi(AsyncChannel) import NIOPosix
-@_spi(AsyncChannel) import NIOHTTP1
-@_spi(AsyncChannel) import NIOWebSocket
+import NIOCore
+import NIOPosix
+import NIOHTTP1
+import NIOWebSocket
 
 @available(macOS 14, *)
 @main

--- a/Sources/NIOWebSocketServer/Server.swift
+++ b/Sources/NIOWebSocketServer/Server.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 #if swift(>=5.9)
-@_spi(AsyncChannel) import NIOCore
-@_spi(AsyncChannel) import NIOPosix
-@_spi(AsyncChannel) import NIOHTTP1
-@_spi(AsyncChannel) import NIOWebSocket
+import NIOCore
+import NIOPosix
+import NIOHTTP1
+import NIOWebSocket
 
 let websocketResponse = """
 <!DOCTYPE html>

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelInboundStreamTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelInboundStreamTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(AsyncChannel) @testable import NIOCore
+@testable import NIOCore
 import XCTest
 
 final class AsyncChannelInboundStreamTests: XCTestCase {

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelOutboundWriterTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelOutboundWriterTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(AsyncChannel) @testable import NIOCore
+@testable import NIOCore
 import XCTest
 
 final class AsyncChannelOutboundWriterTests: XCTestCase {

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Atomics
 import NIOConcurrencyHelpers
-@_spi(AsyncChannel) @testable import NIOCore
+@testable import NIOCore
 import NIOEmbedded
 import XCTest
 
@@ -41,7 +41,7 @@ final class AsyncChannelTests: XCTestCase {
         let thirdRead = try await iterator.next()
         XCTAssertNil(thirdRead)
 
-        try await channel.close()
+        try await channel.closeFuture.get()
     }
 
     func testAsyncChannelBasicWrites() async throws {

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -16,7 +16,7 @@ import XCTest
 import Dispatch
 @testable import NIOCore
 import NIOEmbedded
-@_spi(AsyncChannel) @testable import NIOHTTP1
+@testable import NIOHTTP1
 
 extension EmbeddedChannel {
     

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -16,7 +16,7 @@ import XCTest
 import NIOCore
 import NIOEmbedded
 @testable import NIOPosix
-@testable @_spi(AsyncChannel) import NIOHTTP1
+@testable import NIOHTTP1
 
 extension ChannelPipeline {
     fileprivate func assertDoesNotContainUpgrader() throws {

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -13,10 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 import NIOConcurrencyHelpers
-@_spi(AsyncChannel) @testable import NIOCore
-@_spi(AsyncChannel) @testable import NIOPosix
+@testable import NIOCore
+@testable import NIOPosix
 import XCTest
-@_spi(AsyncChannel) import NIOTLS
+import NIOTLS
 
 private final class IPHeaderRemoverHandler: ChannelInboundHandler {
     typealias InboundIn = AddressedEnvelope<ByteBuffer>

--- a/Tests/NIOTLSTests/NIOTypedApplicationProtocolNegotiationHandlerTests.swift
+++ b/Tests/NIOTLSTests/NIOTypedApplicationProtocolNegotiationHandlerTests.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(AsyncChannel) import NIOTLS
-@_spi(AsyncChannel) import NIOCore
+import NIOTLS
+import NIOCore
 import NIOEmbedded
 import XCTest
 import NIOTestUtils

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -15,8 +15,8 @@
 import XCTest
 import NIOCore
 import NIOEmbedded
-@_spi(AsyncChannel) import NIOHTTP1
-@_spi(AsyncChannel) @testable import NIOWebSocket
+import NIOHTTP1
+@testable import NIOWebSocket
 
 extension EmbeddedChannel {
     

--- a/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
@@ -15,8 +15,8 @@
 import XCTest
 @testable import NIOCore
 import NIOEmbedded
-@_spi(AsyncChannel) import NIOHTTP1
-@testable @_spi(AsyncChannel) import NIOWebSocket
+import NIOHTTP1
+@testable import NIOWebSocket
 
 extension EmbeddedChannel {
     func readAllInboundBuffers() throws -> ByteBuffer {

--- a/docs/public-async-nio-apis.md
+++ b/docs/public-async-nio-apis.md
@@ -72,7 +72,7 @@ overview to review them.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct NIOAsyncChannel<Inbound, Outbound> : Sendable where Inbound : Sendable, Outbound : Sendable {
     public struct Configuration : Sendable {
-        /// The back pressure strategy of the ``NIOAsyncChannel/inboundStream``.
+        /// The back pressure strategy of the ``NIOAsyncChannel/inbound``.
         public var backPressureStrategy: NIOCore.NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark
 
         /// If outbound half closure should be enabled. Outbound half closure is triggered once


### PR DESCRIPTION
# Motivation
Over the past months, we have been working on new async bridges to make using NIO's `Channel` from Swift Concurrency possible. Since this work was far reaching we have opted to land all of it as SPI. Now the time has come and we feel confident enough to make the SPI official API. This comes after testing the new APIs in various scenarios such as HTTP 1&2, HTTP upgrades, protocol negotiation and in benchmarks.

# Modification
This PR removes the SPI from the `NIOAsyncChannel` and the bootstrap methods. The other SPI usages will be removed in follow up PRs to keep the scope of the PRs relatively small.

# Result
Everyone can use the `NIOAsyncChannel` 🚀
