### PR TITLE
EmbeddedEventLoop/Channel: check correct thread

### DIFF
--- a/Sources/NIOPosix/Thread.swift
+++ b/Sources/NIOPosix/Thread.swift
@@ -105,14 +105,14 @@ final class NIOThread {
     }
 
     /// Returns the current running `NIOThread`.
-    static var current: NIOThread {
+    public static var current: NIOThread {
         let handle = ThreadOpsSystem.currentThread
         return NIOThread(handle: handle, desiredName: nil)
     }
 }
 
 extension NIOThread: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         let desiredName = self.desiredName
         let actualName = self.currentName
 
@@ -232,7 +232,7 @@ public final class ThreadSpecificVariable<Value: AnyObject> {
 extension ThreadSpecificVariable: @unchecked Sendable where Value: Sendable {}
 
 extension NIOThread: Equatable {
-    static func == (lhs: NIOThread, rhs: NIOThread) -> Bool {
+    public static func == (lhs: NIOThread, rhs: NIOThread) -> Bool {
         lhs.withUnsafeThreadHandle { lhs in
             rhs.withUnsafeThreadHandle { rhs in
                 ThreadOpsSystem.compareThreads(lhs, rhs)

--- a/Tests/NIOCoreTests/DispatchQueue+WithFutureTest.swift
+++ b/Tests/NIOCoreTests/DispatchQueue+WithFutureTest.swift
@@ -15,6 +15,7 @@
 import Dispatch
 import NIOCore
 import NIOEmbedded
+import NIOPosix
 import XCTest
 
 enum DispatchQueueTestError: Error {
@@ -23,7 +24,11 @@ enum DispatchQueueTestError: Error {
 
 class DispatchQueueWithFutureTest: XCTestCase {
     func testDispatchQueueAsyncWithFuture() {
-        let eventLoop = EmbeddedEventLoop()
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        let eventLoop = group.next()
         let sem = DispatchSemaphore(value: 0)
         var nonBlockingRan = false
         let futureResult: EventLoopFuture<String> = DispatchQueue.global().asyncWithFuture(eventLoop: eventLoop) {
@@ -46,7 +51,11 @@ class DispatchQueueWithFutureTest: XCTestCase {
     }
 
     func testDispatchQueueAsyncWithFutureThrows() {
-        let eventLoop = EmbeddedEventLoop()
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        let eventLoop = group.next()
         let sem = DispatchSemaphore(value: 0)
         var nonBlockingRan = false
         let futureResult: EventLoopFuture<String> = DispatchQueue.global().asyncWithFuture(eventLoop: eventLoop) {

--- a/Tests/NIOPosixTests/NIOScheduledCallbackTests.swift
+++ b/Tests/NIOPosixTests/NIOScheduledCallbackTests.swift
@@ -54,29 +54,6 @@ final class MTELGScheduledCallbackTests: _BaseScheduledCallbackTests {
     }
 }
 
-final class EmbeddedScheduledCallbackTests: _BaseScheduledCallbackTests {
-    struct Requirements: ScheduledCallbackTestRequirements {
-        let _loop = EmbeddedEventLoop()
-        var loop: (any EventLoop) { self._loop }
-
-        func advanceTime(by amount: TimeAmount) async throws {
-            self._loop.advanceTime(by: amount)
-        }
-
-        func shutdownEventLoop() async throws {
-            try await self._loop.shutdownGracefully()
-        }
-
-        func maybeInContext<R: Sendable>(_ body: @escaping @Sendable () throws -> R) async throws -> R {
-            try body()
-        }
-    }
-
-    override func setUp() async throws {
-        self.requirements = Requirements()
-    }
-}
-
 final class NIOAsyncTestingEventLoopScheduledCallbackTests: _BaseScheduledCallbackTests {
     struct Requirements: ScheduledCallbackTestRequirements {
         let _loop = NIOAsyncTestingEventLoop()


### PR DESCRIPTION
### Motivation:

`EmbeddedChannel` & `EmbeddedEventLoop` currently violate `Sendable`. They should store the current thread in `init` and then implement `inEventLoop` and other functions with a check that the current thread is correct.
Since NIO 1.0 `Embedded*` were always documented to not be thread-safe but we should finally police this.

### Modifications:

- Implement the thread check
- For now, just warn (soon hopefully crash)
- Delete EmbeddedScheduledCallbackTests (#2950)

### Result:

- Less Embedded* abuse
- fixes #2949 