### PR TITLE
Remove `@unchecked Sendable` conformance from `ChannelOptions.Storage`

### DIFF
--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -15,7 +15,7 @@
 /// A configuration option that can be set on a `Channel` to configure different behaviour.
 public protocol ChannelOption: Equatable, _NIOPreconcurrencySendable {
     /// The type of the `ChannelOption`'s value.
-    associatedtype Value
+    associatedtype Value: Sendable
 }
 
 public typealias SocketOptionName = Int32
@@ -291,7 +291,7 @@ extension ChannelOptions {
 }
 
 /// Provides `ChannelOption`s to be used with a `Channel`, `Bootstrap` or `ServerBootstrap`.
-public struct ChannelOptions {
+public struct ChannelOptions: Sendable {
     #if !os(Windows)
         public static let socket = { (level: SocketOptionLevel, name: SocketOptionName) -> Types.SocketOption in
             .init(level: NIOBSDSocket.OptionLevel(rawValue: CInt(level)), name: NIOBSDSocket.Option(rawValue: CInt(name)))
@@ -359,9 +359,9 @@ public struct ChannelOptions {
 extension ChannelOptions {
     /// A type-safe storage facility for `ChannelOption`s. You will only ever need this if you implement your own
     /// `Channel` that needs to store `ChannelOption`s.
-    public struct Storage {
+    public struct Storage: Sendable {
         @usableFromInline
-        internal var _storage: [(Any, (Any, (Channel) -> (Any, Any) -> EventLoopFuture<Void>))]
+        internal var _storage: [(any ChannelOption, (any Sendable, @Sendable (Channel) -> (any ChannelOption, any Sendable) -> EventLoopFuture<Void>))]
 
         public init() {
             self._storage = []
@@ -375,7 +375,8 @@ extension ChannelOptions {
         ///    - value: the value for the option
         @inlinable
         public mutating func append<Option: ChannelOption>(key newKey: Option, value newValue: Option.Value) {
-            func applier(_ t: Channel) -> (Any, Any) -> EventLoopFuture<Void> {
+            @Sendable
+            func applier(_ t: Channel) -> (any ChannelOption, any Sendable) -> EventLoopFuture<Void> {
                 return { (option, value) in
                     return t.setOption(option as! Option, value: value as! Option.Value)
                 }
@@ -403,20 +404,25 @@ extension ChannelOptions {
         ///    - An `EventLoopFuture` that is fulfilled when all `ChannelOption`s have been applied to the `Channel`.
         public func applyAllChannelOptions(to channel: Channel) -> EventLoopFuture<Void> {
             let applyPromise = channel.eventLoop.makePromise(of: Void.self)
-            var it = self._storage.makeIterator()
+            let it = self._storage.makeIterator()
 
-            func applyNext() {
-                guard let (key, (value, applier)) = it.next() else {
+            @Sendable
+            func applyNext(iterator: IndexingIterator<[(any ChannelOption, (any Sendable, @Sendable (any Channel) -> (any ChannelOption, any Sendable) -> EventLoopFuture<Void>))]>) {
+                var iterator = iterator
+                guard let (key, (value, applier)) = iterator.next() else {
                     // If we reached the end, everything is applied.
                     applyPromise.succeed(())
                     return
                 }
+                let it = iterator
 
                 applier(channel)(key, value).map {
-                    applyNext()
+                    applyNext(
+                        iterator: it
+                    )
                 }.cascadeFailure(to: applyPromise)
             }
-            applyNext()
+            applyNext(iterator: it)
 
             return applyPromise.futureResult
         }
@@ -436,5 +442,3 @@ extension ChannelOptions {
         }
     }
 }
-
-extension ChannelOptions.Storage: @unchecked Sendable {}

--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -22,7 +22,7 @@ url_prefix=${1-"https://ci.swiftserver.group/job/swift-nio2-swift"}
 target_repo=${2-"$here/.."}
 tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
 
-for f in 56 57 58 59 -nightly; do
+for f in 57 58 59 510 -nightly; do
     echo "swift$f"
     url="$url_prefix$f-prb/lastCompletedBuild/consoleFull"
     echo "$url"

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -35,7 +35,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=147000
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -37,11 +37,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
       - MAX_ALLOCS_ALLOWED_1000_rst_connections=147000
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=155050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=396000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=76050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=393000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -68,7 +68,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=85
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=167050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -36,13 +36,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=148950
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149000
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=159050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=406000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=76050
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -69,7 +68,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=85
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=167050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=151050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=148950
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=159050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -38,11 +38,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
       - MAX_ALLOCS_ALLOWED_1000_rst_connections=149000
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=159050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=405000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=76050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=402000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -69,7 +69,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=85
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=167050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=151050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149000
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=159050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -38,11 +38,11 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
       - MAX_ALLOCS_ALLOWED_1000_rst_connections=149000
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=159050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=77050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=405050
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=76050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=402000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -69,7 +69,7 @@ services:
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=85
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=167050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=151050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149000
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=159050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -35,7 +35,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=147000
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050


### PR DESCRIPTION
# Motivation
We currently have an unchecked `Sendable` conformance on `ChannelOptions.Storage` which is not necessary and in fact we are missing a proper `Sendable` requirement on the `ChannelOption.Value` protocol right now.

# Modification
This PR adds the `Sendable` requirement on the `ChannelOption.Value` and replaces the unchecked conformance on the storage with a regular one.

# Result
No more `Sendable` warnings in strict concurrency mode inside `ChannelOptions`.