### PR TITLE
Improving `description` and adding `debugDescription` to `NIOAny`

### DIFF
--- a/Sources/NIOCore/NIOAny.swift
+++ b/Sources/NIOCore/NIOAny.swift
@@ -272,6 +272,12 @@ extension NIOAny: Sendable {}
 
 extension NIOAny: CustomStringConvertible {
     public var description: String {
-        "NIOAny { \(self.asAny()) }"
+        "\(type(of: self.asAny())): \(self.asAny())"
+    }
+}
+
+extension NIOAny: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        "(\(self.description))"
     }
 }

--- a/Tests/NIOCoreTests/NIOAnyDebugTest.swift
+++ b/Tests/NIOCoreTests/NIOAnyDebugTest.swift
@@ -18,16 +18,14 @@ import XCTest
 class NIOAnyDebugTest: XCTestCase {
 
     func testCustomStringConvertible() throws {
-        XCTAssertEqual(wrappedInNIOAnyBlock("string"), wrappedInNIOAnyBlock("string"))
-        XCTAssertEqual(wrappedInNIOAnyBlock(123), wrappedInNIOAnyBlock("123"))
+        XCTAssertEqual(wrappedInNIOAnyBlock("string").description, "String: string")
+        XCTAssertEqual(wrappedInNIOAnyBlock(123).description, "Int: 123")
 
         let bb = ByteBuffer(string: "byte buffer string")
-        XCTAssertTrue(
-            wrappedInNIOAnyBlock(bb).contains(
-                "NIOAny { [627974652062756666657220737472696e67](18 bytes) }"
-            )
+        XCTAssertEqual(
+            wrappedInNIOAnyBlock(bb).description,
+            "ByteBuffer: [627974652062756666657220737472696e67](18 bytes)"
         )
-        XCTAssertTrue(wrappedInNIOAnyBlock(bb).hasSuffix(" }"))
 
         let fileHandle = NIOFileHandle(descriptor: 1)
         defer {
@@ -35,37 +33,40 @@ class NIOAnyDebugTest: XCTestCase {
         }
         let fileRegion = FileRegion(fileHandle: fileHandle, readerIndex: 1, endIndex: 5)
         XCTAssertEqual(
-            wrappedInNIOAnyBlock(fileRegion),
-            wrappedInNIOAnyBlock(
-                """
-                FileRegion { \
-                handle: \
-                FileHandle \
-                { descriptor: 1 \
-                }, \
-                readerIndex: \(fileRegion.readerIndex), \
-                endIndex: \(fileRegion.endIndex) }
-                """
-            )
+            wrappedInNIOAnyBlock(fileRegion).description,
+            """
+            FileRegion: \
+            FileRegion { \
+            handle: \
+            FileHandle \
+            { descriptor: 1 \
+            }, \
+            readerIndex: \(fileRegion.readerIndex), \
+            endIndex: \(fileRegion.endIndex) }
+            """
         )
 
         let socketAddress = try SocketAddress(unixDomainSocketPath: "socketAdress")
         let envelopeByteBuffer = ByteBuffer(string: "envelope buffer")
         let envelope = AddressedEnvelope<ByteBuffer>(remoteAddress: socketAddress, data: envelopeByteBuffer)
         XCTAssertEqual(
-            wrappedInNIOAnyBlock("\(envelope)"),
-            wrappedInNIOAnyBlock(
-                """
-                AddressedEnvelope { \
-                remoteAddress: \(socketAddress), \
-                data: \(envelopeByteBuffer) }
-                """
-            )
+            wrappedInNIOAnyBlock(envelope).description,
+            """
+            AddressedEnvelope<ByteBuffer>: \
+            AddressedEnvelope { \
+            remoteAddress: \(socketAddress), \
+            data: \(envelopeByteBuffer) }
+            """
         )
     }
 
-    private func wrappedInNIOAnyBlock(_ item: Any) -> String {
-        "NIOAny { \(item) }"
+    func testCustomDebugStringConvertible() {
+        XCTAssertEqual(wrappedInNIOAnyBlock("string").debugDescription, "(String: string)")
+        let any = wrappedInNIOAnyBlock("test")
+        XCTAssertEqual(any.debugDescription, "(\(any.description))")
     }
 
+    private func wrappedInNIOAnyBlock(_ item: Any) -> NIOAny {
+        NIOAny(item)
+    }
 }


### PR DESCRIPTION
Improving `description` and adding `debugDescription` to `NIOAny`

### Motivation
As per: https://github.com/apple/swift-nio/pull/2864#discussion_r1742192300 we would like that the `description` of `NIOAny` prints the type of the underlaying value that it wraps.

### Modification: 
Changing `description` and adding a conformance to `CustomDebugStringConvertible`.

### Result:
A nicer `description` and `debugDescription` for `NIOAny`.