### PR TITLE
WIP: HTTPDecoder: Reenable Parsing After Failed Upgrade

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -473,7 +473,7 @@ public typealias HTTPResponseDecoder = HTTPDecoder<HTTPClientResponsePart, HTTPC
 ///
 /// While the `HTTPRequestDecoder` does not currently have a specific ordering requirement in the
 /// `ChannelPipeline` (unlike `HTTPResponseDecoder`), it is possible that it will develop one. For
-/// that reason, applications should try to ensure that the `HTTPRequestDecoder` *later* in the
+/// that reason, applications should try to ensure that the `HTTPRequestDecoder` is *later* in the
 /// `ChannelPipeline` than the `HTTPResponseEncoder`.
 ///
 /// Rather than set this up manually, consider using `ChannelPipeline.configureHTTPServerPipeline`.
@@ -484,12 +484,18 @@ public enum HTTPDecoderKind: Sendable {
     case response
 }
 
-extension HTTPDecoder: WriteObservingByteToMessageDecoder where In == HTTPClientResponsePart, Out == HTTPClientRequestPart {
+extension HTTPDecoder: WriteObservingByteToMessageDecoder {
     public typealias OutboundIn = Out
 
-    public func write(data: HTTPClientRequestPart) {
-        if case .head(let head) = data {
+    public func write(data: Out) {
+        if Self.self == HTTPResponseDecoder.self,
+            case .head(let head) = (data as? HTTPClientRequestPart) {
             self.parser.requestHeads.append(head)
+        } else if Self.self == HTTPRequestDecoder.self, 
+                    case let .head(head) = data as? HTTPServerResponsePart {
+            if head.isKeepAlive, self.isUpgrade == true, head.status != .switchingProtocols {
+                self.stopParsing = false
+            }
         }
     }
 }
@@ -567,7 +573,6 @@ public final class HTTPDecoder<In, Out>: ByteToMessageDecoder, HTTPDecoderDelega
         case .response:
             self.context!.fireChannelRead(NIOAny(HTTPClientResponsePart.body(self.buffer!.readSlice(length: bytes.count)!)))
         }
-
     }
 
     func didReceiveHeaderName(_ bytes: UnsafeRawBufferPointer) throws {


### PR DESCRIPTION
Reenable parsing in `HTTPDecoder` after an upgrade is attempted but failed by the response.

### Motivation:

Currently, `HTTPDecoder` sets `stopParsing = true` whenever a message is parsed and an update is detected (`isUpgrade == true`). Unfortunately, this means that if the upgrade wasn't successful, the decoder silently blocks any attempt to reuse the connection, essentially hanging the client until they timeout.

### Modifications:

I've attempted to generalize `HTTPDecoder`'s conformance to `WriteObservingByteToMessageDecoder` so that it can reenable parsing based on the outgoing `HTTPServerResponsePart`.

### Result:

A properly reusable decoder.

---

WIP:

I need a few things to finish this PR.

- Proper way to generalize the `write(data:)` implementation. Right now I just check the decoder's full metatype. What's the preferred pattern here?
- Proper condition for reenabling parsing. Right now I ensure that the connection will be kept alive (if it's being killed who cares), that we attempted an upgrade (just realized that `isUpgrade` is reset as soon as the message is decoded, so I need a different condition there), and that the response is NOT an upgrade.
- Proper test. I see the `HTTPDecoderTest` but it's not clear what kind of test would be best here, or how to simulate this scenario exactly.
- Proper way to integrate this local branch with my Vapor server to verify it fixes my observed issue. Simply adding SwiftNIO as a dependency doesn't replace Vapor's expected dependency on it. Do I need to fork Vapor locally too?
