### PR TITLE
Correct the link of sswg-security at SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,6 @@ with the [details usually included with bug reports][issue-template].
 
 [issue-template]: https://github.com/apple/swift-nio/blob/main/.github/ISSUE_TEMPLATE/bug-report.md
 [sswg]: https://github.com/swift-server/sswg
-[sswg-security]: https://github.com/swift-server/sswg/blob/main/process/incubation.md#security-best-practices
+[sswg-security]: https://www.swift.org/sswg/security/
 [swift-forums-sec]: https://forums.swift.org/c/server/security-updates/
 [mitre]: https://cveform.mitre.org/


### PR DESCRIPTION
### Motivation:
Correct the link of sswg-security at SECURITY.md. Currently it is showing "Not Found".

### Modifications:
+ https://github.com/swift-server/sswg/blob/main/process/incubation.md#security-best-practices => https://www.swift.org/sswg/security/

### Result:
Correct the link of sswg-security
