### PR TITLE
Conform `NIOIPProtocol` to `Sendable`

### DIFF
--- a/Sources/NIOCore/IPProtocol.swift
+++ b/Sources/NIOCore/IPProtocol.swift
@@ -16,7 +16,7 @@
 /// called "Protocol" to identify the next level protocol.  This is an 8
 /// bit field.  In Internet Protocol version 6 (IPv6) [RFC8200], this field
 /// is called the "Next Header" field.
-public struct NIOIPProtocol: RawRepresentable, Hashable {
+public struct NIOIPProtocol: RawRepresentable, Hashable, Sendable {
     public typealias RawValue = UInt8
     public var rawValue: RawValue
     


### PR DESCRIPTION
# Motivation

We were missing a `Sendable` conformance on `NIOIPProtocol`
