### PR TITLE
Issue-2900 - Add VisionOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,11 +21,7 @@ import class Foundation.ProcessInfo
 
 let swiftAtomics: PackageDescription.Target.Dependency = .product(name: "Atomics", package: "swift-atomics")
 let swiftCollections: PackageDescription.Target.Dependency = .product(name: "DequeModule", package: "swift-collections")
-let swiftSystem: PackageDescription.Target.Dependency = .product(
-    name: "SystemPackage",
-    package: "swift-system",
-    condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .linux, .android])
-)
+let swiftSystem: PackageDescription.Target.Dependency = .product(name: "SystemPackage", package: "swift-system")
 
 // These platforms require a depdency on `NIOPosix` from `NIOHTTP1` to maintain backward
 // compatibility with previous NIO versions.
@@ -558,7 +554,7 @@ if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-system.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-system.git", from: "1.4.0"),
     ]
 } else {
     package.dependencies += [

--- a/Sources/NIOFileSystem/BufferedReader.swift
+++ b/Sources/NIOFileSystem/BufferedReader.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import DequeModule
 import NIOCore
 
@@ -240,5 +239,3 @@ extension ReadableFileHandleProtocol {
         BufferedReader(wrapping: self, initialOffset: initialOffset, capacity: Int(capacity.bytes))
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/BufferedWriter.swift
+++ b/Sources/NIOFileSystem/BufferedWriter.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 
 /// A writer which buffers bytes in memory before writing them to the file system.
@@ -244,5 +243,3 @@ extension WritableFileHandleProtocol {
         }
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/ByteBuffer+FileSystem.swift
+++ b/Sources/NIOFileSystem/ByteBuffer+FileSystem.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -96,5 +95,3 @@ extension ByteBuffer {
         )
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/ByteCount.swift
+++ b/Sources/NIOFileSystem/ByteCount.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-
 /// Represents the number of bytes.
 public struct ByteCount: Hashable, Sendable {
     /// The number of bytes
@@ -117,5 +115,3 @@ extension ByteCount: Comparable {
         lhs.bytes < rhs.bytes
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/Convenience.swift
+++ b/Sources/NIOFileSystem/Convenience.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 extension String {
@@ -201,5 +200,3 @@ extension AsyncSequence where Self.Element == UInt8, Self: Sendable {
         )
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/DirectoryEntries.swift
+++ b/Sources/NIOFileSystem/DirectoryEntries.swift
@@ -12,13 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import CNIODarwin
 import CNIOLinux
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
-@preconcurrency import SystemPackage
+import SystemPackage
 
 /// An `AsyncSequence` of entries in a directory.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -737,5 +736,3 @@ extension UnsafeMutablePointer<CInterop.FTSEnt> {
         FilePath(platformString: self.pointee.fts_path!)
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/DirectoryEntry.swift
+++ b/Sources/NIOFileSystem/DirectoryEntry.swift
@@ -12,8 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@preconcurrency import SystemPackage
+import SystemPackage
 
 /// Information about an item within a directory.
 public struct DirectoryEntry: Sendable, Hashable, Equatable {
@@ -46,5 +45,3 @@ public struct DirectoryEntry: Sendable, Hashable, Equatable {
         self.type = type
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/Exports.swift
+++ b/Sources/NIOFileSystem/Exports.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-
 // These types are used in our public API; expose them to make
 // life easier for users.
 @_exported import enum SystemPackage.CInterop
@@ -21,5 +19,3 @@
 @_exported import struct SystemPackage.FileDescriptor
 @_exported import struct SystemPackage.FilePath
 @_exported import struct SystemPackage.FilePermissions
-
-#endif

--- a/Sources/NIOFileSystem/FileChunks.swift
+++ b/Sources/NIOFileSystem/FileChunks.swift
@@ -12,11 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
-@preconcurrency import SystemPackage
+import SystemPackage
 
 /// An `AsyncSequence` of ordered chunks read from a file.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -544,4 +543,3 @@ extension ProducerState.Producing {
         return .moreToRead
     }
 }
-#endif

--- a/Sources/NIOFileSystem/FileHandle.swift
+++ b/Sources/NIOFileSystem/FileHandle.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-
 import NIOCore
 
 /// Provides a ``FileHandle``.
@@ -357,5 +355,3 @@ public struct DirectoryFileHandle: DirectoryFileHandleProtocol, _HasFileHandle {
         return DirectoryFileHandle(wrapping: systemFileHandle)
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/NIOFileSystem/FileHandleProtocol.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 import SystemPackage
 
@@ -775,4 +774,3 @@ extension DirectoryFileHandleProtocol {
         }
     }
 }
-#endif

--- a/Sources/NIOFileSystem/FileInfo.swift
+++ b/Sources/NIOFileSystem/FileInfo.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -277,5 +276,3 @@ extension FilePermissions {
         self = .init(rawValue: rawValue & ~S_IFMT)
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/FileSystem.swift
+++ b/Sources/NIOFileSystem/FileSystem.swift
@@ -12,12 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-
 import Atomics
 import NIOCore
 import NIOPosix
-@preconcurrency import SystemPackage
+import SystemPackage
 
 #if canImport(Darwin)
 import Darwin
@@ -1539,4 +1537,3 @@ extension FileSystem {
         }
     }
 }
-#endif

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -1157,5 +1156,3 @@ extension FileSystemError {
         )
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/FileSystemError.swift
+++ b/Sources/NIOFileSystem/FileSystemError.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 /// An error thrown as a result of interaction with the file system.
@@ -279,5 +278,3 @@ extension FileSystemError {
         }
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/NIOFileSystem/FileSystemProtocol.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 /// The interface for interacting with a file system.
@@ -663,5 +662,3 @@ extension FileSystemProtocol {
         }
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/FileType.swift
+++ b/Sources/NIOFileSystem/FileType.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -170,5 +169,3 @@ extension FileType {
         }
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/Internal/BufferedOrAnyStream.swift
+++ b/Sources/NIOFileSystem/Internal/BufferedOrAnyStream.swift
@@ -14,7 +14,6 @@
 
 import NIOCore
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 /// Wraps a ``NIOThrowingAsyncSequenceProducer<Element>`` or ``AnyAsyncSequence<Element>``.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal enum BufferedOrAnyStream<Element, Delegate: NIOAsyncSequenceProducerDelegate> {
@@ -95,5 +94,3 @@ internal struct AnyAsyncSequence<Element>: AsyncSequence {
         }
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/Internal/BufferedStream.swift
+++ b/Sources/NIOFileSystem/Internal/BufferedStream.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import DequeModule
 import NIOConcurrencyHelpers
 
@@ -1732,5 +1731,3 @@ extension BufferedStream {
         }
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/Internal/Cancellation.swift
+++ b/Sources/NIOFileSystem/Internal/Cancellation.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-
 /// Executes the closure and masks cancellation.
 @_spi(Testing)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -54,5 +52,3 @@ public func withUncancellableTearDown<R>(
     try tearDownResult.get()
     return try result.get()
 }
-
-#endif

--- a/Sources/NIOFileSystem/Internal/Concurrency Primitives/UnsafeTransfer.swift
+++ b/Sources/NIOFileSystem/Internal/Concurrency Primitives/UnsafeTransfer.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 @usableFromInline
 struct UnsafeTransfer<Value>: @unchecked Sendable {
     @usableFromInline
@@ -23,4 +22,3 @@ struct UnsafeTransfer<Value>: @unchecked Sendable {
         self.wrappedValue = wrappedValue
     }
 }
-#endif

--- a/Sources/NIOFileSystem/Internal/ParallelDirCopy.swift
+++ b/Sources/NIOFileSystem/Internal/ParallelDirCopy.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -161,4 +160,3 @@ private struct DirCopyDelegate: NIOAsyncSequenceProducerDelegate, Sendable {
     @inlinable
     func didTerminate() {}
 }
-#endif

--- a/Sources/NIOFileSystem/Internal/String+UnsafeUnititializedCapacity.swift
+++ b/Sources/NIOFileSystem/Internal/String+UnsafeUnititializedCapacity.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-
 extension String {
     @inlinable
     init(
@@ -61,5 +59,3 @@ extension String {
         }
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -82,4 +81,3 @@ extension CInterop {
     typealias FTSPointer = UnsafeMutablePointer<FTS>
     typealias FTSEntPointer = UnsafeMutablePointer<CInterop.FTSEnt>
 }
-#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Errno.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Errno.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -147,4 +146,3 @@ public func valueOrErrno<R>(
         }
     }
 }
-#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
 import SystemPackage
 
@@ -324,5 +323,4 @@ extension FileDescriptor {
         Self(rawValue: AT_FDCWD)
     }
 }
-#endif
 #endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Mocking.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Mocking.swift
@@ -17,7 +17,6 @@
 // Licensed under Apache License v2.0 with Runtime Library Exception//
 // See https://swift.org/LICENSE.txt for license information
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -370,4 +369,3 @@ internal func setTLS(_ key: _PlatformTLSKey, _ p: UnsafeMutableRawPointer?) {
 internal func getTLS(_ key: _PlatformTLSKey) -> UnsafeMutableRawPointer? {
     pthread_getspecific(key)
 }
-#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -443,4 +442,3 @@ public enum Libc {
         }
     }
 }
