### PR TITLE
[CI] Add format ignore file

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -126,9 +126,7 @@ jobs:
     - name: Mark the workspace as safe
     # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-    - name: Format Swift files
-      run: git ls-files -z '*.swift' | xargs -0 swift format format --parallel --in-place
-    - name: Lint Swift files
-      run:  git ls-files -z '*.swift' | xargs -0 swift format lint --strict --parallel
-    - name: Check format produced no diff
-      run: GIT_PAGER= git diff --exit-code '*.swift'
+    - name: Run format check
+      run:  |
+        apt-get -qq update && apt-get -qq -y install curl
+        curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-swift-format.sh | bash

--- a/scripts/check-swift-format.sh
+++ b/scripts/check-swift-format.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2024 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+excluded_files=""
+
+if [ -f .swiftformatignore ]; then
+    log "Found swiftformatignore file..."
+    excluded_files=$(cat .swiftformatignore | xargs -I% printf ":(exclude)% ")
+fi
+
+log "Running swift format format..."
+git ls-files -z '*.swift' $excluded_files | xargs -0 swift format format --parallel --in-place
+
+log "Running swift format lint..."
+
+git ls-files -z '*.swift' $excluded_files | xargs -0 swift format lint --strict --parallel
+
+log "Checking for modified files..."
+
+GIT_PAGER= git diff --exit-code '*.swift'
+
+log "✅ Found no formatting issues."


### PR DESCRIPTION
# Motivation

Some repositories may want to exclude files from being format checked.

# Modification

This PR moves the formatting into a separate script and adds an optional `.swiftformatignore` file that can be placed at the repo root similar to the `.licenseignore` file.

# Result

Repos can now decide what files are ignored when running the formatter.
