### PR TITLE
Fix test availability annotations

### DIFF
--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -17,9 +17,9 @@ import NIOConcurrencyHelpers
 import NIOEmbedded
 import XCTest
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncChannelTests: XCTestCase {
     func testAsyncChannelCloseOnWrite() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         final class CloseOnWriteHandler: ChannelOutboundHandler {
             typealias OutboundIn = String
 
@@ -39,7 +39,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testAsyncChannelBasicFunctionality() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try NIOAsyncChannel<String, Never>(wrappingChannelSynchronously: channel)
@@ -65,7 +64,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testAsyncChannelBasicWrites() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try NIOAsyncChannel<Never, String>(wrappingChannelSynchronously: channel)
@@ -84,7 +82,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testFinishingTheWriterClosesTheWriteSideOfTheChannel() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let closeRecorder = CloseRecorder()
         try await channel.pipeline.addHandler(closeRecorder)
@@ -116,7 +113,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testDroppingEverythingDoesntCloseTheChannel() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let closeRecorder = CloseRecorder()
         try await channel.pipeline.addHandler(CloseSuppressor())
@@ -148,7 +144,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testReadsArePropagated() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try NIOAsyncChannel<String, Never>(wrappingChannelSynchronously: channel)
@@ -167,7 +162,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testErrorsArePropagatedButAfterReads() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try NIOAsyncChannel<String, Never>(wrappingChannelSynchronously: channel)
@@ -190,7 +184,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testChannelBecomingNonWritableDelaysWriters() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try NIOAsyncChannel<Never, String>(wrappingChannelSynchronously: channel)
@@ -227,7 +220,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testBufferDropsReadsIfTheReaderIsGone() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         try await channel.pipeline.addHandler(CloseSuppressor()).get()
         do {
@@ -252,7 +244,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testManagingBackPressure() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let readCounter = ReadCounter()
         try await channel.pipeline.addHandler(readCounter)
@@ -367,7 +358,6 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testCanWrapAChannelSynchronously() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let channel = NIOAsyncTestingChannel()
         let wrapped = try await channel.testingEventLoop.executeInContext {
             try NIOAsyncChannel<String, String>(wrappingChannelSynchronously: channel)

--- a/Tests/NIOCoreTests/AsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequenceTests.swift
@@ -25,9 +25,9 @@ fileprivate struct TestCase {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncSequenceCollectTests: XCTestCase {
     func testAsyncSequenceCollect() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let testCases = [
             TestCase([
                 [],

--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -17,9 +17,9 @@ import Atomics
 import NIOCore
 @testable import NIOEmbedded
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class AsyncTestingChannelTests: XCTestCase {
     func testSingleHandlerInit() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         class Handler: ChannelInboundHandler {
             typealias InboundIn = Never
         }
@@ -29,7 +29,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testEmptyInit() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
 
         class Handler: ChannelInboundHandler {
             typealias InboundIn = Never
@@ -43,7 +42,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testMultipleHandlerInit() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         class Handler: ChannelInboundHandler, RemovableChannelHandler {
             typealias InboundIn = Never
             let identifier: String
@@ -67,7 +65,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWaitForInboundWrite() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         let task = Task {
             try await XCTAsyncAssertEqual(try await channel.waitForInboundWrite(), 1)
@@ -82,7 +79,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWaitForMultipleInboundWritesInParallel() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         let task = Task {
             let task1 = Task { try await channel.waitForInboundWrite(as: Int.self) }
@@ -102,7 +98,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWaitForOutboundWrite() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         let task = Task {
             try await XCTAsyncAssertEqual(try await channel.waitForOutboundWrite(), 1)
@@ -117,7 +112,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWaitForMultipleOutboundWritesInParallel() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         let task = Task {
             let task1 = Task { try await channel.waitForOutboundWrite(as: Int.self) }
@@ -137,7 +131,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteOutboundByteBuffer() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         var buf = channel.allocator.buffer(capacity: 1024)
         buf.writeString("hello")
@@ -158,7 +151,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteOutboundByteBufferMultipleTimes() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         var buf = channel.allocator.buffer(capacity: 1024)
         buf.writeString("hello")
@@ -179,7 +171,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteInboundByteBuffer() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         var buf = channel.allocator.buffer(capacity: 1024)
         buf.writeString("hello")
@@ -192,7 +183,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteInboundByteBufferMultipleTimes() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         var buf = channel.allocator.buffer(capacity: 1024)
         buf.writeString("hello")
@@ -213,7 +203,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteInboundByteBufferReThrow() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         XCTAssertNoThrow(try channel.pipeline.addHandler(ExceptionThrowingInboundHandler()).wait())
         await XCTAsyncAssertThrowsError(try await channel.writeInbound("msg")) { error in
@@ -223,7 +212,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteOutboundByteBufferReThrow() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         XCTAssertNoThrow(try channel.pipeline.addHandler(ExceptionThrowingOutboundHandler()).wait())
         await XCTAsyncAssertThrowsError(try await channel.writeOutbound("msg")) { error in
@@ -233,7 +221,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testReadOutboundWrongTypeThrows() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         try await XCTAsyncAssertTrue(await channel.writeOutbound("hello").isFull)
         do {
@@ -248,7 +235,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testReadInboundWrongTypeThrows() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         try await XCTAsyncAssertTrue(await channel.writeInbound("hello").isFull)
         do {
@@ -263,7 +249,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWrongTypesWithFastpathTypes() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
 
         let buffer = channel.allocator.buffer(capacity: 0)
@@ -312,7 +297,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testCloseMultipleTimesThrows() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         try await XCTAsyncAssertTrue(await channel.finish().isClean)
 
@@ -326,7 +310,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testCloseOnInactiveIsOk() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         let inactiveHandler = CloseInChannelInactiveHandler()
         XCTAssertNoThrow(try channel.pipeline.addHandler(inactiveHandler).wait())
@@ -337,7 +320,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testEmbeddedLifecycle() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let handler = ChannelLifecycleHandler()
         XCTAssertEqual(handler.currentState, .unregistered)
 
@@ -383,7 +365,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testEmbeddedChannelAndPipelineAndChannelCoreShareTheEventLoop() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         let pipelineEventLoop = channel.pipeline.eventLoop
         XCTAssert(pipelineEventLoop === channel.eventLoop)
@@ -392,7 +373,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSendingAnythingOnEmbeddedChannel() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         let buffer = ByteBufferAllocator().buffer(capacity: 5)
         let socketAddress = try SocketAddress(unixDomainSocketPath: "path")
@@ -411,7 +391,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testActiveWhenConnectPromiseFiresAndInactiveWhenClosePromiseFires() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         XCTAssertFalse(channel.isActive)
         let connectPromise = channel.eventLoop.makePromise(of: Void.self)
@@ -431,7 +410,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testWriteWithoutFlushDoesNotWrite() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
 
         let buf = ByteBuffer(bytes: [1])
@@ -445,7 +423,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSetLocalAddressAfterSuccessfulBind() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
 
         let channel = NIOAsyncTestingChannel()
         let bindPromise = channel.eventLoop.makePromise(of: Void.self)
@@ -459,7 +436,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSetRemoteAddressAfterSuccessfulConnect() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
 
         let channel = NIOAsyncTestingChannel()
         let connectPromise = channel.eventLoop.makePromise(of: Void.self)
@@ -473,7 +449,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testUnprocessedOutboundUserEventFailsOnEmbeddedChannel() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
 
         let channel = NIOAsyncTestingChannel()
         XCTAssertThrowsError(try channel.triggerUserOutboundEvent("event").wait()) { (error: Error) in
@@ -487,7 +462,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testEmbeddedChannelWritabilityIsWritable() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
 
         let channel = NIOAsyncTestingChannel()
         let opaqueChannel: Channel = channel
@@ -500,7 +474,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testFinishWithRecursivelyScheduledTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
             let channel = NIOAsyncTestingChannel()
             let invocations = AtomicCounter()
 
@@ -518,7 +491,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSyncOptionsAreSupported() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         try channel.testingEventLoop.submit {
             let options = channel.syncOptions
@@ -530,7 +502,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testGetChannelOptionAutoReadIsSupported() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         try channel.testingEventLoop.submit {
             let options = channel.syncOptions
@@ -541,7 +512,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSetGetChannelOptionAllowRemoteHalfClosureIsSupported() throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         try channel.testingEventLoop.submit {
             let options = channel.syncOptions
@@ -559,7 +529,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSecondFinishThrows() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let channel = NIOAsyncTestingChannel()
         _ = try await channel.finish()
         await XCTAsyncAssertThrowsError(try await channel.finish())

--- a/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
@@ -19,9 +19,9 @@ import Atomics
 
 private class EmbeddedTestError: Error { }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class NIOAsyncTestingEventLoopTests: XCTestCase {
     func testExecuteDoesNotImmediatelyRunTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let callbackRan = ManagedAtomic(false)
         let loop = NIOAsyncTestingEventLoop()
         try await loop.executeInContext {
@@ -33,7 +33,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecuteWillRunAllTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let runCount = ManagedAtomic(0)
         let loop = NIOAsyncTestingEventLoop()
         loop.execute { runCount.wrappingIncrement(ordering: .relaxed) }
@@ -50,7 +49,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecuteWillRunTasksAddedRecursively() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let sentinel = ManagedAtomic(0)
         let loop = NIOAsyncTestingEventLoop()
 
@@ -80,7 +78,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecuteRunsImmediately() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let callbackRan = ManagedAtomic(false)
         let loop = NIOAsyncTestingEventLoop()
         loop.execute { callbackRan.store(true, ordering: .relaxed) }
@@ -99,7 +96,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testTasksScheduledAfterRunDontRun() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let callbackRan = ManagedAtomic(false)
         let loop = NIOAsyncTestingEventLoop()
         loop.scheduleTask(deadline: loop.now) { callbackRan.store(true, ordering: .relaxed) }
@@ -120,7 +116,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testSubmitRunsImmediately() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let callbackRan = ManagedAtomic(false)
         let loop = NIOAsyncTestingEventLoop()
         _ = loop.submit { callbackRan.store(true, ordering: .relaxed) }
@@ -139,7 +134,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testSyncShutdownGracefullyRunsTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let callbackRan = ManagedAtomic(false)
         let loop = NIOAsyncTestingEventLoop()
         loop.scheduleTask(deadline: loop.now) { callbackRan.store(true, ordering: .relaxed) }
@@ -154,7 +148,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testShutdownGracefullyRunsTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let callbackRan = ManagedAtomic(false)
         let loop = NIOAsyncTestingEventLoop()
         loop.scheduleTask(deadline: loop.now) { callbackRan.store(true, ordering: .relaxed) }
@@ -169,7 +162,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testCanControlTime() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let callbackCount = ManagedAtomic(0)
         let loop = NIOAsyncTestingEventLoop()
         _ = loop.scheduleTask(in: .nanoseconds(5)) {
@@ -198,7 +190,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testCanScheduleMultipleTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let sentinel = ManagedAtomic(0)
         let loop = NIOAsyncTestingEventLoop()
         for index in 1...10 {
@@ -219,7 +210,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecutedTasksFromScheduledOnesAreRun() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let sentinel = ManagedAtomic(0)
         let loop = NIOAsyncTestingEventLoop()
         _ = loop.scheduleTask(in: .nanoseconds(5)) {
@@ -240,7 +230,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksFromScheduledTasksProperlySchedule() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let sentinel = ManagedAtomic(0)
         let loop = NIOAsyncTestingEventLoop()
         _ = loop.scheduleTask(in: .nanoseconds(5)) {
@@ -280,7 +269,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksFromExecutedTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let sentinel = ManagedAtomic(0)
         let loop = NIOAsyncTestingEventLoop()
         loop.execute {
@@ -299,7 +287,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testCancellingScheduledTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let loop = NIOAsyncTestingEventLoop()
         let task = loop.scheduleTask(in: .nanoseconds(10), { XCTFail("Cancelled task ran") })
         _ = loop.scheduleTask(in: .nanoseconds(5)) {
@@ -310,7 +297,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksFuturesFire() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let fired = ManagedAtomic(false)
         let loop = NIOAsyncTestingEventLoop()
         let task = loop.scheduleTask(in: .nanoseconds(5)) { true }
@@ -323,7 +309,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksFuturesError() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let err = EmbeddedTestError()
         let fired = ManagedAtomic(false)
         let loop = NIOAsyncTestingEventLoop()
@@ -345,7 +330,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testTaskOrdering() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         // This test validates that the ordering of task firing on NIOAsyncTestingEventLoop via
         // advanceTime(by:) is the same as on MultiThreadedEventLoopGroup: specifically, that tasks run via
         // schedule that expire "now" all run at the same time, and that any work they schedule is run
@@ -426,7 +410,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testCancelledScheduledTasksDoNotHoldOnToRunClosure() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let eventLoop = NIOAsyncTestingEventLoop()
         defer {
             XCTAssertNoThrow(try eventLoop.syncShutdownGracefully())
@@ -466,7 +449,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testDrainScheduledTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let eventLoop = NIOAsyncTestingEventLoop()
         let tasksRun = ManagedAtomic(0)
         let startTime = eventLoop.now
@@ -486,7 +468,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testDrainScheduledTasksDoesNotRunNewlyScheduledTasks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let eventLoop = NIOAsyncTestingEventLoop()
         let tasksRun = ManagedAtomic(0)
 
@@ -503,7 +484,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testAdvanceTimeToDeadline() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let eventLoop = NIOAsyncTestingEventLoop()
         let deadline = NIODeadline.uptimeNanoseconds(0) + .seconds(42)
 
@@ -517,7 +497,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testWeCantTimeTravelByAdvancingTimeToThePast() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let eventLoop = NIOAsyncTestingEventLoop()
 
         let tasksRun = ManagedAtomic(0)
@@ -539,7 +518,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testExecuteInOrder() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let eventLoop = NIOAsyncTestingEventLoop()
         let counter = ManagedAtomic(0)
 
@@ -563,7 +541,6 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
     }
 
     func testScheduledTasksInOrder() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let eventLoop = NIOAsyncTestingEventLoop()
         let counter = ManagedAtomic(0)
 

--- a/Tests/NIOPosixTests/NIOThreadPoolTest.swift
+++ b/Tests/NIOPosixTests/NIOThreadPoolTest.swift
@@ -19,6 +19,7 @@ import Dispatch
 import NIOConcurrencyHelpers
 import NIOEmbedded
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class NIOThreadPoolTest: XCTestCase {
     func testThreadNamesAreSetUp() {
         let numberOfThreads = 11
@@ -112,7 +113,6 @@ class NIOThreadPoolTest: XCTestCase {
     }
 
     func testAsyncThreadPool() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let numberOfThreads = 1
         let pool = NIOThreadPool(numberOfThreads: numberOfThreads)
         pool.start()
@@ -127,7 +127,6 @@ class NIOThreadPoolTest: XCTestCase {
     }
 
     func testAsyncThreadPoolErrorPropagation() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         struct ThreadPoolError: Error {}
         let numberOfThreads = 1
         let pool = NIOThreadPool(numberOfThreads: numberOfThreads)
@@ -144,7 +143,6 @@ class NIOThreadPoolTest: XCTestCase {
     }
 
     func testAsyncThreadPoolNotActiveError() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         struct ThreadPoolError: Error {}
         let numberOfThreads = 1
         let pool = NIOThreadPool(numberOfThreads: numberOfThreads)
@@ -160,7 +158,6 @@ class NIOThreadPoolTest: XCTestCase {
     }
 
     func testAsyncShutdownWorks() async throws {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { throw XCTSkip() }
         let threadPool = NIOThreadPool(numberOfThreads: 17)
         let eventLoop = NIOAsyncTestingEventLoop()
 

--- a/Tests/NIOPosixTests/SerialExecutorTests.swift
+++ b/Tests/NIOPosixTests/SerialExecutorTests.swift
@@ -37,14 +37,12 @@ actor EventLoopBoundActor {
 }
 #endif
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class SerialExecutorTests: XCTestCase {
     private func _testBasicExecutorFitsOnEventLoop(loop1: EventLoop, loop2: EventLoop) async throws {
         #if compiler(<5.9)
         throw XCTSkip("Custom executors are only supported in 5.9")
         #else
-        guard #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) else {
-            throw XCTSkip("Custom executors not available on this platform")
-        }
 
         let testActor = EventLoopBoundActor(loop: loop1)
         await testActor.assertInLoop(loop1)
@@ -61,7 +59,6 @@ final class SerialExecutorTests: XCTestCase {
         try await self._testBasicExecutorFitsOnEventLoop(loop1: loops[0], loop2: loops[1])
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testBasicExecutorFitsOnEventLoop_AsyncTestingEventLoop() async throws {
         let loop1 = NIOAsyncTestingEventLoop()
         let loop2 = NIOAsyncTestingEventLoop()

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -68,6 +68,7 @@ func withPipe(_ body: (NIOCore.NIOFileHandle, NIOCore.NIOFileHandle) throws -> [
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func withPipe(_ body: (NIOCore.NIOFileHandle, NIOCore.NIOFileHandle) async throws -> [NIOCore.NIOFileHandle]) async throws {
     var fds: [Int32] = [-1, -1]
     fds.withUnsafeMutableBufferPointer { ptr in
@@ -98,6 +99,7 @@ func withTemporaryDirectory<T>(_ body: (String) throws -> T) rethrows -> T {
     return try body(dir)
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func withTemporaryDirectory<T>(_ body: (String) async throws -> T) async rethrows -> T {
     let dir = createTemporaryDirectory()
     defer {
@@ -170,6 +172,7 @@ func withTemporaryFile<T>(content: String? = nil, _ body: (NIOCore.NIOFileHandle
     return try body(fileHandle, path)
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func withTemporaryFile<T>(content: String? = nil, _ body: @escaping @Sendable (NIOCore.NIOFileHandle, String) async throws -> T) async rethrows -> T {
     let (fd, path) = openTemporaryFile()
     let fileHandle = NIOFileHandle(descriptor: fd)

--- a/Tests/NIOSingletonsTests/GlobalSingletonsTests.swift
+++ b/Tests/NIOSingletonsTests/GlobalSingletonsTests.swift
@@ -18,11 +18,13 @@ import NIOPosix
 import Foundation
 
 final class NIOSingletonsTests: XCTestCase {
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testSingletonMultiThreadedEventLoopWorks() async throws {
         let works = try await MultiThreadedEventLoopGroup.singleton.any().submit { "yes" }.get()
         XCTAssertEqual(works, "yes")
     }
 
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testSingletonBlockingPoolWorks() async throws {
         let works = try await NIOThreadPool.singleton.runIfActive(
             eventLoop: MultiThreadedEventLoopGroup.singleton.any()


### PR DESCRIPTION
# Motivation
We are currently missing a bunch of annotations in our tests which leads to compilation failures if you build against generic iOS/macOS/watchOS/tvOS

# Modification
This PR adds the missing availability annotations in the tests.
