### PR TITLE
Add `closeOnDeinit` to the `NIOAsyncChannel` init

### DIFF
--- a/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEchoAsyncChannel.swift
+++ b/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEchoAsyncChannel.swift
@@ -27,7 +27,8 @@ func runTCPEchoAsyncChannel(numberOfWrites: Int, eventLoop: EventLoop) async thr
                     configuration: .init(
                         inboundType: ByteBuffer.self,
                         outboundType: ByteBuffer.self
-                    )
+                    ),
+                    closeOnDeinit: false
                 )
             }
         }
@@ -43,7 +44,8 @@ func runTCPEchoAsyncChannel(numberOfWrites: Int, eventLoop: EventLoop) async thr
                     configuration: .init(
                         inboundType: ByteBuffer.self,
                         outboundType: ByteBuffer.self
-                    )
+                    ),
+                    closeOnDeinit: false
                 )
             }
         }

--- a/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEchoAsyncChannel.swift
+++ b/Benchmarks/Benchmarks/NIOPosixBenchmarks/TCPEchoAsyncChannel.swift
@@ -23,12 +23,11 @@ func runTCPEchoAsyncChannel(numberOfWrites: Int, eventLoop: EventLoop) async thr
         ) { channel in
             channel.eventLoop.makeCompletedFuture {
                 return try NIOAsyncChannel(
-                    synchronouslyWrapping: channel,
+                    wrappingChannelSynchronously: channel,
                     configuration: .init(
                         inboundType: ByteBuffer.self,
                         outboundType: ByteBuffer.self
-                    ),
-                    closeOnDeinit: false
+                    )
                 )
             }
         }
