### PR TITLE
Revert "Back out new typed HTTP protocol upgrader (#2579)"

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
@@ -1,0 +1,248 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOCore
+
+// MARK: - Server pipeline configuration
+
+/// Configuration for an upgradable HTTP pipeline.
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+public struct NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult: Sendable> {
+    /// Whether to provide assistance handling HTTP clients that pipeline
+    /// their requests. Defaults to `true`. If `false`, users will need to handle clients that pipeline themselves.
+    public var enablePipelining = true
+
+    /// Whether to provide assistance handling protocol errors (e.g. failure to parse the HTTP
+    /// request) by sending 400 errors. Defaults to `true`.
+    public var enableErrorHandling = true
+
+    /// Whether to validate outbound response headers to confirm that they are
+    /// spec compliant. Defaults to `true`.
+    public var enableResponseHeaderValidation = true
+
+    /// The configuration for the ``HTTPResponseEncoder``.
+    public var encoderConfiguration = HTTPResponseEncoder.Configuration()
+
+    /// The configuration for the ``NIOTypedHTTPServerUpgradeHandler``.
+    public var upgradeConfiguration: NIOTypedHTTPServerUpgradeConfiguration<UpgradeResult>
+
+    /// Initializes a new ``NIOUpgradableHTTPServerPipelineConfiguration`` with default values.
+    ///
+    /// The current defaults provide the following features:
+    /// 1. Assistance handling clients that pipeline HTTP requests.
+    /// 2. Assistance handling protocol errors.
+    /// 3. Outbound header fields validation to protect against response splitting attacks.
+    public init(
+        upgradeConfiguration: NIOTypedHTTPServerUpgradeConfiguration<UpgradeResult>
+    ) {
+        self.upgradeConfiguration = upgradeConfiguration
+    }
+}
+
+extension ChannelPipeline {
+    /// Configure a `ChannelPipeline` for use as an HTTP server.
+    ///
+    /// - Parameters:
+    ///   - configuration: The HTTP pipeline's configuration.
+    /// - Returns: An `EventLoopFuture` that will fire when the pipeline is configured. The future contains an `EventLoopFuture`
+    /// that is fired once the pipeline has been upgraded or not and contains the `UpgradeResult`.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    public func configureUpgradableHTTPServerPipeline<UpgradeResult: Sendable>(
+        configuration: NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult>
+    ) -> EventLoopFuture<EventLoopFuture<UpgradeResult>> {
+        self._configureUpgradableHTTPServerPipeline(
+            configuration: configuration
+        )
+    }
+
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    private func _configureUpgradableHTTPServerPipeline<UpgradeResult: Sendable>(
+        configuration: NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult>
+    ) -> EventLoopFuture<EventLoopFuture<UpgradeResult>> {
+        let future: EventLoopFuture<EventLoopFuture<UpgradeResult>>
+
+        if self.eventLoop.inEventLoop {
+            let result = Result<EventLoopFuture<UpgradeResult>, Error> {
+                try self.syncOperations.configureUpgradableHTTPServerPipeline(
+                    configuration: configuration
+                )
+            }
+            future = self.eventLoop.makeCompletedFuture(result)
+        } else {
+            future = self.eventLoop.submit {
+                try self.syncOperations.configureUpgradableHTTPServerPipeline(
+                    configuration: configuration
+                )
+            }
+        }
+
+        return future
+    }
+}
+
+extension ChannelPipeline.SynchronousOperations {
+    /// Configure a `ChannelPipeline` for use as an HTTP server.
+    ///
+    /// - Parameters:
+    ///   - configuration: The HTTP pipeline's configuration.
+    /// - Returns: An `EventLoopFuture` that is fired once the pipeline has been upgraded or not and contains the `UpgradeResult`.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    public func configureUpgradableHTTPServerPipeline<UpgradeResult: Sendable>(
+        configuration: NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult>
+    ) throws -> EventLoopFuture<UpgradeResult> {
+        self.eventLoop.assertInEventLoop()
+
+        let responseEncoder = HTTPResponseEncoder(configuration: configuration.encoderConfiguration)
+        let requestDecoder = ByteToMessageHandler(HTTPRequestDecoder(leftOverBytesStrategy: .forwardBytes))
+
+        var extraHTTPHandlers = [RemovableChannelHandler]()
+        extraHTTPHandlers.reserveCapacity(4)
+        extraHTTPHandlers.append(requestDecoder)
+
+        try self.addHandler(responseEncoder)
+        try self.addHandler(requestDecoder)
+
+        if configuration.enablePipelining {
+            let pipeliningHandler = HTTPServerPipelineHandler()
+            try self.addHandler(pipeliningHandler)
+            extraHTTPHandlers.append(pipeliningHandler)
+        }
+
+        if configuration.enableResponseHeaderValidation {
+            let headerValidationHandler = NIOHTTPResponseHeadersValidator()
+            try self.addHandler(headerValidationHandler)
+            extraHTTPHandlers.append(headerValidationHandler)
+        }
+
+        if configuration.enableErrorHandling {
+            let errorHandler = HTTPServerProtocolErrorHandler()
+            try self.addHandler(errorHandler)
+            extraHTTPHandlers.append(errorHandler)
+        }
+
+        let upgrader = NIOTypedHTTPServerUpgradeHandler(
+            httpEncoder: responseEncoder,
+            extraHTTPHandlers: extraHTTPHandlers,
+            upgradeConfiguration: configuration.upgradeConfiguration
+        )
+        try self.addHandler(upgrader)
+
+        return upgrader.upgradeResultFuture
+    }
+}
+
+// MARK: - Client pipeline configuration
+
+/// Configuration for an upgradable HTTP pipeline.
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+public struct NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult: Sendable> {
+    /// The strategy to use when dealing with leftover bytes after removing the ``HTTPDecoder`` from the pipeline.
+    public var leftOverBytesStrategy = RemoveAfterUpgradeStrategy.dropBytes
+
+    /// Whether to validate outbound response headers to confirm that they are
+    /// spec compliant. Defaults to `true`.
+    public var enableOutboundHeaderValidation = true
+
+    /// The configuration for the ``HTTPRequestEncoder``.
+    public var encoderConfiguration = HTTPRequestEncoder.Configuration()
+
+    /// The configuration for the ``NIOTypedHTTPClientUpgradeHandler``.
+    public var upgradeConfiguration: NIOTypedHTTPClientUpgradeConfiguration<UpgradeResult>
+
+    /// Initializes a new ``NIOUpgradableHTTPClientPipelineConfiguration`` with default values.
+    ///
+    /// The current defaults provide the following features:
+    /// 1. Outbound header fields validation to protect against response splitting attacks.
+    public init(
+        upgradeConfiguration: NIOTypedHTTPClientUpgradeConfiguration<UpgradeResult>
+    ) {
+        self.upgradeConfiguration = upgradeConfiguration
+    }
+}
+
+extension ChannelPipeline {
+    /// Configure a `ChannelPipeline` for use as an HTTP client.
+    ///
+    /// - Parameters:
+    ///   - configuration: The HTTP pipeline's configuration.
+    /// - Returns: An `EventLoopFuture` that will fire when the pipeline is configured. The future contains an `EventLoopFuture`
+    /// that is fired once the pipeline has been upgraded or not and contains the `UpgradeResult`.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    public func configureUpgradableHTTPClientPipeline<UpgradeResult: Sendable>(
+        configuration: NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult>
+    ) -> EventLoopFuture<EventLoopFuture<UpgradeResult>> {
+        self._configureUpgradableHTTPClientPipeline(configuration: configuration)
+    }
+
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    private func _configureUpgradableHTTPClientPipeline<UpgradeResult: Sendable>(
+        configuration: NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult>
+    ) -> EventLoopFuture<EventLoopFuture<UpgradeResult>> {
+        let future: EventLoopFuture<EventLoopFuture<UpgradeResult>>
+
+        if self.eventLoop.inEventLoop {
+            let result = Result<EventLoopFuture<UpgradeResult>, Error> {
+                try self.syncOperations.configureUpgradableHTTPClientPipeline(
+                    configuration: configuration
+                )
+            }
+            future = self.eventLoop.makeCompletedFuture(result)
+        } else {
+            future = self.eventLoop.submit {
+                try self.syncOperations.configureUpgradableHTTPClientPipeline(
+                    configuration: configuration
+                )
+            }
+        }
+
+        return future
+    }
+}
+
+extension ChannelPipeline.SynchronousOperations {
+    /// Configure a `ChannelPipeline` for use as an HTTP client.
+    ///
+    /// - Parameters:
+    ///   - configuration: The HTTP pipeline's configuration.
+    /// - Returns: An `EventLoopFuture` that is fired once the pipeline has been upgraded or not and contains the `UpgradeResult`.
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    public func configureUpgradableHTTPClientPipeline<UpgradeResult: Sendable>(
+        configuration: NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult>
+    ) throws -> EventLoopFuture<UpgradeResult> {
+        self.eventLoop.assertInEventLoop()
+
+        let requestEncoder = HTTPRequestEncoder(configuration: configuration.encoderConfiguration)
+        let responseDecoder = ByteToMessageHandler(HTTPResponseDecoder(leftOverBytesStrategy: configuration.leftOverBytesStrategy))
+        var httpHandlers = [RemovableChannelHandler]()
+        httpHandlers.reserveCapacity(3)
+        httpHandlers.append(requestEncoder)
+        httpHandlers.append(responseDecoder)
+
+        try self.addHandler(requestEncoder)
+        try self.addHandler(responseDecoder)
+
+        if configuration.enableOutboundHeaderValidation {
+            let headerValidationHandler = NIOHTTPRequestHeadersValidator()
+            try self.addHandler(headerValidationHandler)
+            httpHandlers.append(headerValidationHandler)
+        }
+
+        let upgrader = NIOTypedHTTPClientUpgradeHandler(
+            httpHandlers: httpHandlers,
+            upgradeConfiguration: configuration.upgradeConfiguration
+        )
+        try self.addHandler(upgrader)
+
+        return upgrader.upgradeResultFuture
+    }
+}

--- a/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 import NIOCore
 
 // MARK: - Server pipeline configuration
@@ -246,3 +247,4 @@ extension ChannelPipeline.SynchronousOperations {
         return upgrader.upgradeResultFuture
     }
 }
+#endif

--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
@@ -1,0 +1,283 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2013 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOCore
+
+/// An object that implements `NIOTypedHTTPClientProtocolUpgrader` knows how to handle HTTP upgrade to
+/// a protocol on a client-side channel.
+/// It has the option of denying this upgrade based upon the server response.
+public protocol NIOTypedHTTPClientProtocolUpgrader<UpgradeResult> {
+    associatedtype UpgradeResult: Sendable
+
+    /// The protocol this upgrader knows how to support.
+    var supportedProtocol: String { get }
+
+    /// All the header fields the protocol requires in the request to successfully upgrade.
+    /// These header fields will be added to the outbound request's "Connection" header field.
+    /// It is the responsibility of the custom headers call to actually add these required headers.
+    var requiredUpgradeHeaders: [String] { get }
+
+    /// Additional headers to be added to the request, beyond the "Upgrade" and "Connection" headers.
+    func addCustom(upgradeRequestHeaders: inout HTTPHeaders)
+
+    /// Gives the receiving upgrader the chance to deny the upgrade based on the upgrade HTTP response.
+    func shouldAllowUpgrade(upgradeResponse: HTTPResponseHead) -> Bool
+
+    /// Called when the upgrade response has been flushed. At this time it is safe to mutate the channel
+    /// pipeline to add whatever channel handlers are required.
+    /// Until the returned `EventLoopFuture` succeeds, all received data will be buffered.
+    func upgrade(channel: Channel, upgradeResponse: HTTPResponseHead) -> EventLoopFuture<UpgradeResult>
+}
+
+/// The upgrade configuration for the ``NIOTypedHTTPClientUpgradeHandler``.
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+public struct NIOTypedHTTPClientUpgradeConfiguration<UpgradeResult: Sendable> {
+    /// The initial request head that is sent out once the channel becomes active.
+    public var upgradeRequestHead: HTTPRequestHead
+
+    /// The array of potential upgraders.
+    public var upgraders: [any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>]
+
+    /// A closure that is run once it is determined that no protocol upgrade is happening. This can be used
+    /// to configure handlers that expect HTTP.
+    public var notUpgradingCompletionHandler: @Sendable (Channel) -> EventLoopFuture<UpgradeResult>
+
+    public init(
+        upgradeRequestHead: HTTPRequestHead,
+        upgraders: [any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>],
+        notUpgradingCompletionHandler: @Sendable @escaping (Channel) -> EventLoopFuture<UpgradeResult>
+    ) {
+        precondition(upgraders.count > 0, "A minimum of one protocol upgrader must be specified.")
+        self.upgradeRequestHead = upgradeRequestHead
+        self.upgraders = upgraders
+        self.notUpgradingCompletionHandler = notUpgradingCompletionHandler
+    }
+}
+
+/// A client-side channel handler that sends a HTTP upgrade handshake request to perform a HTTP-upgrade.
+/// This handler will add all appropriate headers to perform an upgrade to
+/// the a protocol. It may add headers for a set of protocols in preference order.
+/// If the upgrade fails (i.e. response is not 101 Switching Protocols), this handler simply
+/// removes itself from the pipeline. If the upgrade is successful, it upgrades the pipeline to the new protocol.
+///
+/// The request sends an order of preference to request which protocol it would like to use for the upgrade.
+/// It will only upgrade to the protocol that is returned first in the list and does not currently
+/// have the capability to upgrade to multiple simultaneous layered protocols.
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+public final class NIOTypedHTTPClientUpgradeHandler<UpgradeResult: Sendable>: ChannelDuplexHandler, RemovableChannelHandler {
+    public typealias OutboundIn = HTTPClientRequestPart
+    public typealias OutboundOut = HTTPClientRequestPart
+    public typealias InboundIn = HTTPClientResponsePart
+    public typealias InboundOut = HTTPClientResponsePart
+
+    /// The upgrade future which will be completed once protocol upgrading has been done.
+    public var upgradeResultFuture: EventLoopFuture<UpgradeResult> {
+        self.upgradeResultPromise.futureResult
+    }
+
+    private let upgradeRequestHead: HTTPRequestHead
+    private let httpHandlers: [RemovableChannelHandler]
+    private let notUpgradingCompletionHandler: @Sendable (Channel) -> EventLoopFuture<UpgradeResult>
+    private var stateMachine: NIOTypedHTTPClientUpgraderStateMachine<UpgradeResult>
+    private var _upgradeResultPromise: EventLoopPromise<UpgradeResult>?
+    private var upgradeResultPromise: EventLoopPromise<UpgradeResult> {
+        precondition(
+            self._upgradeResultPromise != nil,
+            "Tried to access the upgrade result before the handler was added to a pipeline"
+        )
+        return self._upgradeResultPromise!
+    }
+
+    /// Create a ``NIOTypedHTTPClientUpgradeHandler``.
+    ///
+    /// - Parameters:
+    ///  - httpHandlers: All `RemovableChannelHandler` objects which will be removed from the pipeline
+    ///     once the upgrade response is sent. This is used to ensure that the pipeline will be in a clean state
+    ///     after the upgrade. It should include any handlers that are directly related to handling HTTP.
+    ///     At the very least this should include the `HTTPEncoder` and `HTTPDecoder`, but should also include
+    ///     any other handler that cannot tolerate receiving non-HTTP data.
+    ///  - upgradeConfiguration: The upgrade configuration.
+    public init(
+        httpHandlers: [RemovableChannelHandler],
+        upgradeConfiguration: NIOTypedHTTPClientUpgradeConfiguration<UpgradeResult>
+    ) {
+        self.httpHandlers = httpHandlers
+        var upgradeRequestHead = upgradeConfiguration.upgradeRequestHead
+        Self.addHeaders(
+            to: &upgradeRequestHead,
+            upgraders: upgradeConfiguration.upgraders
+        )
+        self.upgradeRequestHead = upgradeRequestHead
+        self.stateMachine = .init(upgraders: upgradeConfiguration.upgraders)
+        self.notUpgradingCompletionHandler = upgradeConfiguration.notUpgradingCompletionHandler
+    }
+
+    public func handlerAdded(context: ChannelHandlerContext) {
+        self._upgradeResultPromise = context.eventLoop.makePromise(of: UpgradeResult.self)
+    }
+
+    public func handlerRemoved(context: ChannelHandlerContext) {
+        switch self.stateMachine.handlerRemoved() {
+        case .failUpgradePromise:
+            self.upgradeResultPromise.fail(ChannelError.inappropriateOperationForState)
+        case .none:
+            break
+        }
+    }
+
+    public func channelActive(context: ChannelHandlerContext) {
+        switch self.stateMachine.channelActive() {
+        case .writeUpgradeRequest:
+            context.write(self.wrapOutboundOut(.head(self.upgradeRequestHead)), promise: nil)
+            context.write(self.wrapOutboundOut(.body(.byteBuffer(.init()))), promise: nil)
+            context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+
+        case .none:
+            break
+        }
+    }
+
+    private static func addHeaders(
+        to requestHead: inout HTTPRequestHead,
+        upgraders: [any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>]
+    ) {
+        let requiredHeaders = ["upgrade"] + upgraders.flatMap { $0.requiredUpgradeHeaders }
+        requestHead.headers.add(name: "Connection", value: requiredHeaders.joined(separator: ","))
+
+        let allProtocols = upgraders.map { $0.supportedProtocol.lowercased() }
+        requestHead.headers.add(name: "Upgrade", value: allProtocols.joined(separator: ","))
+
+        // Allow each upgrader the chance to add custom headers.
+        for upgrader in upgraders {
+            upgrader.addCustom(upgradeRequestHeaders: &requestHead.headers)
+        }
+    }
+
+    public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        switch self.stateMachine.write() {
+        case .failWrite(let error):
+            promise?.fail(error)
+
+        case .forwardWrite:
+            context.write(data, promise: promise)
+        }
+    }
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch self.stateMachine.channelReadData(data) {
+        case .unwrapData:
+            let responsePart = self.unwrapInboundIn(data)
+            self.channelRead(context: context, responsePart: responsePart)
+
+        case .fireChannelRead:
+            context.fireChannelRead(data)
+
+        case .none:
+            break
+        }
+    }
+
+    private func channelRead(context: ChannelHandlerContext, responsePart: HTTPClientResponsePart) {
+        switch self.stateMachine.channelReadResponsePart(responsePart) {
+        case .fireErrorCaughtAndRemoveHandler(let error):
+            self.upgradeResultPromise.fail(error)
+            context.fireErrorCaught(error)
+            context.pipeline.removeHandler(self, promise: nil)
+
+        case .runNotUpgradingInitializer:
+            self.notUpgradingCompletionHandler(context.channel)
+                .hop(to: context.eventLoop)
+                .whenComplete { result in
+                    self.upgradingHandlerCompleted(context: context, result)
+                }
+
+        case .startUpgrading(let upgrader, let responseHead):
+            self.startUpgrading(
+                context: context,
+                upgrader: upgrader,
+                responseHead: responseHead
+            )
+
+        case .none:
+            break
+        }
+    }
+
+    private func startUpgrading(
+        context: ChannelHandlerContext,
+        upgrader: any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>,
+        responseHead: HTTPResponseHead
+    ) {
+        // Before we start the upgrade we have to remove the HTTPEncoder and HTTPDecoder handlers from the
+        // pipeline, to prevent them parsing any more data. We'll buffer the incoming data until that completes.
+        self.removeHTTPHandlers(context: context)
+            .flatMap {
+                upgrader.upgrade(channel: context.channel, upgradeResponse: responseHead)
+            }.hop(to: context.eventLoop)
+            .whenComplete { result in
+                self.upgradingHandlerCompleted(context: context, result)
+            }
+    }
+
+    private func upgradingHandlerCompleted(
+        context: ChannelHandlerContext,
+        _ result: Result<UpgradeResult, Error>
+    ) {
+        switch self.stateMachine.upgradingHandlerCompleted(result) {
+        case .fireErrorCaughtAndRemoveHandler(let error):
+            self.upgradeResultPromise.fail(error)
+            context.fireErrorCaught(error)
+            context.pipeline.removeHandler(self, promise: nil)
+
+        case .fireErrorCaughtAndStartUnbuffering(let error):
+            self.upgradeResultPromise.fail(error)
+            context.fireErrorCaught(error)
+            self.unbuffer(context: context)
+
+        case .startUnbuffering(let value):
+            self.upgradeResultPromise.succeed(value)
+            self.unbuffer(context: context)
+
+        case .removeHandler(let value):
+            self.upgradeResultPromise.succeed(value)
+            context.pipeline.removeHandler(self, promise: nil)
+
+        case .none:
+            break
+        }
+    }
+
+    private func unbuffer(context: ChannelHandlerContext) {
+        while true {
+            switch self.stateMachine.unbuffer() {
+            case .fireChannelRead(let data):
+                context.fireChannelRead(data)
+
+            case .fireChannelReadCompleteAndRemoveHandler:
+                context.fireChannelReadComplete()
+                context.pipeline.removeHandler(self, promise: nil)
+                return
+            }
+        }
+    }
+
+    /// Removes any extra HTTP-related handlers from the channel pipeline.
+    private func removeHTTPHandlers(context: ChannelHandlerContext) -> EventLoopFuture<Void> {
+        guard self.httpHandlers.count > 0 else {
+            return context.eventLoop.makeSucceededFuture(())
+        }
+
+        let removeFutures = self.httpHandlers.map { context.pipeline.removeHandler($0) }
+        return .andAllSucceed(removeFutures, on: context.eventLoop)
+    }
+}

