### PR TITLE
Mention file length in bytes in `readFileSize` explicitly

### DIFF
--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -376,12 +376,12 @@ public struct NonBlockingFileIO: Sendable {
         }
     }
 
-    /// Returns the length of the file associated with `fileHandle`.
+    /// Returns the length of the file in bytes associated with `fileHandle`.
     ///
     /// - parameters:
     ///   - fileHandle: The `NIOFileHandle` to read from.
     ///   - eventLoop: The `EventLoop` to create the returned `EventLoopFuture` from.
-    /// - returns: An `EventLoopFuture` which is fulfilled if the write was successful or fails on error.
+    /// - returns: An `EventLoopFuture` which is fulfilled with the length of the file in bytes if the write was successful or fails on error.
     public func readFileSize(fileHandle: NIOFileHandle,
                              eventLoop: EventLoop) -> EventLoopFuture<Int64> {
         return self.threadPool.runIfActive(eventLoop: eventLoop) {


### PR DESCRIPTION
The rest of the functions on `NonBlockingFileIO` are explicit in the fact that they count buffer length in bytes. `readFileSize` should be explicit in its documentation too.
