### PR TITLE
Changes to support building with Musl

### DIFF
--- a/IntegrationTests/tests_02_syscall_wrappers/defines.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/defines.sh
@@ -36,7 +36,10 @@ let package = Package(
             dependencies: ["CNIOLinux", "CNIODarwin", "NIOCore"]),
         .target(
             name: "CNIOLinux",
-            dependencies: []),
+            dependencies: [],
+            cSettings: [
+                .define("_GNU_SOURCE")
+            ]),
         .target(
             name: "CNIODarwin",
             dependencies: []),

--- a/IntegrationTests/tests_05_assertions/defines.sh
+++ b/IntegrationTests/tests_05_assertions/defines.sh
@@ -31,7 +31,10 @@ let package = Package(
             dependencies: ["CNIOLinux", "CNIODarwin", "NIOCore"]),
         .target(
             name: "CNIOLinux",
-            dependencies: []),
+            dependencies: [],
+            cSettings: [
+                .define("_GNU_SOURCE")
+            ]),
         .target(
             name: "CNIODarwin",
             dependencies: []),

--- a/Package.swift
+++ b/Package.swift
@@ -115,7 +115,10 @@ let package = Package(
         ),
         .target(
             name: "CNIOLinux",
-            dependencies: []
+            dependencies: [],
+            cSettings: [
+                .define("_GNU_SOURCE"),
+            ]
         ),
         .target(
             name: "CNIODarwin",

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -18,7 +18,10 @@ void CNIOLinux_i_do_nothing_just_working_around_a_darwin_toolchain_bug(void) {}
 
 #ifdef __linux__
 
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+#error You must define _GNU_SOURCE
+#endif
+
 #include <CNIOLinux.h>
 #include <pthread.h>
 #include <sched.h>

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -19,7 +19,7 @@ public protocol ChannelOption: Equatable, _NIOPreconcurrencySendable {
 }
 
 public typealias SocketOptionName = Int32
-#if os(Linux) || os(Android)
+#if (os(Linux) || os(Android)) && !canImport(Musl)
     public typealias SocketOptionLevel = Int
     public typealias SocketOptionValue = Int
 #else

--- a/Sources/NIOCore/IO.swift
+++ b/Sources/NIOCore/IO.swift
@@ -28,8 +28,10 @@ import typealias WinSDK.WORD
 internal func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
   return DWORD((s << 10) | p)
 }
-#elseif os(Linux) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Darwin)
 import Darwin
 #else

