### PR TITLE
Issue-2748 - Add ByteBuffer Hex init & write

### DIFF
--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -92,19 +92,14 @@ extension ByteBuffer {
     }
 
     // MARK: Hex encoded string APIs
-    /// Write `hex encoded string` into this `ByteBuffer`, moving the writer index forward appropriately.
-    ///
+    /// Write `string` into this `ByteBuffer` in ASCII hexadecimal, moving the writer index forward appropriately.
     /// - parameters:
     ///     - string: The hex encoded string to write.
     /// - returns: The number of bytes written.
     @discardableResult
     @inlinable
     public mutating func writeHexEncodedBytes(_ string: String) -> Int {
-        let hexPlainDecodedBytes = string.hexPlainDecodedBytes
-        guard !hexPlainDecodedBytes.isEmpty else {
-            return 0
-        }
-        let written = self.setBytes(hexPlainDecodedBytes, at: self.writerIndex)
+        let written = self.setBytes(string.hexPlainDecodedBytes, at: self.writerIndex)
         self._moveWriterIndex(forwardBy: written)
         return written
     }

--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -776,6 +776,18 @@ extension ByteBufferAllocator {
         return buffer
     }
 
+    /// Create a fresh `ByteBuffer` containing the `bytes` decoded from the ASCII `hexEncodedBytes` string .
+    ///
+    /// This will allocate a new `ByteBuffer` with enough space to fit `bytes` and potentially some extra space.
+    ///
+    /// - returns: The `ByteBuffer` containing the written bytes.
+    @inlinable
+    public func buffer(hexEncodedBytes string: String) -> ByteBuffer {
+        var buffer = self.buffer(capacity: string.hexPlainDecodedBytes.underestimatedCount)
+        buffer.writeBytes(string.hexPlainDecodedBytes)
+        return buffer
+    }
+    
     /// Create a fresh `ByteBuffer` containing the bytes of the byte representation in the given `endianness` of
     /// `integer`.
     ///

