### PR TITLE
[CI] Add Windows matrix build

### DIFF
--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -67,6 +67,32 @@ on:
         type: string
         description: "The command of the nightly main Swift version linux matrix job to execute."
 
+      matrix_windows_command:
+        type: string
+        description: "The command of the current Swift version windows matrix job to execute."
+        default: ""
+      matrix_windows_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the 6.0 Swift version matrix job. Defaults to true."
+        default: false
+      matrix_windows_6_0_command_override:
+        type: string
+        description: "The command of the 6.0 Swift version windows matrix job to execute."
+      matrix_windows_nightly_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the nightly 6.0 Swift version matrix job. Defaults to true."
+        default: false
+      matrix_windows_nightly_6_0_command_override:
+        type: string
+        description: "The command of the nightly 6.0 Swift version windows matrix job to execute."
+      matrix_windows_nightly_main_enabled:
+        type: boolean
+        description: "Boolean to enable the nightly main Swift version matrix job. Defaults to true."
+        default: false
+      matrix_windows_nightly_main_command_override:
+        type: string
+        description: "The command of the nightly main Swift version windows matrix job to execute."
+
 # We are cancelling previously triggered workflow runs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.name }}
@@ -121,3 +147,64 @@ jobs:
         run: |
           apt-get -qq update && apt-get -qq -y install curl
           curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.sh | bash
