### PR TITLE
Fix warnings when building tests on Swift 5.9.2 Linux

### DIFF
--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
@@ -652,7 +652,7 @@ final class NIOAsyncWriterTests: XCTestCase {
     }
 }
 
-#if !canImport(Darwin) && swift(<5.10)
+#if !canImport(Darwin) && swift(<5.9.2)
 extension XCTestCase {
     func fulfillment(
         of expectations: [XCTestExpectation],


### PR DESCRIPTION
### Motivation:

Since 5.9.2 was released the `5.9` docker tags started resolving to 5.9.2 automatically, which have caused our CI to fail because 5.9.2 includes a new warning, which is promoted to error in our CI.

Explicitly using `5.9.2` tag shows this, but not for `5.9.1`:

```console
❯ docker run --rm -v $PWD:/code -w /code -it swift:5.9.1-jammy swift build --build-tests -Xswiftc -warnings-as-errors
Build complete! (24.22s)

❯ docker run --rm -v $PWD:/code -w /code -it swift:5.9.2-jammy swift build --build-tests -Xswiftc -warnings-as-errors
...
/code/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift:662:9: error: instance method 'wait' is unavailable from asynchronous contexts; Use await fulfillment(of:timeout:enforceOrder:) instead.; this is an error in Swift 6
        wait(for: expectations, timeout: seconds)
        ^
error: fatalError
[464/518] Linking NIOHTTP1Client
```

### Modifications:

Lower compiler guard for test utility backport.

### Result:

Works now with both versions:

```console
❯ docker run --rm -v $PWD:/code -w /code -it swift:5.9.1-jammy swift build --build-tests -Xswiftc -warnings-as-errors
...
Build complete! (36.65s)

❯ docker run --rm -v $PWD:/code -w /code -it swift:5.9.2-jammy swift build --build-tests -Xswiftc -warnings-as-errors
...
Build complete! (21.74s)
```
