### PR TITLE
Fix global concurrency hook integration test

### DIFF
--- a/Sources/NIOCrashTester/CrashTests+EventLoop.swift
+++ b/Sources/NIOCrashTester/CrashTests+EventLoop.swift
@@ -180,7 +180,7 @@ struct EventLoopCrashTests {
         NIOSingletons.groupLoopCountSuggestion = -1
     }
 
-    #if compiler(>=5.9) && swift(<5.11)  // We only support Concurrency executor take-over on 5.9-5.10, as versions greater than 5.10 have not been properly tested.
+    #if compiler(>=5.9) && swift(<6.2)  // We only support Concurrency executor take-over on those Swift versions, as versions greater than that have not been properly tested.
     let testInstallingSingletonMTELGAsConcurrencyExecutorWorksButOnlyOnce = CrashTest(
         regex: #"Fatal error: Must be called only once"#
     ) {
@@ -207,6 +207,6 @@ struct EventLoopCrashTests {
         // This should crash
         _ = NIOSingletons.unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor()
     }
-    #endif  // compiler(>=5.9) && swift(<5.11)
+    #endif  // compiler(>=5.9) && swift(<6.2)
 }
 #endif  // !canImport(Darwin) || os(macOS)

--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -42,7 +42,7 @@ extension NIOSingletons {
     @discardableResult
     public static func unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor() -> Bool {
         // Guard between the minimum and maximum supported version for the hook
-        #if compiler(>=5.9) && compiler(<6.1)
+        #if compiler(>=5.9) && compiler(<6.2)
         guard #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) else {
             return false
         }


### PR DESCRIPTION
# Motivation

Our global concurrency hook was guarding against known Swift versions. Since the nightly are now Swift 6.1 we need to adjust our compiler guards.

# Modification

This PR adjusts our compiler guards for the concurrency hooks.

# Result

Concurrency hooks for everyone
