### PR TITLE
Making ByteBuffer's description more useful

### DIFF
--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -957,8 +957,9 @@ public struct ByteBuffer {
 }
 
 extension ByteBuffer: CustomStringConvertible, CustomDebugStringConvertible {
-    /// A `String` describing this `ByteBuffer`.  For a `ByteBuffer` initialised with `hello world`
-    /// the description would be the following:
+    /// A `String` describing this `ByteBuffer` including length and the bytes it contains (partially).
+    ///
+    /// For a `ByteBuffer` initialised with `hello world` the description would be the following:
     ///
     ///     [68656c6c6f20776f726c64](11 bytes)
     ///
@@ -970,8 +971,9 @@ extension ByteBuffer: CustomStringConvertible, CustomDebugStringConvertible {
         "[\(self.hexDump(format: .compact(maxBytes: 64)))](\(self.readableBytes) bytes)"
     }
 
-    /// A `String` describing this `ByteBuffer`.  For a `ByteBuffer` initialised with `hello world`
-    /// the description would be the following:
+    /// A `String` describing this `ByteBuffer` including length and the bytes it contains (partially).
+    ///
+    /// For a `ByteBuffer` initialised with `hello world` the description would be the following:
     ///
     ///     [68656c6c6f20776f726c64](11 bytes)
     ///

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -957,37 +957,30 @@ public struct ByteBuffer {
 }
 
 extension ByteBuffer: CustomStringConvertible, CustomDebugStringConvertible {
-    /// A `String` describing this `ByteBuffer`. Example:
+    /// A `String` describing this `ByteBuffer`.  For a `ByteBuffer` initialised with `hello world`
+    /// the description would be the following:
     ///
-    ///     ByteBuffer { readerIndex: 0, writerIndex: 4, readableBytes: 4, capacity: 512, storageCapacity: 1024, slice: 256..<768, storage: 0x0000000103001000 (1024 bytes)}
+    ///     [68656c6c6f20776f726c64](11 bytes)
     ///
+    /// Buffers larger that 64 bytes will get truncated when printing out.
     /// The format of the description is not API.
     ///
     /// - returns: A description of this `ByteBuffer`.
     public var description: String {
-        """
-        ByteBuffer { \
-        readerIndex: \(self.readerIndex), \
-        writerIndex: \(self.writerIndex), \
-        readableBytes: \(self.readableBytes), \
-        capacity: \(self.capacity), \
-        storageCapacity: \(self.storageCapacity), \
-        slice: \(self._slice), \
-        storage: \(self._storage.bytes) (\(self._storage.capacity) bytes) \
-        }
-        """
+        "[\(self.hexDump(format: .compact(maxBytes: 64)))](\(self.readableBytes) bytes)"
     }
 
-    /// A `String` describing this `ByteBuffer` with some portion of the readable bytes dumped too. Example:
+    /// A `String` describing this `ByteBuffer`.  For a `ByteBuffer` initialised with `hello world`
+    /// the description would be the following:
     ///
-    ///     ByteBuffer { readerIndex: 0, writerIndex: 4, readableBytes: 4, capacity: 512, slice: 256..<768, storage: 0x0000000103001000 (1024 bytes)}
-    ///     readable bytes (max 1k): [ 00 01 02 03 ]
+    ///     [68656c6c6f20776f726c64](11 bytes)
     ///
+    /// Buffers larger that 64 bytes will get truncated when printing out.
     /// The format of the description is not API.
     ///
-    /// - returns: A description of this `ByteBuffer` useful for debugging.
+    /// - returns: A description of this `ByteBuffer`.
     public var debugDescription: String {
-        "\(self.description)\nreadable bytes (max 1k): \(self._storage.dumpBytes(slice: self._slice, offset: self.readerIndex, length: min(1024, self.readableBytes)))"
+        "[\(self.hexDump(format: .compact(maxBytes: 64)))](\(self.readableBytes) bytes)"
     }
 }
 

--- a/Sources/NIOCore/ByteBuffer-hexdump.swift
+++ b/Sources/NIOCore/ByteBuffer-hexdump.swift
@@ -93,7 +93,7 @@ extension ByteBuffer {
     private func _hexDump(maxBytes: Int, separateWithWhitespace: Bool) -> String {
         // If the buffer length fits in the max bytes limit in the hex dump, just dump the whole thing.
         if self.readableBytes <= maxBytes {
-            return self.hexDump(format: .plain)
+            return self._hexDump(separateWithWhitespace: separateWithWhitespace)
         }
 
         var buffer = self

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1909,6 +1909,11 @@ class ByteBufferTest: XCTestCase {
         let buf = ByteBuffer(string: "Hello")
         XCTAssertEqual("48656c6c6f", buf.hexDump(format: .compact))
     }
+    
+    func testHexDumpCompactReadableBytesLessThenMaxBytes() {
+        let buf = ByteBuffer(string: "hello world")
+        XCTAssertEqual("68656c6c6f20776f726c64", buf.hexDump(format: .compact(maxBytes: 100)))
+    }
 
     func testHexDumpCompactEmptyBuffer() {
         let buf = ByteBuffer(string: "")
@@ -3602,5 +3607,12 @@ extension ByteBufferTest {
             XCTAssertEqual(error as? Base64Error, .invalidCharacter)
         }
     }
-
+    
+    func testByteBufferDescription() {
+        let buffer = ByteBuffer(string: "hello world")
+        
+        XCTAssertEqual(buffer.description, "[68656c6c6f20776f726c64](11 bytes)")
+        
+        XCTAssertEqual(buffer.description, buffer.debugDescription)
+    }
 }

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -3615,4 +3615,25 @@ extension ByteBufferTest {
 
         XCTAssertEqual(buffer.description, buffer.debugDescription)
     }
+
+    func testByteBufferDescriptionEmpty() {
+        let buffer = ByteBuffer()
+
+        XCTAssertEqual(buffer.description, "[](0 bytes)")
+
+        XCTAssertEqual(buffer.description, buffer.debugDescription)
+    }
+
+    func testByteBufferDescriptionTruncated() {
+        let buffer = ByteBuffer(
+            string: "iloveswiftnioiloveswiftnioiloveswiftnioiloveswiftnioiloveswiftnioiloveswiftnio"
+        )
+
+        XCTAssertEqual(
+            buffer.description,
+            "[696c6f766573776966746e696f696c6f766573776966746e696f696c6f766573...6966746e696f696c6f766573776966746e696f696c6f766573776966746e696f](78 bytes)"
+        )
+
+        XCTAssertEqual(buffer.description, buffer.debugDescription)
+    }
 }

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1909,7 +1909,7 @@ class ByteBufferTest: XCTestCase {
         let buf = ByteBuffer(string: "Hello")
         XCTAssertEqual("48656c6c6f", buf.hexDump(format: .compact))
     }
-    
+
     func testHexDumpCompactReadableBytesLessThenMaxBytes() {
         let buf = ByteBuffer(string: "hello world")
         XCTAssertEqual("68656c6c6f20776f726c64", buf.hexDump(format: .compact(maxBytes: 100)))
@@ -3607,12 +3607,12 @@ extension ByteBufferTest {
             XCTAssertEqual(error as? Base64Error, .invalidCharacter)
         }
     }
-    
+
     func testByteBufferDescription() {
         let buffer = ByteBuffer(string: "hello world")
-        
+
         XCTAssertEqual(buffer.description, "[68656c6c6f20776f726c64](11 bytes)")
-        
+
         XCTAssertEqual(buffer.description, buffer.debugDescription)
     }
 }

--- a/Tests/NIOCoreTests/NIOAnyDebugTest.swift
+++ b/Tests/NIOCoreTests/NIOAnyDebugTest.swift
@@ -24,7 +24,7 @@ class NIOAnyDebugTest: XCTestCase {
         let bb = ByteBuffer(string: "byte buffer string")
         XCTAssertTrue(
             wrappedInNIOAnyBlock(bb).contains(
-                "NIOAny { ByteBuffer { readerIndex: 0, writerIndex: 18, readableBytes: 18, capacity: 32, storageCapacity: 32, slice: _ByteBufferSlice { 0..<32 }, storage: "
+                "NIOAny { [627974652062756666657220737472696e67](18 bytes) }"
             )
         )
         XCTAssertTrue(wrappedInNIOAnyBlock(bb).hasSuffix(" }"))


### PR DESCRIPTION
### Motivation:

Resolving the following issue: https://github.com/apple/swift-nio/issues/2863

### Modifications:

Rewrote `description` and `debugDescription` on `ByteBuffer` to make it more useful. Also fixed a bug in the in `hexDumpCompact`.

### Result:

A more useful `description` and `debugDescription`.