-#endif

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 #if canImport(Darwin)
@@ -482,4 +481,3 @@ internal func libc_fts_close(
 ) -> CInt {
     fts_close(fts)
 }
-#endif

--- a/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
@@ -12,11 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
-@preconcurrency import SystemPackage
+import SystemPackage
 
 #if canImport(Darwin)
 import Darwin
@@ -1536,5 +1535,3 @@ extension SystemFileHandle {
         }
     }
 }
-
-#endif

--- a/Sources/NIOFileSystem/Internal/Utilities.swift
+++ b/Sources/NIOFileSystem/Internal/Utilities.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 @usableFromInline
@@ -44,5 +43,3 @@ extension Array where Element == UInt8 {
         return alphaNumericValues
     }()
 }
-
-#endif

--- a/Sources/NIOFileSystem/OpenOptions.swift
+++ b/Sources/NIOFileSystem/OpenOptions.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import SystemPackage
 
 /// Options for opening file handles.
@@ -296,5 +295,3 @@ extension FilePermissions {
         .otherReadExecute,
     ]
 }
-
-#endif

--- a/Sources/NIOFileSystemFoundationCompat/Date+FileInfo.swift
+++ b/Sources/NIOFileSystemFoundationCompat/Date+FileInfo.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import _NIOFileSystem
 
 import struct Foundation.Date
