### PR TITLE
Replace 'R' with 'ReturnType'

### DIFF
--- a/Sources/NIOFileSystem/BufferedWriter.swift
+++ b/Sources/NIOFileSystem/BufferedWriter.swift
@@ -231,11 +231,11 @@ extension WritableFileHandleProtocol {
     ///     buffer to the file system when it exceeds this capacity. Defaults to 512 KiB.
     ///   - body: The closure that writes the contents to the buffer created in this method.
     /// - Returns: The result of the executed closure.
-    public func withBufferedWriter<R>(
+    public func withBufferedWriter<Result>(
         startingAtAbsoluteOffset initialOffset: Int64 = 0,
         capacity: ByteCount = .kibibytes(512),
-        execute body: (inout BufferedWriter<Self>) async throws -> R
-    ) async throws -> R {
+        execute body: (inout BufferedWriter<Self>) async throws -> Result
+    ) async throws -> Result {
         var bufferedWriter = self.bufferedWriter(startingAtAbsoluteOffset: initialOffset, capacity: capacity)
         return try await withUncancellableTearDown {
             return try await body(&bufferedWriter)

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -581,11 +581,11 @@ extension DirectoryFileHandleProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R>(
+    public func withFileHandle<Result>(
         forReadingAt path: FilePath,
         options: OpenOptions.Read = OpenOptions.Read(),
-        execute body: (_ read: ReadFileHandle) async throws -> R
-    ) async throws -> R {
+        execute body: (_ read: ReadFileHandle) async throws -> Result
+    ) async throws -> Result {
         let handle = try await self.openFile(forReadingAt: path, options: options)
 
         return try await withUncancellableTearDown {
@@ -612,11 +612,11 @@ extension DirectoryFileHandleProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R>(
+    public func withFileHandle<Result>(
         forWritingAt path: FilePath,
         options: OpenOptions.Write = .newFile(replaceExisting: false),
-        execute body: (_ write: WriteFileHandle) async throws -> R
-    ) async throws -> R {
+        execute body: (_ write: WriteFileHandle) async throws -> Result
+    ) async throws -> Result {
         let handle = try await self.openFile(forWritingAt: path, options: options)
 
         return try await withUncancellableTearDown {
@@ -647,11 +647,11 @@ extension DirectoryFileHandleProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R>(
+    public func withFileHandle<Result>(
         forReadingAndWritingAt path: FilePath,
         options: OpenOptions.Write = .newFile(replaceExisting: false),
-        execute body: (_ readWrite: ReadWriteFileHandle) async throws -> R
-    ) async throws -> R {
+        execute body: (_ readWrite: ReadWriteFileHandle) async throws -> Result
+    ) async throws -> Result {
         let handle = try await self.openFile(forReadingAndWritingAt: path, options: options)
 
         return try await withUncancellableTearDown {
@@ -673,11 +673,11 @@ extension DirectoryFileHandleProtocol {
     ///   - body: A closure which provides access to the directory.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withDirectoryHandle<R>(
+    public func withDirectoryHandle<Result>(
         atPath path: FilePath,
         options: OpenOptions.Directory = OpenOptions.Directory(),
-        execute body: (_ directory: Self) async throws -> R
-    ) async throws -> R {
+        execute body: (_ directory: Self) async throws -> Result
+    ) async throws -> Result {
         let handle = try await self.openDirectory(atPath: path, options: options)
 
         return try await withUncancellableTearDown {

--- a/Sources/NIOFileSystem/FileSystem.swift
+++ b/Sources/NIOFileSystem/FileSystem.swift
@@ -700,10 +700,10 @@ extension FileSystemProtocol where Self == FileSystem {
 
 /// Provides temporary scoped access to a ``FileSystem`` with the given number of threads.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-public func withFileSystem<R>(
+public func withFileSystem<Result>(
     numberOfThreads: Int,
-    _ body: (FileSystem) async throws -> R
-) async throws -> R {
+    _ body: (FileSystem) async throws -> Result
+) async throws -> Result {
     let fileSystem = await FileSystem(numberOfThreads: numberOfThreads)
     return try await withUncancellableTearDown {
         try await body(fileSystem)

--- a/Sources/NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/NIOFileSystem/FileSystemProtocol.swift
@@ -274,11 +274,11 @@ extension FileSystemProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R>(
+    public func withFileHandle<Result>(
         forReadingAt path: FilePath,
         options: OpenOptions.Read = OpenOptions.Read(),
-        execute: (_ read: ReadFileHandle) async throws -> R
-    ) async throws -> R {
+        execute: (_ read: ReadFileHandle) async throws -> Result
+    ) async throws -> Result {
         let handle = try await self.openFile(forReadingAt: path, options: options)
         return try await withUncancellableTearDown {
             return try await execute(handle)
@@ -301,11 +301,11 @@ extension FileSystemProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R>(
+    public func withFileHandle<Result>(
         forWritingAt path: FilePath,
         options: OpenOptions.Write = .newFile(replaceExisting: false),
-        execute: (_ write: WriteFileHandle) async throws -> R
-    ) async throws -> R {
+        execute: (_ write: WriteFileHandle) async throws -> Result
+    ) async throws -> Result {
         let handle = try await self.openFile(forWritingAt: path, options: options)
         return try await withUncancellableTearDown {
             return try await execute(handle)
@@ -333,11 +333,11 @@ extension FileSystemProtocol {
     ///       automatically after the closure exits.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withFileHandle<R>(
+    public func withFileHandle<Result>(
         forReadingAndWritingAt path: FilePath,
         options: OpenOptions.Write = .newFile(replaceExisting: false),
-        execute: (_ readWrite: ReadWriteFileHandle) async throws -> R
-    ) async throws -> R {
+        execute: (_ readWrite: ReadWriteFileHandle) async throws -> Result
+    ) async throws -> Result {
         let handle = try await self.openFile(forReadingAndWritingAt: path, options: options)
         return try await withUncancellableTearDown {
             return try await execute(handle)
@@ -354,11 +354,11 @@ extension FileSystemProtocol {
     ///   - execute: A closure which provides access to the directory.
     /// - Important: The handle passed to `execute` must not escape the closure.
     /// - Returns: The result of the `execute` closure.
-    public func withDirectoryHandle<R>(
+    public func withDirectoryHandle<Result>(
         atPath path: FilePath,
         options: OpenOptions.Directory = OpenOptions.Directory(),
-        execute: (_ directory: DirectoryFileHandle) async throws -> R
-    ) async throws -> R {
+        execute: (_ directory: DirectoryFileHandle) async throws -> Result
+    ) async throws -> Result {
         let handle = try await self.openDirectory(atPath: path, options: options)
         return try await withUncancellableTearDown {
             return try await execute(handle)
@@ -490,11 +490,11 @@ extension FileSystemProtocol {
     ///   - options: Options used to create the directory.
     ///   - execute: A closure which provides access to the directory and its path.
     /// - Returns: The result of `execute`.
-    public func withTemporaryDirectory<ReturnType>(
+    public func withTemporaryDirectory<Result>(
         prefix: FilePath? = nil,
         options: OpenOptions.Directory = OpenOptions.Directory(),
-        execute: (_ directory: DirectoryFileHandle, _ path: FilePath) async throws -> ReturnType
-    ) async throws -> ReturnType {
+        execute: (_ directory: DirectoryFileHandle, _ path: FilePath) async throws -> Result
+    ) async throws -> Result {
         let template: FilePath
 
         if let prefix = prefix {


### PR DESCRIPTION
Motivation:

Single letter names are discouraged but are used in a handful of places in NIOFileSystem.

Modifications:

- Replace 'R' with 'ReturnType' where appropriate

Result:

Clearer APIs