### PR TITLE
Handle Sendability of RemovableChannelHandler

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -188,6 +188,7 @@ extension ChannelPipeline {
     }
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(*, deprecated, message: "Use .syncOperations.removeHandler(context:) instead, this method is not Sendable-safe.")
     public func removeHandler(context: ChannelHandlerContext) async throws {
         try await self.removeHandler(context: context).get()
     }

--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -188,7 +188,11 @@ extension ChannelPipeline {
     }
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @available(*, deprecated, message: "Use .syncOperations.removeHandler(context:) instead, this method is not Sendable-safe.")
+    @available(
+        *,
+        deprecated,
+        message: "Use .syncOperations.removeHandler(context:) instead, this method is not Sendable-safe."
+    )
     public func removeHandler(context: ChannelHandlerContext) async throws {
         try await self.removeHandler(context: context).get()
     }

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -373,7 +373,11 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - context: the `ChannelHandlerContext` that belongs to `ChannelHandler` that should be removed.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
-    @available(*, deprecated, message: "Use .syncOperations.removeHandler(context:) instead, this method is not Sendable-safe.")
+    @available(
+        *,
+        deprecated,
+        message: "Use .syncOperations.removeHandler(context:) instead, this method is not Sendable-safe."
+    )
     public func removeHandler(context: ChannelHandlerContext) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         self.removeHandler(context: context, promise: promise)
@@ -426,7 +430,11 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - context: the `ChannelHandlerContext` that belongs to `ChannelHandler` that should be removed.
     ///     - promise: An `EventLoopPromise` that will complete when the `ChannelHandler` is removed.
