### PR TITLE
Don't drop bytes from the buffered reader when reading short

### DIFF
--- a/Tests/NIOFileSystemIntegrationTests/BufferedReaderTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/BufferedReaderTests.swift
@@ -86,6 +86,22 @@ final class BufferedReaderTests: XCTestCase {
         }
     }
 
+    func testBufferedReaderReadingShort() async throws {
+        let fs = FileSystem.shared
+        try await fs.withFileHandle(forReadingAt: #filePath) { handle in
+            var reader = handle.bufferedReader(capacity: .bytes(128))
+            var buffer = ByteBuffer()
+            while true {
+                let chunk = try await reader.read(.bytes(128))
+                buffer.writeImmutableBuffer(chunk)
+                if chunk.readableBytes < 128 { break }
+            }
+
+            let info = try await handle.info()
+            XCTAssertEqual(Int64(buffer.readableBytes), info.size)
+        }
+    }
+
     func testBufferedReaderReadWhile() async throws {
         let fs = FileSystem.shared
         let path = try await fs.temporaryFilePath()


### PR DESCRIPTION
Motivation:

When the `BufferedReader` reads short when filling its buffer during a request for some bytes, it may avoid giving the caller all bytes available. The bytes remain in the buffer and are available on the next call but this appears to the caller as if the file has been read completely as the returned bytes are less than those requested.

Modifications:

- Read the expected bytes or whatever is left in the buffer
- Add a test

Result:

Less unexpected behaviour