--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -101,9 +101,15 @@ extension ByteBuffer {
     public mutating func writePlainHexEncodedBytes(_ plainHexEncodedBytes: String) throws -> Int {
         var slice = plainHexEncodedBytes.utf8[...]
         var written = 0
+        var bytesToWrite: [UInt8] = []
 
+        // Single pass to ensure string is a valid representation of hex bytes
         while let nextByte = try slice.popNextHexByte() {
-            written += self.writeInteger(nextByte)
+            bytesToWrite.append(nextByte)
+        }
+
+        for byte in bytesToWrite {
+            written += self.writeInteger(byte)
         }
 
         return written

--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -92,7 +92,8 @@ extension ByteBuffer {
     }
 
     // MARK: Hex encoded string APIs
-    /// Write `string` into this `ByteBuffer` in ASCII hexadecimal, moving the writer index forward appropriately. This method will throw if the string input is not of the "plain" hex encoded format.
+    /// Write ASCII hexadecimal `string` into this `ByteBuffer` as raw bytes, decoding the hexadecimal & moving the writer index forward appropriately.
+    /// This method will throw if the string input is not of the "plain" hex encoded format.
     /// - parameters:
     ///     - plainHexEncodedBytes: The hex encoded string to write. Plain hex dump format is hex bytes optionally separated by spaces, i.e. `48 65 6c 6c 6f` or `48656c6c6f` for `Hello`.
     ///     This format is compatible with `xxd` CLI utility.

--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -101,15 +101,15 @@ extension ByteBuffer {
     @inlinable
     public mutating func writePlainHexEncodedBytes(_ plainHexEncodedBytes: String) throws -> Int {
         var slice = plainHexEncodedBytes.utf8[...]
-        let initialWriterIndex = self._writerIndex
+        let initialWriterIndex = self.writerIndex
 
         do {
             while let nextByte = try slice.popNextHexByte() {
                 self.writeInteger(nextByte)
             }
-            return Int(self._writerIndex - initialWriterIndex)
+            return self.writerIndex - initialWriterIndex
         } catch {
-            self._moveWriterIndex(to: initialWriterIndex)
+            self.moveWriterIndex(to: initialWriterIndex)
             throw error
         }
     }

--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -91,6 +91,24 @@ extension ByteBuffer {
         )
     }
 
+    // MARK: Hex encoded string APIs
+    /// Write `hex encoded string` into this `ByteBuffer`, moving the writer index forward appropriately.
+    ///
+    /// - parameters:
+    ///     - string: The hex encoded string to write.
+    /// - returns: The number of bytes written.
+    @discardableResult
+    @inlinable
+    public mutating func writeHexEncodedBytes(_ string: String) -> Int {
+        let hexPlainDecodedBytes = string.hexPlainDecodedBytes
+        guard !hexPlainDecodedBytes.isEmpty else {
+            return 0
+        }
+        let written = self.setBytes(hexPlainDecodedBytes, at: self.writerIndex)
+        self._moveWriterIndex(forwardBy: written)
+        return written
+    }
+
     // MARK: String APIs
     /// Write `string` into this `ByteBuffer` using UTF-8 encoding, moving the writer index forward appropriately.
     ///

--- a/Sources/NIOCore/ByteBuffer-conversions.swift
+++ b/Sources/NIOCore/ByteBuffer-conversions.swift
@@ -42,7 +42,7 @@ extension String {
     ///
     /// - parameters:
     ///     - radix: radix base to use for conversion.
-    ///     - padding: the desired lenght of the resulting string.
+    ///     - padding: the desired length of the resulting string.
     @inlinable
     internal init<Value>(_ value: Value, radix: Int, padding: Int) where Value: BinaryInteger {
         let formatted = String(value, radix: radix)

--- a/Sources/NIOCore/ByteBuffer-hex.swift
+++ b/Sources/NIOCore/ByteBuffer-hex.swift
@@ -25,13 +25,9 @@ extension ByteBuffer {
     ///         size followed by a `writeHexEncodedBytes` instead of using this method. This allows SwiftNIO to do
     ///         accounting and optimisations of resources acquired for operations on a given `Channel` in the future.
     init(hexEncodedBytes string: String) {
-        let hexPlainDecodedBytes = string.hexPlainDecodedBytes
-        guard !hexPlainDecodedBytes.isEmpty else {
-            self = ByteBufferAllocator.zeroCapacityWithDefaultAllocator
-            return
-        }
-
-        self = ByteBufferAllocator().buffer(bytes: hexPlainDecodedBytes)
+        var buffer = ByteBuffer()
+        buffer.writeHexEncodedBytes(string)
+        self = buffer
     }
 
     /// Describes a ByteBuffer hexDump format.
@@ -365,7 +361,8 @@ extension ByteBuffer {
 extension String {
     /// Plain decode a string representing a hexadecimal sequence them into an UInt8 sequence
     /// - Complexity: O(n)
-    public var hexPlainDecodedBytes: [UInt8] {
+    @inlinable
+    var hexPlainDecodedBytes: UnfoldSequence<UInt8, String> {
         let stringWithoutWhiteSpaces = self.filter { !$0.isWhitespace }
         return sequence(
             state: stringWithoutWhiteSpaces,
@@ -378,6 +375,6 @@ extension String {
                 remainder.removeFirst(2)
                 return UInt8(nextTwo, radix: 16)
             }
-        ).map { $0 }
+        )
     }
 }

--- a/Sources/NIOCore/ByteBuffer-hex.swift
+++ b/Sources/NIOCore/ByteBuffer-hex.swift
@@ -14,7 +14,7 @@
 
 extension ByteBuffer {
 
-    /// Create a fresh `ByteBuffer` containing the `bytes` decoded from  the string representation of `plainHexEncodedBytes`.
+    /// Create a fresh `ByteBuffer` containing the `bytes` decoded from the string representation of `plainHexEncodedBytes`.
     ///
     /// This will allocate a new `ByteBuffer` with enough space to fit the hex decoded `bytes` and potentially some extra space
     /// using the default allocator.
@@ -356,15 +356,18 @@ extension ByteBuffer {
     }
 
     /// An error that is thrown when an invalid hex encoded string was attempted to be written to a ByteBuffer.
-    public struct HexDecodingError: Error {
-        let kind: HexDecodingErrorKind
+    public struct HexDecodingError: Error, Equatable {
+        private let kind: HexDecodingErrorKind
 
-        enum HexDecodingErrorKind {
+        private enum HexDecodingErrorKind {
             /// The hex encoded string was not of the expected even length.
             case invalidHexLength
             /// An invalid hex character was found in the hex encoded string.
             case invalidCharacter
         }
+
+        public static let invalidHexLength = HexDecodingError(kind: .invalidHexLength)
+        public static let invalidCharacter = HexDecodingError(kind: .invalidCharacter)
     }
 }
 
@@ -385,7 +388,7 @@ extension UInt8 {
             case UInt8(ascii: "A")...UInt8(ascii: "F"):
                 return self - UInt8(ascii: "A") + 10
             default:
-                throw ByteBuffer.HexDecodingError(kind: .invalidCharacter)
+                throw ByteBuffer.HexDecodingError.invalidCharacter
             }
         }
     }
@@ -403,7 +406,7 @@ extension Substring.UTF8View {
         }
 
         guard let secondHex = try self.popFirst()?.asciiHexNibble else {
-            throw ByteBuffer.HexDecodingError(kind: .invalidHexLength)
+            throw ByteBuffer.HexDecodingError.invalidHexLength
         }
 
         return (firstHex << 4) | secondHex

--- a/Sources/NIOCore/ByteBuffer-hex.swift
+++ b/Sources/NIOCore/ByteBuffer-hex.swift
@@ -358,27 +358,28 @@ extension ByteBuffer {
 
 enum HexDecodingError: Error {
     case invalidHexLength
+    case invalidCharacter
 }
 
 extension UInt8 {
     fileprivate var isASCIIWhitespace: Bool {
-        switch self {
-        case UInt8(ascii: "\n"), UInt8(ascii: "\t"), UInt8(ascii: "\n"), UInt8(ascii: "\r"), UInt8(ascii: " "):
-            return true
-        default: return false
-        }
+        [UInt8(ascii: "\n"), UInt8(ascii: "\t"), UInt8(ascii: "\n"), UInt8(ascii: "\r"), UInt8(ascii: " ")].contains(
+            self
+        )
     }
 
     fileprivate var asciiHexNibble: UInt8? {
-        switch self {
-        case UInt8(ascii: "0")...UInt8(ascii: "9"):
-            return self - UInt8(ascii: "0")
-        case UInt8(ascii: "a")...UInt8(ascii: "f"):
-            return self - UInt8(ascii: "a") + 10
-        case UInt8(ascii: "A")...UInt8(ascii: "F"):
-            return self - UInt8(ascii: "A") + 10
-        default:
-            return nil
+        get throws {
+            switch self {
+            case UInt8(ascii: "0")...UInt8(ascii: "9"):
+                return self - UInt8(ascii: "0")
+            case UInt8(ascii: "a")...UInt8(ascii: "f"):
+                return self - UInt8(ascii: "a") + 10
+            case UInt8(ascii: "A")...UInt8(ascii: "F"):
+                return self - UInt8(ascii: "A") + 10
+            default:
+                throw HexDecodingError.invalidCharacter
+            }
         }
     }
 }
@@ -390,7 +391,7 @@ extension Substring.UTF8View {
             self = self.dropFirst()
         }
 
-        guard let firstHex = self.popFirst()?.asciiHexNibble else {
+        guard let firstHex = try self.popFirst()?.asciiHexNibble else {
             return nil  // No next byte to pop
         }
 
@@ -398,7 +399,7 @@ extension Substring.UTF8View {
             self = self.dropFirst()
         }
 
-        guard let secondHex = self.popFirst()?.asciiHexNibble else {
+        guard let secondHex = try self.popFirst()?.asciiHexNibble else {
             throw HexDecodingError.invalidHexLength
         }
 

--- a/Sources/NIOCore/ByteBuffer-hex.swift
+++ b/Sources/NIOCore/ByteBuffer-hex.swift
@@ -355,11 +355,14 @@ extension ByteBuffer {
         }
     }
 
+    /// An error that is thrown when an invalid hex encoded string was attempted to be written to a ByteBuffer.
     public struct HexDecodingError: Error {
         let kind: HexDecodingErrorKind
 
-        public enum HexDecodingErrorKind {
+        enum HexDecodingErrorKind {
+            /// The hex encoded string was not of the expected even length.
             case invalidHexLength
+            /// An invalid hex character was found in the hex encoded string.
             case invalidCharacter
         }
     }

--- a/Sources/NIOCore/ByteBuffer-hex.swift
+++ b/Sources/NIOCore/ByteBuffer-hex.swift
@@ -25,9 +25,7 @@ extension ByteBuffer {
     ///         size followed by a `writeHexEncodedBytes` instead of using this method. This allows SwiftNIO to do
     ///         accounting and optimisations of resources acquired for operations on a given `Channel` in the future.
     init(hexEncodedBytes string: String) {
-        var buffer = ByteBuffer()
-        buffer.writeHexEncodedBytes(string)
-        self = buffer
+        self = ByteBufferAllocator().buffer(hexEncodedBytes: string)
     }
 
     /// Describes a ByteBuffer hexDump format.

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1954,6 +1954,7 @@ class ByteBufferTest: XCTestCase {
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("    1  "))
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("    1"))
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("1       "))
+        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("🤓"))
         // The first byte (68 = "h") is valid, the method throws and the valid byte IS written to the ByteBuffer
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("68 1"))
         XCTAssertEqual(ByteBuffer(string: "hello world\nhello world\nh"), buffer)

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1957,24 +1957,24 @@ class ByteBufferTest: XCTestCase {
     func testWriteHexEncodedBytesFails() throws {
         var buffer = ByteBuffer()
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("    1  ")) { error in
-            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidCharacter)
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError) == ByteBuffer.HexDecodingError.invalidCharacter)
         }
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("    1")) { error in
-            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidHexLength)
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError) == ByteBuffer.HexDecodingError.invalidHexLength)
         }
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("1       ")) { error in
-            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidCharacter)
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError) == ByteBuffer.HexDecodingError.invalidCharacter)
         }
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("🤓")) { error in
-            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidCharacter)
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError) == ByteBuffer.HexDecodingError.invalidCharacter)
         }
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("1 1")) { error in
-            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidCharacter)
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError) == ByteBuffer.HexDecodingError.invalidCharacter)
         }
 
         // The first byte (68 = "h") is valid, the method throws and the valid byte IS NOT written to the ByteBuffer
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("68 1")) { error in
-            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidHexLength)
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError) == ByteBuffer.HexDecodingError.invalidHexLength)
         }
         XCTAssertTrue(buffer.readableBytesView.isEmpty)
     }

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1069,6 +1069,17 @@ class ByteBufferTest: XCTestCase {
         XCTAssertNil(self.buf.getString(at: 0, length: capacity + 1))
     }
 
