### PR TITLE
Drop support for Swift 5.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/Benchmarks/Thresholds/5.8/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
+++ b/Benchmarks/Thresholds/5.8/NIOCoreBenchmarks.NIOAsyncChannel.init.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 8000
-}

--- a/Benchmarks/Thresholds/5.8/NIOPosixBenchmarks.TCPEcho.p90.json
+++ b/Benchmarks/Thresholds/5.8/NIOPosixBenchmarks.TCPEcho.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 556
-}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ The default policy for taking contributions is “Squash and Merge” - because 
 
 ### Make sure your patch works for all supported versions of swift
 
-The CI will do this for you, but a project maintainer must kick it off for you.  Currently all versions of Swift >= 5.8 are supported.
+The CI will do this for you, but a project maintainer must kick it off for you.  Currently all versions of Swift >= 5.9 are supported.
 
 If you wish to test this locally you have two options [act](https://github.com/nektos/act) and Docker Compose files.
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This is the current version of SwiftNIO and will be supported for the foreseeabl
 ### Swift Versions
 
 We commit to support the most recently released swift version (currently 5.10) and the last two minor releases before that unless this is impossible to do in one codebase.
-In addition checks are run against the latest beta release (if any) as well as the nightly swift builds and the intent is that these should pass. 
+In addition checks are run against the latest beta release (if any) as well as the nightly swift builds and the intent is that these should pass.
 
 The most recent versions of SwiftNIO support Swift 5.9 and newer. The minimum Swift version supported by SwiftNIO releases are detailed below:
 
@@ -86,8 +86,8 @@ SwiftNIO            | Minimum Swift Version
 `2.43.0 ..< 2.51.0` | 5.5.2
 `2.51.0 ..< 2.60.0` | 5.6
 `2.60.0 ..< 2.65.0` | 5.7
-`2.65.0 ..< 2.75.0  | 5.8
-`2.75.0 ...`        | 5.9
+`2.65.0 ..< 2.76.0  | 5.8
+`2.76.0 ...`        | 5.9
 
 ### SwiftNIO 1
 SwiftNIO 1 is considered end of life - it is strongly recommended that you move to a newer version.  The Core NIO team does not actively work on this version.  No new features will be added to this version but PRs which fix bugs or security vulnerabilities will be accepted until the end of May 2022.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This is the current version of SwiftNIO and will be supported for the foreseeabl
 We commit to support the most recently released swift version (currently 5.10) and the last two minor releases before that unless this is impossible to do in one codebase.
 In addition checks are run against the latest beta release (if any) as well as the nightly swift builds and the intent is that these should pass. 
 
-The most recent versions of SwiftNIO support Swift 5.8 and newer. The minimum Swift version supported by SwiftNIO releases are detailed below:
+The most recent versions of SwiftNIO support Swift 5.9 and newer. The minimum Swift version supported by SwiftNIO releases are detailed below:
 
 SwiftNIO            | Minimum Swift Version
 --------------------|----------------------
@@ -86,7 +86,8 @@ SwiftNIO            | Minimum Swift Version
 `2.43.0 ..< 2.51.0` | 5.5.2
 `2.51.0 ..< 2.60.0` | 5.6
 `2.60.0 ..< 2.65.0` | 5.7
-`2.65.0 ...`        | 5.8
+`2.65.0 ..< 2.75.0  | 5.8
+`2.75.0 ...`        | 5.9
 
 ### SwiftNIO 1
 SwiftNIO 1 is considered end of life - it is strongly recommended that you move to a newer version.  The Core NIO team does not actively work on this version.  No new features will be added to this version but PRs which fix bugs or security vulnerabilities will be accepted until the end of May 2022.

--- a/Sources/NIOCore/EventLoop+SerialExecutor.swift
+++ b/Sources/NIOCore/EventLoop+SerialExecutor.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.9)
 /// A helper protocol that can be mixed in to a NIO ``EventLoop`` to provide an
 /// automatic conformance to `SerialExecutor`.
 ///
@@ -91,4 +90,3 @@ extension NIODefaultSerialEventLoopExecutor: SerialExecutor {
         self.loop === other.loop
     }
 }
-#endif

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -317,7 +317,6 @@ public protocol EventLoop: EventLoopGroup {
     /// allows `EventLoop`s to cache a pre-succeeded `Void` future to prevent superfluous allocations.
     func makeSucceededVoidFuture() -> EventLoopFuture<Void>
 
-    #if compiler(>=5.9)
     /// Returns a `SerialExecutor` corresponding to this ``EventLoop``.
     ///
     /// This executor can be used to isolate an actor to a given ``EventLoop``. Implementers are encouraged to customise
@@ -330,7 +329,6 @@ public protocol EventLoop: EventLoopGroup {
     /// Submit a job to be executed by the `EventLoop`
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     func enqueue(_ job: consuming ExecutorJob)
-    #endif
 
     /// Must crash if it is not safe to call `wait()` on an `EventLoopFuture`.
     ///
@@ -415,7 +413,6 @@ extension EventLoop {
 }
 
 extension EventLoop {
-    #if compiler(>=5.9)
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     public var executor: any SerialExecutor {
         NIODefaultSerialEventLoopExecutor(self)
@@ -432,7 +429,6 @@ extension EventLoop {
             unownedJob.runSynchronously(on: self.executor.asUnownedSerialExecutor())
         }
     }
-    #endif
 }
 
 extension EventLoopGroup {

--- a/Sources/NIOCore/NIOScheduledCallback.swift
+++ b/Sources/NIOCore/NIOScheduledCallback.swift
@@ -89,8 +89,7 @@ public struct NIOScheduledCallback: Sendable {
 }
 
 extension EventLoop {
-    // This could be package once we drop Swift 5.8.
-    public func _scheduleCallback(
+    package func _scheduleCallback(
         at deadline: NIODeadline,
         handler: some NIOScheduledCallbackHandler
     ) -> NIOScheduledCallback {

--- a/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
+++ b/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
@@ -407,10 +407,8 @@ public final class NIOAsyncTestingEventLoop: EventLoop, @unchecked Sendable {
 }
 
 // MARK: SerialExecutor conformance
-#if compiler(>=5.9)
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension NIOAsyncTestingEventLoop: NIOSerialEventLoopExecutor {}
-#endif
 
 /// This is a thread-safe promise creation store.
 ///

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -271,14 +271,12 @@ public final class EmbeddedEventLoop: EventLoop, CustomStringConvertible {
         precondition(scheduledTasks.isEmpty, "Embedded event loop freed with unexecuted scheduled tasks!")
     }
 
-    #if compiler(>=5.9)
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     public var executor: any SerialExecutor {
         fatalError(
             "EmbeddedEventLoop is not thread safe and cannot be used as a SerialExecutor. Use NIOAsyncTestingEventLoop instead."
         )
     }
-    #endif
 }
 
 @usableFromInline

--- a/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
+++ b/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
@@ -489,7 +489,6 @@ extension MultiThreadedEventLoopGroup: CustomStringConvertible {
     }
 }
 
-#if compiler(>=5.9)
 @usableFromInline
 struct ErasedUnownedJob {
     @usableFromInline
@@ -507,7 +506,6 @@ struct ErasedUnownedJob {
         self.erasedJob as! UnownedJob
     }
 }
-#endif
 
 @usableFromInline
 internal struct ScheduledTask {

--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -15,14 +15,12 @@
 import Atomics
 import NIOCore
 
-#if compiler(>=5.9)
 private protocol SilenceWarning {
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     func enqueue(_ job: UnownedJob)
 }
 @available(macOS 14, *)
 extension SelectableEventLoop: SilenceWarning {}
-#endif
 
 private let _haveWeTakenOverTheConcurrencyPool = ManagedAtomic(false)
 extension NIOSingletons {

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -353,7 +353,6 @@ internal final class SelectableEventLoop: EventLoop {
         try? self._schedule0(.immediate(.function(task)))
     }
 
-    #if compiler(>=5.9)
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     @usableFromInline
     func enqueue(_ job: consuming ExecutorJob) {
@@ -361,7 +360,6 @@ internal final class SelectableEventLoop: EventLoop {
         let erasedJob = ErasedUnownedJob(job: UnownedJob(job))
         try? self._schedule0(.immediate(.unownedJob(erasedJob)))
     }
-    #endif
 
     /// Add the `ScheduledTask` to be executed.
     @usableFromInline
@@ -901,17 +899,13 @@ extension SelectableEventLoop: CustomStringConvertible, CustomDebugStringConvert
 }
 
 // MARK: SerialExecutor conformance
-#if compiler(>=5.9)
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension SelectableEventLoop: NIOSerialEventLoopExecutor {}
-#endif
 
 @usableFromInline
 enum UnderlyingTask {
     case function(() -> Void)
-    #if compiler(>=5.9)
     case unownedJob(ErasedUnownedJob)
-    #endif
     case callback(any NIOScheduledCallbackHandler)
 }
 

--- a/Sources/NIOTCPEchoClient/Client.swift
+++ b/Sources/NIOTCPEchoClient/Client.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.9)
 import NIOCore
 import NIOPosix
 
@@ -112,11 +111,3 @@ private final class NewlineDelimiterCoder: ByteToMessageDecoder, MessageToByteEn
         out.writeInteger(self.newLine)
     }
 }
-#else
-@main
-struct Client {
-    static func main() {
-        fatalError("Requires at least Swift 5.9")
-    }
-}
-#endif

--- a/Sources/NIOTCPEchoServer/Server.swift
+++ b/Sources/NIOTCPEchoServer/Server.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.9)
 import NIOCore
 import NIOPosix
 
@@ -122,11 +121,3 @@ private final class NewlineDelimiterCoder: ByteToMessageDecoder, MessageToByteEn
         out.writeInteger(self.newLine)
     }
 }
-#else
-@main
-struct Server {
-    static func main() {
-        fatalError("Requires at least Swift 5.9")
-    }
-}
-#endif

--- a/Tests/NIOPosixTests/SerialExecutorTests.swift
+++ b/Tests/NIOPosixTests/SerialExecutorTests.swift
@@ -16,7 +16,6 @@ import NIOEmbedded
 import NIOPosix
 import XCTest
 
-#if compiler(>=5.9)
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 actor EventLoopBoundActor {
     nonisolated let unownedExecutor: UnownedSerialExecutor
@@ -45,19 +44,13 @@ actor EventLoopBoundActor {
     }
     #endif
 }
-#endif
 
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class SerialExecutorTests: XCTestCase {
     private func _testBasicExecutorFitsOnEventLoop(loop1: EventLoop, loop2: EventLoop) async throws {
-        #if compiler(<5.9)
-        throw XCTSkip("Custom executors are only supported in 5.9")
-        #else
-
         let testActor = EventLoopBoundActor(loop: loop1)
         await testActor.assertInLoop(loop1)
         await testActor.assertNotInLoop(loop2)
-        #endif
     }
 
     func testBasicExecutorFitsOnEventLoop_MTELG() async throws {


### PR DESCRIPTION
# Motivation

We only support the last three Swift released versions which are at this time 5.9, 5.10 and 6.

# Modification

This PR drops anything related to Swift 5.8.

# Result

Version support aligned.
