### PR TITLE
[Proof of concept] Async non-blocking IO using task executor preference

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -89,6 +89,10 @@ let package = Package(
                 "NIOCore",
                 "_NIODataStructures",
                 swiftAtomics,
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete"),
+                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"]),
             ]
         ),
         .target(
@@ -313,6 +317,10 @@ let package = Package(
             dependencies: [
                 "NIOPosix",
                 "NIOCore",
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete"),
+                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"]),
             ]
         ),
         .executableTarget(
@@ -392,6 +400,10 @@ let package = Package(
                 "NIOEmbedded",
                 "CNIOLinux",
                 "NIOTLS",
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete"),
+                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"]),
             ]
         ),
         .testTarget(

--- a/Sources/NIOPosix/New/AsyncSequence/AsyncSocketSequence.swift
+++ b/Sources/NIOPosix/New/AsyncSequence/AsyncSocketSequence.swift
@@ -1,0 +1,117 @@
+import NIOCore
+
+struct AsyncSocketSequence: AsyncSequence {
+    typealias Element = ByteBuffer
+    private let socket: Socket
+    private let executor: IOExecutor
+
+    internal init(socket: Socket, executor: IOExecutor) {
+        self.socket = socket
+        self.executor = executor
+    }
+
+    func makeAsyncIterator() -> AsyncIterator {
+        return AsyncIterator(socket: self.socket, executor: self.executor)
+    }
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+        fileprivate enum State {
+            fileprivate struct Running {
+                fileprivate let socket: Socket
+                fileprivate let allocator: ByteBufferAllocator
+                fileprivate var pooledAllocator: PooledRecvBufferAllocator
+                fileprivate let executor: IOExecutor
+                fileprivate var seenReadEOF = false
+            }
+            case running(Running)
+            case finished
+        }
+
+        private var state: State
+
+        init(socket: Socket, executor: IOExecutor) {
+            self.state = .running(.init(
+                socket: socket,
+                allocator: .init(), // TODO: Inject
+                pooledAllocator: .init(capacity: 10, recvAllocator: AdaptiveRecvByteBufferAllocator()),  // TODO: Inject
+                executor: executor)
+            )
+
+        }
+        mutating func next() async throws -> Element? {
+            // TODO: At best we would want to use `withTaskExecutorPreference` here but it is currently wrongly marked @Sendable
+            switch self.state {
+            case .running(var running):
+                running.executor.preconditionOnExecutor()
+
+                while true {
+                    let socket = running.socket
+                    let (buffer, result) = try running.pooledAllocator.buffer(
+                        allocator: running.allocator
+                    ) { buffer in
+                        try buffer.withMutableWritePointer {
+                            try socket.read(pointer: $0)
+                        }
+                    }
+                    switch result {
+                    case .wouldBlock:
+                        do {
+                            // TODO: How should we handle cancellation here?
+                            let eventSet = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<SelectorEventSet, Error>) in
+                                do {
+                                    try running.executor.reregister(
+                                        selectable: running.socket
+                                    ) { registration in
+                                        registration.interested.insert(.read)
+                                        registration.interested.insert(.readEOF)
+                                        registration.readContinuation = continuation
+                                    }
+                                } catch {
+                                    continuation.resume(with: .failure(error))
+                                }
+                            }
+
+                            if eventSet.contains(.readEOF) {
+                                // We got a readEOF from the selector but there might still be data to
+                                // read from the socket so we are going to continue looping until we
+                                // get a zero byte read.
+                                running.seenReadEOF = true
+                                self.state = .running(running)
+                                continue
+                            }
+
+
+                            if eventSet.contains(.read) {
+                                // We got a read event so let's try to read from the socket again
+                                continue
+                            }
+
+
+                            // We have to unregister for read and readEOF now after we got it
+                            try running.executor.reregister(selectable: running.socket) { registration in
+                                registration.interested.subtract(.read)
+                                registration.interested.subtract(.readEOF)
+                            }
+                        } catch {
+                            // We got an error while trying to re-register
+                            // that means the selector is closed and we just throw whatever error
+                            // we have up the chain
+                            self.state = .finished
+                            throw error
+                        }
+                    case .processed:
+                        if buffer.readableBytes == 0 {
+                            // Reading a 0 byte buffer means that we received a TCP FIN. We can
+                            // transition to finished and return nil now
+                            self.state = .finished
+                            return nil
+                        }
+                        return buffer
+                    }
+                }
+            case .finished:
+                return nil
+            }
+        }
+    }
+}

--- a/Sources/NIOPosix/New/AsyncWriter/AsyncWriter.swift
+++ b/Sources/NIOPosix/New/AsyncWriter/AsyncWriter.swift
@@ -1,0 +1,12 @@
+/// An AsyncWriter provides an abstraction to write elements to an underlying sink.
+public protocol AsyncWriter {
+    associatedtype Element
+
+    /// Writes the element to the underlying sink.
+    mutating func write(_ element: consuming Element) async throws
+
+    /// Finishes the underlying sink.
+    ///
+    /// This method is useful for sinks that support half-closure such as TCP or TLS 1.3.
+    mutating func finish() async throws
+}

