### PR TITLE
Remove temp directories after tests

### DIFF
--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -304,6 +304,10 @@ final class FileHandleTests: XCTestCase {
 
     func testWriteAndReadUnseekableFile() async throws {
         let privateTempDirPath = try await FileSystem.shared.createTemporaryDirectory(template: "test-XXX")
+        self.addTeardownBlock {
+           try await FileSystem.shared.removeItem(at: privateTempDirPath, recursively: true)
+        }
+
         guard mkfifo(privateTempDirPath.appending("fifo").string, 0o644) == 0 else {
             XCTFail("Error calling mkfifo.")
             return
@@ -321,6 +325,10 @@ final class FileHandleTests: XCTestCase {
 
     func testWriteAndReadUnseekableFileOverMaximumSizeAllowedThrowsError() async throws {
         let privateTempDirPath = try await FileSystem.shared.createTemporaryDirectory(template: "test-XXX")
+        self.addTeardownBlock {
+           try await FileSystem.shared.removeItem(at: privateTempDirPath, recursively: true)
+        }
+
         guard mkfifo(privateTempDirPath.appending("fifo").string, 0o644) == 0 else {
             XCTFail("Error calling mkfifo.")
             return
@@ -341,6 +349,10 @@ final class FileHandleTests: XCTestCase {
 
     func testWriteAndReadUnseekableFileWithOffsetsThrows() async throws {
         let privateTempDirPath = try await FileSystem.shared.createTemporaryDirectory(template: "test-XXX")
+        self.addTeardownBlock {
+           try await FileSystem.shared.removeItem(at: privateTempDirPath, recursively: true)
+        }
+
         guard mkfifo(privateTempDirPath.appending("fifo").string, 0o644) == 0 else {
             XCTFail("Error calling mkfifo.")
             return


### PR DESCRIPTION
Motivation:

A couple of filesystem tests create directories but don't clean up after themselves.

Modifications:

- Add teardown blocks to remove the temp directories

Result:

No leftover files after running tests