### PR TITLE
Conditionally include linux/udp.h

### DIFF
--- a/Sources/CNIOLinux/include/CNIOLinux.h
+++ b/Sources/CNIOLinux/include/CNIOLinux.h
@@ -30,7 +30,11 @@
 #include <errno.h>
 #include <pthread.h>
 #include <netinet/ip.h>
+#if __has_include(<linux/udp.h>)
 #include <linux/udp.h>
+#else
+#include <netinet/udp.h>
+#endif
 #include <linux/vm_sockets.h>
 #include <fcntl.h>
 #include <fts.h>


### PR DESCRIPTION
### Motivation:

To enable access to `UDP_MAX_SEGMENTS` we switched from including `netinet/udp.h` to including `linux/udp.h` however the latter isn't available in MUSL.

### Modifications:

if `linux/udp.h` is available then import it in favor of `netinet/udp.h`. If we fall back to the latter then `UDP_MAX_SEGMENTS` won't be defined but that will be caught by the existing paths which account for this case.

### Result:

NIO should be able to build against a static MUSL SDK again.
