### PR TITLE
Fixing an issue with CNIOSHA1 missing an #include for the BYTE_ORDER define.

### DIFF
--- a/Sources/CNIOSHA1/c_nio_sha1.c
+++ b/Sources/CNIOSHA1/c_nio_sha1.c
@@ -4,6 +4,7 @@
     - defined the __min_size macro inline
     - included sys/endian.h on Android
     - use welcoming language (soundness check)
+    - ensure BYTE_ORDER is defined
 */
 /*	$KAME: sha1.c,v 1.5 2000/11/08 06:13:08 itojun Exp $	*/
 /*-
@@ -53,14 +54,15 @@
 #endif
 #ifdef __ANDROID__
 #include <sys/endian.h>
-#elif __linux__
+#elif defined(__linux__) || defined(__APPLE__)
 #include <sys/types.h>
 #endif
 
 
-
 /* soundness check */
-#if BYTE_ORDER != BIG_ENDIAN
+#if !defined(BYTE_ORDER)
+#error "BYTE_ORDER not defined"
+#elif BYTE_ORDER != BIG_ENDIAN
 # if BYTE_ORDER != LITTLE_ENDIAN
 #  define unsupported 1
 # endif

--- a/Sources/CNIOSHA1/include/CNIOSHA1.h
+++ b/Sources/CNIOSHA1/include/CNIOSHA1.h
@@ -4,6 +4,7 @@
     - defined the __min_size macro inline
     - included sys/endian.h on Android
     - use welcoming language (soundness check)
+    - ensure BYTE_ORDER is defined
 */
 /*	$FreeBSD$	*/
 /*	$KAME: sha1.h,v 1.5 2000/03/27 04:36:23 sumikawa Exp $	*/

--- a/Sources/CNIOSHA1/update_and_patch_sha1.sh
+++ b/Sources/CNIOSHA1/update_and_patch_sha1.sh
@@ -33,6 +33,7 @@ for f in sha1.c sha1.h; do
       echo "    - defined the __min_size macro inline"
       echo "    - included sys/endian.h on Android"
       echo "    - use welcoming language (soundness check)"
+      echo "    - ensure BYTE_ORDER is defined"
       echo "*/"
       curl -Ls "https://raw.githubusercontent.com/freebsd/freebsd/master/sys/crypto/$f"
     ) > "$here/c_nio_$f"
@@ -52,8 +53,9 @@ $sed -e $'/#define _CRYPTO_SHA1_H_/a #include <stdint.h>\\\n#include <stddef.h>'
 
 $sed -e 's/u_int\([0-9]\+\)_t/uint\1_t/g'                                        \
      -e '/^#include/d'                                                           \
-     -e $'/__FBSDID/c #include "include/CNIOSHA1.h"\\n#include <string.h>\\n#if !defined(bzero)\\n#define bzero(b,l) memset((b), \'\\\\0\', (l))\\n#endif\\n#if !defined(bcopy)\\n#define bcopy(s,d,l) memmove((d), (s), (l))\\n#endif\\n#ifdef __ANDROID__\\n#include <sys/endian.h>\\n#elif __linux__\\n#include <sys/types.h>\\n#endif' \
+     -e $'/__FBSDID/c #include "include/CNIOSHA1.h"\\n#include <string.h>\\n#if !defined(bzero)\\n#define bzero(b,l) memset((b), \'\\\\0\', (l))\\n#endif\\n#if !defined(bcopy)\\n#define bcopy(s,d,l) memmove((d), (s), (l))\\n#endif\\n#ifdef __ANDROID__\\n#include <sys/endian.h>\\n#elif defined(__linux__) || defined(__APPLE__)\\n#include <sys/types.h>\\n#endif' \
      -e 's/sanit[y]/soundness/g'                                                 \
+     -e 's/#if BYTE_ORDER != BIG_ENDIAN/#if !defined(BYTE_ORDER)\\n#error "BYTE_ORDER not defined"\\n#elif BYTE_ORDER != BIG_ENDIAN/' \
      -i "$here/c_nio_sha1.c"
 
 mv "$here/c_nio_sha1.h" "$here/include/CNIOSHA1.h"


### PR DESCRIPTION
When building swift-nio with a system with explicit modules (bazel build rules) I was getting incorrect sha1 results. It turns out the root cause is the `BYTE_ORDER` macro was not defined in my build context.

Using `-Wundef` in clang I was seeing:

```
Sources/CNIOSHA1/c_nio_sha1.c:56:7: error: '__linux__' is not defined, evaluates to 0 [-Werror,-Wundef]
      ^
Sources/CNIOSHA1/c_nio_sha1.c:63:5: error: 'BYTE_ORDER' is not defined, evaluates to 0 [-Werror,-Wundef]
    ^
Sources/CNIOSHA1/c_nio_sha1.c:63:19: error: 'BIG_ENDIAN' is not defined, evaluates to 0 [-Werror,-Wundef]
                  ^
Sources/CNIOSHA1/c_nio_sha1.c:113:5: error: 'BYTE_ORDER' is not defined, evaluates to 0 [-Werror,-Wundef]
    ^
Sources/CNIOSHA1/c_nio_sha1.c:113:19: error: 'LITTLE_ENDIAN' is not defined, evaluates to 0 [-Werror,-Wundef]
                  ^
Sources/CNIOSHA1/c_nio_sha1.c:222:5: error: 'BYTE_ORDER' is not defined, evaluates to 0 [-Werror,-Wundef]
    ^
Sources/CNIOSHA1/c_nio_sha1.c:222:19: error: 'BIG_ENDIAN' is not defined, evaluates to 0 [-Werror,-Wundef]
                  ^
Sources/CNIOSHA1/c_nio_sha1.c:267:5: error: 'BYTE_ORDER' is not defined, evaluates to 0 [-Werror,-Wundef]
    ^
Sources/CNIOSHA1/c_nio_sha1.c:267:19: error: 'BIG_ENDIAN' is not defined, evaluates to 0 [-Werror,-Wundef]
```

The soundness check was not actually signaling an error because it was implicitly comparing 0 to 0.

This change includes an update to the `#include`'s to ensure `BIG_ENDIAN` is defined on macOS and updates the soundness check to have an explicit error if `BYTE_ORDER` is not defined.
