### PR TITLE
Provide a default CopyStrategy overload for copyItem.

### DIFF
--- a/Sources/NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/NIOFileSystem/FileSystemProtocol.swift
@@ -535,6 +535,52 @@ extension FileSystemProtocol {
             }
         )
     }
+    
+    /// Copies the item at the specified path to a new location.
+    ///
+    /// The following error codes may be thrown:
+    /// - ``FileSystemError/Code-swift.struct/notFound`` if the item at `sourcePath` does not exist,
+    /// - ``FileSystemError/Code-swift.struct/invalidArgument`` if an item at `destinationPath`
+    ///   exists prior to the copy or its parent directory does not exist.
+    ///
+    /// Note that other errors may also be thrown.
+    ///
+    /// If `sourcePath` is a symbolic link then only the link is copied. The copied file will
+    /// preserve permissions and any extended attributes (if supported by the file system).
+    ///
+    /// - Parameters:
+    ///   - sourcePath: The path to the item to copy.
+    ///   - destinationPath: The path at which to place the copy.
+    ///   - shouldProceedAfterError: A closure which is executed to determine whether to continue
+    ///       copying files if an error is encountered during the operation. See Errors section for full details.
+    ///   - shouldCopyItem: A closure which is executed before each copy to determine whether each
+    ///       item should be copied. See Filtering section for full details
+    ///
+    /// #### Parallelism
+    ///
+    /// This overload uses ``CopyStrategy/platformDefault`` which is likely to result in multiple concurrency domains being used
+    /// in the event of copying a directory.
+    /// See the detailed description on ``copyItem(at:to:strategy:shouldProceedAfterError:shouldCopyItem:)``
+    /// for the implications of this with respect to the `shouldProceedAfterError` and `shouldCopyItem` callbacks
+    func copyItem(
+        at sourcePath: FilePath,
+        to destinationPath: FilePath,
+        shouldProceedAfterError: @escaping @Sendable (
+            _ source: DirectoryEntry,
+            _ error: Error
+        ) async throws -> Void,
+        shouldCopyItem: @escaping @Sendable (
+            _ source: DirectoryEntry,
+            _ destination: FilePath
+        ) async -> Bool
+    ) async throws {
+        try await self.copyItem(
+            at: sourcePath,
+            to: destinationPath,
+            strategy: .platformDefault,
+            shouldProceedAfterError: shouldProceedAfterError,
+            shouldCopyItem: shouldCopyItem)
+    }
 
     /// Deletes the file or directory (and its contents) at `path`.
     ///

--- a/Sources/NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/NIOFileSystem/FileSystemProtocol.swift
@@ -562,7 +562,7 @@ extension FileSystemProtocol {
     /// in the event of copying a directory.
     /// See the detailed description on ``copyItem(at:to:strategy:shouldProceedAfterError:shouldCopyItem:)``
     /// for the implications of this with respect to the `shouldProceedAfterError` and `shouldCopyItem` callbacks
-    func copyItem(
+    public func copyItem(
         at sourcePath: FilePath,
         to destinationPath: FilePath,
         shouldProceedAfterError: @escaping @Sendable (

--- a/Sources/NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/NIOFileSystem/FileSystemProtocol.swift
@@ -535,7 +535,7 @@ extension FileSystemProtocol {
             }
         )
     }
-    
+
     /// Copies the item at the specified path to a new location.
     ///
     /// The following error codes may be thrown:
@@ -579,7 +579,8 @@ extension FileSystemProtocol {
             to: destinationPath,
             strategy: .platformDefault,
             shouldProceedAfterError: shouldProceedAfterError,
-            shouldCopyItem: shouldCopyItem)
+            shouldCopyItem: shouldCopyItem
+        )
     }
 
     /// Deletes the file or directory (and its contents) at `path`.

--- a/Sources/NIOFileSystem/Internal/ParallelDirCopy.swift
+++ b/Sources/NIOFileSystem/Internal/ParallelDirCopy.swift
@@ -134,6 +134,8 @@ extension FileSystem {
                     if let item = item {
                         keepConsuming = !onNextItem(item)
                     } else {
+                        // To accurately propagate the cancellation we must check here too
+                        try Task.checkCancellation()
                         keepConsuming = false
                     }
                 }


### PR DESCRIPTION
FilesystemProtocol/copyItem has an overload providing the default CopyStrategy

### Motivation:

Based on user feedback from #2806 
This makes it easier to use, especially when copying files such that it is irrelevant.

### Modifications:

Add overload providing ```(at:to:shouldProceedAfterError:shouldCopyItem:)``` with ```CopyStrategy.platformDefault```
as the strategy.

### Result:

A simpler and more robust to change API will exist for ```copyItem()```
