### PR TITLE
Only compile FileSystem on some platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,11 @@ import PackageDescription
 
 let swiftAtomics: PackageDescription.Target.Dependency = .product(name: "Atomics", package: "swift-atomics")
 let swiftCollections: PackageDescription.Target.Dependency = .product(name: "DequeModule", package: "swift-collections")
-let swiftSystem: PackageDescription.Target.Dependency = .product(name: "SystemPackage", package: "swift-system")
+let swiftSystem: PackageDescription.Target.Dependency = .product(
+  name: "SystemPackage",
+  package: "swift-system",
+  condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .linux, .android])
+)
 
 
 let package = Package(

--- a/Sources/NIOFileSystem/BufferedReader.swift
+++ b/Sources/NIOFileSystem/BufferedReader.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import DequeModule
 import NIOCore
 
@@ -206,3 +207,5 @@ extension ReadableFileHandleProtocol {
         return BufferedReader(wrapping: self, initialOffset: 0, capacity: Int(capacity.bytes))
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/BufferedWriter.swift
+++ b/Sources/NIOFileSystem/BufferedWriter.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
+
 /// A writer which buffers bytes in memory before writing them to the file system.
 ///
 /// You can create a ``BufferedWriter`` by calling
@@ -185,3 +187,5 @@ extension WritableFileHandleProtocol {
         )
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/ByteBuffer+FileSystem.swift
+++ b/Sources/NIOFileSystem/ByteBuffer+FileSystem.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -95,3 +96,5 @@ extension ByteBuffer {
         )
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/ByteCount.swift
+++ b/Sources/NIOFileSystem/ByteCount.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
+
 /// Represents the number of bytes.
 public struct ByteCount: Hashable, Sendable {
     /// The number of bytes
@@ -77,3 +79,5 @@ public struct ByteCount: Hashable, Sendable {
         return ByteCount(bytes: 1024 * 1024 * 1024 * count)
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/Convenience.swift
+++ b/Sources/NIOFileSystem/Convenience.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 extension String {
@@ -200,3 +201,5 @@ extension AsyncSequence where Self.Element == UInt8, Self: Sendable {
         )
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/DirectoryEntries.swift
+++ b/Sources/NIOFileSystem/DirectoryEntries.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import CNIODarwin
 import CNIOLinux
 import NIOConcurrencyHelpers
@@ -652,3 +653,5 @@ extension UnsafeMutablePointer<CInterop.FTSEnt> {
         return FilePath(platformString: self.pointee.fts_path)
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/DirectoryEntry.swift
+++ b/Sources/NIOFileSystem/DirectoryEntry.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @preconcurrency import SystemPackage
 
 /// Information about an item within a directory.
@@ -45,3 +46,5 @@ public struct DirectoryEntry: Sendable, Hashable, Equatable {
         self.type = type
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/Exports.swift
+++ b/Sources/NIOFileSystem/Exports.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
+
 // These types are used in our public API; expose them to make
 // life easier for users.
 @_exported import enum SystemPackage.CInterop
@@ -19,3 +21,5 @@
 @_exported import struct SystemPackage.FileDescriptor
 @_exported import struct SystemPackage.FilePath
 @_exported import struct SystemPackage.FilePermissions
+
+#endif

--- a/Sources/NIOFileSystem/FileChunks.swift
+++ b/Sources/NIOFileSystem/FileChunks.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOConcurrencyHelpers
 import NIOCore
 @preconcurrency import SystemPackage
@@ -335,3 +336,5 @@ private struct ProducerState: Sendable {
         self.state = .done
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/FileHandle.swift
+++ b/Sources/NIOFileSystem/FileHandle.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
+
 import NIOCore
 
 /// Provides a ``FileHandle``.
@@ -305,3 +307,5 @@ public struct DirectoryFileHandle: DirectoryFileHandleProtocol, _HasFileHandle {
         return DirectoryFileHandle(wrapping: systemFileHandle)
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 import SystemPackage
 
@@ -686,3 +687,4 @@ extension DirectoryFileHandleProtocol {
         }
     }
 }
+#endif

--- a/Sources/NIOFileSystem/FileInfo.swift
+++ b/Sources/NIOFileSystem/FileInfo.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -248,3 +249,5 @@ extension FilePermissions {
         self = .init(rawValue: rawValue & ~S_IFMT)
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/FileSystem.swift
+++ b/Sources/NIOFileSystem/FileSystem.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
+
 import Atomics
 import NIOCore
 @preconcurrency import SystemPackage
@@ -1435,3 +1437,5 @@ extension FileSystem {
         }
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -1026,3 +1027,5 @@ extension FileSystemError {
         )
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/FileSystemError.swift
+++ b/Sources/NIOFileSystem/FileSystemError.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 /// An error thrown as a result of interaction with the file system.
@@ -331,3 +332,5 @@ extension FileSystemError {
         }
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/NIOFileSystem/FileSystemProtocol.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 /// The interface for interacting with a file system.
@@ -476,3 +477,5 @@ extension FileSystemProtocol {
         )
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/FileType.swift
+++ b/Sources/NIOFileSystem/FileType.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -167,3 +168,5 @@ extension FileType {
         }
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/Internal/BufferedOrAnyStream.swift
+++ b/Sources/NIOFileSystem/Internal/BufferedOrAnyStream.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 /// Wraps a ``BufferedStream<Element>`` or ``AnyAsyncSequence<Element>``.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal enum BufferedOrAnyStream<Element> {
@@ -88,3 +89,5 @@ internal struct AnyAsyncSequence<Element>: AsyncSequence {
         }
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/Internal/BufferedStream.swift
+++ b/Sources/NIOFileSystem/Internal/BufferedStream.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import DequeModule
 import NIOConcurrencyHelpers
 
@@ -1731,3 +1732,5 @@ extension BufferedStream {
         }
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/Internal/Cancellation.swift
+++ b/Sources/NIOFileSystem/Internal/Cancellation.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
+
 /// Executes the closure and masks cancellation.
 @_spi(Testing)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -51,3 +53,5 @@ public func withUncancellableTearDown<R: Sendable>(
     try tearDownResult.get()
     return try result.get()
 }
+
+#endif

--- a/Sources/NIOFileSystem/Internal/Concurrency Primitives/IOExecutor.swift
+++ b/Sources/NIOFileSystem/Internal/Concurrency Primitives/IOExecutor.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import Atomics
 import DequeModule
 import Dispatch
@@ -419,3 +420,4 @@ extension IOExecutor.Worker {
         }
     }
 }
+#endif

--- a/Sources/NIOFileSystem/Internal/Concurrency Primitives/Thread.swift
+++ b/Sources/NIOFileSystem/Internal/Concurrency Primitives/Thread.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 #if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
 #endif
@@ -95,3 +96,4 @@ final class Thread {
         ThreadOpsSystem.run(handle: &handle, args: box, detachThread: detachThread)
     }
 }
+#endif

--- a/Sources/NIOFileSystem/Internal/Concurrency Primitives/ThreadPosix.swift
+++ b/Sources/NIOFileSystem/Internal/Concurrency Primitives/ThreadPosix.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 #if canImport(Glibc) || canImport(Musl)
 import CNIOLinux
 
@@ -143,3 +144,4 @@ enum ThreadOpsPosix: ThreadOps {
         return pthread_equal(lhs, rhs) != 0
     }
 }
+#endif

--- a/Sources/NIOFileSystem/Internal/Concurrency Primitives/UnsafeTransfer.swift
+++ b/Sources/NIOFileSystem/Internal/Concurrency Primitives/UnsafeTransfer.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @usableFromInline
 struct UnsafeTransfer<Value>: @unchecked Sendable {
     @usableFromInline
@@ -22,3 +23,4 @@ struct UnsafeTransfer<Value>: @unchecked Sendable {
         self.wrappedValue = wrappedValue
     }
 }
+#endif

--- a/Sources/NIOFileSystem/Internal/String+UnsafeUnititializedCapacity.swift
+++ b/Sources/NIOFileSystem/Internal/String+UnsafeUnititializedCapacity.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
+
 extension String {
     @inlinable
     init(
@@ -59,3 +61,5 @@ extension String {
         }
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -71,3 +72,4 @@ extension CInterop {
     typealias FTSPointer = UnsafeMutablePointer<FTS>
     typealias FTSEntPointer = UnsafeMutablePointer<CInterop.FTSEnt>
 }
+#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Errno.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Errno.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -138,3 +139,4 @@ public func valueOrErrno<R>(
         }
     }
 }
+#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 import SystemPackage
 
@@ -320,4 +321,5 @@ extension FileDescriptor {
         Self(rawValue: AT_FDCWD)
     }
 }
+#endif
 #endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Mocking.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Mocking.swift
@@ -21,6 +21,7 @@
  See https://swift.org/LICENSE.txt for license information
  */
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -365,3 +366,4 @@ internal func setTLS(_ key: _PlatformTLSKey, _ p: UnsafeMutableRawPointer?) {
 internal func getTLS(_ key: _PlatformTLSKey) -> UnsafeMutableRawPointer? {
     return pthread_getspecific(key)
 }
+#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -381,3 +382,4 @@ public enum Libc {
         }
     }
 }
