### PR TITLE
Add convenience conformances to `ByteCount`

### DIFF
--- a/Sources/NIOFileSystem/ByteCount.swift
+++ b/Sources/NIOFileSystem/ByteCount.swift
@@ -81,7 +81,7 @@ public struct ByteCount: Hashable, Sendable {
 }
 
 extension ByteCount: AdditiveArithmetic {
-    public static var zero: ByteCount {  ByteCount(bytes: 0) }
+    public static var zero: ByteCount { ByteCount(bytes: 0) }
 
     public static func + (lhs: ByteCount, rhs: ByteCount) -> ByteCount {
         ByteCount(bytes: lhs.bytes + rhs.bytes)

--- a/Sources/NIOFileSystem/ByteCount.swift
+++ b/Sources/NIOFileSystem/ByteCount.swift
@@ -80,4 +80,22 @@ public struct ByteCount: Hashable, Sendable {
     }
 }
 
+extension ByteCount: AdditiveArithmetic {
+    public static var zero = ByteCount(bytes: 0)
+
+    public static func + (lhs: ByteCount, rhs: ByteCount) -> ByteCount {
+        ByteCount(bytes: lhs.bytes + rhs.bytes)
+    }
+
+    public static func - (lhs: ByteCount, rhs: ByteCount) -> ByteCount {
+        ByteCount(bytes: lhs.bytes - rhs.bytes)
+    }
+}
+
+extension ByteCount: Comparable {
+    public static func < (lhs: ByteCount, rhs: ByteCount) -> Bool {
+        lhs.bytes < rhs.bytes
+    }
+}
+
 #endif

--- a/Sources/NIOFileSystem/ByteCount.swift
+++ b/Sources/NIOFileSystem/ByteCount.swift
@@ -81,7 +81,7 @@ public struct ByteCount: Hashable, Sendable {
 }
 
 extension ByteCount: AdditiveArithmetic {
-    public static var zero = ByteCount(bytes: 0)
+    public static var zero: ByteCount {  ByteCount(bytes: 0) }
 
     public static func + (lhs: ByteCount, rhs: ByteCount) -> ByteCount {
         ByteCount(bytes: lhs.bytes + rhs.bytes)

--- a/Tests/NIOFileSystemTests/ByteCountTests.swift
+++ b/Tests/NIOFileSystemTests/ByteCountTests.swift
@@ -58,5 +58,31 @@ class ByteCountTests: XCTestCase {
         XCTAssertEqual(byteCount1, byteCount1)
         XCTAssertNotEqual(byteCount1, byteCount2)
     }
+
+    func testByteCountZero() {
+        let byteCount = ByteCount.zero
+        XCTAssertEqual(byteCount.bytes, 0)
+    }
+
+    func testByteCountAddition() {
+        let byteCount1 = ByteCount.bytes(10)
+        let byteCount2 = ByteCount.bytes(20)
+        let sum = byteCount1 + byteCount2
+        XCTAssertEqual(sum.bytes, 30)
+    }
+
+    func testByteCountSubtraction() {
+        let byteCount1 = ByteCount.bytes(30)
+        let byteCount2 = ByteCount.bytes(20)
+        let difference = byteCount1 - byteCount2
+        XCTAssertEqual(difference.bytes, 10)
+    }
+
+    func testByteCountComparison() {
+        let byteCount1 = ByteCount.bytes(10)
+        let byteCount2 = ByteCount.bytes(20)
+        XCTAssertLessThan(byteCount1, byteCount2)
+        XCTAssertGreaterThan(byteCount2, byteCount1)
+    }
 }
 #endif


### PR DESCRIPTION
Motivation:

Several arithmetic and comparison operations are done with `ByteCount` using the `bytes` property. Operating on the `ByteCount` type directly will be more convenient.

Modifications:

- Add `AdditiveArithmetic` and `Comparable` conformances to `ByteCount`.

Result:

The `ByteCount` type can undergo arithmetic and comparison operations.