### PR TITLE
FileChunkProducer.shouldProduceMore updates state

### DIFF
--- a/Sources/NIOFileSystem/FileChunks.swift
+++ b/Sources/NIOFileSystem/FileChunks.swift
@@ -329,12 +329,14 @@ private struct ProducerState: Sendable {
         }
     }
 
+    /// Update internal state to reflect that we have been notified to produce more.
     mutating func shouldProduceMore() -> NIOThreadPool? {
         switch self.state {
         case let .producing(state):
             return state.handle.threadPool
-        case .pausedProducing:
-            return nil
+        case let .pausedProducing(state):
+            self.state = .producing(state)
+            return state.handle.threadPool
         case .done:
             return nil
         }


### PR DESCRIPTION
### Motivation:

`FileChunkProducer` would not reflect its internal state when requested to produce more elements for the sequence after being paused.

### Modifications:

`FileChunkProducer.shouldProduceMore` updates the internal state and returns the threadpool leading to more elements being produced.

### Result:

`FileChunkProducer` should no longer hang after being paused.
