### PR TITLE
Add `.index-build` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.index-build
 /Packages
 /*.xcodeproj
 Package.pins


### PR DESCRIPTION
### Motivation:

This directory is created when background indexing is enabled in SourceKit-LSP.

### Modifications:

A single line added to `.gitignore` with the name of the directory.

### Result:

No need to clean up the directory before committing.
