### PR TITLE
Implement wrapper for use-once resolvers

### DIFF
--- a/Sources/NIOPosix/DynamicResolver.swift
+++ b/Sources/NIOPosix/DynamicResolver.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOCore
+
+/// A protocol that covers an object that does DNS A and AAAA queries via a single method.
+protocol DNSResolver {
+    associatedtype T
+    
+    /// Initiate DNS A and AAAA queries for a given host.
+    ///
+    /// - parameters:
+    ///     - host: The hostname to do a lookup on.
+    ///     - port: The port we'll be connecting to.
+    /// - returns: The future results (A and AAAA) of the lookup, as well as the instance of the resolver that performed the lookup.
+    func initiateDNSLookup(host: String, port: Int) -> DNSResolverResult
+    
+    /// Cancel all outstanding DNS queries of resolver.
+    func cancelQueries(resolver: T)
+}
+
+/// The result of a lookup performed by resolver.
+/// Stores the A and AAAA futures as well as the instance of the resolver that performed the lookup.
+struct DNSResolverResult {
+    let resolver: Resolver
+    let v4Future: EventLoopFuture<[SocketAddress]>
+    let v6Future: EventLoopFuture<[SocketAddress]>
+}
+
+/// Wraps a use-exactly-once resolver and allows to use it never or more than once.
+///
+/// It uses a different instance of the wrapped resolver each time a lookup is performed.
+/// This can be useful in situations where it's not possible to assure that the resolver's single-use nature is honored.
+class DynamicResolver<T: Resolver>: DNSResolver {
+    private let resolverFactory: () -> T
+    
+    init(resolverFactory: @escaping () -> T) {
+        self.resolverFactory = resolverFactory
+    }
+    
+    func initiateDNSLookup(host: String, port: Int) -> DNSResolverResult {
+        let resolver = resolverFactory()
+        let v4Future = resolver.initiateAQuery(host: host, port: port)
+        let v6Future = resolver.initiateAAAAQuery(host: host, port: port)
+        return DNSResolverResult(resolver: resolver, v4Future: v4Future, v6Future: v6Future)
+    }
+    
+    func cancelQueries(resolver: Resolver) {
+        resolver.cancelQueries()
+    }
+}

--- a/Tests/NIOPosixTests/DynamicResolverTest.swift
+++ b/Tests/NIOPosixTests/DynamicResolverTest.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+@testable import NIOPosix
+import XCTest
+
+class DynamicResolverTest: XCTestCase {
+    
+    func testDynamicResolver() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        let dynamicResolver = DynamicResolver(){ GetaddrinfoResolver(loop: group.next(), aiSocktype: .stream, aiProtocol: .tcp) }
+        
+        let resolutionFirstQuery = dynamicResolver.initiateDNSLookup(host: "127.0.0.1", port: 12345)
+        // Should have no effect, as the cancelQueries implementation of `GetaddrinfoResolver` is a no-op.
+        dynamicResolver.cancelQueries(resolver: resolutionFirstQuery.resolver)
+        let addressV4FirstResult = try resolutionFirstQuery.v4Future.wait()
+        let addressV6FirstResult = try resolutionFirstQuery.v6Future.wait()
+
+        XCTAssertEqual(1, addressV4FirstResult.count)
+        XCTAssertEqual(try SocketAddress(ipAddress: "127.0.0.1", port: 12345), addressV4FirstResult[0])
+        XCTAssertTrue(addressV6FirstResult.isEmpty)
+        
+        let resolutionSecondQuery = dynamicResolver.initiateDNSLookup(host: "::1", port: 12345)
+        // Should have no effect, as the cancelQueries implementation of `GetaddrinfoResolver` is a no-op.
+        dynamicResolver.cancelQueries(resolver: resolutionSecondQuery.resolver)
+        let addressV4SecondResult = try resolutionSecondQuery.v4Future.wait()
+        let addressV6SecondResult = try resolutionSecondQuery.v6Future.wait()
+
+        XCTAssertEqual(1, addressV6SecondResult.count)
+        XCTAssertEqual(try SocketAddress(ipAddress: "::1", port: 12345), addressV6SecondResult[0])
+        XCTAssertTrue(addressV4SecondResult.isEmpty)
+    }
+}


### PR DESCRIPTION
Implement a use-once resolvers wrapper to obscure the wrapped resolver's single-use nature.

### Motivation:

Closes https://github.com/apple/swift-nio/issues/2434

### Modifications:
Implemented a new `DynamicResolver` class that wraps a use-exactly-once resolver and manages its lifecycle, creating a new instance of the resolver each time a new resolution is performed.

### Result:
It's now possible to wrap a single-use resolver in a `DynamicResolver` to use it in situations where it might be used never or more than once.