### PR TITLE
Retain a ref to NIOAsyncWriter until channel active

### DIFF
--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
@@ -97,7 +97,9 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
             finishOnDeinit: closeOnDeinit,
             delegate: .init(handler: handler)
         )
+
         handler.sink = writer.sink
+        handler.writer = writer.writer
 
         try channel.pipeline.syncOperations.addHandler(handler)
 

--- a/Tests/NIOPosixTests/NIOThreadPoolTest.swift
+++ b/Tests/NIOPosixTests/NIOThreadPoolTest.swift
@@ -190,6 +190,6 @@ class NIOThreadPoolTest: XCTestCase {
         let future = threadPool.runIfActive(eventLoop: eventLoop) {
             XCTFail("This shouldn't run because the pool is shutdown.")
         }
-        await XCTAssertThrowsError(try await future.get())
+        await XCTAssertThrowsError { try await future.get() }
     }
 }

--- a/Tests/NIOPosixTests/XCTest+AsyncAwait.swift
+++ b/Tests/NIOPosixTests/XCTest+AsyncAwait.swift
@@ -44,7 +44,7 @@ import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal func XCTAssertThrowsError<T>(
-    _ expression: @autoclosure () async throws -> T,
+    _ expression: () async throws -> T,
     file: StaticString = #filePath,
     line: UInt = #line,
     verify: (Error) -> Void = { _ in }


### PR DESCRIPTION
Motivation:

NIOAsyncChannel requires users to explicitly close it, this is typically done by calling `executeThenClose`. If a `NIOAsyncChannel` isn't closed then its outbound writer will hit a precondition failure on `deinit`. Not calling `executeThenClose` is a programmer error.

However there are some sharp edges: if NIO never returns the `NIOAsyncChannel` to the caller (e.g. if a connect attempt fails) then nothing will finish the writer and precondition will fail in the deinit. Working around this from a user perspective is non-obvious and requires keep tracking of all `NIOAsyncChannel`s created from a connect attempt and closing the unused ones.

We still want to maintain the precondition when users don't close the channel, one way of achieving this is by defining a point in time at which NIO hands responsibility of the channel to the user.

Modifications:

- Retain the writer in the outbound writer handler until channel active
- On successful connect attempts, the channel becomes active and the connected channel is returned to the caller.
- On failed attempts channel active isn't called so the writer is retained until the handler is removed from the pipeline at which point it is finished.

Result:

Failed connect attempts don't result in precondition failures when using NIOAsyncChannel.