### PR TITLE
Close channel during upgrade, if client closes input

### DIFF
--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -154,6 +154,17 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
         }
     }
 
+    public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        switch event {
+        case let evt as ChannelEvent where evt == ChannelEvent.inputClosed:
+            // The remote peer half-closed the channel during the upgrade so we should close
+            context.close(promise: nil)
+
+        default:
+            context.fireUserInboundEventTriggered(event)
+        }
+    }
+
     private func channelRead(context: ChannelHandlerContext, requestPart: HTTPServerRequestPart) {
         switch self.stateMachine.channelReadRequestPart(requestPart) {
         case .failUpgradePromise(let error):

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -160,8 +160,8 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
             // The remote peer half-closed the channel during the upgrade. Should we close the other side
             switch self.stateMachine.inputClosed() {
             case .close:
-                self.upgradeResultPromise.fail(ChannelError.inputClosed)
                 context.close(promise: nil)
+                self.upgradeResultPromise.fail(ChannelError.inputClosed)
             case .continue:
                 break
             case .fireInputClosedEvent:

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -416,6 +416,8 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
     private func unbuffer(context: ChannelHandlerContext) {
         while true {
             switch self.stateMachine.unbuffer() {
+            case .close:
+                context.close(promise: nil)
             case .fireChannelRead(let data):
                 context.fireChannelRead(data)
 

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -160,7 +160,7 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
             // The remote peer half-closed the channel during the upgrade. Should we close the other side
             switch self.stateMachine.closeInbound() {
             case .close:
-                self.upgradeResultPromise.fail(ChannelError.ioOnClosedChannel)
+                self.upgradeResultPromise.fail(ChannelError.inputClosed)
                 context.close(promise: nil)
             case .continue:
                 break

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
@@ -393,5 +393,23 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
         }
     }
 
+    @usableFromInline
+    enum CloseInboundAction {
+        case close
+        case `continue`
+    }
+
+    @inlinable
+    mutating func closeInbound() -> CloseInboundAction {
+        switch self.state {
+        case .initial, .awaitingUpgrader:
+            self.state = .finished
+            return .close
+
+        default:
+            return .continue
+        }
+    }
+ 
 }
 #endif

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
@@ -434,10 +434,12 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
             self.state = .upgrading(upgrading)
             return .continue
 
-        case .upgraderReady(var upgraderReady):
-            upgraderReady.buffer.append(.inputClosed)
-            self.state = .upgraderReady(upgraderReady)
-            return .continue
+        case .upgraderReady:
+            // if the state is `upgraderReady` we have received a `.head` but not an `.end`.
+            // If input is closed then there is no way to move this forward so we should
+            // close.
+            self.state = .finished
+            return .close
 
         case .unbuffering(var unbuffering):
             unbuffering.buffer.append(.inputClosed)

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
@@ -423,7 +423,7 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
                 self.state = .awaitingUpgrader(awaitingUpgrader)
                 return .continue
             } else {
-                // We shouldn't buffer. This means we are still expecting HTTP parts.
+                // We shouldn't buffer. This means we were still expecting HTTP parts.
                 return .close
             }
 
@@ -446,6 +446,6 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
             return .continue
         }
     }
- 
+
 }
 #endif

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -2337,9 +2337,9 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
                 default:
                     break
                 }
-            }
-        ) { (context) in
-        }
+            },
+            { _ in }
+        )
 
         try client.close(mode: .output).wait()
         try connectedServer.closeFuture.wait()
@@ -2358,9 +2358,9 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
             extraHandlers: [],
             upgradeErrorHandler: { error in
                 XCTFail("Error: \(error)")
-            }
-        ) { (context) in
-        }
+            },
+            { _ in }
+        )
 
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
@@ -2370,7 +2370,7 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         XCTAssertEqual(upgradePerformed.wrappedValue, true)
     }
 
-    /// Test that sending an unfinished upgrade request and closing immediately throws 
+    /// Test that sending an unfinished upgrade request and closing immediately throws
     /// an input closed error
     func testSendUnfinishedRequestCloseImmediately() throws {
         let errorCaught = UnsafeMutableTransferBox<Bool>(false)
@@ -2387,9 +2387,9 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
                 default:
                     XCTFail("Error: \(error)")
                 }
