### PR TITLE
Pass initial offset to BufferedReader.init

### DIFF
--- a/Sources/NIOFileSystem/BufferedReader.swift
+++ b/Sources/NIOFileSystem/BufferedReader.swift
@@ -204,7 +204,7 @@ extension ReadableFileHandleProtocol {
         startingAtAbsoluteOffset initialOffset: Int64 = 0,
         capacity: ByteCount = .kibibytes(512)
     ) -> BufferedReader<Self> {
-        return BufferedReader(wrapping: self, initialOffset: 0, capacity: Int(capacity.bytes))
+        return BufferedReader(wrapping: self, initialOffset: initialOffset, capacity: Int(capacity.bytes))
     }
 }
 


### PR DESCRIPTION
Motivation:
There is a bug in `ReadableFileHandleProtocol.bufferedReader(startingAtAbsoluteOffset:capacity:)` where we are hardcoding initial offset to 0 instead of passing the actual param value.

Modifications:
Pass the actual param value.
