### PR TITLE
Fix test compilation on non-macOS Darwin platforms

### DIFF
--- a/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
@@ -502,7 +502,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                try await Task.sleep(for: .milliseconds(1))
+                try await Task.sleep(nanoseconds: 1_000_000)
                 await eventLoop.shutdownGracefully()
             }
             group.addTask {


### PR DESCRIPTION
### Motivation

Some tests were making use of `Task.sleep(for:)` which isn't present on older platforms.

```
/workspace/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift:505:32: error: 'sleep(for:tolerance:clock:)' is only available in tvOS 16.0 or newer
                     try await Task.sleep(for: .milliseconds(1))
```

### Modifications

Update tests to use `Task.sleep(nanoseconds:)` instead, which is available on those platforms.

### Result

Can build tests on older platforms.