### PR TITLE
Fix withConnectedSocket in async mode

### DIFF
--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -1398,7 +1398,7 @@ extension ClientBootstrap {
     private func initializeAndRegisterChannel<ChannelInitializerResult, PostRegistrationTransformationResult>(
         channel: SocketChannel,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<ChannelInitializerResult>,
-        registration: @escaping @Sendable (Channel) -> EventLoopFuture<Void>,
+        registration: @escaping @Sendable (SocketChannel) -> EventLoopFuture<Void>,
         postRegisterTransformation: @escaping @Sendable (ChannelInitializerResult, EventLoop) -> EventLoopFuture<
             PostRegistrationTransformationResult
         >


### PR DESCRIPTION
Motivation:

The async flavour of withConnectedSocket accidentally type-erased the channel, which caused it to be unable to be used.

Modifications:

Un-erase the type of the channel.
Add a test.

Result:

withConnectedSocket works again
Resolves #2936 