### PR TITLE
Remove surplus Sendable requirements from FileSystem with methods

### DIFF
--- a/Sources/NIOFileSystem/BufferedWriter.swift
+++ b/Sources/NIOFileSystem/BufferedWriter.swift
@@ -196,7 +196,7 @@ extension WritableFileHandleProtocol {
     ///     buffer to the file system when it exceeds this capacity. Defaults to 512 KiB.
     ///   - body: The closure that writes the contents to the buffer created in this method.
     /// - Returns: The result of the executed closure.
-    public func withBufferedWriter<R: Sendable>(
+    public func withBufferedWriter<R>(
         startingAtAbsoluteOffset initialOffset: Int64 = 0,
         capacity: ByteCount = .kibibytes(512),
         execute body: (inout BufferedWriter<Self>) async throws -> R

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -581,7 +581,7 @@ extension DirectoryFileHandleProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R: Sendable>(
+    public func withFileHandle<R>(
         forReadingAt path: FilePath,
         options: OpenOptions.Read = OpenOptions.Read(),
         execute body: (_ read: ReadFileHandle) async throws -> R
@@ -612,7 +612,7 @@ extension DirectoryFileHandleProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R: Sendable>(
+    public func withFileHandle<R>(
         forWritingAt path: FilePath,
         options: OpenOptions.Write = .newFile(replaceExisting: false),
         execute body: (_ write: WriteFileHandle) async throws -> R
@@ -647,7 +647,7 @@ extension DirectoryFileHandleProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R: Sendable>(
+    public func withFileHandle<R>(
         forReadingAndWritingAt path: FilePath,
         options: OpenOptions.Write = .newFile(replaceExisting: false),
         execute body: (_ readWrite: ReadWriteFileHandle) async throws -> R
@@ -673,7 +673,7 @@ extension DirectoryFileHandleProtocol {
     ///   - body: A closure which provides access to the directory.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withDirectoryHandle<R: Sendable>(
+    public func withDirectoryHandle<R>(
         atPath path: FilePath,
         options: OpenOptions.Directory = OpenOptions.Directory(),
         execute body: (_ directory: Self) async throws -> R

--- a/Sources/NIOFileSystem/FileSystem.swift
+++ b/Sources/NIOFileSystem/FileSystem.swift
@@ -700,7 +700,7 @@ extension FileSystemProtocol where Self == FileSystem {
 
 /// Provides temporary scoped access to a ``FileSystem`` with the given number of threads.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-public func withFileSystem<R: Sendable>(
+public func withFileSystem<R>(
     numberOfThreads: Int,
     _ body: (FileSystem) async throws -> R
 ) async throws -> R {

--- a/Sources/NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/NIOFileSystem/FileSystemProtocol.swift
@@ -333,7 +333,7 @@ extension FileSystemProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R: Sendable>(
+    public func withFileHandle<R>(
         forReadingAndWritingAt path: FilePath,
         options: OpenOptions.Write = .newFile(replaceExisting: false),
         execute: (_ readWrite: ReadWriteFileHandle) async throws -> R

--- a/Sources/NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/NIOFileSystem/FileSystemProtocol.swift
@@ -274,7 +274,7 @@ extension FileSystemProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R: Sendable>(
+    public func withFileHandle<R>(
         forReadingAt path: FilePath,
         options: OpenOptions.Read = OpenOptions.Read(),
         execute: (_ read: ReadFileHandle) async throws -> R
@@ -301,7 +301,7 @@ extension FileSystemProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R: Sendable>(
+    public func withFileHandle<R>(
         forWritingAt path: FilePath,
         options: OpenOptions.Write = .newFile(replaceExisting: false),
         execute: (_ write: WriteFileHandle) async throws -> R
@@ -354,7 +354,7 @@ extension FileSystemProtocol {
     ///   - execute: A closure which provides access to the directory.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withDirectoryHandle<R: Sendable>(
+    public func withDirectoryHandle<R>(
         atPath path: FilePath,
         options: OpenOptions.Directory = OpenOptions.Directory(),
         execute: (_ directory: DirectoryFileHandle) async throws -> R

--- a/Sources/NIOFileSystem/Internal/Cancellation.swift
+++ b/Sources/NIOFileSystem/Internal/Cancellation.swift
@@ -31,9 +31,9 @@ public func withoutCancellation<R: Sendable>(
 /// Executes `fn` and then `tearDown`, which cannot be cancelled.
 @_spi(Testing)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-public func withUncancellableTearDown<R: Sendable>(
+public func withUncancellableTearDown<R>(
     _ fn: () async throws -> R,
-    tearDown: @escaping (Result<R, Error>) async throws -> Void
+    tearDown: @escaping (Result<Void, Error>) async throws -> Void
 ) async throws -> R {
     let result: Result<R, Error>
     do {
@@ -42,9 +42,10 @@ public func withUncancellableTearDown<R: Sendable>(
         result = .failure(error)
     }
 
+    let errorOnlyResult: Result<Void, Error> = result.map { _ in return () }
     let tearDownResult: Result<Void, Error> = try await withoutCancellation {
         do {
-            return .success(try await tearDown(result))
+            return .success(try await tearDown(errorOnlyResult))
         } catch {
             return .failure(error)
         }


### PR DESCRIPTION
Motivation:

Many of the filesystem with methods have a requirement that the result type is sendable.  In most cases this is not required as the result is not shared or sent.

Modifications:

Remove sendable requirement for result types where it is not required.

Result:

Users will not have to make so many types sendable.