### PR TITLE
Add autogenerated files from VSCode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Package.resolved
 DerivedData
 .swiftpm
 .*.sw?
+.vscode/launch.json


### PR DESCRIPTION
Add .vscode/launch.json to .gitignore

### Motivation:

The Swift VSCode extension autogenerates a `launch.json` file. This ensures anyone who uses VSCode for development doesn't add this to a PR by mistake
