### PR TITLE
Add additional guards in tests for mocking

### DIFF
--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -1093,6 +1093,7 @@ final class FileHandleTests: XCTestCase {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 private func assertThrowsErrorClosed<R>(
     line: UInt = #line,
     _ expression: () async throws -> R

--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
@@ -1028,6 +1028,7 @@ final class FileSystemTests: XCTestCase {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension FileSystemTests {
     private func checkDirectoriesMatch(_ root1: FilePath, _ root2: FilePath) async throws {
         func namesAndTypes(_ root: FilePath) async throws -> [(FilePath.Component, FileType)] {

--- a/Tests/NIOFileSystemIntegrationTests/XCTestExtensions.swift
+++ b/Tests/NIOFileSystemIntegrationTests/XCTestExtensions.swift
@@ -15,6 +15,7 @@
 import NIOFileSystem
 import XCTest
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func XCTAssertThrowsErrorAsync<R>(
     file: StaticString = #file,
     line: UInt = #line,
@@ -48,6 +49,7 @@ func XCTAssertThrowsFileSystemError<R>(
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func XCTAssertThrowsFileSystemErrorAsync<R>(
     file: StaticString = #file,
     line: UInt = #line,

--- a/Tests/NIOFileSystemTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemTests/FileHandleTests.swift
@@ -15,6 +15,7 @@
 @_spi(Testing) import NIOFileSystem
 import XCTest
 
+#if ENABLE_MOCKING
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal final class FileHandleTests: XCTestCase {
     private func withHandleForMocking(
@@ -267,3 +268,4 @@ extension MockingDriver {
         }
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -146,6 +146,7 @@ final class FileSystemErrorTests: XCTestCase {
         )
     }
 
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testCopyOnWrite() throws {
         let error1 = FileSystemError(
             code: .io,
@@ -180,6 +181,7 @@ final class FileSystemErrorTests: XCTestCase {
         XCTAssertEqual(error5.location.line, 42)
     }
 
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testErrorsMapToCorrectSyscallCause() throws {
         let here = FileSystemError.SourceLocation(function: "fn", file: "file", line: 42)
         let path = FilePath("/foo")
@@ -308,6 +310,7 @@ final class FileSystemErrorTests: XCTestCase {
         }
     }
 
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testErrnoMapping_fchmod() {
         self.testErrnoToErrorCode(
             expected: [

--- a/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
@@ -16,6 +16,7 @@ import XCTest
 
 @testable import NIOFileSystem
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class BufferedStreamTests: XCTestCase {
     // MARK: - sequenceDeinitialized
 
@@ -1077,6 +1078,7 @@ final class BufferedStreamTests: XCTestCase {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
     /// Collect all elements in the sequence into an array.
     fileprivate func collect() async rethrows -> [Element] {
@@ -1086,6 +1088,7 @@ extension AsyncSequence {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension BufferedStream.Source.WriteResult {
     func assertIsProducerMore() {
         switch self {
@@ -1108,6 +1111,7 @@ extension BufferedStream.Source.WriteResult {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncStream {
     static func makeStream(
         of elementType: Element.Type = Element.self,
@@ -1119,6 +1123,7 @@ extension AsyncStream {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingStream {
     static func makeStream(
         of elementType: Element.Type = Element.self,

--- a/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/IOExecutorTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/IOExecutorTests.swift
@@ -15,6 +15,7 @@
 @_spi(Testing) import NIOFileSystem
 import XCTest
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal final class IOExecutorTests: XCTestCase {
     func testExecuteAsync() async throws {
         try await withExecutor { executor in
@@ -158,6 +159,7 @@ private func fibonacci(_ n: Int) -> Int {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 private func withExecutor(
     numberOfThreads: Int = 1,
     execute: (IOExecutor) async throws -> Void

--- a/Tests/NIOFileSystemTests/Internal/MockingInfrastructure.swift
+++ b/Tests/NIOFileSystemTests/Internal/MockingInfrastructure.swift
@@ -25,6 +25,7 @@
 import SystemPackage
 import XCTest
 
+#if ENABLE_MOCKING
 internal struct Wildcard: Hashable {}
 
 extension Trace.Entry {
@@ -252,3 +253,4 @@ internal struct MockTestCase: TestCase {
 internal func withWindowsPaths(enabled: Bool, _ body: () -> Void) {
     _withWindowsPaths(enabled: enabled, body)
 }
+#endif

--- a/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
@@ -16,6 +16,7 @@
 import SystemPackage
 import XCTest
 
+#if ENABLE_MOCKING
 final class SyscallTests: XCTestCase {
     func test_openat() throws {
         let fd = FileDescriptor(rawValue: 42)
@@ -468,3 +469,4 @@ extension Array where Element == MockTestCase {
         }
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/XCTestExtensions.swift
+++ b/Tests/NIOFileSystemTests/XCTestExtensions.swift
@@ -15,6 +15,7 @@
 import NIOFileSystem
 import XCTest
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func XCTAssertThrowsErrorAsync<R>(
     file: StaticString = #file,
     line: UInt = #line,


### PR DESCRIPTION
Motivation:

In #2615 some of the syscall tests use a mocking infrastrucutre which is compiled out in release builds. The tests weren't correctly guarded for this so fail to build in release mode.

Modifications:

- Add missing guards

Result:

Tests compile in release mode