### PR TITLE
Add async version of NIOThreadPool.runIfActive

### DIFF
--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -292,6 +292,48 @@ extension NIOThreadPool {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension NIOThreadPool {
+    #if swift(>=5.7)
+    /// Runs the submitted closure if the thread pool is still active, otherwise throw an error.
+    /// The closure will be run on the thread pool so can do blocking work.
+    ///
+    /// - parameters:
+    ///     - body: The closure which performs some blocking work to be done on the thread pool.
+    /// - returns: result of the passed closure.
+    @preconcurrency
+    public func runIfActive<T>(_ body: @escaping @Sendable () throws -> T) async throws -> T {
+        try await self._runIfActive(body)
+    }
+    #else
+    /// Runs the submitted closure if the thread pool is still active, otherwise throw an error.
+    /// The closure will be run on the thread pool so can do blocking work.
+    ///
+    /// - parameters:
+    ///     - body: The closure which performs some blocking work to be done on the thread pool.
+    /// - returns: result of the passed closure.
+    public func runIfActive<T>(_ body: @escaping () throws -> T) async throws -> T {
+        try await self._runIfActive(body)
+    }
+    #endif
+    
+    private func _runIfActive<T>(_ body: @escaping () throws -> T) async throws -> T {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<T, Error>) in
+            self.submit { shouldRun in
+                guard case shouldRun = NIOThreadPool.WorkItemState.active else {
+                    cont.resume(throwing: NIOThreadPoolError.ThreadPoolInactive())
+                    return
+                }
+                do {
+                    try cont.resume(returning: body())
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
 extension NIOThreadPool {
     @preconcurrency
     public func shutdownGracefully(_ callback: @escaping @Sendable (Error?) -> Void) {

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -290,22 +290,16 @@ extension NIOThreadPool {
         }
         return promise.futureResult
     }
-}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension NIOThreadPool {
+
     /// Runs the submitted closure if the thread pool is still active, otherwise throw an error.
     /// The closure will be run on the thread pool so can do blocking work.
     ///
     /// - parameters:
     ///     - body: The closure which performs some blocking work to be done on the thread pool.
     /// - returns: result of the passed closure.
-    @preconcurrency
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func runIfActive<T>(_ body: @escaping @Sendable () throws -> T) async throws -> T {
-        try await self._runIfActive(body)
-    }
-    
-    private func _runIfActive<T>(_ body: @escaping () throws -> T) async throws -> T {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<T, Error>) in
             self.submit { shouldRun in
                 guard case shouldRun = NIOThreadPool.WorkItemState.active else {

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -291,7 +291,6 @@ extension NIOThreadPool {
         return promise.futureResult
     }
 
-
     /// Runs the submitted closure if the thread pool is still active, otherwise throw an error.
     /// The closure will be run on the thread pool so can do blocking work.
     ///

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -298,7 +298,7 @@ extension NIOThreadPool {
     ///     - body: The closure which performs some blocking work to be done on the thread pool.
     /// - returns: result of the passed closure.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func runIfActive<T>(_ body: @escaping @Sendable () throws -> T) async throws -> T {
+    public func runIfActive<T: Sendable>(_ body: @escaping @Sendable () throws -> T) async throws -> T {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<T, Error>) in
             self.submit { shouldRun in
                 guard case shouldRun = NIOThreadPool.WorkItemState.active else {

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -294,7 +294,6 @@ extension NIOThreadPool {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension NIOThreadPool {
-    #if swift(>=5.7)
     /// Runs the submitted closure if the thread pool is still active, otherwise throw an error.
     /// The closure will be run on the thread pool so can do blocking work.
     ///
@@ -305,17 +304,6 @@ extension NIOThreadPool {
     public func runIfActive<T>(_ body: @escaping @Sendable () throws -> T) async throws -> T {
         try await self._runIfActive(body)
     }
-    #else
-    /// Runs the submitted closure if the thread pool is still active, otherwise throw an error.
-    /// The closure will be run on the thread pool so can do blocking work.
-    ///
-    /// - parameters:
-    ///     - body: The closure which performs some blocking work to be done on the thread pool.
-    /// - returns: result of the passed closure.
-    public func runIfActive<T>(_ body: @escaping () throws -> T) async throws -> T {
-        try await self._runIfActive(body)
-    }
-    #endif
     
     private func _runIfActive<T>(_ body: @escaping () throws -> T) async throws -> T {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<T, Error>) in


### PR DESCRIPTION
Add async version of NIOThreadPool.runIfActive

### Motivation:

Currently when using NIOThreadPool in a Swift concurrency context you still need an EventLoop and the call will make two hops, one to the EventLoop and then one back to your Task.

### Modifications:

Added `NIOThreadPool.runIfActive(_) async throws`

### Result:

You don't need an EventLoop to use `NIOThreadPool`

This is the first stage of completing https://github.com/apple/swift-nio/issues/2565
