### PR TITLE
Add benchmark for creating NIOAsyncChannel

### DIFF
--- a/Benchmarks/Benchmarks/NIOCoreBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOCoreBenchmarks/Benchmarks.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import NIOCore
+import NIOEmbedded
+
+let benchmarks = {
+    let defaultMetrics: [BenchmarkMetric] = [
+        .mallocCountTotal,
+    ]
+
+    Benchmark(
+        "NIOAsyncChannel.init",
+        configuration: Benchmark.Configuration(metrics: defaultMetrics)
+    ) { benchmark in
+        // Elide the cost of the 'EmbeddedChannel'. It's only used for its pipeline.
+        var channels: [EmbeddedChannel] = []
+        channels.reserveCapacity(benchmark.scaledIterations.count)
+        for _ in 0 ..< benchmark.scaledIterations.count {
+            channels.append(EmbeddedChannel())
+        }
+
+        benchmark.startMeasurement()
+        defer {
+            benchmark.stopMeasurement()
+        }
+        for channel in channels {
+            let asyncChanel = try NIOAsyncChannel<ByteBuffer, ByteBuffer>(wrappingChannelSynchronously: channel)
+            blackHole(asyncChanel)
+        }
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -37,5 +37,17 @@ let package = Package(
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
             ]
         ),
+        .executableTarget(
+            name: "NIOCoreBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+            ],
+            path: "Benchmarks/NIOCoreBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        ),
     ]
 )

--- a/Benchmarks/Thresholds/5.10/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
+++ b/Benchmarks/Thresholds/5.10/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 12
+}

--- a/Benchmarks/Thresholds/5.8/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
+++ b/Benchmarks/Thresholds/5.8/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 12
+}

--- a/Benchmarks/Thresholds/5.9/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
+++ b/Benchmarks/Thresholds/5.9/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 12
+}

--- a/Benchmarks/Thresholds/main/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
+++ b/Benchmarks/Thresholds/main/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 12
+}


### PR DESCRIPTION
Motivation:

NIOAsyncChannel has a number of allocs associated with it. We should have a benchmark which tracks the number of allocs.

Modifications:

- Add NIOCoreBenchmarks with a single benchmark

Result:

Better insight