### PR TITLE
NIOSingleStepByteToMessageDecoder reentrancy safety

### DIFF
--- a/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
+++ b/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
@@ -273,7 +273,7 @@ public final class NIOSingleStepByteToMessageProcessor<Decoder: NIOSingleStepByt
         }
 
         // force unwrapping is safe because nil case is handled already and asserted above
-        if self._buffer!.readerIndex > 0, self.decoder.shouldReclaimBytes(buffer: self._buffer!) {
+        if let readerIndex = self._buffer?.readerIndex, readerIndex > 0, self.decoder.shouldReclaimBytes(buffer: self._buffer!) {
             self._buffer!.discardReadBytes()
         }
     }

--- a/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
+++ b/Sources/NIOCore/SingleStepByteToMessageDecoder.swift
@@ -233,8 +233,9 @@ public final class NIOSingleStepByteToMessageProcessor<Decoder: NIOSingleStepByt
         }
 
         self._buffer = nil  // To avoid CoW
+        defer { self._buffer = buffer }
+
         let result = try body(&buffer)
-        self._buffer = buffer
         return result
     }
 
@@ -272,8 +273,9 @@ public final class NIOSingleStepByteToMessageProcessor<Decoder: NIOSingleStepByt
             throw ByteToMessageDecoderError.PayloadTooLargeError()
         }
 
-        // force unwrapping is safe because nil case is handled already and asserted above
-        if let readerIndex = self._buffer?.readerIndex, readerIndex > 0, self.decoder.shouldReclaimBytes(buffer: self._buffer!) {
+        if let readerIndex = self._buffer?.readerIndex, readerIndex > 0,
+            self.decoder.shouldReclaimBytes(buffer: self._buffer!)
+        {
             self._buffer!.discardReadBytes()
         }
     }

--- a/Tests/NIOCoreTests/SingleStepByteToMessageDecoderTest.swift
+++ b/Tests/NIOCoreTests/SingleStepByteToMessageDecoderTest.swift
@@ -549,4 +549,35 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         XCTAssertEqual(2, messageReceiver.count)
         XCTAssertEqual(processor.unprocessedBytes, 0)
     }
+
+    /// Tests re-entrancy by having a nested decoding operation empty the buffer and exit part way
+    /// through the outer processing step
+    func testErrorDuringNestedDecoding() {
+        class ThrowingOnLastDecoder: NIOSingleStepByteToMessageDecoder {
+            /// `ByteBuffer` is the expected type passed in.
+            public typealias InboundIn = ByteBuffer
+            /// `ByteBuffer`s will be passed to the next stage.
+            public typealias InboundOut = ByteBuffer
+
+            public init() { }
+
+            struct DecodeLastError: Error {}
+
+            func decodeLast(buffer: inout NIOCore.ByteBuffer, seenEOF: Bool) throws -> NIOCore.ByteBuffer? {
+                throw DecodeLastError()
+            }
+
+            func decode(buffer: inout NIOCore.ByteBuffer) throws -> NIOCore.ByteBuffer? {
+                ByteBuffer()
+            }
+        }
+
+        let decoder = ThrowingOnLastDecoder()
+        let b2mp = NIOSingleStepByteToMessageProcessor(decoder)
+        XCTAssertNoThrow(try b2mp.process(buffer: ByteBuffer(string: "1\n\n2\n3\n")) { line in
+            XCTAssertThrowsError(try b2mp.finishProcessing(seenEOF: true) { _ in }) { error in
+                XCTAssertNotNil(error as? ThrowingOnLastDecoder.DecodeLastError)
+            }
+        })
+    }
 }


### PR DESCRIPTION
### Motivation:

`NIOSingleStepByteToMessageDecoder` calls out part way through its processing step to a user-provided closure which can cause re-entrant behavior which violates the assumption made in the code that if the buffer is non-empty at the start that will be true later in the method.

### Modifications:

`NIOSingleStepByteToMessageDecoder` no longer assumes a non-empty buffer in its final phase of buffer management.

Further changes to protect against re-entrancy shouldn't be necessary because the outside call to `messageReceiver` is the only one which is permitted to be re-entrant (`decode` and `decodeLast` are not).

### Result:

`NIOSingleStepByteToMessageDecoder` can handle re-entrant processing calls.
