### PR TITLE
Add cxx interop build pipeline

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -89,3 +89,6 @@ services:
 
   http:
     image: swift-nio:22.04-5.10
+    
+  cxx-interop-build:
+    image: swift-nio:22.04-5.10

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -90,3 +90,6 @@ services:
 
   http:
     image: swift-nio:22.04-5.9
+    
+  cxx-interop-build:
+    image: swift-nio:22.04-5.9

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -49,6 +49,10 @@ services:
   update-benchmark-baseline:
     <<: *common
     command: /bin/bash -xcl "cd Benchmarks && swift package --disable-sandbox --scratch-path .build/$${SWIFT_VERSION-}/ --allow-writing-to-package-directory benchmark --format metricP90AbsoluteThresholds --path Thresholds/$${SWIFT_VERSION-}/"
+    
+  cxx-interop-build:
+    <<: *common
+    command: /bin/bash -xcl "./scripts/cxx-interop-compatibility.sh"
 
   # util
 

--- a/scripts/cxx-interop-compatibility.sh
+++ b/scripts/cxx-interop-compatibility.sh
@@ -57,12 +57,7 @@ let package = Package(
                 .product(name: "_NIOConcurrency", package: "swift-nio")
             ],
             swiftSettings: [.interoperabilityMode(.Cxx)]
-        ),
-        .testTarget(
-            name: "interopTests",
-            dependencies: ["interop"],
-            swiftSettings: [.interoperabilityMode(.Cxx)]
-        ),
+        )
     ]
 )
 EOF

--- a/scripts/cxx-interop-compatibility.sh
+++ b/scripts/cxx-interop-compatibility.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+
+sourcedir=$(pwd)
+workingdir=$(mktemp -d)
+
+cd $workingdir
+swift package init
+
+cat << EOF > Package.swift
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "interop",
+    products: [
+        .library(
+            name: "interop",
+            targets: ["interop"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "$sourcedir")
+    ],
+    targets: [
+        .target(
+            name: "interop",
+            dependencies: [
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "NIOTLS", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOWebSocket", package: "swift-nio"),
+                .product(name: "NIOTestUtils", package: "swift-nio")
+            ],
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+        .testTarget(
+            name: "interopTests",
+            dependencies: ["interop"],
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+    ]
+)
+EOF
+
+swift build


### PR DESCRIPTION
This PR adds a new target to `docker-compose` that builds a new project that depends on this one, with C++ interoperability enabled, with the goal of adding a new CI pipeline that checks the build succeeds.

### Motivation:

To make sure that C++ interoperability can be used on projects that depend on `swift-nio`.

### Modifications:

- Added a new target to docker-compose that creates a new package that depends on `swift-nio`, and builds it with C++ interoperability enabled.
- Will request a new CI pipeline that runs this new target.

### Result:

We will ensure this projects builds properly with C++ interoperability enabled.