### PR TITLE
[CI] Make container images configurable in soundness and matrix jobs …

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -7,10 +7,18 @@ on:
         type: boolean
         description: "Boolean to enable the API breakage check job. Defaults to true."
         default: true
+      api_breakage_check_container_image:
+        type: string
+        description: "Container image for the API breakage check job. Defaults to latest Swift Ubuntu image."
+        default: "swift:5.10-noble"
       docs_check_enabled:
         type: boolean
         description: "Boolean to enable the docs check job. Defaults to true."
         default: true
+      docs_check_container_image:
+        type: string
+        description: "Container image for the docs check job. Defaults to latest Swift Ubuntu image."
+        default: "swift:5.10-noble"
       unacceptable_language_check_enabled:
         type: boolean
         description: "Boolean to enable the acceptable language check job. Defaults to true."
@@ -51,7 +59,7 @@ jobs:
     if: ${{ inputs.api_breakage_check_enabled }}
     runs-on: ubuntu-latest
     container:
-      image: swift:5.10-noble
+      image: ${{ inputs.api_breakage_check_container_image }}
     timeout-minutes: 20
     steps:
     - name: Checkout repository
@@ -71,7 +79,7 @@ jobs:
     if: ${{ inputs.docs_check_enabled }}
     runs-on: ubuntu-latest
     container:
-      image: swift:5.10-noble
+      image: ${{ inputs.docs_check_container_image }}
     timeout-minutes: 20
     steps:
     - name: Checkout repository

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         description: "Boolean to enable the 5.8 Swift version matrix job. Defaults to true."
         default: true
+      matrix_linux_5_8_container_image:
+        type: string
+        description: "Container image for the 5.8 Swift version matrix job. Defaults to matching Swift Ubuntu image."
+        default: "swift:5.8-jammy"
       matrix_linux_5_8_command_override:
         type: string
         description: "The command of the 5.8 Swift version linux matrix job to execute."
@@ -22,6 +26,10 @@ on:
         type: boolean
         description: "Boolean to enable the 5.9 Swift version matrix job. Defaults to true."
         default: true
+      matrix_linux_5_9_container_image:
+        type: string
+        description: "Container image for the 5.9 Swift version matrix job. Defaults to matching Swift Ubuntu image."
+        default: "swift:5.9-jammy"
       matrix_linux_5_9_command_override:
         type: string
         description: "The command of the 5.9 Swift version linux matrix job to execute."
@@ -29,6 +37,10 @@ on:
         type: boolean
         description: "Boolean to enable the 5.10 Swift version matrix job. Defaults to true."
         default: true
+      matrix_linux_5_10_container_image:
+        type: string
+        description: "Container image for the 5.10 Swift version matrix job. Defaults to matching Swift Ubuntu image."
+        default: "swift:5.10-jammy"
       matrix_linux_5_10_command_override:
         type: string
         description: "The command of the 5.10 Swift version linux matrix job to execute."
@@ -36,6 +48,10 @@ on:
         type: boolean
         description: "Boolean to enable the nightly 6.0 Swift version matrix job. Defaults to true."
         default: true
+      matrix_linux_nightly_6_0_container_image:
+        type: string
+        description: "Container image for the nightly 6.0 Swift version matrix job. Defaults to matching Swift Ubuntu image."
+        default: "swiftlang/swift:nightly-6.0-jammy"
       matrix_linux_nightly_6_0_command_override:
         type: string
         description: "The command of the nightly 6.0 Swift version linux matrix job to execute."
@@ -43,6 +59,10 @@ on:
         type: boolean
         description: "Boolean to enable the nightly main Swift version matrix job. Defaults to true."
         default: true
+      matrix_linux_nightly_main_container_image:
+        type: string
+        description: "Container image for the nightly main Swift version matrix job. Defaults to matching Swift Ubuntu image."
+        default: "swiftlang/swift:nightly-main-jammy"
       matrix_linux_nightly_main_command_override:
         type: string
         description: "The command of the nightly main Swift version linux matrix job to execute."
@@ -61,29 +81,31 @@ jobs:
       matrix:
         # We are specifying only the major and minor of the docker images to automatically pick up the latest patch release
         swift:
-        - image: swift:5.8-jammy
+        - image: ${{ inputs.matrix_linux_5_8_container_image }}
           swift_version: "5.8"
           enabled: ${{ inputs.matrix_linux_5_8_enabled }}
-        - image: swift:5.9-jammy
+        - image: ${{ inputs.matrix_linux_5_9_container_image }}
           swift_version: "5.9"
           enabled: ${{ inputs.matrix_linux_5_9_enabled }}
-        - image: swift:5.10-jammy
+        - image: ${{ inputs.matrix_linux_5_10_container_image }}
           swift_version: "5.10"
           enabled: ${{ inputs.matrix_linux_5_10_enabled }}
-        - image: swiftlang/swift:nightly-6.0-jammy
+        - image: ${{ inputs.matrix_linux_nightly_6_0_container_image }}
           swift_version: "nightly-6.0"
           enabled: ${{ inputs.matrix_linux_nightly_6_0_enabled }}
-        - image: swiftlang/swift:nightly-main-jammy
+        - image: ${{ inputs.matrix_linux_nightly_main_container_image }}
           swift_version: "nightly-main"
           enabled: ${{ inputs.matrix_linux_nightly_main_enabled }}
     container:
       image: ${{ matrix.swift.image }}
     steps:
     - name: Checkout repository
+      if: ${{ matrix.swift.enabled }}
       uses: actions/checkout@v4
       with:
           persist-credentials: false
     - name: Mark the workspace as safe
+      if: ${{ matrix.swift.enabled }}
     # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Run matrix job

--- a/Package.swift
+++ b/Package.swift
@@ -549,7 +549,6 @@ if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-system.git", from: "1.2.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", "1.0.0"..<"1.4.0"),
     ]
 } else {
     package.dependencies += [

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -19,6 +19,13 @@ log() { printf -- "** %s\n" "$*" >&2; }
 error() { printf -- "** ERROR: %s\n" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
 
+log "Editing Package.swift..."
+cat <<EOF >> "Package.swift"
+package.dependencies.append(
+    .package(url: "https://github.com/apple/swift-docc-plugin", "1.0.0"..<"1.4.0")
+)
+EOF
+
 log "Checking documentation targets..."
 for target in $(yq -r '.builder.configs[].documentation_targets[]' .spi.yml); do
   log "Checking target $target..."


### PR DESCRIPTION
…and remove docc plugin

# Motivation

Some repositories might want to run their soundness and matrix jobs checks on different container images e.g. a repo might build against the nightly toolchains only so their soundness jobs should also use nightly images. Other repos might want to build against a different linux distribution since their usual deployment target is not Ubuntu based.

Additionally, we currently require our repos to depend on the docc plugin for building documentation which adds an unnecessary dependency to all of our packages.

# Modification

This PR makes the container images for the soundness and matrix jobs configurable. Furthermore, it modifies the docs check script to add the docc-plugin dependency and removes the current dependency from our manifest.

# Result

Our workflows can be adopted by more repositories.