+#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -415,3 +416,4 @@ internal func libc_fts_close(
 ) -> CInt {
     return fts_close(fts)
 }
+#endif

--- a/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOConcurrencyHelpers
 import NIOCore
 @preconcurrency import SystemPackage
@@ -1303,3 +1304,5 @@ extension SystemFileHandle {
         }
     }
 }
+
+#endif

--- a/Sources/NIOFileSystem/Internal/Utilities.swift
+++ b/Sources/NIOFileSystem/Internal/Utilities.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 @usableFromInline
@@ -43,3 +44,5 @@ extension Array where Element == UInt8 {
         return alphaNumericValues
     }()
 }
+
+#endif

--- a/Sources/NIOFileSystem/OpenOptions.swift
+++ b/Sources/NIOFileSystem/OpenOptions.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 /// Options for opening file handles.
@@ -295,3 +296,5 @@ extension FilePermissions {
         .otherReadExecute,
     ]
 }
+
+#endif

--- a/Sources/NIOFileSystemFoundationCompat/Date+FileInfo.swift
+++ b/Sources/NIOFileSystemFoundationCompat/Date+FileInfo.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOFileSystem
 
 import struct Foundation.Date
@@ -29,3 +30,4 @@ extension FileInfo.Timespec {
         return Date(timespec: self)
     }
 }
