### PR TITLE
Add missing availability guards in tests

### DIFF
--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelInboundStreamTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelInboundStreamTests.swift
@@ -15,6 +15,7 @@
 @testable import NIOCore
 import XCTest
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncChannelInboundStreamTests: XCTestCase {
     func testTestingStream() async throws {
         let (stream, source) = NIOAsyncChannelInboundStream<Int>.makeTestingStream()

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelOutboundWriterTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelOutboundWriterTests.swift
@@ -15,6 +15,7 @@
 @testable import NIOCore
 import XCTest
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncChannelOutboundWriterTests: XCTestCase {
     func testTestingWriter() async throws {
         let (writer, sink) = NIOAsyncChannelOutboundWriter<Int>.makeTestingWriter()

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -425,6 +425,7 @@ private final class CloseSuppressor: ChannelOutboundHandler, RemovableChannelHan
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension NIOAsyncTestingChannel {
     fileprivate func closeIgnoringSuppression() async throws {
         try await self.pipeline.context(handlerType: CloseSuppressor.self).flatMap {
@@ -455,6 +456,7 @@ private enum TestError: Error {
     case bang
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Array {
     fileprivate init<AS: AsyncSequence>(_ sequence: AS) async throws where AS.Element == Self.Element {
         self = []

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
@@ -15,6 +15,7 @@
 import NIOCore
 import XCTest
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class MockNIOElementStreamBackPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategy, @unchecked Sendable {
     enum Event {
         case didYield
@@ -48,6 +49,7 @@ final class MockNIOElementStreamBackPressureStrategy: NIOAsyncSequenceProducerBa
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class MockNIOBackPressuredStreamSourceDelegate: NIOAsyncSequenceProducerDelegate, @unchecked Sendable {
     enum Event {
         case produceMore
@@ -673,6 +675,7 @@ fileprivate func XCTAssertEqualWithoutAutoclosure<T>(
     XCTAssertEqual(expression1, expression2, message(), file: file, line: line)
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncSequence {
     /// Collect all elements in the sequence into an array.
     fileprivate func collect() async rethrows -> [Element] {

--- a/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
@@ -850,6 +850,7 @@ fileprivate func XCTAssertEqualWithoutAutoclosure<T>(
     XCTAssertEqual(expression1, expression2, message(), file: file, line: line)
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncSequence {
     /// Collect all elements in the sequence into an array.
     fileprivate func collect() async rethrows -> [Element] {

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -191,6 +191,7 @@ private final class AddressedEnvelopingHandler: ChannelDuplexHandler {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncChannelBootstrapTests: XCTestCase {
     enum NegotiationResult {
         case string(NIOAsyncChannel<String, String>)
@@ -1358,6 +1359,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncStream {
     fileprivate static func makeStream(
         of elementType: Element.Type = Element.self,

--- a/Tests/NIOPosixTests/SerialExecutorTests.swift
+++ b/Tests/NIOPosixTests/SerialExecutorTests.swift
@@ -61,6 +61,7 @@ final class SerialExecutorTests: XCTestCase {
         try await self._testBasicExecutorFitsOnEventLoop(loop1: loops[0], loop2: loops[1])
     }
 
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testBasicExecutorFitsOnEventLoop_AsyncTestingEventLoop() async throws {
         let loop1 = NIOAsyncTestingEventLoop()
         let loop2 = NIOAsyncTestingEventLoop()


### PR DESCRIPTION
# Motivation
We were missing a few availability guards in our tests which causes compile time errors when building for older Darwin SDKs.

# Modification
This PR adds the missing availability guards.
