### PR TITLE
Adopt strict concurrency in _NIOBase64

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,13 +34,13 @@ let strictConcurrencySettings: [SwiftSetting] = {
         .enableUpcomingFeature("InferSendableFromCaptures"),
     ])
 
-#if compiler(>=6.0)
+    #if compiler(>=6.0)
     if ProcessInfo.processInfo.environment["CI"] != nil {
         // -warnings-as-errors here is a workaround so that IDE-based development can
         // get tripped up on -require-explicit-sendable.
         initialSettings.append(.unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]))
     }
-#endif
+    #endif
 
     return initialSettings
 }()

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,8 @@ let swiftSystem: PackageDescription.Target.Dependency = .product(
     condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .linux, .android])
 )
 
+let strictConcurrencyDevelopment = false
+
 let strictConcurrencySettings: [SwiftSetting] = {
     var initialSettings: [SwiftSetting] = []
     initialSettings.append(contentsOf: [
@@ -34,13 +36,11 @@ let strictConcurrencySettings: [SwiftSetting] = {
         .enableUpcomingFeature("InferSendableFromCaptures"),
     ])
 
-    #if compiler(>=6.0)
-    if ProcessInfo.processInfo.environment["CI"] != nil {
+    if strictConcurrencyDevelopment {
         // -warnings-as-errors here is a workaround so that IDE-based development can
         // get tripped up on -require-explicit-sendable.
         initialSettings.append(.unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]))
     }
-    #endif
 
     return initialSettings
 }()

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,8 @@ let strictConcurrencySettings: [SwiftSetting] = {
 
 #if compiler(>=6.0)
     if ProcessInfo.processInfo.environment["CI"] != nil {
+        // -warnings-as-errors here is a workaround so that IDE-based development can
+        // get tripped up on -require-explicit-sendable.
         initialSettings.append(.unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]))
     }
 #endif

--- a/Sources/_NIOBase64/Base64.swift
+++ b/Sources/_NIOBase64/Base64.swift
@@ -35,7 +35,7 @@ public enum Base64Error: Error {
 }
 
 @usableFromInline
-internal struct Base64 {
+internal enum Base64: Sendable {
 
     @inlinable
     static func encode<Buffer: Collection>(bytes: Buffer) -> String where Buffer.Element == UInt8 {


### PR DESCRIPTION
Motivation:

Another brick in the wall.

Modifications:

- Make Base64 an enum, not a struct, as it's a namespace.
- Make Base64 Sendable, which it trivially is.

Result:

Another pass, another success
