### PR TITLE
Fix failing build for test

### DIFF
--- a/Tests/NIOPosixTests/StreamChannelsTest.swift
+++ b/Tests/NIOPosixTests/StreamChannelsTest.swift
@@ -366,7 +366,7 @@ class StreamChannelTest: XCTestCase {
 
             // We will immediately send exactly the amount of data that fits in the receiver's receive buffer.
             let receiveBufferSize = Int(
-                (try? receiver.getOption(.socketOption(.so_rcvbuf)).wait()) ?? 8192
+                (try? receiver.getOption(ChannelOptions.socketOption(.so_rcvbuf)).wait()) ?? 8192
             )
             var buffer = sender.allocator.buffer(capacity: receiveBufferSize)
             buffer.writeBytes(Array(repeating: UInt8(ascii: "X"), count: receiveBufferSize))


### PR DESCRIPTION
Fix build of test 

### Motivation:

The build of this test fails when using leading dot syntax for changes made in #2816 .

### Modifications:

Reverted the use of dot syntax in this specific test

### Result:

Build is now successful
