### PR TITLE
Re-add CXX compat check script

### DIFF
--- a/scripts/check-cxx-interop-compatibility.sh
+++ b/scripts/check-cxx-interop-compatibility.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2024 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+log "Checking for Cxx interoperability comaptibility..."
+
+source_dir=$(pwd)
+working_dir=$(mktemp -d)
+project_name=$(basename "$working_dir")
+source_file=Sources/$project_name/$(echo "$project_name" | tr . _).swift
+library_products=$( swift package dump-package | jq -r '.products[] | select(.type.library != null) | .name')
+package_name=$(swift package dump-package | jq -r '.name')
+
+cd "$working_dir"
+swift package init
+echo "package.dependencies.append(.package(path: \"$source_dir\"))" >> Package.swift
+
+for product in $library_products; do
+  echo "package.targets.first!.dependencies.append(.product(name: \"$product\", package: \"$package_name\"))" >> Package.swift
+  echo "import $product" >> "$source_file"
+done
+
+swift build
+
+log "✅ Passed the Cxx interoperability tests."


### PR DESCRIPTION
Motivation:

It's still referenced from CI.

Modifications:

Re-add script removed in a previous commit.

Result:

CXX checks on PRs should work again.