### PR TITLE
[GHA] Introduce the first GitHub Action

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -1,0 +1,31 @@
+name: Pull Request
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+## We are cancelling previously triggered workflow runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.ref }}
+  cancel-in-progress: true
+ 
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        swift:
+        - image: swift5.8-jammy
+        - image: swift5.9-jammy
+        - image: swift5.10-noble
+        - image: swiftlang/swift:nightly-6.0-jammy
+        - image: swiftlang/swift:nightly-main-jammy
+    container:
+      image: ${{ matrix.swift.image }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Run tests
+      run: swift test
+      timeout-minutes: 20


### PR DESCRIPTION
# Motivation

We want to move our CI over to use GitHub Actions. We need to cover multiple different things like unit tests, benchmarks, soundness, API breaks, doc validation etc.

# Modification

This PR starts our journey to GitHub Actions by introducing the PR workflow. Right now this workflow only runs the Swift tests on our repository without any additional compiler flags like `-warnings-as-errors`. This aims to get us started and we will continue to modify them in subsequent PRs.

# Result

We got our first GH workflows running