+
+  windows:
+    name: Windows (${{ matrix.swift.swift_version }})
+    runs-on: windows-2022
+    if: ${{ inputs.matrix_windows_6_0_enabled }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # We are specifying only the major and minor of the docker images to automatically pick up the latest patch release
+        swift:
+          - image: swift:6.0-windowsservercore-ltsc2022
+            swift_version: "6.0"
+            enabled: ${{ inputs.matrix_windows_6_0_enabled }}
+    steps:
+      - name: Pull Docker image
+        if: ${{ matrix.swift.enabled }}
+        run: docker pull ${{ matrix.swift.image }}
+      - name: Checkout repository
+        if: ${{ matrix.swift.enabled }}
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Donwload matrix script
+        if: ${{ matrix.swift.enabled }}
+        run: curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.ps1 -o __check-matrix-job.ps1
+      - name: Run matrix job
+        if: ${{ matrix.swift.enabled }}
+        run: |
+          docker run --env SWIFT_VERSION="${{ matrix.swift.swift_version }}" --env COMMAND="${{ inputs.matrix_windows_command }}" --env COMMAND_OVERRIDE_6_0="${{ inputs.matrix_windows_6_0_command_override }}" -v ${{ github.workspace }}:C:\source ${{ matrix.swift.image }} cmd /s /c  "swift --version & cd C:\source\ & powershell -File __check-matrix-job.ps1"
+
+  windows-nightly:
+    name: Windows (${{ matrix.swift.swift_version }})
+    runs-on: windows-2019
+    if: ${{ inputs.matrix_windows_nightly_6_0_enabled }} && ${{ inputs.matrix_windows_nightly_main_enabled }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # We are specifying only the major and minor of the docker images to automatically pick up the latest patch release
+        swift:
+          - image: swiftlang/swift:nightly-6.0-windowsservercore-1809
+            swift_version: "nightly-6.0"
+            enabled: ${{ inputs.matrix_windows_nightly_6_0_enabled }}
+          - image: swiftlang/swift:nightly-main-windowsservercore-1809
+            swift_version: "nightly-main"
+            enabled: ${{ inputs.matrix_windows_nightly_main_enabled }}
+    steps:
+      - name: Pull Docker image
+        if: ${{ matrix.swift.enabled }}
+        run: docker pull ${{ matrix.swift.image }}
+      - name: Checkout repository
+        if: ${{ matrix.swift.enabled }}
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Donwload matrix script
+        if: ${{ matrix.swift.enabled }}
+        run: curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.ps1 -o __check-matrix-job.ps1
+      - name: Run matrix job
+        if: ${{ matrix.swift.enabled }}
+        run: |
+          docker run --env SWIFT_VERSION="${{ matrix.swift.swift_version }}" --env COMMAND="${{ inputs.matrix_windows_command }}" --env COMMAND_OVERRIDE_NIGHTLY_6_0="${{ inputs.matrix_windows_nightly_6_0_command_override }}" --env COMMAND_OVERRIDE_NIGHTLY_MAIN="${{ inputs.matrix_windows_nightly_main_command_override }}" -v ${{ github.workspace }}:C:\source ${{ matrix.swift.image }} cmd /s /c  "swift --version & cd C:\source\ & powershell -File __check-matrix-job.ps1"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -44,6 +44,31 @@ on:
         description: "The arguments passed to swift test in the Linux nightly main Swift version matrix job."
         default: ""
 
+      windows_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows 6.0 Swift version matrix job. Defaults to true."
+        default: false
+      windows_6_0_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Windows 6.0 Swift version matrix job."
+        default: ""
+      windows_nightly_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows nightly 6.0 Swift version matrix job. Defaults to true."
+        default: false
+      windows_nightly_6_0_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Windows nightly 6.0 Swift version matrix job."
+        default: ""
+      windows_nightly_main_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows nightly main Swift version matrix job. Defaults to true."
+        default: false
+      windows_nightly_main_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Windows nightly main Swift version matrix job."
+        default: ""
+
 jobs:
   unit-tests:
     name: Unit tests
@@ -62,3 +87,9 @@ jobs:
       matrix_linux_nightly_6_0_command_override: "swift test ${{ inputs.linux_nightly_6_0_arguments_override }}"
       matrix_linux_nightly_main_enabled: ${{ inputs.linux_nightly_main_enabled }}
       matrix_linux_nightly_main_command_override: "swift test ${{ inputs.linux_nightly_main_arguments_override }}"
+      matrix_windows_6_0_enabled: ${{ inputs.windows_6_0_enabled }}
+      matrix_windows_6_0_command_override: "swift test ${{ inputs.windows_6_0_arguments_override }}"
+      matrix_windows_nightly_6_0_enabled: ${{ inputs.windows_nightly_6_0_enabled }}
+      matrix_windows_nightly_6_0_command_override: "swift test ${{ inputs.windows_nightly_6_0_arguments_override }}"
+      matrix_windows_nightly_main_enabled: ${{ inputs.windows_nightly_main_enabled }}
+      matrix_windows_nightly_main_command_override: "swift test ${{ inputs.windows_nightly_main_arguments_override }}"

--- a/scripts/check-matrix-job.ps1
+++ b/scripts/check-matrix-job.ps1
@@ -1,0 +1,78 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2024 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+# Set strict mode to catch errors
+Set-StrictMode -Version Latest
+
+function Log {
+    param (
+        [string]$Message
+    )
+    Write-Host ("** " + $Message) -ForegroundColor Yellow
+}
+
+function Error {
+    param (
+        [string]$Message
+    )
+    Write-Host ("** ERROR: " + $Message) -ForegroundColor Red
+}
+
+function Fatal {
+    param (
+        [string]$Message
+    )
+    Error $Message
+    exit 1
+}
+
+# Check if SWIFT_VERSION is set
+if (-not $env:SWIFT_VERSION) {
+    Fatal "SWIFT_VERSION unset"
+}
+
+# Check if COMMAND is set
+if (-not $env:COMMAND) {
+    Fatal "COMMAND unset"
+}
+
+$swift_version = $env:SWIFT_VERSION
+$command = $env:COMMAND
+$command_5_9 = $env:COMMAND_OVERRIDE_5_9
+$command_5_10 = $env:COMMAND_OVERRIDE_5_10
+$command_6_0 = $env:COMMAND_OVERRIDE_6_0
+$command_nightly_6_0 = $env:COMMAND_OVERRIDE_NIGHTLY_6_0
+$command_nightly_main = $env:COMMAND_OVERRIDE_NIGHTLY_MAIN
+
+if ($swift_version -eq "5.9" -and $command_5_9) {
+    Log "Running 5.9 command override"
+    Invoke-Expression $command_5_9
+} elseif ($swift_version -eq "5.10" -and $command_5_10) {
+    Log "Running 5.10 command override"
+    Invoke-Expression $command_5_10
+} elseif ($swift_version -eq "6.0" -and $command_6_0) {
+    Log "Running 6.0 command override"
+    Invoke-Expression $command_6_0
+} elseif ($swift_version -eq "nightly-6.0" -and $command_nightly_6_0) {
+    Log "Running nightly 6.0 command override"
+    Invoke-Expression $command_nightly_6_0
+} elseif ($swift_version -eq "nightly-main" -and $command_nightly_main) {
+    Log "Running nightly main command override"
+    Invoke-Expression $command_nightly_main
+} else {
+    Log "Running default command"
+    Invoke-Expression $command
+}
+
+Exit $LASTEXITCODE


### PR DESCRIPTION
# Motivation

In the long term we want to add support for Windows in our Swift packages. To do this we need a CI setup to ensure that our packages are building and the tests are passing.

# Modification

This PR adds a windows job to our swift matrix that installs Swift on the runner and then uses Swift PM to build and test the package. Windows jobs are disabled by default since most of our packages require some work to add Windows support.

# Result

We have a Windows CI pipeline that allows us to verify that our packages are working.