### PR TITLE
Add cancellation to NIOThreadPool's async runIfActive

### DIFF
--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -80,6 +80,23 @@ public final class NIOThreadPool {
     private let lock = NIOLock()
     private var threads: [NIOThread]? = nil  // protected by `lock`
     private var state: State = .stopped
+
+    // WorkItems don't have a handle so they can't be cancelled directly. Instead an ID is assigned
+    // to each cancellable work item and the IDs of each work item to cancel is stored in this set.
+    // The set is checked when dequeuing work items prior to running them, the presence of an ID
+    // indicates it should be cancelled. This approach makes cancellation cheap, but slow, as the
+    // task isn't cancelled until it's dequeued.
+    //
+    // Possible alternatives:
+    // - Removing items from the work queue on cancellation. This is linear and runs the risk of
+    //   being expensive if a task tree with many enqueued work items is cancelled.
+    // - Storing an atomic 'is cancelled' flag with each work item. This adds an allocation per
+    //   work item.
+    //
+    // If a future version of this thread pool has work items which do have a handle this set should
+    // be removed.
+    //
+    // Note: protected by 'lock'.
     private var cancelledWorkIDs: Set<Int> = []
     private let nextWorkID = ManagedAtomic(0)
 
@@ -189,37 +206,28 @@ public final class NIOThreadPool {
     }
 
     private func process(identifier: Int) {
-        var item: (item: IdentifiableWorkItem, isCancelled: Bool)? = nil
-        var lastID: Int?
+        var itemAndState: (item: WorkItem, state: WorkItemState)? = nil
 
         repeat {
             /* wait until work has become available */
-            item = nil  // ensure previous work item is not retained for duration of semaphore wait
+            itemAndState = nil  // ensure previous work item is not retained for duration of semaphore wait
             self.semaphore.wait()
 
-            item = self.lock.withLock { () -> (IdentifiableWorkItem, Bool)? in
+            itemAndState = self.lock.withLock { () -> (WorkItem, WorkItemState)? in
                 switch self.state {
                 case .running(var items):
                     self.state = .modifying
-                    let item = items.removeFirst()
+                    let itemAndID = items.removeFirst()
 
-                    // There's a timing window between returning the work item from the lock and
-                    // running it where the task could be cancelled resulting in the ID being
-                    // stored indefinitely. To avoid that, check the previous ID as at this point
-                    // the work must have run.
-                    if let lastID = lastID {
-                        self.cancelledWorkIDs.remove(lastID)
-                    }
-
-                    let isCancelled: Bool
-                    if let id = item.id {
-                        isCancelled = self.cancelledWorkIDs.remove(id) != nil
+                    let state: WorkItemState
+                    if let id = itemAndID.id, !self.cancelledWorkIDs.isEmpty {
+                        state = self.cancelledWorkIDs.remove(id) == nil ? .active : .cancelled
                     } else {
-                        isCancelled = false
+                        state = .active
                     }
 
                     self.state = .running(items)
-                    return (item, isCancelled)
+                    return (itemAndID.workItem, state)
                 case .shuttingDown(var aliveStates):
                     assert(aliveStates[identifier])
                     aliveStates[identifier] = false
@@ -232,11 +240,8 @@ public final class NIOThreadPool {
                 }
             }
             /* if there was a work item popped, run it */
-            if let (item, isCancelled) = item {
-                lastID = item.id
-                item.workItem(isCancelled ? .cancelled : .active)
-            }
-        } while item != nil
+            itemAndState.map { item, state in item(state) }
+        } while itemAndState != nil
     }
 
     /// Start the `NIOThreadPool` if not already started.

--- a/Tests/NIOPosixTests/NIOThreadPoolTest.swift
+++ b/Tests/NIOPosixTests/NIOThreadPoolTest.swift
@@ -152,7 +152,7 @@ class NIOThreadPoolTest: XCTestCase {
             }
             XCTFail("Should not get here as thread pool isn't active")
         } catch {
-            XCTAssertNotNil(error as? NIOThreadPoolError.ThreadPoolInactive, "Error thrown should be of type ThreadPoolError")
+            XCTAssertNotNil(error as? CancellationError, "Error thrown should be of type CancellationError")
         }
         try await pool.shutdownGracefully()
     }

--- a/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
@@ -1121,7 +1121,7 @@ extension NonBlockingFileIOTest {
         }
     }
 
-    func testAsyncGettingErrorWhenEventLoopGroupIsShutdown() async throws {
+    func testAsyncGettingErrorWhenThreadPoolIsShutdown() async throws {
         try await self.threadPool.shutdownGracefully()
 
         try await withPipe { readFH, writeFH in
@@ -1130,9 +1130,9 @@ extension NonBlockingFileIOTest {
                     fileHandle: readFH,
                     byteCount: 1,
                     allocator: self.allocator)
-                XCTFail("testAsyncGettingErrorWhenEventLoopGroupIsShutdown: fileIO.read should throw an error")
+                XCTFail("testAsyncGettingErrorWhenThreadPoolIsShutdown: fileIO.read should throw an error")
             } catch {
-                XCTAssertTrue(error is NIOThreadPoolError.ThreadPoolInactive)
+                XCTAssertTrue(error is CancellationError)
             }
             return [readFH, writeFH]
         }


### PR DESCRIPTION
Motivation:

To dedupe the thread pool from NIOFileSystem and NIOPosix, the one from NIOPosix needs to gain support for cancellation for its async `runIfActive` function.

Modification:

- Generate a work ID when submitting async work to the pool, add that ID to a set in the cancellation handler
- Check the existence of the ID in the cancel set when dequeuing the work

Result:

Queued NIOThreadPool tasks can be cancelled before they are run.