### PR TITLE
Include nanoseconds in assertion of timestamp for NIOFileSystem tests

### DIFF
--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -1263,7 +1263,8 @@ final class FileHandleTests: XCTestCase {
             // also equal each other.
             actualLastAccessTime = try await handle.info().lastAccessTime
             let actualLastAccessTimeNanosecondsInSeconds = Double(actualLastAccessTime.nanoseconds) / 1e+9
-            let actualLastAccessTimeInSeconds = Double(actualLastAccessTime.seconds) + actualLastAccessTimeNanosecondsInSeconds
+            let actualLastAccessTimeInSeconds =
+                Double(actualLastAccessTime.seconds) + actualLastAccessTimeNanosecondsInSeconds
             XCTAssertEqual(actualLastAccessTimeInSeconds, estimatedCurrentTimeInSeconds, accuracy: 1)
             actualLastDataModificationTime = try await handle.info().lastDataModificationTime
             XCTAssertEqual(actualLastDataModificationTime.seconds, actualLastAccessTime.seconds)
@@ -1293,7 +1294,8 @@ final class FileHandleTests: XCTestCase {
             // also equal each other.
             actualLastAccessTime = try await handle.info().lastAccessTime
             let actualLastAccessTimeNanosecondsInSeconds = Double(actualLastAccessTime.nanoseconds) / 1e+9
-            let actualLastAccessTimeInSeconds = Double(actualLastAccessTime.seconds) + actualLastAccessTimeNanosecondsInSeconds
+            let actualLastAccessTimeInSeconds =
+                Double(actualLastAccessTime.seconds) + actualLastAccessTimeNanosecondsInSeconds
             XCTAssertEqual(actualLastAccessTimeInSeconds, estimatedCurrentTimeInSeconds, accuracy: 1)
             actualLastDataModificationTime = try await handle.info().lastDataModificationTime
             XCTAssertEqual(actualLastDataModificationTime.seconds, actualLastAccessTime.seconds)

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -1262,7 +1262,9 @@ final class FileHandleTests: XCTestCase {
             // to avoid timing flakiness. Both the last accessed and last modification times should
             // also equal each other.
             actualLastAccessTime = try await handle.info().lastAccessTime
-            XCTAssertEqual(Double(actualLastAccessTime.seconds), estimatedCurrentTimeInSeconds, accuracy: 1)
+            let actualLastAccessTimeNanosecondsInSeconds = Double(actualLastAccessTime.nanoseconds) / 1e+9
+            let actualLastAccessTimeInSeconds = Double(actualLastAccessTime.seconds) + actualLastAccessTimeNanosecondsInSeconds
+            XCTAssertEqual(actualLastAccessTimeInSeconds, estimatedCurrentTimeInSeconds, accuracy: 1)
             actualLastDataModificationTime = try await handle.info().lastDataModificationTime
             XCTAssertEqual(actualLastDataModificationTime.seconds, actualLastAccessTime.seconds)
         }
@@ -1290,7 +1292,9 @@ final class FileHandleTests: XCTestCase {
             // to avoid timing flakiness. Both the last accessed and last modification times should
             // also equal each other.
             actualLastAccessTime = try await handle.info().lastAccessTime
-            XCTAssertEqual(Double(actualLastAccessTime.seconds), estimatedCurrentTimeInSeconds, accuracy: 1)
+            let actualLastAccessTimeNanosecondsInSeconds = Double(actualLastAccessTime.nanoseconds) / 1e+9
+            let actualLastAccessTimeInSeconds = Double(actualLastAccessTime.seconds) + actualLastAccessTimeNanosecondsInSeconds
+            XCTAssertEqual(actualLastAccessTimeInSeconds, estimatedCurrentTimeInSeconds, accuracy: 1)
             actualLastDataModificationTime = try await handle.info().lastDataModificationTime
             XCTAssertEqual(actualLastDataModificationTime.seconds, actualLastAccessTime.seconds)
         }


### PR DESCRIPTION
Two NIOFileSystem tests are still a bit flaky after (mostly) fixing them in https://github.com/apple/swift-nio/pull/2842.

```
Test Case 'FileHandleTests.testSetLastAccessAndLastDataModificationTimesToNil' started at 2024-09-06 10:12:54.006
/__w/swift-nio/swift-nio/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift:1265: error: FileHandleTests.testSetLastAccessAndLastDataModificationTimesToNil : XCTAssertEqual failed: ("1725617573.0") is not equal to ("1725617574.006952") +/- ("1.0") -
Test Case 'FileHandleTests.testSetLastAccessAndLastDataModificationTimesToNil' failed (0.001 seconds)
```

This is because we were dropping the nanoseconds when comparing the timestamps, which means that sometimes the two timestamps were off by just over a second. This change includes the nanoseconds to avoid this problem.