### PR TITLE
[CI] Mark the workspace as safe for the matrix job

### DIFF
--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -83,6 +83,9 @@ jobs:
       uses: actions/checkout@v4
       with:
           persist-credentials: false
+    - name: Mark the workspace as safe
+    # https://github.com/actions/checkout/issues/766
+      run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Run matrix job
       if: ${{ matrix.swift.enabled }}
       env:


### PR DESCRIPTION
# Motivation

Some scripts that run as part of a matrix job may want to call git commands and the workspace needs to be marked as safe.

# Modification

This PR adds a step to mark the workspace as safe