--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 import NIOCore
 
 /// An object that implements `NIOTypedHTTPClientProtocolUpgrader` knows how to handle HTTP upgrade to
@@ -281,3 +282,4 @@ public final class NIOTypedHTTPClientUpgradeHandler<UpgradeResult: Sendable>: Ch
         return .andAllSucceed(removeFutures, on: context.eventLoop)
     }
 }
+#endif

--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgraderStateMachine.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 import DequeModule
 import NIOCore
 
@@ -331,3 +332,4 @@ struct NIOTypedHTTPClientUpgraderStateMachine<UpgradeResult> {
         }
     }
 }
+#endif

--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgraderStateMachine.swift
@@ -1,0 +1,333 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import DequeModule
+import NIOCore
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+struct NIOTypedHTTPClientUpgraderStateMachine<UpgradeResult> {
+    @usableFromInline
+    enum State {
+        /// The state before we received a TLSUserEvent. We are just forwarding any read at this point.
+        case initial(upgraders: [any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>])
+
+        /// The request has been sent. We are waiting for the upgrade response.
+        case awaitingUpgradeResponseHead(upgraders: [any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>])
+
+        @usableFromInline
+        struct AwaitingUpgradeResponseEnd {
+            var upgrader: any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>
+            var responseHead: HTTPResponseHead
+        }
+        /// We received the response head and are just waiting for the response end.
+        case awaitingUpgradeResponseEnd(AwaitingUpgradeResponseEnd)
+
+        @usableFromInline
+        struct Upgrading {
+            var buffer: Deque<NIOAny>
+        }
+        /// We are either running the upgrading handler.
+        case upgrading(Upgrading)
+
+        @usableFromInline
+        struct Unbuffering {
+            var buffer: Deque<NIOAny>
+        }
+        case unbuffering(Unbuffering)
+
+        case finished
+
+        case modifying
+    }
+
+    private var state: State
+
+    init(upgraders: [any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>]) {
+        self.state = .initial(upgraders: upgraders)
+    }
+
+    @usableFromInline
+    enum HandlerRemovedAction {
+        case failUpgradePromise
+    }
+
+    @inlinable
+    mutating func handlerRemoved() -> HandlerRemovedAction? {
+        switch self.state {
+        case .initial, .awaitingUpgradeResponseHead, .awaitingUpgradeResponseEnd, .upgrading, .unbuffering:
+            self.state = .finished
+            return .failUpgradePromise
+
+        case .finished:
+            return .none
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum ChannelActiveAction {
+        case writeUpgradeRequest
+    }
+
+    @inlinable
+    mutating func channelActive() -> ChannelActiveAction? {
+        switch self.state {
+        case .initial(let upgraders):
+            self.state = .awaitingUpgradeResponseHead(upgraders: upgraders)
+            return .writeUpgradeRequest
+
+        case .finished:
+            return nil
+
+        case .awaitingUpgradeResponseHead, .awaitingUpgradeResponseEnd, .unbuffering, .upgrading:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum WriteAction {
+        case failWrite(Error)
+        case forwardWrite
+    }
+
+    @usableFromInline
+    func write() -> WriteAction {
+        switch self.state {
+        case .initial, .awaitingUpgradeResponseHead, .awaitingUpgradeResponseEnd, .upgrading:
+            return .failWrite(NIOHTTPClientUpgradeError.writingToHandlerDuringUpgrade)
+
+        case .unbuffering, .finished:
+            return .forwardWrite
+            
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum ChannelReadDataAction {
+        case unwrapData
+        case fireChannelRead
+    }
+
+    @inlinable
+    mutating func channelReadData(_ data: NIOAny) -> ChannelReadDataAction? {
+        switch self.state {
+        case .initial:
+            return .unwrapData
+
+        case .awaitingUpgradeResponseHead, .awaitingUpgradeResponseEnd:
+            return .unwrapData
+
+        case .upgrading(var upgrading):
+            // We got a read while running upgrading.
+            // We have to buffer the read to unbuffer it afterwards
+            self.state = .modifying
+            upgrading.buffer.append(data)
+            self.state = .upgrading(upgrading)
+            return nil
+
+        case .unbuffering(var unbuffering):
+            self.state = .modifying
+            unbuffering.buffer.append(data)
+            self.state = .unbuffering(unbuffering)
+            return nil
+
+        case .finished:
+            return .fireChannelRead
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+        }
+    }
+
+
+    @usableFromInline
+    enum ChannelReadResponsePartAction {
+        case fireErrorCaughtAndRemoveHandler(Error)
+        case runNotUpgradingInitializer
+        case startUpgrading(
+            upgrader: any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>,
+            responseHeaders: HTTPResponseHead
+        )
+    }
+
+    @inlinable
+    mutating func channelReadResponsePart(_ responsePart: HTTPClientResponsePart) -> ChannelReadResponsePartAction? {
+        switch self.state {
+        case .initial:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+
+        case .awaitingUpgradeResponseHead(let upgraders):
+            // We should decide if we can upgrade based on the first response header: if we aren't upgrading,
+            // by the time the body comes in we should be out of the pipeline. That means that if we don't think we're
+            // upgrading, the only thing we should see is a response head. Anything else in an error.
+            guard case .head(let response) = responsePart else {
+                self.state = .finished
+                return .fireErrorCaughtAndRemoveHandler(NIOHTTPClientUpgradeError.invalidHTTPOrdering)
+            }
+
+            // Assess whether the server has accepted our upgrade request.
+            guard case .switchingProtocols = response.status else {
+                var buffer = Deque<NIOAny>()
+                buffer.append(.init(responsePart))
+                self.state = .upgrading(.init(buffer: buffer))
+                return .runNotUpgradingInitializer
+            }
+
+            // Ok, we have a HTTP response. Check if it's an upgrade confirmation.
+            // If it's not, we want to pass it on and remove ourselves from the channel pipeline.
+            let acceptedProtocols = response.headers[canonicalForm: "upgrade"]
+
+            // At the moment we only upgrade to the first protocol returned from the server.
+            guard let protocolName = acceptedProtocols.first?.lowercased() else {
+                // There are no upgrade protocols returned.
+                self.state = .finished
+                return .fireErrorCaughtAndRemoveHandler(NIOHTTPClientUpgradeError.responseProtocolNotFound)
+            }
+
+            let matchingUpgrader = upgraders
+                .first(where: { $0.supportedProtocol.lowercased() == protocolName })
+
+            guard let upgrader = matchingUpgrader else {
+                // There is no upgrader for this protocol.
+                self.state = .finished
+                return .fireErrorCaughtAndRemoveHandler(NIOHTTPClientUpgradeError.responseProtocolNotFound)
+            }
+
+            guard upgrader.shouldAllowUpgrade(upgradeResponse: response) else {
+                // The upgrader says no.
+                self.state = .finished
+                return .fireErrorCaughtAndRemoveHandler(NIOHTTPClientUpgradeError.upgraderDeniedUpgrade)
+            }
+
+            // We received the response head and decided that we can upgrade.
+            // We now need to wait for the response end and then we can perform the upgrade
+            self.state = .awaitingUpgradeResponseEnd(.init(
+                upgrader: upgrader,
+                responseHead: response
+            ))
+            return .none
+
+        case .awaitingUpgradeResponseEnd(let awaitingUpgradeResponseEnd):
+            switch responsePart {
+            case .head:
+                // We got two HTTP response heads.
+                self.state = .finished
+                return .fireErrorCaughtAndRemoveHandler(NIOHTTPClientUpgradeError.invalidHTTPOrdering)
+
+            case .body:
+                // We tolerate body parts to be send but just ignore them
+                return .none
+
+            case .end:
+                // We got the response end and can now run the upgrader.
+                self.state = .upgrading(.init(buffer: .init()))
+                return .startUpgrading(
+                    upgrader: awaitingUpgradeResponseEnd.upgrader,
+                    responseHeaders: awaitingUpgradeResponseEnd.responseHead
+                )
+            }
+
+        case .upgrading, .unbuffering, .finished:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum UpgradingHandlerCompletedAction {
+        case fireErrorCaughtAndStartUnbuffering(Error)
+        case removeHandler(UpgradeResult)
+        case fireErrorCaughtAndRemoveHandler(Error)
+        case startUnbuffering(UpgradeResult)
+    }
+
+    @inlinable
+    mutating func upgradingHandlerCompleted(_ result: Result<UpgradeResult, Error>) -> UpgradingHandlerCompletedAction? {
+        switch self.state {
+        case .initial, .awaitingUpgradeResponseHead, .awaitingUpgradeResponseEnd, .unbuffering:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+
+        case .upgrading(let upgrading):
+            switch result {
+            case .success(let value):
+                if !upgrading.buffer.isEmpty {
+                    self.state = .unbuffering(.init(buffer: upgrading.buffer))
+                    return .startUnbuffering(value)
+                } else {
+                    self.state = .finished
+                    return .removeHandler(value)
+                }
+
+            case .failure(let error):
+                if !upgrading.buffer.isEmpty {
+                    // So we failed to upgrade. There is nothing really that we can do here.
+                    // We are unbuffering the reads but there shouldn't be any handler in the pipeline
+                    // that expects a specific type of reads anyhow.
+                    self.state = .unbuffering(.init(buffer: upgrading.buffer))
+                    return .fireErrorCaughtAndStartUnbuffering(error)
+                } else {
+                    self.state = .finished
+                    return .fireErrorCaughtAndRemoveHandler(error)
+                }
+            }
+
+        case .finished:
+            // We have to tolerate this
+            return nil
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum UnbufferAction {
+        case fireChannelRead(NIOAny)
+        case fireChannelReadCompleteAndRemoveHandler
+    }
+
+    @inlinable
+    mutating func unbuffer() -> UnbufferAction {
+        switch self.state {
+        case .initial, .awaitingUpgradeResponseHead, .awaitingUpgradeResponseEnd, .upgrading, .finished:
+            preconditionFailure("Invalid state \(self.state)")
+
+        case .unbuffering(var unbuffering):
+            self.state = .modifying
+
+            if let element = unbuffering.buffer.popFirst() {
+                self.state = .unbuffering(unbuffering)
+
+                return .fireChannelRead(element)
+            } else {
+                self.state = .finished
+
+                return .fireChannelReadCompleteAndRemoveHandler
+            }
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPClientUpgradeStateMachine")
+
+        }
+    }
+}

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 import NIOCore
 
 /// An object that implements `NIOTypedHTTPServerProtocolUpgrader` knows how to handle HTTP upgrade to
@@ -367,3 +368,4 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
         }
     }
 }
+#endif

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -1,0 +1,369 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOCore
+
+/// An object that implements `NIOTypedHTTPServerProtocolUpgrader` knows how to handle HTTP upgrade to
+/// a protocol on a server-side channel.
+public protocol NIOTypedHTTPServerProtocolUpgrader<UpgradeResult> {
+    associatedtype UpgradeResult: Sendable
+
+    /// The protocol this upgrader knows how to support.
+    var supportedProtocol: String { get }
+
+    /// All the header fields the protocol needs in the request to successfully upgrade. These header fields
+    /// will be provided to the handler when it is asked to handle the upgrade. They will also be validated
+    /// against the inbound request's `Connection` header field.
+    var requiredUpgradeHeaders: [String] { get }
+
+    /// Builds the upgrade response headers. Should return any headers that need to be supplied to the client
+    /// in the 101 Switching Protocols response. If upgrade cannot proceed for any reason, this function should
+    /// return a failed future.
+    func buildUpgradeResponse(
+        channel: Channel,
+        upgradeRequest: HTTPRequestHead,
+        initialResponseHeaders: HTTPHeaders
+    ) -> EventLoopFuture<HTTPHeaders>
+
+    /// Called when the upgrade response has been flushed. At this time it is safe to mutate the channel pipeline
+    /// to add whatever channel handlers are required. Until the returned `EventLoopFuture` succeeds, all received
+    /// data will be buffered.
+    func upgrade(
+        channel: Channel,
+        upgradeRequest: HTTPRequestHead
+    ) -> EventLoopFuture<UpgradeResult>
+}
+
+/// The upgrade configuration for the ``NIOTypedHTTPServerUpgradeHandler``.
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+public struct NIOTypedHTTPServerUpgradeConfiguration<UpgradeResult: Sendable> {
+    /// The array of potential upgraders.
+    public var upgraders: [any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>]
+
+    /// A closure that is run once it is determined that no protocol upgrade is happening. This can be used
+    /// to configure handlers that expect HTTP.
+    public var notUpgradingCompletionHandler: @Sendable (Channel) -> EventLoopFuture<UpgradeResult>
+
+    public init(
+        upgraders: [any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>],
+        notUpgradingCompletionHandler: @Sendable @escaping (Channel) -> EventLoopFuture<UpgradeResult>
+    ) {
+        self.upgraders = upgraders
+        self.notUpgradingCompletionHandler = notUpgradingCompletionHandler
+    }
+}
+
+/// A server-side channel handler that receives HTTP requests and optionally performs an HTTP-upgrade.
+///
+/// Removes itself from the channel pipeline after the first inbound request on the connection, regardless of
+/// whether the upgrade succeeded or not.
+///
+/// This handler behaves a bit differently from its Netty counterpart because it does not allow upgrade
+/// on any request but the first on a connection. This is primarily to handle clients that pipeline: it's
+/// sufficiently difficult to ensure that the upgrade happens at a safe time while dealing with pipelined
+/// requests that we choose to punt on it entirely and not allow it. As it happens this is mostly fine:
+/// the odds of someone needing to upgrade midway through the lifetime of a connection are very low.
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: ChannelInboundHandler, RemovableChannelHandler {
+    public typealias InboundIn = HTTPServerRequestPart
+    public typealias InboundOut = HTTPServerRequestPart
+    public typealias OutboundOut = HTTPServerResponsePart
+
+    private let upgraders: [String: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>]
+    private let notUpgradingCompletionHandler: @Sendable (Channel) -> EventLoopFuture<UpgradeResult>
+    private let httpEncoder: HTTPResponseEncoder
+    private let extraHTTPHandlers: [RemovableChannelHandler]
+    private var stateMachine = NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult>()
+
+    private var _upgradeResultPromise: EventLoopPromise<UpgradeResult>?
+    private var upgradeResultPromise: EventLoopPromise<UpgradeResult> {
+        precondition(
+            self._upgradeResultPromise != nil,
+            "Tried to access the upgrade result before the handler was added to a pipeline"
+        )
+        return self._upgradeResultPromise!
+    }
+
+    /// The upgrade future which will be completed once protocol upgrading has been done.
+    public var upgradeResultFuture: EventLoopFuture<UpgradeResult> {
+        self.upgradeResultPromise.futureResult
+    }
+
+    /// Create a ``NIOTypedHTTPServerUpgradeHandler``.
+    /// 
+    /// - Parameters:
+    ///   - httpEncoder: The ``HTTPResponseEncoder`` encoding responses from this handler and which will
+    ///     be removed from the pipeline once the upgrade response is sent. This is used to ensure
+    ///     that the pipeline will be in a clean state after upgrade.
+    ///  - extraHTTPHandlers: Any other handlers that are directly related to handling HTTP. At the very least
+    ///     this should include the `HTTPDecoder`, but should also include any other handler that cannot tolerate
+    ///     receiving non-HTTP data.
+    ///  - upgradeConfiguration: The upgrade configuration.
+    public init(
+        httpEncoder: HTTPResponseEncoder,
+        extraHTTPHandlers: [RemovableChannelHandler],
+        upgradeConfiguration: NIOTypedHTTPServerUpgradeConfiguration<UpgradeResult>
+    ) {
+        var upgraderMap = [String: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>]()
+        for upgrader in upgradeConfiguration.upgraders {
+            upgraderMap[upgrader.supportedProtocol.lowercased()] = upgrader
+        }
+        self.upgraders = upgraderMap
+        self.notUpgradingCompletionHandler = upgradeConfiguration.notUpgradingCompletionHandler
+        self.httpEncoder = httpEncoder
+        self.extraHTTPHandlers = extraHTTPHandlers
+    }
+
+    public func handlerAdded(context: ChannelHandlerContext) {
+        self._upgradeResultPromise = context.eventLoop.makePromise(of: UpgradeResult.self)
+    }
+
+    public func handlerRemoved(context: ChannelHandlerContext) {
+        switch self.stateMachine.handlerRemoved() {
+        case .failUpgradePromise:
+            self.upgradeResultPromise.fail(ChannelError.inappropriateOperationForState)
+        case .none:
+            break
+        }
+    }
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch self.stateMachine.channelReadData(data) {
+        case .unwrapData:
+            let requestPart = self.unwrapInboundIn(data)
+            self.channelRead(context: context, requestPart: requestPart)
+            
+        case .fireChannelRead:
+            context.fireChannelRead(data)
+
+        case .none:
+            break
+        }
+    }
+
+    private func channelRead(context: ChannelHandlerContext, requestPart: HTTPServerRequestPart) {
+        switch self.stateMachine.channelReadRequestPart(requestPart) {
+        case .failUpgradePromise(let error):
+            self.upgradeResultPromise.fail(error)
+
+        case .runNotUpgradingInitializer:
+            self.notUpgradingCompletionHandler(context.channel)
+                .hop(to: context.eventLoop)
+                .whenComplete { result in
+                    self.upgradingHandlerCompleted(context: context, result, requestHeadAndProtocol: nil)
+                }
+
+        case .findUpgrader(let head, let requestedProtocols, let allHeaderNames, let connectionHeader):
+            let protocolIterator = requestedProtocols.makeIterator()
+            self.handleUpgradeForProtocol(
+                context: context,
+                protocolIterator: protocolIterator,
+                request: head,
+                allHeaderNames: allHeaderNames,
+                connectionHeader: connectionHeader
+            ).whenComplete { result in
+                context.eventLoop.assertInEventLoop()
+                self.findingUpgradeCompleted(context: context, requestHead: head, result)
+            }
+
+        case .startUpgrading(let upgrader, let requestHead, let responseHeaders, let proto):
+            self.startUpgrading(
+                context: context,
+                upgrader: upgrader,
+                requestHead: requestHead,
+                responseHeaders: responseHeaders,
+                proto: proto
+            )
+
+        case .none:
+            break
+        }
+    }
+
+    private func upgradingHandlerCompleted(
+        context: ChannelHandlerContext,
+        _ result: Result<UpgradeResult, Error>,
+        requestHeadAndProtocol: (HTTPRequestHead, String)?
+    ) {
+        switch self.stateMachine.upgradingHandlerCompleted(result) {
+        case .fireErrorCaughtAndRemoveHandler(let error):
+            self.upgradeResultPromise.fail(error)
+            context.fireErrorCaught(error)
+            context.pipeline.removeHandler(self, promise: nil)
+
+        case .fireErrorCaughtAndStartUnbuffering(let error):
+            self.upgradeResultPromise.fail(error)
+            context.fireErrorCaught(error)
+            self.unbuffer(context: context)
+
+        case .startUnbuffering(let value):
+            if let requestHeadAndProtocol = requestHeadAndProtocol {
+                context.fireUserInboundEventTriggered(HTTPServerUpgradeEvents.upgradeComplete(toProtocol: requestHeadAndProtocol.1, upgradeRequest: requestHeadAndProtocol.0))
+            }
+            self.upgradeResultPromise.succeed(value)
+            self.unbuffer(context: context)
+
+        case .removeHandler(let value):
+            if let requestHeadAndProtocol = requestHeadAndProtocol {
+                context.fireUserInboundEventTriggered(HTTPServerUpgradeEvents.upgradeComplete(toProtocol: requestHeadAndProtocol.1, upgradeRequest: requestHeadAndProtocol.0))
+            }
+            self.upgradeResultPromise.succeed(value)
+            context.pipeline.removeHandler(self, promise: nil)
+
+        case .none:
+            break
+        }
+    }
+
+    /// Attempt to upgrade a single protocol.
+    ///
+    /// Will recurse through `protocolIterator` if upgrade fails.
+    private func handleUpgradeForProtocol(
+        context: ChannelHandlerContext,
+        protocolIterator: Array<String>.Iterator,
+        request: HTTPRequestHead,
+        allHeaderNames: Set<String>,
+        connectionHeader: Set<String>
+    ) -> EventLoopFuture<(upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders, proto: String)?> {
+        // We want a local copy of the protocol iterator. We'll pass it to the next invocation of the function.
+        var protocolIterator = protocolIterator
+        guard let proto = protocolIterator.next() else {
+            // We're done! No suitable protocol for upgrade.
+            return context.eventLoop.makeSucceededFuture(nil)
+        }
+
+        guard let upgrader = self.upgraders[proto.lowercased()] else {
+            return self.handleUpgradeForProtocol(context: context, protocolIterator: protocolIterator, request: request, allHeaderNames: allHeaderNames, connectionHeader: connectionHeader)
+        }
+
+        let requiredHeaders = Set(upgrader.requiredUpgradeHeaders.map { $0.lowercased() })
+        guard requiredHeaders.isSubset(of: allHeaderNames) && requiredHeaders.isSubset(of: connectionHeader) else {
+            return self.handleUpgradeForProtocol(context: context, protocolIterator: protocolIterator, request: request, allHeaderNames: allHeaderNames, connectionHeader: connectionHeader)
+        }
+
+        let responseHeaders = self.buildUpgradeHeaders(protocol: proto)
+        return upgrader.buildUpgradeResponse(
+            channel: context.channel,
+            upgradeRequest: request,
+            initialResponseHeaders: responseHeaders
+        )
+        .hop(to: context.eventLoop)
+        .map { (upgrader, $0, proto) }
+        .flatMapError { error in
+            // No upgrade here. We want to fire the error down the pipeline, and then try another loop iteration.
+            context.fireErrorCaught(error)
+            return self.handleUpgradeForProtocol(context: context, protocolIterator: protocolIterator, request: request, allHeaderNames: allHeaderNames, connectionHeader: connectionHeader)
+        }
+    }
+
+    private func findingUpgradeCompleted(
+        context: ChannelHandlerContext,
+        requestHead: HTTPRequestHead,
+        _ result: Result<(upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders, proto: String)?, Error>
+    ) {
+        switch self.stateMachine.findingUpgraderCompleted(requestHead: requestHead, result) {
+        case .startUpgrading(let upgrader, let responseHeaders, let proto):
+            self.startUpgrading(
+                context: context,
+                upgrader: upgrader,
+                requestHead: requestHead,
+                responseHeaders: responseHeaders,
+                proto: proto
+            )
+
+        case .runNotUpgradingInitializer:
+            self.notUpgradingCompletionHandler(context.channel)
+                .hop(to: context.eventLoop)
+                .whenComplete { result in
+                    self.upgradingHandlerCompleted(context: context, result, requestHeadAndProtocol: nil)
+                }
+
+        case .fireErrorCaughtAndStartUnbuffering(let error):
+            self.upgradeResultPromise.fail(error)
+            context.fireErrorCaught(error)
+            self.unbuffer(context: context)
+
+        case .fireErrorCaughtAndRemoveHandler(let error):
+            self.upgradeResultPromise.fail(error)
+            context.fireErrorCaught(error)
+            context.pipeline.removeHandler(self, promise: nil)
+
+        case .none:
+            break
+        }
+    }
+
+    private func startUpgrading(
+        context: ChannelHandlerContext,
+        upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>,
+        requestHead: HTTPRequestHead,
+        responseHeaders: HTTPHeaders,
+        proto: String
+    ) {
+        // Before we finish the upgrade we have to remove the HTTPDecoder and any other non-Encoder HTTP
+        // handlers from the pipeline, to prevent them parsing any more data. We'll buffer the data until
+        // that completes.
+        // While there are a lot of Futures involved here it's quite possible that all of this code will
+        // actually complete synchronously: we just want to program for the possibility that it won't.
+        // Once that's done, we send the upgrade response, then remove the HTTP encoder, then call the
+        // internal handler, then call the user code, and then finally when the user code is done we do
+        // our final cleanup steps, namely we replay the received data we buffered in the meantime and
+        // then remove ourselves from the pipeline.
+        self.removeExtraHandlers(context: context).flatMap {
+            self.sendUpgradeResponse(context: context, responseHeaders: responseHeaders)
+        }.flatMap {
+            context.pipeline.removeHandler(self.httpEncoder)
+        }.flatMap { () -> EventLoopFuture<UpgradeResult> in
+            return upgrader.upgrade(channel: context.channel, upgradeRequest: requestHead)
+        }.hop(to: context.eventLoop)
+        .whenComplete { result in
+            self.upgradingHandlerCompleted(context: context, result, requestHeadAndProtocol: (requestHead, proto))
+        }
+    }
+
+    /// Sends the 101 Switching Protocols response for the pipeline.
+    private func sendUpgradeResponse(context: ChannelHandlerContext, responseHeaders: HTTPHeaders) -> EventLoopFuture<Void> {
+        var response = HTTPResponseHead(version: .http1_1, status: .switchingProtocols)
+        response.headers = responseHeaders
+        return context.writeAndFlush(wrapOutboundOut(HTTPServerResponsePart.head(response)))
+    }
+
+    /// Builds the initial mandatory HTTP headers for HTTP upgrade responses.
+    private func buildUpgradeHeaders(`protocol`: String) -> HTTPHeaders {
+        return HTTPHeaders([("connection", "upgrade"), ("upgrade", `protocol`)])
+    }
+
+    /// Removes any extra HTTP-related handlers from the channel pipeline.
+    private func removeExtraHandlers(context: ChannelHandlerContext) -> EventLoopFuture<Void> {
+        guard self.extraHTTPHandlers.count > 0 else {
+            return context.eventLoop.makeSucceededFuture(())
+        }
+
+        return .andAllSucceed(self.extraHTTPHandlers.map { context.pipeline.removeHandler($0) },
+                              on: context.eventLoop)
+    }
+
+    private func unbuffer(context: ChannelHandlerContext) {
+        while true {
+            switch self.stateMachine.unbuffer() {
+            case .fireChannelRead(let data):
+                context.fireChannelRead(data)
+
+            case .fireChannelReadCompleteAndRemoveHandler:
+                context.fireChannelReadComplete()
+                context.pipeline.removeHandler(self, promise: nil)
+                return
+            }
+        }
+    }
+}

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
@@ -1,0 +1,383 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+import DequeModule
+import NIOCore
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
+    @usableFromInline
+    enum State {
+        /// The state before we received a TLSUserEvent. We are just forwarding any read at this point.
+        case initial
+
+        @usableFromInline
+        struct AwaitingUpgrader {
+            var seenFirstRequest: Bool
+            var buffer: Deque<NIOAny>
+        }
+
+        /// The request head has been received. We're currently running the future chain awaiting an upgrader.
+        case awaitingUpgrader(AwaitingUpgrader)
+
+        @usableFromInline
+        struct UpgraderReady {
+            var upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>
+            var requestHead: HTTPRequestHead
+            var responseHeaders: HTTPHeaders
+            var proto: String
+            var buffer: Deque<NIOAny>
+        }
+
+        /// We have an upgrader, which means we can begin upgrade we are just waiting for the request end.
+        case upgraderReady(UpgraderReady)
+
+        @usableFromInline
+        struct Upgrading {
+            var buffer: Deque<NIOAny>
+        }
+        /// We are either running the upgrading handler.
+        case upgrading(Upgrading)
+
+        @usableFromInline
+        struct Unbuffering {
+            var buffer: Deque<NIOAny>
+        }
+        case unbuffering(Unbuffering)
+
+        case finished
+
+        case modifying
+    }
+
+    private var state = State.initial
+
+    @usableFromInline
+    enum HandlerRemovedAction {
+        case failUpgradePromise
+    }
+
+    @inlinable
+    mutating func handlerRemoved() -> HandlerRemovedAction? {
+        switch self.state {
+        case .initial, .awaitingUpgrader, .upgraderReady, .upgrading, .unbuffering:
+            self.state = .finished
+            return .failUpgradePromise
+
+        case .finished:
+            return .none
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum ChannelReadDataAction {
+        case unwrapData
+        case fireChannelRead
+    }
+
+    @inlinable
+    mutating func channelReadData(_ data: NIOAny) -> ChannelReadDataAction? {
+        switch self.state {
+        case .initial:
+            return .unwrapData
+
+        case .awaitingUpgrader(var awaitingUpgrader):
+            if awaitingUpgrader.seenFirstRequest {
+                // We should buffer the data since we have seen the full request.
+                self.state = .modifying
+                awaitingUpgrader.buffer.append(data)
+                self.state = .awaitingUpgrader(awaitingUpgrader)
+                return nil
+            } else {
+                // We shouldn't buffer. This means we are still expecting HTTP parts.
+                return .unwrapData
+            }
+
+        case .upgraderReady:
+            // We have not seen the end of the HTTP request so this
+            // data is probably an HTTP request part.
+            return .unwrapData
+
+        case .unbuffering(var unbuffering):
+            self.state = .modifying
+            unbuffering.buffer.append(data)
+            self.state = .unbuffering(unbuffering)
+            return nil
+
+        case .finished:
+            return .fireChannelRead
+
+        case .upgrading(var upgrading):
+            // We got a read while running ugprading.
+            // We have to buffer the read to unbuffer it afterwards
+            self.state = .modifying
+            upgrading.buffer.append(data)
+            self.state = .upgrading(upgrading)
+            return nil
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum ChannelReadRequestPartAction {
+        case failUpgradePromise(Error)
+        case runNotUpgradingInitializer
+        case startUpgrading(
+            upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>,
+            requestHead: HTTPRequestHead,
+            responseHeaders: HTTPHeaders,
+            proto: String
+        )
+        case findUpgrader(
+            head: HTTPRequestHead,
+            requestedProtocols: [String],
+            allHeaderNames: Set<String>,
+            connectionHeader: Set<String>
+        )
+    }
+
+    @inlinable
+    mutating func channelReadRequestPart(_ requestPart: HTTPServerRequestPart) -> ChannelReadRequestPartAction? {
+        switch self.state {
+        case .initial:
+            guard case .head(let head) = requestPart else {
+                // The first data that we saw was not a head. This is a protocol error and we are just going to
+                // fail upgrading
+                return .failUpgradePromise(HTTPServerUpgradeErrors.invalidHTTPOrdering)
+            }
+
+            // Ok, we have a HTTP head. Check if it's an upgrade.
+            let requestedProtocols = head.headers[canonicalForm: "upgrade"].map(String.init)
+            guard requestedProtocols.count > 0 else {
+                // We have to buffer now since we got the request head but are not upgrading.
+                // The user is configuring the HTTP pipeline now.
+                var buffer = Deque<NIOAny>()
+                buffer.append(NIOAny(requestPart))
+                self.state = .upgrading(.init(buffer: buffer))
+                return .runNotUpgradingInitializer
+            }
+
+            // We can now transition to awaiting the upgrader. This means that we are trying to
+            // find an upgrade that can handle requested protocols. We are not buffering because
+            // we are waiting for the request end.
+            self.state = .awaitingUpgrader(.init(seenFirstRequest: false, buffer: .init()))
+
+            let connectionHeader = Set(head.headers[canonicalForm: "connection"].map { $0.lowercased() })
+            let allHeaderNames = Set(head.headers.map { $0.name.lowercased() })
+
+            return .findUpgrader(
+                head: head,
+                requestedProtocols: requestedProtocols,
+                allHeaderNames: allHeaderNames,
+                connectionHeader: connectionHeader
+            )
+
+        case .awaitingUpgrader(let awaitingUpgrader):
+            switch (awaitingUpgrader.seenFirstRequest, requestPart) {
+            case (true, _):
+                // This is weird we are seeing more requests parts after we have seen an end
+                // Let's fail upgrading
+                return .failUpgradePromise(HTTPServerUpgradeErrors.invalidHTTPOrdering)
+
+            case (false, .head):
+                // This is weird we are seeing another head but haven't seen the end for the request before
+                return .failUpgradePromise(HTTPServerUpgradeErrors.invalidHTTPOrdering)
+
+            case (false, .body):
+                // This is weird we are seeing body parts for a request that indicated that it wanted
+                // to upgrade.
+                return .failUpgradePromise(HTTPServerUpgradeErrors.invalidHTTPOrdering)
+
+            case (false, .end):
+                // Okay we got the end as expected. Just gotta store this in our state.
+                self.state = .awaitingUpgrader(.init(seenFirstRequest: true, buffer: awaitingUpgrader.buffer))
+                return nil
+            }
+
+        case .upgraderReady(let upgraderReady):
+            switch requestPart {
+            case .head:
+                // This is weird we are seeing another head but haven't seen the end for the request before
+                return .failUpgradePromise(HTTPServerUpgradeErrors.invalidHTTPOrdering)
+
+            case .body:
+                // This is weird we are seeing body parts for a request that indicated that it wanted
+                // to upgrade.
+                return .failUpgradePromise(HTTPServerUpgradeErrors.invalidHTTPOrdering)
+
+            case .end:
+                // Okay we got the end as expected and our upgrader is ready so let's start upgrading
+                self.state = .upgrading(.init(buffer: upgraderReady.buffer))
+                return .startUpgrading(
+                    upgrader: upgraderReady.upgrader,
+                    requestHead: upgraderReady.requestHead,
+                    responseHeaders: upgraderReady.responseHeaders,
+                    proto: upgraderReady.proto
+                )
+            }
+
+        case .upgrading, .unbuffering, .finished:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum UpgradingHandlerCompletedAction {
+        case fireErrorCaughtAndStartUnbuffering(Error)
+        case removeHandler(UpgradeResult)
+        case fireErrorCaughtAndRemoveHandler(Error)
+        case startUnbuffering(UpgradeResult)
+    }
+
+    @inlinable
+    mutating func upgradingHandlerCompleted(_ result: Result<UpgradeResult, Error>) -> UpgradingHandlerCompletedAction? {
+        switch self.state {
+        case .initial:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+
+        case .upgrading(let upgrading):
+            switch result {
+            case .success(let value):
+                if !upgrading.buffer.isEmpty {
+                    self.state = .unbuffering(.init(buffer: upgrading.buffer))
+                    return .startUnbuffering(value)
+                } else {
+                    self.state = .finished
+                    return .removeHandler(value)
+                }
+
+            case .failure(let error):
+                if !upgrading.buffer.isEmpty {
+                    // So we failed to upgrade. There is nothing really that we can do here.
+                    // We are unbuffering the reads but there shouldn't be any handler in the pipeline
+                    // that expects a specific type of reads anyhow.
+                    self.state = .unbuffering(.init(buffer: upgrading.buffer))
+                    return .fireErrorCaughtAndStartUnbuffering(error)
+                } else {
+                    self.state = .finished
+                    return .fireErrorCaughtAndRemoveHandler(error)
+                }
+            }
+
+        case .finished:
+            // We have to tolerate this
+            return nil
+
+        case .awaitingUpgrader, .upgraderReady, .unbuffering:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum FindingUpgraderCompletedAction {
+        case startUpgrading(upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders, proto: String)
+        case runNotUpgradingInitializer
+        case fireErrorCaughtAndStartUnbuffering(Error)
+        case fireErrorCaughtAndRemoveHandler(Error)
+    }
+
+    @inlinable
+    mutating func findingUpgraderCompleted(
+        requestHead: HTTPRequestHead,
+        _ result: Result<(upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders, proto: String)?, Error>
+    ) -> FindingUpgraderCompletedAction? {
+        switch self.state {
+        case .initial, .upgraderReady:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+
+        case .awaitingUpgrader(let awaitingUpgrader):
+            switch result {
+            case .success(.some((let upgrader, let responseHeaders, let proto))):
+                if awaitingUpgrader.seenFirstRequest {
+                    // We have seen the end of the request. So we can upgrade now.
+                    self.state = .upgrading(.init(buffer: awaitingUpgrader.buffer))
+                    return .startUpgrading(upgrader: upgrader, responseHeaders: responseHeaders, proto: proto)
+                } else {
+                    // We have not yet seen the end so we have to wait until that happens
+                    self.state = .upgraderReady(.init(
+                        upgrader: upgrader,
+                        requestHead: requestHead,
+                        responseHeaders: responseHeaders,
+                        proto: proto,
+                        buffer: awaitingUpgrader.buffer
+                    ))
+                    return nil
+                }
+
+            case .success(.none):
+                // There was no upgrader to handle the request. We just run the not upgrading
+                // initializer now.
+                self.state = .upgrading(.init(buffer: awaitingUpgrader.buffer))
+                return .runNotUpgradingInitializer
+
+            case .failure(let error):
+                if !awaitingUpgrader.buffer.isEmpty {
+                    self.state = .unbuffering(.init(buffer: awaitingUpgrader.buffer))
+                    return .fireErrorCaughtAndStartUnbuffering(error)
+                } else {
+                    self.state = .finished
+                    return .fireErrorCaughtAndRemoveHandler(error)
+                }
+            }
+
+        case .upgrading, .unbuffering, .finished:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+        }
+    }
+
+    @usableFromInline
+    enum UnbufferAction {
+        case fireChannelRead(NIOAny)
+        case fireChannelReadCompleteAndRemoveHandler
+    }
+
+    @inlinable
+    mutating func unbuffer() -> UnbufferAction {
+        switch self.state {
+        case .initial, .awaitingUpgrader, .upgraderReady, .upgrading, .finished:
+            preconditionFailure("Invalid state \(self.state)")
+
+        case .unbuffering(var unbuffering):
+            self.state = .modifying
+
+            if let element = unbuffering.buffer.popFirst() {
+                self.state = .unbuffering(unbuffering)
+
+                return .fireChannelRead(element)
+            } else {
+                self.state = .finished
+
+                return .fireChannelReadCompleteAndRemoveHandler
+            }
+
+        case .modifying:
+            fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
+            
+        }
+    }
+
+}

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
@@ -10,6 +10,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+//===----------------------------------------------------------------------===//
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 import DequeModule
 import NIOCore
 
@@ -381,3 +383,4 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
     }
 
 }
+#endif

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -74,6 +74,61 @@ public final class NIOWebSocketClientUpgrader: NIOHTTPClientProtocolUpgrader {
     }
 }
 
+/// A `NIOTypedHTTPClientProtocolUpgrader` that knows how to do the WebSocket upgrade dance.
+///
+/// This upgrader assumes that the `HTTPClientUpgradeHandler` will create and send the upgrade request.
+/// This upgrader also assumes that the `HTTPClientUpgradeHandler` will appropriately mutate the
+/// pipeline to remove the HTTP `ChannelHandler`s.
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+public final class NIOTypedWebSocketClientUpgrader<UpgradeResult: Sendable>: NIOTypedHTTPClientProtocolUpgrader {
+    /// RFC 6455 specs this as the required entry in the Upgrade header.
+    public let supportedProtocol: String = "websocket"
+    /// None of the websocket headers are actually defined as 'required'.
+    public let requiredUpgradeHeaders: [String] = []
+
+    private let requestKey: String
+    private let maxFrameSize: Int
+    private let enableAutomaticErrorHandling: Bool
+    private let upgradePipelineHandler: @Sendable (Channel, HTTPResponseHead) -> EventLoopFuture<UpgradeResult>
+
+    /// - Parameters:
+    ///   - requestKey: Sent to the server in the `Sec-WebSocket-Key` HTTP header. Default is random request key.
+    ///   - maxFrameSize: Largest incoming `WebSocketFrame` size in bytes. Default is 16,384 bytes.
+    ///   - enableAutomaticErrorHandling: If true, adds `WebSocketProtocolErrorHandler` to the channel pipeline to catch and respond to WebSocket protocol errors. Default is true.
+    ///   - upgradePipelineHandler: Called once the upgrade was successful.
+    public init(
+        requestKey: String = NIOWebSocketClientUpgrader.randomRequestKey(),
+        maxFrameSize: Int = 1 << 14,
+        enableAutomaticErrorHandling: Bool = true,
+        upgradePipelineHandler: @escaping @Sendable (Channel, HTTPResponseHead) -> EventLoopFuture<UpgradeResult>
+    ) {
+        precondition(requestKey != "", "The request key must contain a valid Sec-WebSocket-Key")
+        precondition(maxFrameSize <= UInt32.max, "invalid overlarge max frame size")
+        self.requestKey = requestKey
+        self.upgradePipelineHandler = upgradePipelineHandler
+        self.maxFrameSize = maxFrameSize
+        self.enableAutomaticErrorHandling = enableAutomaticErrorHandling
+    }
+
+    public func addCustom(upgradeRequestHeaders: inout NIOHTTP1.HTTPHeaders) {
+        _addCustom(upgradeRequestHeaders: &upgradeRequestHeaders, requestKey: self.requestKey)
+    }
+
+    public func shouldAllowUpgrade(upgradeResponse: HTTPResponseHead) -> Bool {
+        _shouldAllowUpgrade(upgradeResponse: upgradeResponse, requestKey: self.requestKey)
+    }
+
+    public func upgrade(channel: Channel, upgradeResponse: HTTPResponseHead) -> EventLoopFuture<UpgradeResult> {
+        _upgrade(
+            channel: channel,
+            upgradeResponse: upgradeResponse,
+            maxFrameSize: self.maxFrameSize,
+            enableAutomaticErrorHandling: self.enableAutomaticErrorHandling,
+            upgradePipelineHandler: self.upgradePipelineHandler
+        )
+    }
+}
+
 @available(*, unavailable)
 extension NIOWebSocketClientUpgrader: Sendable {}
 

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -74,6 +74,7 @@ public final class NIOWebSocketClientUpgrader: NIOHTTPClientProtocolUpgrader {
     }
 }
 
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 /// A `NIOTypedHTTPClientProtocolUpgrader` that knows how to do the WebSocket upgrade dance.
 ///
 /// This upgrader assumes that the `HTTPClientUpgradeHandler` will create and send the upgrade request.
@@ -128,6 +129,7 @@ public final class NIOTypedWebSocketClientUpgrader<UpgradeResult: Sendable>: NIO
         )
     }
 }
+#endif
 
 @available(*, unavailable)
 extension NIOWebSocketClientUpgrader: Sendable {}

--- a/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
@@ -175,6 +175,90 @@ public final class NIOWebSocketServerUpgrader: HTTPServerProtocolUpgrader, @unch
     }
 }
 
+/// A `NIOTypedHTTPServerProtocolUpgrader` that knows how to do the WebSocket upgrade dance.
+///
+/// Users may frequently want to offer multiple websocket endpoints on the same port. For this
+/// reason, this `WebServerSocketUpgrader` only knows how to do the required parts of the upgrade and to
+/// complete the handshake. Users are expected to provide a callback that examines the HTTP headers
+/// (including the path) and determines whether this is a websocket upgrade request that is acceptable
+/// to them.
+///
+/// This upgrader assumes that the `HTTPServerUpgradeHandler` will appropriately mutate the pipeline to
+/// remove the HTTP `ChannelHandler`s.
+public final class NIOTypedWebSocketServerUpgrader<UpgradeResult: Sendable>: NIOTypedHTTPServerProtocolUpgrader, Sendable {
+    private typealias ShouldUpgrade = @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>
+    private typealias UpgradePipelineHandler = @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<UpgradeResult>
+
+    /// RFC 6455 specs this as the required entry in the Upgrade header.
+    public let supportedProtocol: String = "websocket"
+
+    /// We deliberately do not actually set any required headers here, because the websocket
+    /// spec annoyingly does not actually force the client to send these in the Upgrade header,
+    /// which NIO requires. We check for these manually.
+    public let requiredUpgradeHeaders: [String] = []
+
+    private let shouldUpgrade: ShouldUpgrade
+    private let upgradePipelineHandler: UpgradePipelineHandler
+    private let maxFrameSize: Int
+    private let enableAutomaticErrorHandling: Bool
+
+    /// Create a new ``NIOTypedWebSocketServerUpgrader``.
+    ///
+    /// - Parameters:
+    ///   - maxFrameSize: The maximum frame size the decoder is willing to tolerate from the
+    ///         remote peer. WebSockets in principle allows frame sizes up to `2**64` bytes, but
+    ///         this is an objectively unreasonable maximum value (on AMD64 systems it is not
+    ///         possible to even. Users may set this to any value up to `UInt32.max`.
+    ///   - automaticErrorHandling: Whether the pipeline should automatically handle protocol
+    ///         errors by sending error responses and closing the connection. Defaults to `true`,
+    ///         may be set to `false` if the user wishes to handle their own errors.
+    ///   - shouldUpgrade: A callback that determines whether the websocket request should be
+    ///         upgraded. This callback is responsible for creating a `HTTPHeaders` object with
+    ///         any headers that it needs on the response *except for* the `Upgrade`, `Connection`,
+    ///         and `Sec-WebSocket-Accept` headers, which this upgrader will handle. Should return
+    ///         an `EventLoopFuture` containing `nil` if the upgrade should be refused.
+    ///   - enableAutomaticErrorHandling: A function that will be called once the upgrade response is
+    ///         flushed, and that is expected to mutate the `Channel` appropriately to handle the
+    ///         websocket protocol. This only needs to add the user handlers: the
+    ///         `WebSocketFrameEncoder` and `WebSocketFrameDecoder` will have been added to the
+    ///         pipeline automatically.
+    public init(
+        maxFrameSize: Int = 1 << 14,
+        enableAutomaticErrorHandling: Bool = true,
+        shouldUpgrade: @escaping @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<HTTPHeaders?>,
+        upgradePipelineHandler: @escaping @Sendable (Channel, HTTPRequestHead) -> EventLoopFuture<UpgradeResult>
+    ) {
+        precondition(maxFrameSize <= UInt32.max, "invalid overlarge max frame size")
+        self.shouldUpgrade = shouldUpgrade
+        self.upgradePipelineHandler = upgradePipelineHandler
+        self.maxFrameSize = maxFrameSize
+        self.enableAutomaticErrorHandling = enableAutomaticErrorHandling
+    }
+
+    public func buildUpgradeResponse(
+        channel: Channel,
+        upgradeRequest: HTTPRequestHead,
+        initialResponseHeaders: HTTPHeaders
+    ) -> EventLoopFuture<HTTPHeaders> {
+        _buildUpgradeResponse(
+            channel: channel,
+            upgradeRequest: upgradeRequest,
+            initialResponseHeaders: initialResponseHeaders,
+            shouldUpgrade: self.shouldUpgrade
+        )
+    }
+
+    public func upgrade(channel: Channel, upgradeRequest: HTTPRequestHead) -> EventLoopFuture<UpgradeResult> {
+        _upgrade(
+            channel: channel,
+            upgradeRequest: upgradeRequest,
+            maxFrameSize: self.maxFrameSize,
+            automaticErrorHandling: self.enableAutomaticErrorHandling,
+            upgradePipelineHandler: self.upgradePipelineHandler
+        )
+    }
+}
+
 private func _buildUpgradeResponse(
     channel: Channel,
     upgradeRequest: HTTPRequestHead,

--- a/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
@@ -175,6 +175,7 @@ public final class NIOWebSocketServerUpgrader: HTTPServerProtocolUpgrader, @unch
     }
 }
 
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 /// A `NIOTypedHTTPServerProtocolUpgrader` that knows how to do the WebSocket upgrade dance.
 ///
 /// Users may frequently want to offer multiple websocket endpoints on the same port. For this
@@ -258,6 +259,7 @@ public final class NIOTypedWebSocketServerUpgrader<UpgradeResult: Sendable>: NIO
         )
     }
 }
