### PR TITLE
Disable semver-label-check locally

### DIFF
--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -11,8 +11,10 @@ jobs:
         timeout-minutes: 1
         steps:
             - name: Checkout repository
+              if: ${{ !env.ACT }}
               uses: actions/checkout@v4
               with:
                   persist-credentials: false
             - name: Check for Semantic Version label
+              if: ${{ !env.ACT }}
               uses: ./.github/actions/pull_request_semver_label_checker/


### PR DESCRIPTION
Disable semver-label-check locally when run via `act`.

### Motivation:

This check makes no sense when run locally.

### Modifications:

Disable semver-label-check locally when run via `act`.

### Result:

The label check should no longer run and fail locally.