+    func testWriteEmptyByteArray() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 32)
+        buffer.moveWriterIndex(to: 16)
+        buffer.moveReaderIndex(to: 16)
+        XCTAssertEqual(buffer.setBytes([], at: 16), 0)
+        XCTAssertEqual(buffer.readableBytes, 0)
+        XCTAssertEqual(buffer.writableBytes, 16)
+        XCTAssertEqual(buffer.writerIndex, 16)
+        XCTAssertEqual(buffer.readerIndex, 16)
+    }
+
     func testSetGetBytesAllFine() throws {
         self.buf.moveReaderIndex(to: 0)
         self.buf.setBytes([1, 2, 3, 4], at: 0)
@@ -1932,6 +1943,29 @@ class ByteBufferTest: XCTestCase {
             e0 e1 e2 e3 e4 e5 e6 e7 e8 e9 ea eb ec ed ee ef f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff ]
             """
         XCTAssertEqual(expected, actual)
+    }
+
+    func testWriteHexEncodedBytes() throws {
+        var buffer = ByteBuffer(hexEncodedBytes: "68 65 6c 6c 6f 20 77 6f 72 6c 64 0a")
+        XCTAssertEqual(buffer.writeHexEncodedBytes("68656c6c6f20776f726c64"), 11)
+        XCTAssertEqual(buffer.writeHexEncodedBytes("     0a    "), 1)
+        XCTAssertEqual(buffer.writeHexEncodedBytes(""), 0)
+        XCTAssertEqual(buffer.writeHexEncodedBytes("      "), 0)
+        XCTAssertEqual(ByteBuffer(string: "hello world\nhello world\n"), buffer)
+    }
+
+    func testHexInitialiser() {
+        var allBytes = ByteBufferAllocator().buffer(capacity: Int(UInt8.max))
+        for x in UInt8.min...UInt8.max {
+            allBytes.writeInteger(x)
+        }
+
+        let allBytesHex = allBytes.hexDump(format: .plain)
+        let allBytesDecoded = ByteBuffer(hexEncodedBytes: allBytesHex)
+        XCTAssertEqual(allBytes, allBytesDecoded)
+
+        // Edge case
+        XCTAssertEqual(ByteBuffer(hexEncodedBytes: " "), ByteBufferAllocator.zeroCapacityWithDefaultAllocator)
     }
 
     func testHexDumpPlain() {

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1951,13 +1951,32 @@ class ByteBufferTest: XCTestCase {
         XCTAssertEqual(try buffer.writePlainHexEncodedBytes("     0a    "), 1)
         XCTAssertEqual(try buffer.writePlainHexEncodedBytes(""), 0)
         XCTAssertEqual(try buffer.writePlainHexEncodedBytes("      "), 0)
-        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("    1  "))
-        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("    1"))
-        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("1       "))
-        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("🤓"))
-        // The first byte (68 = "h") is valid, the method throws and the valid byte IS NOT written to the ByteBuffer
-        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("68 1"))
         XCTAssertEqual(ByteBuffer(string: "hello world\nhello world\n"), buffer)
+    }
+
+    func testWriteHexEncodedBytesFails() throws {
+        var buffer = ByteBuffer()
+        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("    1  ")) { error in
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidCharacter)
+        }
+        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("    1")) { error in
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidHexLength)
+        }
+        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("1       ")) { error in
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidCharacter)
+        }
+        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("🤓")) { error in
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidCharacter)
+        }
+        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("1 1")) { error in
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidCharacter)
+        }
+
+        // The first byte (68 = "h") is valid, the method throws and the valid byte IS NOT written to the ByteBuffer
+        XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("68 1")) { error in
+            XCTAssertTrue((error as? ByteBuffer.HexDecodingError)?.kind == .invalidHexLength)
+        }
+        XCTAssertTrue(buffer.readableBytesView.isEmpty)
     }
 
     func testHexInitialiser() throws {

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1955,9 +1955,9 @@ class ByteBufferTest: XCTestCase {
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("    1"))
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("1       "))
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("🤓"))
-        // The first byte (68 = "h") is valid, the method throws and the valid byte IS written to the ByteBuffer
+        // The first byte (68 = "h") is valid, the method throws and the valid byte IS NOT written to the ByteBuffer
         XCTAssertThrowsError(try buffer.writePlainHexEncodedBytes("68 1"))
-        XCTAssertEqual(ByteBuffer(string: "hello world\nhello world\nh"), buffer)
+        XCTAssertEqual(ByteBuffer(string: "hello world\nhello world\n"), buffer)
     }
 
     func testHexInitialiser() throws {


### PR DESCRIPTION
Add ability for below two functions 
`ByteBuffer(hexEncodedBytes: "68 65 6c 6c 6f 20 77 6f 72 6c 64 0a")`
` buffer.writeHexEncodedBytes("68656c6c6f20776f726c640a")`

### Motivation:

https://github.com/apple/swift-nio/issues/2748
