### PR TITLE
[CI] Add Swift 6 language mode workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: PR
 
 on:
     pull_request:
@@ -12,7 +12,7 @@ jobs:
             license_header_check_project_name: "SwiftNIO"
 
     unit-tests:
-        name: Checks
+        name: Unit tests
         uses: ./.github/workflows/unit_tests.yml
         with:
             linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -22,18 +22,22 @@ jobs:
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
     benchmarks:
-        name: Checks
+        name: Benchmarks
         uses: ./.github/workflows/benchmarks.yml
         with:
             benchmark_package_path: "Benchmarks"
 
     cxx-interop:
-        name: Checks
+        name: Cxx interop
         uses: ./.github/workflows/cxx_interop.yml
 
     integration-tests:
-        name: Checks / Integration Tests
+        name: Integration Tests
         uses: ./.github/workflows/swift_matrix.yml
         with:
           name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"
+
+    swift-6-language-mode:
+        name: Swift 6 Language Mode
+        uses: ./.github/workflows/swift_6_language_mode.yml

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -35,6 +35,10 @@ on:
         type: boolean
         description: "Boolean to enable the format check job. Defaults to true."
         default: true
+      shell_check_enabled:
+        type: boolean
+        description: "Boolean to enable the shell check job. Defaults to true."
+        default: true
 
 ## We are cancelling previously triggered workflow runs
 concurrency:
@@ -133,7 +137,7 @@ jobs:
 
   shell-check:
     name: Shell check
-    if: ${{ inputs.format_check_enabled }}
+    if: ${{ inputs.shell_check_enabled }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/swift_6_language_mode.yml
+++ b/.github/workflows/swift_6_language_mode.yml
@@ -1,0 +1,23 @@
+name: Swift 6 language mode
+
+on:
+    workflow_call:
+
+## We are cancelling previously triggered workflow runs
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}-swift-6-language-mode
+    cancel-in-progress: true
+ 
+jobs:
+    swift-6-language-mode:
+        name: Swift 6 language mode
+        runs-on: ubuntu-latest
+        container:
+            image: swiftlang/swift:nightly-6.0-jammy
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            - name: Set the language mode
+              run: swift package tools-version --set 6.0
+            - name: Build with Swift 6 language mode
+              run: swift build -Xswiftc -warnings-as-errors

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: Matrix
 
 on:
   workflow_call:
@@ -54,7 +54,7 @@ concurrency:
  
 jobs:
   linux:
-    name: ${{ matrix.swift.swift_version }}
+    name: Linux (${{ matrix.swift.swift_version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Motivation

We want to check how our packages perform in Swift 6 language mode.

# Modification

This PR adds a new reusable workflow that sets the tools version to Swift 6 and then builds with warnings as errors enabled.

Additionally, I did a bit of cleanup for the workflow names to hopefully make them look nice in every GH Action UI.

# Result

We now get a feeling for our Swift 6 language mode compatibility.
