### PR TITLE
Add release.yml for automatic release note generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: SemVer Major
+      labels:
+        - semver/major
+    - title: SemVer Minor
+      labels:
+        - semver/minor
+    - title: SemVer Patch
+      labels:
+        - semver/patch
+    - title: Other Changes
+      labels:
+        - semver/none


### PR DESCRIPTION
# Motivation

To make our lives easier when doing releases we want to adopt the GitHub automatic release note generation feature.

# Modification

This PR adds the `release.yml` file to the repo and aligns the expected labels with the ones from OpenAPI. We have decided to use the OpenAPI labels going forward since those have been thought out quite well. After this PR is merged and before the next release I am going to rename the SemVer labels in this repo.

# Result

Easier releasing in the future.
