### PR TITLE
Fix Windows build for NIOCore.

### DIFF
--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -18,6 +18,7 @@ import ucrt
 import let WinSDK.IPPROTO_IP
 import let WinSDK.IPPROTO_IPV6
 import let WinSDK.IPPROTO_TCP
+import let WinSDK.IPPROTO_UDP
 
 import let WinSDK.IP_ADD_MEMBERSHIP
 import let WinSDK.IP_DROP_MEMBERSHIP
@@ -40,12 +41,14 @@ import let WinSDK.PF_INET
 import let WinSDK.PF_INET6
 import let WinSDK.PF_UNIX
 
+import let WinSDK.SO_BROADCAST
 import let WinSDK.SO_ERROR
 import let WinSDK.SO_KEEPALIVE
 import let WinSDK.SO_LINGER
 import let WinSDK.SO_RCVBUF
 import let WinSDK.SO_RCVTIMEO
 import let WinSDK.SO_REUSEADDR
+import let WinSDK.SO_SNDBUF
 
 import let WinSDK.SOL_SOCKET
 
@@ -282,6 +285,9 @@ extension NIOBSDSocket.OptionLevel {
     #if os(Linux) || os(Android)
     public static let udp: NIOBSDSocket.OptionLevel =
         NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_UDP))
+    #elseif os(Windows)
+    public static let udp: NIOBSDSocket.OptionLevel =
+        NIOBSDSocket.OptionLevel(rawValue: IPPROTO_UDP.rawValue)
     #else
     public static let udp: NIOBSDSocket.OptionLevel =
         NIOBSDSocket.OptionLevel(rawValue: IPPROTO_UDP)


### PR DESCRIPTION
Fix build failures in `NIOCore` on Windows.

### Motivation:

I'd like it to build on Windows. 

### Modifications:

* Add missing `WinSDK` imports.
* Add missing `#elseif os(Windows)` branch for UDP.

### Result:

```bash
c:\users\jeff\src\swift-nio> swift build -Xcc -DBYTE_ORDER=LITTLE_ENDIAN --target NIOCore
Building for debugging...
[1/1] Write auxiliary file C:\Users\jeffd\src\jeff-swift-nio\.build\x86_64-unknown-windows-msvc\debug\swift-version--15FA6356563A8EA6.txt
Build of target: 'NIOCore' complete! (1.14s)
```
