### PR TITLE
Add "empty" privacy manifests

### DIFF
--- a/.PrivacyInfo.xcprivacy
+++ b/.PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -61,13 +61,22 @@ let package = Package(
                 "_NIODataStructures",
                 swiftCollections,
                 swiftAtomics,
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
-            name: "_NIODataStructures"
+            name: "_NIODataStructures",
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ]
         ),
         .target(
-            name: "_NIOBase64"
+            name: "_NIOBase64",
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ]
         ),
         .target(
             name: "NIOEmbedded",
@@ -77,6 +86,9 @@ let package = Package(
                 "_NIODataStructures",
                 swiftAtomics,
                 swiftCollections,
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
@@ -89,6 +101,9 @@ let package = Package(
                 "NIOCore",
                 "_NIODataStructures",
                 swiftAtomics,
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
@@ -97,6 +112,9 @@ let package = Package(
                 "NIOCore",
                 "NIOEmbedded",
                 "NIOPosix",
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
@@ -104,6 +122,9 @@ let package = Package(
             dependencies: [
                 "NIO",
                 "NIOCore",
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
@@ -111,22 +132,34 @@ let package = Package(
             dependencies: [
                 "NIO",
                 "NIOCore",
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
             name: "CNIOAtomics",
             dependencies: [],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ],
             cSettings: [
                 .define("_GNU_SOURCE"),
             ]
         ),
         .target(
             name: "CNIOSHA1",
-            dependencies: []
+            dependencies: [],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ]
         ),
         .target(
             name: "CNIOLinux",
             dependencies: [],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ],
             cSettings: [
                 .define("_GNU_SOURCE"),
             ]
@@ -134,18 +167,27 @@ let package = Package(
         .target(
             name: "CNIODarwin",
             dependencies: [],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ],
             cSettings: [
                 .define("__APPLE_USE_RFC_3542"),
             ]
         ),
         .target(
             name: "CNIOWindows",
-            dependencies: []
+            dependencies: [],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ]
         ),
         .target(
             name: "NIOConcurrencyHelpers",
             dependencies: [
                 "CNIOAtomics",
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
@@ -156,6 +198,9 @@ let package = Package(
                 "NIOConcurrencyHelpers",
                 "CNIOLLHTTP",
                 swiftCollections
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
@@ -166,10 +211,16 @@ let package = Package(
                 "NIOHTTP1",
                 "CNIOSHA1",
                 "_NIOBase64"
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
             name: "CNIOLLHTTP",
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ],
             cSettings: [
               .define("_GNU_SOURCE"),
               .define("LLHTTP_STRICT_MODE")
@@ -181,6 +232,9 @@ let package = Package(
                 "NIO",
                 "NIOCore",
                 swiftCollections,
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
@@ -191,6 +245,9 @@ let package = Package(
                 "NIOEmbedded",
                 "NIOHTTP1",
                 swiftAtomics,
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .target(
@@ -203,6 +260,9 @@ let package = Package(
                 swiftCollections,
                 swiftSystem,
             ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ],
             swiftSettings: [
                 .define("ENABLE_MOCKING", .when(configuration: .debug))
             ]
@@ -211,6 +271,9 @@ let package = Package(
             name: "NIOFileSystemFoundationCompat",
             dependencies: [
                 "NIOFileSystem",
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
 

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../.PrivacyInfo.xcprivacy

--- a/Sources/CNIOAtomics/PrivacyInfo.xcprivacy
+++ b/Sources/CNIOAtomics/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/CNIODarwin/PrivacyInfo.xcprivacy
+++ b/Sources/CNIODarwin/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/CNIOLLHTTP/PrivacyInfo.xcprivacy
+++ b/Sources/CNIOLLHTTP/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/CNIOLinux/PrivacyInfo.xcprivacy
+++ b/Sources/CNIOLinux/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/CNIOSHA1/PrivacyInfo.xcprivacy
+++ b/Sources/CNIOSHA1/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/CNIOWindows/PrivacyInfo.xcprivacy
+++ b/Sources/CNIOWindows/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIO/PrivacyInfo.xcprivacy
+++ b/Sources/NIO/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOConcurrencyHelpers/PrivacyInfo.xcprivacy
+++ b/Sources/NIOConcurrencyHelpers/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOCore/PrivacyInfo.xcprivacy
+++ b/Sources/NIOCore/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOEmbedded/PrivacyInfo.xcprivacy
+++ b/Sources/NIOEmbedded/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOFileSystem/PrivacyInfo.xcprivacy
+++ b/Sources/NIOFileSystem/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOFileSystemFoundationCompat/PrivacyInfo.xcprivacy
+++ b/Sources/NIOFileSystemFoundationCompat/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOFoundationCompat/PrivacyInfo.xcprivacy
+++ b/Sources/NIOFoundationCompat/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOHTTP1/PrivacyInfo.xcprivacy
+++ b/Sources/NIOHTTP1/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOPosix/PrivacyInfo.xcprivacy
+++ b/Sources/NIOPosix/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOTLS/PrivacyInfo.xcprivacy
+++ b/Sources/NIOTLS/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOTestUtils/PrivacyInfo.xcprivacy
+++ b/Sources/NIOTestUtils/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOWebSocket/PrivacyInfo.xcprivacy
+++ b/Sources/NIOWebSocket/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/_NIOBase64/PrivacyInfo.xcprivacy
+++ b/Sources/_NIOBase64/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/_NIOConcurrency/PrivacyInfo.xcprivacy
+++ b/Sources/_NIOConcurrency/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/_NIODataStructures/PrivacyInfo.xcprivacy
+++ b/Sources/_NIODataStructures/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy


### PR DESCRIPTION
- Add "empty" privacy manifests to all library targets that are depended on (directly or transitively) by library products
- Add resources in Package.swift