### PR TITLE
Build the new FileSystem module for Android

### DIFF
--- a/Sources/NIOFileSystem/DirectoryEntries.swift
+++ b/Sources/NIOFileSystem/DirectoryEntries.swift
@@ -650,7 +650,7 @@ private struct DirectoryEnumerator: Sendable {
 
 extension UnsafeMutablePointer<CInterop.FTSEnt> {
     fileprivate var path: FilePath {
-        return FilePath(platformString: self.pointee.fts_path)
+        return FilePath(platformString: self.pointee.fts_path!)
     }
 }
 

--- a/Sources/NIOFileSystem/FileInfo.swift
+++ b/Sources/NIOFileSystem/FileInfo.swift
@@ -73,8 +73,8 @@ public struct FileInfo: Hashable, Sendable {
     /// Creates a ``FileInfo`` by deriving values from a platform-specific value.
     public init(platformSpecificStatus: CInterop.Stat) {
         self._platformSpecificStatus = Stat(platformSpecificStatus)
-        self.type = FileType(platformSpecificMode: platformSpecificStatus.st_mode)
-        self.permissions = FilePermissions(masking: platformSpecificStatus.st_mode)
+        self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
+        self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)

--- a/Sources/NIOFileSystem/FileSystem.swift
+++ b/Sources/NIOFileSystem/FileSystem.swift
@@ -625,6 +625,8 @@ public struct FileSystem: Sendable, FileSystemProtocol {
                     )
                 }.get()
             }
+            #elseif os(Android)
+            return "/data/local/tmp"
             #else
             return "/tmp"
             #endif
@@ -959,6 +961,7 @@ extension FileSystem {
                 permissions: info.permissions
             )
 
+            #if !os(Android)
             // Copy over extended attributes, if any exist.
             do {
                 let attributes = try await dir.attributeNames()
@@ -979,6 +982,7 @@ extension FileSystem {
                 // that is the case.
                 ()
             }
+            #endif
 
             // Build a list of directories to copy over. Do this after closing the current
             // directory to avoid using too many descriptors.

--- a/Sources/NIOFileSystem/FileType.swift
+++ b/Sources/NIOFileSystem/FileType.swift
@@ -136,7 +136,7 @@ extension FileType {
     /// Initializes a file type from the `d_type` from `dirent`.
     @_spi(Testing)
     public init(direntType: UInt8) {
-        #if canImport(Darwin) || canImport(Musl)
+        #if canImport(Darwin) || canImport(Musl) || os(Android)
         let value = Int32(direntType)
         #elseif canImport(Glibc)
         let value = Int(direntType)

--- a/Sources/NIOFileSystem/Internal/Concurrency Primitives/ThreadPosix.swift
+++ b/Sources/NIOFileSystem/Internal/Concurrency Primitives/ThreadPosix.swift
@@ -18,8 +18,13 @@ import CNIOLinux
 
 private let sys_pthread_getname_np = CNIOLinux_pthread_getname_np
 private let sys_pthread_setname_np = CNIOLinux_pthread_setname_np
+#if os(Android)
+private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer) ->
+    UnsafeMutableRawPointer
+#else
 private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer?) ->
     UnsafeMutableRawPointer?
+#endif
 #elseif canImport(Darwin)
 import Darwin
 
@@ -119,7 +124,11 @@ enum ThreadOpsPosix: ThreadOps {
 
                 body(Thread(handle: hThread, desiredName: name))
 
+                #if os(Android)
+                return UnsafeMutableRawPointer(bitPattern: 0xdeadbee)!
+                #else
                 return nil
+                #endif
             },
             args: argv0
         )

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -239,7 +239,7 @@ public enum Syscall {
         size: Int
     ) -> Result<Int, Errno> {
         valueOrErrno(retryOnInterrupt: false) {
-            system_sendfile(output.rawValue, input.rawValue, offset, size)
+            system_sendfile(output.rawValue, input.rawValue, off_t(offset), size)
         }
     }
     #endif
