### PR TITLE
Underscore the NIOFileSystem module

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [NIO, NIOConcurrencyHelpers, NIOCore, NIOEmbedded, NIOFoundationCompat, NIOHTTP1, NIOPosix, NIOTLS, NIOWebSocket, NIOTestUtils, NIOFileSystem]
+    - documentation_targets: [NIO, NIOConcurrencyHelpers, NIOCore, NIOEmbedded, NIOFoundationCompat, NIOHTTP1, NIOPosix, NIOTLS, NIOWebSocket, NIOTestUtils, _NIOFileSystem]

--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
         .library(name: "NIOFoundationCompat", targets: ["NIOFoundationCompat"]),
         .library(name: "NIOWebSocket", targets: ["NIOWebSocket"]),
         .library(name: "NIOTestUtils", targets: ["NIOTestUtils"]),
-        .library(name: "_NIOFileSystem", targets: ["NIOFileSystem"]),
-        .library(name: "_NIOFileSystemFoundationCompat", targets: ["NIOFileSystemFoundationCompat"]),
+        .library(name: "_NIOFileSystem", targets: ["_NIOFileSystem"]),
+        .library(name: "_NIOFileSystemFoundationCompat", targets: ["_NIOFileSystemFoundationCompat"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
@@ -194,7 +194,7 @@ let package = Package(
             ]
         ),
         .target(
-            name: "NIOFileSystem",
+            name: "_NIOFileSystem",
             dependencies: [
                 "NIOCore",
                 "CNIOLinux",
@@ -203,15 +203,17 @@ let package = Package(
                 swiftCollections,
                 swiftSystem,
             ],
+            path: "Sources/NIOFileSystem",
             swiftSettings: [
                 .define("ENABLE_MOCKING", .when(configuration: .debug))
             ]
         ),
         .target(
-            name: "NIOFileSystemFoundationCompat",
+            name: "_NIOFileSystemFoundationCompat",
             dependencies: [
-                "NIOFileSystem",
-            ]
+                "_NIOFileSystem",
+            ],
+            path: "Sources/NIOFileSystemFoundationCompat"
         ),
 
         // MARK: - Examples
@@ -466,7 +468,7 @@ let package = Package(
             name: "NIOFileSystemTests",
             dependencies: [
                 "NIOCore",
-                "NIOFileSystem",
+                "_NIOFileSystem",
                 swiftAtomics,
                 swiftCollections,
                 swiftSystem,
@@ -479,7 +481,7 @@ let package = Package(
             name: "NIOFileSystemIntegrationTests",
             dependencies: [
                 "NIOCore",
-                "NIOFileSystem",
+                "_NIOFileSystem",
                 "NIOFoundationCompat",
             ],
             exclude: [
@@ -492,8 +494,8 @@ let package = Package(
         .testTarget(
             name: "NIOFileSystemFoundationCompatTests",
             dependencies: [
-                "NIOFileSystem",
-                "NIOFileSystemFoundationCompat",
+                "_NIOFileSystem",
+                "_NIOFileSystemFoundationCompat",
             ]
         )
     ]

--- a/Sources/NIOFileSystem/BufferedWriter.swift
+++ b/Sources/NIOFileSystem/BufferedWriter.swift
@@ -19,9 +19,9 @@
 /// You can create a ``BufferedWriter`` by calling
 /// ``WritableFileHandleProtocol/bufferedWriter(startingAtAbsoluteOffset:capacity:)`` on
 /// ``WritableFileHandleProtocol`` and write bytes to it with one of the following methods:
-/// - ``BufferedWriter/write(contentsOf:)-8dhyg``
-/// - ``BufferedWriter/write(contentsOf:)-2i7d9``
-/// - ``BufferedWriter/write(contentsOf:)-8ukvd`
+/// - ``BufferedWriter/write(contentsOf:)-1rkf6``
+/// - ``BufferedWriter/write(contentsOf:)-7cs3v``
+/// - ``BufferedWriter/write(contentsOf:)-66cts``
 ///
 /// If a call to one of the write functions reaches the buffers ``BufferedWriter/capacity`` the
 /// buffer automatically writes its contents to the file.

--- a/Sources/NIOFileSystem/Docs.docc/Extensions/DirectoryFileHandleProtocol.md
+++ b/Sources/NIOFileSystem/Docs.docc/Extensions/DirectoryFileHandleProtocol.md
@@ -1,4 +1,4 @@
-# ``NIOFileSystem/DirectoryFileHandleProtocol``
+# ``_NIOFileSystem/DirectoryFileHandleProtocol``
 
 ## Topics
 

--- a/Sources/NIOFileSystem/Docs.docc/Extensions/FileHandleProtocol.md
+++ b/Sources/NIOFileSystem/Docs.docc/Extensions/FileHandleProtocol.md
@@ -1,4 +1,4 @@
-# ``NIOFileSystem/FileHandleProtocol``
+# ``_NIOFileSystem/FileHandleProtocol``
 
 ## Topics
 

--- a/Sources/NIOFileSystem/Docs.docc/Extensions/FileSystemProtocol.md
+++ b/Sources/NIOFileSystem/Docs.docc/Extensions/FileSystemProtocol.md
@@ -1,4 +1,4 @@
-# ``NIOFileSystem/FileSystemProtocol``
+# ``_NIOFileSystem/FileSystemProtocol``
 
 ## Topics
 

--- a/Sources/NIOFileSystem/Docs.docc/Extensions/ReadableFileHandleProtocol.md
+++ b/Sources/NIOFileSystem/Docs.docc/Extensions/ReadableFileHandleProtocol.md
@@ -6,12 +6,12 @@
 
 - ``bufferedReader(startingAtAbsoluteOffset:capacity:)``
 - ``readChunks(chunkLength:)``
-- ``readChunks(in:chunkLength:)-8of2k``
-- ``readChunks(in:chunkLength:)-4l2zx``
-- ``readChunks(in:chunkLength:)-8xhv9``
-- ``readChunks(in:chunkLength:)-ecdr``
-- ``readChunks(in:chunkLength:)-ecdr``
-- ``readChunks(in:chunkLength:)-8ty3f``
+- ``readChunks(in:chunkLength:)-2j7r7``
+- ``readChunks(in:chunkLength:)-63rn``
+- ``readChunks(in:chunkLength:)-3fxd``
+- ``readChunks(in:chunkLength:)-9oae1``
+- ``readChunks(in:chunkLength:)-7rjf6``
+- ``readChunks(in:chunkLength:)-7a8x2``
 - ``readToEnd(fromAbsoluteOffset:maximumSizeAllowed:)``
 
 ### Read part of a file

--- a/Sources/NIOFileSystem/Docs.docc/Extensions/ReadableFileHandleProtocol.md
+++ b/Sources/NIOFileSystem/Docs.docc/Extensions/ReadableFileHandleProtocol.md
@@ -1,4 +1,4 @@
-# ``NIOFileSystem/ReadableFileHandleProtocol``
+# ``_NIOFileSystem/ReadableFileHandleProtocol``
 
 ## Topics
 

--- a/Sources/NIOFileSystem/Docs.docc/Extensions/WritableFileHandleProtocol.md
+++ b/Sources/NIOFileSystem/Docs.docc/Extensions/WritableFileHandleProtocol.md
@@ -1,4 +1,4 @@
-# ``NIOFileSystem/WritableFileHandleProtocol``
+# ``_NIOFileSystem/WritableFileHandleProtocol``
 
 ## Topics
 

--- a/Sources/NIOFileSystem/Docs.docc/NIOFileSystem.md
+++ b/Sources/NIOFileSystem/Docs.docc/NIOFileSystem.md
@@ -1,4 +1,4 @@
-# ``NIOFileSystem``
+# ``_NIOFileSystem``
 
 A file system library for Swift.
 
@@ -8,7 +8,7 @@ This module implements a file system library for Swift, providing ways to intera
 files. It provides a concrete ``FileSystem`` for interacting with the local file system in addition
 to a set of protocols for creating other file system implementations.
 
-``NIOFileSystem`` is cross-platform with the following caveats:
+``_NIOFileSystem`` is cross-platform with the following caveats:
 - _Platforms don't have feature parity or system-level API parity._ Where this is the case these
   implementation details are documented. One example is copying files, on Apple platforms files are
   cloned if possible.

--- a/Sources/NIOFileSystem/Docs.docc/NIOFileSystem.md
+++ b/Sources/NIOFileSystem/Docs.docc/NIOFileSystem.md
@@ -24,7 +24,7 @@ to a set of protocols for creating other file system implementations.
 The following sample code demonstrates a number of the APIs offered by this module:
 
 ```swift
-import NIOFileSystem
+import _NIOFileSystem
 
 // NIOFileSystem provides access to the local file system via the FileSystem
 // type which is available as a global shared instance.

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -153,7 +153,7 @@ public protocol FileHandleProtocol {
 ///
 /// There are two requirements for implementing this protocol:
 /// 1. ``readChunk(fromAbsoluteOffset:length:)``, and
-/// 2. ``readChunks(in:chunkLength:)-8of2k``
+/// 2. ``readChunks(chunkLength:)
 ///
 /// A number of overloads are provided which provide sensible defaults.
 ///
@@ -193,7 +193,7 @@ extension ReadableFileHandleProtocol {
     ///   - range: A range of offsets in the file to read.
     ///   - chunkLength: The length of chunks to read, defaults to 128 KiB.
     ///   - as: Type of chunk to read.
-    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-5ljvn``.
+    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-2dz6``
     /// - Returns: An `AsyncSequence` of chunks read from the file.
     public func readChunks(
         in range: ClosedRange<Int64>,
@@ -208,7 +208,7 @@ extension ReadableFileHandleProtocol {
     ///   - range: A range of offsets in the file to read.
     ///   - chunkLength: The length of chunks to read, defaults to 128 KiB.
     ///   - as: Type of chunk to read.
-    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-5ljvn``.
+    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-2dz6``
     /// - Returns: An `AsyncSequence` of chunks read from the file.
     public func readChunks(
         in range: Range<Int64>,
@@ -223,7 +223,7 @@ extension ReadableFileHandleProtocol {
     ///   - range: A range of offsets in the file to read.
     ///   - chunkLength: The length of chunks to read, defaults to 128 KiB.
     ///   - as: Type of chunk to read.
-    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-5ljvn``.
+    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-2dz6``.
     /// - Returns: An `AsyncSequence` of chunks read from the file.
     public func readChunks(
         in range: PartialRangeFrom<Int64>,
@@ -239,7 +239,7 @@ extension ReadableFileHandleProtocol {
     ///   - range: A range of offsets in the file to read.
     ///   - chunkLength: The length of chunks to read, defaults to 128 KiB.
     ///   - as: Type of chunk to read.
-    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-5ljvn``.
+    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-2dz6``.
     /// - Returns: An `AsyncSequence` of chunks read from the file.
     public func readChunks(
         in range: PartialRangeThrough<Int64>,
@@ -255,7 +255,7 @@ extension ReadableFileHandleProtocol {
     ///   - range: A range of offsets in the file to read.
     ///   - chunkLength: The length of chunks to read, defaults to 128 KiB.
     ///   - as: Type of chunk to read.
-    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-5ljvn``.
+    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-2dz6``.
     /// - Returns: An `AsyncSequence` of chunks read from the file.
     public func readChunks(
         in range: PartialRangeUpTo<Int64>,
@@ -271,7 +271,7 @@ extension ReadableFileHandleProtocol {
     ///   - range: A range of offsets in the file to read.
     ///   - chunkLength: The length of chunks to read, defaults to 128 KiB.
     ///   - as: Type of chunk to read.
-    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-5ljvn``.
+    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-2dz6``.
     /// - Returns: An `AsyncSequence` of chunks read from the file.
     public func readChunks(
         in range: UnboundedRange,
@@ -286,7 +286,7 @@ extension ReadableFileHandleProtocol {
     ///   - range: A range of offsets in the file to read.
     ///   - chunkLength: The length of chunks to read, defaults to 128 KiB.
     ///   - as: Type of chunk to read.
-    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-5ljvn``.
+    /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-2dz6``.
     /// - Returns: An `AsyncSequence` of chunks read from the file.
     public func readChunks(
         chunkLength: ByteCount = .kibibytes(128)

--- a/Sources/NIOFileSystemFoundationCompat/Date+FileInfo.swift
+++ b/Sources/NIOFileSystemFoundationCompat/Date+FileInfo.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import NIOFileSystem
+import _NIOFileSystem
 
 import struct Foundation.Date
 

--- a/Tests/NIOFileSystemFoundationCompatTests/FileSystemFoundationCompatTests.swift
+++ b/Tests/NIOFileSystemFoundationCompatTests/FileSystemFoundationCompatTests.swift
@@ -13,8 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import NIOFileSystem
-import NIOFileSystemFoundationCompat
+import _NIOFileSystem
+import _NIOFileSystemFoundationCompat
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemIntegrationTests/BufferedReaderTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/BufferedReaderTests.swift
@@ -14,7 +14,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-import NIOFileSystem
+import _NIOFileSystem
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemIntegrationTests/BufferedWriterTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/BufferedWriterTests.swift
@@ -14,7 +14,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemIntegrationTests/ConvenienceTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/ConvenienceTests.swift
@@ -14,7 +14,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-import NIOFileSystem
+import _NIOFileSystem
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -14,7 +14,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import NIOFoundationCompat
 import XCTest
 

--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests+SPI.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests+SPI.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import SystemPackage
 import XCTest
 

--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
@@ -14,7 +14,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 @preconcurrency import SystemPackage
 import XCTest
 

--- a/Tests/NIOFileSystemIntegrationTests/XCTestExtensions.swift
+++ b/Tests/NIOFileSystemIntegrationTests/XCTestExtensions.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import NIOFileSystem
+import _NIOFileSystem
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemTests/ByteCountTests.swift
+++ b/Tests/NIOFileSystemTests/ByteCountTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import NIOFileSystem
+import _NIOFileSystem
 import XCTest
 
 class ByteCountTests: XCTestCase {

--- a/Tests/NIOFileSystemTests/DirectoryEntriesTests.swift
+++ b/Tests/NIOFileSystemTests/DirectoryEntriesTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import NIOFileSystem
+import _NIOFileSystem
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemTests/FileChunksTests.swift
+++ b/Tests/NIOFileSystemTests/FileChunksTests.swift
@@ -14,7 +14,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-import NIOFileSystem
+import _NIOFileSystem
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemTests/FileHandleTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import XCTest
 
 #if ENABLE_MOCKING

--- a/Tests/NIOFileSystemTests/FileInfoTests.swift
+++ b/Tests/NIOFileSystemTests/FileInfoTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import NIOFileSystem
+import _NIOFileSystem
 import XCTest
 
 #if canImport(Darwin)

--- a/Tests/NIOFileSystemTests/FileOpenOptionsTests.swift
+++ b/Tests/NIOFileSystemTests/FileOpenOptionsTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import XCTest
 
 final class FileOpenOptionsTests: XCTestCase {

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import XCTest
 
 final class FileSystemErrorTests: XCTestCase {

--- a/Tests/NIOFileSystemTests/FileTypeTests.swift
+++ b/Tests/NIOFileSystemTests/FileTypeTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import XCTest
 
 #if canImport(Darwin)

--- a/Tests/NIOFileSystemTests/Internal/CancellationTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/CancellationTests.swift
@@ -14,7 +14,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import Atomics
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
@@ -15,7 +15,7 @@
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import XCTest
 
-@testable import NIOFileSystem
+@testable import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class BufferedStreamTests: XCTestCase {

--- a/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/IOExecutorTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/IOExecutorTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemTests/Internal/MockingInfrastructure.swift
+++ b/Tests/NIOFileSystemTests/Internal/MockingInfrastructure.swift
@@ -22,7 +22,7 @@
  */
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import SystemPackage
 import XCTest
 

--- a/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import NIOFileSystem
+@_spi(Testing) import _NIOFileSystem
 import SystemPackage
 import XCTest
 

--- a/Tests/NIOFileSystemTests/XCTestExtensions.swift
+++ b/Tests/NIOFileSystemTests/XCTestExtensions.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import NIOFileSystem
+import _NIOFileSystem
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)


### PR DESCRIPTION
Motivation:

The 'NIOFileSystem' target isn't yet stable API and is made available via the '_NIOFileSystemModule' product. This doesn't make it obvious enough that the module isn't yet considered stable.

Modifications:

- Rename 'NIOFileSystem' and 'NIOFileSystemFoundationCompat' such that they are prefixed with '_'.

Result:

- More obviously not stable API
- Resolves #2667 