@@ -30,4 +29,3 @@ extension FileInfo.Timespec {
         Date(timespec: self)
     }
 }
-#endif

--- a/Tests/NIOFileSystemFoundationCompatTests/FileSystemFoundationCompatTests.swift
+++ b/Tests/NIOFileSystemFoundationCompatTests/FileSystemFoundationCompatTests.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
+import XCTest
 import _NIOFileSystem
 import _NIOFileSystemFoundationCompat
-import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension FileSystem {
@@ -78,4 +77,3 @@ final class FileSystemBytesConformanceTests: XCTestCase {
         XCTAssertEqual(contents, Data([0, 1, 2]))
     }
 }
-#endif

--- a/Tests/NIOFileSystemIntegrationTests/BufferedReaderTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/BufferedReaderTests.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-import _NIOFileSystem
 import XCTest
+import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class BufferedReaderTests: XCTestCase {
@@ -280,4 +279,3 @@ final class BufferedReaderTests: XCTestCase {
         }
     }
 }
-#endif

--- a/Tests/NIOFileSystemIntegrationTests/BufferedWriterTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/BufferedWriterTests.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-@_spi(Testing) import _NIOFileSystem
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class BufferedWriterTests: XCTestCase {
@@ -254,4 +253,3 @@ final class BufferedWriterTests: XCTestCase {
         }
     }
 }
-#endif

--- a/Tests/NIOFileSystemIntegrationTests/ConvenienceTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/ConvenienceTests.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-import _NIOFileSystem
 import XCTest