+#endif
 
 private func _buildUpgradeResponse(
     channel: Channel,

--- a/Sources/NIOWebSocketClient/Client.swift
+++ b/Sources/NIOWebSocketClient/Client.swift
@@ -12,136 +12,129 @@
 //
 //===----------------------------------------------------------------------===//
 #if swift(>=5.9)
+import NIOCore
+import NIOPosix
+import NIOHTTP1
+import NIOWebSocket
+
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 @main
 struct Client {
-    static func main() {
-        fatalError("Disabled due to https://github.com/apple/swift-nio/issues/2574")
+    /// The host to connect to.
+    private let host: String
+    /// The port to connect to.
+    private let port: Int
+    /// The client's event loop group.
+    private let eventLoopGroup: MultiThreadedEventLoopGroup
+
+    enum UpgradeResult {
+        case websocket(NIOAsyncChannel<WebSocketFrame, WebSocketFrame>)
+        case notUpgraded
+    }
+
+    static func main() async throws {
+        let client = Client(
+            host: "localhost",
+            port: 8888,
+            eventLoopGroup: .singleton
+        )
+        try await client.run()
+    }
+
+    /// This method starts the client and tries to setup a WebSocket connection.
+    func run() async throws {
+        let upgradeResult: EventLoopFuture<UpgradeResult> = try await ClientBootstrap(group: self.eventLoopGroup)
+            .connect(
+                host: self.host,
+                port: self.port
+            ) { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    let upgrader = NIOTypedWebSocketClientUpgrader<UpgradeResult>(
+                        upgradePipelineHandler: { (channel, _) in
+                            channel.eventLoop.makeCompletedFuture {
+                                let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(wrappingChannelSynchronously: channel)
+                                return UpgradeResult.websocket(asyncChannel)
+                            }
+                        }
+                    )
+
+                    var headers = HTTPHeaders()
+                    headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
+                    headers.add(name: "Content-Length", value: "0")
+
+                    let requestHead = HTTPRequestHead(
+                        version: .http1_1,
+                        method: .GET,
+                        uri: "/",
+                        headers: headers
+                    )
+
+                    let clientUpgradeConfiguration = NIOTypedHTTPClientUpgradeConfiguration(
+                        upgradeRequestHead: requestHead,
+                        upgraders: [upgrader],
+                        notUpgradingCompletionHandler: { channel in
+                            channel.eventLoop.makeCompletedFuture {
+                                return UpgradeResult.notUpgraded
+                            }
+                        }
+                    )
+
+                    let negotiationResultFuture = try channel.pipeline.syncOperations.configureUpgradableHTTPClientPipeline(
+                        configuration: .init(upgradeConfiguration: clientUpgradeConfiguration)
+                    )
+
+                    return negotiationResultFuture
+                }
+            }
+
+        // We are awaiting and handling the upgrade result now.
+        try await self.handleUpgradeResult(upgradeResult)
+    }
+
+    /// This method handles the upgrade result.
+    private func handleUpgradeResult(_ upgradeResult: EventLoopFuture<UpgradeResult>) async throws {
+        switch try await upgradeResult.get() {
+        case .websocket(let websocketChannel):
+            print("Handling websocket connection")
+            try await self.handleWebsocketChannel(websocketChannel)
+            print("Done handling websocket connection")
+        case .notUpgraded:
+            // The upgrade to websocket did not succeed. We are just exiting in this case.
+            print("Upgrade declined")
+        }
+    }
+
+    private func handleWebsocketChannel(_ channel: NIOAsyncChannel<WebSocketFrame, WebSocketFrame>) async throws {
+        // We are sending a ping frame and then
+        // start to handle all inbound frames.
+
+        let pingFrame = WebSocketFrame(fin: true, opcode: .ping, data: ByteBuffer(string: "Hello!"))
+        try await channel.executeThenClose { inbound, outbound in
+            try await outbound.write(pingFrame)
+
+            for try await frame in inbound {
+                switch frame.opcode {
+                case .pong:
+                    print("Received pong: \(String(buffer: frame.data))")
+
+                case .text:
+                    print("Received: \(String(buffer: frame.data))")
+
+                case .connectionClose:
+                    // Handle a received close frame. We're just going to close by returning from this method.
+                    print("Received Close instruction from server")
+                    return
+                case .binary, .continuation, .ping:
+                    // We ignore these frames.
+                    break
+                default:
+                    // Unknown frames are errors.
+                    return
+                }
+            }
+        }
     }
 }
-
-// Commented out due https://github.com/apple/swift-nio/issues/2574
-
-//import NIOCore
-//import NIOPosix
-//import NIOHTTP1
-//import NIOWebSocket
-//
-//@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
-//@main
-//struct Client {
-//    /// The host to connect to.
-//    private let host: String
-//    /// The port to connect to.
-//    private let port: Int
-//    /// The client's event loop group.
-//    private let eventLoopGroup: MultiThreadedEventLoopGroup
-//
-//    enum UpgradeResult {
-//        case websocket(NIOAsyncChannel<WebSocketFrame, WebSocketFrame>)
-//        case notUpgraded
-//    }
-//
-//    static func main() async throws {
-//        let client = Client(
-//            host: "localhost",
-//            port: 8888,
-//            eventLoopGroup: .singleton
-//        )
-//        try await client.run()
-//    }
-//
-//    /// This method starts the client and tries to setup a WebSocket connection.
-//    func run() async throws {
-//        let upgradeResult: EventLoopFuture<UpgradeResult> = try await ClientBootstrap(group: self.eventLoopGroup)
-//            .connect(
-//                host: self.host,
-//                port: self.port
-//            ) { channel in
-//                channel.eventLoop.makeCompletedFuture {
-//                    let upgrader = NIOTypedWebSocketClientUpgrader<UpgradeResult>(
-//                        upgradePipelineHandler: { (channel, _) in
-//                            channel.eventLoop.makeCompletedFuture {
-//                                let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(wrappingChannelSynchronously: channel)
-//                                return UpgradeResult.websocket(asyncChannel)
-//                            }
-//                        }
-//                    )
-//
-//                    var headers = HTTPHeaders()
-//                    headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
-//                    headers.add(name: "Content-Length", value: "0")
-//
-//                    let requestHead = HTTPRequestHead(
-//                        version: .http1_1,
-//                        method: .GET,
-//                        uri: "/",
-//                        headers: headers
-//                    )
-//
-//                    let clientUpgradeConfiguration = NIOTypedHTTPClientUpgradeConfiguration(
-//                        upgradeRequestHead: requestHead,
-//                        upgraders: [upgrader],
-//                        notUpgradingCompletionHandler: { channel in
-//                            channel.eventLoop.makeCompletedFuture {
-//                                return UpgradeResult.notUpgraded
-//                            }
-//                        }
-//                    )
-//
-//                    let negotiationResultFuture = try channel.pipeline.syncOperations.configureUpgradableHTTPClientPipeline(
-//                        configuration: .init(upgradeConfiguration: clientUpgradeConfiguration)
-//                    )
-//
-//                    return negotiationResultFuture
-//                }
-//            }
-//
-//        // We are awaiting and handling the upgrade result now.
-//        try await self.handleUpgradeResult(upgradeResult)
-//    }
-//
-//    /// This method handles the upgrade result.
-//    private func handleUpgradeResult(_ upgradeResult: EventLoopFuture<UpgradeResult>) async throws {
-//        switch try await upgradeResult.get() {
-//        case .websocket(let websocketChannel):
-//            print("Handling websocket connection")
-//            try await self.handleWebsocketChannel(websocketChannel)
-//            print("Done handling websocket connection")
-//        case .notUpgraded:
-//            // The upgrade to websocket did not succeed. We are just exiting in this case.
-//            print("Upgrade declined")
-//        }
-//    }
-//
-//    private func handleWebsocketChannel(_ channel: NIOAsyncChannel<WebSocketFrame, WebSocketFrame>) async throws {
-//        // We are sending a ping frame and then
-//        // start to handle all inbound frames.
-//
-//        let pingFrame = WebSocketFrame(fin: true, opcode: .ping, data: ByteBuffer(string: "Hello!"))
-//        try await channel.outbound.write(pingFrame)
-//
-//        for try await frame in channel.inbound {
-//            switch frame.opcode {
-//            case .pong:
-//                print("Received pong: \(String(buffer: frame.data))")
-//
-//            case .text:
-//                print("Received: \(String(buffer: frame.data))")
-//
-//            case .connectionClose:
-//                // Handle a received close frame. We're just going to close by returning from this method.
-//                print("Received Close instruction from server")
-//                return
-//            case .binary, .continuation, .ping:
-//                // We ignore these frames.
-//                break
-//            default:
-//                // Unknown frames are errors.
-//                return
-//            }
-//        }
-//    }
-//}
 
 #else
 @main

--- a/Sources/NIOWebSocketClient/Client.swift
+++ b/Sources/NIOWebSocketClient/Client.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if swift(>=5.9)
+#if (!canImport(Darwin) && swift(>=5.9)) || (canImport(Darwin) && swift(>=5.10))
 import NIOCore
 import NIOPosix
 import NIOHTTP1

--- a/Sources/NIOWebSocketServer/Server.swift
+++ b/Sources/NIOWebSocketServer/Server.swift
@@ -41,247 +41,244 @@ let websocketResponse = """
 </html>
 """
 
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 @main
 struct Server {
-    static func main() {
-        fatalError("Disabled due to https://github.com/apple/swift-nio/issues/2574")
+    /// The server's host.
+    private let host: String
+    /// The server's port.
+    private let port: Int
+    /// The server's event loop group.
+    private let eventLoopGroup: MultiThreadedEventLoopGroup
+
+    private static let responseBody = ByteBuffer(string: websocketResponse)
+
+    enum UpgradeResult {
+        case websocket(NIOAsyncChannel<WebSocketFrame, WebSocketFrame>)
+        case notUpgraded(NIOAsyncChannel<HTTPServerRequestPart, HTTPPart<HTTPResponseHead, ByteBuffer>>)
+    }
+
+    static func main() async throws {
+        let server = Server(
+            host: "localhost",
+            port: 8888,
+            eventLoopGroup: .singleton
+        )
+        try await server.run()
+    }
+
+    /// This method starts the server and handles incoming connections.
+    func run() async throws {
+        let channel: NIOAsyncChannel<EventLoopFuture<UpgradeResult>, Never> = try await ServerBootstrap(group: self.eventLoopGroup)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .bind(
+                host: self.host,
+                port: self.port
+            ) { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    let upgrader = NIOTypedWebSocketServerUpgrader<UpgradeResult>(
+                        shouldUpgrade: { (channel, head) in
+                            channel.eventLoop.makeSucceededFuture(HTTPHeaders())
+                        },
+                        upgradePipelineHandler: { (channel, _) in
+                            channel.eventLoop.makeCompletedFuture {
+                                let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(wrappingChannelSynchronously: channel)
+                                return UpgradeResult.websocket(asyncChannel)
+                            }
+                        }
+                    )
+
+                    let serverUpgradeConfiguration = NIOTypedHTTPServerUpgradeConfiguration(
+                        upgraders: [upgrader],
+                        notUpgradingCompletionHandler: { channel in
+                            channel.eventLoop.makeCompletedFuture {
+                                try channel.pipeline.syncOperations.addHandler(HTTPByteBufferResponsePartHandler())
+                                let asyncChannel = try NIOAsyncChannel<HTTPServerRequestPart, HTTPPart<HTTPResponseHead, ByteBuffer>>(wrappingChannelSynchronously: channel)
+                                return UpgradeResult.notUpgraded(asyncChannel)
+                            }
+                        }
+                    )
+
+                    let negotiationResultFuture = try channel.pipeline.syncOperations.configureUpgradableHTTPServerPipeline(
+                        configuration: .init(upgradeConfiguration: serverUpgradeConfiguration)
+                    )
+
+                    return negotiationResultFuture
+                }
+            }
+
+        // We are handling each incoming connection in a separate child task. It is important
+        // to use a discarding task group here which automatically discards finished child tasks.
+        // A normal task group retains all child tasks and their outputs in memory until they are
+        // consumed by iterating the group or by exiting the group. Since, we are never consuming
+        // the results of the group we need the group to automatically discard them; otherwise, this
+        // would result in a memory leak over time.
+        try await withThrowingDiscardingTaskGroup { group in
+            try await channel.executeThenClose { inbound in
+                for try await upgradeResult in inbound {
+                    group.addTask {
+                        await self.handleUpgradeResult(upgradeResult)
+                    }
+                }
+            }
+        }
+    }
+
+    /// This method handles a single connection by echoing back all inbound data.
+    private func handleUpgradeResult(_ upgradeResult: EventLoopFuture<UpgradeResult>) async {
+        // Note that this method is non-throwing and we are catching any error.
+        // We do this since we don't want to tear down the whole server when a single connection
+        // encounters an error.
+        do {
+            switch try await upgradeResult.get() {
+            case .websocket(let websocketChannel):
+                print("Handling websocket connection")
+                try await self.handleWebsocketChannel(websocketChannel)
+                print("Done handling websocket connection")
+            case .notUpgraded(let httpChannel):
+                print("Handling HTTP connection")
+                try await self.handleHTTPChannel(httpChannel)
+                print("Done handling HTTP connection")
+            }
+        } catch {
+            print("Hit error: \(error)")
+        }
+    }
+
+    private func handleWebsocketChannel(_ channel: NIOAsyncChannel<WebSocketFrame, WebSocketFrame>) async throws {
+        try await channel.executeThenClose { inbound, outbound in
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    for try await frame in inbound {
+                        switch frame.opcode {
+                        case .ping:
+                            print("Received ping")
+                            var frameData = frame.data
+                            let maskingKey = frame.maskKey
+
+                            if let maskingKey = maskingKey {
+                                frameData.webSocketUnmask(maskingKey)
+                            }
+
+                            let responseFrame = WebSocketFrame(fin: true, opcode: .pong, data: frameData)
+                            try await outbound.write(responseFrame)
+
+                        case .connectionClose:
+                            // This is an unsolicited close. We're going to send a response frame and
+                            // then, when we've sent it, close up shop. We should send back the close code the remote
+                            // peer sent us, unless they didn't send one at all.
+                            print("Received close")
+                            var data = frame.unmaskedData
+                            let closeDataCode = data.readSlice(length: 2) ?? ByteBuffer()
+                            let closeFrame = WebSocketFrame(fin: true, opcode: .connectionClose, data: closeDataCode)
+                            try await outbound.write(closeFrame)
+                            return
+                        case .binary, .continuation, .pong:
+                            // We ignore these frames.
+                            break
+                        default:
+                            // Unknown frames are errors.
+                            return
+                        }
+                    }
+                }
+
+                group.addTask {
+                    // This is our main business logic where we are just sending the current time
+                    // every second.
+                    while true {
+                        // We can't really check for error here, but it's also not the purpose of the
+                        // example so let's not worry about it.
+                        let theTime = ContinuousClock().now
+                        var buffer = channel.channel.allocator.buffer(capacity: 12)
+                        buffer.writeString("\(theTime)")
+
+                        let frame = WebSocketFrame(fin: true, opcode: .text, data: buffer)
+
+                        print("Sending time")
+                        try await outbound.write(frame)
+                        try await Task.sleep(for: .seconds(1))
+                    }
+                }
+
+                try await group.next()
+                group.cancelAll()
+            }
+        }
+    }
+
+
+    private func handleHTTPChannel(_ channel: NIOAsyncChannel<HTTPServerRequestPart, HTTPPart<HTTPResponseHead, ByteBuffer>>) async throws {
+        try await channel.executeThenClose { inbound, outbound in
+            for try await requestPart in inbound {
+                // We're not interested in request bodies here: we're just serving up GET responses
+                // to get the client to initiate a websocket request.
+                guard case .head(let head) = requestPart else {
+                    return
+                }
+
+                // GETs only.
+                guard case .GET = head.method else {
+                    try await self.respond405(writer: outbound)
+                    return
+                }
+
+                var headers = HTTPHeaders()
+                headers.add(name: "Content-Type", value: "text/html")
+                headers.add(name: "Content-Length", value: String(Self.responseBody.readableBytes))
+                headers.add(name: "Connection", value: "close")
+                let responseHead = HTTPResponseHead(
+                    version: .init(major: 1, minor: 1),
+                    status: .ok,
+                    headers: headers
+                )
+
+                try await outbound.write(
+                    contentsOf: [
+                        .head(responseHead),
+                        .body(Self.responseBody),
+                        .end(nil)
+                    ]
+                )
+            }
+        }
+    }
+
+    private func respond405(writer: NIOAsyncChannelOutboundWriter<HTTPPart<HTTPResponseHead, ByteBuffer>>) async throws {
+        var headers = HTTPHeaders()
+        headers.add(name: "Connection", value: "close")
+        headers.add(name: "Content-Length", value: "0")
+        let head = HTTPResponseHead(
+            version: .http1_1,
+            status: .methodNotAllowed,
+            headers: headers
+        )
+
+        try await writer.write(
+            contentsOf: [
+                .head(head),
+                .end(nil)
+            ]
+        )
     }
 }
 
