### PR TITLE
Expose UDP_MAX_SEGMENTS via System

### DIFF
--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -143,8 +143,7 @@ extern const unsigned int CNIOLinux_RENAME_EXCHANGE;
 extern const unsigned long CNIOLinux_UTIME_OMIT;
 extern const unsigned long CNIOLinux_UTIME_NOW;
 
-bool CNIOLinux_udp_max_segments_defined();
-extern const unsigned long CNIOLinux_UDP_MAX_SEGMENTS;
+extern const long CNIOLinux_UDP_MAX_SEGMENTS;
 
 #endif
 #endif

--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -30,7 +30,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <netinet/ip.h>
-#include <netinet/udp.h>
+#include <linux/udp.h>
 #include <linux/vm_sockets.h>
 #include <fcntl.h>
 #include <fts.h>
@@ -142,6 +142,9 @@ extern const unsigned int CNIOLinux_RENAME_EXCHANGE;
 
 extern const unsigned long CNIOLinux_UTIME_OMIT;
 extern const unsigned long CNIOLinux_UTIME_NOW;
+
+bool CNIOLinux_udp_max_segments_defined();
+extern const unsigned long CNIOLinux_UDP_MAX_SEGMENTS;
 
 #endif
 #endif

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -216,16 +216,8 @@ const unsigned long CNIOLinux_UTIME_OMIT = UTIME_OMIT;
 const unsigned long CNIOLinux_UTIME_NOW = UTIME_NOW;
 
 
-bool CNIOLinux_udp_max_segments_defined() {
-    #ifdef UDP_MAX_SEGMENTS
-    return true;
-    #else
-    return false;
-    #endif
-}
-
 #ifdef UDP_MAX_SEGMENTS
-const unsigned long CNIOLinux_UDP_MAX_SEGMENTS = UDP_MAX_SEGMENTS;
+const long CNIOLinux_UDP_MAX_SEGMENTS = UDP_MAX_SEGMENTS;
 #endif
-const unsigned long CNIOLinux_UDP_MAX_SEGMENTS = 0;
+const long CNIOLinux_UDP_MAX_SEGMENTS = -1;
 #endif

--- a/Sources/CNIOLinux/shim.c
+++ b/Sources/CNIOLinux/shim.c
@@ -215,4 +215,17 @@ const int CNIOLinux_AT_EMPTY_PATH = AT_EMPTY_PATH;
 const unsigned long CNIOLinux_UTIME_OMIT = UTIME_OMIT;
 const unsigned long CNIOLinux_UTIME_NOW = UTIME_NOW;
 
+
+bool CNIOLinux_udp_max_segments_defined() {
+    #ifdef UDP_MAX_SEGMENTS
+    return true;
+    #else
+    return false;
+    #endif
+}
+
+#ifdef UDP_MAX_SEGMENTS
+const unsigned long CNIOLinux_UDP_MAX_SEGMENTS = UDP_MAX_SEGMENTS;
+#endif
+const unsigned long CNIOLinux_UDP_MAX_SEGMENTS = 0;
 #endif

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -258,3 +258,18 @@ extension System {
     public static let supportsUDPReceiveOffload: Bool = false
     #endif
 }
+
+extension System {
+    /// Returns the UDP maximum segment count if the platform supports and defines it.
+    public static func udpMaxSegments() -> Int? {
+        #if os(Linux)
+        if CNIOLinux_udp_max_segments_defined() {
+            return Int(CNIOLinux_UDP_MAX_SEGMENTS)
+        } else {
+            return nil
+        }
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -257,19 +257,15 @@ extension System {
     /// The option can be enabled by setting the ``ChannelOptions/Types/DatagramReceiveOffload`` channel option.
     public static let supportsUDPReceiveOffload: Bool = false
     #endif
-}
 
-extension System {
     /// Returns the UDP maximum segment count if the platform supports and defines it.
-    public static func udpMaxSegments() -> Int? {
+    public static var udpMaxSegments: Int? {
         #if os(Linux)
-        if CNIOLinux_udp_max_segments_defined() {
-            return Int(CNIOLinux_UDP_MAX_SEGMENTS)
-        } else {
-            return nil
+        let maxSegments = CNIOLinux_UDP_MAX_SEGMENTS
+        if maxSegments != -1 {
+            return maxSegments
         }
-        #else
-        return nil
         #endif
+        return nil
     }
 }

--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -1495,7 +1495,7 @@ class DatagramChannelTests: XCTestCase {
     func testWriteBufferAtGSOSegmentCountLimit() throws {
         try XCTSkipUnless(System.supportsUDPSegmentationOffload, "UDP_SEGMENT (GSO) is not supported on this platform")
 
-        let udpMaxSegments = System.udpMaxSegments() ?? 64
+        let udpMaxSegments = System.udpMaxSegments ?? 64
 
         var segments = udpMaxSegments
 
@@ -1529,7 +1529,7 @@ class DatagramChannelTests: XCTestCase {
         try XCTSkipUnless(System.supportsUDPSegmentationOffload, "UDP_SEGMENT (GSO) is not supported on this platform")
 
         // commonly 64 or 128 on systems which may or may not define UDP_MAX_SEGMENTS, pick the larger to ensure failure
-        let udpMaxSegments = System.udpMaxSegments() ?? 128
+        let udpMaxSegments = System.udpMaxSegments ?? 128
 
         let segmentSize = 10
         let didSet = self.firstChannel.setOption(.datagramSegmentSize, value: CInt(segmentSize))


### PR DESCRIPTION
### Motivation:

Linux kernels recently increased the value of `UDP_MAX_SEGMENTS` from 64 to 128 causing hardcoded assumptions in our tests to become invalid.

### Modifications:

Surface the value of `UDP_MAX_SEGMENTS` if it is defined on the platform in use via new public API `System.udpMaxSegments()` (otherwise return `nil`) and make use of it in `DatagramChannelTests`.

`System.udpMaxSegments()` is added as new public API in analogue to e.g. `System.supportsUDPReceiveOffload`.

### Result:

`DatagramChannelTests` pass and new API.