### PR TITLE
Add slack to rst allocation tests

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=147000
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=147050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=155050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149000
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -36,7 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149000
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
       - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050


### PR DESCRIPTION
Motivation:

Allocation tests are slightly fragile to small changes.

Modifications:

Allow 50 extra allocations over the 1000 cycles.

Result:

Rst tests less flaky