-// Commented out due https://github.com/apple/swift-nio/issues/2574
+final class HTTPByteBufferResponsePartHandler: ChannelOutboundHandler {
+    typealias OutboundIn = HTTPPart<HTTPResponseHead, ByteBuffer>
+    typealias OutboundOut = HTTPServerResponsePart
 
-//@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
-//@main
-//struct Server {
-//    /// The server's host.
-//    private let host: String
-//    /// The server's port.
-//    private let port: Int
-//    /// The server's event loop group.
-//    private let eventLoopGroup: MultiThreadedEventLoopGroup
-//
-//    private static let responseBody = ByteBuffer(string: websocketResponse)
-//
-//    enum UpgradeResult {
-//        case websocket(NIOAsyncChannel<WebSocketFrame, WebSocketFrame>)
-//        case notUpgraded(NIOAsyncChannel<HTTPServerRequestPart, HTTPPart<HTTPResponseHead, ByteBuffer>>)
-//    }
-//
-//    static func main() async throws {
-//        let server = Server(
-//            host: "localhost",
-//            port: 8888,
-//            eventLoopGroup: .singleton
-//        )
-//        try await server.run()
-//    }
-//
-//    /// This method starts the server and handles incoming connections.
-//    func run() async throws {
-//        let channel: NIOAsyncChannel<EventLoopFuture<UpgradeResult>, Never> = try await ServerBootstrap(group: self.eventLoopGroup)
-//            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-//            .bind(
-//                host: self.host,
-//                port: self.port
-//            ) { channel in
-//                channel.eventLoop.makeCompletedFuture {
-//                    let upgrader = NIOTypedWebSocketServerUpgrader<UpgradeResult>(
-//                        shouldUpgrade: { (channel, head) in
-//                            channel.eventLoop.makeSucceededFuture(HTTPHeaders())
-//                        },
-//                        upgradePipelineHandler: { (channel, _) in
-//                            channel.eventLoop.makeCompletedFuture {
-//                                let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(wrappingChannelSynchronously: channel)
-//                                return UpgradeResult.websocket(asyncChannel)
-//                            }
-//                        }
-//                    )
-//
-//                    let serverUpgradeConfiguration = NIOTypedHTTPServerUpgradeConfiguration(
-//                        upgraders: [upgrader],
-//                        notUpgradingCompletionHandler: { channel in
-//                            channel.eventLoop.makeCompletedFuture {
-//                                try channel.pipeline.syncOperations.addHandler(HTTPByteBufferResponsePartHandler())
-//                                let asyncChannel = try NIOAsyncChannel<HTTPServerRequestPart, HTTPPart<HTTPResponseHead, ByteBuffer>>(wrappingChannelSynchronously: channel)
-//                                return UpgradeResult.notUpgraded(asyncChannel)
-//                            }
-//                        }
-//                    )
-//
-//                    let negotiationResultFuture = try channel.pipeline.syncOperations.configureUpgradableHTTPServerPipeline(
-//                        configuration: .init(upgradeConfiguration: serverUpgradeConfiguration)
-//                    )
-//
-//                    return negotiationResultFuture
-//                }
-//            }
-//
-//        // We are handling each incoming connection in a separate child task. It is important
-//        // to use a discarding task group here which automatically discards finished child tasks.
-//        // A normal task group retains all child tasks and their outputs in memory until they are
-//        // consumed by iterating the group or by exiting the group. Since, we are never consuming
-//        // the results of the group we need the group to automatically discard them; otherwise, this
-//        // would result in a memory leak over time.
-//        try await withThrowingDiscardingTaskGroup { group in
-//            for try await upgradeResult in channel.inbound {
-//                group.addTask {
-//                    await self.handleUpgradeResult(upgradeResult)
-//                }
-//            }
-//        }
-//    }
-//
-//    /// This method handles a single connection by echoing back all inbound data.
-//    private func handleUpgradeResult(_ upgradeResult: EventLoopFuture<UpgradeResult>) async {
-//        // Note that this method is non-throwing and we are catching any error.
-//        // We do this since we don't want to tear down the whole server when a single connection
-//        // encounters an error.
-//        do {
-//            switch try await upgradeResult.get() {
-//            case .websocket(let websocketChannel):
-//                print("Handling websocket connection")
-//                try await self.handleWebsocketChannel(websocketChannel)
-//                print("Done handling websocket connection")
-//            case .notUpgraded(let httpChannel):
-//                print("Handling HTTP connection")
-//                try await self.handleHTTPChannel(httpChannel)
-//                print("Done handling HTTP connection")
-//            }
-//        } catch {
-//            print("Hit error: \(error)")
-//        }
-//    }
-//
-//    private func handleWebsocketChannel(_ channel: NIOAsyncChannel<WebSocketFrame, WebSocketFrame>) async throws {
-//        try await withThrowingTaskGroup(of: Void.self) { group in
-//            group.addTask {
-//                for try await frame in channel.inbound {
-//                    switch frame.opcode {
-//                    case .ping:
-//                        print("Received ping")
-//                        var frameData = frame.data
-//                        let maskingKey = frame.maskKey
-//
-//                        if let maskingKey = maskingKey {
-//                            frameData.webSocketUnmask(maskingKey)
-//                        }
-//
-//                        let responseFrame = WebSocketFrame(fin: true, opcode: .pong, data: frameData)
-//                        try await channel.outbound.write(responseFrame)
-//
-//                    case .connectionClose:
-//                        // This is an unsolicited close. We're going to send a response frame and
-//                        // then, when we've sent it, close up shop. We should send back the close code the remote
-//                        // peer sent us, unless they didn't send one at all.
-//                        print("Received close")
-//                        var data = frame.unmaskedData
-//                        let closeDataCode = data.readSlice(length: 2) ?? ByteBuffer()
-//                        let closeFrame = WebSocketFrame(fin: true, opcode: .connectionClose, data: closeDataCode)
-//                        try await channel.outbound.write(closeFrame)
-//                        return
-//                    case .binary, .continuation, .pong:
-//                        // We ignore these frames.
-//                        break
-//                    default:
-//                        // Unknown frames are errors.
-//                        return
-//                    }
-//                }
-//            }
-//
-//            group.addTask {
-//                // This is our main business logic where we are just sending the current time
-//                // every second.
-//                while true {
-//                    // We can't really check for error here, but it's also not the purpose of the
-//                    // example so let's not worry about it.
-//                    let theTime = ContinuousClock().now
-//                    var buffer = channel.channel.allocator.buffer(capacity: 12)
-//                    buffer.writeString("\(theTime)")
-//
-//                    let frame = WebSocketFrame(fin: true, opcode: .text, data: buffer)
-//
-//                    print("Sending time")
-//                    try await channel.outbound.write(frame)
-//                    try await Task.sleep(for: .seconds(1))
-//                }
-//            }
-//
-//            try await group.next()
-//            group.cancelAll()
-//        }
-//    }
-//
-//
-//    private func handleHTTPChannel(_ channel: NIOAsyncChannel<HTTPServerRequestPart, HTTPPart<HTTPResponseHead, ByteBuffer>>) async throws {
-//        for try await requestPart in channel.inbound {
-//            // We're not interested in request bodies here: we're just serving up GET responses
-//            // to get the client to initiate a websocket request.
-//            guard case .head(let head) = requestPart else {
-//                return
-//            }
-//
-//            // GETs only.
-//            guard case .GET = head.method else {
-//                try await self.respond405(writer: channel.outbound)
-//                return
-//            }
-//
-//            var headers = HTTPHeaders()
-//            headers.add(name: "Content-Type", value: "text/html")
-//            headers.add(name: "Content-Length", value: String(Self.responseBody.readableBytes))
-//            headers.add(name: "Connection", value: "close")
-//            let responseHead = HTTPResponseHead(
-//                version: .init(major: 1, minor: 1),
-//                status: .ok,
-//                headers: headers
-//            )
-//
-//            try await channel.outbound.write(
-//                contentsOf: [
-//                    .head(responseHead),
-//                    .body(Self.responseBody),
-//                    .end(nil)
-//                ]
-//            )
-//        }
-//    }
-//
-//    private func respond405(writer: NIOAsyncChannelOutboundWriter<HTTPPart<HTTPResponseHead, ByteBuffer>>) async throws {
-//        var headers = HTTPHeaders()
-//        headers.add(name: "Connection", value: "close")
-//        headers.add(name: "Content-Length", value: "0")
-//        let head = HTTPResponseHead(
-//            version: .http1_1,
-//            status: .methodNotAllowed,
-//            headers: headers
-//        )
-//
-//        try await writer.write(
-//            contentsOf: [
-//                .head(head),
-//                .end(nil)
-//            ]
-//        )
-//    }
-//}
-//
-//final class HTTPByteBufferResponsePartHandler: ChannelOutboundHandler {
-//    typealias OutboundIn = HTTPPart<HTTPResponseHead, ByteBuffer>
-//    typealias OutboundOut = HTTPServerResponsePart
-//
-//    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-//        let part = self.unwrapOutboundIn(data)
-//        switch part {
-//        case .head(let head):
-//            context.write(self.wrapOutboundOut(.head(head)), promise: promise)
-//        case .body(let buffer):
-//            context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: promise)
-//        case .end(let trailers):
-//            context.write(self.wrapOutboundOut(.end(trailers)), promise: promise)
-//        }
-//    }
-//}
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let part = self.unwrapOutboundIn(data)
+        switch part {
+        case .head(let head):
+            context.write(self.wrapOutboundOut(.head(head)), promise: promise)
+        case .body(let buffer):
+            context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: promise)
+        case .end(let trailers):
+            context.write(self.wrapOutboundOut(.end(trailers)), promise: promise)
+        }
+    }
+}
 
 #else
 @main

