### PR TITLE
Remove large temp file after FS tests

### DIFF
--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
@@ -562,6 +562,11 @@ final class FileSystemTests: XCTestCase {
     func testCopyLargeFile() async throws {
         let sourcePath = try await self.fs.temporaryFilePath()
         let destPath = try await self.fs.temporaryFilePath()
+        self.addTeardownBlock {
+            _ = try? await self.fs.removeItem(at: sourcePath)
+            _ = try? await self.fs.removeItem(at: destPath)
+        }
+
         let sourceInfo = try await self.fs.withFileHandle(
             forWritingAt: sourcePath,
             options: .newFile(replaceExisting: false)

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
   update-benchmark-baseline:
     <<: *common
     command: /bin/bash -xcl "cd Benchmarks && swift package --disable-sandbox --scratch-path .build/$${SWIFT_VERSION-}/ --allow-writing-to-package-directory benchmark --format metricP90AbsoluteThresholds --path Thresholds/$${SWIFT_VERSION-}/"
-    
+
   cxx-interop-build:
     <<: *common
     command: /bin/bash -xcl "./scripts/cxx-interop-compatibility.sh"


### PR DESCRIPTION
Motivation:

One of the file system tests copies a large file but didn't clear up after itself.

Modifications:

- Remove the files after the test

Result:

Less disk space used