### PR TITLE
Mark retroactive conformances appropriately.

### DIFF
--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -375,17 +375,23 @@ extension ByteBufferAllocator {
 }
 
 // MARK: - Conformances
+#if compiler(>=5.11)
+extension ByteBufferView: @retroactive ContiguousBytes {}
+extension ByteBufferView: @retroactive DataProtocol {}
+extension ByteBufferView: @retroactive MutableDataProtocol {}
+#else
 extension ByteBufferView: ContiguousBytes {}
+extension ByteBufferView: DataProtocol {}
+extension ByteBufferView: MutableDataProtocol {}
+#endif
 
-extension ByteBufferView: DataProtocol {
+extension ByteBufferView {
     public typealias Regions = CollectionOfOne<ByteBufferView>
 
     public var regions: CollectionOfOne<ByteBufferView> {
         return .init(self)
     }
 }
-
-extension ByteBufferView: MutableDataProtocol {}
 
 // MARK: - Data
 extension Data {


### PR DESCRIPTION
Motivation:

In nightly Swift, we now need to mark retroactive conformances when they are intentional. These conformances are safe for us, so we can safely suppress the warnings.

Modifications:

- Mark NIOFoundationCompat retroactive conformances.

Result:

Nightly builds work again
