### PR TITLE
waitForUpgraderToBeRemoved availability guard

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -55,6 +55,7 @@ extension ChannelPipeline {
 
     // Waits up to 1 second for the upgrader to be removed by polling the pipeline
     // every 50ms checking for the handler.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     fileprivate func waitForUpgraderToBeRemoved() throws {
         for _ in 0..<20 {
             do {


### PR DESCRIPTION
### Motivation:

Tests fail to compile on 5.7, 5.8

### Modifications:

Add `waitForUpgraderToBeRemoved` availability guard

### Result:

Tests should compile