### PR TITLE
Build for Android with NDK 26, by accounting for the new nullability annotations

### DIFF
--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -68,8 +68,13 @@ import Musl
 #endif
 import CNIOLinux
 
+#if os(Android)
+private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer, UnsafeMutablePointer<CChar>, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
+private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>, UnsafeMutableRawPointer) -> CInt = inet_pton
+#else
 private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
 private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> CInt = inet_pton
+#endif
 #elseif canImport(Darwin)
 import Darwin
 

--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -123,7 +123,7 @@ public final class NIONetworkInterface {
     }
 #else
     internal init?(_ caddr: ifaddrs) {
-        self.name = String(cString: caddr.ifa_name)
+        self.name = String(cString: caddr.ifa_name!)
 
         guard caddr.ifa_addr != nil else {
             return nil
@@ -414,7 +414,7 @@ extension NIONetworkDevice {
         }
 #else
         internal init?(_ caddr: ifaddrs) {
-            self.name = String(cString: caddr.ifa_name)
+            self.name = String(cString: caddr.ifa_name!)
             self.address = caddr.ifa_addr.flatMap { $0.convert() }
             self.netmask = caddr.ifa_netmask.flatMap { $0.convert() }
 

--- a/Sources/NIOCore/SystemCallHelpers.swift
+++ b/Sources/NIOCore/SystemCallHelpers.swift
@@ -43,10 +43,15 @@ private let sysOpenWithMode: @convention(c) (UnsafePointer<CChar>, CInt, NIOPOSI
 private let sysLseek: @convention(c) (CInt, off_t, CInt) -> off_t = lseek
 private let sysRead: @convention(c) (CInt, UnsafeMutableRawPointer?, size_t) -> size_t = read
 #endif
-private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsignedInt = if_nametoindex
 
+#if os(Android)
+private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>) -> CUnsignedInt = if_nametoindex
+private let sysGetifaddrs: @convention(c) (UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>) -> CInt = getifaddrs
+#else
+private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsignedInt = if_nametoindex
 #if !os(Windows)
 private let sysGetifaddrs: @convention(c) (UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>?) -> CInt = getifaddrs
+#endif
 #endif
 
 private func isUnacceptableErrno(_ code: Int32) -> Bool {
@@ -173,7 +178,7 @@ enum SystemCalls {
     @inline(never)
     internal static func if_nametoindex(_ name: UnsafePointer<CChar>?) throws -> CUnsignedInt {
         return try syscall(blocking: false) {
-            sysIfNameToIndex(name)
+            sysIfNameToIndex(name!)
         }.result
     }
 

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -90,7 +90,7 @@ func sysRecvFrom_wrapper(sockfd: CInt, buf: UnsafeMutableRawPointer, len: CLong,
     return recvfrom(sockfd, buf, len, flags, src_addr, addrlen) // src_addr is 'UnsafeMutablePointer', but it need to be 'UnsafePointer'
 }
 func sysWritev_wrapper(fd: CInt, iov: UnsafePointer<iovec>?, iovcnt: CInt) -> CLong {
-    return CLong(writev(fd, iov, iovcnt)) // cast 'Int32' to 'CLong'
+    return CLong(writev(fd, iov!, iovcnt)) // cast 'Int32' to 'CLong'
 }
 private let sysWritev = sysWritev_wrapper
 #elseif !os(Windows)
@@ -106,12 +106,16 @@ private let sysGetpeername: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>
 private let sysGetsockname: @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = getsockname
 #endif
 
+#if os(Android)
+private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>) -> CUnsignedInt = if_nametoindex
+#else
 private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsignedInt = if_nametoindex
+#endif
 #if !os(Windows)
 private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>?) -> CInt = socketpair
 #endif
 
-#if os(Linux) && !canImport(Musl)
+#if (os(Linux) && !canImport(Musl)) || os(Android)
 private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>) -> CInt = fstat
 private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat
 private let sysLstat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = lstat
@@ -122,9 +126,14 @@ private let sysMkdir: @convention(c) (UnsafePointer<CChar>, mode_t) -> CInt = mk
 private let sysOpendir: @convention(c) (UnsafePointer<CChar>) -> OpaquePointer? = opendir
 private let sysReaddir: @convention(c) (OpaquePointer) -> UnsafeMutablePointer<dirent>? = readdir
 private let sysClosedir: @convention(c) (OpaquePointer) -> CInt = closedir
+#if os(Android)
+private let sysRename: @convention(c) (UnsafePointer<CChar>, UnsafePointer<CChar>) -> CInt = rename
+private let sysRemove: @convention(c) (UnsafePointer<CChar>) -> CInt = remove
+#else
 private let sysRename: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> CInt = rename
 private let sysRemove: @convention(c) (UnsafePointer<CChar>?) -> CInt = remove
-#elseif canImport(Darwin) || os(Android)
+#endif
+#elseif canImport(Darwin)
 private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>?) -> CInt = fstat
 private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat
 private let sysLstat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = lstat
@@ -132,16 +141,10 @@ private let sysSymlink: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CCh
 private let sysReadlink: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<CChar>?, Int) -> CLong = readlink
 private let sysUnlink: @convention(c) (UnsafePointer<CChar>?) -> CInt = unlink
 private let sysMkdir: @convention(c) (UnsafePointer<CChar>?, mode_t) -> CInt = mkdir
