### PR TITLE
Fix spelling of retroactive guard

### DIFF
--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -376,7 +376,7 @@ extension ByteBufferAllocator {
 
 // MARK: - Conformances
 #if swift(>=5.8)
-#if hasFeature(RetroactiveAttribute)
+#if $RetroactiveAttribute
 extension ByteBufferView: @retroactive ContiguousBytes {}
 extension ByteBufferView: @retroactive DataProtocol {}
 extension ByteBufferView: @retroactive MutableDataProtocol {}


### PR DESCRIPTION
Motivation:

`hasFeature(RetroactiveAttribute)` doesn't work as expected, but `$RetroactiveAttribute` does.

Modifications:

Switch from `hasFeature` to `$RetroactiveAttribute`.

Result:

- `@retroactive` is applied appropriately