### PR TITLE
Fix memory allocations counters on macOS.

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/template/AtomicCounter/Package.swift
+++ b/IntegrationTests/allocation-counter-tests-framework/template/AtomicCounter/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
     name: "AtomicCounter",
     products: [
-        .library(name: "AtomicCounter", targets: ["AtomicCounter"]),
+        .library(name: "AtomicCounter", type: .dynamic, targets: ["AtomicCounter"]),
     ],
     dependencies: [ ],
     targets: [


### PR DESCRIPTION
**Motivation**

Allocation counters are broken on macOS as described here: https://github.com/apple/swift-nio/issues/2672. This PR fixes it.

**Modifications**

`AtomicCounter` library is made `.dynamic`. This deduplicates the two (static) copies that used to exist. One embedded in the main binary, and the other in `HookedFunctions` dylib. This deplication fixes the issue, because there is just one copy of the counters in the process address space.

**Result**

All the tests counting allocations and related statistics work on macOS.
