### PR TITLE
Fix flaky `testRemovesAllHTTPRelatedHandlersAfterUpgrade` test

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -62,8 +62,15 @@ extension ChannelPipeline {
                 // handler present, keep waiting
                 usleep(50)
             } catch ChannelPipelineError.notFound {
-                // No upgrader, we're good.
-                return
+                // Checking if the typed variant is present
+                do {
+                    _ = try self.context(handlerType: NIOTypedHTTPServerUpgradeHandler<Bool>.self).wait()
+                    // handler present, keep waiting
+                    usleep(50)
+                } catch ChannelPipelineError.notFound {
+                    // No upgrader, we're good.
+                    return
+                }
             }
         }
 


### PR DESCRIPTION
# Motivation
This test has been flaky since we only waited for the untyped handler to be removed but we also execute this test for the typed test subclass.

# Modification
This PR fixes the test by also waiting for the typed handler to no longer be present in the pipeline.

# Result
Less flaky tests.
