### PR TITLE
ci: Use ${GITHUB_BASE_REF} as treeish for checking API break

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -65,14 +65,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        # We need to fetch everything otherwise only the head commit will be fetched.
-        fetch-depth: 0
         persist-credentials: false
     - name: Mark the workspace as safe
       # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Run API breakage check
-      run: swift package diagnose-api-breaking-changes origin/main
+      run:  |
+        git fetch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} ${GITHUB_BASE_REF}:pull-base-ref
+        swift package diagnose-api-breaking-changes pull-base-ref
 
   docs-check:
     name: Documentation check


### PR DESCRIPTION
### Motivation:

This repo is providing a reusable workflow for checking API breaks but it has two shortcomings:

1. It presumes the target branch name for the PR to be `main`.
2. It presumes the remote is named `origin`.

(2) is always the case in CI, but isn't always locally. My remote is named `upstream` so cannot run this using `act`. (1) is worse, because it's not actually testing against the target branch of the PR—consider if someone was enabling this reusable workflow on a feature branch or other-named branch.

Fortunately, Github Actions makes the target ref of the pull request available in the `GITHUB_BASE_REF` environment variable[^0].

### Modifications:

Use `GITHUB_BASE_REF` as the argument to `swift package diagnose-api-breaking-changes`.

### Result:

This can now be run locally.

[^0]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables