### PR TITLE
Work around a type checking error when using the Static Linux SDK

### DIFF
--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -73,7 +73,7 @@ extension NIOSingletons {
         let concurrencyEnqueueGlobalHookPtr = dlsym(
             dlopen(nil, RTLD_NOW),
             "swift_task_enqueueGlobal_hook"
-        )?.assumingMemoryBound(to: UnsafeRawPointer?.AtomicRepresentation.self)
+        )?.assumingMemoryBound(to: UnsafeRawPointer?.AtomicRep.self)
         guard let concurrencyEnqueueGlobalHookPtr = concurrencyEnqueueGlobalHookPtr else {
             return false
         }
@@ -125,4 +125,13 @@ extension NIOSingletons {
         return false
         #endif
     }
+}
+
+// Workaround for https://github.com/apple/swift-nio/issues/2893
+extension Optional
+where
+    Wrapped: AtomicOptionalWrappable,
+    Wrapped.AtomicRepresentation.Value == Wrapped
+{
+    typealias AtomicRep = Wrapped.AtomicOptionalRepresentation
 }


### PR DESCRIPTION
 # Motivation

Building `swift-nio` with the Static Linux SDK
(https://www.swift.org/documentation/articles/static-linux-getting-started.html), fails in `PosixSingletons+ConcurrencyTakeOver.swift`:

```
Building for debugging...
error: emit-module command failed with exit code 1 (use -v to see invocation)
/private/tmp/vaportest/.build/checkouts/swift-nio/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift:76:12: error: conflicting arguments to generic parameter 'T' ('Optional<UnsafeRawPointer>.AtomicRepresentation' vs. 'Optional<UnsafeRawPointer>.AtomicRepresentation')
 74 |             dlopen(nil, RTLD_NOW),
 75 |             "swift_task_enqueueGlobal_hook"
 76 |         )?.assumingMemoryBound(to: UnsafeRawPointer?.AtomicRepresentation.self)
    |            `- error: conflicting arguments to generic parameter 'T' ('Optional<UnsafeRawPointer>.AtomicRepresentation' vs. 'Optional<UnsafeRawPointer>.AtomicRepresentation')
 77 |         guard let concurrencyEnqueueGlobalHookPtr = concurrencyEnqueueGlobalHookPtr else {
 78 |             return false
```

This happens because `Foundation` and `swift-atomics` both define `AtomicRepresentation`.  A compiler problem (rdar://132885963) makes these extensions globally visible, causing the two `AtomicRepresentation`
types to collide.   This only affects non-Darwin platforms.

 # Modification

This PR works around the problem by using a local type alias which does not collide with the other `AtomicRepresentation` types.

 # Result

It is now possible to build `swift-nio` with the Static Linux SDK.

Fixes: https://github.com/apple/swift-nio/issues/2893
Suggested-by: Alastair Houghton <ahoughton@apple.com>