### PR TITLE
Fix the typed HTTP upgrade compiler guards

### DIFF
--- a/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 import NIOCore
 
 // MARK: - Server pipeline configuration

--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 import NIOCore
 
 /// An object that implements `NIOTypedHTTPClientProtocolUpgrader` knows how to handle HTTP upgrade to

--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgraderStateMachine.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 import DequeModule
 import NIOCore
 

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 import NIOCore
 
 /// An object that implements `NIOTypedHTTPServerProtocolUpgrader` knows how to handle HTTP upgrade to

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 import DequeModule
 import NIOCore
 

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -74,7 +74,7 @@ public final class NIOWebSocketClientUpgrader: NIOHTTPClientProtocolUpgrader {
     }
 }
 
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 /// A `NIOTypedHTTPClientProtocolUpgrader` that knows how to do the WebSocket upgrade dance.
 ///
 /// This upgrader assumes that the `HTTPClientUpgradeHandler` will create and send the upgrade request.

--- a/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
@@ -175,7 +175,7 @@ public final class NIOWebSocketServerUpgrader: HTTPServerProtocolUpgrader, @unch
     }
 }
 
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 /// A `NIOTypedHTTPServerProtocolUpgrader` that knows how to do the WebSocket upgrade dance.
 ///
 /// Users may frequently want to offer multiple websocket endpoints on the same port. For this

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -32,7 +32,7 @@ extension EmbeddedChannel {
     }
 }
 
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 protocol TypedAndUntypedHTTPClientProtocolUpgrader: NIOHTTPClientProtocolUpgrader, NIOTypedHTTPClientProtocolUpgrader where UpgradeResult == Bool {}
 #else
@@ -287,9 +287,13 @@ private final class RecordingHTTPHandler: ChannelInboundHandler, RemovableChanne
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 private func assertPipelineContainsUpgradeHandler(channel: Channel) {
     let handler = try? channel.pipeline.syncOperations.handler(type: NIOHTTPClientUpgradeHandler.self)
-    let typedHandler = try? channel.pipeline.syncOperations.handler(type: NIOTypedHTTPClientUpgradeHandler<Bool>.self)
 
+    #if !canImport(Darwin) || swift(>=5.10)
+    let typedHandler = try? channel.pipeline.syncOperations.handler(type: NIOTypedHTTPClientUpgradeHandler<Bool>.self)
     XCTAssertTrue(handler != nil || typedHandler != nil)
+    #else
+    XCTAssertTrue(handler != nil)
+    #endif
 }
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
@@ -953,7 +957,7 @@ class HTTPClientUpgradeTestCase: XCTestCase {
     }
 }
 
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
     override func setUpClientChannel(

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -36,11 +36,15 @@ extension ChannelPipeline {
 
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     fileprivate func assertContainsUpgrader() {
+        #if !canImport(Darwin) || swift(>=5.10)
         do {
             _ = try self.context(handlerType: NIOTypedHTTPServerUpgradeHandler<Bool>.self).wait()
         } catch {
             self.assertContains(handlerType: HTTPServerUpgradeHandler.self)
         }
+        #else
+        self.assertContains(handlerType: HTTPServerUpgradeHandler.self)
+        #endif
     }
 
     func assertContains<Handler: ChannelHandler>(handlerType: Handler.Type) {
@@ -63,6 +67,7 @@ extension ChannelPipeline {
                 // handler present, keep waiting
                 usleep(50)
             } catch ChannelPipelineError.notFound {
+                #if !canImport(Darwin) || swift(>=5.10)
                 // Checking if the typed variant is present
                 do {
                     _ = try self.context(handlerType: NIOTypedHTTPServerUpgradeHandler<Bool>.self).wait()
@@ -72,6 +77,9 @@ extension ChannelPipeline {
                     // No upgrader, we're good.
                     return
                 }
+                #else
+                return
+                #endif
             }
         }
 
@@ -174,7 +182,7 @@ internal func assertResponseIs(response: String, expectedResponseLine: String, e
     XCTAssertEqual(lines.count, 0)
 }
 
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 protocol TypedAndUntypedHTTPServerProtocolUpgrader: HTTPServerProtocolUpgrader, NIOTypedHTTPServerProtocolUpgrader where UpgradeResult == Bool {}
 #else
@@ -1557,7 +1565,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
     }
 }
 
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
     fileprivate override func setUpTestWithAutoremoval(

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -405,7 +405,7 @@ class WebSocketClientEndToEndTests: XCTestCase {
     }
 }
 
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
     func setUpClientChannel(

--- a/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
@@ -527,7 +527,7 @@ class WebSocketServerEndToEndTests: XCTestCase {
     }
 }
 
-#if !canImport(Darwin) || (canImport(Darwin) && swift(>=5.10))
+#if !canImport(Darwin) || swift(>=5.10)
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedWebSocketServerEndToEndTests: WebSocketServerEndToEndTests {
     override func createTestFixtures(


### PR DESCRIPTION
The compiler guards were unnecessarily complex and I also didn't cover 3 methods where we used the types.

