### PR TITLE
Add some more `Sendable` annotations to `NIOCore`

### DIFF
--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -293,23 +293,23 @@ extension ChannelOptions {
 /// Provides `ChannelOption`s to be used with a `Channel`, `Bootstrap` or `ServerBootstrap`.
 public struct ChannelOptions: Sendable {
     #if !os(Windows)
-        public static let socket = { (level: SocketOptionLevel, name: SocketOptionName) -> Types.SocketOption in
+        public static let socket: @Sendable (SocketOptionLevel, SocketOptionName) -> ChannelOptions.Types.SocketOption = { (level: SocketOptionLevel, name: SocketOptionName) -> Types.SocketOption in
             .init(level: NIOBSDSocket.OptionLevel(rawValue: CInt(level)), name: NIOBSDSocket.Option(rawValue: CInt(name)))
         }
     #endif
 
     /// - seealso: `SocketOption`.
-    public static let socketOption = { (name: NIOBSDSocket.Option) -> Types.SocketOption in
+    public static let socketOption: @Sendable (NIOBSDSocket.Option) -> ChannelOptions.Types.SocketOption = { (name: NIOBSDSocket.Option) -> Types.SocketOption in
         .init(level: .socket, name: name)
     }
 
     /// - seealso: `SocketOption`.
-    public static let ipOption = { (name: NIOBSDSocket.Option) -> Types.SocketOption in
+    public static let ipOption: @Sendable (NIOBSDSocket.Option) -> ChannelOptions.Types.SocketOption = { (name: NIOBSDSocket.Option) -> Types.SocketOption in
         .init(level: .ip, name: name)
     }
 
     /// - seealso: `SocketOption`.
-    public static let tcpOption = { (name: NIOBSDSocket.Option) -> Types.SocketOption in
+    public static let tcpOption: @Sendable (NIOBSDSocket.Option) -> ChannelOptions.Types.SocketOption = { (name: NIOBSDSocket.Option) -> Types.SocketOption in
         .init(level: .tcp, name: name)
     }
 

--- a/Sources/NIOCore/DeadChannel.swift
+++ b/Sources/NIOCore/DeadChannel.swift
@@ -75,7 +75,7 @@ private final class DeadChannelCore: ChannelCore {
 /// A `ChannelPipeline` that is associated with a closed `Channel` must be careful to no longer use that original
 /// channel as it only holds an unowned reference to the original `Channel`. `DeadChannel` serves as a replacement
 /// that can be used when the original `Channel` might no longer be valid.
-internal final class DeadChannel: Channel {
+internal final class DeadChannel: Channel, @unchecked Sendable {
     let eventLoop: EventLoop
     let pipeline: ChannelPipeline
 

--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -64,7 +64,7 @@ private extension ifaddrs {
 
 /// A representation of a single network interface on a system.
 @available(*, deprecated, renamed: "NIONetworkDevice")
-public final class NIONetworkInterface {
+public final class NIONetworkInterface: Sendable {
     // This is a class because in almost all cases this will carry
     // four structs that are backed by classes, and so will incur 4
     // refcount operations each time it is copied.

--- a/Sources/NIOCore/UniversalBootstrapSupport.swift
+++ b/Sources/NIOCore/UniversalBootstrapSupport.swift
@@ -190,7 +190,7 @@ public struct NIOClientTCPBootstrap {
     ///
     /// - parameters:
     ///     - handler: A closure that initializes the provided `Channel`.
-    public func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> NIOClientTCPBootstrap {
+    public func channelInitializer(_ handler: @escaping @Sendable (Channel) -> EventLoopFuture<Void>) -> NIOClientTCPBootstrap {
         return NIOClientTCPBootstrap(self.underlyingBootstrap.channelInitializer(handler),
                                      tlsEnabler: self.tlsEnablerTypeErased)
     }


### PR DESCRIPTION
# Motivation

We have a few more warnings left under strict concurrency checking in `NIOCore`. This fixes the bulk of them that are not tied to `ChannelHandler` or `ChannelPipeline`.

# Modification

Add more `Sendable` and `@Sendable` annotations and make sure to use types that are `Sendable` annotated.