--- a/Sources/NIOPosix/BSDSocketAPICommon.swift
+++ b/Sources/NIOPosix/BSDSocketAPICommon.swift
@@ -83,8 +83,8 @@ extension NIOBSDSocket.SocketType {
         internal static let stream: NIOBSDSocket.SocketType =
                 NIOBSDSocket.SocketType(rawValue: SOCK_STREAM)
     #endif
-    
-    #if os(Linux)
+
+    #if os(Linux) && !canImport(Musl)
         internal static let raw: NIOBSDSocket.SocketType =
                 NIOBSDSocket.SocketType(rawValue: CInt(SOCK_RAW.rawValue))
     #else

--- a/Sources/NIOPosix/SocketProtocols.swift
+++ b/Sources/NIOPosix/SocketProtocols.swift
@@ -73,7 +73,13 @@ protocol SocketProtocol: BaseSocketProtocol {
 // This is a lazily initialised global variable that when read for the first time, will ignore SIGPIPE.
 private let globallyIgnoredSIGPIPE: Bool = {
     /* no F_SETNOSIGPIPE on Linux :( */
+    #if canImport(Glibc)
     _ = Glibc.signal(SIGPIPE, SIG_IGN)
+    #elseif canImport(Musl)
+    _ = Musl.signal(SIGPIPE, SIG_IGN)
+    #else
+    #error("Don't know which stdlib to use")
+    #endif
     return true
 }()
 #endif

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -115,53 +115,31 @@ private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsigne
 private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>?) -> CInt = socketpair
 #endif
 
-#if (os(Linux) && !canImport(Musl)) || os(Android)
-private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>) -> CInt = fstat
-private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat
-private let sysLstat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = lstat
-private let sysSymlink: @convention(c) (UnsafePointer<CChar>, UnsafePointer<CChar>) -> CInt = symlink
-private let sysReadlink: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<CChar>, Int) -> CLong = readlink
-private let sysUnlink: @convention(c) (UnsafePointer<CChar>) -> CInt = unlink
-private let sysMkdir: @convention(c) (UnsafePointer<CChar>, mode_t) -> CInt = mkdir
-private let sysOpendir: @convention(c) (UnsafePointer<CChar>) -> OpaquePointer? = opendir
-private let sysReaddir: @convention(c) (OpaquePointer) -> UnsafeMutablePointer<dirent>? = readdir
-private let sysClosedir: @convention(c) (OpaquePointer) -> CInt = closedir
-#if os(Android)
-private let sysRename: @convention(c) (UnsafePointer<CChar>, UnsafePointer<CChar>) -> CInt = rename
-private let sysRemove: @convention(c) (UnsafePointer<CChar>) -> CInt = remove
-#else
-private let sysRename: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> CInt = rename
-private let sysRemove: @convention(c) (UnsafePointer<CChar>?) -> CInt = remove
-#endif
-#elseif canImport(Darwin)
-private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>?) -> CInt = fstat
-private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat
-private let sysLstat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = lstat
-private let sysSymlink: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> CInt = symlink
-private let sysReadlink: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<CChar>?, Int) -> CLong = readlink
-private let sysUnlink: @convention(c) (UnsafePointer<CChar>?) -> CInt = unlink
-private let sysMkdir: @convention(c) (UnsafePointer<CChar>?, mode_t) -> CInt = mkdir
-private let sysMkpath: @convention(c) (UnsafePointer<CChar>?, mode_t) -> CInt = mkpath_np
-private let sysOpendir: @convention(c) (UnsafePointer<CChar>?) -> UnsafeMutablePointer<DIR>? = opendir
-private let sysReaddir: @convention(c) (UnsafeMutablePointer<DIR>?) -> UnsafeMutablePointer<dirent>? = readdir
-private let sysClosedir: @convention(c) (UnsafeMutablePointer<DIR>?) -> CInt = closedir
-private let sysRename: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> CInt = rename
-private let sysRemove: @convention(c) (UnsafePointer<CChar>?) -> CInt = remove
+#if os(Linux) || os(Android) || canImport(Darwin)
+private let sysFstat = fstat
+private let sysStat = stat
+private let sysLstat = lstat
+private let sysSymlink = symlink
+private let sysReadlink = readlink
+private let sysUnlink = unlink
+private let sysMkdir = mkdir
+private let sysOpendir = opendir
+private let sysReaddir = readdir
+private let sysClosedir = closedir
+private let sysRename = rename
+private let sysRemove = remove
 #endif
 #if os(Linux) || os(Android)
-private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIOLinux_mmsghdr>?, CUnsignedInt, CInt) -> CInt = CNIOLinux_sendmmsg
-private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIOLinux_mmsghdr>?, CUnsignedInt, CInt, UnsafeMutablePointer<timespec>?) -> CInt  = CNIOLinux_recvmmsg
+private let sysSendMmsg = CNIOLinux_sendmmsg
+private let sysRecvMmsg = CNIOLinux_recvmmsg
 #elseif canImport(Darwin)
 private let sysKevent = kevent
-private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_mmsghdr>?, CUnsignedInt, CInt) -> CInt = CNIODarwin_sendmmsg
-private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_mmsghdr>?, CUnsignedInt, CInt, UnsafeMutablePointer<timespec>?) -> CInt = CNIODarwin_recvmmsg
+private let sysMkpath = mkpath_np
+private let sysSendMmsg = CNIODarwin_sendmmsg
+private let sysRecvMmsg = CNIODarwin_recvmmsg
 #endif
 #if !os(Windows)
-#if canImport(Musl)
-private let sysIoctl: @convention(c) (CInt, CInt, UnsafeMutableRawPointer) -> CInt = ioctl
-#else
 private let sysIoctl: @convention(c) (CInt, CUnsignedLong, UnsafeMutableRawPointer) -> CInt = ioctl
-#endif  // canImport(Musl)
 #endif  // !os(Windows)
 
 private func isUnacceptableErrno(_ code: Int32) -> Bool {


### PR DESCRIPTION
Various changes to allow building NIO for a Linux system that is using Musl instead of Glibc.

### Motivation:

We would like to be able to build NIO on top of Musl, as well as the usual Glibc.

### Modifications:

Define `_GNU_SOURCE` in the `Package.swift` rather than in `shim.c` (this is required because `_GNU_SOURCE` affects modular headers).

Add an import for Musl to IO.swift.

Add code to disable `SIGPIPE` to `SocketProtocols.swift`.

Remove types from a pile of functions in `System.swift`; Swift will use the correct type automatically (except in cases where there are multiple versions of a function, e.g. `ioctl()`, in which case we need to be explicit which one we mean).

### Result:

NIO should build against Musl.
