### PR TITLE
[CI] Enable benchmarks & cxx Windows CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,6 +31,19 @@ on:
         description: "Boolean to enable the Linux nightly main Swift version matrix job. Defaults to true."
         default: true
 
+      windows_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows 6.0 Swift version matrix job. Defaults to true."
+        default: false
+      windows_nightly_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows nightly 6.0 Swift version matrix job. Defaults to true."
+        default: false
+      windows_nightly_main_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows nightly main Swift version matrix job. Defaults to true."
+        default: false
+
 jobs:
   benchmarks:
     name: Benchmarks
@@ -44,3 +57,6 @@ jobs:
       matrix_linux_6_0_enabled: ${{ inputs.linux_6_0_enabled }}
       matrix_linux_nightly_6_0_enabled: ${{ inputs.linux_nightly_6_0_enabled }}
       matrix_linux_nightly_main_enabled: ${{ inputs.linux_nightly_main_enabled }}
+      matrix_windows_6_0_enabled: ${{ inputs.windows_6_0_enabled }}
+      matrix_windows_nightly_6_0_enabled: ${{ inputs.windows_nightly_6_0_enabled }}
+      matrix_windows_nightly_main_enabled: ${{ inputs.windows_nightly_main_enabled }}

--- a/.github/workflows/cxx_interop.yml
+++ b/.github/workflows/cxx_interop.yml
@@ -24,6 +24,19 @@ on:
         description: "Boolean to enable the Linux nightly main Swift version matrix job. Defaults to true."
         default: true
 
+      windows_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows 6.0 Swift version matrix job. Defaults to true."
+        default: false
+      windows_nightly_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows nightly 6.0 Swift version matrix job. Defaults to true."
+        default: false
+      windows_nightly_main_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows nightly main Swift version matrix job. Defaults to true."
+        default: false
+
 jobs:
   cxx-interop:
     name: Cxx interop
@@ -37,3 +50,6 @@ jobs:
       matrix_linux_6_0_enabled: ${{ inputs.linux_6_0_enabled }}
       matrix_linux_nightly_6_0_enabled: ${{ inputs.linux_nightly_6_0_enabled }}
       matrix_linux_nightly_main_enabled: ${{ inputs.linux_nightly_main_enabled }}
+      matrix_windows_6_0_enabled: ${{ inputs.windows_6_0_enabled }}
+      matrix_windows_nightly_6_0_enabled: ${{ inputs.windows_nightly_6_0_enabled }}
+      matrix_windows_nightly_main_enabled: ${{ inputs.windows_nightly_main_enabled }}

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -149,7 +149,7 @@ jobs:
           curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.sh | bash
 
   windows:
-    name: Windows (${{ matrix.swift.swift_version }})
+    name: Windows (6.0)
     runs-on: windows-2022
     strategy:
       fail-fast: false
@@ -191,7 +191,7 @@ jobs:
           - image: swiftlang/swift:nightly-main-windowsservercore-1809
             swift_version: "nightly-main"
             enabled: ${{ inputs.matrix_windows_nightly_main_enabled }}
-    if: ${{ inputs.matrix_windows_nightly_6_0_enabled }} || ${{ inputs.matrix_windows_nightly_main_enabled }}
+    if: (${{ inputs.matrix_windows_nightly_6_0_enabled }} || ${{ inputs.matrix_windows_nightly_main_enabled }})
     steps:
       - name: Pull Docker image
         if: ${{ matrix.swift.enabled }}


### PR DESCRIPTION
This PR makes it possible to enable benchmarks and cxx interop checks on Windows. By default they are turned off. This PR also fixes the job of the Windows 6 pipeline which was broken since single configuration matrix jobs seem to behave differently.
