### PR TITLE
Add (macOS & Windows) unit tests to GitHub Actions workflow.

### DIFF
--- a/.github/workflows/reusable_pull_request.yml
+++ b/.github/workflows/reusable_pull_request.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         swift: ["swift:5.8-jammy", "swift:5.9-jammy", "swift:5.10-noble", "swiftlang/swift:nightly-6.0-jammy", "swiftlang/swift:nightly-main-jammy"]
     container:
-      image: ${{ matrix.swift.image }}
+      image: ${{ matrix.swift }}
     timeout-minutes: 20
     steps:
     - name: Checkout repository

--- a/.github/workflows/reusable_pull_request.yml
+++ b/.github/workflows/reusable_pull_request.yml
@@ -24,6 +24,21 @@ jobs:
     - name: Run tests
       run: swift test
 
+  unit-tests-macos:
+    name: Unit tests (macOS)
+    strategy:
+      matrix:
+        swift: ["5.8", "5.9", "5.10"]
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: ${{ matrix.swift }}
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: swift test
+
   unit-tests-windows:
     name: Unit tests (Windows)
     strategy:
@@ -87,4 +102,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Run unacceptable language check
+      env:
+        UNACCEPTABLE_WORD_LIST: "blacklist whitelist slave master sane sanity insane insanity kill killed killing hang hung hanged hanging"
       run: ./scripts/unacceptable_language_check.sh

--- a/.github/workflows/reusable_pull_request.yml
+++ b/.github/workflows/reusable_pull_request.yml
@@ -30,19 +30,14 @@ concurrency:
   cancel-in-progress: true
  
 jobs:
