### PR TITLE
Add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.licenseignore
+++ b/.licenseignore
@@ -7,6 +7,7 @@
 .mailmap
 .spi.yml
 .swift-format
+.editorconfig
 .github/*
 *.md
 *.txt


### PR DESCRIPTION
# Motivation

[EditorConfig](https://editorconfig.org) helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. It will be helpful to add one of these files to swift-testing so that all contributors use the whitespace conventions described in our [style guide](https://github.com/swiftlang/swift-testing/blob/main/Documentation/StyleGuide.md) automatically when using a supported IDE/editor.

Note that Xcode 16 Beta has added support for EditorConfig files — see 20796230 in the [release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes).

# Modification

This PR adds the `.editorconfig` file.

# Result

Easier to maintain a consistent style
