### PR TITLE
Exclude unused privacy manifests.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -92,6 +92,7 @@ let package = Package(
                 "_NIODataStructures",
                 swiftAtomics,
             ],
+            exclude: includePrivacyManifest ? [] : ["PrivacyInfo.xcprivacy"],
             resources: includePrivacyManifest ? [.copy("PrivacyInfo.xcprivacy")] : []
         ),
         .target(
@@ -208,6 +209,7 @@ let package = Package(
                 swiftSystem,
             ],
             path: "Sources/NIOFileSystem",
+            exclude: includePrivacyManifest ? [] : ["PrivacyInfo.xcprivacy"],
             resources: includePrivacyManifest ? [.copy("PrivacyInfo.xcprivacy")] : [],
             swiftSettings: [
                 .define("ENABLE_MOCKING", .when(configuration: .debug))


### PR DESCRIPTION
Motivation:

On Darwin privacy manifests should be published as resources. On other platforms they result in a warning if not excluded.

Modifications:

Alter Package.swift to exclude privacy manifests when not included.

Result:

Fewer warnings in non-darwin builds.