### PR TITLE
Revert "Adopt `NIOThrowingAsyncSequenceProducer` (#2879)"

### DIFF
--- a/Sources/NIOFileSystem/DirectoryEntries.swift
+++ b/Sources/NIOFileSystem/DirectoryEntries.swift
@@ -16,7 +16,6 @@
 import CNIODarwin
 import CNIOLinux
 import NIOConcurrencyHelpers
-import NIOCore
 import NIOPosix
 @preconcurrency import SystemPackage
 
@@ -90,17 +89,17 @@ extension DirectoryEntries {
         public typealias AsyncIterator = BatchedIterator
         public typealias Element = [DirectoryEntry]
 
-        private let stream: BufferedOrAnyStream<[DirectoryEntry], DirectoryEntryProducer>
+        private let stream: BufferedOrAnyStream<[DirectoryEntry]>
 
         /// Creates a ``DirectoryEntries/Batched`` sequence by wrapping an `AsyncSequence`
         /// of directory entry batches.
         public init<S: AsyncSequence>(wrapping sequence: S) where S.Element == Element {
-            self.stream = BufferedOrAnyStream<[DirectoryEntry], DirectoryEntryProducer>(wrapping: sequence)
+            self.stream = BufferedOrAnyStream(wrapping: sequence)
         }
 
         fileprivate init(handle: SystemFileHandle, recursive: Bool) {
             // Expanding the batches yields watermarks of 256 and 512 directory entries.
-            let stream = NIOThrowingAsyncSequenceProducer.makeBatchedDirectoryEntryStream(
+            let stream = BufferedStream.makeBatchedDirectoryEntryStream(
                 handle: handle,
                 recursive: recursive,
                 entriesPerBatch: 64,
@@ -117,11 +116,9 @@ extension DirectoryEntries {
 
         /// An `AsyncIteratorProtocol` of `Array<DirectoryEntry>`.
         public struct BatchedIterator: AsyncIteratorProtocol {
-            private var iterator: BufferedOrAnyStream<[DirectoryEntry], DirectoryEntryProducer>.AsyncIterator
+            private var iterator: BufferedOrAnyStream<[DirectoryEntry]>.AsyncIterator
 
-            fileprivate init(
-                wrapping iterator: BufferedOrAnyStream<[DirectoryEntry], DirectoryEntryProducer>.AsyncIterator
-            ) {
+            init(wrapping iterator: BufferedOrAnyStream<[DirectoryEntry]>.AsyncIterator) {
                 self.iterator = iterator
             }
 
@@ -138,94 +135,51 @@ extension DirectoryEntries.Batched.AsyncIterator: Sendable {}
 // MARK: - Internal
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension NIOThrowingAsyncSequenceProducer
-where
-    Element == [DirectoryEntry],
-    Failure == (any Error),
-    Strategy == NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark,
-    Delegate == DirectoryEntryProducer
-{
+extension BufferedStream where Element == [DirectoryEntry] {
     fileprivate static func makeBatchedDirectoryEntryStream(
         handle: SystemFileHandle,
         recursive: Bool,
         entriesPerBatch: Int,
         lowWatermark: Int,
         highWatermark: Int
-    ) -> NIOThrowingAsyncSequenceProducer<
-        [DirectoryEntry], any Error, NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark,
-        DirectoryEntryProducer
-    > {
+    ) -> BufferedStream<[DirectoryEntry]> {
+        let state = DirectoryEnumerator(handle: handle, recursive: recursive)
+        let protectedState = NIOLockedValueBox(state)
+
+        var (stream, source) = BufferedStream.makeStream(
+            of: [DirectoryEntry].self,
+            backPressureStrategy: .watermark(low: lowWatermark, high: highWatermark)
+        )
+
+        source.onTermination = {
+            guard let threadPool = protectedState.withLockedValue({ $0.threadPoolForClosing() }) else {
+                return
+            }
+
+            threadPool.submit { _ in  // always run, even if cancelled
+                protectedState.withLockedValue { state in
+                    state.closeIfNecessary()
+                }
+            }
+        }
+
         let producer = DirectoryEntryProducer(
-            handle: handle,
-            recursive: recursive,
+            state: protectedState,
+            source: source,
             entriesPerBatch: entriesPerBatch
         )
+        // Start producing immediately.
+        producer.produceMore()
 
-        let nioThrowingAsyncSequence = NIOThrowingAsyncSequenceProducer.makeSequence(
-            elementType: [DirectoryEntry].self,
-            backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark(
-                lowWatermark: lowWatermark,
-                highWatermark: highWatermark
-            ),
-            finishOnDeinit: false,
-            delegate: producer
-        )
-
-        producer.setSequenceProducerSource(nioThrowingAsyncSequence.source)
-
-        return nioThrowingAsyncSequence.sequence
+        return stream
     }
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-private typealias DirectoryEntrySequenceProducer = NIOThrowingAsyncSequenceProducer<
-    [DirectoryEntry], Error, NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark, DirectoryEntryProducer
->
-
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-private final class DirectoryEntryProducer: NIOAsyncSequenceProducerDelegate {
+private struct DirectoryEntryProducer {
     let state: NIOLockedValueBox<DirectoryEnumerator>
+    let source: BufferedStream<[DirectoryEntry]>.Source
     let entriesPerBatch: Int
-
-    init(handle: SystemFileHandle, recursive: Bool, entriesPerBatch: Int) {
-        let state = DirectoryEnumerator(handle: handle, recursive: recursive)
-        self.state = NIOLockedValueBox(state)
-        self.entriesPerBatch = entriesPerBatch
-    }
-
-    func didTerminate() {
-        guard let threadPool = self.state.withLockedValue({ $0.threadPoolForClosing() }) else {
-            return
-        }
-
-        threadPool.submit { _ in  // always run, even if cancelled
-            self.state.withLockedValue { state in
-                state.closeIfNecessary()
-            }
-        }
-    }
-
-    /// sets the source within the producer state
-    func setSequenceProducerSource(_ sequenceProducerSource: DirectoryEntrySequenceProducer.Source) {
-        self.state.withLockedValue { state in
-            switch state.state {
-            case .idle:
-                state.sequenceProducerSource = sequenceProducerSource
-            case .done:
-                sequenceProducerSource.finish()
-            case .open, .openPausedProducing:
-                fatalError()
-            case .modifying:
-                fatalError()
-            }
-        }
-    }
-
-    func clearSource() {
-        self.state.withLockedValue { state in
-            state.sequenceProducerSource = nil
-        }
-    }
 
     /// The 'entry point' for producing elements.
     ///
@@ -253,12 +207,6 @@ private final class DirectoryEntryProducer: NIOAsyncSequenceProducerDelegate {
         }
     }
 
-    func pauseProducing() {
-        self.state.withLockedValue { state in
-            state.pauseProducing()
-        }
-    }
-
     private func nextBatch() throws -> [DirectoryEntry] {
         try self.state.withLockedValue { state in
             try state.next(self.entriesPerBatch)
@@ -273,28 +221,14 @@ private final class DirectoryEntryProducer: NIOAsyncSequenceProducerDelegate {
             // Failed to read more entries: close and notify the stream so consumers receive the
             // error.
             self.close()
-            let source = self.state.withLockedValue { state in
-                state.sequenceProducerSource
-            }
-            source?.finish(error)
-            self.clearSource()
+            self.source.finish(throwing: error)
         }
     }
 
     private func onNextBatch(_ entries: [DirectoryEntry]) {
-        let source = self.state.withLockedValue { state in
-            state.sequenceProducerSource
-        }
-
-        guard let source else {
-            assertionFailure("unexpectedly missing source")
-            return
-        }
-
         // No entries were read: this must be the end (as the batch size must be greater than zero).
         if entries.isEmpty {
-            source.finish()
-            self.clearSource()
+            self.source.finish(throwing: nil)
             return
         }
 
@@ -302,22 +236,30 @@ private final class DirectoryEntryProducer: NIOAsyncSequenceProducerDelegate {
         let readEOF = entries.count < self.entriesPerBatch
 
         // Entries were produced: yield them and maybe produce more.
-        let writeResult = source.yield(contentsOf: CollectionOfOne(entries))
+        do {
+            let writeResult = try self.source.write(contentsOf: CollectionOfOne(entries))
+            // Exit early if EOF was read; no use in trying to produce more.
+            if readEOF {
+                self.source.finish(throwing: nil)
+                return
+            }
 
-        // Exit early if EOF was read; no use in trying to produce more.
-        if readEOF {
-            source.finish()
-            self.clearSource()
-            return
-        }
-
-        switch writeResult {
-        case .produceMore:
-            self.produceMore()
-        case .stopProducing:
-            self.pauseProducing()
-        case .dropped:
-            // The source is finished; mark ourselves as done.
+            switch writeResult {
+            case .produceMore:
+                self.produceMore()
+            case let .enqueueCallback(token):
+                self.source.enqueueCallback(callbackToken: token) {
+                    switch $0 {
+                    case .success:
+                        self.produceMore()
+                    case .failure:
+                        self.close()
+                    }
+                }
+            }
+        } catch {
+            // Failure to write means the source is already done, that's okay we just need to
+            // update our state and stop producing.
             self.close()
         }
     }
@@ -340,29 +282,24 @@ private final class DirectoryEntryProducer: NIOAsyncSequenceProducerDelegate {
 /// Note that this is not a `Sequence` because we allow for errors to be thrown on `next()`.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 private struct DirectoryEnumerator: Sendable {
-    internal enum State: @unchecked Sendable {
+    private enum State: @unchecked Sendable {
         case modifying
         case idle(SystemFileHandle.SendableView, recursive: Bool)
         case open(NIOThreadPool, Source, [DirectoryEntry])
-        case openPausedProducing(NIOThreadPool, Source, [DirectoryEntry])
         case done
     }
 
     /// The source of directory entries.
-    internal enum Source {
+    private enum Source {
         case readdir(CInterop.DirPointer)
         case fts(CInterop.FTSPointer)
     }
 
     /// The current state of enumeration.
-    internal var state: State
+    private var state: State
 
     /// The path to the directory being enumerated.
     private let path: FilePath
-
-    /// The route via which directory entry batches are yielded,
-    /// the sourcing end of the `DirectoryEntrySequenceProducer`
-    internal var sequenceProducerSource: DirectoryEntrySequenceProducer.Source?
 
     /// Information about an entry returned by FTS. See 'fts(3)'.
     private enum FTSInfo: Hashable, Sendable {
@@ -416,14 +353,11 @@ private struct DirectoryEnumerator: Sendable {
         self.path = handle.path
     }
 
-    internal mutating func produceMore() -> NIOThreadPool? {
+    internal func produceMore() -> NIOThreadPool? {
         switch self.state {
         case let .idle(handle, _):
             return handle.threadPool
         case let .open(threadPool, _, _):
-            return threadPool
-        case .openPausedProducing(let threadPool, let source, let array):
-            self.state = .open(threadPool, source, array)
             return threadPool
         case .done:
             return nil
@@ -432,22 +366,9 @@ private struct DirectoryEnumerator: Sendable {
         }
     }
 
-    internal mutating func pauseProducing() {
-        switch self.state {
-        case .open(let threadPool, let source, let array):
-            self.state = .openPausedProducing(threadPool, source, array)
-        case .idle:
-            ()  // we won't apply back pressure until something has been read
-        case .openPausedProducing, .done:
-            ()  // no-op
-        case .modifying:
-            fatalError()
-        }
-    }
-
     internal func threadPoolForClosing() -> NIOThreadPool? {
         switch self.state {
-        case .open(let threadPool, _, _), .openPausedProducing(let threadPool, _, _):
+        case let .open(threadPool, _, _):
             return threadPool
         case .idle, .done:
             // Don't need to close in the idle state: we don't own the handle.
@@ -476,7 +397,7 @@ private struct DirectoryEnumerator: Sendable {
             // We don't own the handle so don't close it.
             self.state = .done
 
-        case .open(_, let mode, _), .openPausedProducing(_, let mode, _):
+        case let .open(_, mode, _):
             self.state = .done
             switch mode {
             case .readdir(let dir):
@@ -709,9 +630,6 @@ private struct DirectoryEnumerator: Sendable {
                 self.state = state
                 return result
             }
-
-        case .openPausedProducing:
-            return .yield(.success([]))
 
         case .done:
             return .yield(.success([]))

--- a/Sources/NIOFileSystem/FileChunks.swift
+++ b/Sources/NIOFileSystem/FileChunks.swift
@@ -29,7 +29,7 @@ public struct FileChunks: AsyncSequence, Sendable {
     public typealias Element = ByteBuffer
 
     /// The underlying buffered stream.
-    private let stream: BufferedOrAnyStream<ByteBuffer, FileChunkProducer>
+    private let stream: BufferedOrAnyStream<ByteBuffer>
 
     /// Create a ``FileChunks`` sequence backed by wrapping an `AsyncSequence`.
     public init<S: AsyncSequence & Sendable>(wrapping sequence: S) where S.Element == ByteBuffer {
@@ -50,7 +50,7 @@ public struct FileChunks: AsyncSequence, Sendable {
 
         // TODO: choose reasonable watermarks; this should likely be at least somewhat dependent
         // on the chunk size.
-        let stream = NIOThrowingAsyncSequenceProducer.makeFileChunksStream(
+        let stream = BufferedStream.makeFileChunksStream(
             of: ByteBuffer.self,
             handle: handle,
             chunkLength: chunkLength.bytes,
@@ -67,9 +67,9 @@ public struct FileChunks: AsyncSequence, Sendable {
     }
 
     public struct FileChunkIterator: AsyncIteratorProtocol {
-        private var iterator: BufferedOrAnyStream<ByteBuffer, FileChunkProducer>.AsyncIterator
+        private var iterator: BufferedOrAnyStream<ByteBuffer>.AsyncIterator
 
-        fileprivate init(wrapping iterator: BufferedOrAnyStream<ByteBuffer, FileChunkProducer>.AsyncIterator) {
+        fileprivate init(wrapping iterator: BufferedOrAnyStream<ByteBuffer>.AsyncIterator) {
             self.iterator = iterator
         }
 
@@ -85,18 +85,7 @@ extension FileChunks.FileChunkIterator: Sendable {}
 // MARK: - Internal
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-private typealias FileChunkSequenceProducer = NIOThrowingAsyncSequenceProducer<
-    ByteBuffer, Error, NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark, FileChunkProducer
->
-
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension NIOThrowingAsyncSequenceProducer
-where
-    Element == ByteBuffer,
-    Failure == Error,
-    Strategy == NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark,
-    Delegate == FileChunkProducer
-{
+extension BufferedStream where Element == ByteBuffer {
     static func makeFileChunksStream(
         of: Element.Type = Element.self,
         handle: SystemFileHandle,
@@ -104,77 +93,53 @@ where
         range: FileChunks.ChunkRange,
         lowWatermark: Int,
         highWatermark: Int
-    ) -> FileChunkSequenceProducer {
+    ) -> BufferedStream<ByteBuffer> {
+        let state: ProducerState
+        switch range {
+        case .entireFile:
+            state = ProducerState(handle: handle, range: nil)
+        case .partial(let partialRange):
+            state = ProducerState(handle: handle, range: partialRange)
+        }
+        let protectedState = NIOLockedValueBox(state)
 
+        var (stream, source) = BufferedStream.makeStream(
+            of: ByteBuffer.self,
+            backPressureStrategy: .watermark(low: lowWatermark, high: highWatermark)
+        )
+
+        source.onTermination = {
+            protectedState.withLockedValue { state in
+                state.done()
+            }
+        }
+
+        // Start producing immediately.
         let producer = FileChunkProducer(
-            range: range,
-            handle: handle,
+            state: protectedState,
+            source: source,
+            path: handle.path,
             length: chunkLength
         )
+        producer.produceMore()
 
-        let nioThrowingAsyncSequence = NIOThrowingAsyncSequenceProducer.makeSequence(
-            elementType: ByteBuffer.self,
-            backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark(
-                lowWatermark: 4,
-                highWatermark: 8
-            ),
-            finishOnDeinit: false,
-            delegate: producer
-        )
-
-        producer.setSource(nioThrowingAsyncSequence.source)
-
-        return nioThrowingAsyncSequence.sequence
+        return stream
     }
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-private final class FileChunkProducer: NIOAsyncSequenceProducerDelegate, Sendable {
+private struct FileChunkProducer: Sendable {
     let state: NIOLockedValueBox<ProducerState>
-
+    let source: BufferedStream<ByteBuffer>.Source
     let path: FilePath
     let length: Int64
-
-    init(range: FileChunks.ChunkRange, handle: SystemFileHandle, length: Int64) {
-        let state: ProducerState
-        switch range {
-        case .entireFile:
-            state = .init(handle: handle, range: nil)
-        case .partial(let partialRange):
-            state = .init(handle: handle, range: partialRange)
-        }
-
-        self.state = NIOLockedValueBox(state)
-        self.path = handle.path
-        self.length = length
-    }
-
-    /// sets the source within the producer state
-    func setSource(_ source: FileChunkSequenceProducer.Source) {
-        self.state.withLockedValue { state in
-            switch state.state {
-            case .producing, .pausedProducing:
-                state.source = source
-            case .done(let emptyRange):
-                if emptyRange {
-                    source.finish()
-                }
-            }
-        }
-    }
-
-    func clearSource() {
-        self.state.withLockedValue { state in
-            state.source = nil
-        }
-    }
 
     /// The 'entry point' for producing elements.
     ///
     /// Calling this function will start producing file chunks asynchronously by dispatching work
     /// to the IO executor and feeding the result back to the stream source. On yielding to the
     /// source it will either produce more or be scheduled to produce more. Stopping production
-    /// is signaled via the stream's 'onTermination' handler.
+    /// is signalled via the stream's 'onTermination' handler.
     func produceMore() {
         let threadPool = self.state.withLockedValue { state in
             state.shouldProduceMore()
@@ -228,74 +193,65 @@ private final class FileChunkProducer: NIOAsyncSequenceProducerDelegate, Sendabl
         case let .failure(error):
             // Failed to read: update our state then notify the stream so consumers receive the
             // error.
-
-            let source = self.state.withLockedValue { state in
-                state.done()
-                return state.source
-            }
-            source?.finish(error)
-            self.clearSource()
+            self.state.withLockedValue { state in state.done() }
+            self.source.finish(throwing: error)
         }
     }
 
-    private func onReadNextChunk(_ buffer: ByteBuffer) {
+    private func onReadNextChunk(_ bytes: ByteBuffer) {
         // Reading short means EOF.
-        let readEOF = buffer.readableBytes < self.length
-        assert(buffer.readableBytes <= self.length)
+        let readEOF = bytes.readableBytes < self.length
+        assert(bytes.readableBytes <= self.length)
 
-        let source = self.state.withLockedValue { state in
+        self.state.withLockedValue { state in
             if readEOF {
-                state.didReadEnd()
+                state.readEnd()
             } else {
-                state.didReadBytes(buffer.readableBytes)
+                state.readBytes(bytes.readableBytes)
             }
-            return state.source
-        }
-
-        guard let source else {
-            assertionFailure("unexpectedly missing source")
-            return
         }
 
         // No bytes were read: this must be the end as length is required to be greater than zero.
-        if buffer.readableBytes == 0 {
+        if bytes.readableBytes == 0 {
             assert(readEOF, "read zero bytes but did not read EOF")
-            source.finish()
-            self.clearSource()
+            self.source.finish(throwing: nil)
             return
         }
 
         // Bytes were produced: yield them and maybe produce more.
-        let writeResult = source.yield(contentsOf: CollectionOfOne(buffer))
+        do {
+            let writeResult = try self.source.write(contentsOf: CollectionOfOne(bytes))
+            // Exit early if EOF was read; no use in trying to produce more.
+            if readEOF {
+                self.source.finish(throwing: nil)
+                return
+            }
 
-        // Exit early if EOF was read; no use in trying to produce more.
-        if readEOF {
-            source.finish()
-            self.clearSource()
-            return
-        }
-
-        switch writeResult {
-        case .produceMore:
-            self.produceMore()
-        case .stopProducing:
-            self.state.withLockedValue { state in state.pauseProducing() }
-        case .dropped:
-            // The source is finished; mark ourselves as done.
+            switch writeResult {
+            case .produceMore:
+                self.produceMore()
+            case let .enqueueCallback(token):
+                self.source.enqueueCallback(callbackToken: token) {
+                    switch $0 {
+                    case .success:
+                        self.produceMore()
+                    case .failure:
+                        // The source is finished; mark ourselves as done.
+                        self.state.withLockedValue { state in state.done() }
+                    }
+                }
+            }
+        } catch {
+            // Failure to write means the source is already done, that's okay we just need to
+            // update our state and stop producing.
             self.state.withLockedValue { state in state.done() }
-        }
-    }
-
-    func didTerminate() {
-        self.state.withLockedValue { state in
-            state.done()
         }
     }
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 private struct ProducerState: Sendable {
-    fileprivate struct Producing {
+    private struct Producing {
         /// The handle to read from.
         var handle: SystemFileHandle.SendableView
 
@@ -306,24 +262,18 @@ private struct ProducerState: Sendable {
         var range: Range<Int64>?
     }
 
-    internal enum State {
+    private enum State {
         /// Can potentially produce values (if the handle is not closed).
         case producing(Producing)
-        /// Backpressure policy means that we should stop producing new values for now
-        case pausedProducing(Producing)
         /// Done producing values either by reaching EOF, some error or the stream terminating.
-        case done(emptyRange: Bool)
+        case done
     }
 
-    internal var state: State
-
-    /// The route via which file chunks are yielded,
-    /// the sourcing end of the `FileChunkSequenceProducer`
-    internal var source: FileChunkSequenceProducer.Source?
+    private var state: State
 
     init(handle: SystemFileHandle, range: Range<Int64>?) {
         if let range, range.isEmpty {
-            self.state = .done(emptyRange: true)
+            self.state = .done
         } else {
             self.state = .producing(.init(handle: handle.sendableView, range: range))
         }
@@ -333,8 +283,6 @@ private struct ProducerState: Sendable {
         switch self.state {
         case let .producing(state):
             return state.handle.threadPool
-        case .pausedProducing:
-            return nil
         case .done:
             return nil
         }
@@ -354,77 +302,45 @@ private struct ProducerState: Sendable {
                 )
                 return .failure(error)
             }
-        case .pausedProducing:
-            return .success(nil)
         case .done:
             return .success(nil)
         }
     }
 
-    mutating func didReadBytes(_ count: Int) {
+    mutating func readBytes(_ count: Int) {
         switch self.state {
         case var .producing(state):
-            if state.didReadBytes(count) {
-                self.state = .done(emptyRange: false)
+            if let currentRange = state.range {
+                let newRange = (currentRange.lowerBound + Int64(count))..<currentRange.upperBound
+                if newRange.lowerBound >= newRange.upperBound {
+                    assert(newRange.lowerBound == newRange.upperBound)
+                    self.state = .done
+                } else {
+                    state.range = newRange
+                    self.state = .producing(state)
+                }
             } else {
-                self.state = .producing(state)
-            }
-        case var .pausedProducing(state):
-            if state.didReadBytes(count) {
-                self.state = .done(emptyRange: false)
-            } else {
-                self.state = .pausedProducing(state)
+                if count == 0 {
+                    self.state = .done
+                }
             }
         case .done:
             ()
         }
     }
 
-    mutating func didReadEnd() {
+    mutating func readEnd() {
         switch self.state {
-        case .pausedProducing, .producing:
-            self.state = .done(emptyRange: false)
+        case .producing:
+            self.state = .done
         case .done:
-            ()
-        }
-    }
-
-    mutating func pauseProducing() {
-        switch self.state {
-        case .producing(let state):
-            self.state = .pausedProducing(state)
-        case .pausedProducing, .done:
             ()
         }
     }
 
     mutating func done() {
-        self.state = .done(emptyRange: false)
+        self.state = .done
     }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension ProducerState.Producing {
-    /// Updates the range (the offsets to read from and up to) to reflect the number of bytes which have been read.
-    /// - Parameter count: The number of bytes which have been read.
-    /// - Returns: Returns `True` if there are no remaining bytes to read, `False` otherwise.
-    mutating func didReadBytes(_ count: Int) -> Bool {
-        guard let currentRange = self.range else {
-            // if we read 0 bytes we are done
-            return count == 0
-        }
-
-        let newLowerBound = currentRange.lowerBound + Int64(count)
-
-        // we have run out of bytes to read, we are done
-        if newLowerBound >= currentRange.upperBound {
-            self.range = currentRange.upperBound..<currentRange.upperBound
-            return true
-        }
-
-        // update range, we are not done
-        self.range = newLowerBound..<currentRange.upperBound
-        return false
-    }
-}
 #endif

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -546,7 +546,7 @@ final class FileHandleTests: XCTestCase {
 
     func testReadRangeLongerThanChunkAndNotMultipleOfChunkLength() async throws {
         // Reading chunks of bytes from within a range longer than the chunklength
-        // and with size not a multiple of the chunklength.
+        // and with size not a multiple of the chunklegth.
         try await self.withHandle(forFileAtPath: Self.thisFile) { handle in
             var bytes = ByteBuffer()
             for try await chunk in handle.readChunks(in: 0...200, chunkLength: .bytes(128)) {


### PR DESCRIPTION
This reverts commit 282f5935cf3352b3d026c35eb57cb3619dd9536f.

### Motivation:

Repeated testing in linux containers has surfaced issues with the implementation which require some rethinking of the code, let's revert it for now and fix it up.

### Modifications:

Revert the adoption commit.

### Result:

The change is backed out.
