### PR TITLE
Add concrete description for `EmbeddedEventLoop`

### DIFF
--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -97,6 +97,8 @@ public final class EmbeddedEventLoop: EventLoop {
     // execution.
     private var taskNumber: UInt64 = 0
 
+    public var description = "EmbeddedEventLoop"
+
     private func nextTaskNumber() -> UInt64 {
         defer {
             self.taskNumber += 1

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -79,7 +79,7 @@ extension EmbeddedScheduledTask: Comparable {
 ///     is because it is intended to be run in the thread that instantiated it. Users are
 ///     responsible for ensuring they never call into the `EmbeddedEventLoop` in an
 ///     unsynchronized fashion.
-public final class EmbeddedEventLoop: EventLoop {
+public final class EmbeddedEventLoop: EventLoop, CustomStringConvertible {
     /// The current "time" for this event loop. This is an amount in nanoseconds.
     internal var _now: NIODeadline = .uptimeNanoseconds(0)
 

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -97,7 +97,7 @@ public final class EmbeddedEventLoop: EventLoop, CustomStringConvertible {
     // execution.
     private var taskNumber: UInt64 = 0
 
-    public var description = "EmbeddedEventLoop"
+    public let description = "EmbeddedEventLoop"
 
     private func nextTaskNumber() -> UInt64 {
         defer {


### PR DESCRIPTION
### Motivation:

We want to avoid going through `EventLoopGroup`'s [`String(describing: self)`](https://github.com/apple/swift-nio/blob/8307ad610a358513b2190955379829d70f04b8c2/Sources/NIOCore/EventLoop.swift#L414) when obtaining the description of an `EventLoopGroup` or `EventLoop`.

The  concrete `MultiThreadedEventLoopGroup` and `SelectableEventLoop` already implement a `description` property. `EmbeddedEventLoop` does not.

### Modifications:

Added a concrete description property in `EmbeddedEventLoop`.

### Result:

The description of `EmbeddedEventLoop` can be obtained without going through `String(describing: self)`.