### PR TITLE
Remove advice to generate linux tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,6 @@ We require that your commit messages match our template. The easiest way to do t
 
 The default policy for taking contributions is “Squash and Merge” - because of this the commit message format rule above applies to the PR rather than every commit contained within it.
 
-### Make sure Tests work on Linux
-
-SwiftNIO uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not (prior to swift 5.1).
-For this reason, whenever you add new tests **you have to run a script** that generates the hooks needed to run those tests on Linux, or our CI will complain that the tests are not all present on Linux. To do this, merely execute `ruby ./scripts/generate_linux_tests.rb` at the root of the package and check the changes it made.
-
 ### Make sure your patch works for all supported versions of swift
 
 The CI will do this for you.  You can use the docker-compose files included if you wish to check locally.  Currently all versions of swift >= 5.7 are supported.  For example usage of docker compose see the main [README](./README.md#an-alternative-using-docker-compose)


### PR DESCRIPTION
Motivation:

This is no longer needed in the currently supported versions of swift. Advice is misleading as script no longer exists.

Modifications:

Remove contributing advice to generate linux tests.

Result:

Happy contributors, less confusion.