--- a/Sources/NIOPosix/New/IOExecutor.swift
+++ b/Sources/NIOPosix/New/IOExecutor.swift
@@ -1,0 +1,308 @@
+import NIOCore
+import NIOConcurrencyHelpers
+import Atomics
+import DequeModule
+
+//struct SelectableExecutorRegistration: Registration {
+//    var interested: SelectorEventSet
+//    var registrationID: SelectorRegistrationID
+//    var readContinuation: CheckedContinuation<SelectorEventSet, Error>?
+//    var writeContinuation: CheckedContinuation<SelectorEventSet, Error>?
+//}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+public final class IOExecutor: _TaskExecutor, SerialExecutor, @unchecked Sendable {
+    enum Job {
+        case job(UnownedJob)
+        case deregister(BaseSocket)
+    }
+    public static func make(
+        name: String
+    )  -> IOExecutor {
+        let lock = ConditionLock(value: 0)
+
+        /* synchronised by `lock` */
+        var _loop: IOExecutor! = nil
+
+        NIOThread.spawnAndRun(name: name, detachThread: false) { thread in
+            assert(NIOThread.current == thread)
+
+            do {
+                let loop = IOExecutor(
+                    thread: thread
+                )
+                lock.lock(whenValue: 0)
+                _loop = loop
+                lock.unlock(withValue: 1)
+                try loop.run()
+            } catch {
+                // We fatalError here because the only reasons this can be hit is if the underlying kqueue/epoll give us
+                // errors that we cannot handle which is an unrecoverable error for us.
+                fatalError("Unexpected error while running SelectableEventLoop: \(error).")
+            }
+        }
+        lock.lock(whenValue: 1)
+        defer { lock.unlock() }
+        return _loop!
+    }
+
+    /// This is the state that is accessed from multiple threads; hence, it must be protected via a lock.
+    @usableFromInline
+    struct MultiThreadedState {
+        /// Indicates if we are running and about to pop more tasks. If this is true then we don't have to wake the selector.
+        @usableFromInline
+        var pendingTaskPop = false
+        /// This is the deque of enqueued jobs that we have to execute in the order they got enqueued.
+        var jobs = Deque<Job>(minimumCapacity: 4096)
+    }
+
+    /// This is the state that is bound to this thread.
+    @usableFromInline
+    struct ThreadBoundState {
+        /// The executor's thread.
+        private var thread: NIOThread
+
+        /// The executor's selector.
+        var selector: NewKQueueSelector {
+            get {
+                assert(self.thread.isCurrent)
+                return self._selector
+            }
+            set {
+                assert(self.thread.isCurrent)
+                self._selector = newValue
+            }
+        }
+
+        /// The jobs that are next in line to be executed.
+        var nextExecutedJobs: Deque<Job> {
+            get {
+                assert(self.thread.isCurrent)
+                return self._nextExecutedJobs
+            }
+            set {
+                assert(self.thread.isCurrent)
+                self._nextExecutedJobs = newValue
+            }
+        }
+
+        /// This method can be called from off thread so we are not asserting here.
+        func wakeupSelector() throws {
+            try self._selector.wakeup()
+        }
+
+        /// The backing storage for the selector.
+        var _selector: NewKQueueSelector
+
+        /// The backing storage of the next executed jobs.
+        var _nextExecutedJobs: Deque<Job>
+
+        init(thread: NIOThread, _selector: NewKQueueSelector, _nextExecutedJobs: Deque<Job>) {
+            self.thread = thread
+            self._selector = _selector
+            self._nextExecutedJobs = _nextExecutedJobs
+        }
+    }
+
+    /// This is the state that is accessed from multiple threads; hence, it is protected via a lock.
+    ///
+    /// - Note:In the future we could use an MPSC queue and atomics here.
+    @usableFromInline
+    var _multiThreadedState = NIOLockedValueBox(MultiThreadedState())
+
+    /// This is the state that is accessed from the thread backing the executor.
+    private var _threadBoundState: ThreadBoundState
+
+    /// The thread of this executor
+    private var thread: NIOThread
+
+    internal init(thread: NIOThread) {
+        var nextExecutedJobs = Deque<Job>()
+        // We will process 4096 jobs per while loop.
+        nextExecutedJobs.reserveCapacity(4096)
+        self._threadBoundState = .init(
+            thread: thread,
+            _selector: try! NewKQueueSelector(),
+            _nextExecutedJobs: nextExecutedJobs
+        )
+        self.thread = thread
+    }
+
+    deinit {
+        // TODO: We should implement shutting down executors
+        fatalError()
+    }
+
+    public func enqueue(_ job: consuming ExecutorJob) {
+        let job = UnownedJob(job)
+        self.enqueue(.job(job))
+    }
+
+    private func enqueue(_ job: Job) {
+        if self.onExecutor {
+            // We are in the executor so we can just enqueue the job and
+            // it will get dequed after the current run loop tick.
+            self._multiThreadedState.withLockedValue { state in
+                state.jobs.append(job)
+            }
+        } else {
+            let shouldWakeSelector = self._multiThreadedState.withLockedValue { state in
+                state.jobs.append(job)
+                if state.pendingTaskPop {
+                    // There is already a next tick scheduled so we don't have to wake the selector.
+                    return false
+                } else {
+                    // We have to wake the selector and we are going to store that we are about to do that.
+                    state.pendingTaskPop = true
+                    return true
+                }
+            }
+
+            // We only need to wake up the selector if we're not in the EventLoop. If we're in the EventLoop already, we're
+            // either doing IO tasks (which happens before checking the scheduled tasks) or we're running a scheduled task
+            // already which means that we'll check at least once more if there are other scheduled tasks runnable. While we
+            // had the task lock we also checked whether the loop was _already_ going to be woken. This saves us a syscall on
+            // hot loops.
+            //
+            // In the future we'll use an MPSC queue here and that will complicate things, so we may get some spurious wakeups,
+            // but as long as we're using the big dumb lock we can make this optimization safely.
+            if shouldWakeSelector {
+                // Nothing we can do really if we fail to wake the selector
+                try? self._threadBoundState.wakeupSelector()
+            }
+        }
+    }
+
+    public func assertOnExecutor() {
+        assert(self.onExecutor)
+    }
+
+    public func preconditionOnExecutor() {
+        precondition(self.onExecutor)
+    }
+
+    /// Returns if we are currently running on the executor.
+    private var onExecutor: Bool {
+        return self.thread.isCurrent
+    }
+
+    /// - Note: This method must be called from the IOExecutor.
+    func register(
+        selectable: some Selectable,
+        interestedEvent: SelectorEventSet,
+        makeRegistration: (SelectorEventSet, SelectorRegistrationID) -> NewSelectorRegistration
+    ) throws {
+        // TODO: Check state
+        try self._threadBoundState.selector.register(
+            selectable: selectable,
+            interested: interestedEvent,
+            makeRegistration: makeRegistration
+        )
+    }
+
+    /// - Note: This method must be called from the IOExecutor.
+    func deregister(
+        socket: BaseSocket
+    ) throws {
+        // TODO: Check state
+        if self.onExecutor {
+            guard var registration = try self._threadBoundState.selector.deregister(selectable: socket) else {
+                return
+            }
+            registration.readContinuation?.resume(throwing: IOError(errnoCode: ECONNABORTED, reason: "Connection aborted"))
+            registration.readContinuation = nil
+            registration.writeContinuation?.resume(throwing: IOError(errnoCode: ECONNABORTED, reason: "Connection aborted"))
+            registration.writeContinuation = nil
+        } else {
+            self.enqueue(.deregister(socket))
+        }
+    }
+
+    /// - Note: This method must be called from the IOExecutor.
+    func reregister(
+        selectable: Selectable,
+        _ body: (inout NewSelectorRegistration) -> Void
+    ) throws {
+        // TODO: Check state
+
+        try self._threadBoundState.selector.reregister(selectable: selectable, body)
+    }
+
+    /// Wake the `Selector` which means `Selector.whenReady(...)` will unblock.
+    @usableFromInline
+    internal func _wakeupSelector() throws {
+        try self._threadBoundState.selector.wakeup()
+    }
+
+    /// Start processing the jobs and handle any I/O.
+    ///
+    /// This method will continue running and blocking if needed.
+    internal func run() throws {
+        self.assertOnExecutor()
+
+        // We need to ensure we process all jobs even if a job enqueued another job
+        while true {
+            self._multiThreadedState.withLockedValue { state in
+                if !state.jobs.isEmpty {
+                    // We got some jobs that we should execute. Let's copy them over so we can
+                    // give up the lock.
+                    while self._threadBoundState.nextExecutedJobs.count < 4096 {
+                        guard let job = state.jobs.popFirst() else {
+                            break
+                        }
+
+                        // TODO: The following CoWs right now. Need to fix that
+                        self._threadBoundState.nextExecutedJobs.append(job)
+                    }
+                }
+
+                if self._threadBoundState.nextExecutedJobs.isEmpty {
+                    // We got no jobs to execute so we will block and need to be woken up.
+                    state.pendingTaskPop = false
+                }
+            }
+
+            // Execute all the tasks that were submitted
+            let didExecuteJobs = !self._threadBoundState.nextExecutedJobs.isEmpty
+            // TODO: The following CoWs right now. Need to fix that
+            while let job = self._threadBoundState.nextExecutedJobs.popFirst() {
+                withAutoReleasePool {
+                    switch job {
+                    case .job(let unownedJob):
+                        unownedJob.runSynchronously(on: self.asUnownedSerialExecutor())
+                    case .deregister(let socket):
+                        try! self.deregister(socket: socket)
+                    }
+                }
+            }
+
+            if didExecuteJobs {
+                // We executed some jobs that might have enqueued new jobs
+                continue
+            }
+
+            try self._threadBoundState.selector.whenReady(
+                strategy: .block,
+                onLoopBegin: { self._multiThreadedState.withLockedValue { $0.pendingTaskPop = true } }
+            ) { eventSet, registration in
+                if eventSet.contains(.reset) {
+                    registration.readContinuation?.resume(throwing: IOError(errnoCode: ECONNRESET, reason: "connection reset"))
+                    registration.readContinuation = nil
+                    registration.writeContinuation?.resume(throwing: IOError(errnoCode: ECONNRESET, reason: "connection reset"))
+                    registration.writeContinuation = nil
+                }
+
+                if eventSet.contains(.read) || eventSet.contains(.readEOF) {
+                    assert(registration.readContinuation != nil)
+                    registration.readContinuation?.resume(returning: eventSet)
+                    registration.readContinuation = nil
+                }
+                if eventSet.contains(.write) || eventSet.contains(.writeEOF) {
+                    assert(registration.writeContinuation != nil)
+                    registration.writeContinuation?.resume(returning: eventSet)
+                    registration.writeContinuation = nil
+                }
+            }
+        }
+    }
+}

