### PR TITLE
Add support for unidirectional `NIOPipeBootstrap`

### DIFF
--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriterHandler.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriterHandler.swift
@@ -147,6 +147,18 @@ internal final class NIOAsyncChannelOutboundWriterHandler<OutboundOut: Sendable>
         self.sink?.setWritability(to: context.channel.isWritable)
         context.fireChannelWritabilityChanged()
     }
+
+    @inlinable
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        switch event {
+        case ChannelEvent.outputClosed:
+            self.sink?.finish()
+        default:
+            break
+        }
+
+        context.fireUserInboundEventTriggered(event)
+    }
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)

--- a/Sources/NIOCrashTester/OutputGrepper.swift
+++ b/Sources/NIOCrashTester/OutputGrepper.swift
@@ -33,7 +33,7 @@ internal struct OutputGrepper {
                 channel.pipeline.addHandlers([ByteToMessageHandler(NewlineFramer()),
                                               GrepHandler(promise: outputPromise)])
             }
-            .takingOwnershipOfDescriptors(input: dup(processToChannel.fileHandleForReading.fileDescriptor))
+            .takingOwnershipOfDescriptor(input: dup(processToChannel.fileHandleForReading.fileDescriptor))
         let processOutputPipe = NIOFileHandle(descriptor: dup(processToChannel.fileHandleForWriting.fileDescriptor))
         processToChannel.fileHandleForReading.closeFile()
         processToChannel.fileHandleForWriting.closeFile()