-#if os(Android)
-private let sysOpendir: @convention(c) (UnsafePointer<CChar>?) -> OpaquePointer? = opendir
-private let sysReaddir: @convention(c) (OpaquePointer?) -> UnsafeMutablePointer<dirent>? = readdir
-private let sysClosedir: @convention(c) (OpaquePointer?) -> CInt = closedir
-#else
 private let sysMkpath: @convention(c) (UnsafePointer<CChar>?, mode_t) -> CInt = mkpath_np
 private let sysOpendir: @convention(c) (UnsafePointer<CChar>?) -> UnsafeMutablePointer<DIR>? = opendir
 private let sysReaddir: @convention(c) (UnsafeMutablePointer<DIR>?) -> UnsafeMutablePointer<dirent>? = readdir
 private let sysClosedir: @convention(c) (UnsafeMutablePointer<DIR>?) -> CInt = closedir
-#endif
 private let sysRename: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> CInt = rename
 private let sysRemove: @convention(c) (UnsafePointer<CChar>?) -> CInt = remove
 #endif
@@ -732,7 +735,7 @@ internal enum Posix {
     @inline(never)
     internal static func if_nametoindex(_ name: UnsafePointer<CChar>?) throws -> CUnsignedInt {
         return try syscall(blocking: false) {
-            sysIfNameToIndex(name)
+            sysIfNameToIndex(name!)
         }.result
     }
 

--- a/Sources/NIOPosix/ThreadPosix.swift
+++ b/Sources/NIOPosix/ThreadPosix.swift
@@ -19,7 +19,11 @@ import CNIOLinux
 
 private let sys_pthread_getname_np = CNIOLinux_pthread_getname_np
 private let sys_pthread_setname_np = CNIOLinux_pthread_setname_np
+#if os(Android)
+private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
+#else
 private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer?
+#endif
 #elseif canImport(Darwin)
 private let sys_pthread_getname_np = pthread_getname_np
 // Emulate the same method signature as pthread_setname_np on Linux.
@@ -111,7 +115,11 @@ enum ThreadOpsPosix: ThreadOps {
 
             body(NIOThread(handle: hThread, desiredName: name))
 
+            #if os(Android)
+            return UnsafeMutableRawPointer(bitPattern: 0xdeadbee)!
+            #else
             return nil
+            #endif
         }, args: argv0)
         precondition(res == 0, "Unable to create thread: \(res)")
 


### PR DESCRIPTION
### Motivation:

Fix build for the latest LTS NDK 26

### Modifications:

- Update C declarations
- Add force unwraps where needed

### Result:

Everything works on Android with NDK 26b

This is needed because [Bionic recently added a bunch of these annotations](https://android.googlesource.com/platform/bionic/+/1cda74daba3834a819a58e4b4aae909a8ede5a7e%5E%21/#F0). I made sure this pull doesn't break anything by testing it on linux x86_64, and the force unwraps with the previous NDK 25c too. I used this patch with others to build the Swift toolchain and this package for my Android CI, finagolfin/swift-android-sdk#122.