### PR TITLE
[GHA] Only format Swift files that are in Git index

### DIFF
--- a/.github/workflows/pull_request_soundness.yml
+++ b/.github/workflows/pull_request_soundness.yml
@@ -126,9 +126,9 @@ jobs:
     - name: Mark the workspace as safe
     # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-    - name: Run format lint check
-      run:  swift format lint --strict --recursive --parallel .
-    - name: Run format and check for modified files
-      run: |
-        swift format format --parallel --recursive --in-place .
-        git diff-index --quiet HEAD
+    - name: Format Swift files
+      run: git ls-files -z '*.swift' | xargs -0 swift format format --parallel --in-place
+    - name: Lint Swift files
+      run:  git ls-files -z '*.swift' | xargs -0 swift format lint --strict --parallel
+    - name: Check format produced no diff
+      run: GIT_PAGER= git diff --exit-code '*.swift'


### PR DESCRIPTION
### Motivation:

Sometimes you want to be able to run the same commands used in the Github action locally, e.g. before pushing. The format Github action has a couple of issues that make running locally problematic. The most important of these is the fact that it uses `--recursive .` which formats _everything_, including ignored files.

### Modifications:

- Only format `.swift` files in the Git index.
- Don't pollute global Git config.
- Only update local Git config if running in CI.

### Result:

- Commands are better suited to be used locally.