### PR TITLE
Fix `NIOAsyncChannel` allocation benchmarks

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../"),
-        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.11.1"),
+        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.22.0"),
     ],
     targets: [
         .executableTarget(

--- a/Benchmarks/Thresholds/5.10/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
+++ b/Benchmarks/Thresholds/5.10/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 165000
+}

--- a/Benchmarks/Thresholds/5.9/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
+++ b/Benchmarks/Thresholds/5.9/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 164000
+}

--- a/Benchmarks/Thresholds/main/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
+++ b/Benchmarks/Thresholds/main/NIOPosixBenchmarks.TCPEchoAsyncChannel.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 165000
+}


### PR DESCRIPTION
# Motivation
We had to disable the benchmarks since they regressed without us noticing and they appear to be flaky.

# Modification
This PR fixes the allocation regression and tries to re-enable them.
