### PR TITLE
Update PosixSingletons+ConcurrencyTakeOver.swift

### DIFF
--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -35,6 +35,8 @@ extension NIOSingletons {
     /// operation doesn't guarantee anything because another piece of code could have done the same without using atomic operations. But we
     /// do our best.
     ///
+    /// - returns: If ``MultiThreadedEventLoopGroup/singleton`` was successfully installed as Swift Concurrency's global executor or not.
+    ///
     /// - warning: You may only call this method from the main thread.
     /// - warning: You may only call this method once.
     @discardableResult


### PR DESCRIPTION
Document what unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor's return value means