### PR TITLE
[CI] Migrate to Swift 6.0 and drop 5.8

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,10 +10,6 @@ on:
       swift_package_arguments:
         type: string
         description: "Arguments to the switch package command invocation e.g. `--disable-sandbox`"
-      linux_5_8_enabled:
-        type: boolean
-        description: "Boolean to enable the Linux 5.8 Swift version matrix job. Defaults to true."
-        default: true
       linux_5_9_enabled:
         type: boolean
         description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to true."
@@ -21,6 +17,10 @@ on:
       linux_5_10_enabled:
         type: boolean
         description: "Boolean to enable the Linux 5.10 Swift version matrix job. Defaults to true."
+        default: true
+      linux_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 6.0 Swift version matrix job. Defaults to true."
         default: true
       linux_nightly_6_0_enabled:
         type: boolean
@@ -39,8 +39,8 @@ jobs:
     with:
       name: "Benchmarks"
       matrix_linux_command: "apt-get update -y -q && apt-get install -y -q libjemalloc-dev && swift package --package-path ${{ inputs.benchmark_package_path }} ${{ inputs.swift_package_arguments }} benchmark baseline check --check-absolute-path ${{ inputs.benchmark_package_path }}/Thresholds/${SWIFT_VERSION}/"
-      matrix_linux_5_8_enabled: ${{ inputs.linux_5_8_enabled }}
       matrix_linux_5_9_enabled: ${{ inputs.linux_5_9_enabled }}
       matrix_linux_5_10_enabled: ${{ inputs.linux_5_10_enabled }}
+      matrix_linux_6_0_enabled: ${{ inputs.linux_6_0_enabled }}
       matrix_linux_nightly_6_0_enabled: ${{ inputs.linux_nightly_6_0_enabled }}
       matrix_linux_nightly_main_enabled: ${{ inputs.linux_nightly_main_enabled }}

--- a/.github/workflows/cxx_interop.yml
+++ b/.github/workflows/cxx_interop.yml
@@ -3,10 +3,6 @@ name: Cxx interop
 on:
   workflow_call:
     inputs:
-      linux_5_8_enabled:
-        type: boolean
-        description: "Boolean to enable the Linux 5.8 Swift version matrix job. Defaults to true."
-        default: true
       linux_5_9_enabled:
         type: boolean
         description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to true."
@@ -14,6 +10,10 @@ on:
       linux_5_10_enabled:
         type: boolean
         description: "Boolean to enable the Linux 5.10 Swift version matrix job. Defaults to true."
+        default: true
+      linux_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 6.0 Swift version matrix job. Defaults to true."
         default: true
       linux_nightly_6_0_enabled:
         type: boolean
@@ -32,8 +32,8 @@ jobs:
     with:
       name: "Cxx interop"
       matrix_linux_command: "apt-get update -y -q && apt-get install -y -q jq && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-cxx-interop-compatibility.sh | bash"
-      matrix_linux_5_8_enabled: ${{ inputs.linux_5_8_enabled }}
       matrix_linux_5_9_enabled: ${{ inputs.linux_5_9_enabled }}
       matrix_linux_5_10_enabled: ${{ inputs.linux_5_10_enabled }}
