### PR TITLE
Avoid renameat2 on Android

### DIFF
--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -308,6 +308,7 @@ public enum Libc {
         }
     }
 
+    #if !os(Android)
     static func constr(_ name: CInt) -> Result<String, Errno> {
         var buffer = [CInterop.PlatformChar](repeating: 0, count: 128)
 
@@ -331,6 +332,7 @@ public enum Libc {
             }
         } while true
     }
+    #endif
 
     static func ftsOpen(_ path: FilePath, options: FTSOpenOptions) -> Result<CInterop.FTSPointer, Errno> {
         // 'fts_open' needs an unsafe mutable pointer to the C-string, `FilePath` doesn't offer this

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -384,6 +384,7 @@ internal func libc_getcwd(
 }
 
 /// confstr(3)
+#if !os(Android)
 internal func libc_confstr(
     _ name: CInt,
     _ buffer: UnsafeMutablePointer<CInterop.PlatformChar>,
@@ -391,6 +392,7 @@ internal func libc_confstr(
 ) -> Int {
     return confstr(name, buffer, size)
 }
+#endif
 
 /// fts(3)
 internal func libc_fts_open(


### PR DESCRIPTION
Motivation:

Until very recently Android didn't support the `renameat2` syscall, this means that on most systems NIO will fail to compile. `renameat2` is used to delay the materialization of files on Linux. On Darwin a different code path is used which we can make use of on Android too.

Modifications:

- Update a few if-defs to force Android onto the alternative path

Result:

NIO builds on Android