### PR TITLE
Fix `Sendable` conformance for `Lock`

### DIFF
--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -295,5 +295,5 @@ internal func debugOnly(_ body: () -> Void) {
 }
 
 @available(*, deprecated)
-extension Lock: Sendable {}
+extension Lock: @unchecked Sendable {}
 extension ConditionLock: @unchecked Sendable {}


### PR DESCRIPTION
# Motivation
The latest nightly toolchains have merged the patch that removes `Sendable` conformance from the various `Unsafe*Pointer` APIs. Our `Lock` type was using such a type internally and had a `Sendable` conformance. This conformance was now failing since the pointer was no longer `Sendable`.

# Modification
This PR changes the `Sendable` conformance of `Lock` to `@unchecked Sendable`.

# Result
No more `Sendable` warnings in non-strict mode on nightly toolchains