--- a/Sources/NIOWebSocketServer/Server.swift
+++ b/Sources/NIOWebSocketServer/Server.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if swift(>=5.9)
+#if (!canImport(Darwin) && swift(>=5.9)) || (canImport(Darwin) && swift(>=5.10))
 import NIOCore
 import NIOPosix
 import NIOHTTP1

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -32,8 +32,13 @@ extension EmbeddedChannel {
     }
 }
 
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+protocol TypedAndUntypedHTTPClientProtocolUpgrader: NIOHTTPClientProtocolUpgrader, NIOTypedHTTPClientProtocolUpgrader where UpgradeResult == Bool {}
+#else
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 protocol TypedAndUntypedHTTPClientProtocolUpgrader: NIOHTTPClientProtocolUpgrader {}
+#endif
 
 private final class SuccessfulClientUpgrader: TypedAndUntypedHTTPClientProtocolUpgrader {
     fileprivate let supportedProtocol: String
@@ -948,6 +953,7 @@ class HTTPClientUpgradeTestCase: XCTestCase {
     }
 }
 
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
     override func setUpClientChannel(
@@ -1177,3 +1183,4 @@ final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
             .assertDoesNotContain(handlerType: NIOHTTPClientUpgradeHandler.self))
     }
 }
+#endif

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -282,8 +282,9 @@ private final class RecordingHTTPHandler: ChannelInboundHandler, RemovableChanne
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 private func assertPipelineContainsUpgradeHandler(channel: Channel) {
     let handler = try? channel.pipeline.syncOperations.handler(type: NIOHTTPClientUpgradeHandler.self)
+    let typedHandler = try? channel.pipeline.syncOperations.handler(type: NIOTypedHTTPClientUpgradeHandler<Bool>.self)
 
-    XCTAssertTrue(handler != nil)
+    XCTAssertTrue(handler != nil || typedHandler != nil)
 }
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
@@ -944,5 +945,235 @@ class HTTPClientUpgradeTestCase: XCTestCase {
             let reportedError = error as! NIOHTTPClientUpgradeError
             XCTAssertEqual(NIOHTTPClientUpgradeError.receivedResponseBeforeRequestSent, reportedError)
         }
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
+    override func setUpClientChannel(
+        clientHTTPHandler: RemovableChannelHandler,
+        clientUpgraders: [any TypedAndUntypedHTTPClientProtocolUpgrader],
+        _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void
+    ) throws -> EmbeddedChannel {
+
+        let channel = EmbeddedChannel()
+
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
+        headers.add(name: "Content-Length", value: "\(0)")
+
+        let requestHead = HTTPRequestHead(
+            version: .http1_1,
+            method: .GET,
+            uri: "/",
+            headers: headers
+        )
+
+        let upgraders: [any NIOTypedHTTPClientProtocolUpgrader<Bool>] = Array(clientUpgraders.map { $0 as! any NIOTypedHTTPClientProtocolUpgrader<Bool> })
+
+        let config = NIOTypedHTTPClientUpgradeConfiguration<Bool>(
+            upgradeRequestHead: requestHead,
+            upgraders: upgraders
+        ) { channel in
+            channel.eventLoop.makeCompletedFuture {
+                try channel.pipeline.syncOperations.addHandler(clientHTTPHandler)
+            }.map { _ in
+                false
+            }
+        }
+        var configuration = NIOUpgradableHTTPClientPipelineConfiguration(upgradeConfiguration: config)
+        configuration.leftOverBytesStrategy = .forwardBytes
+        let upgradeResult = try channel.pipeline.syncOperations.configureUpgradableHTTPClientPipeline(configuration: configuration)
+        let context = try channel.pipeline.syncOperations.context(handlerType: NIOTypedHTTPClientUpgradeHandler<Bool>.self)
+
+        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0))
+            .wait()
+        upgradeResult.whenSuccess { result in
+            if result {
+                upgradeCompletionHandler(context)
+            }
+        }
+
+        return channel
+    }
+
+    // - MARK: The following tests are all overridden from the base class since they slightly differ in behaviour
+
+    override func testUpgradeOnlyHandlesKnownProtocols() throws {
+        var upgradeHandlerCallbackFired = false
+
+        let clientUpgrader = ExplodingClientUpgrader(forProtocol: "myProto")
+        let clientHandler = RecordingHTTPHandler()
+
+        // The process should kick-off independently by sending the upgrade request to the server.
+        let clientChannel = try setUpClientChannel(clientHTTPHandler: clientHandler,
+                                                   clientUpgraders: [clientUpgrader]) { _ in
+
+                                                    // This is called before the upgrader gets called.
+                                                    upgradeHandlerCallbackFired = true
+        }
+        defer {
+            XCTAssertNoThrow(try clientChannel.finish())
+        }
+
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\nUpgrade: unknownProtocol\r\n\r\n"
+        XCTAssertThrowsError(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response)))  { error in
+            XCTAssertEqual(error as? NIOHTTPClientUpgradeError, .responseProtocolNotFound)
+        }
+
+        clientChannel.embeddedEventLoop.run()
+
+        // Should fail with error (response is malformed) and remove upgrader from pipeline.
+
+        // Check that the http elements are not removed from the pipeline.
+        clientChannel.pipeline.assertContains(handlerType: HTTPRequestEncoder.self)
+        clientChannel.pipeline.assertContains(handlerType: ByteToMessageHandler<HTTPResponseDecoder>.self)
+
+        // Check that the HTTP handler received its response.
+        XCTAssertLessThanOrEqual(0, clientHandler.channelReadChannelHandlerContextDataCallCount)
+        // Check an error is reported
+        XCTAssertEqual(0, clientHandler.errorCaughtChannelHandlerContextCallCount)
+
+        XCTAssertFalse(upgradeHandlerCallbackFired)
+
+        XCTAssertNoThrow(try clientChannel.pipeline
+            .assertDoesNotContain(handlerType: NIOHTTPClientUpgradeHandler.self))
+    }
+
+    override func testUpgradeResponseCanBeRejectedByClientUpgrader() throws {
+        let upgradeProtocol = "myProto"
+
+        var upgradeHandlerCallbackFired = false
+
+        let clientUpgrader = DenyingClientUpgrader(forProtocol: upgradeProtocol)
+        let clientHandler = RecordingHTTPHandler()
+
+        // The process should kick-off independently by sending the upgrade request to the server.
+        let clientChannel = try setUpClientChannel(clientHTTPHandler: clientHandler,
+                                                   clientUpgraders: [clientUpgrader]) { _ in
+
+                                                    // This is called before the upgrader gets called.
+                                                    upgradeHandlerCallbackFired = true
+        }
+        defer {
+            XCTAssertNoThrow(try clientChannel.finish())
+        }
+
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\nUpgrade: \(upgradeProtocol)\r\n\r\n"
+        XCTAssertThrowsError(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response))) { error in
+            XCTAssertEqual(error as? NIOHTTPClientUpgradeError, .upgraderDeniedUpgrade)
+        }
+
+        clientChannel.embeddedEventLoop.run()
+
+        // Should fail with error (response is denied) and remove upgrader from pipeline.
+
+        // Check that the http elements are not removed from the pipeline.
+        clientChannel.pipeline.assertContains(handlerType: HTTPRequestEncoder.self)
+        clientChannel.pipeline.assertContains(handlerType: ByteToMessageHandler<HTTPResponseDecoder>.self)
+
+        XCTAssertEqual(1, clientUpgrader.addCustomUpgradeRequestHeadersCallCount)
+
+        // Check that the HTTP handler received its response.
+        XCTAssertLessThanOrEqual(0, clientHandler.channelReadChannelHandlerContextDataCallCount)
+
+        // Check an error is reported
+        XCTAssertEqual(0, clientHandler.errorCaughtChannelHandlerContextCallCount)
+
+        XCTAssertFalse(upgradeHandlerCallbackFired)
+
+        XCTAssertNoThrow(try clientChannel.pipeline
+            .assertDoesNotContain(handlerType: NIOHTTPClientUpgradeHandler.self))
+    }
+
+    override func testFiresOutboundErrorDuringAddingHandlers() throws {
+        let upgradeProtocol = "myProto"
+        var errorOnAdditionalChannelWrite: Error?
+        var upgradeHandlerCallbackFired = false
+
+        let clientUpgrader = UpgradeDelayClientUpgrader(forProtocol: upgradeProtocol)
+        let clientHandler = RecordingHTTPHandler()
+
+        let clientChannel = try setUpClientChannel(clientHTTPHandler: clientHandler,
+                                                   clientUpgraders: [clientUpgrader]) { (context) in
+
+                                                    // This is called before the upgrader gets called.
+                                                    upgradeHandlerCallbackFired = true
+        }
+        defer {
+            XCTAssertNoThrow(try clientChannel.finish())
+        }
+
+        // Push the successful server response.
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\nUpgrade: \(upgradeProtocol)\r\n\r\n"
+        XCTAssertNoThrow(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response)))
+
+        let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+
+        promise.futureResult.whenFailure() { error in
+            errorOnAdditionalChannelWrite = error
+        }
+
+        // Send another outbound request during the upgrade.
+        let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
+        let secondRequest: HTTPClientRequestPart = .head(requestHead)
+        clientChannel.writeAndFlush(secondRequest, promise: promise)
+
+        clientChannel.embeddedEventLoop.run()
+
+        let promiseError = errorOnAdditionalChannelWrite as! NIOHTTPClientUpgradeError
+        XCTAssertEqual(NIOHTTPClientUpgradeError.writingToHandlerDuringUpgrade, promiseError)
+
+        // Soundness check that the upgrade was delayed.
+        XCTAssertEqual(0, clientUpgrader.upgradedHandler.handlerAddedContextCallCount)
+
+        // Upgrade now.
+        clientUpgrader.unblockUpgrade()
+        clientChannel.embeddedEventLoop.run()
+
+        // Check that the upgrade was still successful, despite the interruption.
+        XCTAssert(upgradeHandlerCallbackFired)
+        XCTAssertEqual(1, clientUpgrader.upgradedHandler.handlerAddedContextCallCount)
+    }
+
+    override func testUpgradeResponseMissingAllProtocols() throws {
+        var upgradeHandlerCallbackFired = false
+
+        let clientUpgrader = ExplodingClientUpgrader(forProtocol: "myProto")
+        let clientHandler = RecordingHTTPHandler()
+
+        // The process should kick-off independently by sending the upgrade request to the server.
+        let clientChannel = try setUpClientChannel(clientHTTPHandler: clientHandler,
+                                                   clientUpgraders: [clientUpgrader]) { _ in
+
+                                                    // This is called before the upgrader gets called.
+                                                    upgradeHandlerCallbackFired = true
+        }
+        defer {
+            XCTAssertNoThrow(try clientChannel.finish())
+        }
+
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\n\r\n"
+        XCTAssertThrowsError(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response))) { error in
+            XCTAssertEqual(error as? NIOHTTPClientUpgradeError, .responseProtocolNotFound)
+        }
+
+        clientChannel.embeddedEventLoop.run()
+
+        // Should fail with error (response is malformed) and remove upgrader from pipeline.
+
+        // Check that the http elements are not removed from the pipeline.
+        clientChannel.pipeline.assertContains(handlerType: HTTPRequestEncoder.self)
+        clientChannel.pipeline.assertContains(handlerType: ByteToMessageHandler<HTTPResponseDecoder>.self)
+
+        // Check that the HTTP handler received its response.
+        XCTAssertLessThanOrEqual(0, clientHandler.channelReadChannelHandlerContextDataCallCount)
+        // Check an error is reported
+        XCTAssertEqual(0, clientHandler.errorCaughtChannelHandlerContextCallCount)
+
+        XCTAssertFalse(upgradeHandlerCallbackFired)
+
+        XCTAssertNoThrow(try clientChannel.pipeline
+            .assertDoesNotContain(handlerType: NIOHTTPClientUpgradeHandler.self))
     }
 }

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -36,7 +36,11 @@ extension ChannelPipeline {
 
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     fileprivate func assertContainsUpgrader() {
-        self.assertContains(handlerType: HTTPServerUpgradeHandler.self)
+        do {
+            _ = try self.context(handlerType: NIOTypedHTTPServerUpgradeHandler<Bool>.self).wait()
+        } catch {
+            self.assertContains(handlerType: HTTPServerUpgradeHandler.self)
+        }
     }
 
     func assertContains<Handler: ChannelHandler>(handlerType: Handler.Type) {
@@ -59,7 +63,15 @@ extension ChannelPipeline {
                 // handler present, keep waiting
                 usleep(50)
             } catch ChannelPipelineError.notFound {
-                return
+                // Checking if the typed variant is present
+                do {
+                    _ = try self.context(handlerType: NIOTypedHTTPServerUpgradeHandler<Bool>.self).wait()
+                    // handler present, keep waiting
+                    usleep(50)
+                } catch ChannelPipelineError.notFound {
+                    // No upgrader, we're good.
+                    return
+                }
             }
         }
 
@@ -1537,5 +1549,505 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         XCTAssertTrue(dataRecorder.receivedData().isEmpty)
         // The upgrade handler should still be in the pipeline.
         channel.pipeline.assertContainsUpgrader()
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
+    fileprivate override func setUpTestWithAutoremoval(
+        pipelining: Bool = false,
+        upgraders: [any TypedAndUntypedHTTPServerProtocolUpgrader],
+        extraHandlers: [ChannelHandler],
+        notUpgradingHandler: (@Sendable (Channel) -> EventLoopFuture<Bool>)? = nil,
+        _ upgradeCompletionHandler: @escaping UpgradeCompletionHandler
+    ) throws -> (Channel, Channel, Channel) {
+        let connectionChannelPromise = Self.eventLoop.makePromise(of: Channel.self)
+        let serverChannelFuture = ServerBootstrap(group: Self.eventLoop)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    connectionChannelPromise.succeed(channel)
+                    var configuration = NIOUpgradableHTTPServerPipelineConfiguration(
+                        upgradeConfiguration: .init(
+                            upgraders: upgraders.map { $0 as! any NIOTypedHTTPServerProtocolUpgrader<Bool> },
+                            notUpgradingCompletionHandler: { notUpgradingHandler?($0) ??  $0.eventLoop.makeSucceededFuture(false) }
+                        )
+                    )
+                    configuration.enablePipelining = pipelining
+                    return try channel.pipeline.syncOperations.configureUpgradableHTTPServerPipeline(configuration: configuration)
+                    .flatMap { result in
+                        if result {
+                            return channel.pipeline.context(handlerType: NIOTypedHTTPServerUpgradeHandler<Bool>.self)
+                                .map {
+                                    upgradeCompletionHandler($0)
+                                }
+                        } else {
+                            return channel.eventLoop.makeSucceededVoidFuture()
+                        }
+                    }
+                }
+                .flatMap { _ in
+                    let futureResults = extraHandlers.map { channel.pipeline.addHandler($0) }
+                    return EventLoopFuture.andAllSucceed(futureResults, on: channel.eventLoop)
+                }
+            }.bind(host: "127.0.0.1", port: 0)
+        let clientChannel = try connectedClientChannel(group: Self.eventLoop, serverAddress: serverChannelFuture.wait().localAddress!)
+        return (try serverChannelFuture.wait(), clientChannel, try connectionChannelPromise.futureResult.wait())
+    }
+
+    func testNotUpgrading() throws {
+        let notUpgraderCbFired = UnsafeMutableTransferBox(false)
+
+        let upgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: ["kafkaesque"]) { _ in }
+
+        let (_, client, connectedServer) = try setUpTestWithAutoremoval(
+            upgraders: [upgrader],
+            extraHandlers: [],
+            notUpgradingHandler: { channel in
+                notUpgraderCbFired.wrappedValue = true
+                // We're closing the connection now.
+                channel.close(promise: nil)
+                return channel.eventLoop.makeSucceededFuture(true)
+            }
+        ) { _ in }
+
+
+        let completePromise = Self.eventLoop.makePromise(of: Void.self)
+        let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
+            let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
+            XCTAssertEqual(resultString, "")
+            completePromise.succeed(())
+        }
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
+
+        // This request is safe to upgrade.
+        let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: notmyproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
+        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+
+        // Let the machinery do its thing.
+        XCTAssertNoThrow(try completePromise.futureResult.wait())
+
+        // At this time we want to assert that the not upgrader got called.
+        XCTAssert(notUpgraderCbFired.wrappedValue)
+
+        // We also want to confirm that the upgrade handler is no longer in the pipeline.
+        try connectedServer.pipeline.assertDoesNotContainUpgrader()
+    }
+
+    // - MARK: The following tests are all overridden from the base class since they slightly differ in behaviour
+
+    override func testSimpleUpgradeSucceeds() throws {
+        // This test is different since we call the completionHandler after the upgrader
+        // modified the pipeline in the typed version.
+        let upgradeRequest = UnsafeMutableTransferBox<HTTPRequestHead?>(nil)
+        let upgradeHandlerCbFired = UnsafeMutableTransferBox(false)
+        let upgraderCbFired = UnsafeMutableTransferBox(false)
+
+        let upgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: ["kafkaesque"]) { req in
+            // This is called before completion block.
+            upgradeRequest.wrappedValue = req
+            upgradeHandlerCbFired.wrappedValue = true
+
+            XCTAssert(upgradeHandlerCbFired.wrappedValue)
+            upgraderCbFired.wrappedValue = true
+        }
+
+        let (_, client, connectedServer) = try setUpTestWithAutoremoval(
+            upgraders: [upgrader],
+            extraHandlers: []
+        ) { (context) in
+            // This is called before the upgrader gets called.
+            XCTAssertNotNil(upgradeRequest.wrappedValue)
+            upgradeHandlerCbFired.wrappedValue = true
+
+            // We're closing the connection now.
+            context.close(promise: nil)
+        }
+
+
+        let completePromise = Self.eventLoop.makePromise(of: Void.self)
+        let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
+            let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
+            assertResponseIs(response: resultString,
+                             expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
+            completePromise.succeed(())
+        }
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
+
+        // This request is safe to upgrade.
+        let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
+        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+
+        // Let the machinery do its thing.
+        XCTAssertNoThrow(try completePromise.futureResult.wait())
+
+        // At this time we want to assert that everything got called. Their own callbacks assert
+        // that the ordering was correct.
+        XCTAssert(upgradeHandlerCbFired.wrappedValue)
+        XCTAssert(upgraderCbFired.wrappedValue)
+
+        // We also want to confirm that the upgrade handler is no longer in the pipeline.
+        try connectedServer.pipeline.assertDoesNotContainUpgrader()
+    }
+
+    override func testUpgradeRespectsClientPreference() throws {
+        // This test is different since we call the completionHandler after the upgrader
+        // modified the pipeline in the typed version.
+        let upgradeRequest = UnsafeMutableTransferBox<HTTPRequestHead?>(nil)
+        let upgradeHandlerCbFired = UnsafeMutableTransferBox(false)
+        let upgraderCbFired = UnsafeMutableTransferBox(false)
+
+        let explodingUpgrader = ExplodingUpgrader(forProtocol: "exploder")
+        let successfulUpgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: ["kafkaesque"]) { req in
+            upgradeRequest.wrappedValue = req
+            XCTAssertFalse(upgradeHandlerCbFired.wrappedValue)
+            upgraderCbFired.wrappedValue = true
+        }
+
+        let (_, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [explodingUpgrader, successfulUpgrader],
+                                                                               extraHandlers: []) { context in
+            // This is called before the upgrader gets called.
+            XCTAssertNotNil(upgradeRequest.wrappedValue)
+            upgradeHandlerCbFired.wrappedValue = true
+
+            // We're closing the connection now.
+            context.close(promise: nil)
+        }
+
+
+        let completePromise = Self.eventLoop.makePromise(of: Void.self)
+        let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
+            let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
+            assertResponseIs(response: resultString,
+                             expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
+            completePromise.succeed(())
+        }
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
+
+        // This request is safe to upgrade.
+        let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto, exploder\r\nKafkaesque: yup\r\nConnection: upgrade, kafkaesque\r\n\r\n"
+        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+
+        // Let the machinery do its thing.
+        XCTAssertNoThrow(try completePromise.futureResult.wait())
+
+        // At this time we want to assert that everything got called. Their own callbacks assert
+        // that the ordering was correct.
+        XCTAssert(upgradeHandlerCbFired.wrappedValue)
+        XCTAssert(upgraderCbFired.wrappedValue)
+
+        // We also want to confirm that the upgrade handler is no longer in the pipeline.
+        try connectedServer.pipeline.waitForUpgraderToBeRemoved()
+    }
+
+    override func testUpgraderCanRejectUpgradeForPersonalReasons() throws {
+        // This test is different since we call the completionHandler after the upgrader
+        // modified the pipeline in the typed version.
+        let upgradeRequest = UnsafeMutableTransferBox<HTTPRequestHead?>(nil)
+        let upgradeHandlerCbFired = UnsafeMutableTransferBox(false)
+        let upgraderCbFired = UnsafeMutableTransferBox(false)
+
+        let explodingUpgrader = UpgraderSaysNo(forProtocol: "noproto")
+        let successfulUpgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: ["kafkaesque"]) { req in
+            upgradeRequest.wrappedValue = req
+            XCTAssertFalse(upgradeHandlerCbFired.wrappedValue)
+            upgraderCbFired.wrappedValue = true
+        }
+        let errorCatcher = ErrorSaver()
+
+        let (_, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [explodingUpgrader, successfulUpgrader],
+                                                                               extraHandlers: [errorCatcher]) { context in
+            // This is called before the upgrader gets called.
+            XCTAssertNotNil(upgradeRequest.wrappedValue)
+            upgradeHandlerCbFired.wrappedValue = true
+
+            // We're closing the connection now.
+            context.close(promise: nil)
+        }
+
+
+        let completePromise = Self.eventLoop.makePromise(of: Void.self)
+        let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
+            let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
+            assertResponseIs(response: resultString,
+                             expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
+            completePromise.succeed(())
+        }
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
+
+        // This request is safe to upgrade.
+        let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: noproto,myproto\r\nKafkaesque: yup\r\nConnection: upgrade, kafkaesque\r\n\r\n"
+        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+
+        // Let the machinery do its thing.
+        XCTAssertNoThrow(try completePromise.futureResult.wait())
+
+        // At this time we want to assert that everything got called. Their own callbacks assert
+        // that the ordering was correct.
+        XCTAssert(upgradeHandlerCbFired.wrappedValue)
+        XCTAssert(upgraderCbFired.wrappedValue)
+
+        // We also want to confirm that the upgrade handler is no longer in the pipeline.
+        try connectedServer.pipeline.waitForUpgraderToBeRemoved()
+
+        // And we want to confirm we saved the error.
+        XCTAssertEqual(errorCatcher.errors.count, 1)
+
+        switch(errorCatcher.errors[0]) {
+        case UpgraderSaysNo.No.no:
+            break
+        default:
+            XCTFail("Unexpected error: \(errorCatcher.errors[0])")
+        }
+    }
+
+    override func testUpgradeWithUpgradePayloadInlineWithRequestWorks() throws {
+        // This test is different since we call the completionHandler after the upgrader
+        // modified the pipeline in the typed version.
+        enum ReceivedTheWrongThingError: Error { case error }
+        let upgradeRequest = UnsafeMutableTransferBox<HTTPRequestHead?>(nil)
+        let upgradeHandlerCbFired = UnsafeMutableTransferBox(false)
+        let upgraderCbFired = UnsafeMutableTransferBox(false)
+
+        class CheckWeReadInlineAndExtraData: ChannelDuplexHandler {
+            typealias InboundIn = ByteBuffer
+            typealias OutboundIn = Never
+            typealias OutboundOut = Never
+
+            enum State {
+                case fresh
+                case added
+                case inlineDataRead
+                case extraDataRead
+                case closed
+            }
+
+            private let firstByteDonePromise: EventLoopPromise<Void>
+            private let secondByteDonePromise: EventLoopPromise<Void>
+            private let allDonePromise: EventLoopPromise<Void>
+            private var state = State.fresh
+
+            init(firstByteDonePromise: EventLoopPromise<Void>,
+                 secondByteDonePromise: EventLoopPromise<Void>,
+                 allDonePromise: EventLoopPromise<Void>) {
+                self.firstByteDonePromise = firstByteDonePromise
+                self.secondByteDonePromise = secondByteDonePromise
+                self.allDonePromise = allDonePromise
+            }
+
+            func handlerAdded(context: ChannelHandlerContext) {
+                XCTAssertEqual(.fresh, self.state)
+                self.state = .added
+            }
+
+            func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+                var buf = self.unwrapInboundIn(data)
+                XCTAssertEqual(1, buf.readableBytes)
+                let stringRead = buf.readString(length: buf.readableBytes)
+                switch self.state {
+                case .added:
+                    XCTAssertEqual("A", stringRead)
+                    self.state = .inlineDataRead
+                    if stringRead == .some("A") {
+                        self.firstByteDonePromise.succeed(())
+                    } else {
+                        self.firstByteDonePromise.fail(ReceivedTheWrongThingError.error)
+                    }
+                case .inlineDataRead:
+                    XCTAssertEqual("B", stringRead)
+                    self.state = .extraDataRead
+                    context.channel.close(promise: nil)
+                    if stringRead == .some("B") {
+                        self.secondByteDonePromise.succeed(())
+                    } else {
+                        self.secondByteDonePromise.fail(ReceivedTheWrongThingError.error)
+                    }
+                default:
+                    XCTFail("channel read in wrong state \(self.state)")
+                }
+            }
+
+            func close(context: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
+                XCTAssertEqual(.extraDataRead, self.state)
+                self.state = .closed
+                context.close(mode: mode, promise: promise)
+
+                self.allDonePromise.succeed(())
+            }
+        }
+
+        let upgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: ["kafkaesque"]) { req in
+            upgradeRequest.wrappedValue = req
+            XCTAssertFalse(upgradeHandlerCbFired.wrappedValue)
+            upgraderCbFired.wrappedValue = true
+        }
+
+        let promiseGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try promiseGroup.syncShutdownGracefully())
+        }
+        let firstByteDonePromise = promiseGroup.next().makePromise(of: Void.self)
+        let secondByteDonePromise = promiseGroup.next().makePromise(of: Void.self)
+        let allDonePromise = promiseGroup.next().makePromise(of: Void.self)
+        let (_, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
+                                                                               extraHandlers: []) { (context) in
+            // This is called before the upgrader gets called.
+            XCTAssertNotNil(upgradeRequest.wrappedValue)
+            upgradeHandlerCbFired.wrappedValue = true
+
+            _ = context.channel.pipeline.addHandler(CheckWeReadInlineAndExtraData(firstByteDonePromise: firstByteDonePromise,
+                                                                                  secondByteDonePromise: secondByteDonePromise,
+                                                                                  allDonePromise: allDonePromise))
+        }
+
+
+        let completePromise = Self.eventLoop.makePromise(of: Void.self)
+        let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
+            let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
+            assertResponseIs(response: resultString,
+                             expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
+            completePromise.succeed(())
+        }
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
+
+        // This request is safe to upgrade.
+        var request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
+        request += "A"
+        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+
+        XCTAssertNoThrow(try firstByteDonePromise.futureResult.wait() as Void)
+
+        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: "B"))).wait())
+
+        XCTAssertNoThrow(try secondByteDonePromise.futureResult.wait() as Void)
+
+        XCTAssertNoThrow(try allDonePromise.futureResult.wait() as Void)
+
+        // Let the machinery do its thing.
+        XCTAssertNoThrow(try completePromise.futureResult.wait())
+
+        // At this time we want to assert that everything got called. Their own callbacks assert
+        // that the ordering was correct.
+        XCTAssert(upgradeHandlerCbFired.wrappedValue)
+        XCTAssert(upgraderCbFired.wrappedValue)
+
+        // We also want to confirm that the upgrade handler is no longer in the pipeline.
+        try connectedServer.pipeline.assertDoesNotContainUpgrader()
+
+        XCTAssertNoThrow(try allDonePromise.futureResult.wait())
+    }
+
+    override func testWeTolerateUpgradeFuturesFromWrongEventLoops() throws {
+        // This test is different since we call the completionHandler after the upgrader
+        // modified the pipeline in the typed version.
+        let upgradeRequest = UnsafeMutableTransferBox<HTTPRequestHead?>(nil)
+        let upgradeHandlerCbFired = UnsafeMutableTransferBox(false)
+        let upgraderCbFired = UnsafeMutableTransferBox(false)
+        let otherELG = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try otherELG.syncShutdownGracefully())
+        }
+
+        let upgrader = SuccessfulUpgrader(forProtocol: "myproto",
+                                          requiringHeaders: ["kafkaesque"],
+                                          buildUpgradeResponseFuture: {
+                                            // this is the wrong EL
+                                            otherELG.next().makeSucceededFuture($1)
+        }) { req in
+            upgradeRequest.wrappedValue = req
+            XCTAssertFalse(upgradeHandlerCbFired.wrappedValue)
+            upgraderCbFired.wrappedValue = true
+        }
+
+        let (_, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
+                                                                               extraHandlers: []) { (context) in
+                                                                                // This is called before the upgrader gets called.
+            XCTAssertNotNil(upgradeRequest.wrappedValue)
+            upgradeHandlerCbFired.wrappedValue = true
+
+            // We're closing the connection now.
+            context.close(promise: nil)
+        }
+
+
+        let completePromise = Self.eventLoop.makePromise(of: Void.self)
+        let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
+            let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
+            assertResponseIs(response: resultString,
+                             expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
+            completePromise.succeed(())
+        }
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
+
+        // This request is safe to upgrade.
+        let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
+        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+
+        // Let the machinery do its thing.
+        XCTAssertNoThrow(try completePromise.futureResult.wait())
+
+        // At this time we want to assert that everything got called. Their own callbacks assert
+        // that the ordering was correct.
+        XCTAssert(upgradeHandlerCbFired.wrappedValue)
+        XCTAssert(upgraderCbFired.wrappedValue)
+
+        // We also want to confirm that the upgrade handler is no longer in the pipeline.
+        try connectedServer.pipeline.assertDoesNotContainUpgrader()
+    }
+
+    override func testUpgradeFiresUserEvent() throws {
+        // This test is different since we call the completionHandler after the upgrader
+        // modified the pipeline in the typed version.
+        let eventSaver = UnsafeTransfer(UserEventSaver<HTTPServerUpgradeEvents>())
+
+        let upgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: []) { req in
+            XCTAssertEqual(eventSaver.wrappedValue.events.count, 0)
+        }
+
+        let (_, client, connectedServer) = try setUpTestWithAutoremoval(upgraders: [upgrader],
+                                                                               extraHandlers: [eventSaver.wrappedValue]) { context in
+            XCTAssertEqual(eventSaver.wrappedValue.events.count, 1)
+            context.close(promise: nil)
+        }
+
+
+        let completePromise = Self.eventLoop.makePromise(of: Void.self)
+        let clientHandler = ArrayAccumulationHandler<ByteBuffer> { buffers in
+            let resultString = buffers.map { $0.getString(at: $0.readerIndex, length: $0.readableBytes)! }.joined(separator: "")
+            assertResponseIs(response: resultString,
+                             expectedResponseLine: "HTTP/1.1 101 Switching Protocols",
+                             expectedResponseHeaders: ["X-Upgrade-Complete: true", "upgrade: myproto", "connection: upgrade"])
+            completePromise.succeed(())
+        }
+        XCTAssertNoThrow(try client.pipeline.addHandler(clientHandler).wait())
+
+        // This request is safe to upgrade.
+        let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade,kafkaesque\r\n\r\n"
+        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+
+        // Let the machinery do its thing.
+        XCTAssertNoThrow(try completePromise.futureResult.wait())
+
+        // At this time we should have received one user event. We schedule this onto the
+        // event loop to guarantee thread safety.
+        XCTAssertNoThrow(try connectedServer.eventLoop.scheduleTask(deadline: .now()) {
+            XCTAssertEqual(eventSaver.wrappedValue.events.count, 1)
+            if case .upgradeComplete(let proto, let req) = eventSaver.wrappedValue.events[0] {
+                XCTAssertEqual(proto, "myproto")
+                XCTAssertEqual(req.method, .OPTIONS)
+                XCTAssertEqual(req.uri, "*")
+                XCTAssertEqual(req.version, .http1_1)
+            } else {
+                XCTFail("Unexpected event: \(eventSaver.wrappedValue.events[0])")
+            }
+        }.futureResult.wait())
+
+        // We also want to confirm that the upgrade handler is no longer in the pipeline.
+        try connectedServer.pipeline.waitForUpgraderToBeRemoved()
     }
 }

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -174,8 +174,13 @@ internal func assertResponseIs(response: String, expectedResponseLine: String, e
     XCTAssertEqual(lines.count, 0)
 }
 
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+protocol TypedAndUntypedHTTPServerProtocolUpgrader: HTTPServerProtocolUpgrader, NIOTypedHTTPServerProtocolUpgrader where UpgradeResult == Bool {}
+#else
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 protocol TypedAndUntypedHTTPServerProtocolUpgrader: HTTPServerProtocolUpgrader {}
+#endif
 
 private class ExplodingUpgrader: TypedAndUntypedHTTPServerProtocolUpgrader {
     let supportedProtocol: String
@@ -1552,6 +1557,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
     }
 }
 
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
     fileprivate override func setUpTestWithAutoremoval(
@@ -2051,3 +2057,4 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         try connectedServer.pipeline.waitForUpgraderToBeRemoved()
     }
 }