@@ -40,12 +39,11 @@ func runTCPEchoAsyncChannel(numberOfWrites: Int, eventLoop: EventLoop) async thr
         ) { channel in
             channel.eventLoop.makeCompletedFuture {
                 return try NIOAsyncChannel(
-                    synchronouslyWrapping: channel,
+                    wrappingChannelSynchronously: channel,
                     configuration: .init(
                         inboundType: ByteBuffer.self,
                         outboundType: ByteBuffer.self
-                    ),
-                    closeOnDeinit: false
+                    )
                 )
             }
         }

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelInboundStream.swift
@@ -80,6 +80,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     init<HandlerInbound: Sendable>(
         channel: Channel,
         backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
+        closeOnDeinit: Bool,
         handler: NIOAsyncChannelInboundStreamChannelHandler<HandlerInbound, Inbound>
     ) throws {
         channel.eventLoop.preconditionInEventLoop()
@@ -95,7 +96,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
 
         let sequence = Producer.makeSequence(
             backPressureStrategy: strategy,
-            finishOnDeinit: false,
+            finishOnDeinit: closeOnDeinit,
             delegate: NIOAsyncChannelInboundStreamChannelHandlerProducerDelegate(handler: handler)
         )
         handler.source = sequence.source
@@ -107,7 +108,8 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     @inlinable
     static func makeWrappingHandler(
         channel: Channel,
-        backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?
+        backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
+        closeOnDeinit: Bool
     ) throws -> NIOAsyncChannelInboundStream {
         let handler = NIOAsyncChannelInboundStreamChannelHandler<Inbound, Inbound>.makeHandler(
             eventLoop: channel.eventLoop
@@ -116,6 +118,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
         return try .init(
             channel: channel,
             backPressureStrategy: backPressureStrategy,
+            closeOnDeinit: closeOnDeinit,
             handler: handler
         )
     }
@@ -125,6 +128,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
     static func makeTransformationHandler(
         channel: Channel,
         backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark?,
+        closeOnDeinit: Bool,
         channelReadTransformation: @Sendable @escaping (Channel) -> EventLoopFuture<Inbound>
     ) throws -> NIOAsyncChannelInboundStream {
         let handler = NIOAsyncChannelInboundStreamChannelHandler<Channel, Inbound>.makeHandlerWithTransformations(
@@ -135,6 +139,7 @@ public struct NIOAsyncChannelInboundStream<Inbound: Sendable>: Sendable {
         return try .init(
             channel: channel,
             backPressureStrategy: backPressureStrategy,
+            closeOnDeinit: closeOnDeinit,
             handler: handler
         )
     }

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
@@ -84,7 +84,8 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
     @inlinable
     init(
         channel: Channel,
-        isOutboundHalfClosureEnabled: Bool
+        isOutboundHalfClosureEnabled: Bool,
+        closeOnDeinit: Bool
     ) throws {
         let handler = NIOAsyncChannelOutboundWriterHandler<OutboundOut>(
             eventLoop: channel.eventLoop,
@@ -93,7 +94,7 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
         let writer = _Writer.makeWriter(
             elementType: OutboundOut.self,
             isWritable: true,
-            finishOnDeinit: false,
+            finishOnDeinit: closeOnDeinit,
             delegate: .init(handler: handler)
         )
         handler.sink = writer.sink

--- a/Sources/NIOCore/Docs.docc/swift-concurrency.md
+++ b/Sources/NIOCore/Docs.docc/swift-concurrency.md
@@ -85,7 +85,7 @@ the inbound data and echo it back outbound.
 
 ```swift
 let channel = ...
-let asyncChannel = try NIOAsyncChannel<ByteBuffer, ByteBuffer>(synchronouslyWrapping: channel)
+let asyncChannel = try NIOAsyncChannel<ByteBuffer, ByteBuffer>(wrappingChannelSynchronously: channel)
 
 try await asyncChannel.executeThenClose { inbound, outbound in
     for try await inboundData in inbound {
@@ -186,7 +186,7 @@ let clientChannel = try await ClientBootstrap(group: eventLoopGroup)
     ) { channel in
         channel.eventLoop.makeCompletedFuture {
             return try NIOAsyncChannel<ByteBuffer, ByteBuffer>(
-                synchronouslyWrapping: channel
+                wrappingChannelSynchronously: channel
             )
         }
     }
@@ -245,7 +245,7 @@ let upgradeResult: EventLoopFuture<UpgradeResult> = try await ClientBootstrap(gr
                     // This configures the pipeline after the websocket upgrade was successful.
                     // We are wrapping the pipeline in a NIOAsyncChannel.
                     channel.eventLoop.makeCompletedFuture {
-                        let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(synchronouslyWrapping: channel)
+                        let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(wrappingChannelSynchronously: channel)
                         return UpgradeResult.websocket(asyncChannel)
                     }
                 }

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -656,6 +656,7 @@ extension ServerBootstrap {
                         ._wrapAsyncChannelWithTransformations(
                             synchronouslyWrapping: serverChannel,
                             backPressureStrategy: serverBackPressureStrategy,
+                            closeOnDeinit: false, // This is fine because we are always finishing the writer since Output == Never
                             channelReadTransformation: { channel -> EventLoopFuture<ChannelInitializerResult> in
                                 // The channelReadTransformation is run on the EL of the server channel
                                 // We have to make sure that we execute child channel initializer on the

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -654,9 +654,8 @@ extension ServerBootstrap {
                     )
                     let asyncChannel = try NIOAsyncChannel<ChannelInitializerResult, Never>
                         ._wrapAsyncChannelWithTransformations(
-                            synchronouslyWrapping: serverChannel,
+                            wrappingChannelSynchronously: serverChannel,
                             backPressureStrategy: serverBackPressureStrategy,
-                            closeOnDeinit: false, // This is fine because we are always finishing the writer since Output == Never
                             channelReadTransformation: { channel -> EventLoopFuture<ChannelInitializerResult> in
                                 // The channelReadTransformation is run on the EL of the server channel
                                 // We have to make sure that we execute child channel initializer on the

--- a/Sources/NIOTCPEchoClient/Client.swift
+++ b/Sources/NIOTCPEchoClient/Client.swift
@@ -63,7 +63,8 @@ struct Client {
                         configuration: NIOAsyncChannel.Configuration(
                             inboundType: String.self,
                             outboundType: String.self
-                        )
+                        ),
+                        closeOnDeinit: false
                     )
                 }
             }

--- a/Sources/NIOTCPEchoClient/Client.swift
+++ b/Sources/NIOTCPEchoClient/Client.swift
@@ -59,12 +59,11 @@ struct Client {
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(NewlineDelimiterCoder()))
 
                     return try NIOAsyncChannel(
-                        synchronouslyWrapping: channel,
+                        wrappingChannelSynchronously: channel,
                         configuration: NIOAsyncChannel.Configuration(
                             inboundType: String.self,
                             outboundType: String.self
-                        ),
-                        closeOnDeinit: false
+                        )
                     )
                 }
             }

--- a/Sources/NIOTCPEchoServer/Server.swift
+++ b/Sources/NIOTCPEchoServer/Server.swift
@@ -48,12 +48,11 @@ struct Server {
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(NewlineDelimiterCoder()))
 
                     return try NIOAsyncChannel(
-                        synchronouslyWrapping: channel,
+                        wrappingChannelSynchronously: channel,
                         configuration: NIOAsyncChannel.Configuration(
                             inboundType: String.self,
                             outboundType: String.self
-                        ),
-                        closeOnDeinit: false
+                        )
                     )
                 }
             }

--- a/Sources/NIOTCPEchoServer/Server.swift
+++ b/Sources/NIOTCPEchoServer/Server.swift
@@ -52,7 +52,8 @@ struct Server {
                         configuration: NIOAsyncChannel.Configuration(
                             inboundType: String.self,
                             outboundType: String.self
-                        )
+                        ),
+                        closeOnDeinit: false
                     )
                 }
             }

--- a/Sources/NIOWebSocketClient/Client.swift
+++ b/Sources/NIOWebSocketClient/Client.swift
@@ -61,7 +61,7 @@ struct Client {
 //                    let upgrader = NIOTypedWebSocketClientUpgrader<UpgradeResult>(
 //                        upgradePipelineHandler: { (channel, _) in
 //                            channel.eventLoop.makeCompletedFuture {
-//                                let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(synchronouslyWrapping: channel)
+//                                let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(wrappingChannelSynchronously: channel)
 //                                return UpgradeResult.websocket(asyncChannel)
 //                            }
 //                        }

--- a/Sources/NIOWebSocketServer/Server.swift
+++ b/Sources/NIOWebSocketServer/Server.swift
@@ -91,7 +91,7 @@ struct Server {
 //                        },
 //                        upgradePipelineHandler: { (channel, _) in
 //                            channel.eventLoop.makeCompletedFuture {
-//                                let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(synchronouslyWrapping: channel)
+//                                let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(wrappingChannelSynchronously: channel)
 //                                return UpgradeResult.websocket(asyncChannel)
 //                            }
 //                        }
@@ -102,7 +102,7 @@ struct Server {
 //                        notUpgradingCompletionHandler: { channel in
 //                            channel.eventLoop.makeCompletedFuture {
 //                                try channel.pipeline.syncOperations.addHandler(HTTPByteBufferResponsePartHandler())
-//                                let asyncChannel = try NIOAsyncChannel<HTTPServerRequestPart, HTTPPart<HTTPResponseHead, ByteBuffer>>(synchronouslyWrapping: channel)
+//                                let asyncChannel = try NIOAsyncChannel<HTTPServerRequestPart, HTTPPart<HTTPResponseHead, ByteBuffer>>(wrappingChannelSynchronously: channel)
 //                                return UpgradeResult.notUpgraded(asyncChannel)
 //                            }
 //                        }

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -30,7 +30,7 @@ final class AsyncChannelTests: XCTestCase {
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try channel.pipeline.syncOperations.addHandler(CloseOnWriteHandler())
-            return try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
+            return try NIOAsyncChannel<String, String>(wrappingChannelSynchronously: channel)
         }
 
         try await wrapped.executeThenClose { _, outbound in
@@ -42,7 +42,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<String, Never>(synchronouslyWrapping: channel, closeOnDeinit: false)
+            try NIOAsyncChannel<String, Never>(wrappingChannelSynchronously: channel)
         }
 
         try await wrapped.executeThenClose { inbound, _ in
@@ -68,7 +68,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<Never, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
+            try NIOAsyncChannel<Never, String>(wrappingChannelSynchronously: channel)
         }
 
         try await wrapped.executeThenClose { _, outbound in
@@ -91,13 +91,12 @@ final class AsyncChannelTests: XCTestCase {
 
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try NIOAsyncChannel(
-                synchronouslyWrapping: channel,
+                wrappingChannelSynchronously: channel,
                 configuration: .init(
                     isOutboundHalfClosureEnabled: true,
                     inboundType: Never.self,
                     outboundType: Never.self
-                ),
-                closeOnDeinit: false
+                )
             )
         }
 
@@ -126,13 +125,12 @@ final class AsyncChannelTests: XCTestCase {
         do {
             _ = try await channel.testingEventLoop.executeInContext {
                 try NIOAsyncChannel(
-                    synchronouslyWrapping: channel,
+                    wrappingChannelSynchronously: channel,
                     configuration: .init(
                         isOutboundHalfClosureEnabled: false,
                         inboundType: Never.self,
                         outboundType: Never.self
-                    ),
-                    closeOnDeinit: false
+                    )
                 )
             }
 
@@ -153,7 +151,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<String, Never>(synchronouslyWrapping: channel, closeOnDeinit: false)
+            try NIOAsyncChannel<String, Never>(wrappingChannelSynchronously: channel)
         }
 
         try await channel.writeInbound("hello")
@@ -172,7 +170,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<String, Never>(synchronouslyWrapping: channel, closeOnDeinit: false)
+            try NIOAsyncChannel<String, Never>(wrappingChannelSynchronously: channel)
         }
 
         try await channel.writeInbound("hello")
@@ -195,7 +193,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<Never, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
+            try NIOAsyncChannel<Never, String>(wrappingChannelSynchronously: channel)
         }
 
         try await channel.testingEventLoop.executeInContext {
@@ -235,7 +233,7 @@ final class AsyncChannelTests: XCTestCase {
         do {
             // Create the NIOAsyncChannel, then drop it. The handler will still be in the pipeline.
             _ = try await channel.testingEventLoop.executeInContext {
-                _ = try NIOAsyncChannel<Sentinel, Never>(synchronouslyWrapping: channel, closeOnDeinit: false)
+                _ = try NIOAsyncChannel<Sentinel, Never>(wrappingChannelSynchronously: channel)
             }
         }
 
@@ -260,13 +258,12 @@ final class AsyncChannelTests: XCTestCase {
         try await channel.pipeline.addHandler(readCounter)
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try NIOAsyncChannel(
-                synchronouslyWrapping: channel,
+                wrappingChannelSynchronously: channel,
                 configuration: .init(
                     backPressureStrategy: .init(lowWatermark: 2, highWatermark: 4),
                     inboundType: Void.self,
                     outboundType: Never.self
-                ),
-                closeOnDeinit: false
+                )
             )
         }
 
@@ -373,7 +370,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
+            try NIOAsyncChannel<String, String>(wrappingChannelSynchronously: channel)
         }
 
         try await wrapped.executeThenClose { inbound, outbound in

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -30,7 +30,7 @@ final class AsyncChannelTests: XCTestCase {
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try channel.pipeline.syncOperations.addHandler(CloseOnWriteHandler())
-            return try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel)
+            return try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
         }
 
         try await wrapped.executeThenClose { _, outbound in
@@ -42,7 +42,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<String, Never>(synchronouslyWrapping: channel)
+            try NIOAsyncChannel<String, Never>(synchronouslyWrapping: channel, closeOnDeinit: false)
         }
 
         try await wrapped.executeThenClose { inbound, _ in
@@ -68,7 +68,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<Never, String>(synchronouslyWrapping: channel)
+            try NIOAsyncChannel<Never, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
         }
 
         try await wrapped.executeThenClose { _, outbound in
@@ -96,7 +96,8 @@ final class AsyncChannelTests: XCTestCase {
                     isOutboundHalfClosureEnabled: true,
                     inboundType: Never.self,
                     outboundType: Never.self
-                )
+                ),
+                closeOnDeinit: false
             )
         }
 
@@ -130,7 +131,8 @@ final class AsyncChannelTests: XCTestCase {
                         isOutboundHalfClosureEnabled: false,
                         inboundType: Never.self,
                         outboundType: Never.self
-                    )
+                    ),
+                    closeOnDeinit: false
                 )
             }
 
@@ -151,7 +153,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<String, Never>(synchronouslyWrapping: channel)
+            try NIOAsyncChannel<String, Never>(synchronouslyWrapping: channel, closeOnDeinit: false)
         }
 
         try await channel.writeInbound("hello")
@@ -170,7 +172,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<String, Never>(synchronouslyWrapping: channel)
+            try NIOAsyncChannel<String, Never>(synchronouslyWrapping: channel, closeOnDeinit: false)
         }
 
         try await channel.writeInbound("hello")
@@ -193,7 +195,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<Never, String>(synchronouslyWrapping: channel)
+            try NIOAsyncChannel<Never, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
         }
 
         try await channel.testingEventLoop.executeInContext {
@@ -233,7 +235,7 @@ final class AsyncChannelTests: XCTestCase {
         do {
             // Create the NIOAsyncChannel, then drop it. The handler will still be in the pipeline.
             _ = try await channel.testingEventLoop.executeInContext {
-                _ = try NIOAsyncChannel<Sentinel, Never>(synchronouslyWrapping: channel)
+                _ = try NIOAsyncChannel<Sentinel, Never>(synchronouslyWrapping: channel, closeOnDeinit: false)
             }
         }
 
@@ -263,7 +265,8 @@ final class AsyncChannelTests: XCTestCase {
                     backPressureStrategy: .init(lowWatermark: 2, highWatermark: 4),
                     inboundType: Void.self,
                     outboundType: Never.self
-                )
+                ),
+                closeOnDeinit: false
             )
         }
 
@@ -370,7 +373,7 @@ final class AsyncChannelTests: XCTestCase {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
-            try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel)
+            try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
         }
 
         try await wrapped.executeThenClose { inbound, outbound in

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -228,7 +228,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                         configuration: .init(
                             inboundType: String.self,
                             outboundType: String.self
-                        )
+                        ),
+                        closeOnDeinit: false
                     )
                 }
             }
@@ -681,7 +682,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe2WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel)
+                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
         } catch {
@@ -695,7 +696,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel)
+                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
         } catch {
@@ -709,7 +710,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     input: pipe2ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel)
+                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
         } catch {
@@ -749,7 +750,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel)
+                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
         } catch {
@@ -763,7 +764,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     input: pipe1ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel)
+                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
         } catch {
@@ -800,7 +801,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     input: pipe1ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel)
+                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
         } catch {
@@ -814,7 +815,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel)
+                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
         } catch {
@@ -868,7 +869,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel)
+                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
         } catch {
@@ -882,7 +883,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     input: pipe2ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel)
+                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
         } catch {
@@ -1014,7 +1015,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel)
+                    return try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
                 }
             }
 
@@ -1048,7 +1049,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                         try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                         try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                         try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                        return try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel)
+                        return try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
                     }
                 }
             try await stringChannel.executeThenClose { _, outbound in
@@ -1098,7 +1099,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder(inboundID: 1)))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder(outboundID: 2)))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel)
+                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                 }
             }
     }
@@ -1115,7 +1116,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder(inboundID: 2)))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder(outboundID: 1)))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel)
+                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                 }
             }
     }
@@ -1163,7 +1164,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel)
+                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                 }
             }
     }
@@ -1214,7 +1215,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel)
+                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                 }
             }
     }
@@ -1247,7 +1248,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel)
+                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
                 }
             }
     }
@@ -1330,7 +1331,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     return channel.eventLoop.makeCompletedFuture {
                         try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
                         let asyncChannel = try NIOAsyncChannel<String, String>(
-                            synchronouslyWrapping: channel
+                            synchronouslyWrapping: channel,
+                            closeOnDeinit: false
                         )
 
                         return .string(asyncChannel)
@@ -1340,7 +1342,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                         try channel.pipeline.syncOperations.addHandler(ByteBufferToByteHandler())
 
                         let asyncChannel = try NIOAsyncChannel<UInt8, UInt8>(
-                            synchronouslyWrapping: channel
+                            synchronouslyWrapping: channel,
+                            closeOnDeinit: false
                         )
 
                         return .byte(asyncChannel)

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -224,12 +224,11 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
                     return try NIOAsyncChannel(
-                        synchronouslyWrapping: channel,
+                        wrappingChannelSynchronously: channel,
                         configuration: .init(
                             inboundType: String.self,
                             outboundType: String.self
-                        ),
-                        closeOnDeinit: false
+                        )
                     )
                 }
             }
@@ -682,7 +681,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe2WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                     }
                 }
         } catch {
@@ -696,7 +695,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                     }
                 }
         } catch {
@@ -710,7 +709,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     input: pipe2ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                     }
                 }
         } catch {
@@ -750,7 +749,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                     }
                 }
         } catch {
@@ -764,7 +763,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     input: pipe1ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                     }
                 }
         } catch {
@@ -801,7 +800,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     input: pipe1ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                     }
                 }
         } catch {
@@ -815,7 +814,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                     }
                 }
         } catch {
@@ -869,7 +868,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     output: pipe1WriteFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                     }
                 }
         } catch {
@@ -883,7 +882,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     input: pipe2ReadFD
                 ) { channel in
                     channel.eventLoop.makeCompletedFuture {
-                        try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                     }
                 }
         } catch {
@@ -1015,7 +1014,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
+                    return try NIOAsyncChannel<String, String>(wrappingChannelSynchronously: channel)
                 }
             }
 
@@ -1049,7 +1048,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                         try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                         try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                         try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                        return try NIOAsyncChannel<String, String>(synchronouslyWrapping: channel, closeOnDeinit: false)
+                        return try NIOAsyncChannel<String, String>(wrappingChannelSynchronously: channel)
                     }
                 }
             try await stringChannel.executeThenClose { _, outbound in
@@ -1099,7 +1098,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder(inboundID: 1)))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder(outboundID: 2)))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                    return try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                 }
             }
     }
@@ -1116,7 +1115,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder(inboundID: 2)))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder(outboundID: 1)))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                    return try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                 }
             }
     }
@@ -1164,7 +1163,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                    return try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                 }
             }
     }
@@ -1215,7 +1214,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                    return try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                 }
             }
     }
@@ -1248,7 +1247,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(MessageToByteHandler(LineDelimiterCoder()))
                     try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
-                    return try NIOAsyncChannel(synchronouslyWrapping: channel, closeOnDeinit: false)
+                    return try NIOAsyncChannel(wrappingChannelSynchronously: channel)
                 }
             }
     }
@@ -1331,8 +1330,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     return channel.eventLoop.makeCompletedFuture {
                         try channel.pipeline.syncOperations.addHandler(ByteBufferToStringHandler())
                         let asyncChannel = try NIOAsyncChannel<String, String>(
-                            synchronouslyWrapping: channel,
-                            closeOnDeinit: false
+                            wrappingChannelSynchronously: channel
                         )
 
                         return .string(asyncChannel)
@@ -1342,8 +1340,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                         try channel.pipeline.syncOperations.addHandler(ByteBufferToByteHandler())
 
                         let asyncChannel = try NIOAsyncChannel<UInt8, UInt8>(
-                            synchronouslyWrapping: channel,
-                            closeOnDeinit: false
+                            wrappingChannelSynchronously: channel
                         )
 
                         return .byte(asyncChannel)


### PR DESCRIPTION
# Motivation
In my previous PR, I already did the work to add `finishOnDeinit` configuration to the `NIOAsyncWriter` and `NIOAsyncSequenceProducer`. This PR also automatically migrated the `NIOAsyncChanell` to set the `finishOnDeinit = false`. This was intentional since we really want users to not use the deinit based cleanup; however, it also broke all current adopters of this API semantically and they might now run into the preconditions.

# Modification
This PR reverts the change in `NIOAsyncChannel` and does the usual deprecate + new init dance to provide users to configure this behaviour while still nudging them to check that this is really what they want.

# Result
Easier migration without semantically breaking current adopters of `NIOAsyncChannel`.