### PR TITLE
ChannelOption: Allow types to be accessed with leading dot syntax

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/shared.swift
@@ -109,7 +109,7 @@ private final class SimpleHTTPServer: ChannelInboundHandler {
 
 func doRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
     let serverChannel = try ServerBootstrap(group: group)
-        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
         .childChannelInitializer { channel in
             channel.pipeline.configureHTTPServerPipeline(
                 withPipeliningAssistance: true,

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet.swift
@@ -32,8 +32,8 @@ func run(identifier: String) {
         let iterations = 1000
 
         for _ in 0..<iterations {
-            let autoReadOption = try! server.getOption(ChannelOptions.autoRead).wait()
-            try! server.setOption(ChannelOptions.autoRead, value: !autoReadOption).wait()
+            let autoReadOption = try! server.getOption(.autoRead).wait()
+            try! server.setOption(.autoRead, value: !autoReadOption).wait()
         }
 
         return iterations

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet_sync.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet_sync.swift
@@ -24,8 +24,8 @@ func run(identifier: String) {
                 let syncOptions = server.syncOptions!
 
                 for _ in 0..<iterations {
-                    let autoReadOption = try! syncOptions.getOption(ChannelOptions.autoRead)
-                    try! syncOptions.setOption(ChannelOptions.autoRead, value: !autoReadOption)
+                    let autoReadOption = try! syncOptions.getOption(.autoRead)
+                    try! syncOptions.setOption(.autoRead, value: !autoReadOption)
                 }
 
                 return iterations

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_tcpconnections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_tcpconnections.swift
@@ -51,7 +51,7 @@ func run(identifier: String) {
     }
 
     let serverChannel = try! ServerBootstrap(group: group)
-        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
         .childChannelInitializer { channel in
             channel.pipeline.addHandler(ReceiveAndCloseHandler())
         }.bind(host: "127.0.0.1", port: 0).wait()

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udp_reqs.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_udp_reqs.swift
@@ -92,7 +92,7 @@ private final class ClientHandler: ChannelInboundHandler {
 
 func run(identifier: String) {
     let serverChannel = try! DatagramBootstrap(group: group)
-        .channelOption(ChannelOptions.explicitCongestionNotification, value: true)
+        .channelOption(.explicitCongestionNotification, value: true)
         // Set the handlers that are applied to the bound channel
         .channelInitializer { channel in
             channel.pipeline.addHandler(ServerEchoHandler())
@@ -106,7 +106,7 @@ func run(identifier: String) {
     let clientHandler = ClientHandler(remoteAddress: remoteAddress)
 
     let clientChannel = try! DatagramBootstrap(group: group)
-        .channelOption(ChannelOptions.explicitCongestionNotification, value: true)
+        .channelOption(.explicitCongestionNotification, value: true)
         .channelInitializer { channel in
             channel.pipeline.addHandler(clientHandler)
         }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_ping_pong_1000_reqs_1_conn.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_ping_pong_1000_reqs_1_conn.swift
@@ -120,8 +120,8 @@ private final class PongHandler: ChannelInboundHandler {
 
 func doPingPongRequests(group: EventLoopGroup, number numberOfRequests: Int) throws -> Int {
     let serverChannel = try ServerBootstrap(group: group)
-        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-        .childChannelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))
+        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+        .childChannelOption(.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))
         .childChannelInitializer { channel in
             channel.pipeline.addHandler(ByteToMessageHandler(PongDecoder())).flatMap {
                 channel.pipeline.addHandler(PongHandler())
@@ -137,7 +137,7 @@ func doPingPongRequests(group: EventLoopGroup, number numberOfRequests: Int) thr
         .channelInitializer { channel in
             channel.pipeline.addHandler(pingHandler)
         }
-        .channelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))
+        .channelOption(.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 4))
         .connect(to: serverChannel.localAddress!)
         .wait()
 

--- a/Sources/NIOChatClient/main.swift
+++ b/Sources/NIOChatClient/main.swift
@@ -45,7 +45,7 @@ private final class ChatHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         channel.pipeline.addHandler(ChatHandler())
     }

--- a/Sources/NIOChatServer/main.swift
+++ b/Sources/NIOChatServer/main.swift
@@ -130,8 +130,8 @@ let chatHandler = ChatHandler()
 let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverChannelOption(ChannelOptions.backlog, value: 256)
-    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .serverChannelOption(.backlog, value: 256)
+    .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer { channel in
@@ -143,9 +143,9 @@ let bootstrap = ServerBootstrap(group: group)
     }
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-    .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
-    .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
+    .childChannelOption(.socketOption(.so_reuseaddr), value: 1)
+    .childChannelOption(.maxMessagesPerRead, value: 16)
+    .childChannelOption(.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 defer {
     try! group.syncShutdownGracefully()
 }

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -360,6 +360,97 @@ public struct ChannelOptions: Sendable {
     public static let receivePacketInfo = Types.ReceivePacketInfo()
 }
 
+/// - seealso: `SocketOption`.
+extension ChannelOption where Self == ChannelOptions.Types.SocketOption {
+    #if !(os(Windows))
+    public static func socket(_ level: SocketOptionLevel, _ name: SocketOptionName) -> Self {
+        .init(level: NIOBSDSocket.OptionLevel(rawValue: CInt(level)), name: NIOBSDSocket.Option(rawValue: CInt(name)))
+    }
+    #endif
+    
+    public static func socketOption(_ name: NIOBSDSocket.Option) -> Self {
+        .init(level: .socket, name: name)
+    }
+    
+    public static func ipOption(_ name: NIOBSDSocket.Option) -> Self {
+        .init(level: .ip, name: name)
+    }
+    
+    public static func tcpOption(_ name: NIOBSDSocket.Option) -> Self {
+        .init(level: .tcp, name: name)
+    }
+}
+
+/// - seealso: `AllocatorOption`.
+extension ChannelOption where Self == ChannelOptions.Types.AllocatorOption {
+    public static var allocator: Self {.init()}
+}
+
+/// - seealso: `RecvAllocatorOption`.
+extension ChannelOption where Self == ChannelOptions.Types.RecvAllocatorOption {
+    public static var recvAllocator: Self {.init()}
+}
+
+/// - seealso: `AutoReadOption`.
+extension ChannelOption where Self == ChannelOptions.Types.AutoReadOption {
+    public static var autoRead: Self {.init()}
+}
+
+/// - seealso: `MaxMessagesPerReadOption`.
+extension ChannelOption where Self == ChannelOptions.Types.MaxMessagesPerReadOption {
+    public static var maxMessagesPerRead: Self {.init()}
+}
+
+/// - seealso: `BacklogOption`.
+extension ChannelOption where Self == ChannelOptions.Types.BacklogOption {
+    public static var backlog: Self {.init()}
+}
+
+/// - seealso: `WriteSpinOption`.
+extension ChannelOption where Self == ChannelOptions.Types.WriteSpinOption {
+    public static var writeSpin: Self {.init()}
+}
+
+/// - seealso: `WriteBufferWaterMarkOption`.
+extension ChannelOption where Self == ChannelOptions.Types.WriteBufferWaterMarkOption {
+    public static var writeBufferWaterMark: Self {.init()}
+}
+
+/// - seealso: `ConnectTimeoutOption`.
+extension ChannelOption where Self == ChannelOptions.Types.ConnectTimeoutOption {
+    public static var connectTimeout: Self {.init()}
+}
+
+/// - seealso: `AllowRemoteHalfClosureOption`.
+extension ChannelOption where Self == ChannelOptions.Types.AllowRemoteHalfClosureOption {
+    public static var allowRemoteHalfClosure: Self {.init()}
+}
+
+/// - seealso: `DatagramVectorReadMessageCountOption`.
+extension ChannelOption where Self == ChannelOptions.Types.DatagramVectorReadMessageCountOption {
+    public static var datagramVectorReadMessageCount: Self {.init()}
+}
+
+/// - seealso: `DatagramSegmentSize`.
+extension ChannelOption where Self == ChannelOptions.Types.DatagramSegmentSize {
+    public static var datagramSegmentSize: Self {.init()}
+}
+
+/// - seealso: `DatagramReceiveOffload`.
+extension ChannelOption where Self == ChannelOptions.Types.DatagramReceiveOffload {
+    public static var datagramReceiveOffload: Self {.init()}
+}
+
+/// - seealso: `ExplicitCongestionNotificationsOption`.
+extension ChannelOption where Self == ChannelOptions.Types.ExplicitCongestionNotificationsOption {
+    public static var explicitCongestionNotification: Self {.init()}
+}
+
+/// - seealso: `ReceivePacketInfo`.
+extension ChannelOption where Self == ChannelOptions.Types.ReceivePacketInfo {
+    public static var receivePacketInfo: Self {.init()}
+}
+
 extension ChannelOptions {
     /// A type-safe storage facility for `ChannelOption`s. You will only ever need this if you implement your own
     /// `Channel` that needs to store `ChannelOption`s.

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -367,15 +367,15 @@ extension ChannelOption where Self == ChannelOptions.Types.SocketOption {
         .init(level: NIOBSDSocket.OptionLevel(rawValue: CInt(level)), name: NIOBSDSocket.Option(rawValue: CInt(name)))
     }
     #endif
-    
+
     public static func socketOption(_ name: NIOBSDSocket.Option) -> Self {
         .init(level: .socket, name: name)
     }
-    
+
     public static func ipOption(_ name: NIOBSDSocket.Option) -> Self {
         .init(level: .ip, name: name)
     }
-    
+
     public static func tcpOption(_ name: NIOBSDSocket.Option) -> Self {
         .init(level: .tcp, name: name)
     }
@@ -383,72 +383,72 @@ extension ChannelOption where Self == ChannelOptions.Types.SocketOption {
 
 /// - seealso: `AllocatorOption`.
 extension ChannelOption where Self == ChannelOptions.Types.AllocatorOption {
-    public static var allocator: Self {.init()}
+    public static var allocator: Self { .init() }
 }
 
 /// - seealso: `RecvAllocatorOption`.
 extension ChannelOption where Self == ChannelOptions.Types.RecvAllocatorOption {
-    public static var recvAllocator: Self {.init()}
+    public static var recvAllocator: Self { .init() }
 }
 
 /// - seealso: `AutoReadOption`.
 extension ChannelOption where Self == ChannelOptions.Types.AutoReadOption {
-    public static var autoRead: Self {.init()}
+    public static var autoRead: Self { .init() }
 }
 
 /// - seealso: `MaxMessagesPerReadOption`.
 extension ChannelOption where Self == ChannelOptions.Types.MaxMessagesPerReadOption {
-    public static var maxMessagesPerRead: Self {.init()}
+    public static var maxMessagesPerRead: Self { .init() }
 }
 
 /// - seealso: `BacklogOption`.
 extension ChannelOption where Self == ChannelOptions.Types.BacklogOption {
-    public static var backlog: Self {.init()}
+    public static var backlog: Self { .init() }
 }
 
 /// - seealso: `WriteSpinOption`.
 extension ChannelOption where Self == ChannelOptions.Types.WriteSpinOption {
-    public static var writeSpin: Self {.init()}
+    public static var writeSpin: Self { .init() }
 }
 
 /// - seealso: `WriteBufferWaterMarkOption`.
 extension ChannelOption where Self == ChannelOptions.Types.WriteBufferWaterMarkOption {
-    public static var writeBufferWaterMark: Self {.init()}
+    public static var writeBufferWaterMark: Self { .init() }
 }
 
 /// - seealso: `ConnectTimeoutOption`.
 extension ChannelOption where Self == ChannelOptions.Types.ConnectTimeoutOption {
-    public static var connectTimeout: Self {.init()}
+    public static var connectTimeout: Self { .init() }
 }
 
 /// - seealso: `AllowRemoteHalfClosureOption`.
 extension ChannelOption where Self == ChannelOptions.Types.AllowRemoteHalfClosureOption {
-    public static var allowRemoteHalfClosure: Self {.init()}
+    public static var allowRemoteHalfClosure: Self { .init() }
 }
 
 /// - seealso: `DatagramVectorReadMessageCountOption`.
 extension ChannelOption where Self == ChannelOptions.Types.DatagramVectorReadMessageCountOption {
-    public static var datagramVectorReadMessageCount: Self {.init()}
+    public static var datagramVectorReadMessageCount: Self { .init() }
 }
 
 /// - seealso: `DatagramSegmentSize`.
 extension ChannelOption where Self == ChannelOptions.Types.DatagramSegmentSize {
-    public static var datagramSegmentSize: Self {.init()}
+    public static var datagramSegmentSize: Self { .init() }
 }
 
 /// - seealso: `DatagramReceiveOffload`.
 extension ChannelOption where Self == ChannelOptions.Types.DatagramReceiveOffload {
-    public static var datagramReceiveOffload: Self {.init()}
+    public static var datagramReceiveOffload: Self { .init() }
 }
 
 /// - seealso: `ExplicitCongestionNotificationsOption`.
 extension ChannelOption where Self == ChannelOptions.Types.ExplicitCongestionNotificationsOption {
-    public static var explicitCongestionNotification: Self {.init()}
+    public static var explicitCongestionNotification: Self { .init() }
 }
 
 /// - seealso: `ReceivePacketInfo`.
 extension ChannelOption where Self == ChannelOptions.Types.ReceivePacketInfo {
-    public static var receivePacketInfo: Self {.init()}
+    public static var receivePacketInfo: Self { .init() }
 }
 
 extension ChannelOptions {

--- a/Sources/NIOCore/ConvenienceOptionSupport.swift
+++ b/Sources/NIOCore/ConvenienceOptionSupport.swift
@@ -176,13 +176,13 @@ extension ChannelOptions {
         mutating func applyFallbackMapping(_ universalBootstrap: NIOClientTCPBootstrap) -> NIOClientTCPBootstrap {
             var result = universalBootstrap
             if self.consumeAllowLocalEndpointReuse().isSet {
-                result = result.channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                result = result.channelOption(.socketOption(.so_reuseaddr), value: 1)
             }
             if self.consumeAllowRemoteHalfClosure().isSet {
-                result = result.channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+                result = result.channelOption(.allowRemoteHalfClosure, value: true)
             }
             if self.consumeDisableAutoRead().isSet {
-                result = result.channelOption(ChannelOptions.autoRead, value: false)
+                result = result.channelOption(.autoRead, value: false)
             }
             return result
         }

--- a/Sources/NIOCrashTester/OutputGrepper.swift
+++ b/Sources/NIOCrashTester/OutputGrepper.swift
@@ -29,7 +29,7 @@ internal struct OutputGrepper {
 
         // We gotta `dup` everything because Pipe is bad and closes file descriptors on `deinit` :(
         let channelFuture = NIOPipeBootstrap(group: group)
-            .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+            .channelOption(.allowRemoteHalfClosure, value: true)
             .channelInitializer { channel in
                 channel.eventLoop.makeCompletedFuture {
                     try channel.pipeline.syncOperations.addHandlers([

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -56,7 +56,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         channel.pipeline.addHandler(EchoHandler())
     }

--- a/Sources/NIOEchoServer/main.swift
+++ b/Sources/NIOEchoServer/main.swift
@@ -40,8 +40,8 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverChannelOption(ChannelOptions.backlog, value: 256)
-    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .serverChannelOption(.backlog, value: 256)
+    .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
     // Set the handlers that are appled to the accepted Channels
     .childChannelInitializer { channel in
@@ -53,9 +53,9 @@ let bootstrap = ServerBootstrap(group: group)
     }
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-    .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
-    .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
+    .childChannelOption(.socketOption(.so_reuseaddr), value: 1)
+    .childChannelOption(.maxMessagesPerRead, value: 16)
+    .childChannelOption(.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 defer {
     try! group.syncShutdownGracefully()
 }

--- a/Sources/NIOHTTP1Client/main.swift
+++ b/Sources/NIOHTTP1Client/main.swift
@@ -79,7 +79,7 @@ private final class HTTPEchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         channel.pipeline.addHTTPClientHandlers(
             position: .first,

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -604,22 +604,22 @@ func childChannelInitializer(channel: Channel) -> EventLoopFuture<Void> {
 let fileIO = NonBlockingFileIO(threadPool: .singleton)
 let socketBootstrap = ServerBootstrap(group: MultiThreadedEventLoopGroup.singleton)
     // Specify backlog and enable SO_REUSEADDR for the server itself
-    .serverChannelOption(ChannelOptions.backlog, value: 256)
-    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .serverChannelOption(.backlog, value: 256)
+    .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
     // Set the handlers that are applied to the accepted Channels
     .childChannelInitializer(childChannelInitializer(channel:))
 
     // Enable SO_REUSEADDR for the accepted Channels
-    .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-    .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
-    .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: allowHalfClosure)
+    .childChannelOption(.socketOption(.so_reuseaddr), value: 1)
+    .childChannelOption(.maxMessagesPerRead, value: 1)
+    .childChannelOption(.allowRemoteHalfClosure, value: allowHalfClosure)
 let pipeBootstrap = NIOPipeBootstrap(group: MultiThreadedEventLoopGroup.singleton)
     // Set the handlers that are applied to the accepted Channels
     .channelInitializer(childChannelInitializer(channel:))
 
-    .channelOption(ChannelOptions.maxMessagesPerRead, value: 1)
-    .channelOption(ChannelOptions.allowRemoteHalfClosure, value: allowHalfClosure)
+    .channelOption(.maxMessagesPerRead, value: 1)
+    .channelOption(.allowRemoteHalfClosure, value: allowHalfClosure)
 print("htdocs = \(htdocs)")
 
 let channel = try { () -> Channel in

--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -69,7 +69,7 @@ let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
 // Begin by setting up the basics of the bootstrap.
 var datagramBootstrap = DatagramBootstrap(group: group)
-    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         channel.pipeline.addHandler(ChatMessageEncoder()).flatMap {
             channel.pipeline.addHandler(ChatMessageDecoder())

--- a/Sources/NIOPerformanceTester/UDPBenchmark.swift
+++ b/Sources/NIOPerformanceTester/UDPBenchmark.swift
@@ -45,7 +45,7 @@ extension UDPBenchmark: Benchmark {
         let address = try SocketAddress.makeAddressResolvingHost("127.0.0.1", port: 0)
         self.server = try DatagramBootstrap(group: group)
             // zero is the same as not applying the option.
-            .channelOption(ChannelOptions.datagramVectorReadMessageCount, value: self.vectorReads)
+            .channelOption(.datagramVectorReadMessageCount, value: self.vectorReads)
             .channelInitializer { channel in
                 channel.pipeline.addHandler(EchoHandler())
             }
@@ -56,7 +56,7 @@ extension UDPBenchmark: Benchmark {
 
         self.client = try DatagramBootstrap(group: group)
             // zero is the same as not applying the option.
-            .channelOption(ChannelOptions.datagramVectorReadMessageCount, value: self.vectorReads)
+            .channelOption(.datagramVectorReadMessageCount, value: self.vectorReads)
             .channelInitializer { channel in
                 let handler = EchoHandlerClient(
                     eventLoop: channel.eventLoop,

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -160,7 +160,7 @@ defer {
 }
 
 let serverChannel = try ServerBootstrap(group: group)
-    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
     .childChannelInitializer { channel in
         channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: true).flatMap {
             channel.pipeline.addHandler(SimpleHTTPServer())

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -1140,7 +1140,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
                     //
                     // getOption0 can only fail if the channel is not active anymore but we assert further up that it is. If
                     // that's not the case this is a precondition failure and we would like to know.
-                    let allowRemoteHalfClosure = try! self.getOption0(ChannelOptions.allowRemoteHalfClosure)
+                    let allowRemoteHalfClosure = try! self.getOption0(.allowRemoteHalfClosure)
 
                     // For EOF, we always fire read complete.
                     self.pipeline.syncOperations.fireChannelReadComplete()

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -46,8 +46,8 @@ internal enum NIOOnSocketsBootstraps {
 ///     }
 ///     let bootstrap = ServerBootstrap(group: group)
 ///         // Specify backlog and enable SO_REUSEADDR for the server itself
-///         .serverChannelOption(ChannelOptions.backlog, value: 256)
-///         .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+///         .serverChannelOption(.backlog, value: 256)
+///         .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 ///
 ///         // Set the handlers that are applied to the accepted child `Channel`s.
 ///         .childChannelInitializer { channel in
@@ -60,9 +60,9 @@ internal enum NIOOnSocketsBootstraps {
 ///         }
 ///
 ///         // Enable SO_REUSEADDR for the accepted Channels
-///         .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-///         .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
-///         .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
+///         .childChannelOption(.socketOption(.so_reuseaddr), value: 1)
+///         .childChannelOption(.maxMessagesPerRead, value: 16)
+///         .childChannelOption(.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 ///     let channel = try! bootstrap.bind(host: host, port: port).wait()
 ///     /* the server will now be accepting connections */
 ///
@@ -150,7 +150,7 @@ public final class ServerBootstrap {
         self._childChannelOptions = ChannelOptions.Storage()
         self.serverChannelInit = nil
         self.childChannelInit = nil
-        self._serverChannelOptions.append(key: ChannelOptions.tcpOption(.tcp_nodelay), value: 1)
+        self._serverChannelOptions.append(key: .tcpOption(.tcp_nodelay), value: 1)
         self.enableMPTCP = false
     }
 
@@ -240,7 +240,7 @@ public final class ServerBootstrap {
         // This is a temporary workaround until we get some stable Linux kernel
         // versions that support TCP_NODELAY and MPTCP.
         if value {
-            self._serverChannelOptions.remove(key: ChannelOptions.tcpOption(.tcp_nodelay))
+            self._serverChannelOptions.remove(key: .tcpOption(.tcp_nodelay))
         }
 
         return self
@@ -839,7 +839,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         }
         self.group = group
         self._channelOptions = ChannelOptions.Storage()
-        self._channelOptions.append(key: ChannelOptions.tcpOption(.tcp_nodelay), value: 1)
+        self._channelOptions.append(key: .tcpOption(.tcp_nodelay), value: 1)
         self._channelInitializer = { channel in channel.eventLoop.makeSucceededFuture(()) }
         self.protocolHandlers = nil
         self.resolver = nil
@@ -930,7 +930,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         // This is a temporary workaround until we get some stable Linux kernel
         // versions that support TCP_NODELAY and MPTCP.
         if value {
-            self._channelOptions.remove(key: ChannelOptions.tcpOption(.tcp_nodelay))
+            self._channelOptions.remove(key: .tcpOption(.tcp_nodelay))
         }
 
         return self

--- a/Sources/NIOPosix/VsockAddress.swift
+++ b/Sources/NIOPosix/VsockAddress.swift
@@ -157,7 +157,7 @@ extension ChannelOptions {
 }
 
 extension ChannelOption where Self == ChannelOptions.Types.LocalVsockContextID {
-    public static var localVsockContextID: Self {.init()}
+    public static var localVsockContextID: Self { .init() }
 }
 
 extension ChannelOptions.Types {

--- a/Sources/NIOPosix/VsockAddress.swift
+++ b/Sources/NIOPosix/VsockAddress.swift
@@ -156,6 +156,10 @@ extension ChannelOptions {
     public static let localVsockContextID = Types.LocalVsockContextID()
 }
 
+extension ChannelOption where Self == ChannelOptions.Types.LocalVsockContextID {
+    public static var localVsockContextID: Self {.init()}
+}
+
 extension ChannelOptions.Types {
     /// This get-only option is used on channels backed by vsock sockets to get the local VSOCK context ID.
     public struct LocalVsockContextID: ChannelOption, Sendable {

--- a/Sources/NIOTCPEchoServer/Server.swift
+++ b/Sources/NIOTCPEchoServer/Server.swift
@@ -38,7 +38,7 @@ struct Server {
     /// This method starts the server and handles incoming connections.
     func run() async throws {
         let channel = try await ServerBootstrap(group: self.eventLoopGroup)
-            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
             .bind(
                 host: self.host,
                 port: self.port

--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -226,7 +226,7 @@ public final class NIOHTTP1TestServer {
         }.flatMap {
             channel.pipeline.addHandler(WebServerHandler(webServer: self))
         }.whenSuccess {
-            _ = channel.setOption(ChannelOptions.autoRead, value: true)
+            _ = channel.setOption(.autoRead, value: true)
         }
     }
 
@@ -239,7 +239,7 @@ public final class NIOHTTP1TestServer {
         self.aggregateBody = aggregateBody
 
         self.serverChannel = try! ServerBootstrap(group: self.eventLoop)
-            .childChannelOption(ChannelOptions.autoRead, value: false)
+            .childChannelOption(.autoRead, value: false)
             .childChannelInitializer { channel in
                 switch self.state {
                 case .channelsAvailable(var channels):

--- a/Sources/NIOUDPEchoClient/main.swift
+++ b/Sources/NIOUDPEchoClient/main.swift
@@ -127,7 +127,7 @@ let remoteAddress = { () -> SocketAddress in
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = DatagramBootstrap(group: group)
     // Enable SO_REUSEADDR.
-    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
         channel.pipeline.addHandler(EchoHandler(remoteAddressInitializer: remoteAddress))
     }

--- a/Sources/NIOUDPEchoServer/main.swift
+++ b/Sources/NIOUDPEchoServer/main.swift
@@ -43,7 +43,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 var bootstrap = DatagramBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR
-    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+    .channelOption(.socketOption(.so_reuseaddr), value: 1)
 
     // Set the handlers that are applied to the bound channel
     .channelInitializer { channel in
@@ -57,9 +57,9 @@ defer {
 
 var arguments = CommandLine.arguments.dropFirst(0)  // just to get an ArraySlice<String> from [String]
 if arguments.dropFirst().first == .some("--enable-gathering-reads") {
-    bootstrap = bootstrap.channelOption(ChannelOptions.datagramVectorReadMessageCount, value: 30)
+    bootstrap = bootstrap.channelOption(.datagramVectorReadMessageCount, value: 30)
     bootstrap = bootstrap.channelOption(
-        ChannelOptions.recvAllocator,
+        .recvAllocator,
         value: FixedSizeRecvByteBufferAllocator(capacity: 30 * 2048)
     )
     arguments = arguments.dropFirst()

--- a/Sources/NIOWebSocketServer/Server.swift
+++ b/Sources/NIOWebSocketServer/Server.swift
@@ -73,7 +73,7 @@ struct Server {
         let channel: NIOAsyncChannel<EventLoopFuture<UpgradeResult>, Never> = try await ServerBootstrap(
             group: self.eventLoopGroup
         )
-        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
         .bind(
             host: self.host,
             port: self.port

--- a/Tests/NIOCoreTests/ChannelOptionStorageTest.swift
+++ b/Tests/NIOCoreTests/ChannelOptionStorageTest.swift
@@ -27,16 +27,16 @@ class ChannelOptionStorageTest: XCTestCase {
     func testSetTwoOptionsOfDifferentType() throws {
         var cos = ChannelOptions.Storage()
         let optionsCollector = OptionsCollectingChannel()
-        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-        cos.append(key: ChannelOptions.backlog, value: 2)
+        cos.append(key: .socketOption(.so_reuseaddr), value: 1)
+        cos.append(key: .backlog, value: 2)
         XCTAssertNoThrow(try cos.applyAllChannelOptions(to: optionsCollector).wait())
         XCTAssertEqual(2, optionsCollector.allOptions.count)
     }
 
     func testSetTwoOptionsOfSameType() throws {
         let options: [(ChannelOptions.Types.SocketOption, SocketOptionValue)] = [
-            (ChannelOptions.socketOption(.so_reuseaddr), 1),
-            (ChannelOptions.socketOption(.so_rcvtimeo), 2),
+            (.socketOption(.so_reuseaddr), 1),
+            (.socketOption(.so_rcvtimeo), 2),
         ]
         var cos = ChannelOptions.Storage()
         let optionsCollector = OptionsCollectingChannel()
@@ -62,12 +62,12 @@ class ChannelOptionStorageTest: XCTestCase {
     func testSetOneOptionTwice() throws {
         var cos = ChannelOptions.Storage()
         let optionsCollector = OptionsCollectingChannel()
-        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 2)
+        cos.append(key: .socketOption(.so_reuseaddr), value: 1)
+        cos.append(key: .socketOption(.so_reuseaddr), value: 2)
         XCTAssertNoThrow(try cos.applyAllChannelOptions(to: optionsCollector).wait())
         XCTAssertEqual(1, optionsCollector.allOptions.count)
         XCTAssertEqual(
-            [ChannelOptions.socketOption(.so_reuseaddr)],
+            [.socketOption(.so_reuseaddr)],
             optionsCollector.allOptions.map { option in
                 option.0 as! ChannelOptions.Types.SocketOption
             }
@@ -83,19 +83,19 @@ class ChannelOptionStorageTest: XCTestCase {
     func testClearingOptions() throws {
         var cos = ChannelOptions.Storage()
         let optionsCollector = OptionsCollectingChannel()
-        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 2)
-        cos.append(key: ChannelOptions.socketOption(.so_keepalive), value: 3)
-        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 4)
-        cos.append(key: ChannelOptions.socketOption(.so_rcvbuf), value: 5)
-        cos.append(key: ChannelOptions.socketOption(.so_reuseaddr), value: 6)
-        cos.remove(key: ChannelOptions.socketOption(.so_reuseaddr))
+        cos.append(key: .socketOption(.so_reuseaddr), value: 1)
+        cos.append(key: .socketOption(.so_reuseaddr), value: 2)
+        cos.append(key: .socketOption(.so_keepalive), value: 3)
+        cos.append(key: .socketOption(.so_reuseaddr), value: 4)
+        cos.append(key: .socketOption(.so_rcvbuf), value: 5)
+        cos.append(key: .socketOption(.so_reuseaddr), value: 6)
+        cos.remove(key: .socketOption(.so_reuseaddr))
         XCTAssertNoThrow(try cos.applyAllChannelOptions(to: optionsCollector).wait())
         XCTAssertEqual(2, optionsCollector.allOptions.count)
         XCTAssertEqual(
             [
-                ChannelOptions.socketOption(.so_keepalive),
-                ChannelOptions.socketOption(.so_rcvbuf),
+                .socketOption(.so_keepalive),
+                .socketOption(.so_rcvbuf),
             ],
             optionsCollector.allOptions.map { option in
                 option.0 as! ChannelOptions.Types.SocketOption

--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -514,7 +514,7 @@ class AsyncTestingChannelTests: XCTestCase {
             let options = channel.syncOptions
             XCTAssertNotNil(options)
             // Unconditionally returns true.
-            XCTAssertEqual(try options?.getOption(ChannelOptions.autoRead), true)
+            XCTAssertEqual(try options?.getOption(.autoRead), true)
             // (Setting options isn't supported.)
         }.wait()
     }
@@ -525,7 +525,7 @@ class AsyncTestingChannelTests: XCTestCase {
             let options = channel.syncOptions
             XCTAssertNotNil(options)
             // Unconditionally returns true.
-            XCTAssertEqual(try options?.getOption(ChannelOptions.autoRead), true)
+            XCTAssertEqual(try options?.getOption(.autoRead), true)
         }.wait()
     }
 
@@ -536,13 +536,13 @@ class AsyncTestingChannelTests: XCTestCase {
             XCTAssertNotNil(options)
 
             // allowRemoteHalfClosure should be false by default
-            XCTAssertEqual(try options?.getOption(ChannelOptions.allowRemoteHalfClosure), false)
+            XCTAssertEqual(try options?.getOption(.allowRemoteHalfClosure), false)
 
             channel.allowRemoteHalfClosure = true
-            XCTAssertEqual(try options?.getOption(ChannelOptions.allowRemoteHalfClosure), true)
+            XCTAssertEqual(try options?.getOption(.allowRemoteHalfClosure), true)
 
-            XCTAssertNoThrow(try options?.setOption(ChannelOptions.allowRemoteHalfClosure, value: false))
-            XCTAssertEqual(try options?.getOption(ChannelOptions.allowRemoteHalfClosure), false)
+            XCTAssertNoThrow(try options?.setOption(.allowRemoteHalfClosure, value: false))
+            XCTAssertEqual(try options?.getOption(.allowRemoteHalfClosure), false)
         }.wait()
     }
 

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
@@ -516,7 +516,7 @@ class EmbeddedChannelTest: XCTestCase {
         let options = channel.syncOptions
         XCTAssertNotNil(options)
         // Unconditionally returns true.
-        XCTAssertEqual(try options?.getOption(ChannelOptions.autoRead), true)
+        XCTAssertEqual(try options?.getOption(.autoRead), true)
     }
 
     func testSetGetChannelOptionAllowRemoteHalfClosureIsSupported() {
@@ -525,13 +525,13 @@ class EmbeddedChannelTest: XCTestCase {
         XCTAssertNotNil(options)
 
         // allowRemoteHalfClosure should be false by default
-        XCTAssertEqual(try options?.getOption(ChannelOptions.allowRemoteHalfClosure), false)
+        XCTAssertEqual(try options?.getOption(.allowRemoteHalfClosure), false)
 
         channel.allowRemoteHalfClosure = true
-        XCTAssertEqual(try options?.getOption(ChannelOptions.allowRemoteHalfClosure), true)
+        XCTAssertEqual(try options?.getOption(.allowRemoteHalfClosure), true)
 
-        XCTAssertNoThrow(try options?.setOption(ChannelOptions.allowRemoteHalfClosure, value: false))
-        XCTAssertEqual(try options?.getOption(ChannelOptions.allowRemoteHalfClosure), false)
+        XCTAssertNoThrow(try options?.setOption(.allowRemoteHalfClosure, value: false))
+        XCTAssertEqual(try options?.getOption(.allowRemoteHalfClosure), false)
     }
 
     func testLocalAddress0() throws {

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -371,7 +371,7 @@ class HTTPServerClientTest: XCTestCase {
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -432,7 +432,7 @@ class HTTPServerClientTest: XCTestCase {
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -491,7 +491,7 @@ class HTTPServerClientTest: XCTestCase {
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -553,7 +553,7 @@ class HTTPServerClientTest: XCTestCase {
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                         channel.pipeline.addHandler(httpHandler)
@@ -613,7 +613,7 @@ class HTTPServerClientTest: XCTestCase {
         let httpHandler = SimpleHTTPServer(mode)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
                 // Set the handlers that are appled to the accepted Channels
                 .childChannelInitializer { channel in
@@ -659,7 +659,7 @@ class HTTPServerClientTest: XCTestCase {
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                         channel.pipeline.addHandler(httpHandler)
@@ -707,7 +707,7 @@ class HTTPServerClientTest: XCTestCase {
         let httpHandler = SimpleHTTPServer(.byteBuffer)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.configureHTTPServerPipeline(withPipeliningAssistance: false).flatMap {
                         channel.pipeline.addHandler(httpHandler)

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -120,7 +120,7 @@ private func serverHTTPChannelWithAutoremoval(
 ) throws -> (Channel, EventLoopFuture<Channel>) {
     let p = group.next().makePromise(of: Channel.self)
     let c = try ServerBootstrap(group: group)
-        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
         .childChannelInitializer { channel in
             p.succeed(channel)
             let upgradeConfig = (upgraders: upgraders, completionHandler: upgradeCompletionHandler)
@@ -1774,7 +1774,7 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
     ) throws -> (Channel, Channel, Channel) {
         let connectionChannelPromise = Self.eventLoop.makePromise(of: Channel.self)
         let serverChannelFuture = ServerBootstrap(group: Self.eventLoop)
-            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.eventLoop.makeCompletedFuture {
                     connectionChannelPromise.succeed(channel)

--- a/Tests/NIOPosixTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOPosixTests/AcceptBackoffHandlerTest.swift
@@ -328,7 +328,7 @@ public final class AcceptBackoffHandlerTest: XCTestCase {
             )
         )
 
-        XCTAssertNoThrow(try serverChannel.setOption(ChannelOptions.autoRead, value: false).wait())
+        XCTAssertNoThrow(try serverChannel.setOption(.autoRead, value: false).wait())
         XCTAssertNoThrow(
             try serverChannel.pipeline.addHandler(readCountHandler).flatMap { _ in
                 serverChannel.pipeline.addHandler(

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -220,8 +220,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
         }
 
         let channel = try await ServerBootstrap(group: eventLoopGroup)
-            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-            .childChannelOption(ChannelOptions.autoRead, value: true)
+            .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+            .childChannelOption(.autoRead, value: true)
             .bind(
                 host: "127.0.0.1",
                 port: 0
@@ -281,8 +281,8 @@ final class AsyncChannelBootstrapTests: XCTestCase {
         let channel: NIOAsyncChannel<EventLoopFuture<NegotiationResult>, Never> = try await ServerBootstrap(
             group: eventLoopGroup
         )
-        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-        .childChannelOption(ChannelOptions.autoRead, value: true)
+        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+        .childChannelOption(.autoRead, value: true)
         .bind(
             host: "127.0.0.1",
             port: 0
@@ -367,7 +367,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
 
         let channel: NIOAsyncChannel<EventLoopFuture<EventLoopFuture<NegotiationResult>>, Never> =
             try await ServerBootstrap(group: eventLoopGroup)
-            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
             .bind(
                 host: "127.0.0.1",
                 port: 0
@@ -506,13 +506,13 @@ final class AsyncChannelBootstrapTests: XCTestCase {
         let channel: NIOAsyncChannel<EventLoopFuture<NegotiationResult>, Never> = try await ServerBootstrap(
             group: eventLoopGroup
         )
-        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
         .serverChannelInitializer { channel in
             channel.eventLoop.makeCompletedFuture {
                 try channel.pipeline.syncOperations.addHandler(CollectingHandler(channels: channels))
             }
         }
-        .childChannelOption(ChannelOptions.autoRead, value: true)
+        .childChannelOption(.autoRead, value: true)
         .bind(
             host: "127.0.0.1",
             port: 0

--- a/Tests/NIOPosixTests/BootstrapTest.swift
+++ b/Tests/NIOPosixTests/BootstrapTest.swift
@@ -255,7 +255,7 @@ class BootstrapTest: XCTestCase {
             let serverAcceptedChannelPromise = group.next().makePromise(of: Channel.self)
             let serverChannel = try assertNoThrowWithValue(
                 ServerBootstrap(group: group)
-                    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                    .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                     .childChannelInitializer { channel in
                         serverAcceptedChannelPromise.succeed(channel)
                         return channel.eventLoop.makeSucceededFuture(())
@@ -313,9 +313,9 @@ class BootstrapTest: XCTestCase {
         var channel: Channel? = nil
         XCTAssertNoThrow(
             channel = try ServerBootstrap(group: self.group)
-                .serverChannelOption(ChannelOptions.autoRead, value: false)
+                .serverChannelOption(.autoRead, value: false)
                 .serverChannelInitializer { channel in
-                    channel.getOption(ChannelOptions.autoRead).whenComplete { result in
+                    channel.getOption(.autoRead).whenComplete { result in
                         func workaround() {
                             XCTAssertNoThrow(XCTAssertFalse(try result.get()))
                         }
@@ -336,9 +336,9 @@ class BootstrapTest: XCTestCase {
                 var channel: Channel? = nil
                 XCTAssertNoThrow(
                     channel = try ClientBootstrap(group: self.group)
-                        .channelOption(ChannelOptions.autoRead, value: false)
+                        .channelOption(.autoRead, value: false)
                         .channelInitializer { channel in
-                            channel.getOption(ChannelOptions.autoRead).whenComplete { result in
+                            channel.getOption(.autoRead).whenComplete { result in
                                 func workaround() {
                                     XCTAssertNoThrow(XCTAssertFalse(try result.get()))
                                 }
@@ -371,9 +371,9 @@ class BootstrapTest: XCTestCase {
                 var channel: Channel? = nil
                 XCTAssertNoThrow(
                     channel = try ClientBootstrap(group: self.group)
-                        .channelOption(ChannelOptions.autoRead, value: false)
+                        .channelOption(.autoRead, value: false)
                         .channelInitializer { channel in
-                            channel.getOption(ChannelOptions.autoRead).whenComplete { result in
+                            channel.getOption(.autoRead).whenComplete { result in
                                 func workaround() {
                                     XCTAssertNoThrow(XCTAssertFalse(try result.get()))
                                 }
@@ -394,9 +394,9 @@ class BootstrapTest: XCTestCase {
         var channel: Channel? = nil
         XCTAssertNoThrow(
             channel = try DatagramBootstrap(group: self.group)
-                .channelOption(ChannelOptions.autoRead, value: false)
+                .channelOption(.autoRead, value: false)
                 .channelInitializer { channel in
-                    channel.getOption(ChannelOptions.autoRead).whenComplete { result in
+                    channel.getOption(.autoRead).whenComplete { result in
                         func workaround() {
                             XCTAssertNoThrow(XCTAssertFalse(try result.get()))
                         }
@@ -425,9 +425,9 @@ class BootstrapTest: XCTestCase {
                 var channel: Channel? = nil
                 XCTAssertNoThrow(
                     channel = try NIOPipeBootstrap(group: self.group)
-                        .channelOption(ChannelOptions.autoRead, value: false)
+                        .channelOption(.autoRead, value: false)
                         .channelInitializer { channel in
-                            channel.getOption(ChannelOptions.autoRead).whenComplete { result in
+                            channel.getOption(.autoRead).whenComplete { result in
                                 func workaround() {
                                     XCTAssertNoThrow(XCTAssertFalse(try result.get()))
                                 }
@@ -671,17 +671,17 @@ class BootstrapTest: XCTestCase {
         }
 
         try checkOptionEquivalence(
-            longOption: ChannelOptions.socketOption(.so_reuseaddr),
+            longOption: .socketOption(.so_reuseaddr),
             setValue: 1,
             shortOption: .allowLocalEndpointReuse
         )
         try checkOptionEquivalence(
-            longOption: ChannelOptions.allowRemoteHalfClosure,
+            longOption: .allowRemoteHalfClosure,
             setValue: true,
             shortOption: .allowRemoteHalfClosure
         )
         try checkOptionEquivalence(
-            longOption: ChannelOptions.autoRead,
+            longOption: .autoRead,
             setValue: false,
             shortOption: .disableAutoRead
         )
@@ -697,14 +697,14 @@ class BootstrapTest: XCTestCase {
                 let clientLocalAddressWholeInterface = try? SocketAddress(ipAddress: localIP, port: 0),
                 let server1 =
                     (try? ServerBootstrap(group: self.group)
-                        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                        .serverChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+                        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                        .serverChannelOption(.maxMessagesPerRead, value: 1)
                         .bind(to: serverLocalAddressChoice)
                         .wait()),
                 let server2 =
                     (try? ServerBootstrap(group: self.group)
-                        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                        .serverChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+                        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                        .serverChannelOption(.maxMessagesPerRead, value: 1)
                         .bind(to: serverLocalAddressChoice)
                         .wait()),
                 let server1LocalAddress = server1.localAddress,
@@ -721,7 +721,7 @@ class BootstrapTest: XCTestCase {
             // Try 1: Directly connect to 127.0.0.1, this won't do Happy Eyeballs.
             XCTAssertNoThrow(
                 try ClientBootstrap(group: self.group)
-                    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                    .channelOption(.socketOption(.so_reuseaddr), value: 1)
                     .bind(to: clientLocalAddressWholeInterface)
                     .connect(to: server1LocalAddress)
                     .wait()
@@ -744,7 +744,7 @@ class BootstrapTest: XCTestCase {
 
             XCTAssertNoThrow(
                 maybeChannel1 = try ClientBootstrap(group: self.group)
-                    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                    .channelOption(.socketOption(.so_reuseaddr), value: 1)
                     .bind(to: clientLocalAddressWholeInterface)
                     .connect(host: localhost, port: server1LocalAddress.port!)
                     .wait()
@@ -757,7 +757,7 @@ class BootstrapTest: XCTestCase {
             // Try 3: Bind the client to the same address/port as in try 2 but to server 2.
             XCTAssertNoThrow(
                 try ClientBootstrap(group: self.group)
-                    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                    .channelOption(.socketOption(.so_reuseaddr), value: 1)
                     .connectTimeout(.hours(2))
                     .bind(to: myChannel1Address)
                     .connect(to: server2LocalAddress)
@@ -822,7 +822,7 @@ private final class MakeSureAutoReadIsOffInChannelInitializer: ChannelInboundHan
     typealias InboundIn = Channel
 
     func channelActive(context: ChannelHandlerContext) {
-        context.channel.getOption(ChannelOptions.autoRead).whenComplete { result in
+        context.channel.getOption(.autoRead).whenComplete { result in
             func workaround() {
                 XCTAssertNoThrow(XCTAssertFalse(try result.get()))
             }

--- a/Tests/NIOPosixTests/ChannelNotificationTest.swift
+++ b/Tests/NIOPosixTests/ChannelNotificationTest.swift
@@ -406,11 +406,11 @@ class ChannelNotificationTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .serverChannelInitializer { channel in
                     channel.pipeline.addHandler(ServerSocketChannelLifecycleVerificationHandler())
                 }
-                .childChannelOption(ChannelOptions.autoRead, value: false)
+                .childChannelOption(.autoRead, value: false)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(
                         AcceptedSocketChannelLifecycleVerificationHandler(acceptedChannelPromise)
@@ -496,8 +496,8 @@ class ChannelNotificationTest: XCTestCase {
         let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .childChannelOption(ChannelOptions.autoRead, value: true)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .childChannelOption(.autoRead, value: true)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(OrderVerificationHandler(promise))
                 }

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -84,7 +84,7 @@ public final class ChannelTests: XCTestCase {
         let serverLifecycleHandler = ChannelLifecycleHandler()
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     serverAcceptedChannelPromise.succeed(channel)
                     return channel.pipeline.addHandler(serverLifecycleHandler)
@@ -138,7 +138,7 @@ public final class ChannelTests: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0).wait()
         )
 
@@ -171,7 +171,7 @@ public final class ChannelTests: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0).wait()
         )
 
@@ -208,7 +208,7 @@ public final class ChannelTests: XCTestCase {
         let childChannelPromise = group.next().makePromise(of: Channel.self)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     childChannelPromise.succeed(channel)
                     return channel.eventLoop.makeSucceededFuture(())
@@ -1269,7 +1269,7 @@ public final class ChannelTests: XCTestCase {
         do {
             // This must throw as 198.51.100.254 is reserved for documentation only
             _ = try ClientBootstrap(group: group)
-                .channelOption(ChannelOptions.connectTimeout, value: .milliseconds(10))
+                .channelOption(.connectTimeout, value: .milliseconds(10))
                 .connect(to: SocketAddress.makeAddressResolvingHost("198.51.100.254", port: 65535)).wait()
             XCTFail()
         } catch let err as ChannelError {
@@ -1403,7 +1403,7 @@ public final class ChannelTests: XCTestCase {
                     channel.pipeline.addHandler(verificationHandler)
                 }
             }
-            .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+            .channelOption(.allowRemoteHalfClosure, value: true)
             .connect(to: try! server.localAddress())
         let accepted = try server.accept()!
         defer {
@@ -1460,7 +1460,7 @@ public final class ChannelTests: XCTestCase {
             .channelInitializer { channel in
                 channel.pipeline.addHandler(verificationHandler)
             }
-            .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+            .channelOption(.allowRemoteHalfClosure, value: true)
             .connect(to: try! server.localAddress())
         let accepted = try server.accept()!
         defer {
@@ -1519,7 +1519,7 @@ public final class ChannelTests: XCTestCase {
         let serverChildChannelInitPromise: EventLoopPromise<Channel> = group.next().makePromise()
         let serverChildChannelInactivePromise: EventLoopPromise<Void> = group.next().makePromise()
         let serverChannel: Channel = try ServerBootstrap(group: group)
-            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)  // Important!
+            .childChannelOption(.allowRemoteHalfClosure, value: true)  // Important!
             .childChannelInitializer { channel in
                 channel.pipeline.addHandlers(
                     PromiseOnChildChannelInitHandler(promise: serverChildChannelInitPromise),
@@ -1540,7 +1540,7 @@ public final class ChannelTests: XCTestCase {
             .connect(to: serverChannel.localAddress!)
             .wait()
 
-        XCTAssertNoThrow(try clientChannel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).wait())
+        XCTAssertNoThrow(try clientChannel.setOption(.allowRemoteHalfClosure, value: true).wait())
 
         // Ok, the connection is definitely up.
         // Now retrieve the client channel that our server opened for the connection to our client.
@@ -1665,7 +1665,7 @@ public final class ChannelTests: XCTestCase {
             let serverChildChannelPromise = group.next().makePromise(of: Channel.self)
             let serverChannel = try assertNoThrowWithValue(
                 ServerBootstrap(group: group)
-                    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                    .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                     .childChannelInitializer { channel in
                         serverChildChannelPromise.succeed(channel)
                         channel.close(promise: nil)
@@ -1731,7 +1731,7 @@ public final class ChannelTests: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0).wait()
         )
 
@@ -1779,7 +1779,7 @@ public final class ChannelTests: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { ch in
                     ch.pipeline.addHandler(AddressVerificationHandler())
                 }
@@ -1847,7 +1847,7 @@ public final class ChannelTests: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer {
                     $0.pipeline.addHandler(readDelayer)
                 }
@@ -1909,8 +1909,8 @@ public final class ChannelTests: XCTestCase {
         let handler = VerifyNoReadBeforeEOFHandler()
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .childChannelOption(ChannelOptions.autoRead, value: false)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .childChannelOption(.autoRead, value: false)
                 .childChannelInitializer { ch in
                     ch.pipeline.addHandler(handler)
                 }
@@ -1971,13 +1971,13 @@ public final class ChannelTests: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .childChannelOption(ChannelOptions.autoRead, value: false)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .childChannelOption(.autoRead, value: false)
                 .childChannelInitializer { ch in
                     ch.pipeline.addHandler(VerifyEOFReadOrderingAndCloseInChannelReadHandler())
                 }
-                .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
-                .childChannelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 8))
+                .childChannelOption(.maxMessagesPerRead, value: 1)
+                .childChannelOption(.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 8))
                 .bind(host: "127.0.0.1", port: 0).wait()
         )
 
@@ -2033,16 +2033,16 @@ public final class ChannelTests: XCTestCase {
         let allDone = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .childChannelOption(ChannelOptions.autoRead, value: false)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .childChannelOption(.autoRead, value: false)
                 .childChannelInitializer { ch in
                     ch.pipeline.addHandler(CloseWhenWeGetEOFHandler(allDone: allDone))
                 }
                 // maxMessagesPerRead is large so that we definitely spin and seen the EOF
-                .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 10)
-                .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+                .childChannelOption(.maxMessagesPerRead, value: 10)
+                .childChannelOption(.allowRemoteHalfClosure, value: true)
                 // that fits the message we prepared
-                .childChannelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 8))
+                .childChannelOption(.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 8))
                 .bind(host: "127.0.0.1", port: 0).wait()
         )
 
@@ -2095,8 +2095,8 @@ public final class ChannelTests: XCTestCase {
         let promise = group.next().makePromise(of: Void.self)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .childChannelOption(ChannelOptions.autoRead, value: false)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .childChannelOption(.autoRead, value: false)
                 .childChannelInitializer { ch in
                     ch.pipeline.addHandler(ChannelInactiveVerificationHandler(promise))
                 }
@@ -2729,7 +2729,7 @@ public final class ChannelTests: XCTestCase {
         }
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "localhost", port: 0)
                 .wait()
         )
@@ -2928,7 +2928,7 @@ public final class ChannelTests: XCTestCase {
                     XCTAssertTrue(serverChannel.isActive)
                     // we allow auto-read again to make sure that the socket buffer is drained on write error
                     // (cf. https://github.com/apple/swift-nio/issues/593)
-                    context.channel.setOption(ChannelOptions.autoRead, value: true).flatMap {
+                    context.channel.setOption(.autoRead, value: true).flatMap {
                         // let's trigger the write error
                         var buffer = context.channel.allocator.buffer(capacity: 16)
                         buffer.writeStaticString("THIS WILL FAIL ANYWAY")
@@ -2974,7 +2974,7 @@ public final class ChannelTests: XCTestCase {
         let allDonePromise = singleThreadedELG.next().makePromise(of: Void.self)
         let server = try assertNoThrowWithValue(
             ServerBootstrap(group: singleThreadedELG)
-                .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+                .childChannelOption(.allowRemoteHalfClosure, value: true)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(
                         WriteWhenActiveHandler(channelAvailablePromise: serverChannelAvailablePromise)
@@ -2994,8 +2994,8 @@ public final class ChannelTests: XCTestCase {
                 eventLoop: singleThreadedELG.next() as! SelectableEventLoop
             )
         )
-        XCTAssertNoThrow(try c.setOption(ChannelOptions.autoRead, value: false).wait())
-        XCTAssertNoThrow(try c.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).wait())
+        XCTAssertNoThrow(try c.setOption(.autoRead, value: false).wait())
+        XCTAssertNoThrow(try c.setOption(.allowRemoteHalfClosure, value: true).wait())
         XCTAssertNoThrow(
             try c.pipeline.addHandler(
                 MakeChannelInactiveInReadCausedByWriteErrorHandler(
@@ -3024,10 +3024,10 @@ public final class ChannelTests: XCTestCase {
         ]
         let server = try assertNoThrowWithValue(
             ServerBootstrap(group: singleThreadedELG)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .serverChannelOption(ChannelOptions.socketOption(.so_timestamp), value: 1)
-                .childChannelOption(ChannelOptions.socketOption(.so_keepalive), value: 1)
-                .childChannelOption(ChannelOptions.tcpOption(.tcp_nodelay), value: 0)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_timestamp), value: 1)
+                .childChannelOption(.socketOption(.so_keepalive), value: 1)
+                .childChannelOption(.tcpOption(.tcp_nodelay), value: 0)
                 .childChannelInitializer { channel in
                     acceptedChannels[numberOfAcceptedChannel].succeed(channel)
                     numberOfAcceptedChannel += 1
@@ -3044,8 +3044,8 @@ public final class ChannelTests: XCTestCase {
 
         let client1 = try assertNoThrowWithValue(
             ClientBootstrap(group: singleThreadedELG)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .channelOption(ChannelOptions.tcpOption(.tcp_nodelay), value: 0)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.tcpOption(.tcp_nodelay), value: 0)
                 .connect(to: server.localAddress!)
                 .wait()
         )
@@ -3055,7 +3055,7 @@ public final class ChannelTests: XCTestCase {
         }
         let client2 = try assertNoThrowWithValue(
             ClientBootstrap(group: singleThreadedELG)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
                 .connect(to: server.localAddress!)
                 .wait()
         )
@@ -3272,7 +3272,7 @@ public final class ChannelTests: XCTestCase {
         var maybeServer: Channel? = nil
         XCTAssertNoThrow(
             maybeServer = try ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
         )
@@ -3307,7 +3307,7 @@ public final class ChannelTests: XCTestCase {
         )
 
         let serverFuture = ServerBootstrap(group: group)
-            .childChannelOption(ChannelOptions.writeBufferWaterMark, value: handler.watermark)
+            .childChannelOption(.writeBufferWaterMark, value: handler.watermark)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(handler)
             }

--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -44,10 +44,10 @@ extension Channel {
         let totalBufferSize = messageCount * 2048
 
         try self.setOption(
-            ChannelOptions.recvAllocator,
+            .recvAllocator,
             value: FixedSizeRecvByteBufferAllocator(capacity: totalBufferSize)
         ).flatMap {
-            self.setOption(ChannelOptions.datagramVectorReadMessageCount, value: messageCount)
+            self.setOption(.datagramVectorReadMessageCount, value: messageCount)
         }.wait()
     }
 }
@@ -118,7 +118,7 @@ class DatagramChannelTests: XCTestCase {
 
     private func buildChannel(group: EventLoopGroup, host: String = "127.0.0.1") throws -> Channel {
         try DatagramBootstrap(group: group)
-            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
                 channel.pipeline.addHandler(DatagramReadRecorder<ByteBuffer>(), name: "ByteReadRecorder")
             }
@@ -198,7 +198,7 @@ class DatagramChannelTests: XCTestCase {
 
     func testDatagramChannelHasWatermark() throws {
         _ = try self.firstChannel.setOption(
-            ChannelOptions.writeBufferWaterMark,
+            .writeBufferWaterMark,
             value: ChannelOptions.Types.WriteBufferWaterMark(low: 1, high: 1024)
         ).wait()
 
@@ -537,7 +537,7 @@ class DatagramChannelTests: XCTestCase {
     public func testSetGetOptionClosedDatagramChannel() throws {
         try assertSetGetOptionOnOpenAndClosed(
             channel: firstChannel,
-            option: ChannelOptions.maxMessagesPerRead,
+            option: .maxMessagesPerRead,
             value: 1
         )
     }
@@ -568,8 +568,8 @@ class DatagramChannelTests: XCTestCase {
     func testSettingTwoDistinctChannelOptionsWorksForDatagramChannel() throws {
         let channel = try assertNoThrowWithValue(
             DatagramBootstrap(group: group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .channelOption(ChannelOptions.socketOption(.so_timestamp), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_timestamp), value: 1)
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
         )
@@ -631,7 +631,7 @@ class DatagramChannelTests: XCTestCase {
         XCTAssertNoThrow(try self.secondChannel.configureForRecvMmsg(messageCount: 10))
         XCTAssertNoThrow(
             try self.secondChannel.setOption(
-                ChannelOptions.recvAllocator,
+                .recvAllocator,
                 value: FixedSizeRecvByteBufferAllocator(capacity: 30)
             ).wait()
         )
@@ -666,8 +666,8 @@ class DatagramChannelTests: XCTestCase {
         XCTAssertNoThrow(try self.secondChannel.configureForRecvMmsg(messageCount: 10))
 
         // We now turn off autoread.
-        XCTAssertNoThrow(try self.secondChannel.setOption(ChannelOptions.autoRead, value: false).wait())
-        XCTAssertNoThrow(try self.secondChannel.setOption(ChannelOptions.maxMessagesPerRead, value: 3).wait())
+        XCTAssertNoThrow(try self.secondChannel.setOption(.autoRead, value: false).wait())
+        XCTAssertNoThrow(try self.secondChannel.setOption(.maxMessagesPerRead, value: 3).wait())
 
         var buffer = self.firstChannel.allocator.buffer(capacity: 256)
         buffer.writeStaticString("data")
@@ -680,7 +680,7 @@ class DatagramChannelTests: XCTestCase {
         XCTAssertNoThrow(try self.firstChannel.writeAndFlush(NIOAny(writeData)).wait())
 
         // Now we read. Rather than issue many read() calls, we'll turn autoread back on.
-        XCTAssertNoThrow(try self.secondChannel.setOption(ChannelOptions.autoRead, value: true).wait())
+        XCTAssertNoThrow(try self.secondChannel.setOption(.autoRead, value: true).wait())
 
         // Wait for all 30 datagrams to come through. There should be no loss here, as this is small datagrams on loopback.
         let reads = try self.secondChannel.waitForDatagrams(count: 30)
@@ -702,11 +702,11 @@ class DatagramChannelTests: XCTestCase {
         XCTAssertNoThrow(
             try {
                 // IPv4
-                try self.firstChannel.setOption(ChannelOptions.explicitCongestionNotification, value: true).wait()
-                XCTAssertTrue(try self.firstChannel.getOption(ChannelOptions.explicitCongestionNotification).wait())
+                try self.firstChannel.setOption(.explicitCongestionNotification, value: true).wait()
+                XCTAssertTrue(try self.firstChannel.getOption(.explicitCongestionNotification).wait())
 
-                try self.secondChannel.setOption(ChannelOptions.explicitCongestionNotification, value: false).wait()
-                XCTAssertFalse(try self.secondChannel.getOption(ChannelOptions.explicitCongestionNotification).wait())
+                try self.secondChannel.setOption(.explicitCongestionNotification, value: false).wait()
+                XCTAssertFalse(try self.secondChannel.getOption(.explicitCongestionNotification).wait())
 
                 // IPv6
                 guard self.supportsIPv6 else {
@@ -716,12 +716,12 @@ class DatagramChannelTests: XCTestCase {
 
                 do {
                     let channel1 = try buildChannel(group: self.group, host: "::1")
-                    try channel1.setOption(ChannelOptions.explicitCongestionNotification, value: true).wait()
-                    XCTAssertTrue(try channel1.getOption(ChannelOptions.explicitCongestionNotification).wait())
+                    try channel1.setOption(.explicitCongestionNotification, value: true).wait()
+                    XCTAssertTrue(try channel1.getOption(.explicitCongestionNotification).wait())
 
                     let channel2 = try buildChannel(group: self.group, host: "::1")
-                    try channel2.setOption(ChannelOptions.explicitCongestionNotification, value: false).wait()
-                    XCTAssertFalse(try channel2.getOption(ChannelOptions.explicitCongestionNotification).wait())
+                    try channel2.setOption(.explicitCongestionNotification, value: false).wait()
+                    XCTAssertFalse(try channel2.getOption(.explicitCongestionNotification).wait())
                 } catch let error as SocketAddressError {
                     switch error {
                     case .unknown:
@@ -748,15 +748,15 @@ class DatagramChannelTests: XCTestCase {
                 let receiveBootstrap: DatagramBootstrap
                 if vectorRead {
                     receiveBootstrap = DatagramBootstrap(group: group)
-                        .channelOption(ChannelOptions.datagramVectorReadMessageCount, value: 4)
+                        .channelOption(.datagramVectorReadMessageCount, value: 4)
                 } else {
                     receiveBootstrap = DatagramBootstrap(group: group)
                 }
 
                 let receiveChannel =
                     try receiveBootstrap
-                    .channelOption(ChannelOptions.explicitCongestionNotification, value: true)
-                    .channelOption(ChannelOptions.receivePacketInfo, value: receivePacketInfo)
+                    .channelOption(.explicitCongestionNotification, value: true)
+                    .channelOption(.receivePacketInfo, value: receivePacketInfo)
                     .channelInitializer { channel in
                         channel.pipeline.addHandler(DatagramReadRecorder<ByteBuffer>(), name: "ByteReadRecorder")
                     }
@@ -882,7 +882,7 @@ class DatagramChannelTests: XCTestCase {
         }
 
         let channel2Future = DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.writeBufferWaterMark, value: handler.watermark)
+            .channelOption(.writeBufferWaterMark, value: handler.watermark)
             .channelInitializer { channel in
                 channel.pipeline.addHandlers([EnvelopingHandler(), handler])
             }
@@ -901,11 +901,11 @@ class DatagramChannelTests: XCTestCase {
         XCTAssertNoThrow(
             try {
                 // IPv4
-                try self.firstChannel.setOption(ChannelOptions.receivePacketInfo, value: true).wait()
-                XCTAssertTrue(try self.firstChannel.getOption(ChannelOptions.receivePacketInfo).wait())
+                try self.firstChannel.setOption(.receivePacketInfo, value: true).wait()
+                XCTAssertTrue(try self.firstChannel.getOption(.receivePacketInfo).wait())
 
-                try self.secondChannel.setOption(ChannelOptions.receivePacketInfo, value: false).wait()
-                XCTAssertFalse(try self.secondChannel.getOption(ChannelOptions.receivePacketInfo).wait())
+                try self.secondChannel.setOption(.receivePacketInfo, value: false).wait()
+                XCTAssertFalse(try self.secondChannel.getOption(.receivePacketInfo).wait())
 
                 // IPv6
                 guard self.supportsIPv6 else {
@@ -915,12 +915,12 @@ class DatagramChannelTests: XCTestCase {
 
                 do {
                     let channel1 = try buildChannel(group: self.group, host: "::1")
-                    try channel1.setOption(ChannelOptions.receivePacketInfo, value: true).wait()
-                    XCTAssertTrue(try channel1.getOption(ChannelOptions.receivePacketInfo).wait())
+                    try channel1.setOption(.receivePacketInfo, value: true).wait()
+                    XCTAssertTrue(try channel1.getOption(.receivePacketInfo).wait())
 
                     let channel2 = try buildChannel(group: self.group, host: "::1")
-                    try channel2.setOption(ChannelOptions.receivePacketInfo, value: false).wait()
-                    XCTAssertFalse(try channel2.getOption(ChannelOptions.receivePacketInfo).wait())
+                    try channel2.setOption(.receivePacketInfo, value: false).wait()
+                    XCTAssertFalse(try channel2.getOption(.receivePacketInfo).wait())
                 } catch let error as SocketAddressError {
                     switch error {
                     case .unknown:
@@ -939,7 +939,7 @@ class DatagramChannelTests: XCTestCase {
         let expectedPacketInfo = try constructNIOPacketInfo(address: address)
 
         let receiveChannel = try DatagramBootstrap(group: group)
-            .channelOption(ChannelOptions.receivePacketInfo, value: true)
+            .channelOption(.receivePacketInfo, value: true)
             .channelInitializer { channel in
                 channel.pipeline.addHandler(DatagramReadRecorder<ByteBuffer>(), name: "ByteReadRecorder")
             }
@@ -1372,7 +1372,7 @@ class DatagramChannelTests: XCTestCase {
     }
 
     func testSetGSOOption() throws {
-        let didSet = self.firstChannel.setOption(ChannelOptions.datagramSegmentSize, value: 1024)
+        let didSet = self.firstChannel.setOption(.datagramSegmentSize, value: 1024)
         if System.supportsUDPSegmentationOffload {
             XCTAssertNoThrow(try didSet.wait())
         } else {
@@ -1383,7 +1383,7 @@ class DatagramChannelTests: XCTestCase {
     }
 
     func testGetGSOOption() throws {
-        let getOption = self.firstChannel.getOption(ChannelOptions.datagramSegmentSize)
+        let getOption = self.firstChannel.getOption(.datagramSegmentSize)
         if System.supportsUDPSegmentationOffload {
             XCTAssertEqual(try getOption.wait(), 0)  // not-set
         } else {
@@ -1404,7 +1404,7 @@ class DatagramChannelTests: XCTestCase {
         let segments = 10
 
         // Enable GSO
-        let didSet = self.firstChannel.setOption(ChannelOptions.datagramSegmentSize, value: segmentSize)
+        let didSet = self.firstChannel.setOption(.datagramSegmentSize, value: segmentSize)
         XCTAssertNoThrow(try didSet.wait())
 
         // Form a handful of segments
@@ -1449,7 +1449,7 @@ class DatagramChannelTests: XCTestCase {
         let segments = 10
 
         // Enable GSO
-        let didSet = self.firstChannel.setOption(ChannelOptions.datagramSegmentSize, value: segmentSize)
+        let didSet = self.firstChannel.setOption(.datagramSegmentSize, value: segmentSize)
         XCTAssertNoThrow(try didSet.wait())
 
         // Form a handful of segments
@@ -1497,7 +1497,7 @@ class DatagramChannelTests: XCTestCase {
 
         var segments = 64
         let segmentSize = 10
-        let didSet = self.firstChannel.setOption(ChannelOptions.datagramSegmentSize, value: CInt(segmentSize))
+        let didSet = self.firstChannel.setOption(.datagramSegmentSize, value: CInt(segmentSize))
         XCTAssertNoThrow(try didSet.wait())
 
         func send(byteCount: Int) throws {
@@ -1512,7 +1512,7 @@ class DatagramChannelTests: XCTestCase {
             // Some older kernel versions report EINVAL with 64 segments. Tolerate that
             // failure and try again with a lower limit.
             self.firstChannel = try self.buildChannel(group: self.group)
-            let didSet = self.firstChannel.setOption(ChannelOptions.datagramSegmentSize, value: CInt(segmentSize))
+            let didSet = self.firstChannel.setOption(.datagramSegmentSize, value: CInt(segmentSize))
             XCTAssertNoThrow(try didSet.wait())
             segments = 61
             try send(byteCount: segments * segmentSize)
@@ -1526,7 +1526,7 @@ class DatagramChannelTests: XCTestCase {
         try XCTSkipUnless(System.supportsUDPSegmentationOffload, "UDP_SEGMENT (GSO) is not supported on this platform")
 
         let segmentSize = 10
-        let didSet = self.firstChannel.setOption(ChannelOptions.datagramSegmentSize, value: CInt(segmentSize))
+        let didSet = self.firstChannel.setOption(.datagramSegmentSize, value: CInt(segmentSize))
         XCTAssertNoThrow(try didSet.wait())
 
         let buffer = self.firstChannel.allocator.buffer(repeating: 1, count: segmentSize * 65)
@@ -1544,7 +1544,7 @@ class DatagramChannelTests: XCTestCase {
     }
 
     func testSetGROOption() throws {
-        let didSet = self.firstChannel.setOption(ChannelOptions.datagramReceiveOffload, value: true)
+        let didSet = self.firstChannel.setOption(.datagramReceiveOffload, value: true)
         if System.supportsUDPReceiveOffload {
             XCTAssertNoThrow(try didSet.wait())
         } else {
@@ -1555,13 +1555,13 @@ class DatagramChannelTests: XCTestCase {
     }
 
     func testGetGROOption() throws {
-        let getOption = self.firstChannel.getOption(ChannelOptions.datagramReceiveOffload)
+        let getOption = self.firstChannel.getOption(.datagramReceiveOffload)
         if System.supportsUDPReceiveOffload {
             XCTAssertEqual(try getOption.wait(), false)  // not-set
 
             // Now set and check.
-            XCTAssertNoThrow(try self.firstChannel.setOption(ChannelOptions.datagramReceiveOffload, value: true).wait())
-            XCTAssertTrue(try self.firstChannel.getOption(ChannelOptions.datagramReceiveOffload).wait())
+            XCTAssertNoThrow(try self.firstChannel.setOption(.datagramReceiveOffload, value: true).wait())
+            XCTAssertTrue(try self.firstChannel.getOption(.datagramReceiveOffload).wait())
         } else {
             XCTAssertThrowsError(try getOption.wait()) { error in
                 XCTAssertEqual(error as? ChannelError, .operationUnsupported)
@@ -1576,24 +1576,24 @@ class DatagramChannelTests: XCTestCase {
 
         /// Set GSO on the first channel.
         XCTAssertNoThrow(
-            try self.firstChannel.setOption(ChannelOptions.datagramSegmentSize, value: CInt(segmentSize)).wait()
+            try self.firstChannel.setOption(.datagramSegmentSize, value: CInt(segmentSize)).wait()
         )
         /// Set GRO on the second channel.
-        XCTAssertNoThrow(try self.secondChannel.setOption(ChannelOptions.datagramReceiveOffload, value: true).wait())
+        XCTAssertNoThrow(try self.secondChannel.setOption(.datagramReceiveOffload, value: true).wait())
         /// The third channel has neither set.
 
         // Enable on second channel
         if let vectorReads = vectorReads {
             XCTAssertNoThrow(
-                try self.secondChannel.setOption(ChannelOptions.datagramVectorReadMessageCount, value: vectorReads)
+                try self.secondChannel.setOption(.datagramVectorReadMessageCount, value: vectorReads)
                     .wait()
             )
         }
 
         /// Increase the size of the read buffer for the second and third channels.
         let fixed = FixedSizeRecvByteBufferAllocator(capacity: 1 << 16)
-        XCTAssertNoThrow(try self.secondChannel.setOption(ChannelOptions.recvAllocator, value: fixed).wait())
-        XCTAssertNoThrow(try self.thirdChannel.setOption(ChannelOptions.recvAllocator, value: fixed).wait())
+        XCTAssertNoThrow(try self.secondChannel.setOption(.recvAllocator, value: fixed).wait())
+        XCTAssertNoThrow(try self.thirdChannel.setOption(.recvAllocator, value: fixed).wait())
 
         // Write a large datagrams on the first channel. They should be split and then accumulated on the receive side.
         // Form a large buffer to write from the first channel.
@@ -1672,10 +1672,10 @@ class DatagramChannelTests: XCTestCase {
         let segments = 2
         let segmentSize = 1000
 
-        XCTAssertNoThrow(try sender.setOption(ChannelOptions.datagramSegmentSize, value: CInt(segmentSize)).wait())
-        XCTAssertNoThrow(try receiver.setOption(ChannelOptions.datagramReceiveOffload, value: true).wait())
+        XCTAssertNoThrow(try sender.setOption(.datagramSegmentSize, value: CInt(segmentSize)).wait())
+        XCTAssertNoThrow(try receiver.setOption(.datagramReceiveOffload, value: true).wait())
         let allocator = FixedSizeRecvByteBufferAllocator(capacity: 1 << 16)
-        XCTAssertNoThrow(try receiver.setOption(ChannelOptions.recvAllocator, value: allocator).wait())
+        XCTAssertNoThrow(try receiver.setOption(.recvAllocator, value: allocator).wait())
 
         let buffer = self.firstChannel.allocator.buffer(repeating: 1, count: segmentSize * segments)
         let writeData = AddressedEnvelope(remoteAddress: receiver.localAddress!, data: buffer)

--- a/Tests/NIOPosixTests/EchoServerClientTest.swift
+++ b/Tests/NIOPosixTests/EchoServerClientTest.swift
@@ -30,7 +30,7 @@ class EchoServerClientTest: XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(countingHandler)
@@ -70,7 +70,7 @@ class EchoServerClientTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(WriteALotHandler())
                 }.bind(host: "127.0.0.1", port: 0).wait()
@@ -110,7 +110,7 @@ class EchoServerClientTest: XCTestCase {
             let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
             let serverChannel = try assertNoThrowWithValue(
                 ServerBootstrap(group: group)
-                    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                    .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
                     // Set the handlers that are appled to the accepted Channels
                     .childChannelInitializer { channel in
@@ -156,7 +156,7 @@ class EchoServerClientTest: XCTestCase {
             let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
             let serverChannel = try assertNoThrowWithValue(
                 ServerBootstrap(group: group)
-                    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                    .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
                     // Set the handlers that are appled to the accepted Channels
                     .childChannelInitializer { channel in
@@ -245,7 +245,7 @@ class EchoServerClientTest: XCTestCase {
         let countingHandler = ByteCountingHandler(numBytes: numBytes, promise: group.next().makePromise())
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(countingHandler)
                 }
@@ -288,7 +288,7 @@ class EchoServerClientTest: XCTestCase {
         let handler = ChannelActiveHandler()
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0).wait()
         )
 
@@ -317,7 +317,7 @@ class EchoServerClientTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(EchoServer())
                 }.bind(host: "127.0.0.1", port: 0).wait()
@@ -528,7 +528,7 @@ class EchoServerClientTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
 
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(handler)
@@ -566,7 +566,7 @@ class EchoServerClientTest: XCTestCase {
         let byteCountingHandler = ByteCountingHandler(numBytes: writingBytes.utf8.count, promise: bytesReceivedPromise)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     // When we've received all the bytes we know the connection is up. Remove the handler.
                     _ = bytesReceivedPromise.futureResult.flatMap { (_: ByteBuffer) in
@@ -613,7 +613,7 @@ class EchoServerClientTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(EchoServer())
                 }.bind(host: "127.0.0.1", port: 0).wait()
@@ -653,7 +653,7 @@ class EchoServerClientTest: XCTestCase {
         let stringToWrite = "hello"
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(WriteOnConnectHandler(toWrite: stringToWrite))
                 }.bind(host: "127.0.0.1", port: 0).wait()
@@ -692,7 +692,7 @@ class EchoServerClientTest: XCTestCase {
         dpGroup.enter()
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(
                         EchoAndEchoAgainAfterSomeTimeServer(
@@ -791,7 +791,7 @@ class EchoServerClientTest: XCTestCase {
         }
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(WriteWhenActiveHandler(str, dpGroup))
                 }.bind(host: "127.0.0.1", port: 0).wait()
@@ -804,8 +804,8 @@ class EchoServerClientTest: XCTestCase {
         let clientChannel = try assertNoThrowWithValue(
             ClientBootstrap(group: group)
                 // We will only start reading once we wrote all data on the accepted channel.
-                //.channelOption(ChannelOptions.autoRead, value: false)
-                .channelOption(ChannelOptions.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 2))
+                //.channelOption(.autoRead, value: false)
+                .channelOption(.recvAllocator, value: FixedSizeRecvByteBufferAllocator(capacity: 2))
                 .channelInitializer { channel in
                     channel.pipeline.addHandler(WriteHandler()).flatMap {
                         channel.pipeline.addHandler(countingHandler)
@@ -857,7 +857,7 @@ class EchoServerClientTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(ErrorHandler(promise))
                 }.bind(host: "127.0.0.1", port: 0).wait()
@@ -890,7 +890,7 @@ class EchoServerClientTest: XCTestCase {
             let serverChannel: Channel
             do {
                 serverChannel = try ServerBootstrap(group: group)
-                    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                    .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                     .childChannelInitializer { channel in
                         acceptedRemotePort.store(channel.remoteAddress?.port ?? -3, ordering: .relaxed)
                         acceptedLocalPort.store(channel.localAddress?.port ?? -4, ordering: .relaxed)
@@ -946,7 +946,7 @@ class EchoServerClientTest: XCTestCase {
         // we're binding to IPv4 only
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(countingHandler)
                 }

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -74,7 +74,7 @@ public final class EventLoopTest: XCTestCase {
         // First, we create a server and client channel, but don't connect them.
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: eventLoopGroup)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0).wait()
         )
         let clientBootstrap = ClientBootstrap(group: eventLoopGroup)
@@ -482,7 +482,7 @@ public final class EventLoopTest: XCTestCase {
         // Create a server channel.
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0).wait()
         )
 
@@ -1274,9 +1274,9 @@ public final class EventLoopTest: XCTestCase {
         var maybeServer: Channel?
         XCTAssertNoThrow(
             maybeServer = try ServerBootstrap(group: elg2)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .serverChannelOption(ChannelOptions.autoRead, value: false)
-                .serverChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.autoRead, value: false)
+                .serverChannelOption(.maxMessagesPerRead, value: 1)
                 .childChannelInitializer { channel in
                     channel.pipeline.addHandler(ExecuteSomethingOnEventLoop(groupToNotify: g))
                 }

--- a/Tests/NIOPosixTests/FileRegionTest.swift
+++ b/Tests/NIOPosixTests/FileRegionTest.swift
@@ -37,7 +37,7 @@ class FileRegionTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
@@ -81,7 +81,7 @@ class FileRegionTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
@@ -138,7 +138,7 @@ class FileRegionTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { $0.pipeline.addHandler(countingHandler) }
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()

--- a/Tests/NIOPosixTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOPosixTests/IdleStateHandlerTest.swift
@@ -83,7 +83,7 @@ class IdleStateHandlerTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.eventLoop.makeCompletedFuture {
                         try channel.pipeline.syncOperations.addHandler(handler)

--- a/Tests/NIOPosixTests/MulticastTest.swift
+++ b/Tests/NIOPosixTests/MulticastTest.swift
@@ -73,7 +73,7 @@ final class MulticastTest: XCTestCase {
         interface: NIONetworkInterface
     ) -> EventLoopFuture<MulticastChannel> {
         DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(.socketOption(.so_reuseaddr), value: 1)
             .bind(host: host, port: port)
             .flatMap { channel in
                 let channel = channel as! MulticastChannel
@@ -108,7 +108,7 @@ final class MulticastTest: XCTestCase {
         device: NIONetworkDevice
     ) -> EventLoopFuture<MulticastChannel> {
         DatagramBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(.socketOption(.so_reuseaddr), value: 1)
             .bind(host: host, port: port)
             .flatMap { channel in
                 let channel = channel as! MulticastChannel
@@ -322,7 +322,7 @@ final class MulticastTest: XCTestCase {
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(
             DatagramBootstrap(group: self.group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
         )
@@ -397,7 +397,7 @@ final class MulticastTest: XCTestCase {
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(
             DatagramBootstrap(group: self.group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "::1", port: 0)
                 .wait()
         )
@@ -443,7 +443,7 @@ final class MulticastTest: XCTestCase {
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(
             DatagramBootstrap(group: self.group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
         )
@@ -508,7 +508,7 @@ final class MulticastTest: XCTestCase {
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(
             DatagramBootstrap(group: self.group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "::1", port: 0)
                 .wait()
         )
@@ -594,7 +594,7 @@ final class MulticastTest: XCTestCase {
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(
             DatagramBootstrap(group: self.group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
         )
@@ -668,7 +668,7 @@ final class MulticastTest: XCTestCase {
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(
             DatagramBootstrap(group: self.group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "::1", port: 0)
                 .wait()
         )
@@ -713,7 +713,7 @@ final class MulticastTest: XCTestCase {
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(
             DatagramBootstrap(group: self.group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
         )
@@ -774,7 +774,7 @@ final class MulticastTest: XCTestCase {
         // Now that we've joined the group, let's send to it.
         let sender = try assertNoThrowWithValue(
             DatagramBootstrap(group: self.group)
-                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelOption(.socketOption(.so_reuseaddr), value: 1)
                 .bind(host: "::1", port: 0)
                 .wait()
         )

--- a/Tests/NIOPosixTests/PipeChannelTest.swift
+++ b/Tests/NIOPosixTests/PipeChannelTest.swift
@@ -98,7 +98,7 @@ final class PipeChannelTest: XCTestCase {
     }
 
     func testWriteErrorsCloseChannel() {
-        XCTAssertNoThrow(try self.channel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).wait())
+        XCTAssertNoThrow(try self.channel.setOption(.allowRemoteHalfClosure, value: true).wait())
         self.fromChannel.closeFile()
         var buffer = self.channel.allocator.buffer(capacity: 1)
         buffer.writeString("X")

--- a/Tests/NIOPosixTests/RawSocketBootstrapTests.swift
+++ b/Tests/NIOPosixTests/RawSocketBootstrapTests.swift
@@ -146,7 +146,7 @@ final class RawSocketBootstrapTests: XCTestCase {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try elg.syncShutdownGracefully()) }
         let channel = try NIORawSocketBootstrap(group: elg)
-            .channelOption(ChannelOptions.ipOption(.ip_hdrincl), value: 1)
+            .channelOption(.ipOption(.ip_hdrincl), value: 1)
             .channelInitializer {
                 $0.pipeline.addHandler(DatagramReadRecorder<ByteBuffer>(), name: "ByteReadRecorder")
             }

--- a/Tests/NIOPosixTests/SALChannelTests.swift
+++ b/Tests/NIOPosixTests/SALChannelTests.swift
@@ -207,8 +207,8 @@ final class SALChannelTest: XCTestCase, SALTest {
 
                 try self.assertParkedRightNow()
             }) { () -> EventLoopFuture<Void> in
-                channel.setOption(ChannelOptions.writeSpin, value: 0).flatMap {
-                    channel.setOption(ChannelOptions.writeBufferWaterMark, value: .init(low: 1, high: 1))
+                channel.setOption(.writeSpin, value: 0).flatMap {
+                    channel.setOption(.writeBufferWaterMark, value: .init(low: 1, high: 1))
                 }.flatMap {
                     channel.pipeline.addHandler(
                         DoWriteFromWritabilityChangedNotification(
@@ -328,7 +328,7 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertClose(expectedFD: .max)
             }) {
                 ClientBootstrap(group: channel.eventLoop)
-                    .channelOption(ChannelOptions.autoRead, value: false)
+                    .channelOption(.autoRead, value: false)
                     .testOnly_connect(injectedChannel: channel, to: serverAddress)
                     .flatMap { channel in
                         channel.close()
@@ -373,8 +373,8 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertClose(expectedFD: .max)
             }) {
                 ClientBootstrap(group: channel.eventLoop)
-                    .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                    .channelOption(ChannelOptions.autoRead, value: false)
+                    .channelOption(.socketOption(.so_reuseaddr), value: 1)
+                    .channelOption(.autoRead, value: false)
                     .bind(to: localAddress)
                     .testOnly_connect(injectedChannel: channel, to: serverAddress)
                     .flatMap { channel in
@@ -585,7 +585,7 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertClose(expectedFD: .max)
             }) {
                 ClientBootstrap(group: channel.eventLoop)
-                    .channelOption(ChannelOptions.autoRead, value: false)
+                    .channelOption(.autoRead, value: false)
                     .channelInitializer { channel in
                         channel.write(firstWrite, promise: nil)
                         channel.write(secondWrite).whenComplete { _ in
@@ -640,7 +640,7 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertClose(expectedFD: .max)
             }) {
                 ClientBootstrap(group: channel.eventLoop)
-                    .channelOption(ChannelOptions.autoRead, value: false)
+                    .channelOption(.autoRead, value: false)
                     .channelInitializer { channel in
                         channel.write(firstWrite, promise: nil)
                         channel.write(secondWrite).whenComplete { _ in
@@ -700,8 +700,8 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertClose(expectedFD: .max)
             }) {
                 ClientBootstrap(group: channel.eventLoop)
-                    .channelOption(ChannelOptions.autoRead, value: false)
-                    .channelOption(ChannelOptions.writeSpin, value: 1)
+                    .channelOption(.autoRead, value: false)
+                    .channelOption(.writeSpin, value: 1)
                     .channelInitializer { channel in
                         channel.write(firstWrite).whenComplete { _ in
                             // An extra EL spin here to ensure that the close doesn't
@@ -760,8 +760,8 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertClose(expectedFD: .max)
             }) {
                 ClientBootstrap(group: channel.eventLoop)
-                    .channelOption(ChannelOptions.autoRead, value: false)
-                    .channelOption(ChannelOptions.writeSpin, value: 1)
+                    .channelOption(.autoRead, value: false)
+                    .channelOption(.writeSpin, value: 1)
                     .channelInitializer { channel in
                         channel.write(firstWrite).whenComplete { _ in
                             // No EL spin here so the close happens in the middle of the write spin.
@@ -866,7 +866,7 @@ final class SALChannelTest: XCTestCase, SALTest {
         let firstWrite = ByteBuffer(string: "foo")
         let secondWrite = ByteBuffer(string: "bar")
         var childChannelOptions = ChannelOptions.Storage()
-        childChannelOptions.append(key: ChannelOptions.autoRead, value: false)
+        childChannelOptions.append(key: .autoRead, value: false)
 
         XCTAssertNoThrow(
             try channel.eventLoop.runSAL(syscallAssertions: {
@@ -954,7 +954,7 @@ final class SALChannelTest: XCTestCase, SALTest {
         let firstWrite = ByteBuffer(string: "foo")
         let secondWrite = ByteBuffer(string: "bar")
         var childChannelOptions = ChannelOptions.Storage()
-        childChannelOptions.append(key: ChannelOptions.autoRead, value: false)
+        childChannelOptions.append(key: .autoRead, value: false)
 
         XCTAssertNoThrow(
             try channel.eventLoop.runSAL(syscallAssertions: {

--- a/Tests/NIOPosixTests/SelectorTest.swift
+++ b/Tests/NIOPosixTests/SelectorTest.swift
@@ -232,7 +232,7 @@ class SelectorTest: XCTestCase {
 
             func channelActive(context: ChannelHandlerContext) {
                 // collect all the channels
-                context.channel.getOption(ChannelOptions.allowRemoteHalfClosure).whenSuccess { halfClosureAllowed in
+                context.channel.getOption(.allowRemoteHalfClosure).whenSuccess { halfClosureAllowed in
                     precondition(
                         halfClosureAllowed,
                         "the test configuration is bogus: half-closure is dis-allowed which breaks the setup of this test"
@@ -394,7 +394,7 @@ class SelectorTest: XCTestCase {
                     (0..<SelectorTest.testWeDoNotDeliverEventsForPreviouslyClosedChannels_numberOfChannelsToUse).map {
                         (_: Int) in
                         ClientBootstrap(group: el)
-                            .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+                            .channelOption(.allowRemoteHalfClosure, value: true)
                             .channelInitializer { channel in
                                 channel.pipeline.addHandler(
                                     CloseEveryOtherAndOpenNewOnesHandler(

--- a/Tests/NIOPosixTests/SocketChannelTest.swift
+++ b/Tests/NIOPosixTests/SocketChannelTest.swift
@@ -62,12 +62,12 @@ public final class SocketChannelTest: XCTestCase {
         let futureA = channelA.eventLoop.submit {
             condition.wrappingIncrement(ordering: .relaxed)
             while condition.load(ordering: .relaxed) < 2 {}
-            _ = channelB.setOption(ChannelOptions.backlog, value: 1)
+            _ = channelB.setOption(.backlog, value: 1)
         }
         let futureB = channelB.eventLoop.submit {
             condition.wrappingIncrement(ordering: .relaxed)
             while condition.load(ordering: .relaxed) < 2 {}
-            _ = channelA.setOption(ChannelOptions.backlog, value: 1)
+            _ = channelA.setOption(.backlog, value: 1)
         }
         try futureA.wait()
         try futureB.wait()
@@ -79,8 +79,8 @@ public final class SocketChannelTest: XCTestCase {
 
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .serverChannelOption(ChannelOptions.backlog, value: 256)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.backlog, value: 256)
                 .bind(host: "127.0.0.1", port: 0).wait()
         )
 
@@ -212,14 +212,14 @@ public final class SocketChannelTest: XCTestCase {
         XCTAssertNoThrow(
             try assertSetGetOptionOnOpenAndClosed(
                 channel: clientChannel,
-                option: ChannelOptions.allowRemoteHalfClosure,
+                option: .allowRemoteHalfClosure,
                 value: true
             )
         )
         XCTAssertNoThrow(
             try assertSetGetOptionOnOpenAndClosed(
                 channel: serverChannel,
-                option: ChannelOptions.backlog,
+                option: .backlog,
                 value: 100
             )
         )
@@ -645,9 +645,9 @@ public final class SocketChannelTest: XCTestCase {
         let serverPromise = group.next().makePromise(of: IOError.self)
         let serverChannel = try assertNoThrowWithValue(
             ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .serverChannelOption(ChannelOptions.backlog, value: 256)
-                .serverChannelOption(ChannelOptions.autoRead, value: false)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .serverChannelOption(.backlog, value: 256)
+                .serverChannelOption(.autoRead, value: false)
                 .serverChannelInitializer { channel in channel.pipeline.addHandler(ErrorHandler(serverPromise)) }
                 .bind(host: "127.0.0.1", port: 0)
                 .wait()
@@ -804,8 +804,8 @@ public final class SocketChannelTest: XCTestCase {
                 group: group
             )
         )
-        XCTAssertNoThrow(try serverChan.setOption(ChannelOptions.maxMessagesPerRead, value: 1).wait())
-        XCTAssertNoThrow(try serverChan.setOption(ChannelOptions.autoRead, value: false).wait())
+        XCTAssertNoThrow(try serverChan.setOption(.maxMessagesPerRead, value: 1).wait())
+        XCTAssertNoThrow(try serverChan.setOption(.autoRead, value: false).wait())
         XCTAssertNoThrow(try serverChan.register().wait())
         XCTAssertNoThrow(try serverChan.bind(to: .init(ipAddress: "127.0.0.1", port: 0)).wait())
 
@@ -868,7 +868,7 @@ public final class SocketChannelTest: XCTestCase {
             var numberOfAcceptedChannels = 0
             let server = try assertNoThrowWithValue(
                 ServerBootstrap(group: group)
-                    .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: mode == .halfClosureEnabled)
+                    .childChannelOption(.allowRemoteHalfClosure, value: mode == .halfClosureEnabled)
                     .childChannelInitializer { channel in
                         numberOfAcceptedChannels += 1
                         XCTAssertEqual(1, numberOfAcceptedChannels)
@@ -947,7 +947,7 @@ public final class SocketChannelTest: XCTestCase {
             )
             let client = try assertNoThrowWithValue(
                 ClientBootstrap(group: group)
-                    .channelOption(ChannelOptions.allowRemoteHalfClosure, value: mode == .halfClosureEnabled)
+                    .channelOption(.allowRemoteHalfClosure, value: mode == .halfClosureEnabled)
                     .channelInitializer { channel in
                         channel.pipeline.addHandlers([
                             eventCounter,

--- a/Tests/NIOPosixTests/StreamChannelsTest.swift
+++ b/Tests/NIOPosixTests/StreamChannelsTest.swift
@@ -80,9 +80,9 @@ class StreamChannelTest: XCTestCase {
                     return
                 }
 
-                XCTAssertTrue(try syncOptions.getOption(ChannelOptions.autoRead))
-                XCTAssertNoThrow(try syncOptions.setOption(ChannelOptions.autoRead, value: false))
-                XCTAssertFalse(try syncOptions.getOption(ChannelOptions.autoRead))
+                XCTAssertTrue(try syncOptions.getOption(.autoRead))
+                XCTAssertNoThrow(try syncOptions.setOption(.autoRead, value: false))
+                XCTAssertFalse(try syncOptions.getOption(.autoRead))
             }
         }
 
@@ -193,7 +193,7 @@ class StreamChannelTest: XCTestCase {
             let allDonePromise = chan1.eventLoop.makePromise(of: ByteBuffer.self)
             let writabilityFalsePromise = chan1.eventLoop.makePromise(of: Void.self)
             let writeFullyDonePromise = chan1.eventLoop.makePromise(of: Void.self)
-            XCTAssertNoThrow(try chan2.setOption(ChannelOptions.autoRead, value: false).wait())
+            XCTAssertNoThrow(try chan2.setOption(.autoRead, value: false).wait())
             XCTAssertNoThrow(try chan2.pipeline.addHandler(AccumulateAllReads(allDonePromise: allDonePromise)).wait())
             XCTAssertNoThrow(
                 try chan1.pipeline.addHandler(
@@ -207,7 +207,7 @@ class StreamChannelTest: XCTestCase {
             // Writability should turn false because we're writing lots of data and we aren't reading.
             XCTAssertNoThrow(try writabilityFalsePromise.futureResult.wait())
             // Ok, let's read.
-            XCTAssertNoThrow(try chan2.setOption(ChannelOptions.autoRead, value: true).wait())
+            XCTAssertNoThrow(try chan2.setOption(.autoRead, value: true).wait())
             // Which should lead to the write to complete.
             XCTAssertNoThrow(try writeFullyDonePromise.futureResult.wait())
             // To finish up, let's just tear this down.
@@ -222,7 +222,7 @@ class StreamChannelTest: XCTestCase {
             let readPromise = chan2.eventLoop.makePromise(of: Void.self)
             let eofPromise = chan1.eventLoop.makePromise(of: Void.self)
 
-            XCTAssertNoThrow(try chan1.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).wait())
+            XCTAssertNoThrow(try chan1.setOption(.allowRemoteHalfClosure, value: true).wait())
             XCTAssertNoThrow(
                 try chan1.pipeline.addHandler(FulfillOnFirstEventHandler(userInboundEventTriggeredPromise: eofPromise))
                     .wait()
@@ -254,7 +254,7 @@ class StreamChannelTest: XCTestCase {
 
             let readPromise = chan1.eventLoop.makePromise(of: Void.self)
 
-            XCTAssertNoThrow(try chan2.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).wait())
+            XCTAssertNoThrow(try chan2.setOption(.allowRemoteHalfClosure, value: true).wait())
             // let's close chan2's input
             XCTAssertNoThrow(try chan2.close(mode: .input).wait())
 
@@ -277,7 +277,7 @@ class StreamChannelTest: XCTestCase {
 
     func testDoubleShutdownInput() {
         func runTest(chan1: Channel, chan2: Channel) throws {
-            XCTAssertNoThrow(try chan1.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).wait())
+            XCTAssertNoThrow(try chan1.setOption(.allowRemoteHalfClosure, value: true).wait())
             XCTAssertNoThrow(try chan1.close(mode: .input).wait())
             XCTAssertThrowsError(try chan1.close(mode: .input).wait()) { error in
                 XCTAssertEqual(ChannelError.inputClosed, error as? ChannelError, "\(chan1)")
@@ -288,7 +288,7 @@ class StreamChannelTest: XCTestCase {
 
     func testDoubleShutdownOutput() {
         func runTest(chan1: Channel, chan2: Channel) throws {
-            XCTAssertNoThrow(try chan2.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).wait())
+            XCTAssertNoThrow(try chan2.setOption(.allowRemoteHalfClosure, value: true).wait())
             XCTAssertNoThrow(try chan1.close(mode: .output).wait())
             XCTAssertThrowsError(try chan1.close(mode: .output).wait()) { error in
                 XCTAssertEqual(ChannelError.outputClosed, error as? ChannelError, "\(chan1)")
@@ -299,7 +299,7 @@ class StreamChannelTest: XCTestCase {
 
     func testWriteFailsAfterOutputClosed() {
         func runTest(chan1: Channel, chan2: Channel) throws {
-            XCTAssertNoThrow(try chan2.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).wait())
+            XCTAssertNoThrow(try chan2.setOption(.allowRemoteHalfClosure, value: true).wait())
             XCTAssertNoThrow(try chan1.close(mode: .output).wait())
             var buffer = chan1.allocator.buffer(capacity: 10)
             buffer.writeString("helloworld")
@@ -358,7 +358,7 @@ class StreamChannelTest: XCTestCase {
                 receiver.eventLoop !== sender.eventLoop,
                 "this test cannot run if sender and receiver live on the same EventLoop. \(receiver)"
             )
-            XCTAssertNoThrow(try receiver.setOption(ChannelOptions.autoRead, value: false).wait())
+            XCTAssertNoThrow(try receiver.setOption(.autoRead, value: false).wait())
             let areReadsOkayNow = ManagedAtomic(false)
             XCTAssertNoThrow(
                 try receiver.pipeline.addHandler(FailOnReadHandler(areReadOkayNow: areReadsOkayNow)).wait()
@@ -366,7 +366,7 @@ class StreamChannelTest: XCTestCase {
 
             // We will immediately send exactly the amount of data that fits in the receiver's receive buffer.
             let receiveBufferSize = Int(
-                (try? receiver.getOption(ChannelOptions.socketOption(.so_rcvbuf)).wait()) ?? 8192
+                (try? receiver.getOption(.socketOption(.so_rcvbuf)).wait()) ?? 8192
             )
             var buffer = sender.allocator.buffer(capacity: receiveBufferSize)
             buffer.writeBytes(Array(repeating: UInt8(ascii: "X"), count: receiveBufferSize))
@@ -442,7 +442,7 @@ class StreamChannelTest: XCTestCase {
 
         func runTest(receiver: Channel, sender: Channel) throws {
             let allDonePromise = receiver.eventLoop.makePromise(of: Void.self)
-            XCTAssertNoThrow(try sender.setOption(ChannelOptions.writeSpin, value: 0).wait())
+            XCTAssertNoThrow(try sender.setOption(.writeSpin, value: 0).wait())
             XCTAssertNoThrow(
                 try receiver.pipeline.addHandler(WaitForTwoBytesHandler(allDonePromise: allDonePromise)).wait()
             )
@@ -486,7 +486,7 @@ class StreamChannelTest: XCTestCase {
                     // raise the high water mark so we don't get another call straight away.
                     var buffer = context.channel.allocator.buffer(capacity: 5)
                     buffer.writeString("hello")
-                    context.channel.setOption(ChannelOptions.writeBufferWaterMark, value: .init(low: 1024, high: 1024))
+                    context.channel.setOption(.writeBufferWaterMark, value: .init(low: 1024, high: 1024))
                         .flatMap {
                             context.writeAndFlush(Self.wrapOutboundOut(buffer))
                         }.whenFailure { error in
@@ -525,10 +525,10 @@ class StreamChannelTest: XCTestCase {
 
         func runTest(receiver: Channel, sender: Channel) throws {
             // Write spin might just disturb this test so let's switch it off
-            XCTAssertNoThrow(try sender.setOption(ChannelOptions.writeSpin, value: 0).wait())
+            XCTAssertNoThrow(try sender.setOption(.writeSpin, value: 0).wait())
             // Writing more than the high water mark will cause the channel to become unwritable very easily
             XCTAssertNoThrow(
-                try sender.setOption(ChannelOptions.writeBufferWaterMark, value: .init(low: 1, high: 1)).wait()
+                try sender.setOption(.writeBufferWaterMark, value: .init(low: 1, high: 1)).wait()
             )
 
             let sevenBytesReceived = receiver.eventLoop.makePromise(of: Void.self)
@@ -624,7 +624,7 @@ class StreamChannelTest: XCTestCase {
                 // We set the high watermark such that if we can't write something immediately, we'll get a
                 // writabilityChanged notification.
                 context.channel.setOption(
-                    ChannelOptions.writeBufferWaterMark,
+                    .writeBufferWaterMark,
                     value: .init(
                         low: self.chunkSize,
                         high: self.chunkSize + 1
@@ -634,7 +634,7 @@ class StreamChannelTest: XCTestCase {
                 }
 
                 // Write spin count would make the test less deterministic, so let's switch it off.
-                context.channel.setOption(ChannelOptions.writeSpin, value: 0).whenFailure { error in
+                context.channel.setOption(.writeSpin, value: 0).whenFailure { error in
                     XCTFail("unexpected error \(error)")
                 }
 
@@ -754,7 +754,7 @@ class StreamChannelTest: XCTestCase {
             var state: State = .waitingForInitialOutsideReadCall
 
             func handlerAdded(context: ChannelHandlerContext) {
-                context.channel.setOption(ChannelOptions.autoRead, value: false).whenFailure { error in
+                context.channel.setOption(.autoRead, value: false).whenFailure { error in
                     XCTFail("unexpected error \(error)")
                 }
             }
@@ -824,7 +824,7 @@ class StreamChannelTest: XCTestCase {
 
             // We need to not read automatically from the receiving end to be able to force writability notifications
             // for the sender.
-            XCTAssertNoThrow(try receiver.setOption(ChannelOptions.autoRead, value: false).wait())
+            XCTAssertNoThrow(try receiver.setOption(.autoRead, value: false).wait())
 
             XCTAssertNoThrow(try receiver.pipeline.addHandler(ReadChunksUntilWeSee1Handler()).wait())
 
@@ -859,7 +859,7 @@ class StreamChannelTest: XCTestCase {
             // Let's prepare the receiver's allocator to allocate exactly the right amount of bytes :), ...
             XCTAssertNoThrow(
                 try receiver.setOption(
-                    ChannelOptions.recvAllocator,
+                    .recvAllocator,
                     value: FixedSizeRecvByteBufferAllocator(capacity: bytes)
                 ).wait()
             )
@@ -875,7 +875,7 @@ class StreamChannelTest: XCTestCase {
             XCTAssertNoThrow(try beganBigWritePromise.futureResult.wait())
 
             // We now just set autoRead to true and let the receiver receive everything to tear everything down.
-            XCTAssertNoThrow(try receiver.setOption(ChannelOptions.autoRead, value: true).wait())
+            XCTAssertNoThrow(try receiver.setOption(.autoRead, value: true).wait())
 
             XCTAssertNoThrow(try finishedBigWritePromise.futureResult.wait())
         }
@@ -922,7 +922,7 @@ class StreamChannelTest: XCTestCase {
             XCTAssertNoThrow(try sender.pipeline.addHandler(CloseInWritabilityChanged(amount: amount)).wait())
             XCTAssertNoThrow(
                 try sender.setOption(
-                    ChannelOptions.writeBufferWaterMark,
+                    .writeBufferWaterMark,
                     value: .init(
                         low: amount - 1,
                         high: amount - 1

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -666,7 +666,7 @@ func withTCPServerChannel<R>(
     _ body: (Channel) throws -> R
 ) throws -> R {
     let server = try ServerBootstrap(group: group)
-        .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
         .bind(to: bindTarget ?? .init(ipAddress: "127.0.0.1", port: 0))
         .wait()
     do {

--- a/Tests/NIOPosixTests/UniversalBootstrapSupportTest.swift
+++ b/Tests/NIOPosixTests/UniversalBootstrapSupportTest.swift
@@ -85,7 +85,7 @@ class UniversalBootstrapSupportTest: XCTestCase {
                     .channelInitializer { channel in
                         channel.pipeline.addHandlers(counter1, DropChannelReadsHandler(), counter2)
                     }
-                    .channelOption(ChannelOptions.autoRead, value: false)
+                    .channelOption(.autoRead, value: false)
                     .connectTimeout(.hours(1))
                     .enableTLS()
                     .connect(to: server.localAddress!)

--- a/Tests/NIOPosixTests/VsockAddressTest.swift
+++ b/Tests/NIOPosixTests/VsockAddressTest.swift
@@ -78,6 +78,6 @@ class VsockAddressTest: XCTestCase {
             eventLoop: eventLoop as! SelectableEventLoop,
             group: singleThreadedELG
         )
-        XCTAssertEqual(try channel.getOption(ChannelOptions.localVsockContextID).wait(), localCID)
+        XCTAssertEqual(try channel.getOption(.localVsockContextID).wait(), localCID)
     }
 }

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -33,7 +33,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
 
     func connect(serverPort: Int, responsePromise: EventLoopPromise<String>) throws -> EventLoopFuture<Channel> {
         let bootstrap = ClientBootstrap(group: self.group)
-            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers(
                     position: .first,


### PR DESCRIPTION
ChannelOption: Allow types to be accessed with leading dot syntax

### Motivation:

Since Swift 5.5 and [SE-0299](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0299-extend-generic-static-member-lookup.md) it is possible to add static members to protocols which are discoverable through the shorthand dot syntax.
This change reduces type repetition and improves call-site legibility.

### Modifications:

Added extensions for ChannelOption with static members where Self is bound to a concrete type.

### Result:

ChannelOption types can be used with the leading dot syntax. For eg:

```
//before
.channelOption(ChannelOptions.explicitCongestionNotification, value: true)
.channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)

//after
.channelOption(.explicitCongestionNotification, value: true)
.channelOption(.socketOption(.so_reuseaddr), value: 1)
```