### PR TITLE
Fix CoW performance bug in `NIOThreadPool` work queue

### DIFF
--- a/Sources/NIOPerformanceTester/RunIfActiveBenchmark.swift
+++ b/Sources/NIOPerformanceTester/RunIfActiveBenchmark.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIOCore
+import NIOPosix
+
+final class RunIfActiveBenchmark: Benchmark {
+    private var threadPool: NIOThreadPool!
+
+    private var loop: EventLoop!
+    private var dg: DispatchGroup!
+    private var counter = 0
+
+    private let numThreads: Int
+    private let numTasks: Int
+
+    init(numThreads: Int, numTasks: Int) {
+        self.numThreads = numThreads
+        self.numTasks = numTasks
+    }
+
+    func setUp() throws {
+        self.threadPool = NIOThreadPool(numberOfThreads: self.numThreads)
+        self.threadPool.start()
+
+        // Prewarm the internal NIOThreadPool request queue, to avoid CoW
+        // work during the test runs.
+        let semaphore = DispatchSemaphore(value: 0)
+        let eventLoop = MultiThreadedEventLoopGroup.singleton.any()
+        let futures = (0..<self.numTasks).map { _ in
+            return self.threadPool.runIfActive(eventLoop: eventLoop) {
+                // Hold back all the work items, until they all got scheduled
+                semaphore.wait()
+            }
+        }
+
+        (0..<self.numTasks).forEach { _ in
+            semaphore.signal()
+        }
+
+        _ = try EventLoopFuture.whenAllSucceed(futures, on: eventLoop).wait()
+    }
+
+    func tearDown() {
+        try! self.threadPool.syncShutdownGracefully()
+    }
+
+    func run() -> Int {
+        let eventLoop = MultiThreadedEventLoopGroup.singleton.any()
+
+        let futures = (0..<self.numTasks).map { _ in
+            return self.threadPool.runIfActive(eventLoop: eventLoop) {
+                // Empty work item body
+            }
+        }
+
+        _ = try! EventLoopFuture.whenAllSucceed(futures, on: eventLoop).wait()
+
+        return 0
+    }
+}

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -1061,6 +1061,16 @@ try measureAndPrint(
 )
 
 try measureAndPrint(
+    desc: "runIfActive_1_thread_100k_tasks",
+    benchmark: RunIfActiveBenchmark(numThreads: 1, numTasks: 100_000)
+)
+
+try measureAndPrint(
+    desc: "runIfActive_8_threads_100k_tasks",
+    benchmark: RunIfActiveBenchmark(numThreads: 8, numTasks: 100_000)
+)
+
+try measureAndPrint(
     desc: "bytebufferview_copy_to_array_100k_times_1kb",
     benchmark: ByteBufferViewCopyToArrayBenchmark(
         iterations: 100_000,

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -57,14 +57,12 @@ public final class NIOThreadPool {
 
     /// The work that should be done by the `NIOThreadPool`.
     public typealias WorkItem = @Sendable (WorkItemState) -> Void
-
     private enum State {
         /// The `NIOThreadPool` is already stopped.
         case stopped
         /// The `NIOThreadPool` is shutting down, the array has one boolean entry for each thread indicating if it has shut down already.
         case shuttingDown([Bool])
-        /// The `NIOThreadPool` is up and running, `WorkItems` contains the yet unprocessed
-        /// `WorkItems`.
+        /// The `NIOThreadPool` is up and running, the `CircularBuffer` containing the yet unprocessed `WorkItems`.
         case running(CircularBuffer<WorkItem>)
         /// Temporary state used when mutating the .running(items). Used to avoid CoW copies.
         /// It should never be "leaked" outside of the lock block.

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import DequeModule
 import Dispatch
 import NIOConcurrencyHelpers
 import NIOCore
@@ -63,7 +64,7 @@ public final class NIOThreadPool {
         /// The `NIOThreadPool` is shutting down, the array has one boolean entry for each thread indicating if it has shut down already.
         case shuttingDown([Bool])
         /// The `NIOThreadPool` is up and running, the `CircularBuffer` containing the yet unprocessed `WorkItems`.
-        case running(CircularBuffer<WorkItem>)
+        case running(Deque<WorkItem>)
         /// Temporary state used when mutating the .running(items). Used to avoid CoW copies.
         /// It should never be "leaked" outside of the lock block.
         case modifying
@@ -221,7 +222,7 @@ public final class NIOThreadPool {
                 // This should never happen
                 fatalError("start() called while in shuttingDown")
             case .stopped:
-                self.state = .running(CircularBuffer(initialCapacity: 16))
+                self.state = .running(Deque(minimumCapacity: 16))
                 return false
             case .modifying:
                 fatalError(".modifying state misuse")

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -205,7 +205,7 @@ public final class NIOThreadPool {
 
             item = self.lock.withLock { () -> (WorkItem)? in
                 switch self.state {
-                case .running(var items):
+                case .running(let items):
                     return items.removeFirst()
                 case .shuttingDown(var aliveStates):
                     assert(aliveStates[identifier])

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -63,7 +63,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=343
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=130050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=110200
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=85

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -63,7 +63,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=341
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=130050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=110200
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=85

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -64,7 +64,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=341
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=130050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=110200
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=85

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -64,7 +64,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=350
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=130050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=110200
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=85

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -63,7 +63,7 @@ services:
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
       - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=343
-      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=130050
+      - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=110200
       - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=85


### PR DESCRIPTION
Fix CoW performance bug in `NIOThreadPool` work queue.

### Motivation:

`NIOThreadPool` uses an enum to track it's state. If the pool is running, it'll be in `State.running(CircularBuffer<WorkItem>)`. However this hard to mutate in place reliably. The current code certainly doesn't achieve that, which leads to CoW on each enqueue and dequeue.

### Modifications:

* I added a test to measure the behaviour before and after. It's called `RunIfActiveBenchmark`. It's run in 1 & 8 threads variants, with 100k tasks.
* I encapsulated the `CircularBuffer<WorkItem>` in a class, thus providing a layer of indirection during mutations, which avoid CoW
* I wrapped `WorkItem` which is a closure in a struct wrapped to avoid the cost of allocations discussed in: https://bugs.swift.org/browse/SR-15872

### Result:

Performance is orders of magnitudes greater. The "after" (measured for [`Deque` version](https://github.com/apple/swift-nio/pull/2669/commits/9380a6b1cdc394b9003ca447c193e9c4ccf1198a), on my own laptop [given current perf testing CI infra breakage]), is:
```
measuring: runIfActive_1_thread_100k_tasks: 0.251138375, 0.247212625, 0.257556917, 0.2396585, 0.245091042, 0.240477125, 0.246961292, 0.244519042, 0.240759375, 0.240233208,
measuring: runIfActive_8_threads_100k_tasks: 0.26803725, 0.262704083, 0.263101083, 0.266763792, 0.269062791, 0.267278875, 0.265546208, 0.266732625, 0.265480375, 0.271898916,
```
The before takes way too long to run (hours).
