### PR TITLE
Update APNSwift Repository Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Protocol | Client | Server | Repository | Module | Comment
 --- |  --- | --- | --- | --- | ---
 HTTP | ✅| ❌ | [swift-server/async-http-client](https://github.com/swift-server/async-http-client) | `AsyncHTTPClient` | SSWG community project
 gRPC | ✅| ✅ | [grpc/grpc-swift](https://github.com/grpc/grpc-swift) | `GRPC` | also offers a low-level API; SSWG community project
-APNS | ✅ | ❌ | [kylebrowning/APNSwift](https://github.com/kylebrowning/APNSwift) | `APNSwift` | SSWG community project
+APNS | ✅ | ❌ | [swift-server-community/APNSwift](https://github.com/swift-server-community/APNSwift) | `APNSwift` | SSWG community project
 PostgreSQL | ✅ | ❌ | [vapor/postgres-nio](https://github.com/vapor/postgres-nio) | `PostgresNIO` | SSWG community project
 Redis | ✅ | ❌ | [swift-server/RediStack](https://github.com/swift-server/RediStack) | `RediStack` | SSWG community project
 


### PR DESCRIPTION
Updated the APNSwift repository link in SwiftNIO’s documentation.

### Motivation:

The original link in the SwiftNIO documentation to the APNSwift repository was outdated, pointing to kylebrowning/APNSwift. This change is to direct users to the currently active and maintained repository

### Modifications:

Replaced the link kylebrowning/APNSwift with swift-server-community/APNSwift in the relevant documentation section.

### Result:

After this change, SwiftNIO documentation will correctly direct users to the active swift-server-community/APNSwift repository, enhancing the reliability and utility of the documentation.
