### PR TITLE
[CI] Exclude disabled jobs

### DIFF
--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -96,6 +96,9 @@ jobs:
         - image: ${{ inputs.matrix_linux_nightly_main_container_image }}
           swift_version: "nightly-main"
           enabled: ${{ inputs.matrix_linux_nightly_main_enabled }}
+        exclude:
+          - swift:
+            - enabled: false
     container:
       image: ${{ matrix.swift.image }}
     steps:


### PR DESCRIPTION
# Motivation

Currently disabled matrix jobs are still shown as skipped.

# Modification

This PR excludes any disabled job which should make them not show up at all.

# Result

No more unneeded skipped jobs.