### PR TITLE
Fix warnings caused by not defining the feature macros.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,10 @@ let package = Package(
         ),
         .target(
             name: "CNIOAtomics",
-            dependencies: []
+            dependencies: [],
+            cSettings: [
+                .define("_GNU_SOURCE"),
+            ]
         ),
         .target(
             name: "CNIOSHA1",
@@ -159,7 +162,10 @@ let package = Package(
         ),
         .target(
             name: "CNIOLLHTTP",
-            cSettings: [.define("LLHTTP_STRICT_MODE")]
+            cSettings: [
+              .define("_GNU_SOURCE"),
+              .define("LLHTTP_STRICT_MODE")
+            ]
         ),
         .target(
             name: "NIOTLS",


### PR DESCRIPTION
We should define `_GNU_SOURCE` for all of the C modules, really. Relying on `features.h` doesn't work for modular headers.

### Motivation:

Unfortunately, the defaults in `<features.h>` don't really work for modular headers, so we need to define `_GNU_SOURCE` in a couple more places (mostly to avoid a compiler warning).

### Modifications:

Add `_GNU_SOURCE` in a couple of places.

### Result:

There shouldn't be a huge impact; we won't generate compiler warnings about `<features.h>` in a couple of places where we were doing before (assuming modular headers).