### PR TITLE
Handle 'atomically' created files more gracefully when detached

### DIFF
--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -195,6 +195,29 @@ public enum Syscall {
     #endif
 
     @_spi(Testing)
+    public static func link(
+        from source: FilePath,
+        to destination: FilePath
+    ) -> Result<Void, Errno> {
+        return nothingOrErrno(retryOnInterrupt: false) {
+            source.withPlatformString { src in
+                destination.withPlatformString { dst in
+                    system_link(src, dst)
+                }
+            }
+        }
+    }
+
+    @_spi(Testing)
+    public static func unlink(path: FilePath) -> Result<Void, Errno> {
+        return nothingOrErrno(retryOnInterrupt: false) {
+            path.withPlatformString { ptr in
+                system_unlink(ptr)
+            }
+        }
+    }
+
+    @_spi(Testing)
     public static func symlink(
         to destination: FilePath,
         from source: FilePath

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -306,6 +306,31 @@ internal func system_linkat(
 }
 #endif
 
+/// link(2): Creates a new link for a file.
+internal func system_link(
+    _ old: UnsafePointer<CInterop.PlatformChar>,
+    _ new: UnsafePointer<CInterop.PlatformChar>
+) -> CInt {
+    #if ENABLE_MOCKING
+    if mockingEnabled {
+        return mock(old, new)
+    }
+    #endif
+    return link(old, new)
+}
+
+/// unlink(2): Remove a directory entry.
+internal func system_unlink(
+    _ path: UnsafePointer<CInterop.PlatformChar>
+) -> CInt {
+    #if ENABLE_MOCKING
+    if mockingEnabled {
+        return mock(path)
+    }
+    #endif
+    return unlink(path)
+}
+
 #if canImport(Glibc) || canImport(Musl)
 /// sendfile(2): Transfer data between descriptors
 internal func system_sendfile(

--- a/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
@@ -272,7 +272,7 @@ extension SystemFileHandle: FileHandleProtocol {
             case let .open(descriptor):
                 lifecycle = .detached
 
-                // We need to be careful handling files which have delayed materialiszation to avoid
+                // We need to be careful handling files which have delayed materialization to avoid
                 // leftover temporary files.
                 //
                 // Where we use the 'link' mode we simply call materialize and return the

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -276,6 +276,10 @@ final class FileSystemErrorTests: XCTestCase {
             .symlink(errno: .badFileDescriptor, link: "link", target: "target", location: here)
         }
 
+        assertCauseIsSyscall("unlink", here) {
+            .unlink(errno: .badFileDescriptor, path: "unlink", location: here)
+        }
+
         assertCauseIsSyscall("readlink", here) {
             .readlink(errno: .badFileDescriptor, path: "link", location: here)
         }
@@ -525,6 +529,19 @@ final class FileSystemErrorTests: XCTestCase {
             ]
         ) { errno in
             .symlink(errno: errno, link: "link", target: "target", location: .fixed)
+        }
+    }
+
+    func testErrnoMapping_unlink() {
+        self.testErrnoToErrorCode(
+            expected: [
+                .permissionDenied: .permissionDenied,
+                .notPermitted: .permissionDenied,
+                .noSuchFileOrDirectory: .notFound,
+                .ioError: .io,
+            ]
+        ) { errno in
+            .unlink(errno: errno, path: "path", location: .fixed)
         }
     }
 

--- a/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
@@ -162,6 +162,24 @@ final class SyscallTests: XCTestCase {
         #endif
     }
 
+    func test_link() throws {
+        let testCases = [
+            MockTestCase(name: "link", .noInterrupt, "src", "dst") { _ in
+                try Syscall.link(from: "src", to: "dst").get()
+            },
+        ]
+        testCases.run()
+    }
+
+    func test_unlink() throws {
+        let testCases = [
+            MockTestCase(name: "unlink", .noInterrupt, "path") { _ in
+                try Syscall.unlink(path: "path").get()
+            },
+        ]
+        testCases.run()
+    }
+
     func test_symlink() throws {
         let testCases = [
             MockTestCase(name: "symlink", .noInterrupt, "one", "two") { _ in


### PR DESCRIPTION
Motivation:

When a file is created 'atomically' and the descriptor is detached from its handle then the user is provided with the descriptor for a temporary file, and the desired file is never created.

Modifications:

Where supported, atomically created files use a temporary unnamed file which is then linked on close. Elsewhere a temporary named file is created which is renamed on closed.

Temporary unnamed files are linked in detach but not closed. Temporary named files are linked to the desired path before being unlinked.

- Break out the logic for materializing a file created using a temporary unnamed file
- Add syscalls and error mappings for link(2) and unlink(2)

Result:

Atomically created files behave as expected when detached