### PR TITLE
Make `assumeIsolated` work with SerialExecutors that are backed by EventLoops

### DIFF
--- a/Sources/NIOCore/EventLoop+SerialExecutor.swift
+++ b/Sources/NIOCore/EventLoop+SerialExecutor.swift
@@ -50,7 +50,7 @@ extension NIOSerialEventLoopExecutor {
         other === self
     }
 
-    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, *)
     @inlinable
     public func checkIsolated() {
         self.preconditionInEventLoop()

--- a/Sources/NIOCore/EventLoop+SerialExecutor.swift
+++ b/Sources/NIOCore/EventLoop+SerialExecutor.swift
@@ -36,7 +36,7 @@ extension NIOSerialEventLoopExecutor {
 
     @inlinable
     public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
-        UnownedSerialExecutor(ordinary: self)
+        UnownedSerialExecutor(complexEquality: self)
     }
 
     @inlinable

--- a/Sources/NIOCore/EventLoop+SerialExecutor.swift
+++ b/Sources/NIOCore/EventLoop+SerialExecutor.swift
@@ -43,6 +43,18 @@ extension NIOSerialEventLoopExecutor {
     public var executor: any SerialExecutor {
         self
     }
+
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    @inlinable
+    public func isSameExclusiveExecutionContext(other: Self) -> Bool {
+        other === self
+    }
+
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @inlinable
+    public func checkIsolated() {
+        self.preconditionInEventLoop()
+    }
 }
 
 /// A type that wraps a NIO ``EventLoop`` into a `SerialExecutor`

--- a/Tests/NIOPosixTests/SerialExecutorTests.swift
+++ b/Tests/NIOPosixTests/SerialExecutorTests.swift
@@ -81,7 +81,7 @@ final class SerialExecutorTests: XCTestCase {
     }
 
     func testAssumeIsolation() async throws {
-        #if compiler(<5.9)
+        #if compiler(<6.0)
         throw XCTSkip("Custom executors are only supported in 5.9")
         #else
 


### PR DESCRIPTION
Allow usage of `assumeIsolated` in SerialExecutors that are backed by EventLoops.

### Motivation:

We want to support all new Swift 6 features in SerialExecutors.

### Modifications:

- Implement `isSameExclusiveExecutionContext`
- Implement `checkIsolated`

### Result:

We can use `assumeIsolated` in actors that use an `EventLoop` as their `SerialExecutor`.
