### PR TITLE
Fix text availability

### DIFF
--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
@@ -882,7 +882,7 @@ final class FileSystemTests: XCTestCase {
                     // Give the cancellation time to kick in, this should be more than plenty.
                     if shouldSleep {
                         do {
-                            try await Task.sleep(for: .seconds(3))
+                            try await Task.sleep(nanoseconds: 3_000_000_000)
                             XCTFail("\(description) Should have been cancelled by now!")
                         } catch is CancellationError {
                             // This is fine - we got cancelled as desired, let the rest of the in flight


### PR DESCRIPTION
Motivation:

022ee1328b uses `Task.sleep(for:)` which isn't available in older SDKs.

Modifications:

- Use `Task.sleep(nanoseconds:)`

Result:

Tests compile with older SDKs