@@ -347,7 +347,11 @@ public enum Libc {
         return valueOrErrno {
             pathBytes.withUnsafeMutableBufferPointer { pointer in
                 // The array must be terminated with a nil.
+                #if os(Android)
+                libc_fts_open([pointer.baseAddress!, unsafeBitCast(0, to: UnsafeMutablePointer<CInterop.PlatformChar>.self)], options.rawValue)
+                #else
                 libc_fts_open([pointer.baseAddress, nil], options.rawValue)
+                #endif
             }
         }
     }

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -330,7 +330,7 @@ internal func system_sendfile(
 internal func libc_fdopendir(
     _ fd: FileDescriptor.RawValue
 ) -> CInterop.DirPointer {
-    return fdopendir(fd)
+    return fdopendir(fd)!
 }
 
 /// readdir(3): Returns a pointer to the next directory entry
@@ -396,12 +396,21 @@ internal func libc_confstr(
 #endif
 
 /// fts(3)
+#if os(Android)
+internal func libc_fts_open(
+    _ path: [UnsafeMutablePointer<CInterop.PlatformChar>],
+    _ options: CInt
+) -> UnsafeMutablePointer<CInterop.FTS> {
+    return fts_open(path, options, nil)!
+}
+#else
 internal func libc_fts_open(
     _ path: [UnsafeMutablePointer<CInterop.PlatformChar>?],
     _ options: CInt
 ) -> UnsafeMutablePointer<CInterop.FTS> {
     return fts_open(path, options, nil)
 }
+#endif
 
 /// fts(3)
 internal func libc_fts_read(

--- a/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
@@ -1116,16 +1116,22 @@ extension SystemFileHandle {
         if delayMaterialization {
             // When opening in this mode we can more "atomically" create the file, that is, by not
             // leaving the user with a half written file should e.g. the system crash or throw an
-            // error while writing. On Linux we do this by opening the directory for the path
-            // with `O_TMPFILE` and creating a hard link when closing the file. On other platforms
-            // we generate a dot file with a randomised suffix name and rename it to the
+            // error while writing. On non-Android Linux we do this by opening the directory for
+            // the path with `O_TMPFILE` and creating a hard link when closing the file. On other
+            // platforms we generate a dot file with a randomised suffix name and rename it to the
             // destination.
+            #if os(Android)
+            let temporaryHardLink = false
+            #else
+            let temporaryHardLink = true
+            #endif
             return Self.syncOpenWithMaterialization(
                 atPath: path,
                 mode: mode,
                 options: options,
                 permissions: permissions,
-                executor: executor
+                executor: executor,
+                useTemporaryFileIfPossible: temporaryHardLink
             )
         } else {
             return Self.syncOpen(

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -34,7 +34,7 @@ final class FileHandleTests: XCTestCase {
         autoClose: Bool = true,
         _ execute: @Sendable (SystemFileHandle) async throws -> Void
     ) async throws {
-        let path = FilePath("/tmp/\(Self.temporaryFileName())")
+        let path = try await FilePath("\(FileSystem.shared.temporaryDirectory)/\(Self.temporaryFileName())")
         defer {
             // Remove the file when we're done.
             XCTAssertNoThrow(try Libc.remove(path).get())

--- a/Tests/NIOFileSystemTests/FileInfoTests.swift
+++ b/Tests/NIOFileSystemTests/FileInfoTests.swift
@@ -26,7 +26,7 @@ final class FileInfoTests: XCTestCase {
     private var status: CInterop.Stat {
         var status = CInterop.Stat()
         status.st_dev = 1
-        status.st_mode = S_IFREG | 0o777
+        status.st_mode = .init(S_IFREG | 0o777)
         status.st_nlink = 3
         status.st_ino = 4
         status.st_uid = 5


### PR DESCRIPTION
### Motivation:

Get the new module [building and tested on my Android CI again](https://github.com/finagolfin/swift-android-sdk/actions/runs/7970885103) (I had to make a few extra modifications there to get this working with the older Android API 24 that I test on my CI)

### Modifications:

- Add force unwraps where needed
- Update C types and account for nullability annotations in NDK 26
- Use /data/local/tmp for the `temporaryDirectory` and invoke it in the tests, instead of /tmp directly
- Don't copy over extended attributes
- Android doesn't support hard-linking on most partitions, so don't use it for materializing temporary files

### Result:

Everything works again on Android

@glbrntt, please review.