### PR TITLE
Support asynchronous MTELG construction

### DIFF
--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -68,7 +68,21 @@ internal final class SelectableEventLoop: EventLoop {
     }
 
     /* private but tests */ internal let _selector: NIOPosix.Selector<NIORegistration>
+
+    /// The thread on which this EL is running.
+    ///
+    /// This is a lazy reference because we may create the SelectableEventLoop before we have
+    /// started the thread on which it runs.
+    ///
+    /// This will be initialized when the EL thread starts (by a call to `launchedThread`).
+    /// It is always initialized by the EL thread, as the first thing the thread does before it
+    /// starts actually running the loop.
+    ///
+    /// This is acceptable because we only use this to detect whether we are "on" the EL. As we
+    /// can only be on the EL when we are on the thread, we know that if this value hasn't yet
+    /// been initialized then we cannot possibly be on the EL thread.
     private let thread: ManagedAtomicLazyReference<NIOThread>
+
     @usableFromInline
     // _pendingTaskPop is set to `true` if the event loop is about to pop tasks off the task queue.
     // This may only be read/written while holding the _tasksLock.

--- a/Sources/NIOPosix/SelectorEpoll.swift
+++ b/Sources/NIOPosix/SelectorEpoll.swift
@@ -281,11 +281,8 @@ extension Selector: _SelectorBackendProtocol {
 
     /* attention, this may (will!) be called from outside the event loop, ie. can't access mutable shared state (such as `self.open`) */
     func wakeup0() throws {
-        guard let thread = self._myThread.load() else {
-            // No need to wake up, the thread hasn't started yet. It'll run anyway.
-            return
-        }
-
+        // If `thread` is unset (and so nil) this assertion is still valid: we can't possibly be on the EL thread.
+        let thread = self._myThread.load()
         assert(NIOThread.current != thread)
         try self.externalSelectorFDLock.withLock {
                 guard self.eventFD >= 0 else {

--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -133,7 +133,21 @@ internal class Selector<R: Registration>  {
         // and the loop is running.
         self._myThread.load()!
     }
+    
+    /// The thread that owns this selector.
+    ///
+    /// This is a lazy reference because we may create the Selector before we have
+    /// started the thread to which it is bound.
+    ///
+    /// This will be initialized when the EL thread starts (by a call to `threadLaunched`).
+    /// It is always initialized by the EL thread, as the first thing the thread does before it
+    /// starts actually running the loop.
+    ///
+    /// This is acceptable because we only use this to detect whether we are "on" the EL. As we
+    /// can only be on the EL when we are on the thread, we know that if this value hasn't yet
+    /// been initialized then we cannot possibly be on the EL thread.
     let _myThread: ManagedAtomicLazyReference<NIOThread>
+    
     // The rules for `self.selectorFD`, `self.eventFD`, and `self.timerFD`:
     // reads: `self.externalSelectorFDLock` OR access from the EventLoop thread
     // writes: `self.externalSelectorFDLock` AND access from the EventLoop thread

--- a/Sources/NIOPosix/SelectorKqueue.swift
+++ b/Sources/NIOPosix/SelectorKqueue.swift
@@ -284,7 +284,12 @@ extension Selector: _SelectorBackendProtocol {
 
     /* attention, this may (will!) be called from outside the event loop, ie. can't access mutable shared state (such as `self.open`) */
     func wakeup0() throws {
-        assert(NIOThread.current != self.myThread)
+        guard let thread = self._myThread.load() else {
+            // No need to wake up, the thread hasn't started yet. It'll run anyway.
+            return
+        }
+
+        assert(NIOThread.current != thread)
         try self.externalSelectorFDLock.withLock {
                 guard self.selectorFD >= 0 else {
                     throw EventLoopError.shutdown

--- a/Sources/NIOPosix/SelectorKqueue.swift
+++ b/Sources/NIOPosix/SelectorKqueue.swift
@@ -284,11 +284,8 @@ extension Selector: _SelectorBackendProtocol {
 
     /* attention, this may (will!) be called from outside the event loop, ie. can't access mutable shared state (such as `self.open`) */
     func wakeup0() throws {
-        guard let thread = self._myThread.load() else {
-            // No need to wake up, the thread hasn't started yet. It'll run anyway.
-            return
-        }
-
+        // If `thread` is unset (and so nil) this assertion is still valid: we can't possibly be on the EL thread.
+        let thread = self._myThread.load()
         assert(NIOThread.current != thread)
         try self.externalSelectorFDLock.withLock {
                 guard self.selectorFD >= 0 else {

--- a/Tests/NIOPosixTests/SelectorTest.swift
+++ b/Tests/NIOPosixTests/SelectorTest.swift
@@ -36,6 +36,7 @@ class SelectorTest: XCTestCase {
         }
 
         let selector = try NIOPosix.Selector<TestRegistration>()
+        selector.threadLaunched(NIOThread.current)
         defer {
             XCTAssertNoThrow(try selector.close())
         }


### PR DESCRIPTION
Motivation

Currently when a MultithreadedEventLoopGroup is constructed we block the calling thread until all the background threads launch. Generally this is ok (we don't expect it to take long), but it can cause issues when the launching thread is high priority, as we will wait for those low priority threads to get time to execute.

Additionally, this causes nuisance warnings for users: see https://github.com/apple/swift-nio/issues/2223 for more.

To make this safe, we need to make it possible to construct a SelectableEventLoop instance before the owning thread has launched. This requires us to make the existing strong stored `thread` property into something that can be lazily initialized.

We need this property in order to correctly implement `inEventLoop`. The good news is that so long as the first thing the background thread does is initialize the property, we can draw a confident signal from this value being `nil`: we know that we aren't on the EL thread. After all, if we were, we would have already initialized that field!

This calls for your friend and mine, `ManagedAtomicLazyReference`.

Modifications

- Move the stored Thread object for SelectableEventLoop and Selector into a `ManagedAtomicLazyReference`.
- Provide convenience accessors that force-unwrap the EL.
- Fix a few specific use-cases that may actually run before the EL is provided.
- Update a couple of tests that can observe this change.

Result

We can now construct MTLEG without waiting for the background threads to spawn, and everything is fully functional.
