### PR TITLE
A DatagramChannelTest now waits for writes

### DIFF
--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -1689,6 +1689,9 @@ class DatagramChannelTests: XCTestCase {
             do {
                 if i % 2 == 0 {
                     self.firstChannel.flush()
+                    XCTAssertNoThrow(
+                        try EventLoopFuture.andAllSucceed(promises, on: self.firstChannel.eventLoop).wait()
+                    )
                     let bufferedAmount = try self.firstChannel.getOption(.bufferedWritableBytes).wait()
                     XCTAssertEqual(bufferedAmount, 0)
                 } else {
@@ -1701,9 +1704,9 @@ class DatagramChannelTests: XCTestCase {
         }
 
         self.firstChannel.flush()
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(promises, on: self.firstChannel.eventLoop).wait())
         let finalBufferedAmount = try self.firstChannel.getOption(.bufferedWritableBytes).wait()
         XCTAssertEqual(finalBufferedAmount, 0)
-        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(promises, on: self.firstChannel.eventLoop).wait())
         let datagrams = try self.secondChannel.waitForDatagrams(count: writeCount)
 
         XCTAssertEqual(datagrams.count, writeCount)


### PR DESCRIPTION
### Motivation:

In `DatagramChannelTests.testChannelCanReportWritableBufferedBytesWithDataLargerThanSendBuffer` we assert that there are no buffered writable bytes immediately after a flush, however in some cases tests fail as this is not true.

We suspect that this is because in some situations the kernel can be slow to drain the write buffer leading to racey behavior.

### Modifications:

Wait for writes to complete before asserting that the buffer is emptied.

### Result:

Tests should be more deterministic.
