### PR TITLE
Speculative fix for flakey AsyncTestingEventLoop test

### DIFF
--- a/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
@@ -507,7 +507,9 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
             try await group.waitForAll()
         }
 
-        XCTAssertGreaterThan(tasksRun.load(ordering: .acquiring), 1)
+        try await eventLoop.executeInContext {
+            XCTAssertGreaterThan(tasksRun.load(ordering: .acquiring), 1)
+        }
     }
 
     func testShutdownCancelsRemainingScheduledTasks() async {


### PR DESCRIPTION
### Motivation:

We're seeing some very rare failures from this test in CI runs but I cannot reproduce locally. The test relies on timing to some degree and the interaction of scheduling tasks at shutdown.

### Modifications:

The `AsyncTestingEventLoop` has an `executeInContext` function which puts the closure on the backing dispatch queue and blocks. In this instance it might be a good way to make sure that all the previous work has happened.

### Result:

(Hopefully) less flakey test.