### PR TITLE
Make NIOFileDescriptor/FileRegion/IOData Sendable & soft-deprecated

### DIFF
--- a/Sources/NIOCore/ChannelInvoker.swift
+++ b/Sources/NIOCore/ChannelInvoker.swift
@@ -195,7 +195,7 @@ extension ChannelOutboundInvoker {
     public func close(mode: CloseMode = .all, file: StaticString = #fileID, line: UInt = #line) -> EventLoopFuture<Void>
     {
         let promise = makePromise(file: file, line: line)
-        close(mode: mode, promise: promise)
+        self.close(mode: mode, promise: promise)
         return promise.futureResult
     }
 

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+import Atomics
+
 #if os(Windows)
 import ucrt
 #elseif canImport(Darwin)
@@ -34,7 +37,105 @@ public typealias NIOPOSIXFileMode = CInt
 public typealias NIOPOSIXFileMode = mode_t
 #endif
 
-/// A `NIOFileHandle` is a handle to an open file.
+#if arch(x86_64) || arch(arm64)
+// 64 bit architectures
+typealias OneUInt32 = UInt32
+typealias TwoUInt32s = UInt64
+
+// Now we need to make `UInt64` match `DoubleWord`'s API but we can't use a custom
+// type because we need special support by the `swift-atomics` package.
+extension UInt64 {
+    fileprivate init(first: UInt32, second: UInt32) {
+        self = UInt64(first) << 32 | UInt64(second)
+    }
+
+    fileprivate var first: UInt32 {
+        get {
+            UInt32(truncatingIfNeeded: self >> 32)
+        }
+        set {
+            self = (UInt64(newValue) << 32) | UInt64(self.second)
+        }
+    }
+
+    fileprivate var second: UInt32 {
+        get {
+            UInt32(truncatingIfNeeded: self & 0xff_ff_ff_ff)
+        }
+        set {
+            self = (UInt64(self.first) << 32) | UInt64(newValue)
+        }
+    }
+}
+#elseif arch(arm) || arch(i386) || arch(arm64_32)
+// 32 bit architectures
+// Note: for testing purposes you can also use these defines for 64 bit platforms, they'll just consume twice as
+// much space, nothing else will go bad.
+typealias OneUInt32 = UInt
+typealias TwoUInt32s = DoubleWord
+#else
+#error("Unknown architecture")
+#endif
+
+internal struct FileDescriptorState {
+    private static let closedValue: OneUInt32 = 0xdead
+    private static let inUseValue: OneUInt32 = 0xbeef
+    private static let openValue: OneUInt32 = 0xcafe
+    internal var rawValue: TwoUInt32s
+
+    internal init(rawValue: TwoUInt32s) {
+        self.rawValue = rawValue
+    }
+
+    internal init(descriptor: CInt) {
+        self.rawValue = TwoUInt32s(
+            first: .init(truncatingIfNeeded: CUnsignedInt(bitPattern: descriptor)),
+            second: Self.openValue
+        )
+    }
+
+    internal var descriptor: CInt {
+        get {
+            CInt(bitPattern: UInt32(truncatingIfNeeded: self.rawValue.first))
+        }
+        set {
+            self.rawValue.first = .init(truncatingIfNeeded: CUnsignedInt(bitPattern: newValue))
+        }
+    }
+
+    internal var isOpen: Bool {
+        self.rawValue.second == Self.openValue
+    }
+
+    internal var isInUse: Bool {
+        self.rawValue.second == Self.inUseValue
+    }
+
+    internal var isClosed: Bool {
+        self.rawValue.second == Self.closedValue
+    }
+
+    mutating func close() {
+        assert(self.isOpen)
+        self.rawValue.second = Self.closedValue
+    }
+
+    mutating func markInUse() {
+        assert(self.isOpen)
+        self.rawValue.second = Self.inUseValue
+    }
+
+    mutating func markNotInUse() {
+        assert(self.rawValue.second == Self.inUseValue)
+        self.rawValue.second = Self.openValue
+    }
+}
+
+/// Deprecated. `NIOFileHandle` is a handle to an open file descriptor.
+///
+/// - warning: The `NIOFileHandle` API is deprecated, do not use going forward. It's not marked as `deprecated` yet such
+///            that users don't get the deprecation warnings affecting their APIs everywhere. For file I/O, please use
+///            the `NIOFileSystem` API.
 ///
 /// When creating a `NIOFileHandle` it takes ownership of the underlying file descriptor. When a `NIOFileHandle` is no longer
 /// needed you must `close` it or take back ownership of the file descriptor using `takeDescriptorOwnership`.
@@ -43,16 +144,54 @@ public typealias NIOPOSIXFileMode = mode_t
 ///
 /// - warning: Failing to manage the lifetime of a `NIOFileHandle` correctly will result in undefined behaviour.
 ///
-/// - warning: `NIOFileHandle` objects are not thread-safe and are mutable. They also cannot be fully thread-safe as they refer to a global underlying file descriptor.
-public final class NIOFileHandle: FileDescriptor {
-    public private(set) var isOpen: Bool
-    private let descriptor: CInt
+/// - Note: As of SwiftNIO 2.77.0, `NIOFileHandle` objects are are thread-safe and enforce singular access. If you access the same `NIOFileHandle`
+///         multiple times, it will throw `IOError(errorCode: EBUSY)` for the second access.
+public final class NIOFileHandle: FileDescriptor & Sendable {
+    private static let descriptorClosed: CInt = CInt.min
+    private let descriptor: UnsafeAtomic<TwoUInt32s>
+
+    public var isOpen: Bool {
+        FileDescriptorState(
+            rawValue: self.descriptor.load(ordering: .sequentiallyConsistent)
+        ).isOpen
+    }
+
+    private static func interpretDescriptorValueThrowIfInUseOrNotOpen(
+        _ descriptor: TwoUInt32s
+    ) throws -> FileDescriptorState {
+        let descriptorState = FileDescriptorState(rawValue: descriptor)
+        if descriptorState.isOpen {
+            return descriptorState
+        } else if descriptorState.isClosed {
+            throw IOError(errnoCode: EBADF, reason: "can't close file (as it's not open anymore).")
+        } else {
+            throw IOError(errnoCode: EBUSY, reason: "file descriptor currently in use")
+        }
+    }
+
+    private func peekAtDescriptorIfOpen() throws -> FileDescriptorState {
+        let descriptor = self.descriptor.load(ordering: .relaxed)
+        return try Self.interpretDescriptorValueThrowIfInUseOrNotOpen(descriptor)
+    }
 
     /// Create a `NIOFileHandle` taking ownership of `descriptor`. You must call `NIOFileHandle.close` or `NIOFileHandle.takeDescriptorOwnership` before
     /// this object can be safely released.
-    public init(descriptor: CInt) {
-        self.descriptor = descriptor
-        self.isOpen = true
+    @available(
+        *,
+        deprecated,
+        message: """
+            Avoid using NIOFileHandle. The type is difficult to hold correctly, \
+            use NIOFileSystem as a replacement API.
+            """
+    )
+    public convenience init(descriptor: CInt) {
+        self.init(_deprecatedTakingOwnershipOfDescriptor: descriptor)
+    }
+
+    /// Create a `NIOFileHandle` taking ownership of `descriptor`. You must call `NIOFileHandle.close` or `NIOFileHandle.takeDescriptorOwnership` before
+    /// this object can be safely released.
+    public init(_deprecatedTakingOwnershipOfDescriptor descriptor: CInt) {
+        self.descriptor = UnsafeAtomic.create(FileDescriptorState(descriptor: descriptor).rawValue)
     }
 
     deinit {
@@ -60,6 +199,7 @@ public final class NIOFileHandle: FileDescriptor {
             !self.isOpen,
             "leaked open NIOFileHandle(descriptor: \(self.descriptor)). Call `close()` to close or `takeDescriptorOwnership()` to take ownership and close by some other means."
         )
+        self.descriptor.destroy()
     }
 
     #if !os(WASI)
@@ -70,11 +210,63 @@ public final class NIOFileHandle: FileDescriptor {
     ///
     /// - Returns: A new `NIOFileHandle` with a fresh underlying file descriptor but shared seek pointer.
     public func duplicate() throws -> NIOFileHandle {
-        try withUnsafeFileDescriptor { fd in
-            NIOFileHandle(descriptor: try SystemCalls.dup(descriptor: fd))
+        try self.withUnsafeFileDescriptor { fd in
+            NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: try SystemCalls.dup(descriptor: fd))
         }
     }
     #endif
+
+    private func activateDescriptor(as descriptor: CInt) {
+        let desired = FileDescriptorState(descriptor: descriptor)
+        var expected = desired
+        expected.markInUse()
+        let (exchanged, original) = self.descriptor.compareExchange(
+            expected: expected.rawValue,
+            desired: desired.rawValue,
+            ordering: .sequentiallyConsistent
+        )
+        guard exchanged || FileDescriptorState(rawValue: original).isClosed else {
+            fatalError("bug in NIO (please report): NIOFileDescritor activate failed \(original)")
+        }
+    }
+
+    private func deactivateDescriptor(toClosed: Bool) throws -> CInt {
+        let peekedDescriptor = try self.peekAtDescriptorIfOpen()
+        // Don't worry, the above is just opportunistic. If we lose the race, we re-check below --> `!exchanged`
+        assert(peekedDescriptor.isOpen)
+        var desired = peekedDescriptor
+        if toClosed {
+            desired.close()
+        } else {
+            desired.markInUse()
+        }
+        assert(desired.rawValue != peekedDescriptor.rawValue, "\(desired.rawValue) == \(peekedDescriptor.rawValue)")
+        let (exchanged, originalDescriptor) = self.descriptor.compareExchange(
+            expected: peekedDescriptor.rawValue,
+            desired: desired.rawValue,
+            ordering: .sequentiallyConsistent
+        )
+
+        if exchanged {
+            assert(peekedDescriptor.rawValue == originalDescriptor)
+            return peekedDescriptor.descriptor
+        } else {
+            // We lost the race above, so this _will_ throw (as we're not closed).
+            let fauxDescriptor = try Self.interpretDescriptorValueThrowIfInUseOrNotOpen(originalDescriptor)
+            // This is impossible, because there are only 4 options in which the exchange above can fail
+            // 1. Descriptor already closed (would've thrown above)
+            // 2. Descriptor in use (would've thrown above)
+            // 3. Descriptor at illegal negative value (would've crashed above)
+            // 4. Descriptor a different, positive value (this is where we're at) --> memory corruption, let's crash
+            fatalError(
+                """
+                bug in NIO (please report): \
+                NIOFileDescriptor illegal state \
+                (\(peekedDescriptor), \(originalDescriptor), \(fauxDescriptor))")
+                """
+            )
+        }
+    }
 
     /// Take the ownership of the underlying file descriptor. This is similar to `close()` but the underlying file
     /// descriptor remains open. The caller is responsible for closing the file descriptor by some other means.
@@ -83,27 +275,20 @@ public final class NIOFileHandle: FileDescriptor {
     ///
     /// - Returns: The underlying file descriptor, now owned by the caller.
     public func takeDescriptorOwnership() throws -> CInt {
-        guard self.isOpen else {
-            throw IOError(errnoCode: EBADF, reason: "can't close file (as it's not open anymore).")
-        }
-
-        self.isOpen = false
-        return self.descriptor
+        try self.deactivateDescriptor(toClosed: true)
     }
 
     public func close() throws {
-        try withUnsafeFileDescriptor { fd in
-            try SystemCalls.close(descriptor: fd)
-        }
-
-        self.isOpen = false
+        let descriptor = try self.deactivateDescriptor(toClosed: true)
+        try SystemCalls.close(descriptor: descriptor)
     }
 
     public func withUnsafeFileDescriptor<T>(_ body: (CInt) throws -> T) throws -> T {
-        guard self.isOpen else {
-            throw IOError(errnoCode: EBADF, reason: "file descriptor already closed!")
+        let descriptor = try self.deactivateDescriptor(toClosed: false)
+        defer {
+            self.activateDescriptor(as: descriptor)
         }
-        return try body(self.descriptor)
+        return try body(descriptor)
     }
 }
 
@@ -180,29 +365,75 @@ extension NIOFileHandle {
     ///   - path: The path of the file to open. The ownership of the file descriptor is transferred to this `NIOFileHandle` and so it will be closed once `close` is called.
     ///   - mode: Access mode. Default mode is `.read`.
     ///   - flags: Additional POSIX flags.
-    public convenience init(path: String, mode: Mode = .read, flags: Flags = .default) throws {
-        #if os(Windows)
-        let fl = mode.posixFlags | flags.posixFlags | _O_NOINHERIT
-        #else
-        let fl = mode.posixFlags | flags.posixFlags | O_CLOEXEC
-        #endif
-        let fd = try SystemCalls.open(file: path, oFlag: fl, mode: flags.posixMode)
-        self.init(descriptor: fd)
+    @available(
+        *,
+        deprecated,
+        message: """
+            Avoid using NIOFileHandle. The type is difficult to hold correctly, \
+            use NIOFileSystem as a replacement API.
+            """
+    )
+    @available(*, noasync, message: "This method may block the calling thread")
+    public convenience init(
+        path: String,
+        mode: Mode = .read,
+        flags: Flags = .default
+    ) throws {
+        try self.init(_deprecatedPath: path, mode: mode, flags: flags)
     }
 
     /// Open a new `NIOFileHandle`. This operation is blocking.
     ///
     /// - Parameters:
     ///   - path: The path of the file to open. The ownership of the file descriptor is transferred to this `NIOFileHandle` and so it will be closed once `close` is called.
+    ///   - mode: Access mode. Default mode is `.read`.
+    ///   - flags: Additional POSIX flags.
+    @available(*, noasync, message: "This method may block the calling thread")
+    public convenience init(
+        _deprecatedPath path: String,
+        mode: Mode = .read,
+        flags: Flags = .default
+    ) throws {
+        #if os(Windows)
+        let fl = mode.posixFlags | flags.posixFlags | _O_NOINHERIT
+        #else
+        let fl = mode.posixFlags | flags.posixFlags | O_CLOEXEC
+        #endif
+        let fd = try SystemCalls.open(file: path, oFlag: fl, mode: flags.posixMode)
+        self.init(_deprecatedTakingOwnershipOfDescriptor: fd)
+    }
+
+    /// Open a new `NIOFileHandle`. This operation is blocking.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to open. The ownership of the file descriptor is transferred to this `NIOFileHandle` and so it will be closed once `close` is called.
+    @available(
+        *,
+        deprecated,
+        message: """
+            Avoid using NIOFileHandle. The type is difficult to hold correctly, \
+            use NIOFileSystem as a replacement API.
+            """
+    )
+    @available(*, noasync, message: "This method may block the calling thread")
     public convenience init(path: String) throws {
+        try self.init(_deprecatedPath: path)
+    }
+
+    /// Open a new `NIOFileHandle`. This operation is blocking.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to open. The ownership of the file descriptor is transferred to this `NIOFileHandle` and so it will be closed once `close` is called.
+    @available(*, noasync, message: "This method may block the calling thread")
+    public convenience init(_deprecatedPath path: String) throws {
         // This function is here because we had a function like this in NIO 2.0, and the one above doesn't quite match. Sadly we can't
         // really deprecate this either, because it'll be preferred to the one above in many cases.
-        try self.init(path: path, mode: .read, flags: .default)
+        try self.init(_deprecatedPath: path, mode: .read, flags: .default)
     }
 }
 
 extension NIOFileHandle: CustomStringConvertible {
     public var description: String {
-        "FileHandle { descriptor: \(self.descriptor) }"
+        "FileHandle { descriptor: \(FileDescriptorState(rawValue: self.descriptor.load(ordering: .relaxed)).descriptor) }"
     }
 }

--- a/Sources/NIOCore/FileRegion.swift
+++ b/Sources/NIOCore/FileRegion.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -29,6 +29,10 @@ import WASILibc
 
 /// A `FileRegion` represent a readable portion usually created to be sent over the network.
 ///
+/// - warning: The `FileRegion` API is deprecated, do not use going forward. It's not marked as `deprecated` yet such
+///            that users don't get the deprecation warnings affecting their APIs everywhere. For file I/O, please use
+///            the `NIOFileSystem` API.
+///
 /// Usually a `FileRegion` will allow the underlying transport to use `sendfile` to transfer its content and so allows transferring
 /// the file content without copying it into user-space at all. If the actual transport implementation really can make use of sendfile
 /// or if it will need to copy the content to user-space first and use `write` / `writev` is an implementation detail. That said
@@ -37,9 +41,9 @@ import WASILibc
 /// One important note, depending your `ChannelPipeline` setup it may not be possible to use a `FileRegion` as a `ChannelHandler` may
 /// need access to the bytes (in a `ByteBuffer`) to transform these.
 ///
-/// - Note: It is important to manually manage the lifetime of the `NIOFileHandle` used to create a `FileRegion`.
-/// - warning: `FileRegion` objects are not thread-safe and are mutable. They also cannot be fully thread-safe as they refer to a global underlying file descriptor.
-public struct FileRegion {
+/// - Note: It is important to manually manage the lifetime of the ``NIOFileHandle`` used to create a ``FileRegion``.
+/// - Note: As of SwiftNIO 2.77.0, `FileRegion` objects are are thread-safe and the underlying ``NIOFileHandle`` does enforce singular access.
+public struct FileRegion: Sendable {
 
     /// The `NIOFileHandle` that is used by this `FileRegion`.
     public let fileHandle: NIOFileHandle

--- a/Sources/NIOCore/IOData.swift
+++ b/Sources/NIOCore/IOData.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,13 +14,18 @@
 
 /// `IOData` unifies standard SwiftNIO types that are raw bytes of data; currently `ByteBuffer` and `FileRegion`.
 ///
+/// - warning: `IOData` is a legacy API, please avoid using it as much as possible.
+///
 /// Many `ChannelHandler`s receive or emit bytes and in most cases this can be either a `ByteBuffer` or a `FileRegion`
 /// from disk. To still form a well-typed `ChannelPipeline` such handlers should receive and emit value of type `IOData`.
-public enum IOData {
+public enum IOData: Sendable {
     /// A `ByteBuffer`.
     case byteBuffer(ByteBuffer)
 
     /// A `FileRegion`.
+    ///
+    /// - warning: `IOData.fileRegion` is a legacy API, please avoid using it. It cannot work with TLS and `FileRegion`
+    ///            and the underlying `NIOFileHandle` objects are very difficult to hold correctly.
     ///
     /// Sending a `FileRegion` through the `ChannelPipeline` using `write` can be useful because some `Channel`s can
     /// use `sendfile` to send a `FileRegion` more efficiently.
@@ -29,9 +34,6 @@ public enum IOData {
 
 /// `IOData` objects are comparable just like the values they wrap.
 extension IOData: Equatable {}
-
-@available(*, unavailable)
-extension IOData: Sendable {}
 
 /// `IOData` provide a number of readable bytes.
 extension IOData {

--- a/Sources/NIOCore/Linux.swift
+++ b/Sources/NIOCore/Linux.swift
@@ -24,7 +24,7 @@ enum Linux {
     static let cfsCpuMaxPath = "/sys/fs/cgroup/cpu.max"
 
     private static func firstLineOfFile(path: String) throws -> Substring {
-        let fh = try NIOFileHandle(path: path)
+        let fh = try NIOFileHandle(_deprecatedPath: path)
         defer { try! fh.close() }
         // linux doesn't properly report /sys/fs/cgroup/* files lengths so we use a reasonable limit
         var buf = ByteBufferAllocator().buffer(capacity: 1024)

--- a/Sources/NIOCrashTester/OutputGrepper.swift
+++ b/Sources/NIOCrashTester/OutputGrepper.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2020-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -39,7 +39,9 @@ internal struct OutputGrepper {
                 }
             }
             .takingOwnershipOfDescriptor(input: dup(processToChannel.fileHandleForReading.fileDescriptor))
-        let processOutputPipe = NIOFileHandle(descriptor: dup(processToChannel.fileHandleForWriting.fileDescriptor))
+        let processOutputPipe = NIOFileHandle(
+            _deprecatedTakingOwnershipOfDescriptor: dup(processToChannel.fileHandleForWriting.fileDescriptor)
+        )
         processToChannel.fileHandleForReading.closeFile()
         processToChannel.fileHandleForWriting.closeFile()
         channelFuture.cascadeFailure(to: outputPromise)

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -422,7 +422,7 @@ private final class HTTPHandler: ChannelInboundHandler {
                 return
             }
             let path = self.htdocsPath + "/" + path
-            let fileHandleAndRegion = self.fileIO.openFile(path: path, eventLoop: context.eventLoop)
+            let fileHandleAndRegion = self.fileIO.openFile(_deprecatedPath: path, eventLoop: context.eventLoop)
             fileHandleAndRegion.whenFailure {
                 sendErrorResponse(request: request, $0)
             }

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -2407,8 +2407,8 @@ extension NIOPipeBootstrap {
         let channelOptions = self._channelOptions
 
         let channel: PipeChannel
-        let inputFileHandle: NIOFileHandle?
-        let outputFileHandle: NIOFileHandle?
+        let pipeChannelInput: SelectablePipeHandle?
+        let pipeChannelOutput: SelectablePipeHandle?
         do {
             if let input = input {
                 try self.validateFileDescriptorIsNotAFile(input)
@@ -2417,18 +2417,18 @@ extension NIOPipeBootstrap {
                 try self.validateFileDescriptorIsNotAFile(output)
             }
 
-            inputFileHandle = input.flatMap { NIOFileHandle(descriptor: $0) }
-            outputFileHandle = output.flatMap { NIOFileHandle(descriptor: $0) }
+            pipeChannelInput = input.flatMap { SelectablePipeHandle(takingOwnershipOfDescriptor: $0) }
+            pipeChannelOutput = output.flatMap { SelectablePipeHandle(takingOwnershipOfDescriptor: $0) }
             do {
                 channel = try self.hooks.makePipeChannel(
                     eventLoop: eventLoop as! SelectableEventLoop,
-                    inputPipe: inputFileHandle,
-                    outputPipe: outputFileHandle
+                    input: pipeChannelInput,
+                    output: pipeChannelOutput
                 )
             } catch {
                 // Release file handles back to the caller in case of failure.
-                _ = try? inputFileHandle?.takeDescriptorOwnership()
-                _ = try? outputFileHandle?.takeDescriptorOwnership()
+                _ = try? pipeChannelInput?.takeDescriptorOwnership()
+                _ = try? pipeChannelOutput?.takeDescriptorOwnership()
                 throw error
             }
         } catch {
@@ -2447,10 +2447,10 @@ extension NIOPipeBootstrap {
                 channel.registerAlreadyConfigured0(promise: promise)
                 return promise.futureResult.map { result }
             }.flatMap { result -> EventLoopFuture<ChannelInitializerResult> in
-                if inputFileHandle == nil {
+                if pipeChannelInput == nil {
                     return channel.close(mode: .input).map { result }
                 }
-                if outputFileHandle == nil {
+                if pipeChannelOutput == nil {
                     return channel.close(mode: .output).map { result }
                 }
                 return channel.selectableEventLoop.makeSucceededFuture(result)
@@ -2476,17 +2476,17 @@ extension NIOPipeBootstrap: Sendable {}
 protocol NIOPipeBootstrapHooks {
     func makePipeChannel(
         eventLoop: SelectableEventLoop,
-        inputPipe: NIOFileHandle?,
-        outputPipe: NIOFileHandle?
+        input: SelectablePipeHandle?,
+        output: SelectablePipeHandle?
     ) throws -> PipeChannel
 }
 
 private struct DefaultNIOPipeBootstrapHooks: NIOPipeBootstrapHooks {
     func makePipeChannel(
         eventLoop: SelectableEventLoop,
-        inputPipe: NIOFileHandle?,
-        outputPipe: NIOFileHandle?
+        input: SelectablePipeHandle?,
+        output: SelectablePipeHandle?
     ) throws -> PipeChannel {
-        try PipeChannel(eventLoop: eventLoop, inputPipe: inputPipe, outputPipe: outputPipe)
+        try PipeChannel(eventLoop: eventLoop, input: input, output: output)
     }
 }

--- a/Sources/NIOPosix/PendingWritesManager.swift
+++ b/Sources/NIOPosix/PendingWritesManager.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -434,9 +434,10 @@ final class PendingStreamWritesManager: PendingWritesManager {
         case .fileRegion(let file):
             let readerIndex = file.readerIndex
             let endIndex = file.endIndex
-            return try file.fileHandle.withUnsafeFileDescriptor { fd in
-                self.didWrite(itemCount: 1, result: try operation(fd, readerIndex, endIndex))
+            let writeResult = try file.fileHandle.withUnsafeFileDescriptor { fd in
+                try operation(fd, readerIndex, endIndex)
             }
+            return self.didWrite(itemCount: 1, result: writeResult)
         case .byteBuffer:
             preconditionFailure("called \(#function) but first item to write was a ByteBuffer")
         }

--- a/Sources/NIOPosix/PipeChannel.swift
+++ b/Sources/NIOPosix/PipeChannel.swift
@@ -23,10 +23,10 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
 
     init(
         eventLoop: SelectableEventLoop,
-        inputPipe: NIOFileHandle?,
-        outputPipe: NIOFileHandle?
+        input: SelectablePipeHandle?,
+        output: SelectablePipeHandle?
     ) throws {
-        self.pipePair = try PipePair(inputFD: inputPipe, outputFD: outputPipe)
+        self.pipePair = try PipePair(input: input, output: output)
         try super.init(
             socket: self.pipePair,
             parent: nil,
@@ -65,17 +65,17 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
     }
 
     override func register(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws {
-        if let inputFD = self.pipePair.inputFD {
+        if let inputSPH = self.pipePair.input {
             try selector.register(
-                selectable: inputFD,
+                selectable: inputSPH,
                 interested: interested.intersection([.read, .reset, .error]),
                 makeRegistration: self.registrationForInput
             )
         }
 
-        if let outputFD = self.pipePair.outputFD {
+        if let outputSPH = self.pipePair.output {
             try selector.register(
-                selectable: outputFD,
+                selectable: outputSPH,
                 interested: interested.intersection([.write, .reset, .error]),
                 makeRegistration: self.registrationForOutput
             )
@@ -83,24 +83,24 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
     }
 
     override func deregister(selector: Selector<NIORegistration>, mode: CloseMode) throws {
-        if let inputFD = self.pipePair.inputFD, (mode == .all || mode == .input) && inputFD.isOpen {
-            try selector.deregister(selectable: inputFD)
+        if let inputSPH = self.pipePair.input, (mode == .all || mode == .input) && inputSPH.isOpen {
+            try selector.deregister(selectable: inputSPH)
         }
-        if let outputFD = self.pipePair.outputFD, (mode == .all || mode == .output) && outputFD.isOpen {
-            try selector.deregister(selectable: outputFD)
+        if let outputSPH = self.pipePair.output, (mode == .all || mode == .output) && outputSPH.isOpen {
+            try selector.deregister(selectable: outputSPH)
         }
     }
 
     override func reregister(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws {
-        if let inputFD = self.pipePair.inputFD, inputFD.isOpen {
+        if let inputSPH = self.pipePair.input, inputSPH.isOpen {
             try selector.reregister(
-                selectable: inputFD,
+                selectable: inputSPH,
                 interested: interested.intersection([.read, .reset, .error])
             )
         }
-        if let outputFD = self.pipePair.outputFD, outputFD.isOpen {
+        if let outputSPH = self.pipePair.output, outputSPH.isOpen {
             try selector.reregister(
-                selectable: outputFD,
+                selectable: outputSPH,
                 interested: interested.intersection([.write, .reset, .error])
             )
         }
@@ -108,19 +108,19 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
 
     override func readEOF() {
         super.readEOF()
-        guard let inputFD = self.pipePair.inputFD, inputFD.isOpen else {
+        guard let inputSPH = self.pipePair.input, inputSPH.isOpen else {
             return
         }
         try! self.selectableEventLoop.deregister(channel: self, mode: .input)
-        try! inputFD.close()
+        try! inputSPH.close()
     }
 
     override func writeEOF() {
-        guard let outputFD = self.pipePair.outputFD, outputFD.isOpen else {
+        guard let outputSPH = self.pipePair.output, outputSPH.isOpen else {
             return
         }
         try! self.selectableEventLoop.deregister(channel: self, mode: .output)
-        try! outputFD.close()
+        try! outputSPH.close()
     }
 
     override func shutdownSocket(mode: CloseMode) throws {

--- a/Sources/NIOPosix/SelectorEpoll.swift
+++ b/Sources/NIOPosix/SelectorEpoll.swift
@@ -167,8 +167,8 @@ extension Selector: _SelectorBackendProtocol {
         assert(self.timerFD == -1, "self.timerFD == \(self.timerFD) in deinitAssertions0, forgot close?")
     }
 
-    func register0<S: Selectable>(
-        selectable: S,
+    func register0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         interested: SelectorEventSet,
         registrationID: SelectorRegistrationID
@@ -180,8 +180,8 @@ extension Selector: _SelectorBackendProtocol {
         try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_ADD, fd: fileDescriptor, event: &ev)
     }
 
-    func reregister0<S: Selectable>(
-        selectable: S,
+    func reregister0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         oldInterested: SelectorEventSet,
         newInterested: SelectorEventSet,
@@ -194,8 +194,8 @@ extension Selector: _SelectorBackendProtocol {
         _ = try Epoll.epoll_ctl(epfd: self.selectorFD, op: Epoll.EPOLL_CTL_MOD, fd: fileDescriptor, event: &ev)
     }
 
-    func deregister0<S: Selectable>(
-        selectable: S,
+    func deregister0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         oldInterested: SelectorEventSet,
         registrationID: SelectorRegistrationID

--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -122,27 +122,29 @@ protocol _SelectorBackendProtocol {
     associatedtype R: Registration
     func initialiseState0() throws
     func deinitAssertions0()  // allows actual implementation to run some assertions as part of the class deinit
-    func register0<S: Selectable>(
-        selectable: S,
+    func register0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         interested: SelectorEventSet,
         registrationID: SelectorRegistrationID
     ) throws
-    func reregister0<S: Selectable>(
-        selectable: S,
+    func reregister0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         oldInterested: SelectorEventSet,
         newInterested: SelectorEventSet,
         registrationID: SelectorRegistrationID
     ) throws
-    func deregister0<S: Selectable>(
-        selectable: S,
+    func deregister0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         oldInterested: SelectorEventSet,
         registrationID: SelectorRegistrationID
     ) throws
+
     // attention, this may (will!) be called from outside the event loop, ie. can't access mutable shared state (such as `self.open`)
     func wakeup0() throws
+
     /// Apply the given `SelectorStrategy` and execute `body` once it's complete (which may produce `SelectorEvent`s to handle).
     ///
     /// - Parameters:
@@ -288,7 +290,7 @@ internal class Selector<R: Registration> {
         try selectable.withUnsafeHandle { fd in
             assert(registrations[Int(fd)] == nil)
             try self.register0(
-                selectable: selectable,
+                selectableFD: fd,
                 fileDescriptor: fd,
                 interested: interested,
                 registrationID: self.registrationID
@@ -315,7 +317,7 @@ internal class Selector<R: Registration> {
         try selectable.withUnsafeHandle { fd in
             var reg = registrations[Int(fd)]!
             try self.reregister0(
-                selectable: selectable,
+                selectableFD: fd,
                 fileDescriptor: fd,
                 oldInterested: reg.interested,
                 newInterested: interested,
@@ -343,7 +345,7 @@ internal class Selector<R: Registration> {
                 return
             }
             try self.deregister0(
-                selectable: selectable,
+                selectableFD: fd,
                 fileDescriptor: fd,
                 oldInterested: reg.interested,
                 registrationID: reg.registrationID

--- a/Sources/NIOPosix/SelectorKqueue.swift
+++ b/Sources/NIOPosix/SelectorKqueue.swift
@@ -163,8 +163,8 @@ extension Selector: _SelectorBackendProtocol {
         }
     }
 
-    private func kqueueUpdateEventNotifications<S: Selectable>(
-        selectable: S,
+    private func kqueueUpdateEventNotifications(
+        selectableFD: CInt,
         interested: SelectorEventSet,
         oldInterested: SelectorEventSet?,
         registrationID: SelectorRegistrationID
@@ -175,14 +175,12 @@ extension Selector: _SelectorBackendProtocol {
         assert(interested.contains(.reset))
         assert(oldInterested?.contains(.reset) ?? true)
 
-        try selectable.withUnsafeHandle {
-            try newKQueueFilters.calculateKQueueFilterSetChanges(
-                previousKQueueFilterSet: oldKQueueFilters,
-                fileDescriptor: $0,
-                registrationID: registrationID,
-                kqueueApplyEventChangeSet
-            )
-        }
+        try newKQueueFilters.calculateKQueueFilterSetChanges(
+            previousKQueueFilterSet: oldKQueueFilters,
+            fileDescriptor: selectableFD,
+            registrationID: registrationID,
+            kqueueApplyEventChangeSet
+        )
     }
 
     func initialiseState0() throws {
@@ -205,44 +203,44 @@ extension Selector: _SelectorBackendProtocol {
     func deinitAssertions0() {
     }
 
-    func register0<S: Selectable>(
-        selectable: S,
+    func register0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         interested: SelectorEventSet,
         registrationID: SelectorRegistrationID
     ) throws {
         try kqueueUpdateEventNotifications(
-            selectable: selectable,
+            selectableFD: selectableFD,
             interested: interested,
             oldInterested: nil,
             registrationID: registrationID
         )
     }
 
-    func reregister0<S: Selectable>(
-        selectable: S,
+    func reregister0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         oldInterested: SelectorEventSet,
         newInterested: SelectorEventSet,
         registrationID: SelectorRegistrationID
     ) throws {
         try kqueueUpdateEventNotifications(
-            selectable: selectable,
+            selectableFD: selectableFD,
             interested: newInterested,
             oldInterested: oldInterested,
             registrationID: registrationID
         )
     }
 
-    func deregister0<S: Selectable>(
-        selectable: S,
+    func deregister0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         oldInterested: SelectorEventSet,
         registrationID: SelectorRegistrationID
     ) throws {
         try kqueueUpdateEventNotifications(
-            selectable: selectable,
-            interested: [.reset, .error],
+            selectableFD: selectableFD,
+            interested: .reset,
             oldInterested: oldInterested,
             registrationID: registrationID
         )

--- a/Sources/NIOPosix/SelectorUring.swift
+++ b/Sources/NIOPosix/SelectorUring.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2021-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -131,8 +131,8 @@ extension Selector: _SelectorBackendProtocol {
         assert(self.eventFD == -1, "self.eventFD == \(self.eventFD) on deinitAssertions0 deinit, forgot close?")
     }
 
-    func register0<S: Selectable>(
-        selectable: S,
+    func register0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         interested: SelectorEventSet,
         registrationID: SelectorRegistrationID
@@ -150,8 +150,8 @@ extension Selector: _SelectorBackendProtocol {
         )
     }
 
-    func reregister0<S: Selectable>(
-        selectable: S,
+    func reregister0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         oldInterested: SelectorEventSet,
         newInterested: SelectorEventSet,
@@ -190,8 +190,8 @@ extension Selector: _SelectorBackendProtocol {
         }
     }
 
-    func deregister0<S: Selectable>(
-        selectable: S,
+    func deregister0(
+        selectableFD: CInt,
         fileDescriptor: CInt,
         oldInterested: SelectorEventSet,
         registrationID: SelectorRegistrationID

--- a/Tests/NIOCoreTests/BaseObjectsTest.swift
+++ b/Tests/NIOCoreTests/BaseObjectsTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -52,7 +52,7 @@ class BaseObjectTest: XCTestCase {
     }
 
     func testNIOFileRegionConversion() {
-        let handle = NIOFileHandle(descriptor: -1)
+        let handle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
         let expected = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
         defer {
             // fake descriptor, so shouldn't be closed.
@@ -74,7 +74,7 @@ class BaseObjectTest: XCTestCase {
     }
 
     func testBadConversions() {
-        let handle = NIOFileHandle(descriptor: -1)
+        let handle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
         let bb = ByteBufferAllocator().buffer(capacity: 1024)
         let fr = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
         defer {
@@ -95,7 +95,7 @@ class BaseObjectTest: XCTestCase {
     }
 
     func testFileRegionFromIOData() {
-        let handle = NIOFileHandle(descriptor: -1)
+        let handle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
         let expected = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
         defer {
             // fake descriptor, so shouldn't be closed.
@@ -106,7 +106,7 @@ class BaseObjectTest: XCTestCase {
     }
 
     func testIODataEquals() {
-        let handle = NIOFileHandle(descriptor: -1)
+        let handle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
         var bb1 = ByteBufferAllocator().buffer(capacity: 1024)
         let bb2 = ByteBufferAllocator().buffer(capacity: 1024)
         bb1.writeString("hello")

--- a/Tests/NIOCoreTests/NIOAnyDebugTest.swift
+++ b/Tests/NIOCoreTests/NIOAnyDebugTest.swift
@@ -27,7 +27,7 @@ class NIOAnyDebugTest: XCTestCase {
             "ByteBuffer: [627974652062756666657220737472696e67](18 bytes)"
         )
 
-        let fileHandle = NIOFileHandle(descriptor: 1)
+        let fileHandle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: 1)
         defer {
             XCTAssertNoThrow(_ = try fileHandle.takeDescriptorOwnership())
         }

--- a/Tests/NIOCoreTests/XCTest+Extensions.swift
+++ b/Tests/NIOCoreTests/XCTest+Extensions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -62,7 +62,7 @@ func withTemporaryFile<T>(content: String? = nil, _ body: (NIOCore.NIOFileHandle
         XCTAssertNoThrow(try FileManager.default.removeItem(atPath: temporaryFilePath))
     }
 
-    let fileHandle = try NIOFileHandle(path: temporaryFilePath, mode: [.read, .write])
+    let fileHandle = try NIOFileHandle(_deprecatedPath: temporaryFilePath, mode: [.read, .write])
     defer {
         XCTAssertNoThrow(try fileHandle.close())
     }

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
@@ -232,7 +232,7 @@ class EmbeddedChannelTest: XCTestCase {
 
         let buffer = channel.allocator.buffer(capacity: 0)
         let ioData = IOData.byteBuffer(buffer)
-        let fileHandle = NIOFileHandle(descriptor: -1)
+        let fileHandle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
         let fileRegion = FileRegion(fileHandle: fileHandle, readerIndex: 0, endIndex: 0)
         defer {
             XCTAssertNoThrow(_ = try fileHandle.takeDescriptorOwnership())
@@ -387,7 +387,7 @@ class EmbeddedChannelTest: XCTestCase {
         let channel = EmbeddedChannel()
         let buffer = ByteBufferAllocator().buffer(capacity: 5)
         let socketAddress = try SocketAddress(unixDomainSocketPath: "path")
-        let handle = NIOFileHandle(descriptor: 1)
+        let handle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: 1)
         let fileRegion = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
         defer {
             // fake descriptor, so shouldn't be closed.

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -98,7 +98,7 @@ class HTTPServerClientTest: XCTestCase {
 
                 let content = buffer.getData(at: 0, length: buffer.readableBytes)!
                 XCTAssertNoThrow(try content.write(to: URL(fileURLWithPath: filePath)))
-                let fh = try! NIOFileHandle(path: filePath)
+                let fh = try! NIOFileHandle(_deprecatedPath: filePath)
                 let region = FileRegion(
                     fileHandle: fh,
                     readerIndex: 0,

--- a/Tests/NIOPosixTests/BootstrapTest.swift
+++ b/Tests/NIOPosixTests/BootstrapTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -451,26 +451,25 @@ class BootstrapTest: XCTestCase {
 
         let eventLoop = self.group.next()
 
-        eventLoop.execute {
-            do {
+        XCTAssertNoThrow(
+            try eventLoop.submit {
                 let pipe = Pipe()
-                let readHandle = NIOFileHandle(descriptor: pipe.fileHandleForReading.fileDescriptor)
-                let writeHandle = NIOFileHandle(descriptor: pipe.fileHandleForWriting.fileDescriptor)
-                _ = NIOPipeBootstrap(group: self.group)
+                defer {
+                    XCTAssertNoThrow(try pipe.fileHandleForReading.close())
+                    XCTAssertNoThrow(try pipe.fileHandleForWriting.close())
+                }
+                return NIOPipeBootstrap(group: self.group)
                     .takingOwnershipOfDescriptors(
-                        input: try readHandle.takeDescriptorOwnership(),
-                        output: try writeHandle.takeDescriptorOwnership()
+                        input: dup(pipe.fileHandleForReading.fileDescriptor),
+                        output: dup(pipe.fileHandleForWriting.fileDescriptor)
                     )
                     .flatMap({ channel in
                         channel.close()
                     }).always({ _ in
                         testGrp.leave()
                     })
-            } catch {
-                XCTFail("Failed to bootstrap pipechannel in eventloop: \(error)")
-                testGrp.leave()
-            }
-        }
+            }.wait()
+        )
         testGrp.wait()
     }
 
@@ -777,9 +776,9 @@ class BootstrapTest: XCTestCase {
         struct NIOPipeBootstrapHooksChannelFail: NIOPipeBootstrapHooks {
             func makePipeChannel(
                 eventLoop: NIOPosix.SelectableEventLoop,
-                inputPipe: NIOCore.NIOFileHandle?,
-                outputPipe: NIOCore.NIOFileHandle?
-            ) throws -> NIOPosix.PipeChannel {
+                input: SelectablePipeHandle?,
+                output: SelectablePipeHandle?
+            ) throws -> PipeChannel {
                 throw IOError(errnoCode: EBADF, reason: "testing")
             }
         }
@@ -790,7 +789,7 @@ class BootstrapTest: XCTestCase {
         }
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
-            try! elg.syncShutdownGracefully()
+            XCTAssertNoThrow(try elg.syncShutdownGracefully())
         }
 
         let bootstrap = NIOPipeBootstrap(validatingGroup: elg, hooks: NIOPipeBootstrapHooksChannelFail())

--- a/Tests/NIOPosixTests/ChannelPipelineTest.swift
+++ b/Tests/NIOPosixTests/ChannelPipelineTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -320,7 +320,7 @@ class ChannelPipelineTest: XCTestCase {
 
         XCTAssertTrue(loop.inEventLoop)
         do {
-            let handle = NIOFileHandle(descriptor: -1)
+            let handle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
             let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 0)
             defer {
                 // fake descriptor, so shouldn't be closed.

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -776,7 +776,7 @@ public final class ChannelTests: XCTestCase {
             )
             buffer.clear()
             buffer.writeBytes([UInt8](repeating: 0xff, count: 1))
-            let handle = NIOFileHandle(descriptor: -1)
+            let handle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
             defer {
                 // fake file handle, so don't actually close
                 XCTAssertNoThrow(try handle.takeDescriptorOwnership())
@@ -962,8 +962,8 @@ public final class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<2).map { (_: Int) in el.makePromise() }
 
-            let fh1 = NIOFileHandle(descriptor: -1)
-            let fh2 = NIOFileHandle(descriptor: -2)
+            let fh1 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
+            let fh2 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -2)
             let fr1 = FileRegion(fileHandle: fh1, readerIndex: 12, endIndex: 14)
             let fr2 = FileRegion(fileHandle: fh2, readerIndex: 0, endIndex: 2)
             defer {
@@ -1027,7 +1027,7 @@ public final class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.makePromise() }
 
-            let fh = NIOFileHandle(descriptor: -1)
+            let fh = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
             let fr = FileRegion(fileHandle: fh, readerIndex: 99, endIndex: 99)
             defer {
                 // fake descriptor, so shouldn't be closed.
@@ -1061,8 +1061,8 @@ public final class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<5).map { (_: Int) in el.makePromise() }
 
-            let fh1 = NIOFileHandle(descriptor: -1)
-            let fh2 = NIOFileHandle(descriptor: -1)
+            let fh1 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
+            let fh2 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
             let fr1 = FileRegion(fileHandle: fh1, readerIndex: 99, endIndex: 99)
             let fr2 = FileRegion(fileHandle: fh1, readerIndex: 0, endIndex: 10)
             defer {
@@ -1320,7 +1320,7 @@ public final class ChannelTests: XCTestCase {
         try withPendingStreamWritesManager { pwm in
             let ps: [EventLoopPromise<Void>] = (0..<1).map { (_: Int) in el.makePromise() }
 
-            let fh = NIOFileHandle(descriptor: -1)
+            let fh = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: -1)
             let fr = FileRegion(fileHandle: fh, readerIndex: 0, endIndex: 8192)
             defer {
                 // fake descriptor, so shouldn't be closed.

--- a/Tests/NIOPosixTests/FileRegionTest.swift
+++ b/Tests/NIOPosixTests/FileRegionTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -60,7 +60,7 @@ class FileRegionTest: XCTestCase {
         try withTemporaryFile { _, filePath in
             try content.write(toFile: filePath, atomically: false, encoding: .ascii)
             try clientChannel.eventLoop.submit {
-                try NIOFileHandle(path: filePath)
+                try NIOFileHandle(_deprecatedPath: filePath)
             }.flatMap { (handle: NIOFileHandle) in
                 let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: bytes.count)
                 let promise = clientChannel.eventLoop.makePromise(of: Void.self)
@@ -118,7 +118,7 @@ class FileRegionTest: XCTestCase {
             try "".write(toFile: filePath, atomically: false, encoding: .ascii)
 
             try clientChannel.eventLoop.submit {
-                try NIOFileHandle(path: filePath)
+                try NIOFileHandle(_deprecatedPath: filePath)
             }.flatMap { (handle: NIOFileHandle) in
                 let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 0)
                 var futures: [EventLoopFuture<Void>] = []
@@ -180,8 +180,8 @@ class FileRegionTest: XCTestCase {
             try content.write(toFile: filePath, atomically: false, encoding: .ascii)
 
             let future = clientChannel.eventLoop.submit {
-                let fh1 = try NIOFileHandle(path: filePath)
-                let fh2 = try NIOFileHandle(path: filePath)
+                let fh1 = try NIOFileHandle(_deprecatedPath: filePath)
+                let fh2 = try NIOFileHandle(_deprecatedPath: filePath)
                 return (fh1, fh2)
             }.flatMap { (fh1, fh2) in
                 let fr1 = FileRegion(fileHandle: fh1, readerIndex: 0, endIndex: bytes.count)
@@ -229,7 +229,7 @@ class FileRegionTest: XCTestCase {
 
     func testWholeFileFileRegion() throws {
         try withTemporaryFile(content: "hello") { fd, path in
-            let handle = try NIOFileHandle(path: path)
+            let handle = try NIOFileHandle(_deprecatedPath: path)
             let region = try FileRegion(fileHandle: handle)
             defer {
                 XCTAssertNoThrow(try handle.close())
@@ -242,7 +242,7 @@ class FileRegionTest: XCTestCase {
 
     func testWholeEmptyFileFileRegion() throws {
         try withTemporaryFile(content: "") { _, path in
-            let handle = try NIOFileHandle(path: path)
+            let handle = try NIOFileHandle(_deprecatedPath: path)
             let region = try FileRegion(fileHandle: handle)
             defer {
                 XCTAssertNoThrow(try handle.close())

--- a/Tests/NIOPosixTests/NIOFileHandleTest.swift
+++ b/Tests/NIOPosixTests/NIOFileHandleTest.swift
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import NIOPosix
+import XCTest
+
+@testable import NIOCore
+
+final class NIOFileHandleTest: XCTestCase {
+    func testOpenCloseWorks() throws {
+        let pipeFDs = try Self.makePipe()
+        let fh1 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: pipeFDs.0)
+        XCTAssertTrue(fh1.isOpen)
+        defer {
+            XCTAssertTrue(fh1.isOpen)
+            XCTAssertNoThrow(try fh1.close())
+            XCTAssertFalse(fh1.isOpen)
+        }
+        let fh2 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: pipeFDs.1)
+        XCTAssertTrue(fh2.isOpen)
+        defer {
+            XCTAssertTrue(fh2.isOpen)
+            XCTAssertNoThrow(try fh2.close())
+            XCTAssertFalse(fh2.isOpen)
+        }
+        XCTAssertTrue(fh1.isOpen)
+        XCTAssertTrue(fh2.isOpen)
+    }
+
+    func testCloseStorm() throws {
+        for _ in 0..<1000 {
+            let pipeFDs = try Self.makePipe()
+            let fh1 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: pipeFDs.0)
+            let fh2 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: pipeFDs.1)
+
+            let threads = 32
+            let threadReadySems = (0..<threads).map { _ in
+                DispatchSemaphore(value: 0)
+            }
+            let threadGoSems = (0..<threads).map { _ in
+                DispatchSemaphore(value: 0)
+            }
+            let allDoneGroup = DispatchGroup()
+
+            for threadID in 0..<threads {
+                DispatchQueue.global().async(group: allDoneGroup) {
+                    threadReadySems[threadID].signal()
+                    threadGoSems[threadID].wait()
+
+                    do {
+                        if threadID % 2 == 0 {
+                            try fh1.close()
+                        } else {
+                            try fh2.close()
+                        }
+                    } catch let error as IOError where error.errnoCode == EBADF {
+                        // expected
+                    } catch {
+                        XCTFail("unexpected error \(error)")
+                    }
+                }
+            }
+
+            for threadReadySem in threadReadySems {
+                threadReadySem.wait()
+            }
+            for threadGoSem in threadGoSems {
+                threadGoSem.signal()
+            }
+            allDoneGroup.wait()
+            XCTAssertFalse(fh1.isOpen)
+            XCTAssertFalse(fh2.isOpen)
+        }
+    }
+
+    func testCloseVsUseRace() throws {
+        for _ in 0..<1000 {
+            let pipeFDs = try Self.makePipe()
+            let fh1 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: pipeFDs.0)
+            let fh2 = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: pipeFDs.1)
+
+            let threads = 32
+            let threadReadySems = (0..<threads).map { _ in
+                DispatchSemaphore(value: 0)
+            }
+            let threadGoSems = (0..<threads).map { _ in
+                DispatchSemaphore(value: 0)
+            }
+            let allDoneGroup = DispatchGroup()
+
+            for threadID in 0..<threads {
+                DispatchQueue.global().async(group: allDoneGroup) {
+                    threadReadySems[threadID].signal()
+                    threadGoSems[threadID].wait()
+
+                    do {
+                        switch threadID % 4 {
+                        case 0:
+                            try fh1.close()
+                        case 1:
+                            try fh2.close()
+                        case 2:
+                            try fh1.withUnsafeFileDescriptor { fd in
+                                precondition(fd >= 0)
+                                usleep(.random(in: 0..<10))
+                            }
+                        case 3:
+                            try fh2.withUnsafeFileDescriptor { fd in
+                                precondition(fd >= 0)
+                                usleep(.random(in: 0..<10))
+                            }
+                        default:
+                            fatalError("impossible")
+                        }
+                    } catch let error as IOError where error.errnoCode == EBADF || error.errnoCode == EBUSY {
+                        // expected
+                    } catch {
+                        XCTFail("unexpected error \(error)")
+                    }
+                }
+            }
+
+            for threadReadySem in threadReadySems {
+                threadReadySem.wait()
+            }
+            for threadGoSem in threadGoSems {
+                threadGoSem.signal()
+            }
+            allDoneGroup.wait()
+            for fh in [fh1, fh2] {
+                // They may or may not be closed, depends on races above.
+                do {
+                    try fh.close()
+                } catch let error as IOError where error.errnoCode == EBADF {
+                    // expected
+                }
+            }
+            XCTAssertFalse(fh1.isOpen)
+            XCTAssertFalse(fh2.isOpen)
+        }
+    }
+
+    // MARK: - Helpers
+    struct POSIXError: Error {
+        var what: String
+        var errnoCode: CInt
+    }
+
+    private static func makePipe() throws -> (CInt, CInt) {
+        var pipeFDs: [CInt] = [-1, -1]
+        let err = pipeFDs.withUnsafeMutableBufferPointer { pipePtr in
+            pipe(pipePtr.baseAddress!)
+        }
+        guard err == 0 else {
+            throw POSIXError(what: "pipe", errnoCode: errno)
+        }
+        return (pipeFDs[0], pipeFDs[1])
+    }
+}

--- a/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -634,7 +634,7 @@ class NonBlockingFileIOTest: XCTestCase {
     func testFileOpenWorks() throws {
         let content = "123"
         try withTemporaryFile(content: content) { (fileHandle, path) -> Void in
-            try self.fileIO.openFile(path: path, eventLoop: self.eventLoop).flatMapThrowing { vals in
+            try self.fileIO.openFile(_deprecatedPath: path, eventLoop: self.eventLoop).flatMapThrowing { vals in
                 let (fh, fr) = vals
                 try fh.withUnsafeFileDescriptor { fd in
                     XCTAssertGreaterThanOrEqual(fd, 0)
@@ -650,7 +650,7 @@ class NonBlockingFileIOTest: XCTestCase {
     func testFileOpenWorksWithEmptyFile() throws {
         let content = ""
         try withTemporaryFile(content: content) { (fileHandle, path) -> Void in
-            try self.fileIO.openFile(path: path, eventLoop: self.eventLoop).flatMapThrowing { vals in
+            try self.fileIO.openFile(_deprecatedPath: path, eventLoop: self.eventLoop).flatMapThrowing { vals in
                 let (fh, fr) = vals
                 try fh.withUnsafeFileDescriptor { fd in
                     XCTAssertGreaterThanOrEqual(fd, 0)
@@ -666,7 +666,7 @@ class NonBlockingFileIOTest: XCTestCase {
     func testFileOpenFails() throws {
         do {
             try self.fileIO.openFile(
-                path: "/dev/null/this/does/not/exist",
+                _deprecatedPath: "/dev/null/this/does/not/exist",
                 eventLoop: self.eventLoop
             ).map { _ in }.wait()
             XCTFail("should've thrown")
@@ -681,7 +681,7 @@ class NonBlockingFileIOTest: XCTestCase {
         XCTAssertNoThrow(
             try withTemporaryDirectory { dir in
                 try self.fileIO!.openFile(
-                    path: "\(dir)/file",
+                    _deprecatedPath: "\(dir)/file",
                     mode: .write,
                     flags: .allowFileCreation(),
                     eventLoop: self.eventLoop
@@ -694,7 +694,7 @@ class NonBlockingFileIOTest: XCTestCase {
         XCTAssertThrowsError(
             try withTemporaryDirectory { dir in
                 try self.fileIO!.openFile(
-                    path: "\(dir)/file",
+                    _deprecatedPath: "\(dir)/file",
                     mode: .write,
                     flags: .default,
                     eventLoop: self.eventLoop
@@ -709,7 +709,7 @@ class NonBlockingFileIOTest: XCTestCase {
         XCTAssertNoThrow(
             try withTemporaryDirectory { dir in
                 let fileHandle = try self.fileIO!.openFile(
-                    path: "\(dir)/file",
+                    _deprecatedPath: "\(dir)/file",
                     mode: .write,
                     flags: .allowFileCreation(),
                     eventLoop: self.eventLoop
@@ -734,7 +734,7 @@ class NonBlockingFileIOTest: XCTestCase {
         XCTAssertNoThrow(
             try withTemporaryDirectory { dir in
                 let fileHandle = try self.fileIO!.openFile(
-                    path: "\(dir)/file",
+                    _deprecatedPath: "\(dir)/file",
                     mode: [.write, .read],
                     flags: .allowFileCreation(),
                     eventLoop: self.eventLoop
@@ -761,7 +761,7 @@ class NonBlockingFileIOTest: XCTestCase {
                 // open 1 + write
                 try {
                     let fileHandle = try self.fileIO!.openFile(
-                        path: "\(dir)/file",
+                        _deprecatedPath: "\(dir)/file",
                         mode: [.write, .read],
                         flags: .allowFileCreation(),
                         eventLoop: self.eventLoop
@@ -782,7 +782,7 @@ class NonBlockingFileIOTest: XCTestCase {
                 // open 2 + write again + read
                 try {
                     let fileHandle = try self.fileIO!.openFile(
-                        path: "\(dir)/file",
+                        _deprecatedPath: "\(dir)/file",
                         mode: [.write, .read],
                         flags: .default,
                         eventLoop: self.eventLoop
@@ -826,7 +826,7 @@ class NonBlockingFileIOTest: XCTestCase {
                 // open 1 + write
                 try {
                     let fileHandle = try self.fileIO!.openFile(
-                        path: "\(dir)/file",
+                        _deprecatedPath: "\(dir)/file",
                         mode: [.write, .read],
                         flags: .allowFileCreation(),
                         eventLoop: self.eventLoop
@@ -847,7 +847,7 @@ class NonBlockingFileIOTest: XCTestCase {
                 // open 2 (with truncation) + write again + read
                 try {
                     let fileHandle = try self.fileIO!.openFile(
-                        path: "\(dir)/file",
+                        _deprecatedPath: "\(dir)/file",
                         mode: [.write, .read],
                         flags: .posix(flags: O_TRUNC, mode: 0),
                         eventLoop: self.eventLoop
@@ -1076,7 +1076,7 @@ class NonBlockingFileIOTest: XCTestCase {
             let expectation = XCTestExpectation(description: "Opened file")
             let threadPool = NIOThreadPool(numberOfThreads: 1)
             let fileIO = NonBlockingFileIO(threadPool: threadPool)
-            fileIO.openFile(path: path, eventLoop: eventLoopGroup.next()).whenFailure { (error) in
+            fileIO.openFile(_deprecatedPath: path, eventLoop: eventLoopGroup.next()).whenFailure { (error) in
                 XCTAssertTrue(error is NIOThreadPoolError.ThreadPoolInactive)
                 expectation.fulfill()
             }
@@ -1166,7 +1166,7 @@ class NonBlockingFileIOTest: XCTestCase {
             try withTemporaryDirectory { path in
                 let file = "\(path)/file"
                 let handle = try self.fileIO.openFile(
-                    path: file,
+                    _deprecatedPath: file,
                     mode: .write,
                     flags: .allowFileCreation(),
                     eventLoop: self.eventLoop
@@ -1186,7 +1186,7 @@ class NonBlockingFileIOTest: XCTestCase {
             try withTemporaryDirectory { path in
                 let file = "\(path)/file"
                 let handle = try self.fileIO.openFile(
-                    path: file,
+                    _deprecatedPath: file,
                     mode: .write,
                     flags: .allowFileCreation(),
                     eventLoop: self.eventLoop
@@ -1216,7 +1216,7 @@ class NonBlockingFileIOTest: XCTestCase {
             try withTemporaryDirectory { path in
                 let file = "\(path)/file"
                 let handle = try self.fileIO.openFile(
-                    path: file,
+                    _deprecatedPath: file,
                     mode: .write,
                     flags: .allowFileCreation(),
                     eventLoop: self.eventLoop
@@ -1557,7 +1557,7 @@ extension NonBlockingFileIOTest {
     func testAsyncFileOpenWorks() async throws {
         let content = "123"
         try await withTemporaryFile(content: content) { (fileHandle, path) -> Void in
-            try await self.fileIO.withFileRegion(path: path) { fr in
+            try await self.fileIO.withFileRegion(_deprecatedPath: path) { fr in
                 try fr.fileHandle.withUnsafeFileDescriptor { fd in
                     XCTAssertGreaterThanOrEqual(fd, 0)
                 }
@@ -1571,7 +1571,7 @@ extension NonBlockingFileIOTest {
     func testAsyncFileOpenWorksWithEmptyFile() async throws {
         let content = ""
         try await withTemporaryFile(content: content) { (fileHandle, path) -> Void in
-            try await self.fileIO.withFileRegion(path: path) { fr in
+            try await self.fileIO.withFileRegion(_deprecatedPath: path) { fr in
                 try fr.fileHandle.withUnsafeFileDescriptor { fd in
                     XCTAssertGreaterThanOrEqual(fd, 0)
                 }
@@ -1584,7 +1584,7 @@ extension NonBlockingFileIOTest {
 
     func testAsyncFileOpenFails() async throws {
         do {
-            _ = try await self.fileIO.withFileRegion(path: "/dev/null/this/does/not/exist") { _ in }
+            _ = try await self.fileIO.withFileRegion(_deprecatedPath: "/dev/null/this/does/not/exist") { _ in }
             XCTFail("should've thrown")
         } catch let e as IOError where e.errnoCode == ENOTDIR {
             // OK
@@ -1596,7 +1596,7 @@ extension NonBlockingFileIOTest {
     func testAsyncOpeningFilesForWriting() async throws {
         try await withTemporaryDirectory { dir in
             try await self.fileIO!.withFileHandle(
-                path: "\(dir)/file",
+                _deprecatedPath: "\(dir)/file",
                 mode: .write,
                 flags: .allowFileCreation()
             ) { _ in }
@@ -1607,7 +1607,7 @@ extension NonBlockingFileIOTest {
         do {
             try await withTemporaryDirectory { dir in
                 try await self.fileIO!.withFileHandle(
-                    path: "\(dir)/file",
+                    _deprecatedPath: "\(dir)/file",
                     mode: .write,
                     flags: .default
                 ) { _ in }
@@ -1621,7 +1621,7 @@ extension NonBlockingFileIOTest {
     func testAsyncOpeningFilesForWritingDoesNotAllowReading() async throws {
         try await withTemporaryDirectory { dir in
             try await self.fileIO!.withFileHandle(
-                path: "\(dir)/file",
+                _deprecatedPath: "\(dir)/file",
                 mode: .write,
                 flags: .allowFileCreation()
             ) { fileHandle in
@@ -1641,7 +1641,7 @@ extension NonBlockingFileIOTest {
     func testAsyncOpeningFilesForWritingAndReading() async throws {
         try await withTemporaryDirectory { dir in
             try await self.fileIO!.withFileHandle(
-                path: "\(dir)/file",
+                _deprecatedPath: "\(dir)/file",
                 mode: [.write, .read],
                 flags: .allowFileCreation()
             ) { fileHandle in
@@ -1663,7 +1663,7 @@ extension NonBlockingFileIOTest {
             // open 1 + write
             do {
                 try await self.fileIO.withFileHandle(
-                    path: "\(dir)/file",
+                    _deprecatedPath: "\(dir)/file",
                     mode: [.write, .read],
                     flags: .allowFileCreation()
                 ) { fileHandle in
@@ -1682,7 +1682,7 @@ extension NonBlockingFileIOTest {
             // open 2 + write again + read
             do {
                 try await self.fileIO!.withFileHandle(
-                    path: "\(dir)/file",
+                    _deprecatedPath: "\(dir)/file",
                     mode: [.write, .read],
                     flags: .default
                 ) { fileHandle in
@@ -1721,7 +1721,7 @@ extension NonBlockingFileIOTest {
             // open 1 + write
             do {
                 try await self.fileIO!.withFileHandle(
-                    path: "\(dir)/file",
+                    _deprecatedPath: "\(dir)/file",
                     mode: [.write, .read],
                     flags: .allowFileCreation()
                 ) { fileHandle in
@@ -1739,7 +1739,7 @@ extension NonBlockingFileIOTest {
             // open 2 (with truncation) + write again + read
             do {
                 try await self.fileIO!.withFileHandle(
-                    path: "\(dir)/file",
+                    _deprecatedPath: "\(dir)/file",
                     mode: [.write, .read],
                     flags: .posix(flags: O_TRUNC, mode: 0)
                 ) { fileHandle in
@@ -1811,7 +1811,7 @@ extension NonBlockingFileIOTest {
             let threadPool = NIOThreadPool(numberOfThreads: 1)
             let fileIO = NonBlockingFileIO(threadPool: threadPool)
             do {
-                try await fileIO.withFileRegion(path: path) { _ in }
+                try await fileIO.withFileRegion(_deprecatedPath: path) { _ in }
                 XCTFail("testAsyncThrowsErrorOnUnstartedPool: openFile should throw an error")
             } catch {
             }
@@ -1873,7 +1873,7 @@ extension NonBlockingFileIOTest {
         try await withTemporaryDirectory { path in
             let file = "\(path)/file"
             try await self.fileIO.withFileHandle(
-                path: file,
+                _deprecatedPath: file,
                 mode: .write,
                 flags: .allowFileCreation()
             ) { handle in
@@ -1887,7 +1887,7 @@ extension NonBlockingFileIOTest {
         try await withTemporaryDirectory { path in
             let file = "\(path)/file"
             try await self.fileIO.withFileHandle(
-                path: file,
+                _deprecatedPath: file,
                 mode: .write,
                 flags: .allowFileCreation()
             ) { handle in
@@ -1914,7 +1914,7 @@ extension NonBlockingFileIOTest {
         try await withTemporaryDirectory { path in
             let file = "\(path)/file"
             try await self.fileIO.withFileHandle(
-                path: file,
+                _deprecatedPath: file,
                 mode: .write,
                 flags: .allowFileCreation()
             ) { handle in

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -45,8 +45,8 @@ func withPipe(_ body: (NIOCore.NIOFileHandle, NIOCore.NIOFileHandle) throws -> [
     fds.withUnsafeMutableBufferPointer { ptr in
         XCTAssertEqual(0, pipe(ptr.baseAddress!))
     }
-    let readFH = NIOFileHandle(descriptor: fds[0])
-    let writeFH = NIOFileHandle(descriptor: fds[1])
+    let readFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[0])
+    let writeFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[1])
     var toClose: [NIOFileHandle] = [readFH, writeFH]
     var error: Error? = nil
     do {
@@ -70,8 +70,8 @@ func withPipe(
     fds.withUnsafeMutableBufferPointer { ptr in
         XCTAssertEqual(0, pipe(ptr.baseAddress!))
     }
-    let readFH = NIOFileHandle(descriptor: fds[0])
-    let writeFH = NIOFileHandle(descriptor: fds[1])
+    let readFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[0])
+    let writeFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[1])
     var toClose: [NIOFileHandle] = [readFH, writeFH]
     var error: Error? = nil
     do {
@@ -149,7 +149,7 @@ func withTemporaryUnixDomainSocketPathName<T>(
 
 func withTemporaryFile<T>(content: String? = nil, _ body: (NIOCore.NIOFileHandle, String) throws -> T) rethrows -> T {
     let (fd, path) = openTemporaryFile()
-    let fileHandle = NIOFileHandle(descriptor: fd)
+    let fileHandle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fd)
     defer {
         XCTAssertNoThrow(try fileHandle.close())
         XCTAssertEqual(0, unlink(path))
@@ -181,7 +181,7 @@ func withTemporaryFile<T>(
     _ body: @escaping @Sendable (NIOCore.NIOFileHandle, String) async throws -> T
 ) async rethrows -> T {
     let (fd, path) = openTemporaryFile()
-    let fileHandle = NIOFileHandle(descriptor: fd)
+    let fileHandle = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fd)
     defer {
         XCTAssertNoThrow(try fileHandle.close())
         XCTAssertEqual(0, unlink(path))


### PR DESCRIPTION
Motivation:

`IOData` is a legacy but alas also core type that needs to be `Sendable`. Before this PR however it can't be `Sendable` because it holds a `FileRegion` which holds a `NIOFileDescriptor`. So let's make all of these `Sendable` but let's also start the deprecation journey for the following types:

- `IOData`, now soft-deprecated (no warnings) because on its reliance on `FileRegion`
- `FileRegion`, now soft-deprecated (no warnings) because on its reliance on `NIOFileHandle`
- `NIOFileHandle`, now soft-deprecated (warnings on the `NIOFileHandle(descriptor:)` constructor but with a `NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor:)` alternative
- `NonBlockingFileIO`, now soft-deprecated (warnings on the `openFile` functions (but with `_deprecated` alternatives) because of their reliance on `NIOFileHandle)

Modification:

- Make `NIOFileDescriptor`, `FileRegion` and `IOData` `Sendable` by tracking the fd number and the usage state in an atomic
- Enforce singular access by making the `withFileDescriptor { fd ... }` function atomically exchange the fd number for a "I'm busy" sentinel value
- Start deprecating `IOData`, `NIOFileHandle`, `NonBlockingFileIO`, `FileRegion`

Result:
- `NIOFileDescriptor`, `FileRegion` and `IOData` can be `Sendable`