+      matrix_linux_6_0_enabled: ${{ inputs.linux_6_0_enabled }}
       matrix_linux_nightly_6_0_enabled: ${{ inputs.linux_nightly_6_0_enabled }}
       matrix_linux_nightly_main_enabled: ${{ inputs.linux_nightly_main_enabled }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
     # Workaround https://github.com/nektos/act/issues/1875
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,9 +18,9 @@ jobs:
     # Workaround https://github.com/nektos/act/issues/1875
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -10,9 +10,9 @@ jobs:
     # Workaround https://github.com/nektos/act/issues/1875
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_8_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/swift_6_language_mode.yml
+++ b/.github/workflows/swift_6_language_mode.yml
@@ -13,7 +13,7 @@ jobs:
     name: Swift 6 language mode
     runs-on: ubuntu-latest
     container:
-      image: swiftlang/swift:nightly-6.0-jammy
+      image: swift:6.0-jammy
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -11,17 +11,6 @@ on:
         type: string
         description: "The command of the current Swift version linux matrix job to execute."
         required: true
-      matrix_linux_5_8_enabled:
-        type: boolean
-        description: "Boolean to enable the 5.8 Swift version matrix job. Defaults to true."
-        default: true
-      matrix_linux_5_8_container_image:
-        type: string
-        description: "Container image for the 5.8 Swift version matrix job. Defaults to matching Swift Ubuntu image."
-        default: "swift:5.8-jammy"
-      matrix_linux_5_8_command_override:
-        type: string
-        description: "The command of the 5.8 Swift version linux matrix job to execute."
       matrix_linux_5_9_enabled:
         type: boolean
         description: "Boolean to enable the 5.9 Swift version matrix job. Defaults to true."
@@ -44,6 +33,17 @@ on:
       matrix_linux_5_10_command_override:
         type: string
         description: "The command of the 5.10 Swift version linux matrix job to execute."
+      matrix_linux_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the 6.0 Swift version matrix job. Defaults to true."
+        default: true
+      matrix_linux_6_0_container_image:
+        type: string
+        description: "Container image for the 6.0 Swift version matrix job. Defaults to matching Swift Ubuntu image."
+        default: "swift:6.0-jammy"
+      matrix_linux_6_0_command_override:
+        type: string
+        description: "The command of the 6.0 Swift version linux matrix job to execute."
       matrix_linux_nightly_6_0_enabled:
         type: boolean
         description: "Boolean to enable the nightly 6.0 Swift version matrix job. Defaults to true."
@@ -81,15 +81,15 @@ jobs:
       matrix:
         # We are specifying only the major and minor of the docker images to automatically pick up the latest patch release
         swift:
-          - image: ${{ inputs.matrix_linux_5_8_container_image }}
-            swift_version: "5.8"
-            enabled: ${{ inputs.matrix_linux_5_8_enabled }}
           - image: ${{ inputs.matrix_linux_5_9_container_image }}
             swift_version: "5.9"
             enabled: ${{ inputs.matrix_linux_5_9_enabled }}
           - image: ${{ inputs.matrix_linux_5_10_container_image }}
             swift_version: "5.10"
             enabled: ${{ inputs.matrix_linux_5_10_enabled }}
+          - image: ${{ inputs.matrix_linux_6_0_container_image }}
+            swift_version: "6.0"
+            enabled: ${{ inputs.matrix_linux_6_0_enabled }}
           - image: ${{ inputs.matrix_linux_nightly_6_0_container_image }}
             swift_version: "nightly-6.0"
             enabled: ${{ inputs.matrix_linux_nightly_6_0_enabled }}
@@ -113,9 +113,9 @@ jobs:
         env:
           SWIFT_VERSION: ${{ matrix.swift.swift_version }}
           COMMAND: ${{ inputs.matrix_linux_command }}
-          COMMAND_OVERRIDE_5_8: ${{ inputs.matrix_linux_5_8_command_override }}
           COMMAND_OVERRIDE_5_9: ${{ inputs.matrix_linux_5_9_command_override }}
           COMMAND_OVERRIDE_5_10: ${{ inputs.matrix_linux_5_10_command_override }}
+          COMMAND_OVERRIDE_6_0: ${{ inputs.matrix_linux_6_0_command_override }}
           COMMAND_OVERRIDE_NIGHTLY_6_0: ${{ inputs.matrix_linux_nightly_6_0_command_override }}
           COMMAND_OVERRIDE_NIGHTLY_MAIN: ${{ inputs.matrix_linux_nightly_main_command_override }}
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,14 +3,6 @@ name: Unit tests
 on:
   workflow_call:
     inputs:
-      linux_5_8_enabled:
-        type: boolean
-        description: "Boolean to enable the Linux 5.8 Swift version matrix job. Defaults to true."
-        default: true
-      linux_5_8_arguments_override:
-        type: string
-        description: "The arguments passed to swift test in the Linux 5.8 Swift version matrix job."
-        default: ""
       linux_5_9_enabled:
         type: boolean
         description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to true."
@@ -26,6 +18,14 @@ on:
       linux_5_10_arguments_override:
         type: string
         description: "The arguments passed to swift test in the Linux 5.10 Swift version matrix job."
+        default: ""
+      linux_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 6.0 Swift version matrix job. Defaults to true."
+        default: true
+      linux_6_0_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux 6.0 Swift version matrix job."
         default: ""
       linux_nightly_6_0_enabled:
         type: boolean
@@ -52,12 +52,12 @@ jobs:
     with:
       name: "Unit tests"
       matrix_linux_command: "swift test"
-      matrix_linux_5_8_enabled: ${{ inputs.linux_5_8_enabled }}
-      matrix_linux_5_8_command_override: "swift test ${{ inputs.linux_5_8_arguments_override }}"
       matrix_linux_5_9_enabled: ${{ inputs.linux_5_9_enabled }}
       matrix_linux_5_9_command_override: "swift test ${{ inputs.linux_5_9_arguments_override }}"
       matrix_linux_5_10_enabled: ${{ inputs.linux_5_10_enabled }}
       matrix_linux_5_10_command_override: "swift test ${{ inputs.linux_5_10_arguments_override }}"
+      matrix_linux_6_0_enabled: ${{ inputs.linux_6_0_enabled }}
+      matrix_linux_6_0_command_override: "swift test ${{ inputs.linux_6_0_arguments_override }}"
       matrix_linux_nightly_6_0_enabled: ${{ inputs.linux_nightly_6_0_enabled }}
       matrix_linux_nightly_6_0_command_override: "swift test ${{ inputs.linux_nightly_6_0_arguments_override }}"
       matrix_linux_nightly_main_enabled: ${{ inputs.linux_nightly_main_enabled }}

--- a/scripts/check-matrix-job.sh
+++ b/scripts/check-matrix-job.sh
@@ -22,21 +22,21 @@ test -n "${SWIFT_VERSION:-}" || fatal "SWIFT_VERSION unset"
 test -n "${COMMAND:-}" || fatal "COMMAND unset"
 swift_version="$SWIFT_VERSION"
 command="$COMMAND"
-command_5_8="$COMMAND_OVERRIDE_5_8"
 command_5_9="$COMMAND_OVERRIDE_5_9"
 command_5_10="$COMMAND_OVERRIDE_5_10"
+command_6_0="$COMMAND_OVERRIDE_6_0"
 command_nightly_6_0="$COMMAND_OVERRIDE_NIGHTLY_6_0"
 command_nightly_main="$COMMAND_OVERRIDE_NIGHTLY_MAIN"
 
-if [[ "$swift_version" == "5.8" ]] && [[ -n "$command_5_8" ]]; then
-  log "Running 5.8 command override"
-  eval "$command_5_8"
-elif [[ "$swift_version" == "5.9" ]] && [[ -n "$command_5_9" ]]; then
+if [[ "$swift_version" == "5.9" ]] && [[ -n "$command_5_9" ]]; then
   log "Running 5.9 command override"
   eval "$command_5_9"
 elif [[ "$swift_version" == "5.10" ]] && [[ -n "$command_5_10" ]]; then
   log "Running 5.10 command override"
   eval "$command_5_10"
+elif [[ "$swift_version" == "6.0" ]] && [[ -n "$command_6_0" ]]; then
+  log "Running 6.0 command override"
+  eval "$command_6_0"
 elif [[ "$swift_version" == "nightly-6.0" ]] && [[ -n "$command_nightly_6_0" ]]; then
   log "Running nightly 6.0 command override"
   eval "$command_nightly_6_0"


### PR DESCRIPTION
# Motivation

Our support strategy includes the last three released Swift versions. After the recent release of Swift 6 this means we now support 5.9, 5.10 and 6.0.

# Modification

This PR updates our CI configuration and scripts to align with our supported Swift versions.

# Result

Up to date CI coverage.
