### PR TITLE
[arch] Add arm64_32 to the 32-bit platform check

### DIFF
--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -137,7 +137,7 @@ extension UInt32 {
 
         var n = self
 
-        #if arch(arm) || arch(i386)
+        #if arch(arm) || arch(i386) || arch(arm64_32)
         // on 32-bit platforms we can't make use of a whole UInt32.max (as it doesn't fit in an Int)
         let max = UInt32(Int.max)
         #else

--- a/Sources/NIOWebSocket/WebSocketFrameEncoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameEncoder.swift
@@ -16,7 +16,7 @@ import NIOCore
 
 private let maxOneByteSize = 125
 private let maxTwoByteSize = Int(UInt16.max)
-#if arch(arm) || arch(i386)
+#if arch(arm) || arch(i386) || arch(arm64_32)
 // on 32-bit platforms we can't put a whole UInt32 in an Int
 private let maxNIOFrameSize = Int(UInt32.max / 2)
 #else

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1327,7 +1327,7 @@ class ByteBufferTest: XCTestCase {
     }
 
     func testAllocationOfReallyBigByteBuffer() throws {
-        #if arch(arm) || arch(i386)
+        #if arch(arm) || arch(i386) || arch(arm64_32)
         // this test doesn't work on 32-bit platforms because the address space is only 4GB large and we're trying
         // to make a 4GB ByteBuffer which just won't fit. Even going down to 2GB won't make it better.
         return


### PR DESCRIPTION
On watchOS, the arm64_32 bit architecture restricts software to ILP32 which means integers are 32-bit. This expands our existing 32-bit checks to include arm64_32.

### Motivation:

Without adding the arm64_32 architecture to the 32-bit check, we run into Int overflow errors.

### Modifications:

This adds arm64_32 to the 32-bit checks.