-  unit-tests:
-    name: Unit tests
+  unit-tests-ubuntu:
+    name: Unit tests (Ubuntu)
     if: ${{ inputs.unit_tests_enabled }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        swift:
-        - image: swift:5.8-jammy
-        - image: swift:5.9-jammy
-        - image: swift:5.10-noble
-        - image: swiftlang/swift:nightly-6.0-jammy
-        - image: swiftlang/swift:nightly-main-jammy
+        swift: ["swift:5.8-jammy", "swift:5.9-jammy", "swift:5.10-noble", "swiftlang/swift:nightly-6.0-jammy", "swiftlang/swift:nightly-main-jammy"]
     container:
       image: ${{ matrix.swift.image }}
     timeout-minutes: 20
@@ -51,6 +46,23 @@ jobs:
       uses: actions/checkout@v4
     - name: Run tests
       run: swift test
+
+  unit-tests-windows:
+    name: Unit tests (Windows)
+    if: ${{ inputs.unit_tests_enabled }}
+    strategy:
+      matrix:
+        swift: ["5.8", "5.9", "5.10"]
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-${{ matrix.swift }}-release
+          tag: ${{ matrix.swift }}-RELEASE
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: swift test
 
   api-breakage-check:
     name: API breakage check

--- a/.github/workflows/reusable_pull_request.yml
+++ b/.github/workflows/reusable_pull_request.yml
@@ -103,5 +103,5 @@ jobs:
       uses: actions/checkout@v4
     - name: Run unacceptable language check
       env:
-        UNACCEPTABLE_WORD_LIST: "blacklist whitelist slave master sane sanity insane insanity kill killed killing hang hung hanged hanging"
+        UNACCEPTABLE_WORD_LIST: "blacklist whitelist slave master sane sanity insane insanity kill killed killing hang hung hanged hanging" #ignore-unacceptable-language
       run: ./scripts/unacceptable_language_check.sh

--- a/.github/workflows/reusable_pull_request.yml
+++ b/.github/workflows/reusable_pull_request.yml
@@ -1,6 +1,28 @@
 name: Pull Request
 
-on: [push]
+on:
+  workflow_call:
+    inputs:
+      unit_tests_enabled:
+        type: boolean
+        description: "Boolean to enable the unit tests job. Defaults to true."
+        default: true
+      api_breakage_check_enabled:
+        type: boolean
+        description: "Boolean to enable the API breakage check job. Defaults to true."
+        default: true
+      docs_check_enabled:
+        type: boolean
+        description: "Boolean to enable the docs check job. Defaults to true."
+        default: true
+      unacceptable_language_check_enabled:
+        type: boolean
+        description: "Boolean to enable the acceptable language check job. Defaults to true."
+        default: true
+      unacceptable_language_check_word_list:
+        type: string
+        description: "List of unacceptable words. Defaults to a sensible list of words."
+        default: "blacklist whitelist slave master sane sanity insane insanity kill killed killing hang hung hanged hanging" #ignore-unacceptable-language
 
 ## We are cancelling previously triggered workflow runs
 concurrency:
@@ -10,6 +32,7 @@ concurrency:
 jobs:
   unit-tests-ubuntu:
     name: Unit tests (Ubuntu)
+    if: ${{ inputs.unit_tests_enabled }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -26,6 +49,7 @@ jobs:
 
   unit-tests-macos:
     name: Unit tests (macOS)
+    if: ${{ inputs.unit_tests_enabled }}
     strategy:
       matrix:
         swift: ["5.8", "5.9", "5.10"]
@@ -41,6 +65,7 @@ jobs:
 
   unit-tests-windows:
     name: Unit tests (Windows)
+    if: ${{ inputs.unit_tests_enabled }}
     strategy:
       matrix:
         swift: ["5.8", "5.9", "5.10"]
@@ -57,6 +82,7 @@ jobs:
 
   api-breakage-check:
     name: API breakage check
+    if: ${{ inputs.api_breakage_check_enabled }}
     runs-on: ubuntu-latest
     container:
       image: swift:5.10-noble
@@ -75,6 +101,7 @@ jobs:
 
   docs-check:
     name: Documentation check
+    if: ${{ inputs.docs_check_enabled }}
     runs-on: ubuntu-latest
     container:
       image: swift:5.10-noble
@@ -96,6 +123,7 @@ jobs:
 
   unacceptable-language-check:
     name: Unacceptable language check
+    if: ${{ inputs.unacceptable_language_check_enabled }}
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
@@ -103,5 +131,5 @@ jobs:
       uses: actions/checkout@v4
     - name: Run unacceptable language check
       env:
-        UNACCEPTABLE_WORD_LIST: "blacklist whitelist slave master sane sanity insane insanity kill killed killing hang hung hanged hanging" #ignore-unacceptable-language
+        UNACCEPTABLE_WORD_LIST: ${{ inputs.unacceptable_language_check_word_list}}
       run: ./scripts/unacceptable_language_check.sh

--- a/.github/workflows/reusable_pull_request.yml
+++ b/.github/workflows/reusable_pull_request.yml
@@ -1,28 +1,6 @@
 name: Pull Request
 
-on:
-  workflow_call:
-    inputs:
-      unit_tests_enabled:
-        type: boolean
-        description: "Boolean to enable the unit tests job. Defaults to true."
-        default: true
-      api_breakage_check_enabled:
-        type: boolean
-        description: "Boolean to enable the API breakage check job. Defaults to true."
-        default: true
-      docs_check_enabled:
-        type: boolean
-        description: "Boolean to enable the docs check job. Defaults to true."
-        default: true
-      unacceptable_language_check_enabled:
-        type: boolean
-        description: "Boolean to enable the acceptable language check job. Defaults to true."
-        default: true
-      unacceptable_language_check_word_list:
-        type: string
-        description: "List of unacceptable words. Defaults to a sensible list of words."
-        default: "blacklist whitelist slave master sane sanity insane insanity kill killed killing hang hung hanged hanging" #ignore-unacceptable-language
+on: [push]
 
 ## We are cancelling previously triggered workflow runs
 concurrency:
@@ -32,7 +10,6 @@ concurrency:
 jobs:
   unit-tests-ubuntu:
     name: Unit tests (Ubuntu)
-    if: ${{ inputs.unit_tests_enabled }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -49,7 +26,6 @@ jobs:
 
   unit-tests-windows:
     name: Unit tests (Windows)
-    if: ${{ inputs.unit_tests_enabled }}
     strategy:
       matrix:
         swift: ["5.8", "5.9", "5.10"]
@@ -66,7 +42,6 @@ jobs:
 
   api-breakage-check:
     name: API breakage check
-    if: ${{ inputs.api_breakage_check_enabled }}
     runs-on: ubuntu-latest
     container:
       image: swift:5.10-noble
@@ -85,7 +60,6 @@ jobs:
 
   docs-check:
     name: Documentation check
-    if: ${{ inputs.docs_check_enabled }}
     runs-on: ubuntu-latest
     container:
       image: swift:5.10-noble
@@ -107,13 +81,10 @@ jobs:
 
   unacceptable-language-check:
     name: Unacceptable language check
-    if: ${{ inputs.unacceptable_language_check_enabled }}
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Run unacceptable language check
-      env:
-        UNACCEPTABLE_WORD_LIST: ${{ inputs.unacceptable_language_check_word_list}}
       run: ./scripts/unacceptable_language_check.sh


### PR DESCRIPTION
_Extended the existing GitHub Actions workflow with unit tests on macOS and Windows_.

### Motivation:

- I had mentioned [here](https://github.com/apple/swift-nio/issues/2065#issuecomment-2219307850), that I would like to assist in bringing support for **Microsoft Windows**.
- The response [here](https://github.com/apple/swift-nio/issues/2065#issuecomment-2219914901), from @FranzBusch was:
  > One of the first steps for proper Windows support is getting Windows CI setup. We are currently migrating our CI to Github actions and this might allow us to setup Windows CI in the future.

### Modifications:

Extended the GitHub Actions workflow to support (in addition to the existing **Ubuntu** unit tests):
1. **macOS** unit tests.
2. **Microsoft Windows** unit tests.

### Result:

1. #### Deprecate Existing GitHub Action
   - Your [existing (**Ubuntu only**) workflow run](https://github.com/apple/swift-nio/actions/runs/9871714577).

2. #### Replace With Extended GitHub Action
   - The existing workflow, [extended (for **Ubuntu**, **macOS**, and **Microsoft Windows**) workflow run](https://github.com/wabiverse/swift-nio/actions/runs/9872952067).
