### PR TITLE
[CI] Add action and workflow to check for semver label

### DIFF
--- a/.github/actions/pull_request_semver_label_checker.yml
+++ b/.github/actions/pull_request_semver_label_checker.yml
@@ -1,0 +1,9 @@
+name: 'Pull request semver label checker'
+description: 'Checks that at least one semver label is applied to the pull request'
+runs:
+    using: "composite"
+    steps:
+      - name: Check labels
+        run: |
+            gh pr view ${{ github.event.number }} --repo apple/swift-nio --json labels \
+            | jq -e '[.labels[].name] | any(. == "semver/major" or . == "semver/minor" or . == "semver/patch" or . == "semver/none")'

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -1,0 +1,14 @@
+name: PR
+
+on:
+    pull_request:
+        types: [labeled, unlabeled]
+
+jobs:
+    semver-label-check:
+        name: Semver label check
+        runs-on: ubuntu-latest
+        timeout-minutes: 1
+        steps:
+            - name: Check for semver label
+              uses: ./github/actions/pull_request_label_checker.yml


### PR DESCRIPTION
# Motivation

We want to make sure every PR that gets merged is appropriately labeled.

# Modification

This PR adds a new workflow and action to check for a semver label to be present.

# Result

No more labeling after a PR got merged.
