### PR TITLE
Disable semver label check locally

### DIFF
--- a/.github/actions/pull_request_semver_label_checker/action.yml
+++ b/.github/actions/pull_request_semver_label_checker/action.yml
@@ -12,6 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Check labels
+      if: ${{ !env.ACT }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -11,8 +11,10 @@ jobs:
         timeout-minutes: 1
         steps:
             - name: Checkout repository
+              if: ${{ !env.ACT }}
               uses: actions/checkout@v4
               with:
                   persist-credentials: false
             - name: Check for Semantic Version label
+              if: ${{ !env.ACT }}
               uses: ./.github/actions/pull_request_semver_label_checker/

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -11,7 +11,6 @@ jobs:
         timeout-minutes: 1
         steps:
             - name: Checkout repository
-              if: ${{ !env.ACT }}
               uses: actions/checkout@v4
               with:
                   persist-credentials: false

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -15,5 +15,4 @@ jobs:
               with:
                   persist-credentials: false
             - name: Check for Semantic Version label
-              if: ${{ !env.ACT }}
               uses: ./.github/actions/pull_request_semver_label_checker/


### PR DESCRIPTION
Disable semver-label-check locally when run via `act`.

### Motivation:

This check makes no sense when run locally.

### Modifications:

Disable semver-label-check locally when run via `act`.

### Result:

The label check should no longer run and fail locally.