### PR TITLE
Update pull_request_label.yml

### DIFF
--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -16,4 +16,4 @@ jobs:
                   persist-credentials: false
             - name: Check for Semantic Version label
               # Workaround https://github.com/nektos/act/issues/1875
-              uses: apple/swift-nio/.github/actions/pull_request_semver_label_checker/
+              uses: apple/swift-nio/.github/actions/pull_request_semver_label_checker/action.yml@main

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -15,4 +15,5 @@ jobs:
               with:
                   persist-credentials: false
             - name: Check for Semantic Version label
-              uses: ./.github/actions/pull_request_semver_label_checker/
+              # Workaround https://github.com/nektos/act/issues/1875
+              uses: apple/swift-nio/.github/actions/pull_request_semver_label_checker/


### PR DESCRIPTION
Speculative fix to update the pull request table check to workaround https://github.com/nektos/act/issues/1875 and allow it to be used by remote repositories.

### Motivation:

I believe using a local reference will mean that the pull request label check can't be re-used from other repos

### Modifications:

Use a global reference.

### Result:

We should be able to re-use the semVer check from other repos.
