### PR TITLE
[CI] Fix the Windows 6.0 check name

### DIFF
--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -149,7 +149,7 @@ jobs:
           curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.sh | bash
 
   windows:
-    name: Windows (6.0)
+    name: Windows (${{ matrix.swift.swift_version }})
     runs-on: windows-2022
     strategy:
       fail-fast: false
@@ -159,7 +159,6 @@ jobs:
           - image: swift:6.0-windowsservercore-ltsc2022
             swift_version: "6.0"
             enabled: ${{ inputs.matrix_windows_6_0_enabled }}
-    if: ${{ inputs.matrix_windows_6_0_enabled }}
     steps:
       - name: Pull Docker image
         if: ${{ matrix.swift.enabled }}
@@ -191,7 +190,6 @@ jobs:
           - image: swiftlang/swift:nightly-main-windowsservercore-1809
             swift_version: "nightly-main"
             enabled: ${{ inputs.matrix_windows_nightly_main_enabled }}
-    if: (${{ inputs.matrix_windows_nightly_6_0_enabled }} || ${{ inputs.matrix_windows_nightly_main_enabled }})
     steps:
       - name: Pull Docker image
         if: ${{ matrix.swift.enabled }}


### PR DESCRIPTION
# Motivation

Currently, the Windows 6.0 check name includes the matrix properties.

# Modification

This PR makes it dynamic with the swift version again.

# Result

Aligned CI check names across platforms.
