### PR TITLE
Fix `NIOFileSystem` flaky tests

### DIFF
--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -1256,14 +1256,15 @@ final class FileHandleTests: XCTestCase {
                 lastAccess: nil,
                 lastDataModification: nil
             )
-            let estimatedCurrentTime = Date.now.timeIntervalSince1970
+            let estimatedCurrentTimeInSeconds = Date.now.timeIntervalSince1970
 
-            // Assert that the times are equal to the current time, with up to a second difference (to avoid timing flakiness).
+            // Assert that the times are equal to the current time, with up to 10 seconds difference
+            // to avoid timing flakiness. Both the last accessed and last modification times should
+            // also equal each other.
             actualLastAccessTime = try await handle.info().lastAccessTime
-            XCTAssertEqual(Float(actualLastAccessTime.seconds), Float(estimatedCurrentTime), accuracy: 1)
-
+            XCTAssertEqual(Double(actualLastAccessTime.seconds), estimatedCurrentTimeInSeconds, accuracy: 1)
             actualLastDataModificationTime = try await handle.info().lastDataModificationTime
-            XCTAssertEqual(Float(actualLastDataModificationTime.seconds), Float(estimatedCurrentTime), accuracy: 1)
+            XCTAssertEqual(actualLastDataModificationTime.seconds, actualLastAccessTime.seconds)
         }
     }
 
@@ -1283,14 +1284,15 @@ final class FileHandleTests: XCTestCase {
             XCTAssertEqual(actualLastDataModificationTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))
 
             try await handle.touch()
-            let estimatedCurrentTime = Date.now.timeIntervalSince1970
+            let estimatedCurrentTimeInSeconds = Date.now.timeIntervalSince1970
 
-            // Assert that the times are equal to the current time, with up to a second difference (to avoid timing flakiness).
+            // Assert that the times are equal to the current time, with up to 10 seconds difference
+            // to avoid timing flakiness. Both the last accessed and last modification times should
+            // also equal each other.
             actualLastAccessTime = try await handle.info().lastAccessTime
-            XCTAssertEqual(Float(actualLastAccessTime.seconds), Float(estimatedCurrentTime), accuracy: 1)
-
+            XCTAssertEqual(Double(actualLastAccessTime.seconds), estimatedCurrentTimeInSeconds, accuracy: 1)
             actualLastDataModificationTime = try await handle.info().lastDataModificationTime
-            XCTAssertEqual(Float(actualLastDataModificationTime.seconds), Float(estimatedCurrentTime), accuracy: 1)
+            XCTAssertEqual(actualLastDataModificationTime.seconds, actualLastAccessTime.seconds)
         }
     }
 }

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -1258,7 +1258,7 @@ final class FileHandleTests: XCTestCase {
             )
             let estimatedCurrentTimeInSeconds = Date.now.timeIntervalSince1970
 
-            // Assert that the times are equal to the current time, with up to 10 seconds difference
+            // Assert that the times are equal to the current time, with up to a second difference
             // to avoid timing flakiness. Both the last accessed and last modification times should
             // also equal each other.
             actualLastAccessTime = try await handle.info().lastAccessTime
@@ -1286,7 +1286,7 @@ final class FileHandleTests: XCTestCase {
             try await handle.touch()
             let estimatedCurrentTimeInSeconds = Date.now.timeIntervalSince1970
 
-            // Assert that the times are equal to the current time, with up to 10 seconds difference
+            // Assert that the times are equal to the current time, with up to a second difference
             // to avoid timing flakiness. Both the last accessed and last modification times should
             // also equal each other.
             actualLastAccessTime = try await handle.info().lastAccessTime


### PR DESCRIPTION
Two NIOFileSystem tests are flaky. This PR makes them less flaky.

### Motivation:

We want fewer flaky tests.

### Modifications:

- Replaced the cast to `Float` with a cast to `Double` instead. The number of seconds since the Epoch is over a billion, which is beyond the "accurate" precision for the non-decimal part of a `Float`. The theory is that the numbers we're comparing are high enough that they start diverging wildly.
- The last accessed and last modified time are now asserted to be equal against each other (as they should).

### Result:

Less flaky tests.