### PR TITLE
Add support for `SWIFTCI_USE_LOCAL_DEPS` convention

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,12 +41,6 @@ let package = Package(
         .library(name: "_NIOFileSystem", targets: ["_NIOFileSystem", "NIOFileSystem"]),
         .library(name: "_NIOFileSystemFoundationCompat", targets: ["_NIOFileSystemFoundationCompat"]),
     ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-system.git", from: "1.2.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-    ],
     targets: [
         // MARK: - Targets
 
@@ -509,3 +503,18 @@ let package = Package(
         )
     ]
 )
+
+if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+    package.dependencies += [
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.2"),
+        .package(url: "https://github.com/apple/swift-system.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    ]
+} else {
+    package.dependencies += [
+        .package(path: "../swift-atomics"),
+        .package(path: "../swift-collections"),
+        .package(path: "../swift-system"),
+    ]
+}


### PR DESCRIPTION
Support ci.swift.org convention

### Motivation:

This package is used by https://github.com/apple/swift-sdk-generator and it needs to be built during build-script pipeline, so we need to make its dependencies follow the CI convention. 

### Modifications:

Changed `Package.swift` to respect `SWIFTCI_USE_LOCAL_DEPS` environment variable and use locally checked out packages if defined.

### Result:

We can use `swift-nio` [2.41.0](https://github.com/apple/swift-nio/releases/tag/2.41.0), which is the first version with dependencies, and later in utils/build-script pipeline.

CC: @MaxDesiatov 