+import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class ConvenienceTests: XCTestCase {
@@ -72,4 +71,3 @@ final class ConvenienceTests: XCTestCase {
         XCTAssertEqual(bytes, ByteBuffer(bytes: Array(0..<64)))
     }
 }
-#endif

--- a/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileHandleTests.swift
@@ -12,12 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-import NIOPosix
-@_spi(Testing) import _NIOFileSystem
 import NIOFoundationCompat
+import NIOPosix
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 final class FileHandleTests: XCTestCase {
@@ -1314,4 +1313,3 @@ private func assertThrowsErrorClosed<R>(
         XCTAssertEqual(error.code, .closed)
     }
 }
-#endif

--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests+SPI.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests+SPI.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import _NIOFileSystem
 import SystemPackage
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension FileSystemTests {
@@ -26,4 +25,3 @@ extension FileSystemTests {
         XCTAssertEqual(removed, 0)
     }
 }
-#endif

--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
@@ -12,12 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import NIOCore
-@_spi(Testing) @testable import _NIOFileSystem
-@preconcurrency import SystemPackage
-import XCTest
 import NIOConcurrencyHelpers
+import NIOCore
+import SystemPackage
+import XCTest
+@_spi(Testing) @testable import _NIOFileSystem
 
 extension FilePath {
     static let testData = FilePath(#filePath)
@@ -1864,5 +1863,4 @@ extension XCTestCase {
         wait(for: expectations, timeout: seconds)
     }
 }
-#endif
 #endif

--- a/Tests/NIOFileSystemIntegrationTests/XCTestExtensions.swift
+++ b/Tests/NIOFileSystemIntegrationTests/XCTestExtensions.swift
@@ -12,9 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import _NIOFileSystem
 import XCTest
+import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func XCTAssertThrowsErrorAsync<R>(
@@ -81,4 +80,3 @@ func XCTAssertNoThrowAsync<T>(
         XCTFail("Expression did throw: \(error)", file: file, line: line)
     }
 }
-#endif

--- a/Tests/NIOFileSystemTests/ByteCountTests.swift
+++ b/Tests/NIOFileSystemTests/ByteCountTests.swift
@@ -12,9 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import _NIOFileSystem
 import XCTest
+import _NIOFileSystem
 
 class ByteCountTests: XCTestCase {
     func testByteCountBytes() {
@@ -90,4 +89,3 @@ class ByteCountTests: XCTestCase {
         XCTAssertGreaterThan(byteCount2, byteCount1)
     }
 }
-#endif

--- a/Tests/NIOFileSystemTests/DirectoryEntriesTests.swift
+++ b/Tests/NIOFileSystemTests/DirectoryEntriesTests.swift
@@ -12,9 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import _NIOFileSystem
 import XCTest
+import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class DirectoryEntriesTests: XCTestCase {
@@ -71,4 +70,3 @@ final class DirectoryEntriesTests: XCTestCase {
         XCTAssertNil(end)
     }
 }
-#endif

--- a/Tests/NIOFileSystemTests/FileChunksTests.swift
+++ b/Tests/NIOFileSystemTests/FileChunksTests.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import NIOCore
-import _NIOFileSystem
 import XCTest
+import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class FileChunksTests: XCTestCase {
@@ -39,4 +38,3 @@ final class FileChunksTests: XCTestCase {
         XCTAssertNil(end)
     }
 }
-#endif

--- a/Tests/NIOFileSystemTests/FileHandleTests.swift
+++ b/Tests/NIOFileSystemTests/FileHandleTests.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import _NIOFileSystem
 import NIOPosix
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 #if ENABLE_MOCKING
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -270,5 +269,4 @@ extension MockingDriver {
         }
     }
 }
-#endif
 #endif

--- a/Tests/NIOFileSystemTests/FileInfoTests.swift
+++ b/Tests/NIOFileSystemTests/FileInfoTests.swift
@@ -12,9 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import _NIOFileSystem
 import XCTest
+import _NIOFileSystem
 
 #if canImport(Darwin)
 import Darwin
