### PR TITLE
ci: Refer to nested reusable workflows using remote variant

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,8 @@ on:
 jobs:
     benchmarks:
         name: Benchmarks
-        uses: ./.github/workflows/swift_matrix.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Benchmarks"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q libjemalloc-dev && swift package --package-path ${{ inputs.benchmark_package_path }} ${{ inputs.swift_package_arguments }} benchmark baseline check --check-absolute-path ${{ inputs.benchmark_package_path }}/Thresholds/${SWIFT_VERSION}/"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
     benchmarks:
         name: Benchmarks
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/swift_matrix.yml@main
+        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Benchmarks"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q libjemalloc-dev && swift package --package-path ${{ inputs.benchmark_package_path }} ${{ inputs.swift_package_arguments }} benchmark baseline check --check-absolute-path ${{ inputs.benchmark_package_path }}/Thresholds/${SWIFT_VERSION}/"

--- a/.github/workflows/cxx_interop.yml
+++ b/.github/workflows/cxx_interop.yml
@@ -28,7 +28,7 @@ jobs:
     cxx-interop:
         name: Cxx interop
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/swift_matrix.yml@main
+        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Cxx interop"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q jq && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-cxx-interop-compatibility.sh | bash"

--- a/.github/workflows/cxx_interop.yml
+++ b/.github/workflows/cxx_interop.yml
@@ -27,7 +27,8 @@ on:
 jobs:
     cxx-interop:
         name: Cxx interop
-        uses: ./.github/workflows/swift_matrix.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Cxx interop"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q jq && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-cxx-interop-compatibility.sh | bash"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     unit-tests:
         name: Unit tests
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/unit_tests.yml@main
+        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -19,19 +19,19 @@ jobs:
     benchmarks:
         name: Benchmarks
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/benchmarks.yml@main
+        uses: apple/swift-nio/.github/workflows/benchmarks.yml@main
         with:
             benchmark_package_path: "Benchmarks"
 
     cxx-interop:
         name: Cxx interop
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/cxx_interop.yml@main
+        uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
 
     integration-tests:
         name: Integration Tests
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/swift_matrix.yml@main
+        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,8 @@ on:
 jobs:
     unit-tests:
         name: Unit tests
-        uses: ./.github/workflows/unit_tests.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -17,17 +18,20 @@ jobs:
 
     benchmarks:
         name: Benchmarks
-        uses: ./.github/workflows/benchmarks.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/benchmarks.yml@main
         with:
             benchmark_package_path: "Benchmarks"
 
     cxx-interop:
         name: Cxx interop
-        uses: ./.github/workflows/cxx_interop.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/cxx_interop.yml@main
 
     integration-tests:
         name: Integration Tests
-        uses: ./.github/workflows/swift_matrix.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,14 +8,14 @@ jobs:
     soundness:
         name: Soundness
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/soundness.yml@main
+        uses: apple/swift-nio/.github/workflows/soundness.yml@main
         with:
             license_header_check_project_name: "SwiftNIO"
 
     unit-tests:
         name: Unit tests
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/unit_tests.yml@main
+        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -26,7 +26,7 @@ jobs:
     benchmarks:
         name: Benchmarks
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/benchmarks.yml@main
+        uses: apple/swift-nio/.github/workflows/benchmarks.yml@main
         with:
             benchmark_package_path: "Benchmarks"
 
@@ -38,7 +38,7 @@ jobs:
     integration-tests:
         name: Integration Tests
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/swift_matrix.yml@main
+        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"
@@ -46,4 +46,4 @@ jobs:
     swift-6-language-mode:
         name: Swift 6 Language Mode
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/swift_6_language_mode.yml@main
+        uses: apple/swift-nio/.github/workflows/swift_6_language_mode.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,13 +7,15 @@ on:
 jobs:
     soundness:
         name: Soundness
-        uses: ./.github/workflows/soundness.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/soundness.yml@main
         with:
             license_header_check_project_name: "SwiftNIO"
 
     unit-tests:
         name: Unit tests
-        uses: ./.github/workflows/unit_tests.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -23,21 +25,25 @@ jobs:
 
     benchmarks:
         name: Benchmarks
-        uses: ./.github/workflows/benchmarks.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/benchmarks.yml@main
         with:
             benchmark_package_path: "Benchmarks"
 
     cxx-interop:
         name: Cxx interop
-        uses: ./.github/workflows/cxx_interop.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/cxx_interop.yml@main
 
     integration-tests:
         name: Integration Tests
-        uses: ./.github/workflows/swift_matrix.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"
 
     swift-6-language-mode:
         name: Swift 6 Language Mode
-        uses: ./.github/workflows/swift_6_language_mode.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/swift_6_language_mode.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
     cxx-interop:
         name: Cxx interop
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/cxx_interop.yml@main
+        uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
 
     integration-tests:
         name: Integration Tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -7,7 +7,8 @@ on:
 jobs:
     unit-tests:
         name: Unit tests
-        uses: ./.github/workflows/unit_tests.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -17,13 +18,15 @@ jobs:
 
     benchmarks:
         name: Benchmarks
-        uses: ./.github/workflows/benchmarks.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/benchmarks.yml@main
         with:
             benchmark_package_path: "Benchmarks"
 
     integration-tests:
         name: Integration Tests
-        uses: ./.github/workflows/swift_matrix.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -8,7 +8,7 @@ jobs:
     unit-tests:
         name: Unit tests
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/unit_tests.yml@main
+        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -19,14 +19,14 @@ jobs:
     benchmarks:
         name: Benchmarks
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/benchmarks.yml@main
+        uses: apple/swift-nio/.github/workflows/benchmarks.yml@main
         with:
             benchmark_package_path: "Benchmarks"
 
     integration-tests:
         name: Integration Tests
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/swift_matrix.yml@main
+        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -47,7 +47,8 @@ on:
 jobs:
     unit-tests:
         name: Unit tests
-        uses: ./.github/workflows/swift_matrix.yml
+        # Workaround https://github.com/nektos/act/issues/1875
+        uses: apple/nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Unit tests"
           matrix_linux_command: "swift test"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -48,7 +48,7 @@ jobs:
     unit-tests:
         name: Unit tests
         # Workaround https://github.com/nektos/act/issues/1875
-        uses: apple/nio/.github/workflows/swift_matrix.yml@main
+        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
           name: "Unit tests"
           matrix_linux_command: "swift test"


### PR DESCRIPTION
### Motivation:

This repo contains reusable workflows, intended for use in _other_ repos. Right now, some of these reusable workflows are nested, i.e. some of the YAML files refer to other YAML files in the repo by a relative path.

Unfortunately, this makes them currently unusable locally with `act` because of https://github.com/nektos/act/issues/1875.

For now, it appears the only workaround is to have these referred to without the local, relative path.

### Modifications:

Use the remote syntax for referencing nested workflows.

### Result:

Commands like `act -j unit-tests` will work in repos that aren't NIO itself.