### PR TITLE
concurrency takeover safe for 6.0

### DIFF
--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -39,7 +39,7 @@ extension NIOSingletons {
     /// - warning: You may only call this method once.
     @discardableResult
     public static func unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor() -> Bool {
-        #if /* minimum supported */ compiler(>=5.9) && /* maximum tested */ swift(<5.11)
+        #if /* minimum supported */ compiler(>=5.9) && /* maximum tested */ compiler(<6.1)
         guard #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) else {
             return false
         }


### PR DESCRIPTION
### Motivation:

Letting NIO take over the Concurrency thread pool is important for performance. We saw roughly 30% improvements on Linux for non-I/O code and much more for I/O code.

### Modifications:

Allowlist Swift 6.0.

### Result:

More perf for more versions.