### PR TITLE
Adopt NIOThrowingAsyncSequenceProducer 2nd try

### DIFF
--- a/Sources/NIOFileSystem/FileChunks.swift
+++ b/Sources/NIOFileSystem/FileChunks.swift
@@ -29,7 +29,7 @@ public struct FileChunks: AsyncSequence, Sendable {
     public typealias Element = ByteBuffer
 
     /// The underlying buffered stream.
-    private let stream: BufferedOrAnyStream<ByteBuffer>
+    private let stream: BufferedOrAnyStream<ByteBuffer, FileChunkProducer>
 
     /// Create a ``FileChunks`` sequence backed by wrapping an `AsyncSequence`.
     public init<S: AsyncSequence & Sendable>(wrapping sequence: S) where S.Element == ByteBuffer {
@@ -50,7 +50,7 @@ public struct FileChunks: AsyncSequence, Sendable {
 
         // TODO: choose reasonable watermarks; this should likely be at least somewhat dependent
         // on the chunk size.
-        let stream = BufferedStream.makeFileChunksStream(
+        let stream = NIOThrowingAsyncSequenceProducer.makeFileChunksStream(
             of: ByteBuffer.self,
             handle: handle,
             chunkLength: chunkLength.bytes,
@@ -67,9 +67,9 @@ public struct FileChunks: AsyncSequence, Sendable {
     }
 
     public struct FileChunkIterator: AsyncIteratorProtocol {
-        private var iterator: BufferedOrAnyStream<ByteBuffer>.AsyncIterator
+        private var iterator: BufferedOrAnyStream<ByteBuffer, FileChunkProducer>.AsyncIterator
 
-        fileprivate init(wrapping iterator: BufferedOrAnyStream<ByteBuffer>.AsyncIterator) {
+        fileprivate init(wrapping iterator: BufferedOrAnyStream<ByteBuffer, FileChunkProducer>.AsyncIterator) {
             self.iterator = iterator
         }
 
@@ -85,7 +85,18 @@ extension FileChunks.FileChunkIterator: Sendable {}
 // MARK: - Internal
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension BufferedStream where Element == ByteBuffer {
+private typealias FileChunkSequenceProducer = NIOThrowingAsyncSequenceProducer<
+    ByteBuffer, Error, NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark, FileChunkProducer
+>
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension NIOThrowingAsyncSequenceProducer
+where
+    Element == ByteBuffer,
+    Failure == Error,
+    Strategy == NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark,
+    Delegate == FileChunkProducer
+{
     static func makeFileChunksStream(
         of: Element.Type = Element.self,
         handle: SystemFileHandle,
@@ -93,53 +104,77 @@ extension BufferedStream where Element == ByteBuffer {
         range: FileChunks.ChunkRange,
         lowWatermark: Int,
         highWatermark: Int
-    ) -> BufferedStream<ByteBuffer> {
-        let state: ProducerState
-        switch range {
-        case .entireFile:
-            state = ProducerState(handle: handle, range: nil)
-        case .partial(let partialRange):
-            state = ProducerState(handle: handle, range: partialRange)
-        }
-        let protectedState = NIOLockedValueBox(state)
+    ) -> FileChunkSequenceProducer {
 
-        var (stream, source) = BufferedStream.makeStream(
-            of: ByteBuffer.self,
-            backPressureStrategy: .watermark(low: lowWatermark, high: highWatermark)
-        )
-
-        source.onTermination = {
-            protectedState.withLockedValue { state in
-                state.done()
-            }
-        }
-
-        // Start producing immediately.
         let producer = FileChunkProducer(
-            state: protectedState,
-            source: source,
-            path: handle.path,
+            range: range,
+            handle: handle,
             length: chunkLength
         )
-        producer.produceMore()
 
-        return stream
+        let nioThrowingAsyncSequence = NIOThrowingAsyncSequenceProducer.makeSequence(
+            elementType: ByteBuffer.self,
+            backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark(
+                lowWatermark: 4,
+                highWatermark: 8
+            ),
+            finishOnDeinit: false,
+            delegate: producer
+        )
+
+        producer.setSource(nioThrowingAsyncSequence.source)
+
+        return nioThrowingAsyncSequence.sequence
     }
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-private struct FileChunkProducer: Sendable {
+private final class FileChunkProducer: NIOAsyncSequenceProducerDelegate, Sendable {
     let state: NIOLockedValueBox<ProducerState>
-    let source: BufferedStream<ByteBuffer>.Source
+
     let path: FilePath
     let length: Int64
+
+    init(range: FileChunks.ChunkRange, handle: SystemFileHandle, length: Int64) {
+        let state: ProducerState
+        switch range {
+        case .entireFile:
+            state = .init(handle: handle, range: nil)
+        case .partial(let partialRange):
+            state = .init(handle: handle, range: partialRange)
+        }
+
+        self.state = NIOLockedValueBox(state)
+        self.path = handle.path
+        self.length = length
+    }
+
+    /// sets the source within the producer state
+    func setSource(_ source: FileChunkSequenceProducer.Source) {
+        self.state.withLockedValue { state in
+            switch state.state {
+            case .producing, .pausedProducing:
+                state.source = source
+            case .done(let emptyRange):
+                if emptyRange {
+                    source.finish()
+                }
+            }
+        }
+    }
+
+    func clearSource() {
+        self.state.withLockedValue { state in
+            state.source = nil
+        }
+    }
 
     /// The 'entry point' for producing elements.
     ///
     /// Calling this function will start producing file chunks asynchronously by dispatching work
     /// to the IO executor and feeding the result back to the stream source. On yielding to the
     /// source it will either produce more or be scheduled to produce more. Stopping production
-    /// is signalled via the stream's 'onTermination' handler.
+    /// is signaled via the stream's 'onTermination' handler.
     func produceMore() {
         let threadPool = self.state.withLockedValue { state in
             state.shouldProduceMore()
@@ -193,65 +228,74 @@ private struct FileChunkProducer: Sendable {
         case let .failure(error):
             // Failed to read: update our state then notify the stream so consumers receive the
             // error.
-            self.state.withLockedValue { state in state.done() }
-            self.source.finish(throwing: error)
+
+            let source = self.state.withLockedValue { state in
+                state.done()
+                return state.source
+            }
+            source?.finish(error)
+            self.clearSource()
         }
     }
 
-    private func onReadNextChunk(_ bytes: ByteBuffer) {
+    private func onReadNextChunk(_ buffer: ByteBuffer) {
         // Reading short means EOF.
-        let readEOF = bytes.readableBytes < self.length
-        assert(bytes.readableBytes <= self.length)
+        let readEOF = buffer.readableBytes < self.length
+        assert(buffer.readableBytes <= self.length)
 
-        self.state.withLockedValue { state in
+        let source = self.state.withLockedValue { state in
             if readEOF {
-                state.readEnd()
+                state.didReadEnd()
             } else {
-                state.readBytes(bytes.readableBytes)
+                state.didReadBytes(buffer.readableBytes)
             }
+            return state.source
+        }
+
+        guard let source else {
+            assertionFailure("unexpectedly missing source")
+            return
         }
 
         // No bytes were read: this must be the end as length is required to be greater than zero.
-        if bytes.readableBytes == 0 {
+        if buffer.readableBytes == 0 {
             assert(readEOF, "read zero bytes but did not read EOF")
-            self.source.finish(throwing: nil)
+            source.finish()
+            self.clearSource()
             return
         }
 
         // Bytes were produced: yield them and maybe produce more.
-        do {
-            let writeResult = try self.source.write(contentsOf: CollectionOfOne(bytes))
-            // Exit early if EOF was read; no use in trying to produce more.
-            if readEOF {
-                self.source.finish(throwing: nil)
-                return
-            }
+        let writeResult = source.yield(contentsOf: CollectionOfOne(buffer))
 
-            switch writeResult {
-            case .produceMore:
-                self.produceMore()
-            case let .enqueueCallback(token):
-                self.source.enqueueCallback(callbackToken: token) {
-                    switch $0 {
-                    case .success:
-                        self.produceMore()
-                    case .failure:
-                        // The source is finished; mark ourselves as done.
-                        self.state.withLockedValue { state in state.done() }
-                    }
-                }
-            }
-        } catch {
-            // Failure to write means the source is already done, that's okay we just need to
-            // update our state and stop producing.
+        // Exit early if EOF was read; no use in trying to produce more.
+        if readEOF {
+            source.finish()
+            self.clearSource()
+            return
+        }
+
+        switch writeResult {
+        case .produceMore:
+            self.produceMore()
+        case .stopProducing:
+            self.state.withLockedValue { state in state.pauseProducing() }
+        case .dropped:
+            // The source is finished; mark ourselves as done.
             self.state.withLockedValue { state in state.done() }
+        }
+    }
+
+    func didTerminate() {
+        self.state.withLockedValue { state in
+            state.done()
         }
     }
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 private struct ProducerState: Sendable {
-    private struct Producing {
+    fileprivate struct Producing {
         /// The handle to read from.
         var handle: SystemFileHandle.SendableView
 
@@ -262,18 +306,24 @@ private struct ProducerState: Sendable {
         var range: Range<Int64>?
     }
 
-    private enum State {
+    internal enum State {
         /// Can potentially produce values (if the handle is not closed).
         case producing(Producing)
+        /// Backpressure policy means that we should stop producing new values for now
+        case pausedProducing(Producing)
         /// Done producing values either by reaching EOF, some error or the stream terminating.
-        case done
+        case done(emptyRange: Bool)
     }
 
-    private var state: State
+    internal var state: State
+
+    /// The route via which file chunks are yielded,
+    /// the sourcing end of the `FileChunkSequenceProducer`
+    internal var source: FileChunkSequenceProducer.Source?
 
     init(handle: SystemFileHandle, range: Range<Int64>?) {
         if let range, range.isEmpty {
-            self.state = .done
+            self.state = .done(emptyRange: true)
         } else {
             self.state = .producing(.init(handle: handle.sendableView, range: range))
         }
@@ -283,6 +333,8 @@ private struct ProducerState: Sendable {
         switch self.state {
         case let .producing(state):
             return state.handle.threadPool
+        case .pausedProducing:
+            return nil
         case .done:
             return nil
         }
@@ -302,45 +354,77 @@ private struct ProducerState: Sendable {
                 )
                 return .failure(error)
             }
+        case .pausedProducing:
+            return .success(nil)
         case .done:
             return .success(nil)
         }
     }
 
-    mutating func readBytes(_ count: Int) {
+    mutating func didReadBytes(_ count: Int) {
         switch self.state {
         case var .producing(state):
-            if let currentRange = state.range {
-                let newRange = (currentRange.lowerBound + Int64(count))..<currentRange.upperBound
-                if newRange.lowerBound >= newRange.upperBound {
-                    assert(newRange.lowerBound == newRange.upperBound)
-                    self.state = .done
-                } else {
-                    state.range = newRange
-                    self.state = .producing(state)
-                }
+            if state.didReadBytes(count) {
+                self.state = .done(emptyRange: false)
             } else {
-                if count == 0 {
-                    self.state = .done
-                }
+                self.state = .producing(state)
+            }
+        case var .pausedProducing(state):
+            if state.didReadBytes(count) {
+                self.state = .done(emptyRange: false)
+            } else {
+                self.state = .pausedProducing(state)
             }
         case .done:
             ()
         }
     }
 
-    mutating func readEnd() {
+    mutating func didReadEnd() {
         switch self.state {
-        case .producing:
-            self.state = .done
+        case .pausedProducing, .producing:
+            self.state = .done(emptyRange: false)
         case .done:
             ()
         }
     }
 
+    mutating func pauseProducing() {
+        switch self.state {
+        case .producing(let state):
+            self.state = .pausedProducing(state)
+        case .pausedProducing, .done:
+            ()
+        }
+    }
+
     mutating func done() {
-        self.state = .done
+        self.state = .done(emptyRange: false)
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension ProducerState.Producing {
+    /// Updates the range (the offsets to read from and up to) to reflect the number of bytes which have been read.
+    /// - Parameter count: The number of bytes which have been read.
+    /// - Returns: Returns `True` if there are no remaining bytes to read, `False` otherwise.
+    mutating func didReadBytes(_ count: Int) -> Bool {
+        guard let currentRange = self.range else {
+            // if we read 0 bytes we are done
+            return count == 0
+        }
+
+        let newLowerBound = currentRange.lowerBound + Int64(count)
+
+        // we have run out of bytes to read, we are done
+        if newLowerBound >= currentRange.upperBound {
+            self.range = currentRange.upperBound..<currentRange.upperBound
+            return true
+        }
+
+        // update range, we are not done
+        self.range = newLowerBound..<currentRange.upperBound
+        return false
+    }
+}
 #endif

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -546,7 +546,7 @@ final class FileHandleTests: XCTestCase {
 
     func testReadRangeLongerThanChunkAndNotMultipleOfChunkLength() async throws {
         // Reading chunks of bytes from within a range longer than the chunklength
-        // and with size not a multiple of the chunklegth.
+        // and with size not a multiple of the chunklength.
         try await self.withHandle(forFileAtPath: Self.thisFile) { handle in
             var bytes = ByteBuffer()
             for try await chunk in handle.readChunks(in: 0...200, chunkLength: .bytes(128)) {


### PR DESCRIPTION
### Motivation:

Adopt `NIOThrowingAsyncSequenceProducer` in NIOFileSystem to reduce code
duplication.

### Modifications:

Adopt `NIOThrowingAsyncSequenceProducer` in NIOFileSystem `DirectoryEntryProducer` and `FileChunkProducer`.

This change was previously merged and then backed out due to issues (#2879). The original change is in the first commit, the second commit contains additional changes.

In the original adoption of `NIOThrowingAsyncSequenceProducer` the code did not deal with backpressure being applied very well, in some cases causes hangs.

A key bug was that it was not protected against re-entrant calls to `produceMore`. Such calls may happen e.g. when the producer has been asked to pause producing and then resume again before the initial read had completed. This resulted in overlapping reads and re-ordered data.

This change introduces a new activity state which is protected by a lock and keeps track of if we are in the critical section to serialize access.

`DirectoryEntryProducer` performs most of its logic within a lock and so
doesn't seem to be impacted in the same way.

### Result:

No functional changes. Internal changes reduce code duplication.
