### PR TITLE
Disable semver-label-check locally

### DIFF
--- a/.github/actions/pull_request_semver_label_checker/action.yml
+++ b/.github/actions/pull_request_semver_label_checker/action.yml
@@ -12,6 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Check labels
+      if: ${{ !env.ACT }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
Supersedes https://github.com/apple/swift-nio/pull/2926

Disable semver-label-check locally when run via `act`.

### Motivation:

This check makes no sense when run locally.

### Modifications:

Disable semver-label-check locally when run via `act`.

### Result:

The label check should no longer run and fail locally.
