### PR TITLE
Adopt strict concurrency in _NIODataStructures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,12 @@ let strictConcurrencySettings: [SwiftSetting] = [
     .enableUpcomingFeature("InferSendableFromCaptures"),
 ]
 
+// Add these Swift settings to targets that need to be validated
+// for strict concurrency.
+let diagnosticSettings: [SwiftSetting] = [
+    .unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]),
+]
+
 // This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and
 // Foundation will be linked. This is, however, strictly better than unconditionally adding the
 // resource.
@@ -71,7 +77,8 @@ let package = Package(
             ]
         ),
         .target(
-            name: "_NIODataStructures"
+            name: "_NIODataStructures",
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "_NIOBase64"

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let strictConcurrencySettings: [SwiftSetting] = [
 // Add these Swift settings to targets that need to be validated
 // for strict concurrency.
 let diagnosticSettings: [SwiftSetting] = [
-    .unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]),
+    .unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"])
 ]
 
 // This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and

--- a/Sources/_NIODataStructures/_TinyArray.swift
+++ b/Sources/_NIODataStructures/_TinyArray.swift
@@ -99,6 +99,8 @@ extension _TinyArray: RandomAccessCollection {
     }
 }
 
+extension _TinyArray.Iterator: Sendable where Element: Sendable {}
+
 extension _TinyArray {
     @inlinable
     public init(_ elements: some Sequence<Element>) {


### PR DESCRIPTION
Motivation:

We're slowly adopting strict concurrency in NIO. This is next.

Modifications:

- Make TinyArray's Iterator Sendable
- Add the stict concurrency flags

Result:

One small step for NIO, one giant leap for NIOkind.
