### PR TITLE
NonBlockingFileIO: tolerate chunk handlers from other ELs

### DIFF
--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -202,7 +202,7 @@ public struct NonBlockingFileIO: Sendable {
                             return
                         }
                         let bytesRead = Int64(buffer.readableBytes)
-                        chunkHandler(buffer).whenComplete { result in
+                        chunkHandler(buffer).hop(to: eventLoop).whenComplete { result in
                             switch result {
                             case .success(_):
                                 eventLoop.assertInEventLoop()


### PR DESCRIPTION
### Motivation:

Anywhere in SwiftNIO a user supplies a future, NIO should tolerate futures from any EL.
That wasn't the case in `NonBlockingFileIO.readChunked`.

### Modifications:

Hop the `chunkHandler`'s future to the correct EL.

### Result:

More user-friendly and correct