### PR TITLE
Pre-box some errors to reduce allocations

### DIFF
--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriterHandler.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriterHandler.swift
@@ -137,7 +137,7 @@ internal final class NIOAsyncChannelOutboundWriterHandler<OutboundOut: Sendable>
     @inlinable
     func handlerRemoved(context: ChannelHandlerContext) {
         self.context = nil
-        self.sink?.finish(error: ChannelError.ioOnClosedChannel)
+        self.sink?.finish(error: ChannelError._ioOnClosedChannel)
         self.writer = nil
     }
 
@@ -150,7 +150,7 @@ internal final class NIOAsyncChannelOutboundWriterHandler<OutboundOut: Sendable>
 
     @inlinable
     func channelInactive(context: ChannelHandlerContext) {
-        self.sink?.finish(error: ChannelError.ioOnClosedChannel)
+        self.sink?.finish(error: ChannelError._ioOnClosedChannel)
         context.fireChannelInactive()
     }
 

--- a/Sources/NIOCore/Channel.swift
+++ b/Sources/NIOCore/Channel.swift
@@ -377,6 +377,7 @@ extension ChannelError {
     // 'any Error' is unconditionally boxed, avoid allocating per use by statically boxing them.
     static let _alreadyClosed: any Error = ChannelError.alreadyClosed
     static let _inputClosed: any Error = ChannelError.inputClosed
+    @usableFromInline
     static let _ioOnClosedChannel: any Error = ChannelError.ioOnClosedChannel
     static let _operationUnsupported: any Error = ChannelError.operationUnsupported
     static let _outputClosed: any Error = ChannelError.outputClosed

--- a/Sources/NIOCore/Channel.swift
+++ b/Sources/NIOCore/Channel.swift
@@ -202,7 +202,7 @@ extension Channel {
     }
 
     public func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError.operationUnsupported)
