### PR TITLE
`ReadableFileHandleProtocol.readToEnd` can fail to read the complete contents of file sizes less than the single shot read limit

### DIFF
--- a/Sources/NIOFileSystem/FileHandle.swift
+++ b/Sources/NIOFileSystem/FileHandle.swift
@@ -190,7 +190,7 @@ public struct ReadFileHandle: ReadableFileHandleProtocol, _HasFileHandle {
         )
     }
 
-    public func readChunks(in range: Range<Int64>, chunkLength: ByteCount) -> FileChunks {
+    public func readChunks(in range: Range<Int64>?, chunkLength: ByteCount) -> FileChunks {
         self.fileHandle.systemFileHandle.readChunks(in: range, chunkLength: chunkLength)
     }
 
@@ -265,7 +265,7 @@ public struct ReadWriteFileHandle: ReadableAndWritableFileHandleProtocol, _HasFi
         )
     }
 
-    public func readChunks(in offset: Range<Int64>, chunkLength: ByteCount) -> FileChunks {
+    public func readChunks(in offset: Range<Int64>?, chunkLength: ByteCount) -> FileChunks {
         self.fileHandle.systemFileHandle.readChunks(in: offset, chunkLength: chunkLength)
     }
 

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -201,7 +201,7 @@ public protocol ReadableFileHandleProtocol: FileHandleProtocol {
     ///   - range: The absolute offsets into the file to read.
     ///   - chunkLength: The maximum length of the chunk to read as a ``ByteCount``.
     /// - Returns: A sequence of chunks read from the file.
-    func readChunks(in range: Range<Int64>, chunkLength: ByteCount) -> FileChunks
+    func readChunks(in range: Range<Int64>?, chunkLength: ByteCount) -> FileChunks
 }
 
 // MARK: - Read chunks with default chunk length
@@ -227,15 +227,13 @@ extension ReadableFileHandleProtocol {
     ///
     /// - Parameters:
     ///   - range: A range of offsets in the file to read.
-    ///   - chunkLength: The length of chunks to read, defaults to 128 KiB.
     ///   - as: Type of chunk to read.
     /// - SeeAlso: ``ReadableFileHandleProtocol/readChunks(in:chunkLength:)-2dz6``
     /// - Returns: An `AsyncSequence` of chunks read from the file.
     public func readChunks(
-        in range: Range<Int64>,
-        chunkLength: ByteCount = .kibibytes(128)
+        in range: Range<Int64>?
     ) -> FileChunks {
-        return self.readChunks(in: range, chunkLength: chunkLength)
+        return self.readChunks(in: range, chunkLength: .kibibytes(128))
     }
 
     /// Returns an asynchronous sequence of chunks read from the file.
@@ -413,7 +411,7 @@ extension ReadableFileHandleProtocol {
             var accumulator = ByteBuffer()
             accumulator.reserveCapacity(readSize)
 
-            for try await chunk in self.readChunks(in: ..., chunkLength: .mebibytes(8)) {
+            for try await chunk in self.readChunks(in: nil, chunkLength: .mebibytes(8)) {
                 accumulator.writeImmutableBuffer(chunk)
                 if accumulator.readableBytes > maximumSizeAllowed.bytes {
                     throw FileSystemError(

--- a/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
@@ -1069,7 +1069,7 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
     }
 
     public func readChunks(
-        in range: Range<Int64>,
+        in range: Range<Int64>?,
         chunkLength size: ByteCount
     ) -> FileChunks {
         return FileChunks(handle: self, chunkLength: size, range: range)

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -21,6 +21,111 @@ import XCTest
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 final class FileHandleTests: XCTestCase {
+    private enum MockFileHandleError: Error {
+        case unimplemented(function: String)
+    }
+
+    private final class MockFileHandle: ReadableFileHandleProtocol {
+        struct ChunkedByteBufferSequence: AsyncSequence {
+            struct Interator: AsyncIteratorProtocol {
+                let buffer: ByteBuffer
+                private(set) var range: Range<Int64>
+                let chunkLength: Int
+                mutating func next() async throws -> ByteBuffer? {
+                    guard let slice = self.buffer.getSlice(at: Int(range.lowerBound), length: self.chunkLength) else {
+                        return nil
+                    }
+                    self.range = self.range.lowerBound+Int64(slice.readableBytes)..<self.range.upperBound
+                    return slice
+
+                }
+            }
+            let buffer: ByteBuffer
+            let range: Range<Int64>
+            let chunkLength: ByteCount
+            func makeAsyncIterator() -> Interator {
+                .init(buffer: self.buffer, range: self.range, chunkLength: Int(self.chunkLength.bytes))
+            }
+        }
+        let bytes: ByteBuffer
+        let size: Int
+        let chunkSize: ByteCount
+
+        init(bytes: ByteBuffer, chunkSize: ByteCount = .bytes(Int64.max)) {
+            self.bytes = bytes
+            self.size = bytes.readableBytes  // capture initial size since we might be moving the read/write index later
+            self.chunkSize = chunkSize
+        }
+
+        func readChunk(fromAbsoluteOffset offset: Int64, length: ByteCount) async throws -> ByteBuffer {
+            self.bytes.getSlice(at: Int(offset), length: Int(min(length.bytes, self.chunkSize.bytes))) ?? .init()
+        }
+
+        func readChunks(in range: Range<Int64>, chunkLength: ByteCount) -> FileChunks {
+            .init(wrapping: ChunkedByteBufferSequence(buffer: self.bytes, range: range, chunkLength: chunkLength))
+        }
+
+        func info() async throws -> FileInfo {
+            .init(
+                type: .regular,
+                permissions: [.ownerReadWrite, .groupRead, .otherRead],
+                size: Int64(self.size),
+                userID: .init(rawValue: 501),
+                groupID: .init(rawValue: 20),
+                lastAccessTime: .omit,
+                lastDataModificationTime: .omit,
+                lastStatusChangeTime: .omit
+            )
+        }
+
+        func replacePermissions(_ permissions: FilePermissions) async throws {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func addPermissions(_ permissions: FilePermissions) async throws -> FilePermissions {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func removePermissions(_ permissions: FilePermissions) async throws -> FilePermissions {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func attributeNames() async throws -> [String] {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func valueForAttribute(_ name: String) async throws -> [UInt8] {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func updateValueForAttribute(_ bytes: some RandomAccessCollection<UInt8> & Sendable, attribute name: String) async throws {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func removeValueForAttribute(_ name: String) async throws {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func synchronize() async throws {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func withUnsafeDescriptor<R>(_ execute: @escaping @Sendable (FileDescriptor) throws -> R) async throws -> R where R : Sendable {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func detachUnsafeFileDescriptor() throws -> FileDescriptor {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func close() async throws {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+
+        func setTimes(lastAccess: FileInfo.Timespec?, lastDataModification: FileInfo.Timespec?) async throws {
+            throw MockFileHandleError.unimplemented(function: #function)
+        }
+    }
     static let thisFile = FilePath(#filePath)
     static let testData = FilePath(#filePath)
         .removingLastComponent()  // FileHandleTests.swift
@@ -301,6 +406,20 @@ final class FileHandleTests: XCTestCase {
                 "Contents of \(Self.thisFile) differ to that read by Foundation"
             )
         }
+    }
+
+    func testReadWholeFilePartialChunk() async throws {
+        let fileContents = ByteBuffer(string: "the quick brown fox jumped over the lazy dog")
+        let mockHandle = MockFileHandle(
+            bytes: fileContents,
+            chunkSize: .bytes(Int64(fileContents.readableBytes / 2))  // simulate reading a chunk of less than the requested size
+        )
+        let contents = try await mockHandle.readToEnd(maximumSizeAllowed: .bytes(Int64.max))
+        XCTAssertEqual(
+            contents,
+            fileContents,
+            "Contents of mock file differ to what was read by readToEnd"
+        )
     }
 
     func testWriteAndReadUnseekableFile() async throws {


### PR DESCRIPTION
Resolved an issue where `ReadableFileHandleProtocol.readToEnd` could fail to read the contents of files smaller than the single shot read limit (64 MiB).

### Motivation:

If `readToEnd` detects that the file in question is smaller than the single shot read limit, then it will read the file using a single call to `readChunk`, however, there isn't a guarantee that `readChunk` will return the entire requested chunk. If this happens, then `readToEnd` only returns the result of the first read and does not execute any followup reads.

### Modifications:

I separated this into two sections (two commits) because I found another issue that I had to resolve in order to fix the chunking problem.

#### First Commit

This is what is required to fix the missing chunk reads, but it causes `testReadFileAsChunks` to fail because `handle.readChunks(in: ..., chunkLength: .bytes(128))` moves the file access position to the end, which means that the subsequent `handle.readToEnd(maximumSizeAllowed: .bytes(1024 * 1024))` reads zero bytes since the file is fully read, so we get a precondition failure when we run `contents.moveReaderIndex(forwardBy: 100)` because we're trying to move the reader index to 100 for a byte array of length zero.

The problem is that when we initialize a `FileChunks` object, if the range is set to `0..<Int.max`, we use the `.entireFile` chunk range. This causes `BufferedStream` to use a `ProducerState` with a `nil` range, which means that no seeking is done when reading chunks. It looks like this behavior is intended for the case where we want to read an unseekable file, but it's being inadvertently triggered when we request a chunked read of a whole file.

TLDR: If we do any chunked read of a file, then try to do a chunked read of the entire file, the second read will begin where the first one left off instead of moving the pointer to the beginning of the file, despite the caller requesting a range starting at index zero.

#### Second Commit

- Rewrite `ChunkRange` to have two modes:
  - `current`: reads from whatever the underlying file handle's offset currently is.
  - `specified`: reads from the specified range.
- Allow the range to be unspecified when calling `ReadableFileHandleProtocol.readChunks`. This will trigger the use of `ChunkRange.current`.
- Use the nil range argument from `ReadableFileHandleProtocol.readToEnd` when reading an unseekable file.
- `testWriteAndReadUnseekableFile`: I think that this test was incorrect and there's no reason that we should not be able to read the contents of a fifo that we just wrote to.

#### General Comment

Part of the reason I think this is happening is because the `readToEnd` function is a bit counter intuitive in that it has a default parameter of 0 for `fromAbsoluteOffset`. When it's called using the default, it's not clear to the caller that it's going to go back to offset zero before reading (if the file is not a fifo). Maybe this should be changed to a `nil` default?

### Result:

`readToEnd` should now return the full file contents when the file size is lower than the single shot read limit but `readChunk` does not return the entire requested chunk.
