### PR TITLE
Adopt strict concurrency and Sendable in NIOConcurrencyHelpers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,11 @@ let swiftSystem: PackageDescription.Target.Dependency = .product(
     condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .linux, .android])
 )
 
+let strictConcurrencySettings: [SwiftSetting] = [
+    .enableUpcomingFeature("StrictConcurrency"),
+    .enableUpcomingFeature("InferSendableFromCaptures"),
+]
+
 // This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and
 // Foundation will be linked. This is, however, strictly better than unconditionally adding the
 // resource.
@@ -150,7 +155,8 @@ let package = Package(
             name: "NIOConcurrencyHelpers",
             dependencies: [
                 "CNIOAtomics"
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "NIOHTTP1",

--- a/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
@@ -19,6 +19,19 @@ import CNIOAtomics
 /// **Do not add conformance to this protocol for arbitrary types**. Only a small range
 /// of types have appropriate atomic operations supported by the CPU, and those types
 /// already have conformances implemented.
+#if compiler(>=6.0)
+@preconcurrency
+public protocol NIOAtomicPrimitive {
+    associatedtype AtomicWrapper
+    static var nio_atomic_create_with_existing_storage: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Void { get }
+    static var nio_atomic_compare_and_exchange: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self, Self) -> Bool { get }
+    static var nio_atomic_add: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Self { get }
+    static var nio_atomic_sub: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Self { get }
+    static var nio_atomic_exchange: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Self { get }
+    static var nio_atomic_load: @Sendable (UnsafeMutablePointer<AtomicWrapper>) -> Self { get }
+    static var nio_atomic_store: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Void { get }
+}
+#else
 public protocol NIOAtomicPrimitive {
     associatedtype AtomicWrapper
     static var nio_atomic_create_with_existing_storage: (UnsafeMutablePointer<AtomicWrapper>, Self) -> Void { get }
@@ -29,6 +42,7 @@ public protocol NIOAtomicPrimitive {
     static var nio_atomic_load: (UnsafeMutablePointer<AtomicWrapper>) -> Self { get }
     static var nio_atomic_store: (UnsafeMutablePointer<AtomicWrapper>, Self) -> Void { get }
 }
+#endif
 
 extension Bool: NIOAtomicPrimitive {
     public typealias AtomicWrapper = catmc_nio_atomic__Bool

--- a/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOAtomic.swift
@@ -23,8 +23,12 @@ import CNIOAtomics
 @preconcurrency
 public protocol NIOAtomicPrimitive {
     associatedtype AtomicWrapper
-    static var nio_atomic_create_with_existing_storage: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Void { get }
-    static var nio_atomic_compare_and_exchange: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self, Self) -> Bool { get }
+    static var nio_atomic_create_with_existing_storage: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Void {
+        get
+    }
+    static var nio_atomic_compare_and_exchange: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self, Self) -> Bool {
+        get
+    }
     static var nio_atomic_add: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Self { get }
     static var nio_atomic_sub: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Self { get }
     static var nio_atomic_exchange: @Sendable (UnsafeMutablePointer<AtomicWrapper>, Self) -> Self { get }

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -166,7 +166,7 @@ public struct UnsafeEmbeddedAtomic<T: AtomicPrimitive> {
 }
 
 @available(*, deprecated)
-extension UnsafeEmbeddedAtomic: @unchecked Sendable where T: Sendable { }
+extension UnsafeEmbeddedAtomic: @unchecked Sendable where T: Sendable {}
 
 /// An encapsulation of an atomic primitive object.
 ///

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -288,7 +288,7 @@ public final class Atomic<T: AtomicPrimitive> {
 }
 
 @available(*, deprecated)
-extension Atomic: @unchecked Sendable where T: Sendable { }
+extension Atomic: @unchecked Sendable where T: Sendable {}
 
 /// The protocol that all types that can be made atomic must conform to.
 ///
@@ -619,4 +619,4 @@ public final class AtomicBox<T: AnyObject> {
 }
 
 @available(*, deprecated)
-extension AtomicBox: @unchecked Sendable where T: Sendable { }
+extension AtomicBox: @unchecked Sendable where T: Sendable {}

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -165,6 +165,9 @@ public struct UnsafeEmbeddedAtomic<T: AtomicPrimitive> {
     }
 }
 
+@available(*, deprecated)
+extension UnsafeEmbeddedAtomic: @unchecked Sendable where T: Sendable { }
+
 /// An encapsulation of an atomic primitive object.
 ///
 /// Atomic objects support a wide range of atomic operations:
@@ -284,11 +287,27 @@ public final class Atomic<T: AtomicPrimitive> {
     }
 }
 
+@available(*, deprecated)
+extension Atomic: @unchecked Sendable where T: Sendable { }
+
 /// The protocol that all types that can be made atomic must conform to.
 ///
 /// **Do not add conformance to this protocol for arbitrary types**. Only a small range
 /// of types have appropriate atomic operations supported by the CPU, and those types
 /// already have conformances implemented.
+#if compiler(>=6.0)
+@preconcurrency
+public protocol AtomicPrimitive {
+    static var atomic_create: @Sendable (Self) -> OpaquePointer { get }
+    static var atomic_destroy: @Sendable (OpaquePointer) -> Void { get }
+    static var atomic_compare_and_exchange: @Sendable (OpaquePointer, Self, Self) -> Bool { get }
+    static var atomic_add: @Sendable (OpaquePointer, Self) -> Self { get }
+    static var atomic_sub: @Sendable (OpaquePointer, Self) -> Self { get }
+    static var atomic_exchange: @Sendable (OpaquePointer, Self) -> Self { get }
+    static var atomic_load: @Sendable (OpaquePointer) -> Self { get }
+    static var atomic_store: @Sendable (OpaquePointer, Self) -> Void { get }
+}
+#else
 public protocol AtomicPrimitive {
     static var atomic_create: (Self) -> OpaquePointer { get }
     static var atomic_destroy: (OpaquePointer) -> Void { get }
@@ -299,6 +318,7 @@ public protocol AtomicPrimitive {
     static var atomic_load: (OpaquePointer) -> Self { get }
     static var atomic_store: (OpaquePointer, Self) -> Void { get }
 }
+#endif
 
 extension Bool: AtomicPrimitive {
     public static let atomic_create = catmc_atomic__Bool_create
@@ -597,3 +617,6 @@ public final class AtomicBox<T: AnyObject> {
         _ = self.exchange(with: value)
     }
 }
+
+@available(*, deprecated)
+extension AtomicBox: @unchecked Sendable where T: Sendable { }


### PR DESCRIPTION
Motivation:

This patch adds strict concurrency and Sendable support to NIOConcurrencyHelpers. This is a useful first step in adding full support across the ecosystem.

Modifications:

- Added some explicit Sendable conformances that were missing.
- Fixed some declarations to make them Strict Sendable safe.

Result:

One step towards strict concurrency