+#endif

--- a/Tests/NIOFileSystemFoundationCompatTests/FileSystemFoundationCompatTests.swift
+++ b/Tests/NIOFileSystemFoundationCompatTests/FileSystemFoundationCompatTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOFileSystem
 import NIOFileSystemFoundationCompat
 import XCTest
@@ -33,3 +34,4 @@ final class FileSystemBytesConformanceTests: XCTestCase {
         )
     }
 }
+#endif

--- a/Tests/NIOFileSystemIntegrationTests/BufferedReaderTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/BufferedReaderTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 import NIOFileSystem
 import XCTest
@@ -259,3 +260,4 @@ final class BufferedReaderTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/NIOFileSystemIntegrationTests/BufferedWriterTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/BufferedWriterTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 @_spi(Testing) import NIOFileSystem
 import XCTest
@@ -141,3 +142,4 @@ final class BufferedWriterTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/NIOFileSystemIntegrationTests/ConvenienceTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/ConvenienceTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 import NIOFileSystem
 import XCTest
@@ -71,3 +72,4 @@ final class ConvenienceTests: XCTestCase {
         XCTAssertEqual(bytes, ByteBuffer(bytes: Array(0..<64)))
     }
 }
+#endif

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 @_spi(Testing) import NIOFileSystem
 import NIOFoundationCompat
@@ -1104,3 +1105,4 @@ private func assertThrowsErrorClosed<R>(
         XCTAssertEqual(error.code, .closed)
     }
 }
+#endif

--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests+SPI.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests+SPI.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @_spi(Testing) import NIOFileSystem
 import SystemPackage
 import XCTest
@@ -25,3 +26,4 @@ extension FileSystemTests {
         XCTAssertEqual(removed, 0)
     }
 }
+#endif

--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 @_spi(Testing) import NIOFileSystem
 @preconcurrency import SystemPackage
@@ -1429,3 +1430,4 @@ extension FileSystemTests {
         }
     }
 }
+#endif

--- a/Tests/NIOFileSystemIntegrationTests/XCTestExtensions.swift
+++ b/Tests/NIOFileSystemIntegrationTests/XCTestExtensions.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOFileSystem
 import XCTest
 
@@ -68,3 +69,4 @@ func XCTAssertThrowsFileSystemErrorAsync<R>(
         }
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/ByteCountTests.swift
+++ b/Tests/NIOFileSystemTests/ByteCountTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOFileSystem
 import XCTest
 
