### PR TITLE
Add API for setting last accessed and last modified file times

### DIFF
--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -133,5 +133,7 @@ extern const int CNIOLinux_AT_EMPTY_PATH;
 extern const unsigned int CNIOLinux_RENAME_NOREPLACE;
 extern const unsigned int CNIOLinux_RENAME_EXCHANGE;
 
+extern const unsigned long CNIOLinux_UTIME_OMIT;
+
 #endif
 #endif

--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -134,6 +134,7 @@ extern const unsigned int CNIOLinux_RENAME_NOREPLACE;
 extern const unsigned int CNIOLinux_RENAME_EXCHANGE;
 
 extern const unsigned long CNIOLinux_UTIME_OMIT;
+extern const unsigned long CNIOLinux_UTIME_NOW;
 
 #endif
 #endif

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -33,6 +33,7 @@ void CNIOLinux_i_do_nothing_just_working_around_a_darwin_toolchain_bug(void) {}
 #include <assert.h>
 #include <time.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 
 _Static_assert(sizeof(CNIOLinux_mmsghdr) == sizeof(struct mmsghdr),
                "sizes of CNIOLinux_mmsghdr and struct mmsghdr differ");
@@ -210,5 +211,7 @@ const int CNIOLinux_O_TMPFILE = O_TMPFILE;
 const unsigned int CNIOLinux_RENAME_NOREPLACE = RENAME_NOREPLACE;
 const unsigned int CNIOLinux_RENAME_EXCHANGE = RENAME_EXCHANGE;
 const int CNIOLinux_AT_EMPTY_PATH = AT_EMPTY_PATH;
+
+const unsigned long CNIOLinux_UTIME_OMIT = UTIME_OMIT;
 
 #endif

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -213,5 +213,6 @@ const unsigned int CNIOLinux_RENAME_EXCHANGE = RENAME_EXCHANGE;
 const int CNIOLinux_AT_EMPTY_PATH = AT_EMPTY_PATH;
 
 const unsigned long CNIOLinux_UTIME_OMIT = UTIME_OMIT;
+const unsigned long CNIOLinux_UTIME_NOW = UTIME_NOW;
 
 #endif

--- a/Sources/NIOFileSystem/FileHandle.swift
+++ b/Sources/NIOFileSystem/FileHandle.swift
@@ -203,6 +203,16 @@ public struct WriteFileHandle: WritableFileHandleProtocol, _HasFileHandle {
     public func close(makeChangesVisible: Bool) async throws {
         try await self.fileHandle.systemFileHandle.close(makeChangesVisible: makeChangesVisible)
     }
+
+    public func setTimes(
+        lastAccessTime: FileInfo.Timespec?,
+        lastDataModificationTime: FileInfo.Timespec?
+    ) async throws {
+        try await self.fileHandle.systemFileHandle.setTimes(
+            lastAccessTime: lastAccessTime,
+            lastDataModificationTime: lastDataModificationTime
+        )
+    }
 }
 
 /// Implements ``ReadableAndWritableFileHandleProtocol`` by making system calls to interact with the
@@ -246,6 +256,16 @@ public struct ReadWriteFileHandle: ReadableAndWritableFileHandleProtocol, _HasFi
 
     public func close(makeChangesVisible: Bool) async throws {
         try await self.fileHandle.systemFileHandle.close(makeChangesVisible: makeChangesVisible)
+    }
+
+    public func setTimes(
+        lastAccessTime: FileInfo.Timespec?,
+        lastDataModificationTime: FileInfo.Timespec?
+    ) async throws {
+        try await self.fileHandle.systemFileHandle.setTimes(
+            lastAccessTime: lastAccessTime,
+            lastDataModificationTime: lastDataModificationTime
+        )
     }
 }
 

