### PR TITLE
Improve rename error

### DIFF
--- a/Sources/NIOFileSystem/FileSystem.swift
+++ b/Sources/NIOFileSystem/FileSystem.swift
@@ -1216,6 +1216,7 @@ extension FileSystem {
 
         case let .failure(errno):
             let error = FileSystemError.rename(
+                "rename",
                 errno: errno,
                 oldName: sourcePath,
                 newName: destinationPath,

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -689,6 +689,7 @@ extension FileSystemError {
 
     @_spi(Testing)
     public static func rename(
+        _ name: String,
         errno: Errno,
         oldName: FilePath,
         newName: FilePath,
@@ -739,7 +740,7 @@ extension FileSystemError {
         return FileSystemError(
             code: code,
             message: message,
-            systemCall: "rename",
+            systemCall: name,
             errno: errno,
             location: location
         )

--- a/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
@@ -804,7 +804,9 @@ extension SystemFileHandle.SendableView {
         case .rename:
             if materialize {
                 let renameResult: Result<Void, Errno>
+                let renameFunction: String
                 #if canImport(Darwin)
+                renameFunction = "renamex_np"
                 renameResult = Syscall.rename(
                     from: createdPath,
                     to: desiredPath,
@@ -814,6 +816,7 @@ extension SystemFileHandle.SendableView {
                 // The created and desired paths are absolute, so the relative descriptors are
                 // ignored. However, they must still be provided to 'rename' in order to pass
                 // flags.
+                renameFunction = "renameat2"
                 renameResult = Syscall.rename(
                     from: createdPath,
                     relativeTo: .currentWorkingDirectory,
@@ -831,6 +834,7 @@ extension SystemFileHandle.SendableView {
 
                 result = renameResult.mapError { errno in
                     .rename(
+                        renameFunction,
                         errno: errno,
                         oldName: createdPath,
                         newName: desiredPath,

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -230,7 +230,7 @@ final class FileSystemErrorTests: XCTestCase {
         }
 
         assertCauseIsSyscall("rename", here) {
-            .rename(errno: .badFileDescriptor, oldName: "old", newName: "new", location: here)
+            .rename("rename", errno: .badFileDescriptor, oldName: "old", newName: "new", location: here)
         }
 
         assertCauseIsSyscall("remove", here) {
@@ -465,7 +465,7 @@ final class FileSystemErrorTests: XCTestCase {
                 .ioError: .io,
             ]
         ) { errno in
-            .rename(errno: errno, oldName: "old", newName: "new", location: .fixed)
+            .rename("rename", errno: errno, oldName: "old", newName: "new", location: .fixed)
         }
     }
 


### PR DESCRIPTION
Motivation:

The name of the syscall used in errors for all rename calls is "rename". However, this isn't always correct, in some cases "renamex_np" is used, and in others "renameat2" is used.

Modifications:

- Allow the name of the syscall to be provided to the rename error
- Use the correct syscall name

Result:

Better errors