### PR TITLE
Update repository docs for swift-version support and recent CI check changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ The default policy for taking contributions is “Squash and Merge” - because 
 
 ### Make sure your patch works for all supported versions of swift
 
-The CI will do this for you.  Currently all versions of Swift >= 5.8 are supported.
+The CI will do this for you, but a project maintainer must kick it off for you.  Currently all versions of Swift >= 5.8 are supported.
 
 If you wish to test this locally you have two options [act](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://github.com/nektos/act) and Docker Compose files.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,9 @@ The default policy for taking contributions is “Squash and Merge” - because 
 
 ### Make sure your patch works for all supported versions of swift
 
-The CI will do this for you.  Currently all versions of swift >= 5.8 are supported.
+The CI will do this for you.  Currently all versions of Swift >= 5.8 are supported.
 
-If you wish to test this locally you have two options [act](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://github.com/nektos/act) and docker compose files.
+If you wish to test this locally you have two options [act](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://github.com/nektos/act) and Docker Compose files.
 
 #### Act
 
@@ -79,9 +79,9 @@ act pull_request
 ```
 Note that SwiftNIO matrix testing makes use of nightly builds, so you may want to make use of the ```--action-offline-mode``` to avoid repulling those.
 
-#### Doccker compose files
+#### Docker Compose files
 
-You can use the docker-compose files.    For example usage of docker compose see the main [README](./README.md#an-alternative-using-docker-compose)
+You can use the docker-compose files.  For example usage of Docker Compose see the main [README](./README.md#an-alternative-using-docker-compose)
 
 ### Make sure your code is performant
 
@@ -91,9 +91,9 @@ SwiftNIO has been created to be high performance.  The integration tests cover s
 
 Try to keep your lines less than 120 characters long so github can correctly display your changes.
 
-SwiftNIO now uses the [swift-format](https://github.com/swiftlang/swift-format) tool to bring consistency to code formatting.    Their is a specific [.swift-format](./.swift-format) configuration file.    This will be checked and enforced on PRs, note that the check will run on the current most recent stable version target which may not match that in your own local development environment.
+SwiftNIO uses the [swift-format](https://github.com/swiftlang/swift-format) tool to bring consistency to code formatting.  There is a specific [.swift-format](./.swift-format) configuration file.  This will be checked and enforced on PRs.  Note that the check will run on the current most recent stable version target which may not match that in your own local development environment.
 
-If you want to apply the formatting to your local repo before commit then you can either run [check-swift-format.sh](./scripts/check-swift-format.sh) which will use your current tool chain, or to match the CI checks exactly you can use act (see above):
+If you want to apply the formatting to your local repo before you commit then you can either run [check-swift-format.sh](./scripts/check-swift-format.sh) which will use your current toolchain, or to match the CI checks exactly you can use `act` (see above):
 ```
 act --action-offline-mode --bind workflow_call -j format-check --input format_check_enabled=true
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ If you wish to test this locally you have two options [act](https://github.com/n
 
 #### Act
 
-[Install act](https://nektosact.com) and then you can run the full suite of checks via:
+[Install act](https://nektosact.com/installation/) and then you can run the full suite of checks via:
 ```
 act pull_request
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ If you wish to test this locally you have two options [act](https://www.google.c
 ```
 act pull_request
 ```
-Note that NIOSwift matrix testing makes use of nightly builds, so you may want to make use of the ```--action-offline-mode``` to avoid repulling those.
+Note that SwiftNIO matrix testing makes use of nightly builds, so you may want to make use of the ```--action-offline-mode``` to avoid repulling those.
 
 #### Doccker compose files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,21 @@ The default policy for taking contributions is “Squash and Merge” - because 
 
 ### Make sure your patch works for all supported versions of swift
 
-The CI will do this for you.  You can use the docker-compose files included if you wish to check locally.  Currently all versions of swift >= 5.7 are supported.  For example usage of docker compose see the main [README](./README.md#an-alternative-using-docker-compose)
+The CI will do this for you.  Currently all versions of swift >= 5.8 are supported.
+
+If you wish to test this locally you have two options [act](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://github.com/nektos/act) and docker compose files.
+
+#### Act
+
+[Install act](https://nektosact.com) and then you can run the full suite of checks via:
+```
+act pull_request
+```
+Note that NIOSwift matrix testing makes use of nightly builds, so you may want to make use of the ```--action-offline-mode``` to avoid repulling those.
+
+#### Doccker compose files
+
+You can use the docker-compose files.    For example usage of docker compose see the main [README](./README.md#an-alternative-using-docker-compose)
 
 ### Make sure your code is performant
 
@@ -77,7 +91,15 @@ SwiftNIO has been created to be high performance.  The integration tests cover s
 
 Try to keep your lines less than 120 characters long so github can correctly display your changes.
 
-It is intended SwiftNIO will use the swift-format tool in the future to bring consistency to code formatting.  To follow the discussion on this topic see the swift evolution proposal [SE-250](https://github.com/apple/swift-evolution/blob/main/proposals/0250-swift-style-guide-and-formatter.md)
+SwiftNIO now uses the [swift-format](https://github.com/swiftlang/swift-format) tool to bring consistency to code formatting.    Their is a specific [.swift-format](./.swift-format) configuration file.    This will be checked and enforced on PRs, note that the check will run on the current most recent stable version target which may not match that in your own local development environment.
+
+If you want to apply the formatting to your local repo before commit then you can either run [check-swift-format.sh](./scripts/check-swift-format.sh) which will use your current tool chain, or to match the CI checks exactly you can use act (see above):
+```
+act --action-offline-mode --bind workflow_call -j format-check --input format_check_enabled=true
+```
+
+This will run the format checks, binding to your local checkout so the edits made are to your own source.
+
 
 ### Extensibility
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ The default policy for taking contributions is “Squash and Merge” - because 
 
 The CI will do this for you, but a project maintainer must kick it off for you.  Currently all versions of Swift >= 5.8 are supported.
 
-If you wish to test this locally you have two options [act](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://github.com/nektos/act) and Docker Compose files.
+If you wish to test this locally you have two options [act](https://github.com/nektos/act) and Docker Compose files.
 
 #### Act
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Try to keep your lines less than 120 characters long so github can correctly dis
 
 SwiftNIO uses the [swift-format](https://github.com/swiftlang/swift-format) tool to bring consistency to code formatting.  There is a specific [.swift-format](./.swift-format) configuration file.  This will be checked and enforced on PRs.  Note that the check will run on the current most recent stable version target which may not match that in your own local development environment.
 
-If you want to apply the formatting to your local repo before you commit then you can either run [check-swift-format.sh](./scripts/check-swift-format.sh) which will use your current toolchain, or to match the CI checks exactly you can use `act` (see above):
+If you want to apply the formatting to your local repo before you commit then you can either run [check-swift-format.sh](./scripts/check-swift-format.sh) which will use your current toolchain, or to match the CI checks exactly you can use `act` (see [act section](#act)):
 ```
 act --action-offline-mode --bind workflow_call -j format-check --input format_check_enabled=true
 ```

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -110,6 +110,7 @@ needs to be listed here.
 - Markus Kieselmann <markus@kieselmann.eu>
 - Marli Oshlack <marli.oshlack@apple.com>
 - Matt Eaton <agnosticdev@gmail.com>
+- Matt Hope <matt_hope@apple.com>
 - Matteo Comisso <matteo.comisso@me.com>
 - Max Desiatov <m_desiatov@apple.com>
 - Max Desiatov <max@desiatov.com>

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This is the current version of SwiftNIO and will be supported for the foreseeabl
 
 ### Swift Versions
 
-The intention is to support the most recently released swift version (currently 5.10) and the last two minor releases before that.
+We commit to support the most recently released swift version (currently 5.10) and the last two minor releases before that unless this is impossible to do in one codebase.
 In addition checks are run against the latest beta release (if any) as well as the nightly swift builds and the intent is that these should pass. 
 
 The most recent versions of SwiftNIO support Swift 5.8 and newer. The minimum Swift version supported by SwiftNIO releases are detailed below:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ Redis | ✅ | ❌ | [swift-server/RediStack](https://github.com/swift-server/Red
 
 This is the current version of SwiftNIO and will be supported for the foreseeable future.
 
-The most recent versions of SwiftNIO support Swift 5.7 and newer. The minimum Swift version supported by SwiftNIO releases are detailed below:
+### Swift Versions
+
+The intention is to support the most recently released swift version (currently 5.10) and the last two minor releases before that.
+In addition checks are run against the latest beta release (if any) as well as the nightly swift builds and the intent is that these should pass. 
+
+The most recent versions of SwiftNIO support Swift 5.8 and newer. The minimum Swift version supported by SwiftNIO releases are detailed below:
 
 SwiftNIO            | Minimum Swift Version
 --------------------|----------------------
@@ -104,7 +109,6 @@ SwiftNIO follows [SemVer 2.0.0](https://semver.org/#semantic-versioning-200) wit
 What this means for you is that you should depend on SwiftNIO with a version range that covers everything from the minimum SwiftNIO version you require up to the next major version.
 In SwiftPM that can be easily done specifying for example `from: "2.0.0"` meaning that you support SwiftNIO in every version starting from 2.0.0 up to (excluding) 3.0.0.
 SemVer and SwiftNIO's Public API guarantees should result in a working program without having to worry about testing every single version for compatibility.
-
 
 
 ## Conceptual Overview


### PR DESCRIPTION
Make sure repository docs represent the current status quo

### Motivation:

Some parts of the docs were out of date and confusing/wrong.

### Modifications:

Made references to supported versions appropriate for the current mainline version supported (5.10) and the retained support for 5.9 and 5.8.
In addition made that operating mode an explicit statement of intent, along with the use of nightlies of pre release versions..

Now that more checks are present as GitHub Actions they are easier for users to run directly with act, so provided some links and one liners to do that.

The old references to swift-format were no longer hopeful, they became true! 

Added myself as a committer at the same time

### Result:

Docs should be more accurate and helpful. Intent of the matrix for support should be clearer
