### PR TITLE
Add explicit `Sendable` unavailability and add missing `Sendable` conformances

### DIFF
--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
@@ -21,7 +21,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     typealias Producer = NIOThrowingAsyncSequenceProducer<Inbound, Error, NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark, NIOAsyncChannelInboundStreamChannelHandlerProducerDelegate>
 
     /// A source used for driving a ``NIOAsyncChannelInboundStream`` during tests.
-    public struct TestSource {
+    public struct TestSource: Sendable{
         @usableFromInline
         internal let continuation: AsyncThrowingStream<Inbound, Error>.Continuation
 

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
@@ -162,3 +162,6 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension NIOAsyncChannelOutboundWriter.TestSink: Sendable {}
+
+@available(*, unavailable)
+extension NIOAsyncChannelOutboundWriter.TestSink.AsyncIterator: Sendable { }

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncSequenceProducer.swift
@@ -251,7 +251,7 @@ extension NIOAsyncSequenceProducer {
         }
 
         /// The result of a call to ``NIOAsyncSequenceProducer/Source/yield(_:)``.
-        public enum YieldResult: Hashable {
+        public enum YieldResult: Hashable, Sendable {
             /// Indicates that the caller should produce more elements for now. The delegate's ``NIOAsyncSequenceProducerDelegate/produceMore()``
             /// will **NOT** get called, since the demand was already signalled through this ``NIOAsyncSequenceProducer/Source/YieldResult``.
             case produceMore

--- a/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOAsyncWriter.swift
@@ -147,7 +147,7 @@ public struct NIOAsyncWriter<
     /// This struct contains two properties:
     /// 1. The ``sink`` which should be retained by the consumer and is used to set the writability.
     /// 2. The ``writer`` which is the actual ``NIOAsyncWriter`` and should be passed to the producer.
-    public struct NewWriter {
+    public struct NewWriter: @unchecked Sendable {
         /// The ``sink`` which **MUST** be retained by the consumer and is used to set the writability.
         public let sink: Sink
         /// The ``writer`` which is the actual ``NIOAsyncWriter`` and should be passed to the producer.
@@ -375,6 +375,9 @@ extension NIOAsyncWriter {
         }
     }
 }
+
+@available(*, unavailable)
+extension NIOAsyncWriter.Sink: Sendable { }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension NIOAsyncWriter {

--- a/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
+++ b/Sources/NIOCore/AsyncSequences/NIOThrowingAsyncSequenceProducer.swift
@@ -264,7 +264,7 @@ extension NIOThrowingAsyncSequenceProducer {
         }
 
         /// The result of a call to ``NIOThrowingAsyncSequenceProducer/Source/yield(_:)``.
-        public enum YieldResult: Hashable {
+        public enum YieldResult: Hashable, Sendable {
             /// Indicates that the caller should produce more elements.
             case produceMore
             /// Indicates that the caller should stop producing elements.

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -93,7 +93,7 @@ let SO_TIMESTAMP = CNIOLinux_SO_TIMESTAMP
 let SO_RCVTIMEO = CNIOLinux_SO_RCVTIMEO
 #endif
 
-public enum NIOBSDSocket {
+public enum NIOBSDSocket: Sendable{
 #if os(Windows)
     public typealias Handle = SOCKET
 #else

--- a/Sources/NIOCore/Channel.swift
+++ b/Sources/NIOCore/Channel.swift
@@ -378,7 +378,7 @@ extension ChannelError: Equatable { }
 /// The removal of a `ChannelHandler` using `ChannelPipeline.removeHandler` has been attempted more than once.
 public struct NIOAttemptedToRemoveHandlerMultipleTimesError: Error {}
 
-public enum DatagramChannelError {
+public enum DatagramChannelError: Sendable {
     public struct WriteOnUnconnectedSocketWithoutAddress: Error {
         public init() {}
     }

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -64,7 +64,7 @@ public typealias ConnectTimeoutOption = ChannelOptions.Types.ConnectTimeoutOptio
 public typealias AllowRemoteHalfClosureOption = ChannelOptions.Types.AllowRemoteHalfClosureOption
 
 extension ChannelOptions {
-    public enum Types {
+    public enum Types: Sendable {
 
         /// `SocketOption` allows users to specify configuration settings that are directly applied to the underlying socket file descriptor.
         ///
@@ -291,7 +291,7 @@ extension ChannelOptions {
 }
 
 /// Provides `ChannelOption`s to be used with a `Channel`, `Bootstrap` or `ServerBootstrap`.
-public struct ChannelOptions {
+public struct ChannelOptions: Sendable {
     #if !os(Windows)
         public static let socket = { (level: SocketOptionLevel, name: SocketOptionName) -> Types.SocketOption in
             .init(level: NIOBSDSocket.OptionLevel(rawValue: CInt(level)), name: NIOBSDSocket.Option(rawValue: CInt(name)))

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -97,6 +97,9 @@ public final class NIOFileHandle: FileDescriptor {
     }
 }
 
+@available(*, unavailable)
+extension NIOFileHandle: Sendable { }
+
 extension NIOFileHandle {
     /// `Mode` represents file access modes.
     public struct Mode: OptionSet, Sendable {

--- a/Sources/NIOCore/GlobalSingletons.swift
+++ b/Sources/NIOCore/GlobalSingletons.swift
@@ -33,7 +33,7 @@ import Musl
 /// `NIOSingletons.singletonsEnabledSuggestion = false`. All singleton-creating facilities should check
 /// this setting and if `false` restrain from creating any global singleton resources. Please note that disabling the
 /// global singletons will lead to a crash if _any_ code attempts to use any of the singletons.
-public enum NIOSingletons {
+public enum NIOSingletons: Sendable {
 }
 
 extension NIOSingletons {

--- a/Sources/NIOCore/IO.swift
+++ b/Sources/NIOCore/IO.swift
@@ -39,7 +39,7 @@ import Darwin
 /// An `Error` for an IO operation.
 public struct IOError: Swift.Error {
     @available(*, deprecated, message: "NIO no longer uses FailureDescription.")
-    public enum FailureDescription {
+    public enum FailureDescription : Sendable{
         case function(StaticString)
         case reason(String)
     }

--- a/Sources/NIOCore/IPProtocol.swift
+++ b/Sources/NIOCore/IPProtocol.swift
@@ -16,7 +16,7 @@
 /// called "Protocol" to identify the next level protocol.  This is an 8
 /// bit field.  In Internet Protocol version 6 (IPv6) [RFC8200], this field
 /// is called the "Next Header" field.
-public struct NIOIPProtocol: RawRepresentable, Hashable {
+public struct NIOIPProtocol: RawRepresentable, Hashable, Sendable {
     public typealias RawValue = UInt8
     public var rawValue: RawValue
     

--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -64,7 +64,7 @@ private extension ifaddrs {
 
 /// A representation of a single network interface on a system.
 @available(*, deprecated, renamed: "NIONetworkDevice")
-public final class NIONetworkInterface {
+public final class NIONetworkInterface: Sendable{
     // This is a class because in almost all cases this will carry
     // four structs that are backed by classes, and so will incur 4
     // refcount operations each time it is copied.

--- a/Sources/NIOCore/UniversalBootstrapSupport.swift
+++ b/Sources/NIOCore/UniversalBootstrapSupport.swift
@@ -248,6 +248,10 @@ public struct NIOClientTCPBootstrap {
     }
 }
 
+@available(*, unavailable)
+extension NIOClientTCPBootstrap: Sendable { }
+
+
 public protocol NIOClientTLSProvider {
     associatedtype Bootstrap
 
@@ -261,3 +265,7 @@ public struct NIOInsecureNoTLS<Bootstrap: NIOClientTCPBootstrapProtocol>: NIOCli
         fatalError("NIOInsecureNoTLS cannot enable TLS.")
     }
 }
+
+@available(*, unavailable)
+extension NIOInsecureNoTLS: Sendable { }
+

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -60,7 +60,7 @@ final class Box<T> {
 
 extension Box: Sendable where T: Sendable {}
 
-public enum System {
+public enum System: Sendable {
     /// A utility function that returns an estimate of the number of *logical* cores
     /// on the system available for use.
     ///

--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -611,7 +611,7 @@ public final class NIOAsyncTestingChannel: Channel {
         }
     }
 
-    public struct SynchronousOptions: NIOSynchronousChannelOptions {
+    public struct SynchronousOptions: NIOSynchronousChannelOptions, Sendable {
         @usableFromInline
         internal let channel: NIOAsyncTestingChannel
 
@@ -636,6 +636,7 @@ public final class NIOAsyncTestingChannel: Channel {
         return SynchronousOptions(channel: self)
     }
 }
+
 
 // MARK: Unchecked sendable
 //

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -857,6 +857,14 @@ public final class EmbeddedChannel: Channel {
     }
 }
 
+// Stores NIOAny which isn't Sendable
+@available(*, unavailable)
+extension EmbeddedChannel.LeftOverState: Sendable { }
+
+// Stores NIOAny which isn't Sendable
+@available(*, unavailable)
+extension EmbeddedChannel.BufferState: Sendable { }
+
 extension EmbeddedChannel {
     public struct SynchronousOptions: NIOSynchronousChannelOptions {
         @usableFromInline

--- a/Sources/NIOPosix/BSDSocketAPICommon.swift
+++ b/Sources/NIOPosix/BSDSocketAPICommon.swift
@@ -142,7 +142,7 @@ extension NIOBSDSocket {
     /// They aren't necessarily protocols in their own right: for example, ``mptcp``
     /// is not. They act to modify the socket type instead: thus, ``mptcp`` acts
     /// to modify `SOCK_STREAM` to ask for ``mptcp`` support.
-    public struct ProtocolSubtype: RawRepresentable, Hashable {
+    public struct ProtocolSubtype: RawRepresentable, Hashable, Sendable {
         public typealias RawValue = CInt
 
         /// The underlying value of the protocol subtype.

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -17,7 +17,7 @@ import NIOCore
 import NIOConcurrencyHelpers
 
 /// Errors that may be thrown when executing work on a `NIOThreadPool`
-public enum NIOThreadPoolError {
+public enum NIOThreadPoolError: Sendable{
 
     /// The `NIOThreadPool` was not active.
     public struct ThreadPoolInactive: Error { 

--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -697,7 +697,7 @@ public struct NonBlockingFileIO: Sendable {
 
 #if !os(Windows)
 /// A `NIODirectoryEntry` represents a single directory entry.
-public struct NIODirectoryEntry: Hashable {
+public struct NIODirectoryEntry: Hashable, Sendable {
     // File number of entry
     public var ino: UInt64
     // File type

--- a/Sources/_NIODataStructures/_TinyArray.swift
+++ b/Sources/_NIODataStructures/_TinyArray.swift
@@ -99,6 +99,8 @@ extension _TinyArray: RandomAccessCollection {
     }
 }
 
+extension _TinyArray.Iterator: Sendable where Element: Sendable {}
+
 extension _TinyArray {
     @inlinable
     public init(_ elements: some Sequence<Element>) {


### PR DESCRIPTION
Found with `-require-explicit-sendable` compiler flag. We may want to enable this flag in CI but it currently warns also for internal types that are @usableFromInline but we could mark them explicitly as well if we wanted.
