### PR TITLE
Clone files on Darwin rather than copying them

### DIFF
--- a/Sources/NIOFileSystem/FileSystem.swift
+++ b/Sources/NIOFileSystem/FileSystem.swift
@@ -1183,7 +1183,7 @@ extension FileSystem {
             state: nil,
             flags: flags
         ).mapError { errno in
-            FileSystemError.fcopyfile(
+            FileSystemError.copyfile(
                 errno: errno,
                 from: sourcePath,
                 to: destinationPath,

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -1016,6 +1016,25 @@ extension FileSystemError {
                 Can't copy file from '\(sourcePath)' to '\(destinationPath)', the destination \
                 path already exists.
                 """
+        case .fileExists:
+            code = .fileAlreadyExists
+            message = """
+                Unable to create file at path '\(destinationPath)', no existing file options were set \
+                which implies that no file should exist but a file already exists at the \
+                specified path.
+                """
+        case .tooManyOpenFiles:
+            code = .unavailable
+            message = """
+                Unable to open the source ('\(sourcePath)') or destination ('\(destinationPath)') files, \
+                too many file descriptors are open.
+                """
+        case .noSuchFileOrDirectory:
+            code = .notFound
+            message = """
+                Unable to open or create file at path '\(sourcePath)', either a component of the \
+                path did not exist or the named file to be opened did not exist.
+                """
         default:
             code = .unknown
             message = "Can't copy file from '\(sourcePath)' to '\(destinationPath)'."

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -993,6 +993,38 @@ extension FileSystemError {
         to destinationPath: FilePath,
         location: SourceLocation
     ) -> Self {
+        Self._copyfile(
+            "fcopyfile",
+            errno: errno,
+            from: sourcePath,
+            to: destinationPath,
+            location: location
+        )
+    }
+
+    @_spi(Testing)
+    public static func copyfile(
+        errno: Errno,
+        from sourcePath: FilePath,
+        to destinationPath: FilePath,
+        location: SourceLocation
+    ) -> Self {
+        Self._copyfile(
+            "copyfile",
+            errno: errno,
+            from: sourcePath,
+            to: destinationPath,
+            location: location
+        )
+    }
+
+    private static func _copyfile(
+        _ name: String,
+        errno: Errno,
+        from sourcePath: FilePath,
+        to destinationPath: FilePath,
+        location: SourceLocation
+    ) -> Self {
         let code: Code
         let message: String
 
@@ -1043,7 +1075,7 @@ extension FileSystemError {
         return FileSystemError(
             code: code,
             message: message,
-            systemCall: "fcopyfile",
+            systemCall: name,
             errno: errno,
             location: location
         )

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -313,6 +313,24 @@ public enum Libc {
     }
     #endif
 
+    #if canImport(Darwin)
+    @_spi(Testing)
+    public static func copyfile(
+        from source: FilePath,
+        to destination: FilePath,
+        state: copyfile_state_t?,
+        flags: copyfile_flags_t
+    ) -> Result<Void, Errno> {
+        source.withPlatformString { sourcePath in
+            destination.withPlatformString { destinationPath in
+                nothingOrErrno(retryOnInterrupt: false) {
+                    libc_copyfile(sourcePath, destinationPath, state, flags)
+                }
+            }
+        }
+    }
+    #endif
+
     @_spi(Testing)
     public static func remove(
         _ path: FilePath

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -400,7 +400,7 @@ internal func libc_remove(
 }
 
 #if canImport(Darwin)
-/// copyfile(3): Copy a file from one file to another. (fcopyfile)
+/// fcopyfile(3): Copy a file from one file to another.
 internal func libc_fcopyfile(
     _ from: CInt,
     _ to: CInt,
@@ -417,7 +417,7 @@ internal func libc_fcopyfile(
 #endif
 
 #if canImport(Darwin)
-/// copyfile(3): Copy a file from one file to another. (copyfile)
+/// copyfile(3): Copy a file from one file to another.
 internal func libc_copyfile(
     _ from: UnsafePointer<CInterop.PlatformChar>,
     _ to: UnsafePointer<CInterop.PlatformChar>,

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -400,7 +400,7 @@ internal func libc_remove(
 }
 
 #if canImport(Darwin)
-/// copyfile(3): Copy a file from one file to another.
+/// copyfile(3): Copy a file from one file to another. (fcopyfile)
 internal func libc_fcopyfile(
     _ from: CInt,
     _ to: CInt,
@@ -413,6 +413,23 @@ internal func libc_fcopyfile(
     }
     #endif
     return fcopyfile(from, to, state, flags)
+}
+#endif
+
+#if canImport(Darwin)
+/// copyfile(3): Copy a file from one file to another. (copyfile)
+internal func libc_copyfile(
+    _ from: UnsafePointer<CInterop.PlatformChar>,
+    _ to: UnsafePointer<CInterop.PlatformChar>,
+    _ state: copyfile_state_t?,
+    _ flags: copyfile_flags_t
+) -> CInt {
+    #if ENABLE_MOCKING
+    if mockingEnabled {
+        return mock(from, to, state, flags)
+    }
+    #endif
+    return copyfile(from, to, state, flags)
 }
 #endif
 

--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
@@ -659,14 +659,14 @@ final class FileSystemTests: XCTestCase {
     /// This is is not quite the same as sequential, different code paths are used.
     /// Tests using this ensure use of the parallel paths (which are more complex) while keeping actual
     /// parallelism to minimal levels to make debugging simpler.
-    private let minimalParallel: CopyStrategy = try! .parallel(maxDescriptors: 2)
+    private static let minimalParallel: CopyStrategy = try! .parallel(maxDescriptors: 2)
 
     func testCopyEmptyDirectorySequential() async throws {
         try await testCopyEmptyDirectory(.sequential)
     }
 
     func testCopyEmptyDirectoryParallelMinimal() async throws {
-        try await testCopyEmptyDirectory(minimalParallel)
+        try await testCopyEmptyDirectory(Self.minimalParallel)
     }
 
     func testCopyEmptyDirectoryParallelDefault() async throws {
@@ -690,7 +690,7 @@ final class FileSystemTests: XCTestCase {
     }
 
     func testCopyOnGeneratedTreeStructureParallelMinimal() async throws {
-        try await testAnyCopyStrategyOnGeneratedTreeStructure(minimalParallel)
+        try await testAnyCopyStrategyOnGeneratedTreeStructure(Self.minimalParallel)
     }
 
     func testCopyOnGeneratedTreeStructureParallelDefault() async throws {
@@ -737,7 +737,7 @@ final class FileSystemTests: XCTestCase {
     }
 
     func testCopySelectivelyParallelMinimal() async throws {
-        try await testCopySelectively(minimalParallel)
+        try await testCopySelectively(Self.minimalParallel)
     }
 
     func testCopySelectivelyParallelDefault() async throws {
@@ -780,7 +780,7 @@ final class FileSystemTests: XCTestCase {
     }
 
     func testCopyCancelledPartWayThroughParallelMinimal() async throws {
-        try await testCopyCancelledPartWayThrough(minimalParallel)
+        try await testCopyCancelledPartWayThrough(Self.minimalParallel)
     }
 
     func testCopyCancelledPartWayThroughParallelDefault() async throws {
@@ -927,7 +927,7 @@ final class FileSystemTests: XCTestCase {
     }
 
     func testCopyNonExistentFileParallelMinimal() async throws {
-        try await testCopyNonExistentFile(minimalParallel)
+        try await testCopyNonExistentFile(Self.minimalParallel)
     }
 
     func testCopyNonExistentFileParallelDefault() async throws {
@@ -953,7 +953,7 @@ final class FileSystemTests: XCTestCase {
     }
 
     func testCopyToExistingDestinationParallelMinimal() async throws {
-        try await testCopyToExistingDestination(minimalParallel)
+        try await testCopyToExistingDestination(Self.minimalParallel)
     }
 
     func testCopyToExistingDestinationParallelDefault() async throws {

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -261,6 +261,10 @@ final class FileSystemErrorTests: XCTestCase {
             .fcopyfile(errno: .badFileDescriptor, from: "src", to: "dst", location: here)
         }
 
+        assertCauseIsSyscall("copyfile", here) {
+            .copyfile(errno: .badFileDescriptor, from: "src", to: "dst", location: here)
+        }
+
         assertCauseIsSyscall("sendfile", here) {
             .sendfile(errno: .badFileDescriptor, from: "src", to: "dst", location: here)
         }
@@ -520,6 +524,21 @@ final class FileSystemErrorTests: XCTestCase {
             ]
         ) { errno in
             .readlink(errno: errno, path: "", location: .fixed)
+        }
+    }
+
+    func testErrnoMapping_copyfile() {
+        self.testErrnoToErrorCode(
+            expected: [
+                .notSupported: .invalidArgument,
+                .permissionDenied: .permissionDenied,
+                .invalidArgument: .invalidArgument,
+                .fileExists: .fileAlreadyExists,
+                .tooManyOpenFiles: .unavailable,
+                .noSuchFileOrDirectory: .notFound,
+            ]
+        ) { errno in
+            .copyfile(errno: errno, from: "src", to: "dst", location: .fixed)
         }
     }
 

--- a/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
@@ -389,6 +389,20 @@ final class SyscallTests: XCTestCase {
         #endif
     }
 
+    func test_copyfile() throws {
+        #if canImport(Darwin)
+
+        let testCases: [MockTestCase] = [
+            MockTestCase(name: "copyfile", .noInterrupt, "foo", "bar", "nil", 0) { _ in
+                try Libc.copyfile(from: "foo", to: "bar", state: nil, flags: 0).get()
+            }
+        ]
+        testCases.run()
+        #else
+        throw XCTSkip("'copyfile' is only supported on Darwin")
+        #endif
+    }
+
     func test_remove() throws {
         let testCases: [MockTestCase] = [
             MockTestCase(name: "remove", .noInterrupt, "somepath") { _ in


### PR DESCRIPTION
### Motivation:

Copying regular files on Darwin was taking more time than it needed to because it was manually opening files and copying over bites rather than making use of the system's ability to create CoW clones.

### Modifications:

The primary change is to switch `copyItem` to be backed by Darwin's `copyfile` method rather than `fcopyfile`. `fcopyfile` ignores the flag we were passing in to indicate that the file should be cloned if possible, whereas `copyfile` is a higher-level API which takes this into account.

This change exposes a `copyfile` wrapper method as a new public function.

This change also adds a workaround to a seeming compiler bug on channel options blocking building tests on more recent Xcodes.

### Result:

Copying files on Darwin will be faster.
