### PR TITLE
Remove storage indirection for FileSystemError

### DIFF
--- a/Sources/NIOFileSystem/FileSystemError.swift
+++ b/Sources/NIOFileSystem/FileSystemError.swift
@@ -26,75 +26,19 @@ import SystemPackage
 ///
 /// Errors may have a ``FileSystemError/cause``, an underlying error which caused the operation to
 /// fail which may be platform specific.
-public struct FileSystemError: Error, @unchecked Sendable {
-    // Note: @unchecked because we use a backing class for storage.
-
-    private var storage: Storage
-    private mutating func ensureStorageIsUnique() {
-        if !isKnownUniquelyReferenced(&self.storage) {
-            self.storage = self.storage.copy()
-        }
-    }
-
-    private final class Storage {
-        var code: Code
-        var message: String
-        var cause: Error?
-        var location: SourceLocation
-
-        init(code: Code, message: String, cause: Error?, location: SourceLocation) {
-            self.code = code
-            self.message = message
-            self.cause = cause
-            self.location = location
-        }
-
-        func copy() -> Self {
-            return Self(
-                code: self.code,
-                message: self.message,
-                cause: self.cause,
-                location: self.location
-            )
-        }
-    }
-
+public struct FileSystemError: Error, Sendable {
     /// A high-level error code to provide broad a classification.
-    public var code: Code {
-        get { self.storage.code }
-        set {
-            self.ensureStorageIsUnique()
-            self.storage.code = newValue
-        }
-    }
+    public var code: Code
 
     /// A message describing what went wrong and how it may be remedied.
-    public var message: String {
-        get { self.storage.message }
-        set {
-            self.ensureStorageIsUnique()
-            self.storage.message = newValue
-        }
-    }
+    public var message: String
 
     /// An underlying error which caused the operation to fail. This may include additional details
     /// about the root cause of the failure.
-    public var cause: Error? {
-        get { self.storage.cause }
-        set {
-            self.ensureStorageIsUnique()
-            self.storage.cause = newValue
-        }
-    }
+    public var cause: Error?
 
     /// The location from which this error was thrown.
-    public var location: SourceLocation {
-        get { self.storage.location }
-        set {
-            self.ensureStorageIsUnique()
-            self.storage.location = newValue
-        }
-    }
+    public var location: SourceLocation
 
     public init(
         code: Code,
@@ -102,7 +46,10 @@ public struct FileSystemError: Error, @unchecked Sendable {
         cause: Error?,
         location: SourceLocation
     ) {
-        self.storage = Storage(code: code, message: message, cause: cause, location: location)
+        self.code = code
+        self.message = message
+        self.cause = cause
+        self.location = location
     }
 
     /// Creates a ``FileSystemError`` by wrapping the given `cause` and its location and code.

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -148,41 +148,6 @@ final class FileSystemErrorTests: XCTestCase {
     }
 
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    func testCopyOnWrite() throws {
-        let error1 = FileSystemError(
-            code: .io,
-            message: "a message",
-            cause: nil,
-            location: .init(function: "fn(_:)", file: "file.swift", line: 42)
-        )
-
-        var error2 = error1
-        error2.code = .invalidArgument
-        XCTAssertEqual(error1.code, .io)
-        XCTAssertEqual(error2.code, .invalidArgument)
-
-        var error3 = error1
-        error3.message = "a different message"
-        XCTAssertEqual(error1.message, "a message")
-        XCTAssertEqual(error3.message, "a different message")
-
-        var error4 = error1
-        error4.cause = CancellationError()
-        XCTAssertNil(error1.cause)
-        XCTAssert(error4.cause is CancellationError)
-
-        var error5 = error1
-        error5.location.file = "different-file.swift"
-        XCTAssertEqual(error1.location.function, "fn(_:)")
-        XCTAssertEqual(error1.location.file, "file.swift")
-        XCTAssertEqual(error1.location.line, 42)
-
-        XCTAssertEqual(error5.location.function, "fn(_:)")
-        XCTAssertEqual(error5.location.file, "different-file.swift")
-        XCTAssertEqual(error5.location.line, 42)
-    }
-
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testErrorsMapToCorrectSyscallCause() throws {
         let here = FileSystemError.SourceLocation(function: "fn", file: "file", line: 42)
         let path = FilePath("/foo")


### PR DESCRIPTION
Motivation:

Existentials are boxed if they are wider than 24 bytes. A number of value types in NIO are implemented with storage classes so that the alloaction is only paid for once. However, existential errors are treated differently, they are unconditionally boxed. Implementing errors with storage classes therefore introduces an unnecessary allocation.

Modifications:

- Remove the storage class for FileSystemError
- Remove the copy-on-write test

Result:

Fewer allocations