### PR TITLE
testSimpleMPTCP should not fail for ENOPROTOOPT

### DIFF
--- a/Tests/NIOPosixTests/SocketChannelTest.swift
+++ b/Tests/NIOPosixTests/SocketChannelTest.swift
@@ -922,7 +922,7 @@ public final class SocketChannelTest : XCTestCase {
                     .wait()
             } catch let error as IOError {
                 // Older Linux kernel versions don't support MPTCP, which is fine.
-                if error.errnoCode != EINVAL && error.errnoCode != EPROTONOSUPPORT {
+                if error.errnoCode != EINVAL && error.errnoCode != EPROTONOSUPPORT && error.errnoCode != ENOPROTOOPT {
                     XCTFail("Unexpected error: \(error)")
                 }
                 return


### PR DESCRIPTION
### Motivation:

MPTCP implementations are permitted to return `ENOPROTOOPT` if MPTCP has been disabled. This should not report as a test failure.

Source: https://www.mptcp.dev/implementation.html

### Modifications:

Instead of failing the test, log the permitted error and return.

### Result:

No more misleading testSimpleMPTCP test failures