### PR TITLE
workaround Xcode 15.4 bug with swift build --arch x86_64 --arch arm64

### DIFF
--- a/Sources/NIOCore/NIOScheduledCallback.swift
+++ b/Sources/NIOCore/NIOScheduledCallback.swift
@@ -90,7 +90,11 @@ public struct NIOScheduledCallback: Sendable {
 
 extension EventLoop {
     @preconcurrency
-    package func _scheduleCallback(
+    /// This method is not part of the public API
+    ///
+    /// Should use `package` not `public` but then it won't compile in
+    /// Xcode 15.4 if you run `swift build --arch x86_64 --arch arm64`.
+    public func _scheduleCallback(
         at deadline: NIODeadline,
         handler: some (NIOScheduledCallbackHandler & Sendable)
     ) -> NIOScheduledCallback {


### PR DESCRIPTION
### Motivation:

`swift build --arch x64_64 --arch arm64` on at least Xcode 15.4 fails with 

```
/Users/johannes/devel/my-proj/.build/checkouts/swift-nio/Sources/NIOCore/NIOScheduledCallback.swift:93:18: error: '_scheduleCallback' has a package access level but no -package-name was specified: /Users/johannes/devel/tfai-swift/.build/checkouts/swift-nio/Sources/NIOCore/NIOScheduledCallback.swift
    package func _scheduleCallback(
                 ^
```

That's clearly an Xcode bug but that needs a workaround.

### Modifications:

- Don't use the `package` modifier for now

### Result:

SwiftNIO builds again.