### PR TITLE
[GHA] Broken symlink and format check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,3 +11,4 @@ jobs:
     with:
       benchmarks_linux_package_path: "Benchmarks"
       license_header_check_project_name: "SwiftNIO"
+      format_check_enabled: false

--- a/.github/workflows/reusable_pull_request.yml
+++ b/.github/workflows/reusable_pull_request.yml
@@ -39,6 +39,14 @@ on:
         type: string
         description: "Name of the project called out in the license header."
         required: true
+      broken_symlink_check_enabled:
+        type: boolean
+        description: "Boolean to enable the broken symlink check job. Defaults to true."
+        default: true
+      format_check_enabled:
+        type: boolean
+        description: "Boolean to enable the format check job. Defaults to true."
+        default: true
 
 ## We are cancelling previously triggered workflow runs
 concurrency:
@@ -159,3 +167,27 @@ jobs:
       env:
         PROJECT_NAME: ${{ inputs.license_header_check_project_name }}
       run: curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-license-header.sh | bash
+
+  broken-symlink-check:
+    name: Broken symlinks check
+    if: ${{ inputs.broken_symlink_check_enabled }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Run broken symlinks check
+      run: curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-broken-symlinks.sh | bash
+
+  format-check:
+    name: Format check
+    if: ${{ inputs.format_check_enabled }}
+    runs-on: ubuntu-latest
+    container:
+      image: swiftlang/swift:nightly-6.0-jammy
+    timeout-minutes: 5
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Run format check
+      run: swift format lint --parallel --recursive --strict

--- a/scripts/check-broken-symlinks.sh
+++ b/scripts/check-broken-symlinks.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2024 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+log "Checking for broken symlinks..."
+num_broken_symlinks=0
+while read -r -d '' file; do
+  if ! test -e "./${file}"; then
+    error "Broken symlink: ${file}"
+    ((num_broken_symlinks++))
+  fi
+done < <(git ls-files -z)
+
+if [ "${num_broken_symlinks}" -gt 0 ]; then
+  fatal "❌ Found ${num_broken_symlinks} symlinks."
+fi
+
+log "✅ Found 0 symlinks."


### PR DESCRIPTION
# Motivation

The next two reusable checks that we need to create are for broken symlinks and formatting. The latter is disabled for this repo for now since we need to discuss the formatting rules separately.

# Modification

This PR adds two new checks - broken symlinks and formatting.

# Result

Closer to having everything on GitHub actions.