### PR TITLE
No longer need test discovery command line.

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -70,7 +70,6 @@ services:
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=89
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
-      - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -70,7 +70,6 @@ services:
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=89
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
-      - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -70,7 +70,6 @@ services:
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=89
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
-      - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -69,7 +69,6 @@ services:
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=89
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
       - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
-      - FORCE_TEST_DISCOVERY=--enable-test-discovery
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   unit-tests:
     <<: *common
-    command: /bin/bash -xcl "swift $${SWIFT_TEST_VERB-test} $${FORCE_TEST_DISCOVERY-} $${WARN_AS_ERROR_ARG-} $${IMPORT_CHECK_ARG-}"
+    command: /bin/bash -xcl "swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${IMPORT_CHECK_ARG-}"
 
   integration-tests:
     <<: *common
@@ -40,7 +40,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "uname -a && swift -version && swift $${SWIFT_TEST_VERB-test} $${FORCE_TEST_DISCOVERY-} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} && ./scripts/integration_tests.sh $${INTEGRATION_TESTS_ARG-} && cd Benchmarks && swift package benchmark baseline check --check-absolute-path Thresholds/$${SWIFT_VERSION-}/"
+    command: /bin/bash -xcl "uname -a && swift -version && swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} && ./scripts/integration_tests.sh $${INTEGRATION_TESTS_ARG-} && cd Benchmarks && swift package benchmark baseline check --check-absolute-path Thresholds/$${SWIFT_VERSION-}/"
 
   performance-test:
     <<: *common


### PR DESCRIPTION
Motivation:

Command line argument has not been needed for several swift version.

Modifications:

This causes warnings in recent swift versions.

Result:

No more warnings about swift command line when testing