### PR TITLE
Checkout any submodules when running Actions

### DIFF
--- a/.github/workflows/swift_6_language_mode.yml
+++ b/.github/workflows/swift_6_language_mode.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          submodules: true
       - name: Set the language mode
         run: swift package tools-version --set 6.0
       - name: Build with Swift 6 language mode

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -130,6 +130,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          submodules: true
       - name: Mark the workspace as safe
         if: ${{ matrix.swift.enabled }}
         # https://github.com/actions/checkout/issues/766
@@ -168,6 +169,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          format_check_enabled: true
       - name: Donwload matrix script
         if: ${{ matrix.swift.enabled }}
         run: curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.ps1 -o __check-matrix-job.ps1
@@ -199,6 +201,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          submodules: true
       - name: Donwload matrix script
         if: ${{ matrix.swift.enabled }}
         run: curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.ps1 -o __check-matrix-job.ps1

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -169,7 +169,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          format_check_enabled: true
       - name: Donwload matrix script
         if: ${{ matrix.swift.enabled }}
         run: curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.ps1 -o __check-matrix-job.ps1


### PR DESCRIPTION
Motivation:

Some repos using this as their source of GitHub Actions logic have submodules.

Modifications:

Change workflows to checkout submodules.

Result:

All CI will work cleanly