--- a/Sources/NIOPosix/New/Selector/NewSelector.swift
+++ b/Sources/NIOPosix/New/Selector/NewSelector.swift
@@ -1,0 +1,396 @@
+import NIOCore
+import NIOConcurrencyHelpers
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+struct NewSelectorRegistration {
+    /// The `SelectorEventSet` in which the `Registration` is interested.
+    var interested: SelectorEventSet
+    var registrationID: SelectorRegistrationID
+    var readContinuation: CheckedContinuation<SelectorEventSet, Error>?
+    var writeContinuation: CheckedContinuation<SelectorEventSet, Error>?
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+struct NewSelectorEvent {
+    public let registration: NewSelectorRegistration
+    public var io: SelectorEventSet
+
+    /// Create new instance
+    ///
+    /// - parameters:
+    ///     - io: The `SelectorEventSet` that triggered this event.
+    ///     - registration: The registration that belongs to the event.
+    init(io: SelectorEventSet, registration: NewSelectorRegistration) {
+        self.io = io
+        self.registration = registration
+    }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+struct NewKQueueSelector {
+    private static let initialEventsCapacity = 64
+    fileprivate enum State {
+        fileprivate struct Open {
+            fileprivate var registrations = [Int: NewSelectorRegistration]()
+            fileprivate var currentRegistrationID = SelectorRegistrationID.initialRegistrationID
+            fileprivate let myThread: NIOThread
+            fileprivate var selectorFD: CInt
+            fileprivate var events: UnsafeMutablePointer<kevent>
+            fileprivate var eventsCapacity: Int
+        }
+        case open(Open)
+        case closed
+    }
+
+    private var state: State
+
+    private var _selectorFD: CInt {
+        switch self.state {
+        case .open(let open):
+            return open.selectorFD
+        case .closed:
+            return -1
+        }
+    }
+
+    init() throws {
+        let selectorFD = try KQueue.kqueue()
+        self.state = .open(.init(
+            myThread: NIOThread.current,
+            selectorFD: selectorFD,
+            events: Self.allocateEventsArray(capacity: Self.initialEventsCapacity),
+            eventsCapacity: Self.initialEventsCapacity
+        ))
+
+        var event = kevent()
+        event.ident = 0
+        event.filter = Int16(EVFILT_USER)
+        event.fflags = UInt32(NOTE_FFNOP)
+        event.data = 0
+        event.udata = nil
+        event.flags = UInt16(EV_ADD | EV_ENABLE | EV_CLEAR)
+        try withUnsafeMutablePointer(to: &event) { ptr in
+            try Self.kqueueApplyEventChangeSet(selectorFD: selectorFD, keventBuffer: UnsafeMutableBufferPointer(start: ptr, count: 1))
+        }
+    }
+
+    /// Apply a kqueue changeset by calling the `kevent` function with the `kevent`s supplied in `keventBuffer`.
+    private static func kqueueApplyEventChangeSet(
+        selectorFD: CInt,
+        keventBuffer: UnsafeMutableBufferPointer<kevent>
+    ) throws {
+        // WARNING: This is called on `self.myThread` OR with `self.externalSelectorFDLock` held.
+        // So it MUST NOT touch anything on `self.` apart from constants and `self.selectorFD`.
+        guard keventBuffer.count > 0 else {
+            // nothing to do
+            return
+        }
+        do {
+            try KQueue.kevent(
+                kq: selectorFD,
+                changelist: keventBuffer.baseAddress!,
+                nchanges: CInt(keventBuffer.count),
+                eventlist: nil,
+                nevents: 0,
+                timeout: nil
+            )
+        } catch let err as IOError {
+            if err.errnoCode == EINTR {
+                // See https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
+                // When kevent() call fails with EINTR error, all changes in the changelist have been applied.
+                return
+            }
+            throw err
+        }
+    }
+
+    private func kqueueUpdateEventNotifications<S: Selectable>(
+        selectorFD: CInt,
+        selectable: S,
+        interested: SelectorEventSet,
+        oldInterested: SelectorEventSet?,
+        registrationID: SelectorRegistrationID
+    ) throws {
+//        assert(self.myThread == NIOThread.current)
+        let oldKQueueFilters = KQueueEventFilterSet(selectorEventSet: oldInterested ?? ._none)
+        let newKQueueFilters = KQueueEventFilterSet(selectorEventSet: interested)
+        assert(interested.contains(.reset))
+        assert(oldInterested?.contains(.reset) ?? true)
+
+        try selectable.withUnsafeHandle {
+            try newKQueueFilters.calculateKQueueFilterSetChanges(
+                previousKQueueFilterSet: oldKQueueFilters,
+                fileDescriptor: $0,
+                registrationID: registrationID,
+                selectorFD: selectorFD,
+                Self.kqueueApplyEventChangeSet
+            )
+        }
+    }
+
+    private static func toKQueueTimeSpec(strategy: SelectorStrategy) -> timespec? {
+        switch strategy {
+        case .block:
+            return nil
+        case .now:
+            return timespec(tv_sec: 0, tv_nsec: 0)
+        case .blockUntilTimeout(let nanoseconds):
+            // A scheduledTask() specified with a zero or negative timeAmount, will be scheduled immediately
+            // and therefore SHOULD NOT result in a kevent being created with a negative or zero timespec.
+            precondition(nanoseconds.nanoseconds > 0, "\(nanoseconds) is invalid (0 < nanoseconds)")
+
+            var ts = timespec(timeAmount: nanoseconds)
+            // Check that the timespec tv_nsec field conforms to the definition in the C11 standard (ISO/IEC 9899:2011).
+            assert((0..<1_000_000_000).contains(ts.tv_nsec), "\(ts) is invalid (0 <= tv_nsec < 1_000_000_000)")
+
+            // The maximum value in seconds supported by the Darwin-kernel interval timer (kern_time.c:itimerfix())
+            // (note that - whilst unlikely - this value *could* change).
+            let sysIntervalTimerMaxSec = 100_000_000
+
+            // Clamp the timespec tv_sec value to the maximum supported by the Darwin-kernel.
+            // Whilst this schedules the event far into the future (several years) it will still be triggered provided
+            // the system stays up.
+            ts.tv_sec = min(ts.tv_sec, sysIntervalTimerMaxSec)
+
+            return ts
+        }
+    }
+
+//    deinit {
+//        self.deinitAssertions0()
+//        assert(self.registrations.count == 0, "left-over registrations: \(self.registrations)")
+//        assert(self.lifecycleState == .closed, "Selector \(self.lifecycleState) (expected .closed) on deinit")
+//        assert(self.selectorFD == -1, "self.selectorFD == \(self.selectorFD) on Selector deinit, forgot close?")
+//        Selector.deallocateEventsArray(events: events, capacity: eventsCapacity)
+//    }
+
+    private static func allocateEventsArray(capacity: Int) -> UnsafeMutablePointer<kevent> {
+        let events: UnsafeMutablePointer<kevent> = UnsafeMutablePointer.allocate(capacity: capacity)
+        events.initialize(to: kevent())
+        return events
+    }
+
+    private static func deallocateEventsArray(events: UnsafeMutablePointer<kevent>, capacity: Int) {
+        events.deinitialize(count: capacity)
+        events.deallocate()
+    }
+
+    private mutating func growEventArrayIfNeeded(ready: Int) {
+//          assert(self.myThread == NIOThread.current)
+        switch self.state {
+        case .open(var open):
+            Self.deallocateEventsArray(events: open.events, capacity: open.eventsCapacity)
+            // double capacity
+            open.eventsCapacity = ready << 1
+            open.events = Self.allocateEventsArray(capacity: open.eventsCapacity)
+            self.state = .open(open)
+
+        case .closed:
+            fatalError()
+        }
+      }
+
+    /// Register `Selectable` on the `Selector`.
+    ///
+    /// - parameters:
+    ///     - selectable: The `Selectable` to register.
+    ///     - interested: The `SelectorEventSet` in which we are interested and want to be notified about.
+    ///     - makeRegistration: Creates the registration data for the given `SelectorEventSet`.
+    mutating func register<S: Selectable>(
+        selectable: S,
+        interested: SelectorEventSet,
+        makeRegistration: (SelectorEventSet, SelectorRegistrationID) -> NewSelectorRegistration
+    ) throws {
+//        assert(self.myThread == NIOThread.current)
+        assert(interested.contains(.reset))
+
+        switch self.state {
+        case .open(var open):
+            try selectable.withUnsafeHandle { fd in
+                assert(open.registrations[Int(fd)] == nil)
+                try kqueueUpdateEventNotifications(
+                    selectorFD: open.selectorFD,
+                    selectable: selectable,
+                    interested: interested,
+                    oldInterested: nil,
+                    registrationID: open.currentRegistrationID
+                )
+                let newRegistrationID = open.currentRegistrationID.nextRegistrationID()
+                let registration = makeRegistration(interested, newRegistrationID)
+
+                open.registrations[Int(fd)] = registration
+                self.state = .open(open)
+            }
+        case .closed:
+            throw IOError(errnoCode: EBADF, reason: "can't register on closed selector.")
+        }
+    }
+
+    mutating func reregister<S: Selectable>(
+        selectable: S,
+        _ body: (inout NewSelectorRegistration) -> Void
+    ) throws {
+        // assert(self.myThread == NIOThread.current)
+
+        switch self.state {
+        case .open(var open):
+            try selectable.withUnsafeHandle { fd in
+                var registration = open.registrations[Int(fd)]!
+                let oldInterested = registration.interested
+                body(&registration)
+
+                assert(registration.interested.contains(.reset), "must register for at least .reset but tried registering for \(registration.interested)")
+                try kqueueUpdateEventNotifications(
+                    selectorFD: open.selectorFD,
+                    selectable: selectable,
+                    interested: registration.interested,
+                    oldInterested: oldInterested,
+                    registrationID: registration.registrationID
+                )
+                open.registrations[Int(fd)] = registration
+                self.state = .open(open)
+            }
+        case .closed:
+            throw IOError(errnoCode: EBADF, reason: "can't re-register on closed selector.")
+        }
+    }
+
+    mutating func deregister<S: Selectable>(
+        selectable: S
+    ) throws -> NewSelectorRegistration? {
+//        assert(self.myThread == NIOThread.current)
+        switch self.state {
+        case .open(var open):
+            return try selectable.withUnsafeHandle { fd in
+                guard let registration = open.registrations.removeValue(forKey: Int(fd)) else {
+                    return nil
+                }
+                self.state = .open(open)
+                try kqueueUpdateEventNotifications(
+                    selectorFD: open.selectorFD,
+                    selectable: selectable,
+                    interested: .reset,
+                    oldInterested: registration.interested,
+                    registrationID: open.currentRegistrationID
+                )
+
+                return registration
+            }
+
+        case .closed:
+            throw IOError(errnoCode: EBADF, reason: "can't deregister from selector as it's closed.")
+        }
+    }
+
+    mutating func whenReady(
+        strategy: SelectorStrategy,
+        onLoopBegin loopStart: () -> Void,
+        _ body: (SelectorEventSet, inout NewSelectorRegistration) throws -> Void
+    ) throws -> Void {
+//        assert(self.myThread == NIOThread.current)
+
+        switch self.state {
+        case .open(var open):
+            let timespec = Self.toKQueueTimeSpec(strategy: strategy)
+            let ready = try timespec.withUnsafeOptionalPointer { ts in
+                Int(try KQueue.kevent(
+                    kq: open.selectorFD,
+                    changelist: nil,
+                    nchanges: 0,
+                    eventlist: open.events,
+                    nevents: Int32(open.eventsCapacity),
+                    timeout: ts
+                ))
+            }
+
+            loopStart()
+
+            for i in 0..<ready {
+                let ev = open.events[i]
+                let filter = Int32(ev.filter)
+                let eventRegistrationID = SelectorRegistrationID(kqueueUData: ev.udata)
+                guard Int32(ev.flags) & EV_ERROR == 0 else {
+                    throw IOError(errnoCode: Int32(ev.data), reason: "kevent returned with EV_ERROR set: \(String(describing: ev))")
+                }
+                guard filter != EVFILT_USER, var registration = open.registrations[Int(ev.ident)] else {
+                    continue
+                }
+                guard eventRegistrationID == registration.registrationID else {
+                    continue
+                }
+                var selectorEvent: SelectorEventSet = ._none
+                switch filter {
+                case EVFILT_READ:
+                    selectorEvent.formUnion(.read)
+                    fallthrough // falling through here as `EVFILT_READ` also delivers `EV_EOF` (meaning `.readEOF`)
+                case EVFILT_EXCEPT:
+                    if Int32(ev.flags) & EV_EOF != 0 && registration.interested.contains(.readEOF) {
+                        // we only add `.readEOF` if it happened and the user asked for it
+                        selectorEvent.formUnion(.readEOF)
+                    }
+                case EVFILT_WRITE:
+                    selectorEvent.formUnion(.write)
+                default:
+                    // We only use EVFILT_USER, EVFILT_READ, EVFILT_EXCEPT and EVFILT_WRITE.
+                    fatalError("unexpected filter \(ev.filter)")
+                }
+                if ev.fflags != 0 {
+                    selectorEvent.formUnion(.reset)
+                }
+                // we can only verify the events for i == 0 as for i > 0 the user might have changed the registrations since then.
+                assert(i != 0 || selectorEvent.isSubset(of: registration.interested), "selectorEvent: \(selectorEvent), registration: \(registration)")
+
+                // in any case we only want what the user is currently registered for & what we got
+                selectorEvent = selectorEvent.intersection(registration.interested)
+
+                guard selectorEvent != ._none else {
+                    continue
+                }
+                do {
+                    try body(selectorEvent, &registration)
+                    open.registrations[Int(ev.ident)] = registration
+                    self.state = .open(open)
+                } catch {
+                    open.registrations[Int(ev.ident)] = registration
+                    self.state = .open(open)
+                    throw error
+                }
+            }
+
+            self.growEventArrayIfNeeded(ready: ready)
+        case .closed:
+            throw IOError(errnoCode: EBADF, reason: "can't call whenReady for selector as it's closed.")
+        }
+    }
+//
+//    /// Close the `Selector`.
+//    ///
+//    /// After closing the `Selector` it's no longer possible to use it.
+//    func close() throws {
+//        assert(self.myThread == NIOThread.current)
+//        guard self.lifecycleState == .open else {
+//            throw IOError(errnoCode: EBADF, reason: "can't close selector as it's \(self.lifecycleState).")
+//        }
+//        try self.close0()
+//        self.lifecycleState = .closed
+//        self.registrations.removeAll()
+//    }
+//
+    /* attention, this may (will!) be called from outside the event loop, ie. can't access mutable shared state (such as `self.open`) */
+    func wakeup() throws {
+//        assert(NIOThread.current != self.myThread)
+        guard self._selectorFD >= 0 else {
+            throw EventLoopError.shutdown
+        }
+        var event = kevent()
+        event.ident = 0
+        event.filter = Int16(EVFILT_USER)
+        event.fflags = UInt32(NOTE_TRIGGER | NOTE_FFNOP)
+        event.data = 0
+        event.udata = nil
+        event.flags = 0
+        try withUnsafeMutablePointer(to: &event) { ptr in
+            try Self.kqueueApplyEventChangeSet(selectorFD: self._selectorFD, keventBuffer: UnsafeMutableBufferPointer(start: ptr, count: 1))
+        }
+    }
+}

--- a/Sources/NIOPosix/New/TCP/TCPConnection.swift
+++ b/Sources/NIOPosix/New/TCP/TCPConnection.swift
@@ -1,0 +1,186 @@
+import NIOCore
+
+/// A struct representing a TCP connection.
+public struct TCPConnection {
+    /// Connects to the target.
+    public static func connect(
+        executor: IOExecutor,
+        target: SocketAddress, // TODO: We want to introduce a target concept here
+        _ body: (Inbound, inout Outbound) async throws -> Void
+    ) async throws {
+        try await _withTaskExecutor(executor) {
+            let socket = try Socket(
+                protocolFamily: target.protocol,
+                type: .stream,
+                protocolSubtype: .default,
+                setNonBlocking: true
+            )
+
+            let inbound = Inbound(socket: socket, executor: executor)
+            var outbound = Outbound(socket: socket, executor: executor)
+
+            do {
+                try executor.register(
+                    selectable: socket,
+                    interestedEvent: [.reset]
+                ) { eventSet, registrationID in
+                    NewSelectorRegistration(
+                        interested: eventSet,
+                        registrationID: registrationID
+                    )
+                }
+
+                if !(try socket.connect(to: target)) {
+                    // We are not connected right away so we have to wait until we become writable
+                    let eventSet = try await withCheckedThrowingContinuation { continuation in
+                        do {
+                            try executor.reregister(
+                                selectable: socket
+                            ) { registration in
+                                registration.interested.insert(.write)
+                                registration.interested.insert(.writeEOF)
+                                registration.writeContinuation = continuation
+                            }
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
+                    }
+
+                    // We became writable and can now finish connecting
+                    try executor.reregister(selectable: socket) { registration in
+                        registration.interested.subtract(.write)
+                    }
+
+                    assert(eventSet.contains(.write))
+                    try socket.finishConnect()
+                }
+                try await body(inbound, &outbound)
+                // TODO: This needs better handling
+                try executor.deregister(socket: socket)
+                try socket.close()
+            } catch {
+                try executor.deregister(socket: socket)
+                try socket.close()
+                throw error
+            }
+        }
+    }
+
+    private let socket: Socket
+    private let executor: IOExecutor
+
+    internal init(socket: Socket, executor: IOExecutor) {
+        self.socket = socket
+        self.executor = executor
+    }
+
+    public func withInboundOutbound(
+        _ body: (Inbound, inout Outbound) async throws -> Void
+    ) async throws {
+        let inbound = Inbound(socket: self.socket, executor: self.executor)
+        var outbound = Outbound(socket: self.socket, executor: self.executor)
+
+        try await _withTaskExecutor(self.executor) {
+            do {
+                try executor.register(
+                    selectable: self.socket,
+                    interestedEvent: [.reset]
+                ) { eventSet, registrationID in
+                    NewSelectorRegistration(
+                        interested: eventSet,
+                        registrationID: registrationID
+                    )
+                }
+                try await body(inbound, &outbound)
+                try executor.deregister(socket: socket)
+                try socket.close()
+            } catch {
+                try executor.deregister(socket: socket)
+                try socket.close()
+                throw error
+            }
+        }
+    }
+
+    public struct Inbound: AsyncSequence {
+        public typealias Element = ByteBuffer
+        private let asyncSocketSequence: AsyncSocketSequence
+
+        internal init(socket: Socket, executor: IOExecutor) {
+            self.asyncSocketSequence = .init(socket: socket, executor: executor)
+        }
+
+        public func makeAsyncIterator() -> AsyncIterator {
+            return AsyncIterator(iterator: self.asyncSocketSequence.makeAsyncIterator())
+        }
+
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            private var iterator: AsyncSocketSequence.AsyncIterator
+
+            init(iterator: AsyncSocketSequence.AsyncIterator) {
+                self.iterator = iterator
+            }
+
+            public mutating func next() async throws -> Element? {
+                try await self.iterator.next()
+            }
+        }
+    }
+
+    public struct Outbound: AsyncWriter {
+        private let socket: Socket
+        private let executor: IOExecutor
+
+        internal init(socket: Socket, executor: IOExecutor) {
+            self.socket = socket
+            self.executor = executor
+        }
+
+        public mutating func write(_ element: consuming ByteBuffer) async throws {
+            self.executor.preconditionOnExecutor()
+            while true {
+                do {
+                    let result = try element.withUnsafeReadableBytes {
+                        try self.socket.write(pointer: $0)
+                    }
+
+                    switch result {
+                    case .wouldBlock(let writtenBytes):
+                        assert(writtenBytes == 0)
+                        try await withCheckedThrowingContinuation { continuation in
+                            do {
+                                try self.executor.reregister(
+                                    selectable: self.socket
+                                ) { registration in
+                                    registration.interested.insert(.write)
+                                    registration.writeContinuation = continuation
+                                }
+                            } catch {
+                                continuation.resume(with: .failure(error))
+                            }
+                        }
+
+                        try self.executor.reregister(selectable: self.socket) { registration in
+                            registration.interested.subtract(.write)
+                        }
+
+                    case .processed(let writtenBytes):
+                        element.moveReaderIndex(forwardBy: writtenBytes)
+                        if element.readableBytes == 0 {
+                            return
+                        } else {
+                            continue
+                        }
+                    }
+                } catch {
+                    throw error
+                }
+            }
+        }
+
+        public func finish() async throws {
+            self.executor.preconditionOnExecutor()
+            try self.socket.shutdown(how: .WR)
+        }
+    }
+}

--- a/Sources/NIOPosix/New/TCP/TCPListener.swift
+++ b/Sources/NIOPosix/New/TCP/TCPListener.swift
@@ -1,0 +1,151 @@
+import NIOCore
+
+public struct TCPListener: AsyncSequence {
+    public typealias Element = TCPConnection
+
+    public let localAddress: SocketAddress
+
+    private let socket: ServerSocket
+    private let executor: IOExecutor
+
+    private init(socket: ServerSocket, executor: IOExecutor) throws {
+        self.socket = socket
+        self.executor = executor
+        self.localAddress = try socket.localAddress()
+    }
+
+    public static func bind(
+        executor: IOExecutor,
+        host: String,
+        port: Int,
+        _ body: (TCPListener) async throws -> Void
+    ) async throws {
+        try await _withTaskExecutor(executor) {
+            let socket = try ServerSocket.bootstrap(
+                protocolFamily: .inet,
+                host: host,
+                port: port
+            )
+            try socket.setNonBlocking()
+
+            try socket.setOption(level: .socket, name: .so_reuseaddr, value: 1)
+
+            // We should switch to an IO executor here
+            do {
+                try executor.register(
+                    selectable: socket,
+                    interestedEvent: [.reset]
+                ) { eventSet, registrationID in
+                    NewSelectorRegistration(
+                        interested: eventSet,
+                        registrationID: registrationID
+                    )
+                }
+                try socket.listen()
+
+                let listener = try Self.init(socket: socket, executor: executor)
+                try await body(listener)
+                try executor.deregister(socket: socket)
+                try socket.close()
+            } catch {
+                do {
+                    try executor.deregister(socket: socket)
+                } catch {
+                    try socket.close()
+                    throw error
+                }
+                try socket.close()
+                throw error
+            }
+        }
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        return AsyncIterator(socket: self.socket, executor: self.executor)
+    }
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        private let socket: ServerSocket
+        private let executor: IOExecutor
+        private var finished = false
+
+        init(socket: ServerSocket, executor: IOExecutor) {
+            self.socket = socket
+            self.executor = executor
+
+        }
+        public mutating func next() async throws -> Element? {
+            // TODO: At best we would want to use `withTaskExecutorPreference` here but it is currently wrongly marked @Sendable
+            guard !finished else {
+                return nil
+            }
+
+            while true {
+                if let result = try self.socket.accept(setNonBlocking: true) {
+                    // We probably want to get the next executor out of the pool
+                    return TCPConnection(socket: result, executor: self.executor)
+                } else {
+                    if self.finished {
+                        return nil
+                    }
+
+                    do {
+                        // TODO: Handle cancellation
+                        let socket = self.socket
+                        let executor = self.executor
+                        let shouldContinue = try await withTaskCancellationHandler {
+                            let eventSet = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<SelectorEventSet, Error>) in
+                                do {
+                                    try self.executor.reregister(
+                                        selectable: self.socket
+                                    ) { registration in
+                                        registration.interested.insert(.read)
+                                        registration.interested.insert(.readEOF)
+                                        registration.readContinuation = continuation
+                                    }
+                                } catch {
+                                    continuation.resume(with: .failure(error))
+                                }
+                            }
+
+                            if eventSet.contains(.reset) {
+                                self.finished = true
+                                return true
+                            }
+
+                            if eventSet.contains(.readEOF) {
+                                self.finished = true
+                                return true
+                            }
+
+                            try self.executor.reregister(selectable: self.socket) { registration in
+                                registration.interested.subtract(.read)
+                                registration.interested.subtract(.readEOF)
+                            }
+
+                            if eventSet.contains(.read) {
+                                return true
+                            } else {
+                                fatalError()
+                            }
+                        } onCancel: {
+                            // TODO: We should introduce some kind of token system here
+                            try! executor.deregister(socket: socket)
+                        }
+
+                        if shouldContinue {
+                            continue
+                        } else {
+                            return nil
+                        }
+
+
+                    } catch {
+                        finished = true
+                        throw error
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -17,7 +17,7 @@ import NIOConcurrencyHelpers
 
 internal enum SelectorLifecycleState {
     case open
-    case closing
+//    case closing
     case closed
 }
 
@@ -155,7 +155,11 @@ internal class Selector<R: Registration>  {
     #error("Unsupported platform, no suitable selector backend (we need kqueue or epoll support)")
     #endif
 
-    var events: UnsafeMutablePointer<EventType>
+    var events: UnsafeMutablePointer<EventType> {
+        didSet {
+            print("Set events")
+        }
+    }
     var eventsCapacity = 64
 
     internal func testsOnly_withUnsafeSelectorFD<T>(_ body: (CInt) throws -> T) throws -> T {

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -547,6 +547,7 @@ internal enum Posix {
             return true
         } catch let err as IOError {
             if err.errnoCode == EINPROGRESS {
+                print("Connect in progress")
                 return false
             }
             throw err

--- a/Tests/NIOPosixTests/New/IOExecutorTests.swift
+++ b/Tests/NIOPosixTests/New/IOExecutorTests.swift
@@ -1,0 +1,21 @@
+import NIOPosix
+import XCTest
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+final class IOExecutorTests: XCTestCase {
+    static let executor = IOExecutor.make(name: "Test")
+
+    func testBasicExecutor() async throws {
+        await _withTaskExecutor(Self.executor) {
+            Self.executor.preconditionOnExecutor()
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    Self.executor.preconditionOnExecutor()
+                }
+                group.addTask {
+                    Self.executor.preconditionOnExecutor()
+                }
+            }
+        }
+    }
+}

--- a/Tests/NIOPosixTests/New/TCPTests.swift
+++ b/Tests/NIOPosixTests/New/TCPTests.swift
@@ -1,0 +1,196 @@
+import NIOPosix
+import NIOCore
+import XCTest
+
+final class EchoHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    var halfClosureAfterFirstRead = false
+
+    init(halfClosureAfterFirstRead: Bool = false) {
+        self.halfClosureAfterFirstRead = halfClosureAfterFirstRead
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        context.write(data, promise: nil)
+    }
+
+    func channelReadComplete(context: ChannelHandlerContext) {
+        context.flush()
+
+        if halfClosureAfterFirstRead {
+            context.close(mode: .output, promise: nil)
+        }
+    }
+}
+
+final class TCPTests: XCTestCase {
+    static let executor = IOExecutor.make(name: "Test")
+
+    func test() async throws {
+        let serverChannel = try await ServerBootstrap(group: MultiThreadedEventLoopGroup.singleton)
+            .childChannelInitializer { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    try channel.pipeline.syncOperations.addHandler(EchoHandler())
+                }
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .get()
+
+        try await TCPConnection.connect(
+            executor: Self.executor,
+            target: serverChannel.localAddress!
+        ) { inbound, outbound in
+            let hello = ByteBuffer(string: "Hello")
+            try await outbound.write(hello)
+            var iterator = inbound.makeAsyncIterator()
+            let response = try await iterator.next()
+            XCTAssertEqual(response, hello)
+        }
+    }
+
+    func testHalfClosure() async throws {
+        let serverChannel = try await ServerBootstrap(group: MultiThreadedEventLoopGroup.singleton)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    try channel.pipeline.syncOperations.addHandler(EchoHandler(halfClosureAfterFirstRead: true))
+                }
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .get()
+
+        try await TCPConnection.connect(
+            executor: Self.executor,
+            target: serverChannel.localAddress!
+        ) { inbound, outbound in
+            let hello = ByteBuffer(string: "Hello")
+            try await outbound.write(hello)
+            var iterator = inbound.makeAsyncIterator()
+            let response1 = try await iterator.next()
+            XCTAssertEqual(response1, hello)
+            let response2 = try await iterator.next()
+            XCTAssertNil(response2)
+        }
+    }
+
+    func testServerAndClient() async throws {
+        try await TCPListener.bind(
+            executor: Self.executor,
+            host: "127.0.0.1",
+            port: 0
+        ) { listener in
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await withThrowingDiscardingTaskGroup { group in
+                        print("Waiting for connections")
+                        for try await connection in listener {
+                            print("Got connection")
+                            group.addTask {
+                                try! await connection.withInboundOutbound { inbound, outbound in
+                                    for try await data in inbound {
+                                        try await outbound.write(data)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                try await TCPConnection.connect(
+                    executor: Self.executor,
+                    target: listener.localAddress
+                ) { inbound, outbound in
+                    print("Connected to server")
+                    let hello = ByteBuffer(string: "Hello")
+                    try await outbound.write(hello)
+                    var iterator = inbound.makeAsyncIterator()
+                    let response = try await iterator.next()
+                    XCTAssertEqual(response, hello)
+                }
+
+                group.cancelAll()
+            }
+        }
+    }
+
+    func testServerAndClient_sererHalfClosure() async throws {
+        try await TCPListener.bind(
+            executor: Self.executor,
+            host: "127.0.0.1",
+            port: 0
+        ) { listener in
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await withThrowingDiscardingTaskGroup { group in
+                        for try await connection in listener {
+                            group.addTask {
+                                try! await connection.withInboundOutbound { inbound, outbound in
+                                    var iterator = inbound.makeAsyncIterator()
+                                    guard let data = try await iterator.next() else {
+                                        return
+                                    }
+                                    try await outbound.write(data)
+                                    try await outbound.finish()
+                                }
+                            }
+                        }
+                    }
+                }
+
+                try await TCPConnection.connect(
+                    executor: Self.executor,
+                    target: listener.localAddress
+                ) { inbound, outbound in
+                    let hello = ByteBuffer(string: "Hello")
+                    try await outbound.write(hello)
+                    var iterator = inbound.makeAsyncIterator()
+                    let response1 = try await iterator.next()
+                    XCTAssertEqual(response1, hello)
+                    let response2 = try await iterator.next()
+                    XCTAssertNil(response2)
+                }
+
+                group.cancelAll()
+            }
+        }
+    }
+
+    func testServerAndClient_clientHalfClosure() async throws {
+        try await TCPListener.bind(
+            executor: Self.executor,
+            host: "127.0.0.1",
+            port: 0
+        ) { listener in
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await withThrowingDiscardingTaskGroup { group in
+                        for try await connection in listener {
+                            group.addTask {
+                                try! await connection.withInboundOutbound { inbound, outbound in
+                                    for try await data in inbound {
+                                        try await outbound.write(data)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                try await TCPConnection.connect(
+                    executor: Self.executor,
+                    target: listener.localAddress
+                ) { inbound, outbound in
+                    let hello = ByteBuffer(string: "Hello")
+                    try await outbound.write(hello)
+                    var iterator = inbound.makeAsyncIterator()
+                    let response = try await iterator.next()
+                    XCTAssertEqual(response, hello)
+                    try await outbound.finish()
+                }
+
+                group.cancelAll()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This a PoC PR mostly for educational reasons. Don't expect any more work on this but I wanted to showcase that it is possible and it might be interesting for others in the community.

# Motivation

During the adoption of our new `NIOAsyncChannel` we came across a few issues such as:
- The current bootstraps are not providing scoping to the underlying channel which doesn't work nicely with structured concurrency
- Unnecessary buffering between the `NIOAsyncChannel` components and the underlying pipeline
- Things like HTTP upgrades are inherently tied to the NIO pipeline; hence, they must use `EventLoopFutures`. This leads to API problems higher up the stack where we cannot spell it nicely with async primitives.

The first one can be fixed with new bootstraps but the last one is inherently tied to how our current networking stack works. After thinking about this more, I wanted to try if we could respell NIO with purely asynchronous primitives. This became possible via the newly introduced task executor preference feature that allows us to implement thread hops in normal async code.

# Modification

This PR is mostly a showcase of how the very lowest level could work for a non-blocking networking stack that is written using concurrency primitives such as `TaskExecutor`s and `AsyncSequence`. This PR shows three separate pieces working:

1. An `IOExecutor: TaskExecutor` that spawns a `pthread`. This thread is running a loop to execute `UnownedJob`s and knows how to handle I/O via a selector (kqueue)
2. A `TCPConenction` that uses the `IOExecutor` to handle non blocking reads and writes. It exposes them via an `AsyncSequence` and and `AsyncWriter`
3. A `TCPListener` that can accept new inbound `TCPConnection`s.

# TODOs
- Make this work in Linux (epoll)
- Fix the CoWs inside the executor
- Support Cancellation (only done for the listener right now)
- Make sure we close everything correctly
- Scoped IOExecutor access
- Handle all events and make sure we handle them correctly