+#endif

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -405,6 +405,7 @@ class WebSocketClientEndToEndTests: XCTestCase {
     }
 }
 
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
     func setUpClientChannel(
@@ -615,3 +616,4 @@ final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
         return (clientChannel, handler)
     }
 }
+#endif

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -404,3 +404,214 @@ class WebSocketClientEndToEndTests: XCTestCase {
         XCTAssertNoThrow(try clientChannel.close().wait())
     }
 }
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
+    func setUpClientChannel(
+        clientUpgraders: [any NIOTypedHTTPClientProtocolUpgrader<Void>],
+        notUpgradingCompletionHandler: @Sendable @escaping (Channel) -> EventLoopFuture<Void>
+    ) throws -> (EmbeddedChannel, EventLoopFuture<Void>) {
+
+        let channel = EmbeddedChannel()
+
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
+        headers.add(name: "Content-Length", value: "\(0)")
+
+        let requestHead = HTTPRequestHead(
+            version: .http1_1,
+            method: .GET,
+            uri: "/",
+            headers: headers
+        )
+
+        let config = NIOTypedHTTPClientUpgradeConfiguration(
+            upgradeRequestHead: requestHead,
+            upgraders: clientUpgraders,
+            notUpgradingCompletionHandler: notUpgradingCompletionHandler
+        )
+
+        let upgradeResult = try channel.pipeline.syncOperations.configureUpgradableHTTPClientPipeline(configuration: .init(upgradeConfiguration: config))
+
+        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0))
+            .wait()
+
+        return (channel, upgradeResult)
+    }
+
+    override func testSimpleUpgradeSucceeds() throws {
+        let requestKey = "OfS0wDaT5NoxF2gqm7Zj2YtetzM="
+        let responseKey = "yKEqitDFPE81FyIhKTm+ojBqigk="
+
+        let basicUpgrader = NIOTypedWebSocketClientUpgrader(
+            requestKey: requestKey,
+            upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
+                channel.pipeline.addHandler(WebSocketRecorderHandler())
+        })
+
+        // The process should kick-off independently by sending the upgrade request to the server.
+        let (clientChannel, upgradeResult) = try setUpClientChannel(
+            clientUpgraders: [basicUpgrader],
+            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+        )
+
+        // Read the server request.
+        if let requestString = try clientChannel.readByteBufferOutputAsString() {
+            XCTAssertEqual(requestString, basicRequest() + "\r\nConnection: upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: \(requestKey)\r\nSec-WebSocket-Version: 13\r\n\r\n")
+        } else {
+            XCTFail()
+        }
+
+        // Push the successful server response.
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Accept:\(responseKey)\r\n\r\n"
+
+        XCTAssertNoThrow(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response)))
+
+        clientChannel.embeddedEventLoop.run()
+
+        // Once upgraded, validate the http pipeline has been removed.
+        XCTAssertNoThrow(try clientChannel.pipeline
+            .assertDoesNotContain(handlerType: HTTPRequestEncoder.self))
+        XCTAssertNoThrow(try clientChannel.pipeline
+            .assertDoesNotContain(handlerType: ByteToMessageHandler<HTTPResponseDecoder>.self))
+        XCTAssertNoThrow(try clientChannel.pipeline
+            .assertDoesNotContain(handlerType: NIOHTTPClientUpgradeHandler.self))
+
+        // Check that the pipeline now has the correct websocket handlers added.
+        XCTAssertNoThrow(try clientChannel.pipeline
+            .assertContains(handlerType: WebSocketFrameEncoder.self))
+        XCTAssertNoThrow(try clientChannel.pipeline
+            .assertContains(handlerType: ByteToMessageHandler<WebSocketFrameDecoder>.self))
+        XCTAssertNoThrow(try clientChannel.pipeline
+            .assertContains(handlerType: WebSocketRecorderHandler.self))
+
+        try upgradeResult.wait()
+
+        // Close the pipeline.
+        XCTAssertNoThrow(try clientChannel.close().wait())
+    }
+
+    override func testRejectUpgradeIfMissingAcceptKey() throws {
+        let requestKey = "OfS0wDaT5NoxF2gqm7Zj2YtetzM="
+
+        let basicUpgrader = NIOTypedWebSocketClientUpgrader(
+            requestKey: requestKey,
+            upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
+                channel.pipeline.addHandler(WebSocketRecorderHandler())
+        })
+
+        // The process should kick-off independently by sending the upgrade request to the server.
+        let (clientChannel, upgradeResult) = try setUpClientChannel(
+            clientUpgraders: [basicUpgrader],
+            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+        )
+
+        // Push the successful server response but with a missing accept key.
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n"
+
+        XCTAssertThrowsError(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response))) { error in
+            XCTAssertEqual(error as? NIOHTTPClientUpgradeError, NIOHTTPClientUpgradeError.upgraderDeniedUpgrade)
+        }
+
+        // Close the pipeline.
+        XCTAssertNoThrow(try clientChannel.close().wait())
+
+        XCTAssertThrowsError(try upgradeResult.wait()) { error in
+            XCTAssertEqual(error as? NIOHTTPClientUpgradeError, NIOHTTPClientUpgradeError.upgraderDeniedUpgrade)
+        }
+    }
+
+    override func testRejectUpgradeIfIncorrectAcceptKey() throws {
+        let requestKey = "OfS0wDaT5NoxF2gqm7Zj2YtetzM="
+        let responseKey = "notACorrectKeyL1am=F1y=nn="
+
+        let basicUpgrader = NIOTypedWebSocketClientUpgrader(
+            requestKey: requestKey,
+            upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
+                channel.pipeline.addHandler(WebSocketRecorderHandler())
+        })
+
+        // The process should kick-off independently by sending the upgrade request to the server.
+        let (clientChannel, upgradeResult) = try setUpClientChannel(
+            clientUpgraders: [basicUpgrader],
+            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+        )
+
+        // Push the successful server response but with an incorrect response key.
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Accept:\(responseKey)\r\n\r\n"
+
+        XCTAssertThrowsError(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response))) { error in
+            XCTAssertEqual(error as? NIOHTTPClientUpgradeError, NIOHTTPClientUpgradeError.upgraderDeniedUpgrade)
+        }
+
+        // Close the pipeline.
+        XCTAssertNoThrow(try clientChannel.close().wait())
+
+        XCTAssertThrowsError(try upgradeResult.wait()) { error in
+            XCTAssertEqual(error as? NIOHTTPClientUpgradeError, NIOHTTPClientUpgradeError.upgraderDeniedUpgrade)
+        }
+    }
+
+    override func testRejectUpgradeIfNotWebsocket() throws {
+        let requestKey = "OfS0wDaT5NoxF2gqm7Zj2YtetzM="
+        let responseKey = "yKEqitDFPE81FyIhKTm+ojBqigk="
+
+        let basicUpgrader = NIOTypedWebSocketClientUpgrader(
+            requestKey: requestKey,
+            upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
+                channel.pipeline.addHandler(WebSocketRecorderHandler())
+        })
+
+        // The process should kick-off independently by sending the upgrade request to the server.
+        let (clientChannel, upgradeResult) = try setUpClientChannel(
+            clientUpgraders: [basicUpgrader],
+            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+        )
+
+        // Push the successful server response with an incorrect protocol.
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\nUpgrade: myProtocol\r\nSec-WebSocket-Accept:\(responseKey)\r\n\r\n"
+
+        XCTAssertThrowsError(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response))) { error in
+            XCTAssertEqual(error as? NIOHTTPClientUpgradeError, NIOHTTPClientUpgradeError.responseProtocolNotFound)
+        }
+
+        // Close the pipeline.
+        XCTAssertNoThrow(try clientChannel.close().wait())
+
+        XCTAssertThrowsError(try upgradeResult.wait()) { error in
+            XCTAssertEqual(error as? NIOHTTPClientUpgradeError, NIOHTTPClientUpgradeError.responseProtocolNotFound)
+        }
+    }
+
+    override fileprivate func runSuccessfulUpgrade() throws -> (EmbeddedChannel, WebSocketRecorderHandler) {
+        let handler = WebSocketRecorderHandler()
+
+        let basicUpgrader = NIOTypedWebSocketClientUpgrader(
+            requestKey: "OfS0wDaT5NoxF2gqm7Zj2YtetzM=",
+            upgradePipelineHandler: { (channel: Channel, _: HTTPResponseHead) in
+                channel.pipeline.addHandler(handler)
+        })
+
+        // The process should kick-off independently by sending the upgrade request to the server.
+        let (clientChannel, upgradeResult) = try setUpClientChannel(
+            clientUpgraders: [basicUpgrader],
+            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+        )
+
+        // Push the successful server response.
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Accept:yKEqitDFPE81FyIhKTm+ojBqigk=\r\n\r\n"
+
+        XCTAssertNoThrow(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response)))
+
+        clientChannel.embeddedEventLoop.run()
+
+        // We now have a successful upgrade, clear the output channels read to test the frames.
+        XCTAssertNoThrow(try clientChannel.readOutbound(as: ByteBuffer.self))
+
+        clientChannel.embeddedEventLoop.run()
+
+        try upgradeResult.wait()
+
+        return (clientChannel, handler)
+    }
+}

--- a/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
@@ -527,6 +527,7 @@ class WebSocketServerEndToEndTests: XCTestCase {
     }
 }
 
+#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedWebSocketServerEndToEndTests: WebSocketServerEndToEndTests {
     override func createTestFixtures(
@@ -553,3 +554,4 @@ final class TypedWebSocketServerEndToEndTests: WebSocketServerEndToEndTests {
         return (loop: loop, serverChannel: serverChannel, clientChannel: clientChannel)
     }
 }
+#endif


### PR DESCRIPTION
# Motivation
We have reverted the typed HTTP protocol upgrader pieces since adopters were running into a compiler bug (https://github.com/apple/swift/pull/69459) that caused the compiler to emit strong references to `swift_getExtendedExistentialTypeMetadata`. The problem is that `swift_getExtendedExistentialTypeMetadata` is not available on older runtimes before constrained existentials have been introduced. This caused adopters to run into runtime crashes when loading any library compiled with this NIO code.

# Modifications
This PR reverts the revert and guard all new code in a compiler guard that checks that we are either on non-Darwin platforms or on a new enough Swift compiler that contains the fix.

# Result
We can offer the typed HTTP upgrade code to our adopters again.