### PR TITLE
[CI] Fix pull request label workflow

### DIFF
--- a/.github/actions/pull_request_semver_label_checker/action.yml
+++ b/.github/actions/pull_request_semver_label_checker/action.yml
@@ -16,5 +16,5 @@ runs:
         env:
             GH_TOKEN: ${{ inputs.token }}
         run: |
-            gh pr view ${{ github.event.number }} --repo apple/swift-nio --json labels \
+            gh pr view ${{ github.event.number }} --repo ${{ github.repository }} --json labels \
             | jq -e '[.labels[].name] | any(. == "semver/major" or . == "semver/minor" or . == "semver/patch" or . == "semver/none")'


### PR DESCRIPTION
The workflow was hard coded to use `apple/swift-nio`. If we want to adopt this in other repos we need to extract the event from the github context.
