### PR TITLE
Update the triggers for the Semantic Version label check

### DIFF
--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -2,7 +2,7 @@ name: PR label
 
 on:
     pull_request:
-        types: [labeled, unlabeled]
+        types: [labeled, unlabeled, opened, reopened, synchronize]
 
 jobs:
     semver-label-check:


### PR DESCRIPTION
# Motivation

The checks get cleared when the PR state changes however we weren't re-running the label workflow.

# Modification

This PR modifiers the triggers for the label workflow to also run on the triggers when the other workflow runs

# Result

Always correct label checks