### PR TITLE
Fix compose file used in update-benchmark-thresholds script

### DIFF
--- a/dev/update-benchmark-thresholds.sh
+++ b/dev/update-benchmark-thresholds.sh
@@ -32,7 +32,7 @@ set -o pipefail
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 target_repo=${2-"$here/.."}
 
-for f in 58 59 510 main next; do
+for f in 58 59 510 nightly-6.0 main; do
     echo "swift$f"
 
     docker_file=$(ls "$target_repo/docker/docker-compose."*"$f"*".yaml")


### PR DESCRIPTION
### Motivation:

We have a script in `dev/` that updates the benchmark thresholds. It does so by looping over a set of versions, for which it expects to find named Docker Compose files. It was looking for `next`, but the corresponding Docker Compose file is named with `nightly-6.0`.

### Modifications:

Fix the script to find the correct Docker Compose file.

### Result:

Can run the script to update allocation thresholds for all the pipelines again.