--- a/Sources/NIOFileSystem/FileHandle.swift
+++ b/Sources/NIOFileSystem/FileHandle.swift
@@ -83,6 +83,16 @@ extension _HasFileHandle {
     public func close() async throws {
         try await self.fileHandle.close()
     }
+
+    public func setTimes(
+        lastAccess: FileInfo.Timespec?,
+        lastDataModification: FileInfo.Timespec?
+    ) async throws {
+        try await self.fileHandle.setTimes(
+            lastAccess: lastAccess,
+            lastDataModification: lastDataModification
+        )
+    }
 }
 
 /// Implements ``FileHandleProtocol`` by making system calls to interact with the local file system.
@@ -148,6 +158,16 @@ public struct FileHandle: FileHandleProtocol {
     public func close() async throws {
         try await self.systemFileHandle.close()
     }
+
+    public func setTimes(
+        lastAccess: FileInfo.Timespec?,
+        lastDataModification: FileInfo.Timespec?
+    ) async throws {
+        try await self.systemFileHandle.setTimes(
+            lastAccess: lastAccess,
+            lastDataModification: lastDataModification
+        )
+    }
 }
 
 /// Implements ``ReadableFileHandleProtocol`` by making system calls to interact with the local
@@ -172,6 +192,16 @@ public struct ReadFileHandle: ReadableFileHandleProtocol, _HasFileHandle {
 
     public func readChunks(in range: Range<Int64>, chunkLength: ByteCount) -> FileChunks {
         self.fileHandle.systemFileHandle.readChunks(in: range, chunkLength: chunkLength)
+    }
+
+    public func setTimes(
+        lastAccess: FileInfo.Timespec?,
+        lastDataModification: FileInfo.Timespec?
+    ) async throws {
+        try await self.fileHandle.systemFileHandle.setTimes(
+            lastAccess: lastAccess,
+            lastDataModification: lastDataModification
+        )
     }
 }
 
@@ -205,12 +235,12 @@ public struct WriteFileHandle: WritableFileHandleProtocol, _HasFileHandle {
     }
 
     public func setTimes(
-        lastAccessTime: FileInfo.Timespec?,
-        lastDataModificationTime: FileInfo.Timespec?
+        lastAccess: FileInfo.Timespec?,
+        lastDataModification: FileInfo.Timespec?
     ) async throws {
         try await self.fileHandle.systemFileHandle.setTimes(
-            lastAccessTime: lastAccessTime,
-            lastDataModificationTime: lastDataModificationTime
+            lastAccess: lastAccess,
+            lastDataModification: lastDataModification
         )
     }
 }
@@ -259,12 +289,12 @@ public struct ReadWriteFileHandle: ReadableAndWritableFileHandleProtocol, _HasFi
     }
 
     public func setTimes(
-        lastAccessTime: FileInfo.Timespec?,
-        lastDataModificationTime: FileInfo.Timespec?
+        lastAccess: FileInfo.Timespec?,
+        lastDataModification: FileInfo.Timespec?
     ) async throws {
         try await self.fileHandle.systemFileHandle.setTimes(
-            lastAccessTime: lastAccessTime,
-            lastDataModificationTime: lastDataModificationTime
+            lastAccess: lastAccess,
+            lastDataModification: lastDataModification
         )
     }
 }

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -507,7 +507,30 @@ extension WritableFileHandleProtocol {
     ) async throws -> Int64 {
         try await self.write(contentsOf: buffer.readableBytesView, toAbsoluteOffset: offset)
     }
