### PR TITLE
Import `FoundationEssentials` in `NIOFoundationCompat`

### DIFF
--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import NIOCore
 
 /// Errors that may be thrown by ByteBuffer methods that call into Foundation.

--- a/Sources/NIOFoundationCompat/Codable+ByteBuffer.swift
+++ b/Sources/NIOFoundationCompat/Codable+ByteBuffer.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import NIOCore
 
 extension ByteBuffer {

--- a/Sources/NIOFoundationCompat/JSONSerialization+ByteBuffer.swift
+++ b/Sources/NIOFoundationCompat/JSONSerialization+ByteBuffer.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import NIOCore
 
 extension JSONSerialization {


### PR DESCRIPTION
Import `FoundationEssentials` in `NIOFoundationCompat`, when possible.

### Motivation:

In `NIOFoundationCompat` we only use symbols that are part of the reduced `FoundationEssentials` module. To reduce binary size, we should only import `FoundationEssentials`.

### Modifications:

- Add `canImport(FoundationEssentials)` dance.

### Result:

Hopefully smaller binary sizes.
