### PR TITLE
Fix up the markdown output generated by `scripts/analyze_performance_results.rb`

### DIFF
--- a/scripts/analyze_performance_results.rb
+++ b/scripts/analyze_performance_results.rb
@@ -79,9 +79,9 @@ end
 def print_results_markdown(results)
   columns = ["min", "max", "mean", "std"]
   puts "| name | #{columns.join(" | ")} |"
-  puts "|#{Array.new(columns.size+1, '--').join("|")}|"
+  puts "|#{Array.new(columns.size+1, '---').join("|")}|"
   results.keys.each do |key|
-    print "| #{key}"
+    print "| `#{key}`"
     columns.each do |column|
       print " | #{results[key][column]}"
     end
@@ -111,9 +111,9 @@ end
 
 def print_comparison_markdown(results)
   puts "| name | current | previous | winner | diff |"
-  puts "|#{Array.new(5, '--').join("|")}|"
+  puts "|#{Array.new(5, '---').join("|")}|"
   results.keys.each do |key|
-    puts "| #{key} | #{results[key]["current"][::METRIC]} | #{results[key]["previous"][::METRIC]} | #{results[key]["winner"]} | #{results[key]["diff"]}% |"
+    puts "| `#{key}` | #{results[key]["current"][::METRIC]} | #{results[key]["previous"][::METRIC]} | #{results[key]["winner"]} | #{results[key]["diff"]}% |"
   end
 end
 


### PR DESCRIPTION
###Motivation:

`scripts/analyze_performance_results.rb` has `-o markdown`. But the output that it currently generates isn't compliant. It outputs: `|--|--|...` as the header separator. There need to be three or more `-` in that (or `:` replacing one of the dashes).

I've also put the test names in code blocks, this improves the rendering slightly.

###Modifications:

* Fix header separator output in markdown
* Put the test names in code blocks

###Result:

Markdown output renders properly in standard markdown viewers (github, MacDown).