-            }
-        ) { (context) in
-        }
+            },
+            { _ in }
+        )
 
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\ncontent-length: 10\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -489,6 +489,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         upgraders: [any TypedAndUntypedHTTPServerProtocolUpgrader],
         extraHandlers: [ChannelHandler],
         notUpgradingHandler: (@Sendable (Channel) -> EventLoopFuture<Bool>)? = nil,
+        upgradeErrorHandler: (@Sendable (Error) -> Void)? = nil,
         _ upgradeCompletionHandler: @escaping UpgradeCompletionHandler
     ) throws -> (Channel, Channel, Channel) {
         let (serverChannel, connectedServerChannelFuture) = try serverHTTPChannelWithAutoremoval(
@@ -1770,11 +1771,13 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         upgraders: [any TypedAndUntypedHTTPServerProtocolUpgrader],
         extraHandlers: [ChannelHandler],
         notUpgradingHandler: (@Sendable (Channel) -> EventLoopFuture<Bool>)? = nil,
+        upgradeErrorHandler: (@Sendable (Error) -> Void)? = nil,
         _ upgradeCompletionHandler: @escaping UpgradeCompletionHandler
     ) throws -> (Channel, Channel, Channel) {
         let connectionChannelPromise = Self.eventLoop.makePromise(of: Channel.self)
         let serverChannelFuture = ServerBootstrap(group: Self.eventLoop)
-            .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
             .childChannelInitializer { channel in
                 channel.eventLoop.makeCompletedFuture {
                     connectionChannelPromise.succeed(channel)
@@ -1799,6 +1802,10 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
                         } else {
                             return channel.eventLoop.makeSucceededVoidFuture()
                         }
+                    }
+                    .flatMapErrorThrowing { error in
+                        upgradeErrorHandler?(error)
+                        throw error
                     }
                 }
                 .flatMap { _ in
@@ -2313,5 +2320,31 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         // We also want to confirm that the upgrade handler is no longer in the pipeline.
         try connectedServer.pipeline.waitForUpgraderToBeRemoved()
     }
+
+    func testHalfClosure() throws {
+        let errorCaught = UnsafeMutableTransferBox<Bool>(false)
+
+        let upgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: ["kafkaesque"]) { req in
+            XCTFail("Upgrade cannot be successful if we don't send any data to server")
+        }
+        let (_, client, connectedServer) = try setUpTestWithAutoremoval(
+            upgraders: [upgrader],
+            extraHandlers: [],
+            upgradeErrorHandler: { error in
+                switch error {
+                case ChannelError.inputClosed:
+                    errorCaught.wrappedValue = true
+                default:
+                    break
+                }
+            }
+        ) { (context) in
+        }
+
+        try client.close().wait()
+        try connectedServer.closeFuture.wait()
+        XCTAssertEqual(errorCaught.wrappedValue, true)
+    }
+
 }
 #endif

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -2213,7 +2213,7 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         ) {
             // this is the wrong EL
             otherELG.next().makeSucceededFuture($1)
-        } onUpgradeComplete:  { req in
+        } onUpgradeComplete: { req in
             upgradeRequest.wrappedValue = req
             XCTAssertFalse(upgradeHandlerCbFired.wrappedValue)
             upgraderCbFired.wrappedValue = true

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -2364,11 +2364,10 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
 
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
         try client.close(mode: .output).wait()
         try connectedServer.pipeline.waitForUpgraderToBeRemoved()
         XCTAssertEqual(upgradePerformed.wrappedValue, true)
     }
-
 }
 #endif


### PR DESCRIPTION
Check for half closure during server upgrade and close channel if client closes the channel

### Motivation:

This is to fix #2742 

### Modifications:

Add `userInboundEventTriggered` function to `NIOTypedHTTPServerProtocolUpgrader` which checks for `ChannelEvent.inputClosed`

### Result:

Negotiation future now errors when client closes the connection instead of never completing
