### PR TITLE
Fix the broken performance test binary

### DIFF
--- a/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
+++ b/Sources/NIOPerformanceTester/NIOAsyncWriterSingleWritesBenchmark.swift
@@ -44,7 +44,9 @@ final class NIOAsyncWriterSingleWritesBenchmark: AsyncBenchmark, @unchecked Send
     }
 
     func setUp() async throws {}
-    func tearDown() {}
+    func tearDown() {
+        self.writer.finish()
+    }
 
     func run() async throws -> Int {
         for i in 0..<self.iterations {


### PR DESCRIPTION
Motivation:

The performance test binary was crashing ever since #2589 added the crash on deinit flow. Crashes here are preventing us from using the performance tester.

Modifications:

Correctly clean up the async writer.

Result:

The writer is cleaned up now.
