### PR TITLE
NIOPosix on Darwin: inherit main thread QoS

### DIFF
--- a/Sources/NIOPosix/ThreadPosix.swift
+++ b/Sources/NIOPosix/ThreadPosix.swift
@@ -43,7 +43,12 @@ private func sysPthread_create(
     args: UnsafeMutableRawPointer?
 ) -> CInt {
     #if canImport(Darwin)
-    return pthread_create(handle, nil, destructor, args)
+    var attr: pthread_attr_t = .init()
+    pthread_attr_init(&attr)
+    pthread_attr_set_qos_class_np(&attr, qos_class_main(), 0)
+    let thread = pthread_create(handle, &attr, destructor, args)
+    pthread_attr_destroy(&attr)
+    return thread
     #else
     #if canImport(Musl)
     var handleLinux: OpaquePointer? = nil


### PR DESCRIPTION
### Motivation:

On Darwin, QoS (quality of service) of threads plays an important role, especially on Apple Silicon machines with P-cores and E-cores. If you spawn raw threads (like NIOPosix) and use a mechanism that doesn't support QoS propagation (like reading/writing to networks -- like NIOPosix does), it's recommended to default to the main thread's QoS.

Otherwise you'll always be at the default QoS for "legacy" threads which means bad latencies, especially on Apple Silicon machines.

In a follow-up PR #2943 we're adding better configurability for thread configuration.

### Modifications:

Default to main thread QoS on Darwin.

### Result:

Better latencies for applications with higher QoS classes.