### PR TITLE
Fix broken tests

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
+++ b/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
@@ -40,7 +40,7 @@ function hooked_package_swift_start() {
     shift 2
 
     cat <<"EOF"
-// swift-tools-version:5.1
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(
@@ -61,8 +61,8 @@ EOF
     cat <<EOF
     ],
     dependencies: [
-        .package(url: "HookedFunctions/", .branch("main")),
-        .package(url: "$swiftpm_pkg_name/", .branch("main")),
+        .package(url: "HookedFunctions/", branch: "main"),
+        .package(url: "$swiftpm_pkg_name/", branch: "main"),
 EOF
     if [[ -n "$extra_dependencies_file" ]]; then
         cat "$extra_dependencies_file"
@@ -79,11 +79,11 @@ function hooked_package_swift_target() {
     shift
     local deps=""
     for dep in "$@"; do
-        deps="$deps \"$dep\","
+        deps="$deps .product(name: \"$dep\", package: \"swift-nio\"),"
     done
     cat <<EOF
             .target(name: "Test_$target_name", dependencies: [$deps]),
-            .target(name: "bootstrap_$target_name",
+            .executableTarget(name: "bootstrap_$target_name",
                     dependencies: ["Test_$target_name", "HookedFunctions"]),
 EOF
 }
@@ -110,7 +110,7 @@ function dir_basename() {
 
 function fake_package_swift() {
     cat > Package.swift <<EOF
-// swift-tools-version:5.0
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(name: "$1")

--- a/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
+++ b/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
@@ -62,6 +62,7 @@ EOF
     ],
     dependencies: [
         .package(url: "HookedFunctions/", branch: "main"),
+        .package(url: "AtomicCounter/", branch: "main"),
         .package(url: "$swiftpm_pkg_name/", branch: "main"),
 EOF
     if [[ -n "$extra_dependencies_file" ]]; then
@@ -82,7 +83,7 @@ function hooked_package_swift_target() {
         deps="$deps .product(name: \"$dep\", package: \"swift-nio\"),"
     done
     cat <<EOF
-            .target(name: "Test_$target_name", dependencies: [$deps]),
+            .target(name: "Test_$target_name", dependencies: [$deps "AtomicCounter"]),
             .executableTarget(name: "bootstrap_$target_name",
                     dependencies: ["Test_$target_name", "HookedFunctions"]),
 EOF

--- a/IntegrationTests/allocation-counter-tests-framework/template/AtomicCounter/Package.swift
+++ b/IntegrationTests/allocation-counter-tests-framework/template/AtomicCounter/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //===----------------------------------------------------------------------===//
 //

--- a/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Package.swift
+++ b/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //===----------------------------------------------------------------------===//
 //
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "HookedFunctions", type: .dynamic, targets: ["HookedFunctions"]),
     ],
     dependencies: [
-        .package(url: "../AtomicCounter/", .branch("main")),
+        .package(url: "../AtomicCounter/", branch: "main"),
     ],
     targets: [
         .target(name: "HookedFunctions", dependencies: ["AtomicCounter"]),

--- a/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoNotHook/Package.swift
+++ b/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoNotHook/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //===----------------------------------------------------------------------===//
 //
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "HookedFunctions", type: .dynamic, targets: ["HookedFunctions"]),
     ],
     dependencies: [
-        .package(url: "../AtomicCounter/", .branch("main")),
+        .package(url: "../AtomicCounter/", branch: "main"),
     ],
     targets: [
         .target(name: "HookedFunctions", dependencies: ["AtomicCounter"]),

--- a/IntegrationTests/tests_05_assertions/defines.sh
+++ b/IntegrationTests/tests_05_assertions/defines.sh
@@ -17,7 +17,7 @@ set -eu
 
 function make_package() {
     cat > "$tmpdir/syscallwrapper/Package.swift" <<"EOF"
-// swift-tools-version:5.2
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/NIOCrashTester/CrashTests+EventLoop.swift
+++ b/Sources/NIOCrashTester/CrashTests+EventLoop.swift
@@ -180,7 +180,7 @@ struct EventLoopCrashTests {
         NIOSingletons.groupLoopCountSuggestion = -1
     }
 
-    #if compiler(>=5.9) // We only support Concurrency executor take-over on 5.9+
+    #if compiler(>=5.9) && swift(<5.11) // We only support Concurrency executor take-over on 5.9-5.10, as versions greater than 5.10 have not been properly tested.
     let testInstallingSingletonMTELGAsConcurrencyExecutorWorksButOnlyOnce = CrashTest(
         regex: #"Fatal error: Must be called only once"#
     ) {
@@ -207,6 +207,6 @@ struct EventLoopCrashTests {
         // This should crash
         _ = NIOSingletons.unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor()
     }
-    #endif // compiler(>=5.9)
+    #endif // compiler(>=5.9) && swift(<5.11)
 }
 #endif // !canImport(Darwin) || os(macOS)

--- a/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
@@ -860,31 +860,18 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
     }
 
     func testIteratorThrows_whenCancelled() async {
-        let maxSequenceValue = 99
-        _ = self.source.yield(contentsOf: Array(0...maxSequenceValue))
+        _ = self.source.yield(contentsOf: Array(1...100))
         await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                var counter = 0
+                var itemsYieldedCounter = 0
                 guard let sequence = self.sequence else {
                     return XCTFail("Expected to have an AsyncSequence")
                 }
 
                 do {
                     for try await next in sequence {
-                        XCTAssertEqual(next, counter)
-                        
-                        if next < maxSequenceValue {
-                            // This loop will exit when the task is cancelled
-                            // or when all of the elements have been iterated.
-                            // It is possible that the cancellation will be
-                            // triggered after the last element was yielded,
-                            // just before the iterator can return the `nil`
-                            // signifying the end of the sequence.
-                            // If this happens, we avoid incrementing the counter,
-                            // so that we don't increase it to a value beyond the
-                            // maximum possible sequence value.
-                            counter += 1
-                        }
+                        itemsYieldedCounter += 1
+                        XCTAssertEqual(next, itemsYieldedCounter)
                     }
                     XCTFail("Expected that this throws")
                 } catch is CancellationError {
@@ -893,7 +880,7 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
                     XCTFail("Unexpected error: \(error)")
                 }
 
-                XCTAssertLessThan(counter, 100)
+                XCTAssertLessThanOrEqual(itemsYieldedCounter, 100)
             }
 
             group.cancelAll()

--- a/dev/make-single-file-spm
+++ b/dev/make-single-file-spm
@@ -51,7 +51,7 @@ function setup_swiftpm_package() {
 
     cd "$destination"
     cat > Package.swift <<"EOF"
-// swift-tools-version:5.1
+// swift-tools-version:5.7
 import PackageDescription
 
 var targets: [PackageDescription.Target] = [


### PR DESCRIPTION
### Motivation:

This PR fixes several broken/flaky unit and integration tests, that started failing in our nightly pipeline. 

Namely:
- `NIOThrowingAsyncSequenceTests.testIteratorThrows_whenCancelled`: unit test was flaky.
- `EventLoopCrashTests.testInstallingSingletonMTELGAsConcurrencyExecutorWorksButOnlyOnce`: integration test failed in nightly.
- Compilation of allocation tests in nightly was failing.

### Modifications:

- Modified flaky unit test by fixing a small, edge-case bug (see [this comment](https://github.com/apple/swift-nio/pull/2621#discussion_r1443106360) for details).
- `EventLoopCrashTests.testInstallingSingletonMTELGAsConcurrencyExecutorWorksButOnlyOnce` was failing because we forgot to disable the test for Swift versions greater than 5.10. There isn't sufficient testing done on this feature on versions greater than 5.10, so the whole feature is simply disabled in those cases, so the test should be too.
- Building allocation tests was failing in nightly because `AtomicCounter` was not an explicit dependency of the test targets. This worked before because all modules were always visible to targets, but this changed in https://github.com/apple/swift-package-manager/pull/7103. I added `AtomicCounter` as a dependency to these targets and the build now succeeds.
- Updated old `swift-tools-version` in generated `Package.swift`s to 5.7. This wasn't necessary to fixing the issues but they were lagging behind by a lot (some were version 5.0).

### Result:

Happy nightly pipeline.