-    
+}
+
+// MARK: - File times modifiers
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension FileHandleProtocol {
+    /// Sets the file's last access time to the given time.
+    /// 
+    /// - Parameter time: The time to which the file's last access time should be set.
+    ///
+    /// - Throws: If there's an error updating the time. If this happens, the original value won't be modified.
+    public func setLastAccessTime(to time: FileInfo.Timespec) async throws {
+        try await self.setTimes(lastAccess: time, lastDataModification: nil)
+    }
+
+    /// Sets the file's last data modification time to the given time.
+    ///
+    /// - Parameter time: The time to which the file's last data modification time should be set.
+    ///
+    /// - Throws: If there's an error updating the time. If this happens, the original value won't be modified.
+    public func setLastDataModificationTime(to time: FileInfo.Timespec) async throws {
+        try await self.setTimes(lastAccess: nil, lastDataModification: time)
+    }
+
     /// Sets the file's last access and last data modification times to the current time.
     ///
     /// - Throws: If there's an error updating the times. If this happens, the original values won't be modified.

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -151,8 +151,9 @@ public protocol FileHandleProtocol {
     ///
     /// > Important: Times are only considered valid if their nanoseconds components are one of the following:
     /// > - `UTIME_NOW` (you can use ``FileInfo/Timespec/now`` to get a Timespec set to this value),
-    /// > - `UTIME_OMIT` (you can use ``FileInfo/Timespec/omit`` to get a Timespec set to this value),,
-    /// > - Greater than zero and no larger than 1000 million
+    /// > - `UTIME_OMIT` (you can use ``FileInfo/Timespec/omit`` to get a Timespec set to this value),
+    /// > - Greater than zero and no larger than 1000 million: if outside of this range, the value will be clamped to the closest valid value.
+    /// > The seconds component must also be positive: if it's not, zero will be used as the value instead.
     ///
     /// - Parameters:
     ///   - lastAccessTime: The new value of the file's last access time, as time elapsed since the Epoch.

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -15,6 +15,15 @@
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 import SystemPackage
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("The File Handle Protocol module was unable to identify your C library.")
+#endif
 
 /// A handle for a file system object.
 ///
@@ -463,6 +472,26 @@ public protocol WritableFileHandleProtocol: FileHandleProtocol {
     ///       filesystem with the expected name, otherwise no file will be created or the original
     ///       file won't be modified (if one existed).
     func close(makeChangesVisible: Bool) async throws
+    
+    /// Sets the file's last access and last data modification times to the given values.
+    ///
+    /// If **either** time is `nil`, the current value will not be changed.
+    /// If **both** times are `nil`, then both times will be set to the current time.
+    ///
+    /// > Important: Times are only considered valid if their nanoseconds components are one of the following:
+    /// > - `UTIME_NOW`,
+    /// > - `UTIME_OMIT`,
+    /// > - Greater than zero and no larger than 1000 million
+    ///
+    /// - Parameters:
+    ///   - lastAccessTime: The new value of the file's last access time, as time elapsed since the Epoch.
+    ///   - lastDataModificationTime: The new value of the file's last data modification time, as time elapsed since the Epoch.
+    ///
+    /// - Throws: If there's an error updating the times. If this happens, the original values won't be modified.
+    func setTimes(
+        lastAccessTime: FileInfo.Timespec?,
+        lastDataModificationTime: FileInfo.Timespec?
+    ) async throws
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -485,6 +514,13 @@ extension WritableFileHandleProtocol {
         toAbsoluteOffset offset: Int64
     ) async throws -> Int64 {
         try await self.write(contentsOf: buffer.readableBytesView, toAbsoluteOffset: offset)
+    }
+    
+    /// Sets the file's last access and last data modification times to the current time.
+    ///
+    /// - Throws: If there's an error updating the times. If this happens, the original values won't be modified.
+    public func touch() async throws {
+        try await self.setTimes(lastAccessTime: nil, lastDataModificationTime: nil)
     }
 }
 

--- a/Sources/NIOFileSystem/FileInfo.swift
+++ b/Sources/NIOFileSystem/FileInfo.swift
@@ -148,26 +148,26 @@ extension FileInfo {
     /// A time interval consisting of whole seconds and nanoseconds.
     public struct Timespec: Hashable, Sendable {
         #if canImport(Darwin)
-        private static let UTIME_OMIT_INT = Int(UTIME_OMIT)
-        private static let UTIME_NOW_INT = Int(UTIME_NOW)
+        private static let utimeOmit = Int(UTIME_OMIT)
+        private static let utimeNow = Int(UTIME_NOW)
         #elseif canImport(Glibc) || canImport(Musl)
-        private static let UTIME_OMIT_INT = Int(CNIOLinux_UTIME_OMIT)
-        private static let UTIME_NOW_INT = Int(CNIOLinux_UTIME_NOW)
+        private static let utimeOmit = Int(CNIOLinux_UTIME_OMIT)
+        private static let utimeNow = Int(CNIOLinux_UTIME_NOW)
         #endif
 
         /// A timespec where the seconds are set to zero and the nanoseconds set to `UTIME_OMIT`.
         /// In syscalls such as `futimens`, this means the time component set to this value will be ignored.
-        public static var omit = Self.init(
+        public static let omit = Self(
             seconds: 0,
-            nanoseconds: Self.UTIME_OMIT_INT
+            nanoseconds: Self.utimeOmit
         )
 
         /// A timespec where the seconds are set to zero and the nanoseconds set to `UTIME_NOW`.
         /// In syscalls such as `futimens`, this means the time component set to this value will be
         /// be set to the current time or the largest value supported by the platform, whichever is smaller.
-        public static var now = Self.init(
+        public static let now = Self(
             seconds: 0,
-            nanoseconds: Self.UTIME_NOW_INT
+            nanoseconds: Self.utimeNow
         )
 
         /// The number of seconds.

--- a/Sources/NIOFileSystem/FileInfo.swift
+++ b/Sources/NIOFileSystem/FileInfo.swift
@@ -19,8 +19,10 @@ import SystemPackage
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+import CNIOLinux
 #elseif canImport(Musl)
 import Musl
+import CNIOLinux
 #endif
 
 /// Information about a file system object.
@@ -145,6 +147,29 @@ extension FileInfo {
 
     /// A time interval consisting of whole seconds and nanoseconds.
     public struct Timespec: Hashable, Sendable {
+        #if canImport(Darwin)
+        private static let UTIME_OMIT_INT = Int(UTIME_OMIT)
+        private static let UTIME_NOW_INT = Int(UTIME_NOW)
+        #elseif canImport(Glibc) || canImport(Musl)
+        private static let UTIME_OMIT_INT = Int(CNIOLinux_UTIME_OMIT)
+        private static let UTIME_NOW_INT = Int(CNIOLinux_UTIME_NOW)
+        #endif
+
+        /// A timespec where the seconds are set to zero and the nanoseconds set to `UTIME_OMIT`.
+        /// In syscalls such as `futimens`, this means the time component set to this value will be ignored.
+        public static var omit = Self.init(
+            seconds: 0,
+            nanoseconds: Self.UTIME_OMIT_INT
+        )
+
+        /// A timespec where the seconds are set to zero and the nanoseconds set to `UTIME_NOW`.
+        /// In syscalls such as `futimens`, this means the time component set to this value will be
+        /// be set to the current time or the largest value supported by the platform, whichever is smaller.
+        public static var now = Self.init(
+            seconds: 0,
+            nanoseconds: Self.UTIME_NOW_INT
+        )
+
         /// The number of seconds.
         public var seconds: Int
 

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -1067,6 +1067,7 @@ extension FileSystemError {
         )
     }
 
+    @_spi(Testing)
     public static func futimens(
         errno: Errno,
         path: FilePath,
@@ -1082,16 +1083,9 @@ extension FileSystemError {
             code = .permissionDenied
             message = "Not permited to change last access or last data modification times for \(path)."
 
-        case .invalidArgument:
-            code = .invalidArgument
-            message = """
-                Invalid times value: nanoseconds for both timespecs must be UTIME_NOW, UTIME_OMIT, or a number between 0 and 1000 million
-                (last access time: \(String(describing: lastAccessTime)), last data modification time: \(String(describing: lastDataModificationTime))).
-            """
-
         case .readOnlyFileSystem:
             code = .unsupported
-            message = "Not permited to change last access or last data modification times for \(path): this is a read-only file system."
+            message = "Not permitted to change last access or last data modification times for \(path): this is a read-only file system."
 
         case .badFileDescriptor:
             code = .closed

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -1081,7 +1081,7 @@ extension FileSystemError {
         switch errno {
         case .permissionDenied, .notPermitted:
             code = .permissionDenied
-            message = "Not permited to change last access or last data modification times for \(path)."
+            message = "Not permitted to change last access or last data modification times for \(path)."
 
         case .readOnlyFileSystem:
             code = .unsupported

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -1066,6 +1066,50 @@ extension FileSystemError {
             location: location
         )
     }
+
+    public static func futimens(
+        errno: Errno,
+        path: FilePath,
+        lastAccessTime: FileInfo.Timespec?,
+        lastDataModificationTime: FileInfo.Timespec?,
+        location: SourceLocation
+    ) -> FileSystemError {
+        let code: FileSystemError.Code
+        let message: String
+
+        switch errno {
+        case .permissionDenied, .notPermitted:
+            code = .permissionDenied
+            message = "Not permited to change last access or last data modification times for \(path)."
+
+        case .invalidArgument:
+            code = .invalidArgument
+            message = """
+                Invalid times value: nanoseconds for both timespecs must be UTIME_NOW, UTIME_OMIT, or a number between 0 and 1000 million
+                (last access time: \(String(describing: lastAccessTime)), last data modification time: \(String(describing: lastDataModificationTime))).
+            """
+
+        case .readOnlyFileSystem:
+            code = .unsupported
+            message = "Not permited to change last access or last data modification times for \(path): this is a read-only file system."
+
+        case .badFileDescriptor:
+            code = .closed
+            message = "Could not change last access or last data modification dates for \(path): file is closed."
+
+        default:
+            code = .unknown
+            message = "Could not change last access or last data modification dates for \(path)."
+        }
+
+        return FileSystemError(
+            code: code,
+            message: message,
+            systemCall: "futimens",
+            errno: errno,
+            location: location
+        )
+    }
 }
 
 #endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -266,6 +266,16 @@ public enum Syscall {
         }
     }
     #endif
+
+    @_spi(Testing)
+    public static func futimens(
+        fileDescriptor fd: FileDescriptor,
+        times: UnsafePointer<timespec>?
+    ) -> Result<Void, Errno> {
+        nothingOrErrno(retryOnInterrupt: false) {
+            system_futimens(fd.rawValue, times)
+        }
+    }
 }
 
 @_spi(Testing)

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -349,6 +349,18 @@ internal func system_sendfile(
 }
 #endif
 
+internal func system_futimens(
+    _ fd: CInt,
+    _ times: UnsafePointer<timespec>?
+) -> CInt {
+    #if ENABLE_MOCKING
+    if mockingEnabled {
+        return mock(fd, times)
+    }
+    #endif
+    return futimens(fd, times)
+}
+
 // MARK: - libc
 
 /// fdopendir(3): Opens a directory stream for the file descriptor

--- a/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
@@ -981,8 +981,8 @@ extension SystemFileHandle.SendableView {
     }
 }
 
-fileprivate extension timespec {
-    init(_ fileinfoTimespec: FileInfo.Timespec) {
+extension timespec {
+    fileprivate init(_ fileinfoTimespec: FileInfo.Timespec) {
         // Clamp seconds to be positive
         let seconds = max(0, fileinfoTimespec.seconds)
 

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -1185,8 +1185,8 @@ final class FileHandleTests: XCTestCase {
             let originalLastAccessTime = try await handle.info().lastAccessTime
 
             try await handle.setTimes(
-                lastAccessTime: FileInfo.Timespec(seconds: 10, nanoseconds: 5),
-                lastModificationTime: nil
+                lastAccess: FileInfo.Timespec(seconds: 10, nanoseconds: 5),
+                lastDataModification: nil
             )
 
             let actualLastAccessTime = try await handle.info().lastAccessTime
@@ -1204,8 +1204,8 @@ final class FileHandleTests: XCTestCase {
             let originalLastAccessTime = try await handle.info().lastAccessTime
 
             try await handle.setTimes(
-                lastAccessTime: nil,
-                lastModificationTime: FileInfo.Timespec(seconds: 10, nanoseconds: 5)
+                lastAccess: nil,
+                lastDataModification: FileInfo.Timespec(seconds: 10, nanoseconds: 5)
             )
 
             let actualLastDataModificationTime = try await handle.info().lastDataModificationTime
@@ -1223,8 +1223,8 @@ final class FileHandleTests: XCTestCase {
             let originalLastAccessTime = try await handle.info().lastAccessTime
 
             try await handle.setTimes(
-                lastAccessTime: FileInfo.Timespec(seconds: 20, nanoseconds: 25),
-                lastModificationTime: FileInfo.Timespec(seconds: 10, nanoseconds: 5)
+                lastAccess: FileInfo.Timespec(seconds: 20, nanoseconds: 25),
+                lastDataModification: FileInfo.Timespec(seconds: 10, nanoseconds: 5)
             )
 
             let actualLastAccessTime = try await handle.info().lastAccessTime
@@ -1242,8 +1242,8 @@ final class FileHandleTests: XCTestCase {
             // Set some random value for both times, only to be overwritten by the current time
             // right after.
             try await handle.setTimes(
-                lastAccessTime: FileInfo.Timespec(seconds: 1, nanoseconds: 0),
-                lastModificationTime: FileInfo.Timespec(seconds: 1, nanoseconds: 0)
+                lastAccess: FileInfo.Timespec(seconds: 1, nanoseconds: 0),
+                lastDataModification: FileInfo.Timespec(seconds: 1, nanoseconds: 0)
             )
 
             var actualLastAccessTime = try await handle.info().lastAccessTime
@@ -1253,8 +1253,8 @@ final class FileHandleTests: XCTestCase {
             XCTAssertEqual(actualLastDataModificationTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))
 
             try await handle.setTimes(
-                lastAccessTime: nil,
-                lastModificationTime: nil
+                lastAccess: nil,
+                lastDataModification: nil
             )
             let estimatedCurrentTime = Date.now.timeIntervalSince1970
 
@@ -1272,8 +1272,8 @@ final class FileHandleTests: XCTestCase {
             // Set some random value for both times, only to be overwritten by the current time
             // right after.
             try await handle.setTimes(
-                lastAccessTime: FileInfo.Timespec(seconds: 1, nanoseconds: 0),
-                lastModificationTime: FileInfo.Timespec(seconds: 1, nanoseconds: 0)
+                lastAccess: FileInfo.Timespec(seconds: 1, nanoseconds: 0),
+                lastDataModification: FileInfo.Timespec(seconds: 1, nanoseconds: 0)
             )
 
             var actualLastAccessTime = try await handle.info().lastAccessTime

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -1178,6 +1178,121 @@ final class FileHandleTests: XCTestCase {
             }
         }
     }
+
+    func testSetLastAccesTime() async throws {
+        try await self.withTemporaryFile { handle in
+            let originalLastDataModificationTime = try await handle.info().lastDataModificationTime
+            let originalLastAccessTime = try await handle.info().lastAccessTime
+
+            try await handle.setTimes(
+                lastAccessTime: FileInfo.Timespec(seconds: 10, nanoseconds: 5),
+                lastModificationTime: nil
+            )
+
+            let actualLastAccessTime = try await handle.info().lastAccessTime
+            XCTAssertEqual(actualLastAccessTime, FileInfo.Timespec(seconds: 10, nanoseconds: 5))
+            XCTAssertNotEqual(actualLastAccessTime, originalLastAccessTime)
+
+            let actualLastDataModificationTime = try await handle.info().lastDataModificationTime
+            XCTAssertEqual(actualLastDataModificationTime, originalLastDataModificationTime)
+        }
+    }
+
+    func testSetLastDataModificationTime() async throws {
+        try await self.withTemporaryFile { handle in
+            let originalLastDataModificationTime = try await handle.info().lastDataModificationTime
+            let originalLastAccessTime = try await handle.info().lastAccessTime
+
+            try await handle.setTimes(
+                lastAccessTime: nil,
+                lastModificationTime: FileInfo.Timespec(seconds: 10, nanoseconds: 5)
+            )
+
+            let actualLastDataModificationTime = try await handle.info().lastDataModificationTime
+            XCTAssertEqual(actualLastDataModificationTime, FileInfo.Timespec(seconds: 10, nanoseconds: 5))
+            XCTAssertNotEqual(actualLastDataModificationTime, originalLastDataModificationTime)
+
+            let actualLastAccessTime = try await handle.info().lastAccessTime
+            XCTAssertEqual(actualLastAccessTime, originalLastAccessTime)
+        }
+    }
+
+    func testSetLastAccessAndLastDataModificationTimes() async throws {
+        try await self.withTemporaryFile { handle in
+            let originalLastDataModificationTime = try await handle.info().lastDataModificationTime
+            let originalLastAccessTime = try await handle.info().lastAccessTime
+
+            try await handle.setTimes(
+                lastAccessTime: FileInfo.Timespec(seconds: 20, nanoseconds: 25),
+                lastModificationTime: FileInfo.Timespec(seconds: 10, nanoseconds: 5)
+            )
+
+            let actualLastAccessTime = try await handle.info().lastAccessTime
+            XCTAssertEqual(actualLastAccessTime, FileInfo.Timespec(seconds: 20, nanoseconds: 25))
+            XCTAssertNotEqual(actualLastAccessTime, originalLastAccessTime)
+
+            let actualLastDataModificationTime = try await handle.info().lastDataModificationTime
+            XCTAssertEqual(actualLastDataModificationTime, FileInfo.Timespec(seconds: 10, nanoseconds: 5))
+            XCTAssertNotEqual(actualLastDataModificationTime, originalLastDataModificationTime)
+        }
+    }
+
+    func testSetLastAccessAndLastDataModificationTimesToNil() async throws {
+        try await self.withTemporaryFile { handle in
+            // Set some random value for both times, only to be overwritten by the current time
+            // right after.
+            try await handle.setTimes(
+                lastAccessTime: FileInfo.Timespec(seconds: 1, nanoseconds: 0),
+                lastModificationTime: FileInfo.Timespec(seconds: 1, nanoseconds: 0)
+            )
+
+            var actualLastAccessTime = try await handle.info().lastAccessTime
+            XCTAssertEqual(actualLastAccessTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))
+
+            var actualLastDataModificationTime = try await handle.info().lastDataModificationTime
+            XCTAssertEqual(actualLastDataModificationTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))
+
+            try await handle.setTimes(
+                lastAccessTime: nil,
+                lastModificationTime: nil
+            )
+            let estimatedCurrentTime = Date.now.timeIntervalSince1970
+
+            // Assert that the times are equal to the current time, with up to a second difference (to avoid timing flakiness).
+            actualLastAccessTime = try await handle.info().lastAccessTime
+            XCTAssertEqual(Float(actualLastAccessTime.seconds), Float(estimatedCurrentTime), accuracy: 1)
+
+            actualLastDataModificationTime = try await handle.info().lastDataModificationTime
+            XCTAssertEqual(Float(actualLastDataModificationTime.seconds), Float(estimatedCurrentTime), accuracy: 1)
+        }
+    }
+
+    func testTouchFile() async throws {
+        try await self.withTemporaryFile { handle in
+            // Set some random value for both times, only to be overwritten by the current time
+            // right after.
+            try await handle.setTimes(
+                lastAccessTime: FileInfo.Timespec(seconds: 1, nanoseconds: 0),
+                lastModificationTime: FileInfo.Timespec(seconds: 1, nanoseconds: 0)
+            )
+
+            var actualLastAccessTime = try await handle.info().lastAccessTime
+            XCTAssertEqual(actualLastAccessTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))
+
+            var actualLastDataModificationTime = try await handle.info().lastDataModificationTime
+            XCTAssertEqual(actualLastDataModificationTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))
+
+            try await handle.touch()
+            let estimatedCurrentTime = Date.now.timeIntervalSince1970
+
+            // Assert that the times are equal to the current time, with up to a second difference (to avoid timing flakiness).
+            actualLastAccessTime = try await handle.info().lastAccessTime
+            XCTAssertEqual(Float(actualLastAccessTime.seconds), Float(estimatedCurrentTime), accuracy: 1)
+
+            actualLastDataModificationTime = try await handle.info().lastDataModificationTime
+            XCTAssertEqual(Float(actualLastDataModificationTime.seconds), Float(estimatedCurrentTime), accuracy: 1)
+        }
+    }
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -558,6 +558,19 @@ final class FileSystemErrorTests: XCTestCase {
         }
     }
 
+    func testErrnoMapping_futimens() {
+        self.testErrnoToErrorCode(
+            expected: [
+                .permissionDenied: .permissionDenied,
+                .notPermitted: .permissionDenied,
+                .readOnlyFileSystem: .unsupported,
+                .badFileDescriptor: .closed,
+            ]
+        ) { errno in
+                .futimens(errno: errno, path: "", lastAccessTime: nil, lastDataModificationTime: nil, location: .fixed)
+        }
+    }
+
     private func testErrnoToErrorCode(
         expected mapping: [Errno: FileSystemError.Code],
         _ makeError: (Errno) -> FileSystemError

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -567,7 +567,7 @@ final class FileSystemErrorTests: XCTestCase {
                 .badFileDescriptor: .closed,
             ]
         ) { errno in
-                .futimens(errno: errno, path: "", lastAccessTime: nil, lastDataModificationTime: nil, location: .fixed)
+            .futimens(errno: errno, path: "", lastAccessTime: nil, lastDataModificationTime: nil, location: .fixed)
         }
     }
 

--- a/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
@@ -398,6 +398,22 @@ final class SyscallTests: XCTestCase {
         testCases.run()
     }
 
+    func test_futimens() throws {
+        let fd = FileDescriptor(rawValue: 42)
+        let times = timespec(tv_sec: 1, tv_nsec: 1)
+        withUnsafePointer(to: times) { unsafeTimesPointer in
+            let testCases = [
+                MockTestCase(name: "futimens", .noInterrupt, 42, unsafeTimesPointer) { _ in
+                    try Syscall.futimens(
+                        fileDescriptor: fd,
+                        times: unsafeTimesPointer
+                    ).get()
+                }
+            ]
+            testCases.run()
+        }
+    }
+
     func testValueOrErrno() throws {
         let r1: Result<Int, Errno> = valueOrErrno(retryOnInterrupt: false) {
             Errno._current = .addressInUse


### PR DESCRIPTION
This PR adds API to set a file's last accessed and last modified times, as well as a `touch()` shorthand that updates both to the current time.

### Motivation:

Feature request: https://github.com/apple/swift-nio/issues/2712

### Modifications:

This PR adds API to set a file's last accessed and last modified times, as well as a `touch()` shorthand that updates both to the current time.

### Result:

Files' last accessed and last modified times can be updated.
