### PR TITLE
clean up 5.8 thresholds

### DIFF
--- a/Benchmarks/Thresholds/5.8/NIOCoreBenchmarks.WaitOnPromise.p90.json
+++ b/Benchmarks/Thresholds/5.8/NIOCoreBenchmarks.WaitOnPromise.p90.json
@@ -1,4 +1,0 @@
-{
-  "mallocCountTotal" : 6000,
-  "memoryLeaked" : 0
-}


### PR DESCRIPTION
clean up 5.8 thresholds

### Motivation:

GitHub's merge retained files we don't need now we've dropped 5.8

### Modifications:

remove 5.8 thresholds

### Result:

no unused files
