### PR TITLE
clean up @retroactive conformances

### DIFF
--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -375,16 +375,10 @@ extension ByteBufferAllocator {
 }
 
 // MARK: - Conformances
-#if swift(>=5.8)
-#if $RetroactiveAttribute
+#if compiler(>=6.0)
 extension ByteBufferView: @retroactive ContiguousBytes {}
 extension ByteBufferView: @retroactive DataProtocol {}
 extension ByteBufferView: @retroactive MutableDataProtocol {}
-#else
-extension ByteBufferView: ContiguousBytes {}
-extension ByteBufferView: DataProtocol {}
-extension ByteBufferView: MutableDataProtocol {}
-#endif
 #else
 extension ByteBufferView: ContiguousBytes {}
 extension ByteBufferView: DataProtocol {}


### PR DESCRIPTION
### Motivation:

- `#if swift` is mostly wrong
- too many `#if`s that were misleading and unnecessary

### Modifications:

- Clean up with a single `#if compiler(>=6.0)`

### Result:

- Nicer code

---

proof 1: Only Swift 6 has `@retroactive` via check for `#if $RetroactiveAttribute`

```
$ for image in swift:5.8 swift:5.9 swift:5.10 swiftlang/swift:nightly-6.0-jammy; do echo -n "does $image have @retroactive? "; echo -e '#if $RetroactiveAttribute\nprint("yes")\n#else\nprint("no")\n#endif\n' | docker run -i --rm "$image" swift -; done
does swift:5.8 have @retroactive? no
does swift:5.9 have @retroactive? no
does swift:5.10 have @retroactive? no
does swiftlang/swift:nightly-6.0-jammy have @retroactive? yes
```

proof 2: Only Swift 6 has `@retroactive` via compiling something

```
$ for image in swift:5.8 swift:5.9 swift:5.10 swiftlang/swift:nightly-6.0-jammy; do echo -n "does $image have @retroactive? "; echo -e 'protocol P {}\nstruct S {}\n extension S: @retroactive P {}\n' | docker run -i --rm "$image" swift - 2>/dev/null && echo yes || echo no; done
does swift:5.8 have @retroactive? no
does swift:5.9 have @retroactive? no
does swift:5.10 have @retroactive? no
does swiftlang/swift:nightly-6.0-jammy have @retroactive? yes
```

---

See also #2718