### PR TITLE
Change BufferedReader.read(while:) signature

### DIFF
--- a/Sources/NIOFileSystem/BufferedReader.swift
+++ b/Sources/NIOFileSystem/BufferedReader.swift
@@ -130,7 +130,7 @@ public struct BufferedReader<Handle: ReadableFileHandleProtocol> {
     /// condition doesn't hold true anymore.
     public mutating func read(
         while predicate: (UInt8) -> Bool
-    ) async throws -> (ByteBuffer, Bool) {
+    ) async throws -> (bytes: ByteBuffer, readEOF: Bool) {
         // Check if the required bytes are in the buffer already.
         let view = self.buffer.readableBytesView
 

--- a/Sources/NIOFileSystem/BufferedReader.swift
+++ b/Sources/NIOFileSystem/BufferedReader.swift
@@ -20,7 +20,7 @@ import NIOCore
 ///
 /// You can create a reader from a ``ReadableFileHandleProtocol`` by calling
 /// ``ReadableFileHandleProtocol/bufferedReader(startingAtAbsoluteOffset:capacity:)``. Call
-/// ``read(_:)`` to read a fixed number of bytes from the file or ``read(while:)`` to read
+/// ``read(_:)`` to read a fixed number of bytes from the file or ``read(while:)-8aukk`` to read
 /// from the file while the bytes match a predicate.
 ///
 /// You can also read bytes without returning them to caller by calling ``drop(_:)`` and
@@ -112,7 +112,7 @@ public struct BufferedReader<Handle: ReadableFileHandleProtocol> {
     /// - Parameters:
     ///   - predicate: A predicate which evaluates to `true` for all bytes returned.
     /// - Returns: The bytes read from the file.
-    /// - Important: This method has been deprecated: use ``read(while:)-1fg7e`` instead.
+    /// - Important: This method has been deprecated: use ``read(while:)-8aukk`` instead.
     @available(*, deprecated, message: "Use the read(while:) method returning a (ByteBuffer, Bool) tuple instead.")
     public mutating func read(
         while predicate: (UInt8) -> Bool


### PR DESCRIPTION
Return whether EOF read or predicate doesn't hold anymore in `BufferedReader.read(while:)`.

### Motivation:

Using `BufferedReader.read(while:)` isn't currently too nice to use because we can't differentiate between reading EOF and the predicate not holding anymore. See https://github.com/apple/swift-nio/issues/2665.

### Modifications:

This change deprecates `BufferedReader.read(while:)` and replaces it with a new version that returns not only the read bytes (as a `ByteBuffer`) but also a boolean indicating whether we finished reading because EOF has been read, or because the predicate doesn't hold true anymore.

### Result:

`BufferedReader.read(while:)` now returns not only the read bytes (as a `ByteBuffer`) but also a boolean indicating whether we finished reading because EOF has been read, or because the predicate doesn't hold true anymore.
