### PR TITLE
Fixed CI Cancelling Workflows On Past Default Branch Commits

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,7 +37,6 @@ jobs:
         # Workaround https://github.com/nektos/act/issues/1875
         uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
-          name: "Benchmarks"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q libjemalloc-dev && swift package --package-path ${{ inputs.benchmark_package_path }} ${{ inputs.swift_package_arguments }} benchmark baseline check --check-absolute-path ${{ inputs.benchmark_package_path }}/Thresholds/${SWIFT_VERSION}/"
           matrix_linux_5_8_enabled: ${{ inputs.linux_5_8_enabled }}
           matrix_linux_5_9_enabled: ${{ inputs.linux_5_9_enabled }}

--- a/.github/workflows/cxx_interop.yml
+++ b/.github/workflows/cxx_interop.yml
@@ -30,7 +30,6 @@ jobs:
         # Workaround https://github.com/nektos/act/issues/1875
         uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
-          name: "Cxx interop"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q jq && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-cxx-interop-compatibility.sh | bash"
           matrix_linux_5_8_enabled: ${{ inputs.linux_5_8_enabled }}
           matrix_linux_5_9_enabled: ${{ inputs.linux_5_9_enabled }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,5 +33,4 @@ jobs:
         # Workaround https://github.com/nektos/act/issues/1875
         uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
-          name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
       types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     soundness:
         name: Soundness
@@ -40,7 +44,6 @@ jobs:
         # Workaround https://github.com/nektos/act/issues/1875
         uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
-          name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"
 
     swift-6-language-mode:

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
         types: [labeled, unlabeled, opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     semver-label-check:
         name: Semantic Version label check

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -28,5 +28,4 @@ jobs:
         # Workaround https://github.com/nektos/act/issues/1875
         uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
-          name: "Integration tests"
           matrix_linux_command: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq && ./scripts/integration_tests.sh"

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -51,11 +51,6 @@ on:
         type: string
         description: "Container image for the shell check job. Defaults to latest Swift Ubuntu image."
         default: "swift:5.10-noble"
-
-## We are cancelling previously triggered workflow runs
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-soundness
-  cancel-in-progress: true
  
 jobs:
   api-breakage-check:

--- a/.github/workflows/swift_6_language_mode.yml
+++ b/.github/workflows/swift_6_language_mode.yml
@@ -2,11 +2,6 @@ name: Swift 6 language mode
 
 on:
     workflow_call:
-
-## We are cancelling previously triggered workflow runs
-concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}-swift-6-language-mode
-    cancel-in-progress: true
  
 jobs:
     swift-6-language-mode:

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -3,10 +3,6 @@ name: Matrix
 on:
   workflow_call:
     inputs:
-      name:
-        type: string
-        description: "The name of the workflow used for the concurrency group."
-        required: true
       matrix_linux_command:
         type: string
         description: "The command of the current Swift version linux matrix job to execute."
@@ -66,11 +62,6 @@ on:
       matrix_linux_nightly_main_command_override:
         type: string
         description: "The command of the nightly main Swift version linux matrix job to execute."
-
-## We are cancelling previously triggered workflow runs
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.name }}
-  cancel-in-progress: true
  
 jobs:
   linux:


### PR DESCRIPTION
Fixed an issue where workflows running for the latest commit on main would cancel past those running on just-merged commits.

### Motivation:

I noticed while updating CI in other swift-server repos that some of these workflows would cancel for commits just merged on main.

### Modifications:

This will only cancel PR-related workflows, which means those running on main will be allowed to always finish, maintaining historical status checks.

### Result:

Hopefully, workflows that cancel each other less often.