-    @available(*, deprecated, message: "Use .syncOperations.removeHandler(context:) instead, this method is not Sendable-safe.")
+    @available(
+        *,
+        deprecated,
+        message: "Use .syncOperations.removeHandler(context:) instead, this method is not Sendable-safe."
+    )
     public func removeHandler(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
         let sendableView = context.sendableView
 
@@ -454,7 +462,11 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - handler: the `ChannelHandler` for which the `ChannelHandlerContext` should be returned
     /// - returns: the `EventLoopFuture` which will be notified once the the operation completes.
-    @available(*, deprecated, message: "This method is not strict concurrency safe. Prefer .syncOperations.context(handler:)")
+    @available(
+        *,
+        deprecated,
+        message: "This method is not strict concurrency safe. Prefer .syncOperations.context(handler:)"
+    )
     @preconcurrency
     public func context(handler: ChannelHandler & Sendable) -> EventLoopFuture<ChannelHandlerContext> {
         let promise = self.eventLoop.makePromise(of: ChannelHandlerContext.self)

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -1446,9 +1446,6 @@ extension ChannelPipeline {
     }
 }
 
-@available(*, unavailable)
-extension ChannelPipeline.Position: Sendable {}
-
 /// Special `ChannelHandler` that forwards all events to the `Channel.Unsafe` implementation.
 final class HeadChannelHandler: _ChannelOutboundHandler, Sendable {
 

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -167,8 +167,9 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - handler: the `ChannelHandler` to add
     ///     - position: The position in the `ChannelPipeline` to add `handler`. Defaults to `.last`.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was added.
+    @preconcurrency
     public func addHandler(
-        _ handler: ChannelHandler,
+        _ handler: ChannelHandler & Sendable,
         name: String? = nil,
         position: ChannelPipeline.Position = .last
     ) -> EventLoopFuture<Void> {
@@ -349,7 +350,8 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - handler: the `ChannelHandler` to remove.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
-    public func removeHandler(_ handler: RemovableChannelHandler) -> EventLoopFuture<Void> {
+    @preconcurrency
+    public func removeHandler(_ handler: RemovableChannelHandler & Sendable) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         self.removeHandler(handler, promise: promise)
         return promise.futureResult
@@ -371,6 +373,7 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - context: the `ChannelHandlerContext` that belongs to `ChannelHandler` that should be removed.
     /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
+    @available(*, deprecated, message: "Use .syncOperations.removeHandler(context:) instead, this method is not Sendable-safe.")
     public func removeHandler(context: ChannelHandlerContext) -> EventLoopFuture<Void> {
         let promise = self.eventLoop.makePromise(of: Void.self)
         self.removeHandler(context: context, promise: promise)
@@ -382,14 +385,11 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - handler: the `ChannelHandler` to remove.
     ///     - promise: An `EventLoopPromise` that will complete when the `ChannelHandler` is removed.
-    public func removeHandler(_ handler: RemovableChannelHandler, promise: EventLoopPromise<Void>?) {
+    @preconcurrency
+    public func removeHandler(_ handler: RemovableChannelHandler & Sendable, promise: EventLoopPromise<Void>?) {
+        @Sendable
         func removeHandler0() {
-            switch self.contextSync(handler: handler) {
-            case .success(let context):
-                self.removeHandler(context: context, promise: promise)
-            case .failure(let error):
-                promise?.fail(error)
-            }
+            self.syncOperations.removeHandler(handler, promise: promise)
         }
 
         if self.eventLoop.inEventLoop {
@@ -407,13 +407,9 @@ public final class ChannelPipeline: ChannelInvoker {
     ///     - name: the name that was used to add the `ChannelHandler` to the `ChannelPipeline` before.
     ///     - promise: An `EventLoopPromise` that will complete when the `ChannelHandler` is removed.
     public func removeHandler(name: String, promise: EventLoopPromise<Void>?) {
+        @Sendable
         func removeHandler0() {
-            switch self.contextSync(name: name) {
-            case .success(let context):
-                self.removeHandler(context: context, promise: promise)
-            case .failure(let error):
-                promise?.fail(error)
-            }
+            self.syncOperations.removeHandler(name: name, promise: promise)
         }
 
         if self.eventLoop.inEventLoop {
@@ -430,13 +426,18 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - context: the `ChannelHandlerContext` that belongs to `ChannelHandler` that should be removed.
     ///     - promise: An `EventLoopPromise` that will complete when the `ChannelHandler` is removed.
+    @available(*, deprecated, message: "Use .syncOperations.removeHandler(context:) instead, this method is not Sendable-safe.")
     public func removeHandler(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
-        guard context.handler is RemovableChannelHandler else {
+        let sendableView = context.sendableView
+
+        guard sendableView.channelHandlerIsRemovable else {
             promise?.fail(ChannelError._unremovableHandler)
             return
         }
+
+        @Sendable
         func removeHandler0() {
-            context.startUserTriggeredRemoval(promise: promise)
+            sendableView.wrappedValue.startUserTriggeredRemoval(promise: promise)
         }
 
         if self.eventLoop.inEventLoop {
@@ -453,7 +454,9 @@ public final class ChannelPipeline: ChannelInvoker {
     /// - parameters:
     ///     - handler: the `ChannelHandler` for which the `ChannelHandlerContext` should be returned
     /// - returns: the `EventLoopFuture` which will be notified once the the operation completes.
-    public func context(handler: ChannelHandler) -> EventLoopFuture<ChannelHandlerContext> {
+    @available(*, deprecated, message: "This method is not strict concurrency safe. Prefer .syncOperations.context(handler:)")
+    @preconcurrency
+    public func context(handler: ChannelHandler & Sendable) -> EventLoopFuture<ChannelHandlerContext> {
         let promise = self.eventLoop.makePromise(of: ChannelHandlerContext.self)
 
         if self.eventLoop.inEventLoop {
@@ -1005,8 +1008,9 @@ extension ChannelPipeline {
     ///     - position: The position in the `ChannelPipeline` to add `handlers`. Defaults to `.last`.
     ///
     /// - returns: A future that will be completed when all of the supplied `ChannelHandler`s were added.
+    @preconcurrency
     public func addHandlers(
-        _ handlers: [ChannelHandler],
+        _ handlers: [ChannelHandler & Sendable],
         position: ChannelPipeline.Position = .last
     ) -> EventLoopFuture<Void> {
         let future: EventLoopFuture<Void>
@@ -1030,8 +1034,9 @@ extension ChannelPipeline {
     ///     - position: The position in the `ChannelPipeline` to add `handlers`. Defaults to `.last`.
     ///
     /// - returns: A future that will be completed when all of the supplied `ChannelHandler`s were added.
+    @preconcurrency
     public func addHandlers(
-        _ handlers: ChannelHandler...,
+        _ handlers: (ChannelHandler & Sendable)...,
         position: ChannelPipeline.Position = .last
     ) -> EventLoopFuture<Void> {
         self.addHandlers(handlers, position: position)
@@ -1149,16 +1154,49 @@ extension ChannelPipeline {
         /// - parameters:
         ///     - handler: the `ChannelHandler` to remove.
         /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
-        @preconcurrency
         public func removeHandler(_ handler: RemovableChannelHandler) -> EventLoopFuture<Void> {
             let promise = self.eventLoop.makePromise(of: Void.self)
+            self.removeHandler(handler, promise: promise)
+            return promise.futureResult
+        }
+
+        /// Remove a ``ChannelHandler`` from the ``ChannelPipeline``.
+        ///
+        /// - parameters:
+        ///     - handler: the ``ChannelHandler`` to remove.
+        ///     - promise: an ``EventLoopPromise`` to notify when the ``ChannelHandler`` was removed.
+        public func removeHandler(_ handler: RemovableChannelHandler, promise: EventLoopPromise<Void>?) {
             switch self._pipeline.contextSync(handler: handler) {
             case .success(let context):
-                self._pipeline.removeHandler(context: context, promise: promise)
+                self.removeHandler(context: context, promise: promise)
             case .failure(let error):
-                promise.fail(error)
+                promise?.fail(error)
             }
+        }
+
+        /// Remove a `ChannelHandler` from the `ChannelPipeline`.
+        ///
+        /// - parameters:
+        ///     - name: the name that was used to add the `ChannelHandler` to the `ChannelPipeline` before.
+        /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
+        public func removeHandler(name: String) -> EventLoopFuture<Void> {
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            self.removeHandler(name: name, promise: promise)
             return promise.futureResult
+        }
+
+        /// Remove a ``ChannelHandler`` from the ``ChannelPipeline``.
+        ///
+        /// - parameters:
+        ///     - name: the name that was used to add the `ChannelHandler` to the `ChannelPipeline` before.
+        ///     - promise: an ``EventLoopPromise`` to notify when the ``ChannelHandler`` was removed.
+        public func removeHandler(name: String, promise: EventLoopPromise<Void>?) {
+            switch self._pipeline.contextSync(name: name) {
+            case .success(let context):
+                self.removeHandler(context: context, promise: promise)
+            case .failure(let error):
+                promise?.fail(error)
+            }
         }
 
         /// Remove a `ChannelHandler` from the `ChannelPipeline`.
@@ -1168,8 +1206,17 @@ extension ChannelPipeline {
         /// - returns: the `EventLoopFuture` which will be notified once the `ChannelHandler` was removed.
         public func removeHandler(context: ChannelHandlerContext) -> EventLoopFuture<Void> {
             let promise = self.eventLoop.makePromise(of: Void.self)
-            self._pipeline.removeHandler(context: context, promise: promise)
+            self.removeHandler(context: context, promise: promise)
             return promise.futureResult
+        }
+
+        /// Remove a `ChannelHandler` from the `ChannelPipeline`.
+        ///
+        /// - parameters:
+        ///     - context: the `ChannelHandlerContext` that belongs to `ChannelHandler` that should be removed.
+        ///     - promise: an ``EventLoopPromise`` to notify when the ``ChannelHandler`` was removed.
+        public func removeHandler(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
+            context.startUserTriggeredRemoval(promise: promise)
         }
 
         /// Returns the `ChannelHandlerContext` for the given handler instance if it is in
@@ -1367,7 +1414,8 @@ extension ChannelPipeline.SynchronousOperations: Sendable {}
 
 extension ChannelPipeline {
     /// A `Position` within the `ChannelPipeline` used to insert handlers into the `ChannelPipeline`.
-    public enum Position {
+    @preconcurrency
+    public enum Position: Sendable {
         /// The first `ChannelHandler` -- the front of the `ChannelPipeline`.
         case first
 
@@ -1375,10 +1423,10 @@ extension ChannelPipeline {
         case last
 
         /// Before the given `ChannelHandler`.
-        case before(ChannelHandler)
+        case before(ChannelHandler & Sendable)
 
         /// After the given `ChannelHandler`.
-        case after(ChannelHandler)
+        case after(ChannelHandler & Sendable)
     }
 }
 
@@ -1386,7 +1434,7 @@ extension ChannelPipeline {
 extension ChannelPipeline.Position: Sendable {}
 
 /// Special `ChannelHandler` that forwards all events to the `Channel.Unsafe` implementation.
-final class HeadChannelHandler: _ChannelOutboundHandler {
+final class HeadChannelHandler: _ChannelOutboundHandler, Sendable {
 
     static let name = "head"
     static let sharedInstance = HeadChannelHandler()
@@ -1442,7 +1490,7 @@ extension CloseMode {
 }
 
 /// Special `ChannelInboundHandler` which will consume all inbound events.
-final class TailChannelHandler: _ChannelInboundHandler {
+final class TailChannelHandler: _ChannelInboundHandler, Sendable {
 
     static let name = "tail"
     static let sharedInstance = TailChannelHandler()
@@ -1974,6 +2022,42 @@ extension ChannelHandlerContext {
             context: self,
             removalToken: .init(promise: promise)
         )
+    }
+}
+
+extension ChannelHandlerContext {
+    var sendableView: SendableView {
+        SendableView(wrapping: self)
+    }
+
+    /// A wrapper over ``ChannelHandlerContext`` that allows access to the thread-safe API
+    /// surface on the type.
+    ///
+    /// Very little of ``ChannelHandlerContext`` is thread-safe, but in a rare few places
+    /// there are things we can access. This type makes those available.
+    struct SendableView: @unchecked Sendable {
+        private let context: ChannelHandlerContext
+
+        fileprivate init(wrapping context: ChannelHandlerContext) {
+            self.context = context
+        }
+
+        /// Whether the ``ChannelHandler`` associated with this context conforms to
+        /// ``RemovableChannelHandler``.
+        var channelHandlerIsRemovable: Bool {
+            // `context.handler` is not mutable, and set at construction, so this access is
+            // acceptable. The protocol conformance check is also safe.
+            self.context.handler is RemovableChannelHandler
+        }
+
+        /// Grabs the underlying ``ChannelHandlerContext``. May only be called on the
+        /// event loop.
+        var wrappedValue: ChannelHandlerContext {
+            // The event loop lookup here is also thread-safe, so we can grab the value out
+            // and use it.
+            self.context.eventLoop.preconditionInEventLoop()
+            return self.context
+        }
     }
 }
 

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -1228,7 +1228,11 @@ extension ChannelPipeline {
         ///     - context: the `ChannelHandlerContext` that belongs to `ChannelHandler` that should be removed.
         ///     - promise: an ``EventLoopPromise`` to notify when the ``ChannelHandler`` was removed.
         public func removeHandler(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
-            context.startUserTriggeredRemoval(promise: promise)
+            if context.handler is RemovableChannelHandler {
+                context.startUserTriggeredRemoval(promise: promise)
+            } else {
+                promise?.fail(ChannelError.unremovableHandler)
+            }
         }
 
         /// Returns the `ChannelHandlerContext` for the given handler instance if it is in

--- a/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
@@ -290,7 +290,7 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
                         )
                         self.upgradeState = .upgradeComplete
                         // When we remove ourselves we'll be delivering any buffered data.
-                        context.pipeline.removeHandler(context: context, promise: nil)
+                        context.pipeline.syncOperations.removeHandler(context: context, promise: nil)
 
                     case .failure(let error):
                         // Remain in the '.upgrading' state.
@@ -357,7 +357,7 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
         context.fireChannelReadComplete()
 
         // Ok, we've delivered all the parts. We can now remove ourselves, which should happen synchronously.
-        context.pipeline.removeHandler(context: context, promise: nil)
+        context.pipeline.syncOperations.removeHandler(context: context, promise: nil)
     }
 
     /// Builds the initial mandatory HTTP headers for HTTP upgrade responses.

--- a/Sources/NIOHTTP1/NIOHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOHTTPClientUpgradeHandler.swift
@@ -356,7 +356,7 @@ public final class NIOHTTPClientUpgradeHandler: ChannelDuplexHandler, RemovableC
                     self.upgradeState = .upgradeComplete
                 }
                 .whenComplete { _ in
-                    context.pipeline.removeHandler(context: context, promise: nil)
+                    context.pipeline.syncOperations.removeHandler(context: context, promise: nil)
                 }
         }
     }
@@ -397,7 +397,7 @@ public final class NIOHTTPClientUpgradeHandler: ChannelDuplexHandler, RemovableC
         context.fireChannelRead(Self.wrapInboundOut(data))
 
         // We've delivered the data. We can now remove ourselves, which should happen synchronously.
-        context.pipeline.removeHandler(context: context, promise: nil)
+        context.pipeline.syncOperations.removeHandler(context: context, promise: nil)
     }
 }
 

--- a/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
@@ -138,7 +138,7 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
         case .fireErrorCaughtAndRemoveHandler(let error):
             self.negotiatedPromise.fail(error)
             context.fireErrorCaught(error)
-            context.pipeline.removeHandler(self, promise: nil)
+            context.pipeline.syncOperations.removeHandler(self, promise: nil)
 
         case .fireErrorCaughtAndStartUnbuffering(let error):
             self.negotiatedPromise.fail(error)
@@ -151,7 +151,7 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
 
         case .removeHandler(let value):
             self.negotiatedPromise.succeed(value)
-            context.pipeline.removeHandler(self, promise: nil)
+            context.pipeline.syncOperations.removeHandler(self, promise: nil)
 
         case .none:
             break
@@ -166,7 +166,7 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
 
             case .fireChannelReadCompleteAndRemoveHandler:
                 context.fireChannelReadComplete()
-                context.pipeline.removeHandler(self, promise: nil)
+                context.pipeline.syncOperations.removeHandler(self, promise: nil)
                 return
             }
         }

--- a/Sources/NIOTLS/SNIHandler.swift
+++ b/Sources/NIOTLS/SNIHandler.swift
@@ -426,9 +426,11 @@ public final class SNIHandler: ByteToMessageDecoder {
     ///    ByteToMessageDecoder to automatically deliver the buffered bytes to the next handler
     ///    in the pipeline, which is now responsible for the work.
     private func sniComplete(result: SNIResult, context: ChannelHandlerContext) {
+        let boundContext = NIOLoopBound(context, eventLoop: context.eventLoop)
         waitingForUser = true
-        completionHandler(result).whenSuccess {
-            context.pipeline.removeHandler(context: context, promise: nil)
+        completionHandler(result).hop(to: context.eventLoop).whenSuccess {
+            let context = boundContext.value
+            context.pipeline.syncOperations.removeHandler(context: context, promise: nil)
         }
     }
 }

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -442,7 +442,7 @@ private final class CloseSuppressor: ChannelOutboundHandler, RemovableChannelHan
 extension NIOAsyncTestingChannel {
     fileprivate func closeIgnoringSuppression() async throws {
         try await self.pipeline.context(handlerType: CloseSuppressor.self).flatMap {
-            self.pipeline.removeHandler(context: $0)
+            self.pipeline.syncOperations.removeHandler(context: $0)
         }.flatMap {
             self.close()
         }.get()

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -58,7 +58,7 @@ extension ChannelPipeline {
 
     fileprivate func removeUpgrader() throws {
         try self.context(handlerType: HTTPServerUpgradeHandler.self).flatMap {
-            self.removeHandler(context: $0)
+            self.syncOperations.removeHandler(context: $0)
         }.wait()
     }
 

--- a/Tests/NIOPosixTests/AcceptBackoffHandlerTest.swift
+++ b/Tests/NIOPosixTests/AcceptBackoffHandlerTest.swift
@@ -344,8 +344,8 @@ public final class AcceptBackoffHandlerTest: XCTestCase {
 
         XCTAssertNoThrow(try serverChannel.setOption(.autoRead, value: false).wait())
         XCTAssertNoThrow(
-            try serverChannel.pipeline.addHandler(readCountHandler).flatMap { _ in
-                serverChannel.pipeline.addHandler(
+            try serverChannel.pipeline.addHandler(readCountHandler).flatMapThrowing { _ in
+                try serverChannel.pipeline.syncOperations.addHandler(
                     AcceptBackoffHandler(backoffProvider: backoffProvider),
                     name: self.acceptHandlerName
                 )

--- a/Tests/NIOPosixTests/ChannelPipelineTest.swift
+++ b/Tests/NIOPosixTests/ChannelPipelineTest.swift
@@ -810,7 +810,7 @@ class ChannelPipelineTest: XCTestCase {
 
         XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
         XCTAssertNoThrow(try channel.throwIfErrorCaught())
-        channel.pipeline.removeHandler(context: context, promise: removalPromise)
+        channel.pipeline.syncOperations.removeHandler(context: context, promise: removalPromise)
 
         XCTAssertNoThrow(try removalPromise.futureResult.wait())
         guard case .some(.byteBuffer(let receivedBuffer)) = try channel.readOutbound(as: IOData.self) else {
@@ -845,7 +845,7 @@ class ChannelPipelineTest: XCTestCase {
 
         XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
         XCTAssertNoThrow(try channel.throwIfErrorCaught())
-        channel.pipeline.removeHandler(context: context).whenSuccess {
+        channel.pipeline.syncOperations.removeHandler(context: context).whenSuccess {
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
         }
@@ -1058,7 +1058,7 @@ class ChannelPipelineTest: XCTestCase {
         // let's trigger the removal process
         XCTAssertNoThrow(
             try channel.pipeline.context(handlerType: NeverCompleteRemovalHandler.self).map { handler in
-                channel.pipeline.removeHandler(context: handler, promise: nil)
+                channel.pipeline.syncOperations.removeHandler(context: handler, promise: nil)
             }.wait()
         )
 
@@ -1111,7 +1111,7 @@ class ChannelPipelineTest: XCTestCase {
 
         XCTAssertNoThrow(try channel.pipeline.removeHandler(name: "the first one to remove").wait())
         XCTAssertNoThrow(try channel.pipeline.removeHandler(allHandlers[1]).wait())
-        XCTAssertNoThrow(try channel.pipeline.removeHandler(context: lastContext).wait())
+        XCTAssertNoThrow(try channel.pipeline.syncOperations.removeHandler(context: lastContext).wait())
 
         for handler in allHandlers {
             XCTAssertTrue(handler.removeHandlerCalled)
@@ -1187,7 +1187,7 @@ class ChannelPipelineTest: XCTestCase {
                 XCTFail("unexpected error: \(error)")
             }
         }
-        XCTAssertThrowsError(try channel.pipeline.removeHandler(context: lastContext).wait()) { error in
+        XCTAssertThrowsError(try channel.pipeline.syncOperations.removeHandler(context: lastContext).wait()) { error in
             if let error = error as? ChannelError {
                 XCTAssertEqual(ChannelError.unremovableHandler, error)
             } else {

--- a/Tests/NIOPosixTests/CodecTest.swift
+++ b/Tests/NIOPosixTests/CodecTest.swift
@@ -616,7 +616,7 @@ public final class ByteToMessageDecoderTest: XCTestCase {
         XCTAssertNoThrow(try channel.writeInbound(buffer))
 
         channel.pipeline.context(handlerType: ByteToMessageHandler<PairOfBytesDecoder>.self).flatMap { context in
-            channel.pipeline.removeHandler(context: context)
+            channel.pipeline.syncOperations.removeHandler(context: context)
         }.whenFailure { error in
             XCTFail("unexpected error: \(error)")
         }
@@ -834,7 +834,7 @@ public final class ByteToMessageDecoderTest: XCTestCase {
             mutating func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
                 if let slice = buffer.readSlice(length: 16) {
                     context.fireChannelRead(Self.wrapInboundOut(slice))
-                    context.pipeline.removeHandler(context: context).whenFailure { error in
+                    context.pipeline.syncOperations.removeHandler(context: context).whenFailure { error in
                         XCTFail("unexpected error: \(error)")
                     }
                     return .continue
@@ -943,7 +943,7 @@ public final class ByteToMessageDecoderTest: XCTestCase {
                         )
                     )
                 )
-                context.pipeline.removeHandler(context: context).whenFailure { error in
+                context.pipeline.syncOperations.removeHandler(context: context).whenFailure { error in
                     XCTFail("unexpected error: \(error)")
                 }
                 return .continue
@@ -1101,7 +1101,7 @@ public final class ByteToMessageDecoderTest: XCTestCase {
         buffer.writeString("x")
         XCTAssertNoThrow(try channel.writeInbound(buffer))
         let removalFuture = channel.pipeline.context(handlerType: ByteToMessageHandler<Decoder>.self).flatMap {
-            channel.pipeline.removeHandler(context: $0)
+            channel.pipeline.syncOperations.removeHandler(context: $0)
         }
         channel.embeddedEventLoop.run()
         XCTAssertNoThrow(try removalFuture.wait())
@@ -1135,7 +1135,7 @@ public final class ByteToMessageDecoderTest: XCTestCase {
         let channel = EmbeddedChannel(handler: ByteToMessageHandler(decoder))
         XCTAssertNoThrow(try channel.connect(to: SocketAddress(ipAddress: "1.2.3.4", port: 5678)).wait())
         let removalFuture = channel.pipeline.context(handlerType: ByteToMessageHandler<Decoder>.self).flatMap {
-            channel.pipeline.removeHandler(context: $0)
+            channel.pipeline.syncOperations.removeHandler(context: $0)
         }
         channel.embeddedEventLoop.run()
         XCTAssertNoThrow(try removalFuture.wait())

--- a/Tests/NIOPosixTests/MulticastTest.swift
+++ b/Tests/NIOPosixTests/MulticastTest.swift
@@ -27,7 +27,7 @@ final class PromiseOnReadHandler: ChannelInboundHandler {
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         self.promise.succeed(Self.unwrapInboundIn(data))
-        _ = context.pipeline.removeHandler(context: context)
+        context.pipeline.syncOperations.removeHandler(context: context, promise: nil)
     }
 }
 


### PR DESCRIPTION
Motivation:

RemovableChannelHandlers have a large API surface in NIOCore. That API surface is a bit awkward with regard to strict concurrency, and needs some cleanup.

Modifications:

This patch adds some new API that is necessary to safely work with RemovableChannelHandlers, deprecates some API that cannot plausibly be used, and cleans up some other parts of the API.

Result:

Easier to work with RemovableChannelHandlers
