### PR TITLE
Fix `NIOAsyncSequenceProducer` watermark strategy.

### DIFF
--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceProducer+HighLowWatermarkBackPressureStrategyTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceProducer+HighLowWatermarkBackPressureStrategyTests.swift
@@ -51,10 +51,10 @@ final class NIOAsyncSequenceProducerBackPressureStrategiesHighLowWatermarkTests:
     }
 
     func testDidConsume_whenAboveLowWatermark() {
-        XCTAssertFalse(self.strategy.didConsume(bufferDepth: 6))
+        XCTAssertTrue(self.strategy.didConsume(bufferDepth: 6))
     }
 
     func testDidConsume_whenAtLowWatermark() {
-        XCTAssertFalse(self.strategy.didConsume(bufferDepth: 5))
+        XCTAssertTrue(self.strategy.didConsume(bufferDepth: 5))
     }
 }

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
@@ -149,6 +149,42 @@ final class NIOAsyncSequenceProducerTests: XCTestCase {
         XCTAssertEqual(self.source.yield(contentsOf: [7, 8, 9, 10, 11]), .stopProducing)
     }
 
+    func testWatermarkBackpressure_whenBelowLowwatermark_andOutstandingDemand() async {
+        let newSequence = NIOAsyncSequenceProducer.makeSequence(
+            elementType: Int.self,
+            backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark(
+                lowWatermark: 2,
+                highWatermark: 5
+            ),
+            finishOnDeinit: false,
+            delegate: self.delegate
+        )
+        let iterator = newSequence.sequence.makeAsyncIterator()
+        var eventsIterator = self.delegate.events.makeAsyncIterator()
+        let source = newSequence.source
+
+        XCTAssertEqual(source.yield(1), .produceMore)
+        XCTAssertEqual(source.yield(2), .produceMore)
+        XCTAssertEqual(source.yield(3), .produceMore)
+        XCTAssertEqual(source.yield(4), .produceMore)
+        XCTAssertEqual(source.yield(5), .stopProducing)
+        XCTAssertEqualWithoutAutoclosure(await iterator.next(), 1)
+        XCTAssertEqualWithoutAutoclosure(await iterator.next(), 2)
+        XCTAssertEqualWithoutAutoclosure(await iterator.next(), 3)
+        XCTAssertEqualWithoutAutoclosure(await iterator.next(), 4)
+        XCTAssertEqualWithoutAutoclosure(await iterator.next(), 5)
+        XCTAssertEqualWithoutAutoclosure(await eventsIterator.next(), .produceMore)
+        XCTAssertEqual(source.yield(6), .produceMore)
+        XCTAssertEqual(source.yield(7), .produceMore)
+        XCTAssertEqual(source.yield(8), .produceMore)
+        XCTAssertEqualWithoutAutoclosure(await iterator.next(), 6)
+        XCTAssertEqualWithoutAutoclosure(await iterator.next(), 7)
+        XCTAssertEqualWithoutAutoclosure(await iterator.next(), 8)
+        source.finish()
+        XCTAssertEqualWithoutAutoclosure(await iterator.next(), nil)
+        XCTAssertEqualWithoutAutoclosure(await eventsIterator.next(), .didTerminate)
+    }
+
     // MARK: - Yield
 
     func testYield_whenInitial_andStopDemanding() async {


### PR DESCRIPTION
# Motivation

It was currently possible that the producer's delegate is getting called twice with `produceMore` even if no `yield` returned a `stopProducing`. This could happen when we expected the producer to yield elements but the consumer went below the low watermark again. Resulting in two subsequent calls.

# Modification

This PR stores the current demand state in the strategy which let's us avoid flipping the `hasOustandingDemand` state of the sequence.

# Result

Correctly, ensured the call order of `produceMore` and `stopProducing`.
