### PR TITLE
Add a NIOFileSystem shim

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .library(name: "NIOFoundationCompat", targets: ["NIOFoundationCompat"]),
         .library(name: "NIOWebSocket", targets: ["NIOWebSocket"]),
         .library(name: "NIOTestUtils", targets: ["NIOTestUtils"]),
-        .library(name: "_NIOFileSystem", targets: ["_NIOFileSystem"]),
+        .library(name: "_NIOFileSystem", targets: ["_NIOFileSystem", "NIOFileSystem"]),
         .library(name: "_NIOFileSystemFoundationCompat", targets: ["_NIOFileSystemFoundationCompat"]),
     ],
     dependencies: [
@@ -207,6 +207,13 @@ let package = Package(
             swiftSettings: [
                 .define("ENABLE_MOCKING", .when(configuration: .debug))
             ]
+        ),
+        .target(
+            name: "NIOFileSystem",
+            dependencies: [
+                "_NIOFileSystem",
+            ],
+            path: "Sources/_NIOFileSystemExported"
         ),
         .target(
             name: "_NIOFileSystemFoundationCompat",

--- a/Sources/_NIOFileSystemExported/Exports.swift
+++ b/Sources/_NIOFileSystemExported/Exports.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import _NIOFileSystem


### PR DESCRIPTION
Motivation:

Renaming the `NIOFileSystem` module to `_NIOFileSystem` is a breaking change (which is okay, it's documented to be unstable API). However, users will be presented with a wall of build errors on updating to the next version of NIO. We can make the transition slightly easier for them.

Modifications:

Add back a `NIOFileSystem` module which re-exports `_NIOFileSystem` and add it as a target to the `_NIOFileSystem` product. This makes both modules available to users. We can then remove `NIOFileSystem` after a grace period.

Result:

Users can still build using `NIOFileSystem` while transitioning to `_NIOFileSystem`.