### PR TITLE
[CI] Don't persist git credentials in CI

### DIFF
--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -12,5 +12,7 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
             - name: Check for Semantic Version label
               uses: ./.github/actions/pull_request_semver_label_checker/

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -59,6 +59,7 @@ jobs:
       with:
         # We need to fetch everything otherwise only the head commit will be fetched.
         fetch-depth: 0
+        persist-credentials: false
     - name: Mark the workspace as safe
       # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -75,6 +76,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+          persist-credentials: false
     - name: Run documentation check
       run: |
         apt-get -qq update && apt-get -qq -y install curl yq
@@ -88,6 +91,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+          persist-credentials: false
     - name: Run unacceptable language check
       env:
         UNACCEPTABLE_WORD_LIST: ${{ inputs.unacceptable_language_check_word_list}}
@@ -101,6 +106,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+          persist-credentials: false
     - name: Run license header check
       env:
         PROJECT_NAME: ${{ inputs.license_header_check_project_name }}
@@ -114,6 +121,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+          persist-credentials: false
     - name: Run broken symlinks check
       run: curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-broken-symlinks.sh | bash
 
@@ -127,6 +136,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+          persist-credentials: false
     - name: Mark the workspace as safe
     # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -143,6 +154,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+          persist-credentials: false
     - name: Mark the workspace as safe
     # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}

--- a/.github/workflows/swift_6_language_mode.yml
+++ b/.github/workflows/swift_6_language_mode.yml
@@ -17,6 +17,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
             - name: Set the language mode
               run: swift package tools-version --set 6.0
             - name: Build with Swift 6 language mode

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -81,6 +81,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+          persist-credentials: false
     - name: Run matrix job
       if: ${{ matrix.swift.enabled }}
       env:


### PR DESCRIPTION
# Motivation

https://yossarian.net/til/post/actions-checkout-can-leak-github-credentials shows a common way to leak git credentials in CI. While we are not publishing artifacts right now, we can harden our security here by disabling the persistence of git credentials as much as possible.

# Modification

Don't persist git credentials when not needed.

# Result

Less likely to leak credentials.