--- a/Sources/NIOCrashTester/OutputGrepper.swift
+++ b/Sources/NIOCrashTester/OutputGrepper.swift
@@ -22,7 +22,6 @@ internal struct OutputGrepper {
 
     internal static func make(group: EventLoopGroup) -> OutputGrepper {
         let processToChannel = Pipe()
-        let deadPipe = Pipe() // just so we have an output...
 
         let eventLoop = group.next()
         let outputPromise = eventLoop.makePromise(of: ProgramOutput.self)
@@ -34,13 +33,10 @@ internal struct OutputGrepper {
                 channel.pipeline.addHandlers([ByteToMessageHandler(NewlineFramer()),
                                               GrepHandler(promise: outputPromise)])
             }
-            .takingOwnershipOfDescriptors(input: dup(processToChannel.fileHandleForReading.fileDescriptor),
-                       output: dup(deadPipe.fileHandleForWriting.fileDescriptor))
+            .takingOwnershipOfDescriptors(input: dup(processToChannel.fileHandleForReading.fileDescriptor))
         let processOutputPipe = NIOFileHandle(descriptor: dup(processToChannel.fileHandleForWriting.fileDescriptor))
         processToChannel.fileHandleForReading.closeFile()
         processToChannel.fileHandleForWriting.closeFile()
-        deadPipe.fileHandleForReading.closeFile()
-        deadPipe.fileHandleForWriting.closeFile()
         channelFuture.cascadeFailure(to: outputPromise)
         return OutputGrepper(result: outputPromise.futureResult,
                              processOutputPipe: processOutputPipe)

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2058,43 +2058,37 @@ public final class NIOPipeBootstrap {
         self._takingOwnershipOfDescriptors(input: input, output: output)
     }
 
-    /// Create the `PipeChannel` with the provided input and output file descriptors.
+    /// Create the `PipeChannel` with the provided input file descriptor.
     ///
-    /// The input and output file descriptors must be distinct. If you have a single file descriptor, consider using
-    /// `ClientBootstrap.withConnectedSocket(descriptor:)` if it's a socket or
-    /// `NIOPipeBootstrap.takingOwnershipOfDescriptor` if it is not a socket.
+    /// The input file descriptor must be distinct.
     ///
-    /// - Note: If this method returns a succeeded future, SwiftNIO will close `input` and `output`
-    ///         when the `Channel` becomes inactive. You _must not_ do any further operations `input` or
-    ///         `output`, including `close`.
-    ///         If this method returns a failed future, you still own the file descriptors and are responsible for
+    /// - Note: If this method returns a succeeded future, SwiftNIO will close `input` when the `Channel`
+    ///         becomes inactive. You _must not_ do any further operations to `input`, including `close`.
+    ///         If this method returns a failed future, you still own the file descriptor and are responsible for
     ///         closing them.
     ///
     /// - Parameters:
     ///   - input: The _Unix file descriptor_ for the input (ie. the read side).
     /// - Returns: an `EventLoopFuture<Channel>` to deliver the `Channel`.
-    public func takingOwnershipOfDescriptors(
+    public func takingOwnershipOfDescriptor(
         input: CInt
     ) -> EventLoopFuture<Channel> {
         self._takingOwnershipOfDescriptors(input: input, output: nil)
     }
 
-    /// Create the `PipeChannel` with the provided input and output file descriptors.
+    /// Create the `PipeChannel` with the provided output file descriptor.
     ///
-    /// The input and output file descriptors must be distinct. If you have a single file descriptor, consider using
-    /// `ClientBootstrap.withConnectedSocket(descriptor:)` if it's a socket or
-    /// `NIOPipeBootstrap.takingOwnershipOfDescriptor` if it is not a socket.
+    /// The output file descriptor must be distinct.
     ///
-    /// - Note: If this method returns a succeeded future, SwiftNIO will close `input` and `output`
-    ///         when the `Channel` becomes inactive. You _must not_ do any further operations `input` or
-    ///         `output`, including `close`.
-    ///         If this method returns a failed future, you still own the file descriptors and are responsible for
+    /// - Note: If this method returns a succeeded future, SwiftNIO will close `output` when the `Channel`
+    ///         becomes inactive. You _must not_ do any further operations to `output`, including `close`.
+    ///         If this method returns a failed future, you still own the file descriptor and are responsible for
     ///         closing them.
     ///
     /// - Parameters:
     ///   - output: The _Unix file descriptor_ for the output (ie. the write side).
     /// - Returns: an `EventLoopFuture<Channel>` to deliver the `Channel`.
-    public func takingOwnershipOfDescriptors(
+    public func takingOwnershipOfDescriptor(
         output: CInt
     ) -> EventLoopFuture<Channel> {
         self._takingOwnershipOfDescriptors(input: nil, output: output)
@@ -2170,9 +2164,7 @@ extension NIOPipeBootstrap {
 
     /// Create the `PipeChannel` with the provided input and output file descriptors.
     ///
-    /// The input and output file descriptors must be distinct. If you have a single file descriptor, consider using
-    /// `ClientBootstrap.withConnectedSocket(descriptor:)` if it's a socket or
-    /// `NIOPipeBootstrap.takingOwnershipOfDescriptor` if it is not a socket.
+    /// The input and output file descriptors must be distinct.
     ///
     /// - Note: If this method returns a succeeded future, SwiftNIO will close `input` and `output`
     ///         when the `Channel` becomes inactive. You _must not_ do any further operations `input` or
@@ -2199,16 +2191,13 @@ extension NIOPipeBootstrap {
         )
     }
 
-    /// Create the `PipeChannel` with the provided input and output file descriptors.
+    /// Create the `PipeChannel` with the provided input file descriptor.
     ///
-    /// The input and output file descriptors must be distinct. If you have a single file descriptor, consider using
-    /// `ClientBootstrap.withConnectedSocket(descriptor:)` if it's a socket or
-    /// `NIOPipeBootstrap.takingOwnershipOfDescriptor` if it is not a socket.
+    /// The input file descriptor must be distinct.
     ///
-    /// - Note: If this method returns a succeeded future, SwiftNIO will close `input` and `output`
-    ///         when the `Channel` becomes inactive. You _must not_ do any further operations `input` or
-    ///         `output`, including `close`.
-    ///         If this method returns a failed future, you still own the file descriptors and are responsible for
+    /// - Note: If this method returns a succeeded future, SwiftNIO will close `input` when the `Channel`
+    ///         becomes inactive. You _must not_ do any further operations to `input`, including `close`.
+    ///         If this method returns a failed future, you still own the file descriptor and are responsible for
     ///         closing them.
     ///
     /// - Parameters:
@@ -2217,7 +2206,7 @@ extension NIOPipeBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func takingOwnershipOfDescriptors<Output: Sendable>(
+    public func takingOwnershipOfDescriptor<Output: Sendable>(
         input: CInt,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
     ) async throws -> Output {
@@ -2228,16 +2217,13 @@ extension NIOPipeBootstrap {
         )
     }
 
-    /// Create the `PipeChannel` with the provided input and output file descriptors.
+    /// Create the `PipeChannel` with the provided output file descriptor.
     ///
-    /// The input and output file descriptors must be distinct. If you have a single file descriptor, consider using
-    /// `ClientBootstrap.withConnectedSocket(descriptor:)` if it's a socket or
-    /// `NIOPipeBootstrap.takingOwnershipOfDescriptor` if it is not a socket.
+    /// The output file descriptor must be distinct.
     ///
-    /// - Note: If this method returns a succeeded future, SwiftNIO will close `input` and `output`
-    ///         when the `Channel` becomes inactive. You _must not_ do any further operations `input` or
-    ///         `output`, including `close`.
-    ///         If this method returns a failed future, you still own the file descriptors and are responsible for
+    /// - Note: If this method returns a succeeded future, SwiftNIO will close `output` when the `Channel`
+    ///         becomes inactive. You _must not_ do any further operations to `output`, including `close`.
+    ///         If this method returns a failed future, you still own the file descriptor and are responsible for
     ///         closing them.
     ///
     /// - Parameters:
@@ -2246,7 +2232,7 @@ extension NIOPipeBootstrap {
     ///   method.
     /// - Returns: The result of the channel initializer.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func takingOwnershipOfDescriptors<Output: Sendable>(
+    public func takingOwnershipOfDescriptor<Output: Sendable>(
         output: CInt,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
     ) async throws -> Output {
@@ -2318,15 +2304,11 @@ extension NIOPipeBootstrap {
             }.flatMap { result -> EventLoopFuture<ChannelInitializerResult> in
                 if inputFileHandle == nil {
                     return channel.close(mode: .input).map { result }
-                } else {
-                    return channel.selectableEventLoop.makeSucceededFuture(result)
                 }
-            }.flatMap { result in
                 if outputFileHandle == nil {
                     return channel.close(mode: .output).map { result }
-                } else {
-                    return channel.selectableEventLoop.makeSucceededFuture(result)
                 }
+                return channel.selectableEventLoop.makeSucceededFuture(result)
             }.flatMapError { error in
                 channel.close0(error: error, mode: .all, promise: nil)
                 return channel.eventLoop.makeFailedFuture(error)

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -645,7 +645,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
         do {
             toChannel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .takingOwnershipOfDescriptors(
+                .takingOwnershipOfDescriptor(
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
@@ -659,7 +659,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
         do {
             fromChannel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .takingOwnershipOfDescriptors(
+                .takingOwnershipOfDescriptor(
                     input: pipe2ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
@@ -693,7 +693,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
         do {
             channel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .takingOwnershipOfDescriptors(
+                .takingOwnershipOfDescriptor(
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
@@ -707,7 +707,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
         do {
             fromChannel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .takingOwnershipOfDescriptors(
+                .takingOwnershipOfDescriptor(
                     input: pipe1ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
@@ -740,7 +740,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
         do {
             channel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .takingOwnershipOfDescriptors(
+                .takingOwnershipOfDescriptor(
                     input: pipe1ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
@@ -754,7 +754,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
         do {
             toChannel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .takingOwnershipOfDescriptors(
+                .takingOwnershipOfDescriptor(
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
@@ -804,7 +804,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
         do {
             toChannel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .takingOwnershipOfDescriptors(
+                .takingOwnershipOfDescriptor(
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
@@ -818,7 +818,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
         do {
             fromChannel = try await NIOPipeBootstrap(group: eventLoopGroup)
-                .takingOwnershipOfDescriptors(
+                .takingOwnershipOfDescriptor(
                     input: pipe2ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {


### PR DESCRIPTION
# Motivation
In some scenarios, it is useful to only have either an input or output side for a `PipeChannel`. This fixes https://github.com/apple/swift-nio/issues/2444.

# Modification
This PR adds new methods to `NIOPipeBootstrap` that make either the input or the output optional. Furthermore, I am intentionally breaking the API for the new async methods since those haven't shipped yet to reflect the same API there.

# Result
It is now possible to bootstrap a `PipeChannel` with either the input or output side closed.