@@ -159,4 +158,3 @@ final class FileInfoTests: XCTestCase {
         #endif
     }
 }
-#endif

--- a/Tests/NIOFileSystemTests/FileOpenOptionsTests.swift
+++ b/Tests/NIOFileSystemTests/FileOpenOptionsTests.swift
@@ -12,9 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import _NIOFileSystem
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 final class FileOpenOptionsTests: XCTestCase {
     private let expectedDefaults: FilePermissions = [
@@ -99,4 +98,3 @@ final class FileOpenOptionsTests: XCTestCase {
         XCTAssertEqual(FileDescriptor.OpenOptions(options), [.create, .exclusiveCreate, .noFollow])
     }
 }
-#endif

--- a/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFileSystemTests/FileSystemErrorTests.swift
@@ -12,9 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import _NIOFileSystem
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 final class FileSystemErrorTests: XCTestCase {
     func testFileSystemErrorCustomStringConvertible() throws {
@@ -623,4 +622,3 @@ private func assertCauseIsSyscall(
 extension FileSystemError.SourceLocation {
     fileprivate static let fixed = Self(function: "fn", file: "file", line: 1)
 }
-#endif

--- a/Tests/NIOFileSystemTests/FileTypeTests.swift
+++ b/Tests/NIOFileSystemTests/FileTypeTests.swift
@@ -12,9 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import _NIOFileSystem
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 #if canImport(Darwin)
 import Darwin
@@ -80,4 +79,3 @@ final class FileTypeTests: XCTestCase {
         #endif
     }
 }
-#endif

--- a/Tests/NIOFileSystemTests/Internal/CancellationTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/CancellationTests.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import Atomics
-@_spi(Testing) import _NIOFileSystem
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class CancellationTests: XCTestCase {
@@ -88,4 +87,3 @@ final class CancellationTests: XCTestCase {
         }
     }
 }
-#endif

--- a/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
 import XCTest
 
 @testable import _NIOFileSystem
@@ -1140,4 +1139,3 @@ extension AsyncThrowingStream {
         return (stream, continuation!)
     }
 }
-#endif

--- a/Tests/NIOFileSystemTests/Internal/MockingInfrastructure.swift
+++ b/Tests/NIOFileSystemTests/Internal/MockingInfrastructure.swift
@@ -19,10 +19,9 @@
 //
 //See https://swift.org/LICENSE.txt for license information
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import _NIOFileSystem
 import SystemPackage
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 #if ENABLE_MOCKING
 internal struct Wildcard: Hashable {}
@@ -252,5 +251,4 @@ internal struct MockTestCase: TestCase {
 internal func withWindowsPaths(enabled: Bool, _ body: () -> Void) {
     _withWindowsPaths(enabled: enabled, body)
 }
-#endif
 #endif

--- a/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFileSystemTests/Internal/SyscallTests.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-@_spi(Testing) import _NIOFileSystem
 import SystemPackage
 import XCTest
+@_spi(Testing) import _NIOFileSystem
 
 #if ENABLE_MOCKING
 final class SyscallTests: XCTestCase {
@@ -518,5 +517,4 @@ extension Array where Element == MockTestCase {
         }
     }
 }
-#endif
 #endif

--- a/Tests/NIOFileSystemTests/XCTestExtensions.swift
+++ b/Tests/NIOFileSystemTests/XCTestExtensions.swift
@@ -12,9 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
-import _NIOFileSystem
 import XCTest
+import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func XCTAssertThrowsErrorAsync<R>(
@@ -68,4 +67,3 @@ func XCTAssertSystemCallError(
     XCTAssertEqual(systemCallError.systemCall, name, file: file, line: line)
     XCTAssertEqual(systemCallError.errno, errno, file: file, line: line)
 }
-#endif


### PR DESCRIPTION
Add Vision support

### Motivation:
https://github.com/apple/swift-nio/issues/2900 - close this

### Modifications:
- Bump SystemPackage to 1.4.0 and remove @preconcurrency 
- remove `#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)` to allow for visionOS support 
- Remove conditional import for swift system

### Result:

Vision OS support
