### PR TITLE
Add privacy manifest

### DIFF
--- a/.PrivacyInfo.xcprivacy
+++ b/.PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>0A2A.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -26,10 +26,10 @@ let swiftSystem: PackageDescription.Target.Dependency = .product(
 // This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and
 // Foundation will be linked. This is, however, strictly better than unconditionally adding the
 // resource.
-#if os(Linux) || os(Android)
-let includePrivacyManifest = false
-#else
+#if canImport(Darwin)
 let includePrivacyManifest = true
+#else
+let includePrivacyManifest = false
 #endif
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,14 @@ let swiftSystem: PackageDescription.Target.Dependency = .product(
   condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .linux, .android])
 )
 
+// This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and
+// Foundation will be linked. This is, however, strictly better than unconditionally adding the
+// resource.
+#if os(Linux) || os(Android)
+let includePrivacyManifest = false
+#else
+let includePrivacyManifest = true
+#endif
 
 let package = Package(
     name: "swift-nio",
@@ -89,7 +97,8 @@ let package = Package(
                 "NIOCore",
                 "_NIODataStructures",
                 swiftAtomics,
-            ]
+            ],
+            resources: includePrivacyManifest ? [.copy("PrivacyInfo.xcprivacy")] : []
         ),
         .target(
             name: "NIO",
@@ -205,6 +214,7 @@ let package = Package(
                 swiftSystem,
             ],
             path: "Sources/NIOFileSystem",
+            resources: includePrivacyManifest ? [.copy("PrivacyInfo.xcprivacy")] : [],
             swiftSettings: [
                 .define("ENABLE_MOCKING", .when(configuration: .debug))
             ]

--- a/Sources/NIOFileSystem/PrivacyInfo.xcprivacy
+++ b/Sources/NIOFileSystem/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/NIOPosix/PrivacyInfo.xcprivacy
+++ b/Sources/NIOPosix/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy


### PR DESCRIPTION
Motivation:

NIOPosix and NIOFileSystem use stat(2) (or some variation of it). These are "required reason APIs" meaning that their usage and reason must be declared in a privacy manifest in order to be submitted to the App Store.

Modifications:

- Add a privacy manifest to NIOPosix and NIOFileSystem

Result:

Apps using NIO won't be rejected from App Store submission for missing privacy manifests.