### PR TITLE
ci: Install shellcheck if not present in CI runner

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -47,6 +47,10 @@ on:
         type: boolean
         description: "Boolean to enable the shell check job. Defaults to true."
         default: true
+      shell_check_container_image:
+        type: string
+        description: "Container image for the shell check job. Defaults to latest Swift Ubuntu image."
+        default: "swift:5.10-noble"
 
 ## We are cancelling previously triggered workflow runs
 concurrency:
@@ -158,6 +162,8 @@ jobs:
     name: Shell check
     if: ${{ inputs.shell_check_enabled }}
     runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.shell_check_container_image }}
     timeout-minutes: 5
     steps:
     - name: Checkout repository
@@ -168,4 +174,6 @@ jobs:
     # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Run shellcheck
-      run:  git ls-files -z '*.sh' | xargs -0 shellcheck
+      run:  |
+        apt-get -qq update && apt-get -qq -y install shellcheck
+        git ls-files -z '*.sh' | xargs -0 shellcheck


### PR DESCRIPTION
### Motivation:

We want to be able to run the soundness checks locally, and our current guidance for this is to use `act`. However, there is a documented[^0] difference in the runner images it uses and those used by Github Actions proper. One such difference is a lack of `shellcheck` in both the small and medium runners, which _is_ present in Github's image for the `ubuntu-latest` platform.

### Modifications:

There are official images for `shellcheck`: both a single binary and an alpine-based image, which are very small. Neither of these has `bash`, nor `git`, which are dependencies of the script.

This PR updates the workflow to use a container for this job and uses the same image used in some other jobs, along with a step to install `shellcheck`, which is in keeping with what we do for other jobs in the soundness workflow already to e.g. install `yq`.

### Result:

Can run the soundness job locally using `act`. No change in CI.

 [^0]: https://nektosact.com/usage/runners.html#default-runners-are-intentionally-incomplete