@@ -58,3 +59,4 @@ class ByteCountTests: XCTestCase {
         XCTAssertNotEqual(byteCount1, byteCount2)
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/DirectoryEntriesTests.swift
+++ b/Tests/NIOFileSystemTests/DirectoryEntriesTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOFileSystem
 import XCTest
 
@@ -70,3 +71,4 @@ final class DirectoryEntriesTests: XCTestCase {
         XCTAssertNil(end)
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/FileChunksTests.swift
+++ b/Tests/NIOFileSystemTests/FileChunksTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 import NIOFileSystem
 import XCTest
@@ -38,3 +39,4 @@ final class FileChunksTests: XCTestCase {
         XCTAssertNil(end)
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemTests/FileHandleTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @_spi(Testing) import NIOFileSystem
 import XCTest
 
@@ -268,4 +269,5 @@ extension MockingDriver {
         }
     }
 }
+#endif
 #endif

--- a/Tests/NIOFileSystemTests/FileInfoTests.swift
+++ b/Tests/NIOFileSystemTests/FileInfoTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOFileSystem
 import XCTest
 
@@ -156,3 +157,4 @@ final class FileInfoTests: XCTestCase {
         #endif
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/FileOpenOptionsTests.swift
+++ b/Tests/NIOFileSystemTests/FileOpenOptionsTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @_spi(Testing) import NIOFileSystem
 import XCTest
 
@@ -98,3 +99,4 @@ final class FileOpenOptionsTests: XCTestCase {
         XCTAssertEqual(FileDescriptor.OpenOptions(options), [.create, .exclusiveCreate, .noFollow])
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @_spi(Testing) import NIOFileSystem
 import XCTest
 
@@ -608,3 +609,4 @@ private func assertCauseIsSyscall(
 extension FileSystemError.SourceLocation {
     fileprivate static let fixed = Self(function: "fn", file: "file", line: 1)
 }
+#endif

--- a/Tests/NIOFileSystemTests/FileTypeTests.swift
+++ b/Tests/NIOFileSystemTests/FileTypeTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @_spi(Testing) import NIOFileSystem
 import XCTest
 
@@ -79,3 +80,4 @@ final class FileTypeTests: XCTestCase {
         #endif
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/Internal/CancellationTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/CancellationTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import Atomics
 @_spi(Testing) import NIOFileSystem
 import XCTest
@@ -87,3 +88,4 @@ final class CancellationTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import XCTest
 
 @testable import NIOFileSystem
@@ -1139,3 +1140,4 @@ extension AsyncThrowingStream {
         return (stream, continuation!)
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/IOExecutorTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/IOExecutorTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @_spi(Testing) import NIOFileSystem
 import XCTest
 
@@ -172,3 +173,4 @@ private func withExecutor(
         await executor.drain()
     }
 }
+#endif

--- a/Tests/NIOFileSystemTests/Internal/MockingInfrastructure.swift
+++ b/Tests/NIOFileSystemTests/Internal/MockingInfrastructure.swift
@@ -21,6 +21,7 @@
  See https://swift.org/LICENSE.txt for license information
  */
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @_spi(Testing) import NIOFileSystem
 import SystemPackage
 import XCTest
@@ -253,4 +254,5 @@ internal struct MockTestCase: TestCase {
 internal func withWindowsPaths(enabled: Bool, _ body: () -> Void) {
     _withWindowsPaths(enabled: enabled, body)
 }
+#endif
 #endif

--- a/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @_spi(Testing) import NIOFileSystem
 import SystemPackage
 import XCTest
@@ -469,4 +470,5 @@ extension Array where Element == MockTestCase {
         }
     }
 }
+#endif
 #endif

--- a/Tests/NIOFileSystemTests/XCTestExtensions.swift
+++ b/Tests/NIOFileSystemTests/XCTestExtensions.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOFileSystem
 import XCTest
 
@@ -67,3 +68,4 @@ func XCTAssertSystemCallError(
     XCTAssertEqual(systemCallError.systemCall, name, file: file, line: line)
     XCTAssertEqual(systemCallError.errno, errno, file: file, line: line)
 }
+#endif

--- a/Tests/NIOPosixTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOPosixTests/SocketOptionProviderTest.swift
@@ -290,6 +290,8 @@ final class SocketOptionProviderTest: XCTestCase {
         // We just need to soundness check something here to ensure that the data is vaguely reasonable.
         XCTAssertEqual(tcpConnectionInfo.tcpi_state, UInt8(TSI_S_ESTABLISHED))
         #endif
+        // Suppress the unused warning
+        _ = tcpConnectionInfo
         #endif
     }
 }


### PR DESCRIPTION
Motivation:

SwiftNIO doesn't compile for visionOS because NIOFileSystem depends on Swift System which doesn't yet support visionOS.

As NIOFileSystem isn't yet stable API we can define it out on some platforms.

Modifications:

- Only define NIOFileSystem on macOS, iOS, tvOS, watchOS, Linux and Android.
- Only include Swift System on the same platforms

Result:

SwiftNIO compiles on visionOS, albeit with an empty NIOFileSystem.