+        promise?.fail(ChannelError._operationUnsupported)
     }
 
     public func triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {
@@ -371,6 +371,16 @@ public enum ChannelError: Error {
 
     /// An attempt was made to remove a ChannelHandler that is not removable.
     case unremovableHandler
+}
+
+extension ChannelError {
+    // 'any Error' is unconditionally boxed, avoid allocating per use by statically boxing them.
+    static let _alreadyClosed: any Error = ChannelError.alreadyClosed
+    static let _inputClosed: any Error = ChannelError.inputClosed
+    static let _ioOnClosedChannel: any Error = ChannelError.ioOnClosedChannel
+    static let _operationUnsupported: any Error = ChannelError.operationUnsupported
+    static let _outputClosed: any Error = ChannelError.outputClosed
+    static let _unremovableHandler: any Error = ChannelError.unremovableHandler
 }
 
 extension ChannelError: Equatable { }

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -198,7 +198,7 @@ public final class ChannelPipeline: ChannelInvoker {
         self.eventLoop.assertInEventLoop()
 
         if self.destroyed {
-            return .failure(ChannelError.ioOnClosedChannel)
+            return .failure(ChannelError._ioOnClosedChannel)
         }
 
         switch position {
@@ -247,7 +247,7 @@ public final class ChannelPipeline: ChannelInvoker {
                       operation: (ChannelHandlerContext, ChannelHandlerContext) -> Void) -> Result<Void, Error> {
         self.eventLoop.assertInEventLoop()
         if self.destroyed {
-            return .failure(ChannelError.ioOnClosedChannel)
+            return .failure(ChannelError._ioOnClosedChannel)
         }
 
         guard let context = self.contextForPredicate0({ $0.handler === relativeHandler }) else {
@@ -280,7 +280,7 @@ public final class ChannelPipeline: ChannelInvoker {
         self.eventLoop.assertInEventLoop()
 
         if self.destroyed {
-            return .failure(ChannelError.ioOnClosedChannel)
+            return .failure(ChannelError._ioOnClosedChannel)
         }
 
         let context = ChannelHandlerContext(name: name ?? nextName(), handler: handler, pipeline: self)
@@ -416,7 +416,7 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - promise: An `EventLoopPromise` that will complete when the `ChannelHandler` is removed.
     public func removeHandler(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
         guard context.handler is RemovableChannelHandler else {
-            promise?.fail(ChannelError.unremovableHandler)
+            promise?.fail(ChannelError._unremovableHandler)
             return
         }
         func removeHandler0() {
@@ -826,7 +826,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeClose(mode: mode, promise: promise)
         } else {
-            promise?.fail(ChannelError.alreadyClosed)
+            promise?.fail(ChannelError._alreadyClosed)
         }
     }
 
@@ -846,7 +846,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWrite(data, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -854,7 +854,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWriteAndFlush(data, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -862,7 +862,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeBind(to: address, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -870,7 +870,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeConnect(to: address, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -878,7 +878,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeRegister(promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -886,7 +886,7 @@ public final class ChannelPipeline: ChannelInvoker {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeTriggerUserOutboundEvent(event, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -1378,14 +1378,14 @@ extension ChannelPipeline.Position: Sendable {}
 
 private extension CloseMode {
     /// Returns the error to fail outstanding operations writes with.
-    var error: ChannelError {
+    var error: any Error {
         switch self {
         case .all:
-            return .ioOnClosedChannel
+            return ChannelError._ioOnClosedChannel
         case .output:
-            return .outputClosed
+            return ChannelError._outputClosed
         case .input:
-            return .inputClosed
+            return ChannelError._inputClosed
         }
     }
 }
@@ -1577,7 +1577,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeRegister(promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -1591,7 +1591,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeBind(to: address, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -1605,7 +1605,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeConnect(to: address, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -1620,7 +1620,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeWrite(data, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -1647,7 +1647,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeWriteAndFlush(data, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 
@@ -1671,7 +1671,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeClose(mode: mode, promise: promise)
         } else {
-            promise?.fail(ChannelError.alreadyClosed)
+            promise?.fail(ChannelError._alreadyClosed)
         }
     }
 
@@ -1684,7 +1684,7 @@ public final class ChannelHandlerContext: ChannelInvoker {
         if let outboundNext = self.prev {
             outboundNext.invokeTriggerUserOutboundEvent(event, promise: promise)
         } else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
         }
     }
 

--- a/Sources/NIOCore/DeadChannel.swift
+++ b/Sources/NIOCore/DeadChannel.swift
@@ -17,31 +17,31 @@
 /// all operations.
 private final class DeadChannelCore: ChannelCore {
     func localAddress0() throws -> SocketAddress {
-        throw ChannelError.ioOnClosedChannel
+        throw ChannelError._ioOnClosedChannel
     }
 
     func remoteAddress0() throws -> SocketAddress {
-        throw ChannelError.ioOnClosedChannel
+        throw ChannelError._ioOnClosedChannel
     }
 
     func register0(promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError._ioOnClosedChannel)
     }
 
     func registerAlreadyConfigured0(promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError._ioOnClosedChannel)
     }
 
     func bind0(to: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError._ioOnClosedChannel)
     }
 
     func connect0(to: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError._ioOnClosedChannel)
     }
 
     func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError._ioOnClosedChannel)
     }
 
     func flush0() {
@@ -51,11 +51,11 @@ private final class DeadChannelCore: ChannelCore {
     }
 
     func close0(error: Error, mode: CloseMode, promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError.alreadyClosed)
+        promise?.fail(ChannelError._alreadyClosed)
     }
 
     func triggerUserOutboundEvent0(_ event: Any, promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError.ioOnClosedChannel)
+        promise?.fail(ChannelError._ioOnClosedChannel)
     }
 
     func channelRead0(_ data: NIOAny) {
@@ -104,11 +104,11 @@ internal final class DeadChannel: Channel, @unchecked Sendable {
     let parent: Channel? = nil
 
     func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> EventLoopFuture<Void> {
-        return self.pipeline.eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
+        return self.pipeline.eventLoop.makeFailedFuture(ChannelError._ioOnClosedChannel)
     }
 
     func getOption<Option: ChannelOption>(_ option: Option) -> EventLoopFuture<Option.Value> {
-        return eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
+        return eventLoop.makeFailedFuture(ChannelError._ioOnClosedChannel)
     }
 
     let isWritable = false

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -26,7 +26,7 @@ public struct Scheduled<T> {
     @usableFromInline typealias CancelationCallback = @Sendable () -> Void
     /* private but usableFromInline */ @usableFromInline let _promise: EventLoopPromise<T>
     /* private but usableFromInline */ @usableFromInline let _cancellationTask: CancelationCallback
-    
+
     @inlinable
     @preconcurrency
     public init(promise: EventLoopPromise<T>, cancellationTask: @escaping @Sendable () -> Void) {
@@ -40,7 +40,7 @@ public struct Scheduled<T> {
     ///  This means that cancellation is not guaranteed.
     @inlinable
     public func cancel() {
-        self._promise.fail(EventLoopError.cancelled)
+        self._promise.fail(EventLoopError._cancelled)
         self._cancellationTask()
     }
 
@@ -1217,6 +1217,11 @@ public enum EventLoopError: Error {
 
     /// Shutting down the `EventLoop` failed.
     case shutdownFailed
+}
+
+extension EventLoopError {
+    @usableFromInline
+    static let _cancelled: any Error = EventLoopError.cancelled
 }
 
 extension EventLoopError: CustomStringConvertible {

--- a/Sources/NIOPosix/BSDSocketAPIPosix.swift
+++ b/Sources/NIOPosix/BSDSocketAPIPosix.swift
@@ -277,7 +277,7 @@ extension NIOBSDSocket {
                             option_value: &segmentSize,
                             option_len: socklen_t(MemoryLayout<CInt>.size))
         #else
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
         #endif
     }
 
@@ -294,7 +294,7 @@ extension NIOBSDSocket {
         }
         return segmentSize
         #else
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
         #endif
     }
 
@@ -307,7 +307,7 @@ extension NIOBSDSocket {
                             option_value: &isEnabled,
                             option_len: socklen_t(MemoryLayout<CInt>.size))
         #else
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
         #endif
     }
 
@@ -324,7 +324,7 @@ extension NIOBSDSocket {
         }
         return enabled != 0
         #else
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
         #endif
     }
 }

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -515,7 +515,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
     public final func localAddress0() throws -> SocketAddress {
         self.eventLoop.assertInEventLoop()
         guard self.isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
         return try self.socket.localAddress()
     }
@@ -523,7 +523,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
     public final func remoteAddress0() throws -> SocketAddress {
         self.eventLoop.assertInEventLoop()
         guard self.isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
         return try self.socket.remoteAddress()
     }
@@ -610,7 +610,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -658,7 +658,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -697,7 +697,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
             return
         }
 
@@ -712,7 +712,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
 
         guard self.isOpen else {
             // Channel was already closed, fail the promise and not even queue it.
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
             return
         }
 
@@ -834,12 +834,12 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(ChannelError.alreadyClosed)
+            promise?.fail(ChannelError._alreadyClosed)
             return
         }
 
         guard mode == .all else {
-            promise?.fail(ChannelError.operationUnsupported)
+            promise?.fail(ChannelError._operationUnsupported)
             return
         }
 
@@ -906,17 +906,17 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
             return
         }
 
         guard !self.lifecycleManager.isPreRegistered else {
-            promise?.fail(ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError._inappropriateOperationForState)
             return
         }
 
         guard self.selectableEventLoop.isOpen else {
-            let error = EventLoopError.shutdown
+            let error = EventLoopError._shutdown
             self.pipeline.syncOperations.fireErrorCaught(error)
             // `close0`'s error is about the result of the `close` operation, ...
             self.close0(error: error, mode: .all, promise: nil)
@@ -956,7 +956,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         case let event as VsockChannelEvents.ConnectToAddress:
             self.connect0(to: .vsockAddress(event.address), promise: promise)
         default:
-            promise?.fail(ChannelError.operationUnsupported)
+            promise?.fail(ChannelError._operationUnsupported)
         }
     }
 
@@ -1210,17 +1210,17 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
             return
         }
 
         guard pendingConnect == nil else {
-            promise?.fail(ChannelError.connectPending)
+            promise?.fail(ChannelError._connectPending)
             return
         }
 
         guard self.lifecycleManager.isPreRegistered else {
-            promise?.fail(ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError._inappropriateOperationForState)
             return
         }
 
@@ -1289,7 +1289,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         assert(!self.lifecycleManager.isRegisteredFully)
 
         guard self.isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         self.interestedEvent = interested

--- a/Sources/NIOPosix/BaseStreamSocketChannel.swift
+++ b/Sources/NIOPosix/BaseStreamSocketChannel.swift
@@ -47,7 +47,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -66,7 +66,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -112,7 +112,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         var result = ReadResult.none
         for _ in 1...self.maxMessagesPerRead {
             guard self.isOpen && !self.inputShutdown else {
-                throw ChannelError.eof
+                throw ChannelError._eof
             }
 
             let (buffer, readResult) = try self.recvBufferPool.buffer(allocator: self.allocator) { buffer in
@@ -148,7 +148,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
                         return result
                     }
                     // end-of-file
-                    throw ChannelError.eof
+                    throw ChannelError._eof
                 }
             case .wouldBlock(let bytesRead):
                 assert(bytesRead == 0)
@@ -180,7 +180,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
             switch mode {
             case .output:
                 if self.outputShutdown {
-                    promise?.fail(ChannelError.outputClosed)
+                    promise?.fail(ChannelError._outputClosed)
                     return
                 }
                 if self.inputShutdown {
@@ -197,7 +197,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
                 self.pipeline.fireUserInboundEventTriggered(ChannelEvent.outputClosed)
             case .input:
                 if self.inputShutdown {
-                    promise?.fail(ChannelError.inputClosed)
+                    promise?.fail(ChannelError._inputClosed)
                     return
                 }
                 if self.outputShutdown {
@@ -261,7 +261,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
 
     final override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
         if self.outputShutdown {
-            promise?.fail(ChannelError.outputClosed)
+            promise?.fail(ChannelError._outputClosed)
             return
         }
 

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -322,7 +322,7 @@ public final class ServerBootstrap {
     public func withBoundSocket(_ socket: NIOBSDSocket.Handle) -> EventLoopFuture<Channel> {
         func makeChannel(_ eventLoop: SelectableEventLoop, _ childEventLoopGroup: EventLoopGroup, _ enableMPTCP: Bool) throws -> ServerSocketChannel {
             if enableMPTCP {
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
             return try ServerSocketChannel(socket: socket, eventLoop: eventLoop, group: childEventLoopGroup)
         }
@@ -429,7 +429,7 @@ public final class ServerBootstrap {
                 future.flatMap { (_) -> EventLoopFuture<Void> in
                     ctxEventLoop.assertInEventLoop()
                     guard context.channel.isActive else {
-                        return context.eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
+                        return context.eventLoop.makeFailedFuture(ChannelError._ioOnClosedChannel)
                     }
                     context.fireChannelRead(data)
                     return context.eventLoop.makeSucceededFuture(())
@@ -604,7 +604,7 @@ extension ServerBootstrap {
         return try await bind0(
             makeServerChannel: { eventLoop, childEventLoopGroup, enableMPTCP in
                 if enableMPTCP {
-                    throw ChannelError.operationUnsupported
+                    throw ChannelError._operationUnsupported
                 }
                 return try ServerSocketChannel(
                     socket: socket,
@@ -2014,7 +2014,7 @@ public final class NIOPipeBootstrap {
         case DWORD(FILE_TYPE_PIPE):
             break
         default:
-            throw ChannelError.operationUnsupported
+            throw ChannelError._operationUnsupported
         }
 #else
         var s: stat = .init()
@@ -2023,7 +2023,7 @@ public final class NIOPipeBootstrap {
         }
         switch s.st_mode & S_IFMT {
         case S_IFREG, S_IFDIR, S_IFLNK, S_IFBLK:
-            throw ChannelError.operationUnsupported
+            throw ChannelError._operationUnsupported
         default:
             () // Let's default to ok
         }

--- a/Sources/NIOPosix/Errors+Any.swift
+++ b/Sources/NIOPosix/Errors+Any.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+
+import NIOCore
+
+// 'any Error' is unconditionally boxed, avoid allocating per use by statically boxing them.
+extension ChannelError {
+    static let _alreadyClosed: any Error = ChannelError.alreadyClosed
+    static let _badInterfaceAddressFamily: any Error = ChannelError.badInterfaceAddressFamily
+    static let _badMulticastGroupAddressFamily: any Error = ChannelError.badMulticastGroupAddressFamily
+    static let _connectPending: any Error = ChannelError.connectPending
+    static let _eof: any Error = ChannelError.eof
+    static let _inappropriateOperationForState: any Error = ChannelError.inappropriateOperationForState
+    static let _inputClosed: any Error = ChannelError.inputClosed
+    static let _ioOnClosedChannel: any Error = ChannelError.ioOnClosedChannel
+    static let _operationUnsupported: any Error = ChannelError.operationUnsupported
+    static let _outputClosed: any Error = ChannelError.outputClosed
+    static let _unknownLocalAddress: any Error = ChannelError.unknownLocalAddress
+    static let _writeHostUnreachable: any Error = ChannelError.writeHostUnreachable
+    static let _writeMessageTooLarge: any Error = ChannelError.writeMessageTooLarge
+}
+
+extension EventLoopError {
+    static let _shutdown: any Error = EventLoopError.shutdown
+    static let _unsupportedOperation: any Error = EventLoopError._unsupportedOperation
+}

--- a/Sources/NIOPosix/Errors+Any.swift
+++ b/Sources/NIOPosix/Errors+Any.swift
@@ -34,5 +34,5 @@ extension ChannelError {
 
 extension EventLoopError {
     static let _shutdown: any Error = EventLoopError.shutdown
-    static let _unsupportedOperation: any Error = EventLoopError._unsupportedOperation
+    static let _unsupportedOperation: any Error = EventLoopError.unsupportedOperation
 }

--- a/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
+++ b/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
@@ -304,7 +304,7 @@ public final class MultiThreadedEventLoopGroup: EventLoopGroup {
     private func _shutdownGracefully(queue: DispatchQueue, _ handler: @escaping ShutdownGracefullyCallback) {
         guard self.canBeShutDown else {
             queue.async {
-                handler(EventLoopError.unsupportedOperation)
+                handler(EventLoopError._unsupportedOperation)
             }
             return
         }

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -547,11 +547,11 @@ final class PendingDatagramWritesManager: PendingWritesManager {
     private func handleError(_ error: Error) throws -> OneWriteOperationResult {
         switch error {
         case let e as IOError where e.errnoCode == EMSGSIZE:
-            let (promise, result) = self.state.recoverableError(ChannelError.writeMessageTooLarge)
+            let (promise, result) = self.state.recoverableError(ChannelError._writeMessageTooLarge)
             self.fulfillPromise(promise)
             return result
         case let e as IOError where e.errnoCode == EHOSTUNREACH:
-            let (promise, result) = self.state.recoverableError(ChannelError.writeHostUnreachable)
+            let (promise, result) = self.state.recoverableError(ChannelError._writeHostUnreachable)
             self.fulfillPromise(promise)
             return result
         default:

--- a/Sources/NIOPosix/PipeChannel.swift
+++ b/Sources/NIOPosix/PipeChannel.swift
@@ -48,15 +48,15 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     override func connectSocket(to address: VsockAddress) throws -> Bool {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     override func finishConnectSocket() throws {
-        throw ChannelError.inappropriateOperationForState
+        throw ChannelError._inappropriateOperationForState
     }
 
     override func register(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws {

--- a/Sources/NIOPosix/PipePair.swift
+++ b/Sources/NIOPosix/PipePair.swift
@@ -65,11 +65,11 @@ final class PipePair: SocketProtocol {
     }
 
     func connect(to address: SocketAddress) throws -> Bool {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func finishConnect() throws {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func write(pointer: UnsafeRawBufferPointer) throws -> IOResult<Int> {
@@ -103,26 +103,26 @@ final class PipePair: SocketProtocol {
                  storage: inout sockaddr_storage,
                  storageLen: inout socklen_t,
                  controlBytes: inout UnsafeReceivedControlBytes) throws -> IOResult<Int> {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
-    
+
     func sendmsg(pointer: UnsafeRawBufferPointer,
                  destinationPtr: UnsafePointer<sockaddr>?,
                  destinationSize: socklen_t,
                  controlBytes: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func sendFile(fd: CInt, offset: Int, count: Int) throws -> IOResult<Int> {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func recvmmsg(msgs: UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int> {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func sendmmsg(msgs: UnsafeMutableBufferPointer<MMsgHdr>) throws -> IOResult<Int> {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func shutdown(how: Shutdown) throws {
@@ -142,7 +142,7 @@ final class PipePair: SocketProtocol {
 
     func close() throws {
         guard self.isOpen else {
-            throw ChannelError.alreadyClosed
+            throw ChannelError._alreadyClosed
         }
         let r1 = Result {
             if let inputFD = self.inputFD, inputFD.isOpen {
@@ -159,22 +159,22 @@ final class PipePair: SocketProtocol {
     }
 
     func bind(to address: SocketAddress) throws {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func localAddress() throws -> SocketAddress {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func remoteAddress() throws -> SocketAddress {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func setOption<T>(level: NIOBSDSocket.OptionLevel, name: NIOBSDSocket.Option, value: T) throws {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     func getOption<T>(level: NIOBSDSocket.OptionLevel, name: NIOBSDSocket.Option) throws -> T {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 }

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -253,7 +253,7 @@ Further information:
 
         // Don't allow registration when we're closed.
         guard self.isOpen else {
-            throw EventLoopError.shutdown
+            throw EventLoopError._shutdown
         }
 
         try channel.register(selector: self._selector, interested: channel.interestedEvent)
@@ -660,7 +660,7 @@ Further information:
                 }
                 // Fail all the scheduled tasks.
                 for task in scheduledTasksCopy {
-                    task.fail(EventLoopError.shutdown)
+                    task.fail(EventLoopError._shutdown)
                 }
 
                 iterations += 1
@@ -767,7 +767,7 @@ Further information:
             }
             guard goAhead else {
                 queue.async {
-                    completionHandler(Result.failure(EventLoopError.shutdown))
+                    completionHandler(Result.failure(EventLoopError._shutdown))
                 }
                 return
             }
@@ -819,7 +819,7 @@ Further information:
             // This function is never called legally because the only possibly owner of an `SelectableEventLoop` is
             // `MultiThreadedEventLoopGroup` which calls `initiateClose` followed by `syncFinaliseClose`.
             queue.async {
-                callback(EventLoopError.unsupportedOperation)
+                callback(EventLoopError._unsupportedOperation)
             }
         }
     }

--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -162,7 +162,7 @@ internal class Selector<R: Registration>  {
         assert(self.myThread != NIOThread.current)
         return try self.externalSelectorFDLock.withLock {
             guard self.selectorFD != -1 else {
-                throw EventLoopError.shutdown
+                throw EventLoopError._shutdown
             }
             return try body(self.selectorFD)
         }

--- a/Sources/NIOPosix/SelectorKqueue.swift
+++ b/Sources/NIOPosix/SelectorKqueue.swift
@@ -287,7 +287,7 @@ extension Selector: _SelectorBackendProtocol {
         assert(NIOThread.current != self.myThread)
         try self.externalSelectorFDLock.withLock {
                 guard self.selectorFD >= 0 else {
-                    throw EventLoopError.shutdown
+                    throw EventLoopError._shutdown
                 }
                 var event = kevent()
                 event.ident = 0

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -54,7 +54,7 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
         var protocolSubtype = NIOBSDSocket.ProtocolSubtype.default
         if enableMPTCP {
             guard let subtype = NIOBSDSocket.ProtocolSubtype.mptcp else {
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
             protocolSubtype = subtype
         }
@@ -75,7 +75,7 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -90,7 +90,7 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -178,7 +178,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         var protocolSubtype = NIOBSDSocket.ProtocolSubtype.default
         if enableMPTCP {
             guard let subtype = NIOBSDSocket.ProtocolSubtype.mptcp else {
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
             protocolSubtype = subtype
         }
@@ -212,7 +212,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -227,7 +227,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -249,12 +249,12 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         self.eventLoop.assertInEventLoop()
 
         guard self.isOpen else {
-            promise?.fail(ChannelError.ioOnClosedChannel)
+            promise?.fail(ChannelError._ioOnClosedChannel)
             return
         }
 
         guard self.isRegistered else {
-            promise?.fail(ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError._inappropriateOperationForState)
             return
         }
 
@@ -282,18 +282,18 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     }
 
     override func connectSocket(to address: SocketAddress) throws -> Bool {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     override func finishConnectSocket() throws {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     override func readFromSocket() throws -> ReadResult {
         var result = ReadResult.none
         for _ in 1...maxMessagesPerRead {
             guard self.isOpen else {
-                throw ChannelError.eof
+                throw ChannelError._eof
             }
             if let accepted = try self.socket.accept(setNonBlocking: true) {
                 readPending = false
@@ -352,7 +352,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         ch.eventLoop.execute {
             ch.register().flatMapThrowing {
                 guard ch.isOpen else {
-                    throw ChannelError.ioOnClosedChannel
+                    throw ChannelError._ioOnClosedChannel
                 }
                 ch.becomeActive0(promise: nil)
             }.whenFailure { error in
@@ -366,7 +366,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
     }
 
     override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError.operationUnsupported)
+        promise?.fail(ChannelError._operationUnsupported)
     }
 
     override func markFlushPoint() {
@@ -397,7 +397,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
         case let event as VsockChannelEvents.BindToAddress:
             self.bind0(to: .vsockAddress(event.address), promise: promise)
         default:
-            promise?.fail(ChannelError.operationUnsupported)
+            promise?.fail(ChannelError._operationUnsupported)
         }
     }
 }
@@ -493,7 +493,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -523,7 +523,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                                           value: valueAsInt)
             default:
                 // Explicit congestion notification is only supported for IP
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
         case _ as ChannelOptions.Types.ReceivePacketInfo:
             let valueAsInt: CInt = value as! Bool ? 1 : 0
@@ -540,17 +540,17 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                                           value: valueAsInt)
             default:
                 // Receiving packet info is only supported for IP
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
         case _ as ChannelOptions.Types.DatagramSegmentSize:
             guard System.supportsUDPSegmentationOffload else {
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
             let segmentSize = value as! ChannelOptions.Types.DatagramSegmentSize.Value
             try self.socket.setUDPSegmentSize(segmentSize)
         case _ as ChannelOptions.Types.DatagramReceiveOffload:
             guard System.supportsUDPReceiveOffload else {
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
             let enable = value as! ChannelOptions.Types.DatagramReceiveOffload.Value
             try self.socket.setUDPReceiveOffload(enable)
@@ -563,7 +563,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
         self.eventLoop.assertInEventLoop()
 
         guard isOpen else {
-            throw ChannelError.ioOnClosedChannel
+            throw ChannelError._ioOnClosedChannel
         }
 
         switch option {
@@ -583,7 +583,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                                                   name: .ipv6_recv_tclass) != 0) as! Option.Value
             default:
                 // Explicit congestion notification is only supported for IP
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
         case _ as ChannelOptions.Types.ReceivePacketInfo:
             switch self.localAddress?.protocol {
@@ -595,16 +595,16 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
                                                   name: .ipv6_recv_pktinfo) != 0) as! Option.Value
             default:
                 // Receiving packet info is only supported for IP
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
         case _ as ChannelOptions.Types.DatagramSegmentSize:
             guard System.supportsUDPSegmentationOffload else {
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
             return try self.socket.getUDPSegmentSize() as! Option.Value
         case _ as ChannelOptions.Types.DatagramReceiveOffload:
             guard System.supportsUDPReceiveOffload else {
-                throw ChannelError.operationUnsupported
+                throw ChannelError._operationUnsupported
             }
             return try self.socket.getUDPReceiveOffload() as! Option.Value
         default:
@@ -636,12 +636,12 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     }
 
     override func connectSocket(to address: VsockAddress) throws -> Bool {
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     override func finishConnectSocket() throws {
         // This is not required for connected datagram channels connect is a synchronous operation.
-        throw ChannelError.operationUnsupported
+        throw ChannelError._operationUnsupported
     }
 
     override func readFromSocket() throws -> ReadResult {
@@ -665,7 +665,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
         for _ in 1...self.maxMessagesPerRead {
             guard self.isOpen else {
-                throw ChannelError.eof
+                throw ChannelError._eof
             }
 
             var controlBytes = UnsafeReceivedControlBytes(controlBytesBuffer: controlBytesBuffer)
@@ -715,7 +715,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
         readLoop: for _ in 1...self.maxMessagesPerRead {
             guard self.isOpen else {
-                throw ChannelError.eof
+                throw ChannelError._eof
             }
             guard let vectorReadManager = self.vectorReadManager else {
                 // The vector read manager went away. This happens if users unset the vector read manager
@@ -868,7 +868,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
     override func bind0(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         self.eventLoop.assertInEventLoop()
         guard self.isRegistered else {
-            promise?.fail(ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError._inappropriateOperationForState)
             return
         }
         do {
@@ -1002,7 +1002,7 @@ extension DatagramChannel: MulticastChannel {
         self.eventLoop.assertInEventLoop()
 
         guard self.isActive else {
-            promise?.fail(ChannelError.inappropriateOperationForState)
+            promise?.fail(ChannelError._inappropriateOperationForState)
             return
         }
 
@@ -1017,12 +1017,12 @@ extension DatagramChannel: MulticastChannel {
         // We need to check that we have the appropriate address types in all cases. They all need to overlap with
         // the address type of this channel, or this cannot work.
         guard let localAddress = self.localAddress else {
-            promise?.fail(ChannelError.unknownLocalAddress)
+            promise?.fail(ChannelError._unknownLocalAddress)
             return
         }
 
         guard localAddress.protocol == group.protocol else {
-            promise?.fail(ChannelError.badMulticastGroupAddressFamily)
+            promise?.fail(ChannelError._badMulticastGroupAddressFamily)
             return
         }
 
@@ -1055,7 +1055,7 @@ extension DatagramChannel: MulticastChannel {
                 try self.socket.setOption(level: .ipv6, name: operation.optionName(level: .ipv6), value: multicastRequest)
             case (.v4, .some(.v6)), (.v6, .some(.v4)), (.v4, .some(.unixDomainSocket)), (.v6, .some(.unixDomainSocket)):
                 // Mismatched group and interface address: this is an error.
-                throw ChannelError.badInterfaceAddressFamily
+                throw ChannelError._badInterfaceAddressFamily
             }
 
             promise?.succeed(())

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -24,8 +24,8 @@ services:
       - SWIFT_VERSION=5.10
       - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=21
       - MAX_ALLOCS_ALLOWED_1000000_asyncwriter=1000050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=45050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=44050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=37050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=8050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=8050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=8050
@@ -36,13 +36,13 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=147050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=145050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=3050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=155050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=152050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=76050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=393000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=75050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=389000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -63,13 +63,13 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=343
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=319
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=110200
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=40100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=89
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=162050
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -24,8 +24,8 @@ services:
       - SWIFT_VERSION=5.8
       - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=22
       - MAX_ALLOCS_ALLOWED_1000000_asyncwriter=1000050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=45050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=44050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=37050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=8050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=8050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=8050
@@ -36,13 +36,13 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=147050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=76050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=402000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=75050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=398000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -63,13 +63,13 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=341
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=334
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=110200
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=40100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=89
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=162050
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -24,8 +24,8 @@ services:
       - SWIFT_VERSION=5.9
       - MAX_ALLOCS_ALLOWED_10000000_asyncsequenceproducer=21
       - MAX_ALLOCS_ALLOWED_1000000_asyncwriter=1000050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers=45050
-      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=38050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers=44050
+      - MAX_ALLOCS_ALLOWED_1000_addHandlers_sync=37050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlercontext=8050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlername=8050
       - MAX_ALLOCS_ALLOWED_1000_addRemoveHandlers_handlertype=8050
@@ -36,13 +36,13 @@ services:
       - MAX_ALLOCS_ALLOWED_1000_getHandlers=8050
       - MAX_ALLOCS_ALLOWED_1000_getHandlers_sync=36
       - MAX_ALLOCS_ALLOWED_1000_reqs_1_conn=26400
-      - MAX_ALLOCS_ALLOWED_1000_rst_connections=149050
+      - MAX_ALLOCS_ALLOWED_1000_rst_connections=147050
       - MAX_ALLOCS_ALLOWED_1000_tcpbootstraps=4050
-      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=157050
+      - MAX_ALLOCS_ALLOWED_1000_tcpconnections=154050
       - MAX_ALLOCS_ALLOWED_1000_udp_reqs=6050
       - MAX_ALLOCS_ALLOWED_1000_udpbootstraps=2050
-      - MAX_ALLOCS_ALLOWED_1000_udpconnections=76050
-      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=402000
+      - MAX_ALLOCS_ALLOWED_1000_udpconnections=75050
+      - MAX_ALLOCS_ALLOWED_1_reqs_1000_conn=398000
       - MAX_ALLOCS_ALLOWED_bytebuffer_lots_of_rw=2050
       - MAX_ALLOCS_ALLOWED_creating_10000_headers=0
       - MAX_ALLOCS_ALLOWED_decode_1000_ws_frames=2050
@@ -63,13 +63,13 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=700050
       - MAX_ALLOCS_ALLOWED_modifying_1000_circular_buffer_elements=0
       - MAX_ALLOCS_ALLOWED_modifying_byte_buffer_view=6050
-      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=350
+      - MAX_ALLOCS_ALLOWED_ping_pong_1000_reqs_1_conn=334
       - MAX_ALLOCS_ALLOWED_read_10000_chunks_from_file=110200
-      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=50100
+      - MAX_ALLOCS_ALLOWED_schedule_10000_tasks=40100
       - MAX_ALLOCS_ALLOWED_schedule_and_run_10000_tasks=50050
       - MAX_ALLOCS_ALLOWED_scheduling_10000_executions=89
       - MAX_ALLOCS_ALLOWED_udp_1000_reqs_1_conn=6200
-      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=165050
+      - MAX_ALLOCS_ALLOWED_udp_1_reqs_1000_conn=162050
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still


### PR DESCRIPTION
Motivation:

Existential errors (`any Error`) are unconditionally boxed. In NIO we often create errors to fail promises. One place we do this is in the head channel handler when the pipeline is closed. This error is created regardless of whether there are actually any promises to fail. The result is an unnecessary allocation when every channel is closed. This is particuarly egregious when multiplexed protocols such as HTTP/2 are used.

As the majority of errors in NIO carry no information beyond their type/name we can declare these statically and pay the cost of each error just once rather than once per use.

Modifications:

- Add internal static constants for `ChannelError` and `EventLoopError` and use them throughout NIOCore and NIOPosix where they would otherwise be boxed.

Result:

Fewer allocations