### PR TITLE
More changes to support building with Musl.

### DIFF
--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -27,6 +27,7 @@ void CNIOLinux_i_do_nothing_just_working_around_a_darwin_toolchain_bug(void) {}
 #include <sched.h>
 #include <stdio.h>
 #include <sys/prctl.h>
+#include <sys/syscall.h>
 #include <sys/utsname.h>
 #include <unistd.h>
 #include <assert.h>
@@ -189,12 +190,18 @@ int CNIOLinux_system_info(struct utsname* uname_data) {
 const unsigned long CNIOLinux_IOCTL_VM_SOCKETS_GET_LOCAL_CID = IOCTL_VM_SOCKETS_GET_LOCAL_CID;
 
 const char* CNIOLinux_dirent_dname(struct dirent* ent) {
-  return ent->d_name;
+    return ent->d_name;
 }
 
 int CNIOLinux_renameat2(int oldfd, const char* old, int newfd, const char* newName, unsigned int flags) {
-  return renameat2(oldfd, old, newfd, newName, flags);
+    // Musl doesn't have renameat2, so we make the raw system call directly
+    return syscall(SYS_renameat2, oldfd, old, newfd, newName, flags);
 }
+
+// Musl also doesn't define the flags for renameat2, so we will do so.
+// Again, we may as well do this unconditionally.
+#define RENAME_NOREPLACE 1
+#define RENAME_EXCHANGE  2
 
 const int CNIOLinux_O_TMPFILE = O_TMPFILE;
 const unsigned int CNIOLinux_RENAME_NOREPLACE = RENAME_NOREPLACE;

--- a/Sources/NIOFileSystem/FileInfo.swift
+++ b/Sources/NIOFileSystem/FileInfo.swift
@@ -18,6 +18,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 /// Information about a file system object.
@@ -80,7 +82,7 @@ public struct FileInfo: Hashable, Sendable {
         self.lastAccessTime = Timespec(platformSpecificStatus.st_atimespec)
         self.lastDataModificationTime = Timespec(platformSpecificStatus.st_mtimespec)
         self.lastStatusChangeTime = Timespec(platformSpecificStatus.st_ctimespec)
-        #elseif canImport(Glibc)
+        #elseif canImport(Glibc) || canImport(Musl)
         self.lastAccessTime = Timespec(platformSpecificStatus.st_atim)
         self.lastDataModificationTime = Timespec(platformSpecificStatus.st_mtim)
         self.lastStatusChangeTime = Timespec(platformSpecificStatus.st_ctim)
@@ -190,7 +192,7 @@ private struct Stat: Hashable {
         hasher.combine(FileInfo.Timespec(stat.st_birthtimespec))
         hasher.combine(stat.st_flags)
         hasher.combine(stat.st_gen)
-        #elseif canImport(Glibc)
+        #elseif canImport(Glibc) || canImport(Musl)
         hasher.combine(FileInfo.Timespec(stat.st_atim))
         hasher.combine(FileInfo.Timespec(stat.st_mtim))
         hasher.combine(FileInfo.Timespec(stat.st_ctim))
@@ -231,7 +233,7 @@ private struct Stat: Hashable {
                 == FileInfo.Timespec(rStat.st_birthtimespec)
         isEqual = isEqual && lStat.st_flags == rStat.st_flags
         isEqual = isEqual && lStat.st_gen == rStat.st_gen
-        #elseif canImport(Glibc)
+        #elseif canImport(Glibc) || canImport(Musl)
         isEqual = isEqual && FileInfo.Timespec(lStat.st_atim) == FileInfo.Timespec(rStat.st_atim)
         isEqual = isEqual && FileInfo.Timespec(lStat.st_mtim) == FileInfo.Timespec(rStat.st_mtim)
         isEqual = isEqual && FileInfo.Timespec(lStat.st_ctim) == FileInfo.Timespec(rStat.st_ctim)

--- a/Sources/NIOFileSystem/FileSystem.swift
+++ b/Sources/NIOFileSystem/FileSystem.swift
@@ -20,6 +20,8 @@ import NIOCore
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 /// A file system which interacts with the local system. The file system uses a thread pool to
@@ -1146,7 +1148,7 @@ extension FileSystem {
                         location: .here()
                     )
                 }
-                #elseif canImport(Glibc)
+                #elseif canImport(Glibc) || canImport(Musl)
                 var offset = 0
 
                 while offset < sourceInfo.size {

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -18,6 +18,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 extension FileSystemError {

--- a/Sources/NIOFileSystem/FileType.swift
+++ b/Sources/NIOFileSystem/FileType.swift
@@ -18,6 +18,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 /// The type of a file system object.
@@ -133,7 +135,7 @@ extension FileType {
     /// Initializes a file type from the `d_type` from `dirent`.
     @_spi(Testing)
     public init(direntType: UInt8) {
-        #if canImport(Darwin)
+        #if canImport(Darwin) || canImport(Musl)
         let value = Int32(direntType)
         #elseif canImport(Glibc)
         let value = Int(direntType)

--- a/Sources/NIOFileSystem/Internal/Concurrency Primitives/ThreadPosix.swift
+++ b/Sources/NIOFileSystem/Internal/Concurrency Primitives/ThreadPosix.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Glibc)
+#if canImport(Glibc) || canImport(Musl)
 import CNIOLinux
 
 private let sys_pthread_getname_np = CNIOLinux_pthread_getname_np
@@ -41,8 +41,12 @@ private func sysPthread_create(
 ) -> CInt {
     #if canImport(Darwin)
     return pthread_create(handle, nil, destructor, args)
-    #elseif canImport(Glibc)
+    #elseif canImport(Glibc) || canImport(Musl)
+    #if canImport(Glibc)
     var handleLinux = pthread_t()
+    #else
+    var handleLinux = pthread_t(bitPattern: 0)
+    #endif
     let result = pthread_create(
         &handleLinux,
         nil,
@@ -61,7 +65,7 @@ enum ThreadOpsPosix: ThreadOps {
     typealias ThreadSpecificKey = pthread_key_t
     #if canImport(Darwin)
     typealias ThreadSpecificKeyDestructor = @convention(c) (UnsafeMutableRawPointer) -> Void
-    #elseif canImport(Glibc)
+    #elseif canImport(Glibc) || canImport(Musl)
     typealias ThreadSpecificKeyDestructor = @convention(c) (UnsafeMutableRawPointer?) -> Void
     #endif
 
@@ -100,7 +104,7 @@ enum ThreadOpsPosix: ThreadOps {
 
                 if let name = name {
                     let maximumThreadNameLength: Int
-                    #if canImport(Glibc)
+                    #if canImport(Glibc) || canImport(Musl)
                     maximumThreadNameLength = 15
                     #elseif canImport(Darwin)
                     maximumThreadNameLength = .max

--- a/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
@@ -20,6 +20,9 @@ import CNIODarwin
 #elseif canImport(Glibc)
 import Glibc
 import CNIOLinux
+#elseif canImport(Musl)
+import Musl
+import CNIOLinux
 #endif
 
 /// Aliases for platform-dependent types used for system calls.
@@ -28,6 +31,8 @@ extension CInterop {
     public typealias Stat = Darwin.stat
     #elseif canImport(Glibc)
     public typealias Stat = Glibc.stat
+    #elseif canImport(Musl)
+    public typealias Stat = Musl.stat
     #endif
 
     #if canImport(Darwin)
@@ -36,11 +41,14 @@ extension CInterop {
     #elseif canImport(Glibc)
     @_spi(Testing)
     public static let maxPathLength = Glibc.PATH_MAX
+    #elseif canImport(Musl)
+    @_spi(Testing)
+    public static let maxPathLength = Musl.PATH_MAX
     #endif
 
     #if canImport(Darwin)
     typealias DirPointer = UnsafeMutablePointer<Darwin.DIR>
-    #elseif canImport(Glibc)
+    #elseif canImport(Glibc) || canImport(Musl)
     typealias DirPointer = OpaquePointer
     #endif
 
@@ -48,12 +56,14 @@ extension CInterop {
     typealias DirEnt = Darwin.dirent
     #elseif canImport(Glibc)
     typealias DirEnt = Glibc.dirent
+    #elseif canImport(Musl)
+    typealias DirEnt = Musl.dirent
     #endif
 
     #if canImport(Darwin)
     typealias FTS = CNIODarwin.FTS
     typealias FTSEnt = CNIODarwin.FTSENT
-    #elseif canImport(Glibc)
+    #elseif canImport(Glibc) || canImport(Musl)
     typealias FTS = CNIOLinux.FTS
     typealias FTSEnt = CNIOLinux.FTSENT
     #endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Errno.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Errno.swift
@@ -18,6 +18,8 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 extension Errno {
@@ -28,6 +30,8 @@ extension Errno {
             return Errno(rawValue: Darwin.errno)
             #elseif canImport(Glibc)
             return Errno(rawValue: Glibc.errno)
+            #elseif canImport(Musl)
+            return Errno(rawValue: Musl.errno)
             #endif
         }
         set {
@@ -35,6 +39,8 @@ extension Errno {
             Darwin.errno = newValue.rawValue
             #elseif canImport(Glibc)
             Glibc.errno = newValue.rawValue
+            #elseif canImport(Musl)
+            Musl.errno = newValue.rawValue
             #endif
         }
     }
@@ -44,6 +50,8 @@ extension Errno {
         Darwin.errno = 0
         #elseif canImport(Glibc)
         Glibc.errno = 0
+        #elseif canImport(Musl)
+        Musl.errno = 0
         #endif
     }
 }

--- a/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
@@ -20,6 +20,9 @@ import Darwin
 #elseif canImport(Glibc)
 import Glibc
 import CNIOLinux
+#elseif canImport(Musl)
+import Musl
+import CNIOLinux
 #endif
 
 extension FileDescriptor {
@@ -305,7 +308,7 @@ extension FileDescriptor {
     }
 }
 
-#if canImport(Glibc)
+#if canImport(Glibc) || canImport(Musl)
 extension FileDescriptor.OpenOptions {
     static var temporaryFile: Self {
         Self(rawValue: CNIOLinux_O_TMPFILE)

--- a/Sources/NIOFileSystem/Internal/System Calls/Mocking.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Mocking.swift
@@ -28,6 +28,9 @@ import Darwin
 #elseif canImport(Glibc)
 import Glibc
 import CNIOLinux
+#elseif canImport(Musl)
+import Musl
+import CNIOLinux
 #endif
 
 // Syscall mocking support.
@@ -278,6 +281,11 @@ internal var system_errno: CInt {
 internal var system_errno: CInt {
     get { Glibc.errno }
     set { Glibc.errno = newValue }
+}
+#elseif canImport(Musl)
+internal var system_errno: CInt {
+    get { Musl.errno }
+    set { Musl.errno = newValue }
 }
 #endif
 

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -20,6 +20,9 @@ import CNIODarwin
 #elseif canImport(Glibc)
 import Glibc
 import CNIOLinux
+#elseif canImport(Musl)
+import Musl
+import CNIOLinux
 #endif
 
 @_spi(Testing)
@@ -102,7 +105,7 @@ public enum Syscall {
     }
     #endif
 
-    #if canImport(Glibc)
+    #if canImport(Glibc) || canImport(Musl)
     @_spi(Testing)
     public static func rename(
         from old: FilePath,
@@ -144,7 +147,7 @@ public enum Syscall {
     }
     #endif
 
-    #if canImport(Glibc)
+    #if canImport(Glibc) || canImport(Musl)
     @_spi(Testing)
     public struct LinkAtFlags: OptionSet {
         @_spi(Testing)
@@ -226,7 +229,7 @@ public enum Syscall {
         }
     }
 
-    #if canImport(Glibc)
+    #if canImport(Glibc) || canImport(Musl)
     @_spi(Testing)
     public static func sendfile(
         to output: FileDescriptor,

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -20,6 +20,9 @@ import CNIODarwin
 #elseif canImport(Glibc)
 import Glibc
 import CNIOLinux
+#elseif canImport(Musl)
+import Musl
+import CNIOLinux
 #endif
 
 // MARK: - system
@@ -171,7 +174,7 @@ internal func system_flistxattr(
     #if canImport(Darwin)
     // The final parameter is 'options'; there is no equivalent on Linux.
     return flistxattr(fd, namebuf, size, 0)
-    #elseif canImport(Glibc)
+    #elseif canImport(Glibc) || canImport(Musl)
     return flistxattr(fd, namebuf, size)
     #endif
 }
@@ -193,7 +196,7 @@ internal func system_fgetxattr(
     // Penultimate parameter is position which is reserved and should be zero.
     // The final parameter is 'options'; there is no equivalent on Linux.
     return fgetxattr(fd, name, value, size, 0, 0)
-    #elseif canImport(Glibc)
+    #elseif canImport(Glibc) || canImport(Musl)
     return fgetxattr(fd, name, value, size)
     #endif
 }
@@ -215,7 +218,7 @@ internal func system_fsetxattr(
     #if canImport(Darwin)
     // Penultimate parameter is position which is reserved and should be zero.
     return fsetxattr(fd, name, value, size, 0, 0)
-    #elseif canImport(Glibc)
+    #elseif canImport(Glibc) || canImport(Musl)
     return fsetxattr(fd, name, value, size, 0)
     #endif
 }
@@ -234,7 +237,7 @@ internal func system_fremovexattr(
     #if canImport(Darwin)
     // The final parameter is 'options'; there is no equivalent on Linux.
     return fremovexattr(fd, name, 0)
-    #elseif canImport(Glibc)
+    #elseif canImport(Glibc) || canImport(Musl)
     return fremovexattr(fd, name)
     #endif
 }
@@ -267,7 +270,7 @@ internal func system_renamex_np(
 }
 #endif
 
-#if canImport(Glibc)
+#if canImport(Glibc) || canImport(Musl)
 internal func system_renameat2(
     _ oldFD: FileDescriptor.RawValue,
     _ old: UnsafePointer<CInterop.PlatformChar>,
@@ -285,7 +288,7 @@ internal func system_renameat2(
 #endif
 
 /// link(2): Creates a new link for a file.
-#if canImport(Glibc)
+#if canImport(Glibc) || canImport(Musl)
 internal func system_linkat(
     _ oldFD: FileDescriptor.RawValue,
     _ old: UnsafePointer<CInterop.PlatformChar>,
@@ -302,7 +305,7 @@ internal func system_linkat(
 }
 #endif
 
-#if canImport(Glibc)
+#if canImport(Glibc) || canImport(Musl)
 /// sendfile(2): Transfer data between descriptors
 internal func system_sendfile(
     _ outFD: CInt,


### PR DESCRIPTION
Support using NIO with Musl on Linux.

### Motivation:

I'm trying to make Swift NIO work on top of Musl so that we can build fully statically linked binaries for Linux.

### Modifications:

Use direct syscall for `renameat2` because Musl doesn't include a wrapper for it.  Similarly, define the constants ourselves.

Add Musl imports in relevant places.

### Result:

Building NIO on Musl will work again :-)
