### PR TITLE
Add a version of 'write' for 'ByteBuffer'

### DIFF
--- a/Sources/NIOFileSystem/Docs.docc/Extensions/WritableFileHandleProtocol.md
+++ b/Sources/NIOFileSystem/Docs.docc/Extensions/WritableFileHandleProtocol.md
@@ -4,7 +4,8 @@
 
 ### Write bytes to a file
 
-- ``write(contentsOf:toAbsoluteOffset:)``
+- ``write(contentsOf:toAbsoluteOffset:)-57fnc``
+- ``write(contentsOf:toAbsoluteOffset:)-4na03``
 - ``bufferedWriter(startingAtAbsoluteOffset:capacity:)``
 
 ### Resize a file

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -465,6 +465,29 @@ public protocol WritableFileHandleProtocol: FileHandleProtocol {
     func close(makeChangesVisible: Bool) async throws
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension WritableFileHandleProtocol {
+    /// Write the readable bytes of the `ByteBuffer` to the open file.
+    ///
+    /// - Important: This method checks whether the file is seekable or not (i.e., whether it's a socket,
+    /// pipe or FIFO), and will throw ``FileSystemError/Code-swift.struct/unsupported``
+    /// if an offset other than zero is passed.
+    ///
+    /// - Parameters:
+    ///   - buffer: The bytes to write.
+    ///   - offset: The absolute offset into the file to write the bytes.
+    /// - Returns: The number of bytes written.
+    /// - Throws: ``FileSystemError/Code-swift.struct/unsupported`` if file is
+    /// unseekable and `offset` is not 0.
+    @discardableResult
+    public func write(
+        contentsOf buffer: ByteBuffer,
+        toAbsoluteOffset offset: Int64
+    ) async throws -> Int64 {
+        try await self.write(contentsOf: buffer.readableBytesView, toAbsoluteOffset: offset)
+    }
+}
+
 /// A file handle which is suitable for reading and writing.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public typealias ReadableAndWritableFileHandleProtocol = ReadableFileHandleProtocol


### PR DESCRIPTION
Motivation:

At the moment 'WritableFileHandleProtocol' is in terms of `some Sequence<UInt8>`. To use a `ByteBuffer` users must pass in the readable view of the buffer, which is inconvenient.

Modifications:

- Add an extension to `WritableFileHandleProtocol` which takes a `ByteBuffer`.

Result:

Easier to use API