### PR TITLE
Clean up Sendability for ChannelInvoker

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -88,7 +88,8 @@ extension Channel {
     ///                or `nil` if not interested in the outcome of the operation.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @inlinable
-    public func writeAndFlush<T>(_ any: T) async throws {
+    @preconcurrency
+    public func writeAndFlush<T: Sendable>(_ any: T) async throws {
         try await self.writeAndFlush(any).get()
     }
 
@@ -140,6 +141,7 @@ extension ChannelOutboundInvoker {
     ///     - data: the data to write
     /// - returns: the future which will be notified once the `write` operation completes.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(*, deprecated, message: "NIOAny is not Sendable: avoid wrapping the value in NIOAny to silence this warning.")
     public func writeAndFlush(_ data: NIOAny, file: StaticString = #fileID, line: UInt = #line) async throws {
         try await self.writeAndFlush(data, file: file, line: line).get()
     }
@@ -159,8 +161,9 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - event: the event itself.
     /// - returns: the future which will be notified once the operation completes.
+    @preconcurrency
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func triggerUserOutboundEvent(_ event: Any, file: StaticString = #fileID, line: UInt = #line) async throws {
+    public func triggerUserOutboundEvent(_ event: Any & Sendable, file: StaticString = #fileID, line: UInt = #line) async throws {
         try await self.triggerUserOutboundEvent(event, file: file, line: line).get()
     }
 }

--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -141,7 +141,11 @@ extension ChannelOutboundInvoker {
     ///     - data: the data to write
     /// - returns: the future which will be notified once the `write` operation completes.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @available(*, deprecated, message: "NIOAny is not Sendable: avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable: avoid wrapping the value in NIOAny to silence this warning."
+    )
     public func writeAndFlush(_ data: NIOAny, file: StaticString = #fileID, line: UInt = #line) async throws {
         try await self.writeAndFlush(data, file: file, line: line).get()
     }
@@ -163,7 +167,11 @@ extension ChannelOutboundInvoker {
     /// - returns: the future which will be notified once the operation completes.
     @preconcurrency
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func triggerUserOutboundEvent(_ event: Any & Sendable, file: StaticString = #fileID, line: UInt = #line) async throws {
+    public func triggerUserOutboundEvent(
+        _ event: Any & Sendable,
+        file: StaticString = #fileID,
+        line: UInt = #line
+    ) async throws {
         try await self.triggerUserOutboundEvent(event, file: file, line: line).get()
     }
 }

--- a/Sources/NIOCore/Channel.swift
+++ b/Sources/NIOCore/Channel.swift
@@ -201,7 +201,11 @@ extension Channel {
         pipeline.connect(to: address, promise: promise)
     }
 
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     public func write(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         pipeline.write(data, promise: promise)
     }
@@ -214,7 +218,11 @@ extension Channel {
         pipeline.flush()
     }
 
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     public func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         pipeline.writeAndFlush(data, promise: promise)
     }

--- a/Sources/NIOCore/Channel.swift
+++ b/Sources/NIOCore/Channel.swift
@@ -145,6 +145,30 @@ public protocol Channel: AnyObject, ChannelOutboundInvoker, _NIOPreconcurrencySe
     /// The default implementation returns `nil`, and `Channel` implementations must opt in to
     /// support this behavior.
     var syncOptions: NIOSynchronousChannelOptions? { get }
+
+    /// Write data into the `Channel`, automatically wrapping with `NIOAny`.
+    ///
+    /// - seealso: `ChannelOutboundInvoker.write`.
+    @preconcurrency
+    func write<T: Sendable>(_ any: T) -> EventLoopFuture<Void>
+
+    /// Write data into the `Channel`, automatically wrapping with `NIOAny`.
+    ///
+    /// - seealso: `ChannelOutboundInvoker.write`.
+    @preconcurrency
+    func write<T: Sendable>(_ any: T, promise: EventLoopPromise<Void>?)
+
+    /// Write and flush data into the `Channel`, automatically wrapping with `NIOAny`.
+    ///
+    /// - seealso: `ChannelOutboundInvoker.writeAndFlush`.
+    @preconcurrency
+    func writeAndFlush<T: Sendable>(_ any: T) -> EventLoopFuture<Void>
+
+    /// Write and flush data into the `Channel`, automatically wrapping with `NIOAny`.
+    ///
+    /// - seealso: `ChannelOutboundInvoker.writeAndFlush`.
+    @preconcurrency
+    func writeAndFlush<T: Sendable>(_ any: T, promise: EventLoopPromise<Void>?)
 }
 
 extension Channel {
@@ -177,7 +201,12 @@ extension Channel {
         pipeline.connect(to: address, promise: promise)
     }
 
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func write(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+        pipeline.write(data, promise: promise)
+    }
+
+    public func write<T: Sendable>(_ data: T, promise: EventLoopPromise<Void>?) {
         pipeline.write(data, promise: promise)
     }
 
@@ -185,7 +214,12 @@ extension Channel {
         pipeline.flush()
     }
 
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+        pipeline.writeAndFlush(data, promise: promise)
+    }
+
+    public func writeAndFlush<T: Sendable>(_ data: T, promise: EventLoopPromise<Void>?) {
         pipeline.writeAndFlush(data, promise: promise)
     }
 
@@ -205,7 +239,8 @@ extension Channel {
         promise?.fail(ChannelError._operationUnsupported)
     }
 
-    public func triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {
+    @preconcurrency
+    public func triggerUserOutboundEvent(_ event: Any & Sendable, promise: EventLoopPromise<Void>?) {
         pipeline.triggerUserOutboundEvent(event, promise: promise)
     }
 }
@@ -213,32 +248,24 @@ extension Channel {
 /// Provides special extension to make writing data to the `Channel` easier by removing the need to wrap data in `NIOAny` manually.
 extension Channel {
 
-    /// Write data into the `Channel`, automatically wrapping with `NIOAny`.
+    /// Write data into the `Channel`.
     ///
     /// - seealso: `ChannelOutboundInvoker.write`.
-    public func write<T>(_ any: T) -> EventLoopFuture<Void> {
-        self.write(NIOAny(any))
+    @preconcurrency
+    public func write<T: Sendable>(_ any: T) -> EventLoopFuture<Void> {
+        let promise = self.eventLoop.makePromise(of: Void.self)
+        self.write(any, promise: promise)
+        return promise.futureResult
     }
 
-    /// Write data into the `Channel`, automatically wrapping with `NIOAny`.
-    ///
-    /// - seealso: `ChannelOutboundInvoker.write`.
-    public func write<T>(_ any: T, promise: EventLoopPromise<Void>?) {
-        self.write(NIOAny(any), promise: promise)
-    }
-
-    /// Write and flush data into the `Channel`, automatically wrapping with `NIOAny`.
+    /// Write and flush data into the `Channel`.
     ///
     /// - seealso: `ChannelOutboundInvoker.writeAndFlush`.
-    public func writeAndFlush<T>(_ any: T) -> EventLoopFuture<Void> {
-        self.writeAndFlush(NIOAny(any))
-    }
-
-    /// Write and flush data into the `Channel`, automatically wrapping with `NIOAny`.
-    ///
-    /// - seealso: `ChannelOutboundInvoker.writeAndFlush`.
-    public func writeAndFlush<T>(_ any: T, promise: EventLoopPromise<Void>?) {
-        self.writeAndFlush(NIOAny(any), promise: promise)
+    @preconcurrency
+    public func writeAndFlush<T: Sendable>(_ any: T) -> EventLoopFuture<Void> {
+        let promise = self.eventLoop.makePromise(of: Void.self)
+        self.writeAndFlush(any, promise: promise)
+        return promise.futureResult
     }
 }
 

--- a/Sources/NIOCore/ChannelInvoker.swift
+++ b/Sources/NIOCore/ChannelInvoker.swift
@@ -45,6 +45,7 @@ public protocol ChannelOutboundInvoker {
     ///     - data: the data to write
     ///     - promise: the `EventLoopPromise` that will be notified once the operation completes,
     ///                or `nil` if not interested in the outcome of the operation.
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     func write(_ data: NIOAny, promise: EventLoopPromise<Void>?)
 
     /// Flush data that was previously written via `write` to the remote peer.
@@ -56,6 +57,7 @@ public protocol ChannelOutboundInvoker {
     ///     - data: the data to write
     ///     - promise: the `EventLoopPromise` that will be notified once the `write` operation completes,
     ///                or `nil` if not interested in the outcome of the operation.
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?)
 
     /// Signal that we want to read from the `Channel` once there is data ready.
@@ -78,7 +80,8 @@ public protocol ChannelOutboundInvoker {
     /// - parameters:
     ///     - promise: the `EventLoopPromise` that will be notified once the operation completes,
     ///                or `nil` if not interested in the outcome of the operation.
-    func triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?)
+    @preconcurrency
+    func triggerUserOutboundEvent(_ event: Any & Sendable, promise: EventLoopPromise<Void>?)
 
     /// The `EventLoop` which is used by this `ChannelOutboundInvoker` for execution.
     var eventLoop: EventLoop { get }
@@ -135,6 +138,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - data: the data to write
     /// - returns: the future which will be notified once the operation completes.
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func write(_ data: NIOAny, file: StaticString = #fileID, line: UInt = #line) -> EventLoopFuture<Void> {
         let promise = makePromise(file: file, line: line)
         write(data, promise: promise)
@@ -146,6 +150,7 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - data: the data to write
     /// - returns: the future which will be notified once the `write` operation completes.
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func writeAndFlush(_ data: NIOAny, file: StaticString = #fileID, line: UInt = #line) -> EventLoopFuture<Void>
     {
         let promise = makePromise(file: file, line: line)
@@ -170,8 +175,9 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - event: the event itself.
     /// - returns: the future which will be notified once the operation completes.
+    @preconcurrency
     public func triggerUserOutboundEvent(
-        _ event: Any,
+        _ event: Any & Sendable,
         file: StaticString = #fileID,
         line: UInt = #line
     ) -> EventLoopFuture<Void> {
@@ -210,6 +216,7 @@ public protocol ChannelInboundInvoker {
     ///
     /// - parameters:
     ///     - data: the data that was read and is ready to be processed.
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     func fireChannelRead(_ data: NIOAny)
 
     /// Called once there is no more data to read immediately on a `Channel`. Any new data received will be handled later.
@@ -238,7 +245,8 @@ public protocol ChannelInboundInvoker {
     ///
     /// - parameters:
     ///     - event: the event itself.
-    func fireUserInboundEventTriggered(_ event: Any)
+    @preconcurrency
+    func fireUserInboundEventTriggered(_ event: Any & Sendable)
 }
 
 /// A protocol that signals that outbound and inbound events are triggered by this invoker.

--- a/Sources/NIOCore/ChannelInvoker.swift
+++ b/Sources/NIOCore/ChannelInvoker.swift
@@ -45,7 +45,11 @@ public protocol ChannelOutboundInvoker {
     ///     - data: the data to write
     ///     - promise: the `EventLoopPromise` that will be notified once the operation completes,
     ///                or `nil` if not interested in the outcome of the operation.
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     func write(_ data: NIOAny, promise: EventLoopPromise<Void>?)
 
     /// Flush data that was previously written via `write` to the remote peer.
@@ -57,7 +61,11 @@ public protocol ChannelOutboundInvoker {
     ///     - data: the data to write
     ///     - promise: the `EventLoopPromise` that will be notified once the `write` operation completes,
     ///                or `nil` if not interested in the outcome of the operation.
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?)
 
     /// Signal that we want to read from the `Channel` once there is data ready.
@@ -138,7 +146,11 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - data: the data to write
     /// - returns: the future which will be notified once the operation completes.
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     public func write(_ data: NIOAny, file: StaticString = #fileID, line: UInt = #line) -> EventLoopFuture<Void> {
         let promise = makePromise(file: file, line: line)
         write(data, promise: promise)
@@ -150,7 +162,11 @@ extension ChannelOutboundInvoker {
     /// - parameters:
     ///     - data: the data to write
     /// - returns: the future which will be notified once the `write` operation completes.
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     public func writeAndFlush(_ data: NIOAny, file: StaticString = #fileID, line: UInt = #line) -> EventLoopFuture<Void>
     {
         let promise = makePromise(file: file, line: line)
@@ -216,7 +232,11 @@ public protocol ChannelInboundInvoker {
     ///
     /// - parameters:
     ///     - data: the data that was read and is ready to be processed.
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     func fireChannelRead(_ data: NIOAny)
 
     /// Called once there is no more data to read immediately on a `Channel`. Any new data received will be handled later.

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -705,7 +705,11 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     public func fireChannelRead(_ data: NIOAny) {
         if eventLoop.inEventLoop {
             _fireChannelRead0(data)
@@ -800,7 +804,11 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     public func write(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
             _write0(data, promise: promise)
@@ -824,7 +832,11 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
+    @available(
+        *,
+        deprecated,
+        message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning."
+    )
     public func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
             _writeAndFlush0(data, promise: promise)

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -708,12 +708,12 @@ public final class ChannelPipeline: ChannelInvoker {
     @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func fireChannelRead(_ data: NIOAny) {
         if eventLoop.inEventLoop {
-            fireChannelRead0(data)
+            _fireChannelRead0(data)
         } else {
             // This is unsafe, but necessary.
             let unsafeTransfer = UnsafeTransfer(data)
             eventLoop.execute {
-                self.fireChannelRead0(unsafeTransfer.wrappedValue)
+                self._fireChannelRead0(unsafeTransfer.wrappedValue)
             }
         }
     }
@@ -721,10 +721,10 @@ public final class ChannelPipeline: ChannelInvoker {
     @inlinable
     public func fireChannelRead<T: Sendable>(_ data: T) {
         if eventLoop.inEventLoop {
-            fireChannelRead0(NIOAny(data))
+            _fireChannelRead0(NIOAny(data))
         } else {
             eventLoop.execute {
-                self.fireChannelRead0(NIOAny(data))
+                self._fireChannelRead0(NIOAny(data))
             }
         }
     }
@@ -803,12 +803,12 @@ public final class ChannelPipeline: ChannelInvoker {
     @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func write(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
-            write0(data, promise: promise)
+            _write0(data, promise: promise)
         } else {
             // This is unsafe, but unavoidable.
             let unsafeTransfer = UnsafeTransfer(data)
             eventLoop.execute {
-                self.write0(unsafeTransfer.wrappedValue, promise: promise)
+                self._write0(unsafeTransfer.wrappedValue, promise: promise)
             }
         }
     }
@@ -816,10 +816,10 @@ public final class ChannelPipeline: ChannelInvoker {
     @inlinable
     public func write<T: Sendable>(_ data: T, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
-            write0(NIOAny(data), promise: promise)
+            _write0(NIOAny(data), promise: promise)
         } else {
             eventLoop.execute {
-                self.write0(NIOAny(data), promise: promise)
+                self._write0(NIOAny(data), promise: promise)
             }
         }
     }
@@ -827,12 +827,12 @@ public final class ChannelPipeline: ChannelInvoker {
     @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
-            writeAndFlush0(data, promise: promise)
+            _writeAndFlush0(data, promise: promise)
         } else {
             // This is unsafe, but unavoidable.
             let unsafeTransfer = UnsafeTransfer(data)
             eventLoop.execute {
-                self.writeAndFlush0(unsafeTransfer.wrappedValue, promise: promise)
+                self._writeAndFlush0(unsafeTransfer.wrappedValue, promise: promise)
             }
         }
     }
@@ -840,10 +840,10 @@ public final class ChannelPipeline: ChannelInvoker {
     @inlinable
     public func writeAndFlush<T: Sendable>(_ data: T, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
-            writeAndFlush0(NIOAny(data), promise: promise)
+            _writeAndFlush0(NIOAny(data), promise: promise)
         } else {
             eventLoop.execute {
-                self.writeAndFlush0(NIOAny(data), promise: promise)
+                self._writeAndFlush0(NIOAny(data), promise: promise)
             }
         }
     }
@@ -919,7 +919,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    /* private but */ @usableFromInline func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+    @usableFromInline func _write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWrite(data, promise: promise)
         } else {
@@ -927,7 +927,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    /* private but */ @usableFromInline func writeAndFlush0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+    @usableFromInline func _writeAndFlush0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWriteAndFlush(data, promise: promise)
         } else {
@@ -991,7 +991,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    /* private but */ @usableFromInline func fireChannelRead0(_ data: NIOAny) {
+    @usableFromInline func _fireChannelRead0(_ data: NIOAny) {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelRead(data)
         }
@@ -1354,7 +1354,7 @@ extension ChannelPipeline {
         /// This method should typically only be called by `Channel` implementations directly.
         public func fireChannelRead(_ data: NIOAny) {
             self.eventLoop.assertInEventLoop()
-            self._pipeline.fireChannelRead0(data)
+            self._pipeline._fireChannelRead0(data)
         }
 
         /// Fires `channelReadComplete` from the head to the tail.
@@ -1418,7 +1418,7 @@ extension ChannelPipeline {
         /// This method should typically only be called by `Channel` implementations directly.
         public func write(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
             self.eventLoop.assertInEventLoop()
-            self._pipeline.write0(data, promise: promise)
+            self._pipeline._write0(data, promise: promise)
         }
 
         /// Fires `write` from the tail to the head.
@@ -1427,7 +1427,7 @@ extension ChannelPipeline {
         public func write(_ data: NIOAny) -> EventLoopFuture<Void> {
             self.eventLoop.assertInEventLoop()
             let promise = self.eventLoop.makePromise(of: Void.self)
-            self._pipeline.write0(data, promise: promise)
+            self._pipeline._write0(data, promise: promise)
             return promise.futureResult
         }
 
@@ -1436,7 +1436,7 @@ extension ChannelPipeline {
         /// This method should typically only be called by `Channel` implementations directly.
         public func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
             self.eventLoop.assertInEventLoop()
-            self._pipeline.writeAndFlush0(data, promise: promise)
+            self._pipeline._writeAndFlush0(data, promise: promise)
         }
 
         /// Fires `writeAndFlush` from the tail to the head.
@@ -1445,7 +1445,7 @@ extension ChannelPipeline {
         public func writeAndFlush(_ data: NIOAny) -> EventLoopFuture<Void> {
             self.eventLoop.assertInEventLoop()
             let promise = self.eventLoop.makePromise(of: Void.self)
-            self._pipeline.writeAndFlush0(data, promise: promise)
+            self._pipeline._writeAndFlush0(data, promise: promise)
             return promise.futureResult
         }
 

--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -705,12 +705,26 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func fireChannelRead(_ data: NIOAny) {
         if eventLoop.inEventLoop {
             fireChannelRead0(data)
         } else {
+            // This is unsafe, but necessary.
+            let unsafeTransfer = UnsafeTransfer(data)
             eventLoop.execute {
-                self.fireChannelRead0(data)
+                self.fireChannelRead0(unsafeTransfer.wrappedValue)
+            }
+        }
+    }
+
+    @inlinable
+    public func fireChannelRead<T: Sendable>(_ data: T) {
+        if eventLoop.inEventLoop {
+            fireChannelRead0(NIOAny(data))
+        } else {
+            eventLoop.execute {
+                self.fireChannelRead0(NIOAny(data))
             }
         }
     }
@@ -735,7 +749,8 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    public func fireUserInboundEventTriggered(_ event: Any) {
+    @preconcurrency
+    public func fireUserInboundEventTriggered(_ event: Any & Sendable) {
         if eventLoop.inEventLoop {
             fireUserInboundEventTriggered0(event)
         } else {
@@ -785,22 +800,50 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func write(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
             write0(data, promise: promise)
         } else {
+            // This is unsafe, but unavoidable.
+            let unsafeTransfer = UnsafeTransfer(data)
             eventLoop.execute {
-                self.write0(data, promise: promise)
+                self.write0(unsafeTransfer.wrappedValue, promise: promise)
             }
         }
     }
 
+    @inlinable
+    public func write<T: Sendable>(_ data: T, promise: EventLoopPromise<Void>?) {
+        if eventLoop.inEventLoop {
+            write0(NIOAny(data), promise: promise)
+        } else {
+            eventLoop.execute {
+                self.write0(NIOAny(data), promise: promise)
+            }
+        }
+    }
+
+    @available(*, deprecated, message: "NIOAny is not Sendable. Avoid wrapping the value in NIOAny to silence this warning.")
     public func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
             writeAndFlush0(data, promise: promise)
         } else {
+            // This is unsafe, but unavoidable.
+            let unsafeTransfer = UnsafeTransfer(data)
             eventLoop.execute {
-                self.writeAndFlush0(data, promise: promise)
+                self.writeAndFlush0(unsafeTransfer.wrappedValue, promise: promise)
+            }
+        }
+    }
+
+    @inlinable
+    public func writeAndFlush<T: Sendable>(_ data: T, promise: EventLoopPromise<Void>?) {
+        if eventLoop.inEventLoop {
+            writeAndFlush0(NIOAny(data), promise: promise)
+        } else {
+            eventLoop.execute {
+                self.writeAndFlush0(NIOAny(data), promise: promise)
             }
         }
     }
@@ -835,7 +878,8 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    public func triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {
+    @preconcurrency
+    public func triggerUserOutboundEvent(_ event: Any & Sendable, promise: EventLoopPromise<Void>?) {
         if eventLoop.inEventLoop {
             triggerUserOutboundEvent0(event, promise: promise)
         } else {
@@ -875,7 +919,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    private func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+    /* private but */ @usableFromInline func write0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWrite(data, promise: promise)
         } else {
@@ -883,7 +927,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    private func writeAndFlush0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
+    /* private but */ @usableFromInline func writeAndFlush0(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
         if let firstOutboundCtx = firstOutboundCtx {
             firstOutboundCtx.invokeWriteAndFlush(data, promise: promise)
         } else {
@@ -947,7 +991,7 @@ public final class ChannelPipeline: ChannelInvoker {
         }
     }
 
-    private func fireChannelRead0(_ data: NIOAny) {
+    /* private but */ @usableFromInline func fireChannelRead0(_ data: NIOAny) {
         if let firstInboundCtx = firstInboundCtx {
             firstInboundCtx.invokeChannelRead(data)
         }
@@ -1377,12 +1421,32 @@ extension ChannelPipeline {
             self._pipeline.write0(data, promise: promise)
         }
 
+        /// Fires `write` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func write(_ data: NIOAny) -> EventLoopFuture<Void> {
+            self.eventLoop.assertInEventLoop()
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            self._pipeline.write0(data, promise: promise)
+            return promise.futureResult
+        }
+
         /// Fires `writeAndFlush` from the tail to the head.
         ///
         /// This method should typically only be called by `Channel` implementations directly.
         public func writeAndFlush(_ data: NIOAny, promise: EventLoopPromise<Void>?) {
             self.eventLoop.assertInEventLoop()
             self._pipeline.writeAndFlush0(data, promise: promise)
+        }
+
+        /// Fires `writeAndFlush` from the tail to the head.
+        ///
+        /// This method should typically only be called by `Channel` implementations directly.
+        public func writeAndFlush(_ data: NIOAny) -> EventLoopFuture<Void> {
+            self.eventLoop.assertInEventLoop()
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            self._pipeline.writeAndFlush0(data, promise: promise)
+            return promise.futureResult
         }
 
         /// Fires `bind` from the tail to the head.
@@ -1681,6 +1745,15 @@ public final class ChannelHandlerContext: ChannelInvoker {
     }
 
     /// Send a user event to the next inbound `ChannelHandler`.
+    ///
+    /// This method exists for compatiblity with ``ChannelInboundInvoker``.
+    @available(*, deprecated)
+    @_disfavoredOverload
+    public func fireUserInboundEventTriggered(_ event: Any & Sendable) {
+        self.next?.invokeUserInboundEventTriggered(event)
+    }
+
+    /// Send a user event to the next inbound `ChannelHandler` from on the event loop.
     public func fireUserInboundEventTriggered(_ event: Any) {
         self.next?.invokeUserInboundEventTriggered(event)
     }
@@ -1795,7 +1868,22 @@ public final class ChannelHandlerContext: ChannelInvoker {
     /// - parameters:
     ///     - event: The user event to send.
     ///     - promise: The promise fulfilled when the user event has been sent or failed if it couldn't be sent.
+    @available(*, deprecated)
+    @_disfavoredOverload
+    public func triggerUserOutboundEvent(_ event: Any & Sendable, promise: EventLoopPromise<Void>?) {
+        self._triggerUserOutboundEvent(event, promise: promise)
+    }
+
+    /// Send a user event to the next outbound `ChannelHandler` in the `ChannelPipeline`.
+    ///
+    /// - parameters:
+    ///     - event: The user event to send.
+    ///     - promise: The promise fulfilled when the user event has been sent or failed if it couldn't be sent.
     public func triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {
+        self._triggerUserOutboundEvent(event, promise: promise)
+    }
+
+    private func _triggerUserOutboundEvent(_ event: Any, promise: EventLoopPromise<Void>?) {
         if let outboundNext = self.prev {
             outboundNext.invokeTriggerUserOutboundEvent(event, promise: promise)
         } else {
@@ -1998,6 +2086,37 @@ public final class ChannelHandlerContext: ChannelInvoker {
         self.removeHandlerInvoked = true
 
         handler.handlerRemoved(context: self)
+    }
+}
+
+// This extension "un-deprecates" some parts of the ChannelInvoker API for
+// ChannelHandlerContext specifically. These methods were not sound elsewhere,
+// but they're fine here.
+extension ChannelHandlerContext {
+    /// Write data to the remote peer.
+    ///
+    /// Be aware that to be sure that data is really written to the remote peer you need to call `flush` or use `writeAndFlush`.
+    /// Calling `write` multiple times and then `flush` may allow the `Channel` to `write` multiple data objects to the remote peer with one syscall.
+    ///
+    /// - parameters:
+    ///     - data: the data to write
+    /// - returns: the future which will be notified once the operation completes.
+    public func write(_ data: NIOAny, file: StaticString = #fileID, line: UInt = #line) -> EventLoopFuture<Void> {
+        let promise = self.eventLoop.makePromise(of: Void.self, file: file, line: line)
+        self.write(data, promise: promise)
+        return promise.futureResult
+    }
+
+    /// Shortcut for calling `write` and `flush`.
+    ///
+    /// - parameters:
+    ///     - data: the data to write
+    /// - returns: the future which will be notified once the `write` operation completes.
+    public func writeAndFlush(_ data: NIOAny, file: StaticString = #fileID, line: UInt = #line) -> EventLoopFuture<Void>
+    {
+        let promise = self.eventLoop.makePromise(of: Void.self, file: file, line: line)
+        self.writeAndFlush(data, promise: promise)
+        return promise.futureResult
     }
 }
 

--- a/Sources/NIOCore/Docs.docc/swift-concurrency.md
+++ b/Sources/NIOCore/Docs.docc/swift-concurrency.md
@@ -297,6 +297,35 @@ case .notUpgraded:
 }
 ```
 
+### NIOAny
+
+In NIO 2.77.0, a number of methods that took ``NIOAny`` as a parameter started
+emitting deprecation warnings. These deprecation warnings are a substitute for the
+concurrency warnings that you might otherwise see.
+
+The problem with these methods (most of which were defined on ``ChannelInvoker``)
+is that they frequently would send a ``NIOAny`` across an event loop boundary.
+Most commonly users will encounter this when calling methods on ``Channel`` types
+(which conform to ``ChannelInvoker``), though they may encounter it on
+``ChannelPipeline`` as well.
+
+The problem these methods have is that they can be safely called both on and off
+of the ``EventLoop`` to which a ``Channel`` is bound. That means that they must be
+capable of sending the value across an isolation domain, into the ``EventLoop``.
+That requires the parameter to be `Sendable` (or to be `sending`).
+
+``NIOAny`` cannot be made to be `Sendable`, so these methods are now deprecated.
+They have been replaced with equivalent methods that take a generic type that
+must be `Sendable`, and they take charge of wrapping the type in ``NIOAny``. If
+you encounter such a warning, this is the most common change.
+
+In cases where a non-`Sendable` value must actually be sent into the pipeline, there
+are a few methods that can still be used. These methods are available on
+``ChannelPipeline/SynchronousOperations``, which can be accessed via
+``ChannelPipeline/syncOperations``. The ``ChannelPipeline/SynchronousOperations`` type
+can only be accessed from on the `EventLoop`, and so no sending of a value
+across isolation domains will occur here.
+
 ### General guidance
 
 #### Where should your code live?

--- a/Sources/NIOCore/Docs.docc/swift-concurrency.md
+++ b/Sources/NIOCore/Docs.docc/swift-concurrency.md
@@ -299,12 +299,12 @@ case .notUpgraded:
 
 ### NIOAny
 
-In NIO 2.77.0, a number of methods that took ``NIOAny`` as a parameter started
+In NIO 2.77.0, a number of methods that took `NIOAny` as a parameter started
 emitting deprecation warnings. These deprecation warnings are a substitute for the
 concurrency warnings that you might otherwise see.
 
 The problem with these methods (most of which were defined on ``ChannelInvoker``)
-is that they frequently would send a ``NIOAny`` across an event loop boundary.
+is that they frequently would send a `NIOAny` across an event loop boundary.
 Most commonly users will encounter this when calling methods on ``Channel`` types
 (which conform to ``ChannelInvoker``), though they may encounter it on
 ``ChannelPipeline`` as well.
@@ -314,9 +314,9 @@ of the ``EventLoop`` to which a ``Channel`` is bound. That means that they must 
 capable of sending the value across an isolation domain, into the ``EventLoop``.
 That requires the parameter to be `Sendable` (or to be `sending`).
 
-``NIOAny`` cannot be made to be `Sendable`, so these methods are now deprecated.
+`NIOAny` cannot be made to be `Sendable`, so these methods are now deprecated.
 They have been replaced with equivalent methods that take a generic type that
-must be `Sendable`, and they take charge of wrapping the type in ``NIOAny``. If
+must be `Sendable`, and they take charge of wrapping the type in `NIOAny`. If
 you encounter such a warning, this is the most common change.
 
 In cases where a non-`Sendable` value must actually be sent into the pipeline, there

--- a/Sources/NIOCore/NIOAny.swift
+++ b/Sources/NIOCore/NIOAny.swift
@@ -268,6 +268,9 @@ public struct NIOAny {
 }
 
 @available(*, unavailable)
+extension NIOAny._NIOAny: Sendable {}
+
+@available(*, unavailable)
 extension NIOAny: Sendable {}
 
 extension NIOAny: CustomStringConvertible {

--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -477,7 +477,7 @@ public final class NIOAsyncTestingChannel: Channel {
     @inlinable
     @discardableResult public func writeInbound<T: Sendable>(_ data: T) async throws -> BufferState {
         try await self.testingEventLoop.executeInContext {
-            self.pipeline.fireChannelRead(NIOAny(data))
+            self.pipeline.fireChannelRead(data)
             self.pipeline.fireChannelReadComplete()
             try self._throwIfErrorCaught()
             return self.channelcore.inboundBuffer.isEmpty ? .empty : .full(self.channelcore.inboundBuffer)
@@ -496,7 +496,7 @@ public final class NIOAsyncTestingChannel: Channel {
     //             all the way.
     @inlinable
     @discardableResult public func writeOutbound<T: Sendable>(_ data: T) async throws -> BufferState {
-        try await self.writeAndFlush(NIOAny(data))
+        try await self.writeAndFlush(data)
 
         return try await self.testingEventLoop.executeInContext {
             self.channelcore.outboundBuffer.isEmpty ? .empty : .full(self.channelcore.outboundBuffer)

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -694,7 +694,10 @@ measureAndPrint(desc: "http1_1k_reqs_100_conns") {
         try! clientChannel.eventLoop.flatSubmit {
             let promise = clientChannel.eventLoop.makePromise(of: Void.self)
             clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            clientChannel.pipeline.syncOperations.writeAndFlush(
+                NIOAny(HTTPClientRequestPart.end(nil)),
+                promise: promise
+            )
             return promise.futureResult
         }.wait()
         reqs.append(try! repeatedRequestsHandler.wait())

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -664,8 +664,12 @@ measureAndPrint(desc: "http1_1k_reqs_1_conn") {
         .connect(to: serverChannel.localAddress!)
         .wait()
 
-    clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-    try! clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
+    try! clientChannel.eventLoop.flatSubmit {
+        let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+        clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
+        clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+        return promise.futureResult
+    }.wait()
     return try! repeatedRequestsHandler.wait()
 }
 
@@ -687,8 +691,12 @@ measureAndPrint(desc: "http1_1k_reqs_100_conns") {
             .connect(to: serverChannel.localAddress!)
             .wait()
 
-        clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-        try! clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
+        try! clientChannel.eventLoop.flatSubmit {
+            let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+            clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
+            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            return promise.futureResult
+        }.wait()
         reqs.append(try! repeatedRequestsHandler.wait())
     }
     return reqs.reduce(0, +) / numConns

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -825,7 +825,7 @@ final class DatagramChannel: BaseSocketChannel<Socket> {
 
                 var messageIterator = results.makeIterator()
                 while self.isActive, let message = messageIterator.next() {
-                    pipeline.fireChannelRead(NIOAny(message))
+                    pipeline.fireChannelRead(message)
                 }
 
                 readResult = .some

--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -40,7 +40,9 @@ extension SendableHTTPServerResponsePart {
         case .body(.byteBuffer(let body)):
             self = .body(body)
         case .body(.fileRegion):
-            throw NIOHTTP1TestServerError(reason: "FileRegion is not Sendable and cannot be passed across concurrency domains")
+            throw NIOHTTP1TestServerError(
+                reason: "FileRegion is not Sendable and cannot be passed across concurrency domains"
+            )
         case .end(let end):
             self = .end(end)
         }

--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -17,6 +17,48 @@ import NIOCore
 import NIOHTTP1
 import NIOPosix
 
+typealias SendableHTTPServerResponsePart = HTTPPart<HTTPResponseHead, ByteBuffer>
+
+extension HTTPServerResponsePart {
+    init(_ target: SendableHTTPServerResponsePart) {
+        switch target {
+        case .head(let head):
+            self = .head(head)
+        case .body(let body):
+            self = .body(.byteBuffer(body))
+        case .end(let end):
+            self = .end(end)
+        }
+    }
+}
+
+extension SendableHTTPServerResponsePart {
+    init(_ target: HTTPServerResponsePart) throws {
+        switch target {
+        case .head(let head):
+            self = .head(head)
+        case .body(.byteBuffer(let body)):
+            self = .body(body)
+        case .body(.fileRegion):
+            throw NIOHTTP1TestServerError(reason: "FileRegion is not Sendable and cannot be passed across concurrency domains")
+        case .end(let end):
+            self = .end(end)
+        }
+    }
+}
+
+/// A helper handler to transform a Sendable response into a
+/// non-Sendable one, to manage warnings.
+private final class TransformerHandler: ChannelOutboundHandler {
+    typealias OutboundIn = SendableHTTPServerResponsePart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let response = self.unwrapOutboundIn(data)
+        context.write(self.wrapOutboundOut(.init(response)), promise: promise)
+    }
+}
+
 private final class BlockingQueue<Element> {
     private let condition = ConditionLock(value: false)
     private var buffer = CircularBuffer<Result<Element, Error>>()
@@ -225,6 +267,8 @@ public final class NIOHTTP1TestServer {
             }
         }.flatMap {
             channel.pipeline.addHandler(WebServerHandler(webServer: self))
+        }.flatMap {
+            channel.pipeline.addHandler(TransformerHandler())
         }.whenSuccess {
             _ = channel.setOption(.autoRead, value: true)
         }
@@ -305,9 +349,11 @@ extension NIOHTTP1TestServer {
 
     public func writeOutbound(_ data: HTTPServerResponsePart) throws {
         self.eventLoop.assertNotInEventLoop()
+
+        let transformed = try SendableHTTPServerResponsePart(data)
         try self.eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             if let channel = self.currentClientChannel {
-                return channel.writeAndFlush(data)
+                return channel.writeAndFlush(transformed)
             } else {
                 return self.eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
             }

--- a/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
+++ b/Tests/NIOCoreTests/AsyncChannel/AsyncChannelTests.swift
@@ -292,9 +292,9 @@ final class AsyncChannelTests: XCTestCase {
 
         // Push 3 elements into the buffer. Reads continue to work.
         try await channel.testingEventLoop.executeInContext {
-            channel.pipeline.fireChannelRead(NIOAny(()))
-            channel.pipeline.fireChannelRead(NIOAny(()))
-            channel.pipeline.fireChannelRead(NIOAny(()))
+            channel.pipeline.fireChannelRead(())
+            channel.pipeline.fireChannelRead(())
+            channel.pipeline.fireChannelRead(())
             channel.pipeline.fireChannelReadComplete()
 
             channel.pipeline.read()
@@ -305,7 +305,7 @@ final class AsyncChannelTests: XCTestCase {
 
         // Add one more element into the buffer. This should flip our backpressure mode, and the reads should now be delayed.
         try await channel.testingEventLoop.executeInContext {
-            channel.pipeline.fireChannelRead(NIOAny(()))
+            channel.pipeline.fireChannelRead(())
             channel.pipeline.fireChannelReadComplete()
 
             channel.pipeline.read()
@@ -316,7 +316,7 @@ final class AsyncChannelTests: XCTestCase {
 
         // More elements don't help.
         try await channel.testingEventLoop.executeInContext {
-            channel.pipeline.fireChannelRead(NIOAny(()))
+            channel.pipeline.fireChannelRead(())
             channel.pipeline.fireChannelReadComplete()
 
             channel.pipeline.read()
@@ -345,7 +345,7 @@ final class AsyncChannelTests: XCTestCase {
                 channel.pipeline.read()
                 channel.pipeline.read()
 
-                channel.pipeline.fireChannelRead(NIOAny(()))
+                channel.pipeline.fireChannelRead(())
                 channel.pipeline.fireChannelReadComplete()
 
                 channel.pipeline.read()
@@ -357,8 +357,8 @@ final class AsyncChannelTests: XCTestCase {
             // The next reads arriving pushes us past the limit again.
             // This time we won't read.
             try await channel.testingEventLoop.executeInContext {
-                channel.pipeline.fireChannelRead(NIOAny(()))
-                channel.pipeline.fireChannelRead(NIOAny(()))
+                channel.pipeline.fireChannelRead(())
+                channel.pipeline.fireChannelRead(())
                 channel.pipeline.fireChannelReadComplete()
             }
             XCTAssertEqual(readCounter.readCount, 13)

--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -394,17 +394,10 @@ class AsyncTestingChannelTests: XCTestCase {
         let channel = NIOAsyncTestingChannel()
         let buffer = ByteBufferAllocator().buffer(capacity: 5)
         let socketAddress = try SocketAddress(unixDomainSocketPath: "path")
-        let handle = NIOFileHandle(descriptor: 1)
-        let fileRegion = FileRegion(fileHandle: handle, readerIndex: 1, endIndex: 2)
-        defer {
-            // fake descriptor, so shouldn't be closed.
-            XCTAssertNoThrow(try handle.takeDescriptorOwnership())
-        }
+
         try await channel.writeAndFlush(1)
         try await channel.writeAndFlush("1")
         try await channel.writeAndFlush(buffer)
-        try await channel.writeAndFlush(IOData.byteBuffer(buffer))
-        try await channel.writeAndFlush(IOData.fileRegion(fileRegion))
         try await channel.writeAndFlush(AddressedEnvelope(remoteAddress: socketAddress, data: buffer))
     }
 

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
@@ -396,8 +396,8 @@ class EmbeddedChannelTest: XCTestCase {
         try channel.writeAndFlush(1).wait()
         try channel.writeAndFlush("1").wait()
         try channel.writeAndFlush(buffer).wait()
-        try channel.writeAndFlush(IOData.byteBuffer(buffer)).wait()
-        try channel.writeAndFlush(IOData.fileRegion(fileRegion)).wait()
+        try channel.writeOutbound(IOData.byteBuffer(buffer))
+        try channel.writeOutbound(IOData.fileRegion(fileRegion))
         try channel.writeAndFlush(AddressedEnvelope(remoteAddress: socketAddress, data: buffer)).wait()
     }
 

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -403,8 +403,12 @@ class HTTPServerClientTest: XCTestCase {
 
         var head = HTTPRequestHead(version: httpVersion, method: .GET, uri: uri)
         head.headers.add(name: "Host", value: "apple.com")
-        clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-        try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
+        try clientChannel.eventLoop.flatSubmit {
+            let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+            clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
+            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            return promise.futureResult
+        }.wait()
 
         accumulation.syncWaitForCompletion()
     }
@@ -464,8 +468,12 @@ class HTTPServerClientTest: XCTestCase {
 
         var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/count-to-ten")
         head.headers.add(name: "Host", value: "apple.com")
-        clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-        try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
+        try clientChannel.eventLoop.flatSubmit {
+            let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+            clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
+            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            return promise.futureResult
+        }.wait()
         accumulation.syncWaitForCompletion()
     }
 
@@ -523,8 +531,12 @@ class HTTPServerClientTest: XCTestCase {
 
         var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/zero-length-body-part")
         head.headers.add(name: "Host", value: "apple.com")
-        clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-        try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
+        try clientChannel.eventLoop.flatSubmit {
+            let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+            clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
+            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            return promise.futureResult
+        }.wait()
         accumulation.syncWaitForCompletion()
     }
 
@@ -581,8 +593,12 @@ class HTTPServerClientTest: XCTestCase {
 
         var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/trailers")
         head.headers.add(name: "Host", value: "apple.com")
-        clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-        try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
+        try clientChannel.eventLoop.flatSubmit {
+            let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+            clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
+            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            return promise.futureResult
+        }.wait()
 
         accumulation.syncWaitForCompletion()
     }
@@ -640,7 +656,7 @@ class HTTPServerClientTest: XCTestCase {
         var buffer = clientChannel.allocator.buffer(capacity: numBytes)
         buffer.writeStaticString("GET /massive-response HTTP/1.1\r\nHost: nio.net\r\n\r\n")
 
-        try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+        try clientChannel.writeAndFlush(buffer).wait()
         accumulation.syncWaitForCompletion()
     }
 
@@ -687,8 +703,12 @@ class HTTPServerClientTest: XCTestCase {
 
         var head = HTTPRequestHead(version: .http1_1, method: .HEAD, uri: "/head")
         head.headers.add(name: "Host", value: "apple.com")
-        clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-        try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
+        try clientChannel.eventLoop.flatSubmit {
+            let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+            clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
+            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            return promise.futureResult
+        }.wait()
 
         accumulation.syncWaitForCompletion()
     }
@@ -734,8 +754,12 @@ class HTTPServerClientTest: XCTestCase {
 
         var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/204")
         head.headers.add(name: "Host", value: "apple.com")
-        clientChannel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-        try clientChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil))).wait()
+        try clientChannel.eventLoop.flatSubmit {
+            let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+            clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
+            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            return promise.futureResult
+        }.wait()
 
         accumulation.syncWaitForCompletion()
     }

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -406,7 +406,10 @@ class HTTPServerClientTest: XCTestCase {
         try clientChannel.eventLoop.flatSubmit {
             let promise = clientChannel.eventLoop.makePromise(of: Void.self)
             clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            clientChannel.pipeline.syncOperations.writeAndFlush(
+                NIOAny(HTTPClientRequestPart.end(nil)),
+                promise: promise
+            )
             return promise.futureResult
         }.wait()
 
@@ -471,7 +474,10 @@ class HTTPServerClientTest: XCTestCase {
         try clientChannel.eventLoop.flatSubmit {
             let promise = clientChannel.eventLoop.makePromise(of: Void.self)
             clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            clientChannel.pipeline.syncOperations.writeAndFlush(
+                NIOAny(HTTPClientRequestPart.end(nil)),
+                promise: promise
+            )
             return promise.futureResult
         }.wait()
         accumulation.syncWaitForCompletion()
@@ -534,7 +540,10 @@ class HTTPServerClientTest: XCTestCase {
         try clientChannel.eventLoop.flatSubmit {
             let promise = clientChannel.eventLoop.makePromise(of: Void.self)
             clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            clientChannel.pipeline.syncOperations.writeAndFlush(
+                NIOAny(HTTPClientRequestPart.end(nil)),
+                promise: promise
+            )
             return promise.futureResult
         }.wait()
         accumulation.syncWaitForCompletion()
@@ -596,7 +605,10 @@ class HTTPServerClientTest: XCTestCase {
         try clientChannel.eventLoop.flatSubmit {
             let promise = clientChannel.eventLoop.makePromise(of: Void.self)
             clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            clientChannel.pipeline.syncOperations.writeAndFlush(
+                NIOAny(HTTPClientRequestPart.end(nil)),
+                promise: promise
+            )
             return promise.futureResult
         }.wait()
 
@@ -706,7 +718,10 @@ class HTTPServerClientTest: XCTestCase {
         try clientChannel.eventLoop.flatSubmit {
             let promise = clientChannel.eventLoop.makePromise(of: Void.self)
             clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            clientChannel.pipeline.syncOperations.writeAndFlush(
+                NIOAny(HTTPClientRequestPart.end(nil)),
+                promise: promise
+            )
             return promise.futureResult
         }.wait()
 
@@ -757,7 +772,10 @@ class HTTPServerClientTest: XCTestCase {
         try clientChannel.eventLoop.flatSubmit {
             let promise = clientChannel.eventLoop.makePromise(of: Void.self)
             clientChannel.pipeline.syncOperations.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-            clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: promise)
+            clientChannel.pipeline.syncOperations.writeAndFlush(
+                NIOAny(HTTPClientRequestPart.end(nil)),
+                promise: promise
+            )
             return promise.futureResult
         }.wait()
 

--- a/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
@@ -173,8 +173,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Unblock by sending a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // Two requests should have made it through now.
         XCTAssertEqual(
@@ -188,8 +188,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Now send the last response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // Now all three.
         XCTAssertEqual(
@@ -221,8 +221,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Send a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // This should have automatically triggered a call to read(), but only one.
         XCTAssertEqual(self.readCounter.readCount, 2)
@@ -246,8 +246,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Send a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // This should have not triggered a call to read.
         XCTAssertEqual(self.readCounter.readCount, 1)
@@ -258,8 +258,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Now send in the last response, and see the read go through.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
         XCTAssertEqual(self.readCounter.readCount, 2)
     }
 
@@ -273,8 +273,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Now the server sends a response immediately.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // We're still moving forward and can read.
         XCTAssertEqual(self.readCounter.readCount, 1)
@@ -310,8 +310,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Unblock by sending a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // Two requests should have made it through now.
         XCTAssertEqual(
@@ -325,8 +325,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Now send the last response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // Now the half-closure should be delivered.
         XCTAssertEqual(
@@ -362,8 +362,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Unblock by sending a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // The second request head, followed by the half-close, should have made it through.
         XCTAssertEqual(
@@ -396,15 +396,15 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Send a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // This should have not triggered a call to read.
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Now send in the last response. This should also not issue a read.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
         XCTAssertEqual(self.readCounter.readCount, 1)
     }
 
@@ -425,8 +425,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Unblock by sending a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // Two requests should have made it through now. Still no half-closure.
         XCTAssertEqual(
@@ -558,7 +558,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(.req2HeadExpected, handler.state)
 
         // finish 1st request, that will send through the 2nd one which will then write the 'req_boom' request
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         XCTAssertEqual(.done, handler.state)
     }
@@ -585,8 +585,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Now send a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // No further events should have happened.
         XCTAssertEqual(
@@ -616,8 +616,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
 
         // Now send a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // still missing the request .end
         XCTAssertTrue(self.channel.isActive)
@@ -656,8 +656,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
 
         // Now send a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         XCTAssertFalse(self.channel.isActive)
 
@@ -689,14 +689,14 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Now send the response .head.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
 
         XCTAssertTrue(self.channel.isActive)
         self.channel.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
         XCTAssertTrue(self.channel.isActive)
 
         // Now send the response .end.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
         XCTAssertFalse(self.channel.isActive)
 
         XCTAssertEqual(
@@ -721,7 +721,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Now send the response .head.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
 
         XCTAssertTrue(self.channel.isActive)
         self.channel.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
@@ -740,7 +740,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
 
         // Response .end.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
         XCTAssertFalse(self.channel.isActive)
 
         XCTAssertEqual(
@@ -767,14 +767,14 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         )
 
         // Now send the response .head.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
 
         XCTAssertTrue(self.channel.isActive)
         self.channel.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
         XCTAssertTrue(self.channel.isActive)
 
         // Response .end.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
         XCTAssertTrue(self.channel.isActive)
 
         // Request .end.
@@ -825,8 +825,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertTrue(self.channel.isActive)
 
         // Now send a response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         XCTAssertFalse(self.channel.isActive)
 
@@ -999,7 +999,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Send a partial response, which should not trigger a read.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
         XCTAssertEqual(self.readCounter.readCount, 1)
 
         // Remove the handler.
@@ -1136,14 +1136,14 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         continueResponse!.status = .continue
 
         // Now the server sends a continue response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(continueResponse!)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(continueResponse!)))
 
         // The client response completes.
         XCTAssertNoThrow(try self.channel.writeInbound(HTTPServerRequestPart.end(nil)))
 
         // Now the server sends the final response.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
     }
 
     func testServerCanRespondProcessingMultipleTimes() throws {
@@ -1160,7 +1160,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         processResponse.status = .processing
 
         // Now the server sends multiple processing responses.
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(processResponse)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(processResponse)))
 
         // We are processing... Reading not allowed
         XCTAssertEqual(self.readCounter.readCount, 0)
@@ -1168,7 +1168,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 0)
 
         // Continue processing...
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(processResponse)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(processResponse)))
 
         // We are processing... Reading not allowed
         XCTAssertEqual(self.readCounter.readCount, 0)
@@ -1176,7 +1176,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 0)
 
         // Continue processing...
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(processResponse)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(processResponse)))
 
         // We are processing... Reading not allowed
         XCTAssertEqual(self.readCounter.readCount, 0)
@@ -1184,8 +1184,8 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
         XCTAssertEqual(self.readCounter.readCount, 0)
 
         // Now send the actual response!
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.head(self.responseHead)).wait())
-        XCTAssertNoThrow(try channel.writeAndFlush(HTTPServerResponsePart.end(nil)).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(self.responseHead)))
+        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
 
         // This should have triggered a read
         XCTAssertEqual(self.readCounter.readCount, 1)

--- a/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerProtocolErrorHandlerTest.swift
@@ -93,7 +93,7 @@ class HTTPServerProtocolErrorHandlerTest: XCTestCase {
                 headers: .init([("Content-Length", "0")])
             )
         )
-        XCTAssertNoThrow(try channel.writeAndFlush(res).wait())
+        XCTAssertNoThrow(try channel.writeOutbound(res))
         // now we have started a response but it's not complete yet, let's inject a parser error
         channel.pipeline.fireErrorCaught(HTTPParserError.invalidEOFState)
         var allOutbound = try channel.readAllOutboundBuffers()

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -473,7 +473,7 @@ private class ReentrantReadOnChannelReadCompleteHandler: ChannelInboundHandler {
             let data = context.channel.allocator.buffer(string: "re-entrant read from channelReadComplete!")
 
             // Please never do this.
-            context.channel.pipeline.fireChannelRead(NIOAny(data))
+            context.channel.pipeline.fireChannelRead(data)
         }
         context.fireChannelReadComplete()
     }
@@ -518,7 +518,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         }
 
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // At this time the channel pipeline should not contain our handler: it should have removed itself.
         try connectedServer.pipeline.waitForUpgraderToBeRemoved()
@@ -539,7 +539,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         // This request fires a subsequent upgrade in immediately. It should also be ignored.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\n\r\nOPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // At this time the channel pipeline should not contain our handler: it should have removed itself.
         try connectedServer.pipeline.waitForUpgraderToBeRemoved()
@@ -613,7 +613,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -640,7 +640,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         }
 
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nConnection: upgrade\r\nUpgrade: myproto\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // At this time the channel pipeline should not contain our handler: it should have removed itself.
         try connectedServer.pipeline.waitForUpgraderToBeRemoved()
@@ -661,7 +661,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         // This request is missing a 'Kafkaesque' connection header.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nConnection: upgrade\r\nUpgrade: myproto\r\nKafkaesque: true\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // At this time the channel pipeline should not contain our handler: it should have removed itself.
         try connectedServer.pipeline.waitForUpgraderToBeRemoved()
@@ -680,7 +680,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         }
 
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nConnection: upgrade\r\nUpgrade: something-else\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // At this time the channel pipeline should not contain our handler: it should have removed itself.
         try connectedServer.pipeline.waitForUpgraderToBeRemoved()
@@ -727,7 +727,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto, exploder\r\nKafkaesque: yup\r\nConnection: upgrade, kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -775,7 +775,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade,kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -842,7 +842,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: noproto,myproto\r\nKafkaesque: yup\r\nConnection: upgrade, kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -925,7 +925,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
 
         // This request is safe to upgrade.
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Ok, we don't think this upgrade should have succeeded yet, but neither should it have failed. We want to
         // dispatch onto the server event loop and check that the channel still contains the upgrade handler.
@@ -968,11 +968,11 @@ class HTTPServerUpgradeTestCase: XCTestCase {
 
         // This request is safe to upgrade, but is immediately followed by non-HTTP data.
         let request = "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nConnection: upgrade\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Ok, send the application data in.
         let appData = "supersecretawesome data definitely not http\r\nawesome\r\ndata\ryeah"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: appData))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: appData)).wait())
 
         // Now we need to wait a little bit before we move forward. This needs to give time for the
         // I/O to settle. 100ms should be plenty to handle that I/O.
@@ -1276,7 +1276,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try connectedServer.pipeline.waitForUpgraderToBeRemoved())
@@ -1414,11 +1414,11 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         var request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
         request += "A"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         XCTAssertNoThrow(try firstByteDonePromise.futureResult.wait() as Void)
 
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: "B"))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: "B")).wait())
 
         XCTAssertNoThrow(try secondByteDonePromise.futureResult.wait() as Void)
 
@@ -1608,7 +1608,7 @@ class HTTPServerUpgradeTestCase: XCTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -1842,7 +1842,7 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: notmyproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -1901,7 +1901,7 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -1958,7 +1958,7 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto, exploder\r\nKafkaesque: yup\r\nConnection: upgrade, kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -2016,7 +2016,7 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: noproto,myproto\r\nKafkaesque: yup\r\nConnection: upgrade, kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -2165,11 +2165,11 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         var request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
         request += "A"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         XCTAssertNoThrow(try firstByteDonePromise.futureResult.wait() as Void)
 
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: "B"))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: "B")).wait())
 
         XCTAssertNoThrow(try secondByteDonePromise.futureResult.wait() as Void)
 
@@ -2241,7 +2241,7 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade\r\nConnection: kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())
@@ -2289,7 +2289,7 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         // This request is safe to upgrade.
         let request =
             "OPTIONS * HTTP/1.1\r\nHost: localhost\r\nUpgrade: myproto\r\nKafkaesque: yup\r\nConnection: upgrade,kafkaesque\r\n\r\n"
-        XCTAssertNoThrow(try client.writeAndFlush(NIOAny(client.allocator.buffer(string: request))).wait())
+        XCTAssertNoThrow(try client.writeAndFlush(client.allocator.buffer(string: request)).wait())
 
         // Let the machinery do its thing.
         XCTAssertNoThrow(try completePromise.futureResult.wait())

--- a/Tests/NIOPosixTests/BootstrapTest.swift
+++ b/Tests/NIOPosixTests/BootstrapTest.swift
@@ -270,7 +270,7 @@ class BootstrapTest: XCTestCase {
 
             var buffer = clientChannel.allocator.buffer(capacity: 1)
             buffer.writeString("a")
-            try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+            try clientChannel.writeAndFlush(buffer).wait()
 
             let serverAcceptedChannel = try serverAcceptedChannelPromise.futureResult.wait()
 

--- a/Tests/NIOPosixTests/ChannelPipelineTest.swift
+++ b/Tests/NIOPosixTests/ChannelPipelineTest.swift
@@ -216,7 +216,7 @@ class ChannelPipelineTest: XCTestCase {
             }
         ).wait()
 
-        XCTAssertNoThrow(try channel.writeAndFlush(NIOAny("msg")).wait() as Void)
+        XCTAssertNoThrow(try channel.writeAndFlush("msg").wait() as Void)
         if let data = try channel.readOutbound(as: ByteBuffer.self) {
             XCTAssertEqual(buf, data)
         } else {

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -100,7 +100,7 @@ public final class ChannelTests: XCTestCase {
 
         var buffer = clientChannel.allocator.buffer(capacity: 1)
         buffer.writeString("a")
-        try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+        try clientChannel.writeAndFlush(buffer).wait()
 
         let serverAcceptedChannel = try serverAcceptedChannelPromise.futureResult.wait()
 
@@ -153,11 +153,11 @@ public final class ChannelTests: XCTestCase {
         for _ in 0..<Socket.writevLimitIOVectors {
             buffer.clear()
             buffer.writeString("a")
-            clientChannel.write(NIOAny(buffer), promise: nil)
+            clientChannel.write(buffer, promise: nil)
         }
         buffer.clear()
         buffer.writeString("a")
-        try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+        try clientChannel.writeAndFlush(buffer).wait()
 
         // Start shutting stuff down.
         XCTAssertNoThrow(try clientChannel.close().wait())
@@ -189,11 +189,11 @@ public final class ChannelTests: XCTestCase {
         let lotsOfData = Int(Int32.max)
         var written: Int64 = 0
         while written <= lotsOfData {
-            clientChannel.write(NIOAny(buffer), promise: nil)
+            clientChannel.write(buffer, promise: nil)
             written += Int64(bufferSize)
         }
 
-        XCTAssertNoThrow(try clientChannel.writeAndFlush(NIOAny(buffer)).wait())
+        XCTAssertNoThrow(try clientChannel.writeAndFlush(buffer).wait())
 
         // Start shutting stuff down.
         XCTAssertNoThrow(try clientChannel.close().wait())
@@ -1440,11 +1440,11 @@ public final class ChannelTests: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 12)
         buffer.writeString("1234")
 
-        try channel.writeAndFlush(NIOAny(buffer)).wait()
+        try channel.writeAndFlush(buffer).wait()
         try channel.close(mode: .output).wait()
 
         verificationHandler.waitForEvent()
-        XCTAssertThrowsError(try channel.writeAndFlush(NIOAny(buffer)).wait()) { error in
+        XCTAssertThrowsError(try channel.writeAndFlush(buffer).wait()) { error in
             XCTAssertEqual(.outputClosed, error as? ChannelError)
         }
         let written = try buffer.withUnsafeReadableBytes { p in
@@ -1565,7 +1565,7 @@ public final class ChannelTests: XCTestCase {
         var buffer = channel.allocator.buffer(capacity: 12)
         buffer.writeString("1234")
 
-        try channel.writeAndFlush(NIOAny(buffer)).wait()
+        try channel.writeAndFlush(buffer).wait()
     }
 
     func testInputAndOutputClosedResultsInFullClosure() throws {
@@ -1791,7 +1791,7 @@ public final class ChannelTests: XCTestCase {
             try pipeline.eventLoop.submit { () -> Channel in
                 XCTAssertTrue(pipeline.channel is DeadChannel)
                 return pipeline.channel
-            }.wait().writeAndFlush(NIOAny(())).wait()
+            }.wait().writeAndFlush(()).wait()
         ) { error in
             XCTAssertEqual(.ioOnClosedChannel, error as? ChannelError)
         }
@@ -2580,7 +2580,7 @@ public final class ChannelTests: XCTestCase {
                 .childChannelInitializer { channel in
                     var buffer = channel.allocator.buffer(capacity: 4)
                     buffer.writeString("foo")
-                    channel.writeAndFlush(NIOAny(buffer), promise: nil)
+                    channel.writeAndFlush(buffer, promise: nil)
                     return channel.eventLoop.makeSucceededVoidFuture()
                 }
                 .bind(host: "127.0.0.1", port: 0)
@@ -2953,7 +2953,7 @@ public final class ChannelTests: XCTestCase {
             func channelActive(context: ChannelHandlerContext) {
                 var buffer = context.channel.allocator.buffer(capacity: 1)
                 buffer.writeStaticString("X")
-                context.channel.writeAndFlush(Self.wrapOutboundOut(buffer)).map { context.channel }.cascade(
+                context.channel.writeAndFlush(buffer).map { context.channel }.cascade(
                     to: self.channelAvailablePromise
                 )
             }
@@ -3435,7 +3435,7 @@ public final class ChannelTests: XCTestCase {
         let buffer = client.allocator.buffer(string: "abcd")
         let writeCount = 3
 
-        let promises = (0..<writeCount).map { _ in client.write(NIOAny(buffer)) }
+        let promises = (0..<writeCount).map { _ in client.write(buffer) }
         let bufferedAmount = try client.getOption(.bufferedWritableBytes).wait()
         XCTAssertEqual(bufferedAmount, buffer.readableBytes * writeCount)
         client.flush()
@@ -3464,10 +3464,10 @@ public final class ChannelTests: XCTestCase {
         let buffer = client.allocator.buffer(string: "abcd")
         let writeCount = 20
 
-        var promises = (0..<writeCount).map { _ in client.writeAndFlush(NIOAny(buffer)) }
+        var promises = (0..<writeCount).map { _ in client.writeAndFlush(buffer) }
         var bufferedAmount = try client.getOption(.bufferedWritableBytes).wait()
         XCTAssertTrue(bufferedAmount >= 0 && bufferedAmount <= buffer.readableBytes * writeCount)
-        promises.append(client.write(NIOAny(buffer)))
+        promises.append(client.write(buffer))
         bufferedAmount = try client.getOption(.bufferedWritableBytes).wait()
         XCTAssertTrue(
             bufferedAmount >= buffer.readableBytes && bufferedAmount <= buffer.readableBytes * (writeCount + 1)

--- a/Tests/NIOPosixTests/EchoServerClientTest.swift
+++ b/Tests/NIOPosixTests/EchoServerClientTest.swift
@@ -57,7 +57,7 @@ class EchoServerClientTest: XCTestCase {
             buffer.writeInteger(UInt8(i % 256))
         }
 
-        try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+        try clientChannel.writeAndFlush(buffer).wait()
 
         try countingHandler.assertReceived(buffer: buffer)
     }
@@ -139,7 +139,7 @@ class EchoServerClientTest: XCTestCase {
                 buffer.writeInteger(UInt8(i % 256))
             }
 
-            XCTAssertNoThrow(try clientChannel.writeAndFlush(NIOAny(buffer)).wait())
+            XCTAssertNoThrow(try clientChannel.writeAndFlush(buffer).wait())
 
             XCTAssertNoThrow(try countingHandler.assertReceived(buffer: buffer))
         }
@@ -184,7 +184,7 @@ class EchoServerClientTest: XCTestCase {
                 buffer.writeInteger(UInt8(i % 256))
             }
 
-            try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+            try clientChannel.writeAndFlush(buffer).wait()
 
             try countingHandler.assertReceived(buffer: buffer)
         }
@@ -274,7 +274,7 @@ class EchoServerClientTest: XCTestCase {
             buffer.writeInteger(UInt8(i % 256))
         }
 
-        try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+        try clientChannel.writeAndFlush(buffer).wait()
 
         try countingHandler.assertReceived(buffer: buffer)
     }
@@ -343,7 +343,7 @@ class EchoServerClientTest: XCTestCase {
         for i in 0..<numBytes {
             buffer.writeInteger(UInt8(i % 256))
         }
-        XCTAssertNoThrow(try clientChannel.writeAndFlush(NIOAny(buffer)).wait())
+        XCTAssertNoThrow(try clientChannel.writeAndFlush(buffer).wait())
 
         XCTAssertNoThrow(try countingHandler.assertReceived(buffer: buffer))
     }
@@ -592,7 +592,7 @@ class EchoServerClientTest: XCTestCase {
 
         // First we confirm that the channel really is up by sending in the appropriate number of bytes.
         let bytesToWrite = clientChannel.allocator.buffer(string: writingBytes)
-        let lastWriteFuture = clientChannel.writeAndFlush(NIOAny(bytesToWrite))
+        let lastWriteFuture = clientChannel.writeAndFlush(bytesToWrite)
 
         // When we've received all the bytes we know the connection is up.
         _ = try bytesReceivedPromise.futureResult.wait()
@@ -718,7 +718,7 @@ class EchoServerClientTest: XCTestCase {
         )
 
         let buffer = clientChannel.allocator.buffer(string: str)
-        try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+        try clientChannel.writeAndFlush(buffer).wait()
 
         try countingHandler.assertReceived(buffer: buffer)
 
@@ -979,7 +979,7 @@ class EchoServerClientTest: XCTestCase {
             buffer.writeInteger(UInt8(i % 256))
         }
 
-        try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+        try clientChannel.writeAndFlush(buffer).wait()
 
         try countingHandler.assertReceived(buffer: buffer)
     }

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -500,7 +500,7 @@ public final class EventLoopTest: XCTestCase {
                 buffer.writeInteger(UInt8(i % 256))
             }
 
-            try clientChannel.writeAndFlush(NIOAny(buffer)).wait()
+            try clientChannel.writeAndFlush(buffer).wait()
         }
 
         // We should now shut down gracefully.

--- a/Tests/NIOPosixTests/FileRegionTest.swift
+++ b/Tests/NIOPosixTests/FileRegionTest.swift
@@ -58,13 +58,25 @@ class FileRegionTest: XCTestCase {
         }
 
         try withTemporaryFile { _, filePath in
-            let handle = try NIOFileHandle(path: filePath)
-            let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: bytes.count)
-            defer {
-                XCTAssertNoThrow(try handle.close())
-            }
             try content.write(toFile: filePath, atomically: false, encoding: .ascii)
-            try clientChannel.writeAndFlush(NIOAny(fr)).wait()
+            try clientChannel.eventLoop.submit {
+                try NIOFileHandle(path: filePath)
+            }.flatMap { (handle: NIOFileHandle) in
+                let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: bytes.count)
+                let promise = clientChannel.eventLoop.makePromise(of: Void.self)
+                clientChannel.pipeline.syncOperations.writeAndFlush(
+                    NIOAny(fr), promise: promise
+                )
+
+                let bound = NIOLoopBound(handle, eventLoop: clientChannel.eventLoop)
+                return promise.futureResult.flatMapErrorThrowing { error in
+                    try? bound.value.close()
+                    throw error
+                }.flatMapThrowing {
+                    try bound.value.close()
+                }
+            }.wait()
+
             var buffer = clientChannel.allocator.buffer(capacity: bytes.count)
             buffer.writeBytes(bytes)
             try countingHandler.assertReceived(buffer: buffer)
@@ -102,21 +114,26 @@ class FileRegionTest: XCTestCase {
         }
 
         try withTemporaryFile { _, filePath in
-            let handle = try NIOFileHandle(path: filePath)
-            let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 0)
-            defer {
-                XCTAssertNoThrow(try handle.close())
-            }
             try "".write(toFile: filePath, atomically: false, encoding: .ascii)
 
-            var futures: [EventLoopFuture<Void>] = []
-            for _ in 0..<10 {
-                futures.append(clientChannel.write(NIOAny(fr)))
-            }
-            try clientChannel.writeAndFlush(NIOAny(fr)).wait()
-            for future in futures {
-                try future.wait()
-            }
+            try clientChannel.eventLoop.submit {
+                try NIOFileHandle(path: filePath)
+            }.flatMap { (handle: NIOFileHandle) in
+                let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: 0)
+                var futures: [EventLoopFuture<Void>] = []
+                for _ in 0..<10 {
+                    futures.append(clientChannel.pipeline.syncOperations.write(NIOAny(fr)))
+                }
+                futures.append(clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(fr)))
+
+                let bound = NIOLoopBound(handle, eventLoop: clientChannel.eventLoop)
+                return .andAllSucceed(futures, on: clientChannel.eventLoop).flatMapErrorThrowing { error in
+                    try? bound.value.close()
+                    throw error
+                }.flatMapThrowing {
+                    try bound.value.close()
+                }
+            }.wait()
         }
     }
 
@@ -159,25 +176,45 @@ class FileRegionTest: XCTestCase {
         }
 
         try withTemporaryFile { fd, filePath in
-            let fh1 = try NIOFileHandle(path: filePath)
-            let fh2 = try NIOFileHandle(path: filePath)
-            let fr1 = FileRegion(fileHandle: fh1, readerIndex: 0, endIndex: bytes.count)
-            let fr2 = FileRegion(fileHandle: fh2, readerIndex: 0, endIndex: bytes.count)
-            defer {
-                XCTAssertNoThrow(try fh1.close())
-                XCTAssertNoThrow(try fh2.close())
-            }
             try content.write(toFile: filePath, atomically: false, encoding: .ascii)
-            XCTAssertThrowsError(
-                try clientChannel.writeAndFlush(NIOAny(fr1)).flatMap { () -> EventLoopFuture<Void> in
-                    let frFuture = clientChannel.write(NIOAny(fr2))
+
+            let future = clientChannel.eventLoop.submit {
+                let fh1 = try NIOFileHandle(path: filePath)
+                let fh2 = try NIOFileHandle(path: filePath)
+                return (fh1, fh2)
+            }.flatMap { (fh1, fh2) in
+                let fr1 = FileRegion(fileHandle: fh1, readerIndex: 0, endIndex: bytes.count)
+                let fr2 = FileRegion(fileHandle: fh2, readerIndex: 0, endIndex: bytes.count)
+
+                let loopBoundFr2 = NIOLoopBound(fr2, eventLoop: clientChannel.eventLoop)
+                let loopBoundHandles = NIOLoopBound((fh1, fh2), eventLoop: clientChannel.eventLoop)
+
+                return clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(fr1)).flatMap { () -> EventLoopFuture<Void> in
+                    let frFuture = clientChannel.pipeline.syncOperations.write(NIOAny(loopBoundFr2.value))
                     var buffer = clientChannel.allocator.buffer(capacity: bytes.count)
                     buffer.writeBytes(bytes)
-                    let bbFuture = clientChannel.write(NIOAny(buffer))
+                    let bbFuture = clientChannel.pipeline.syncOperations.write(NIOAny(buffer))
                     clientChannel.close(promise: nil)
                     clientChannel.flush()
                     return frFuture.flatMap { bbFuture }
-                }.wait()
+                }.flatMapErrorThrowing { error in
+                    let (fh1, fh2) = loopBoundHandles.value
+                    try? fh1.close()
+                    try? fh2.close()
+                    throw error
+                }.flatMapThrowing {
+                    let (fh1, fh2) = loopBoundHandles.value
+                    do {
+                        try fh1.close()
+                    } catch {
+                        try? fh2.close()
+                        throw error
+                    }
+                    try fh2.close()
+                }
+            }
+            XCTAssertThrowsError(
+                try future.wait()
             ) { error in
                 XCTAssertEqual(.ioOnClosedChannel, error as? ChannelError)
             }

--- a/Tests/NIOPosixTests/FileRegionTest.swift
+++ b/Tests/NIOPosixTests/FileRegionTest.swift
@@ -65,7 +65,8 @@ class FileRegionTest: XCTestCase {
                 let fr = FileRegion(fileHandle: handle, readerIndex: 0, endIndex: bytes.count)
                 let promise = clientChannel.eventLoop.makePromise(of: Void.self)
                 clientChannel.pipeline.syncOperations.writeAndFlush(
-                    NIOAny(fr), promise: promise
+                    NIOAny(fr),
+                    promise: promise
                 )
 
                 let bound = NIOLoopBound(handle, eventLoop: clientChannel.eventLoop)
@@ -189,7 +190,8 @@ class FileRegionTest: XCTestCase {
                 let loopBoundFr2 = NIOLoopBound(fr2, eventLoop: clientChannel.eventLoop)
                 let loopBoundHandles = NIOLoopBound((fh1, fh2), eventLoop: clientChannel.eventLoop)
 
-                return clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(fr1)).flatMap { () -> EventLoopFuture<Void> in
+                return clientChannel.pipeline.syncOperations.writeAndFlush(NIOAny(fr1)).flatMap {
+                    () -> EventLoopFuture<Void> in
                     let frFuture = clientChannel.pipeline.syncOperations.write(NIOAny(loopBoundFr2.value))
                     var buffer = clientChannel.allocator.buffer(capacity: bytes.count)
                     buffer.writeBytes(bytes)

--- a/Tests/NIOPosixTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOPosixTests/IdleStateHandlerTest.swift
@@ -104,7 +104,7 @@ class IdleStateHandlerTest: XCTestCase {
         if !writeToChannel {
             var buffer = clientChannel.allocator.buffer(capacity: 4)
             buffer.writeStaticString("test")
-            XCTAssertNoThrow(try clientChannel.writeAndFlush(NIOAny(buffer)).wait())
+            XCTAssertNoThrow(try clientChannel.writeAndFlush(buffer).wait())
         }
         XCTAssertNoThrow(try clientChannel.closeFuture.wait())
     }
@@ -178,7 +178,7 @@ class IdleStateHandlerTest: XCTestCase {
 
         channel.pipeline.fireChannelRegistered()
         channel.pipeline.fireChannelActive()
-        channel.pipeline.fireChannelRead(NIOAny(""))
+        channel.pipeline.fireChannelRead("")
         channel.pipeline.fireChannelReadComplete()
         channel.pipeline.fireErrorCaught(ChannelError.alreadyClosed)
         channel.pipeline.fireUserInboundEventTriggered("")

--- a/Tests/NIOPosixTests/UniversalBootstrapSupportTest.swift
+++ b/Tests/NIOPosixTests/UniversalBootstrapSupportTest.swift
@@ -128,7 +128,7 @@ class UniversalBootstrapSupportTest: XCTestCase {
                 // let's check that the order is right
                 XCTAssertNoThrow(
                     try client.eventLoop.submit {
-                        client.pipeline.fireChannelRead(NIOAny(buffer))
+                        client.pipeline.fireChannelRead(buffer)
                         client.pipeline.fireUserInboundEventTriggered(buffer)
                     }.wait()
                 )

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -18,6 +18,48 @@ import NIOPosix
 import NIOTestUtils
 import XCTest
 
+typealias SendableRequestPart = HTTPPart<HTTPRequestHead, ByteBuffer>
+
+extension HTTPClientRequestPart {
+    init(_ target: SendableRequestPart) {
+        switch target {
+        case .head(let head):
+            self = .head(head)
+        case .body(let body):
+            self = .body(.byteBuffer(body))
+        case .end(let end):
+            self = .end(end)
+        }
+    }
+}
+
+extension SendableRequestPart {
+    init(_ target: HTTPClientRequestPart) throws {
+        switch target {
+        case .head(let head):
+            self = .head(head)
+        case .body(.byteBuffer(let body)):
+            self = .body(body)
+        case .body(.fileRegion):
+            throw NIOHTTP1TestServerError(reason: "FileRegion is not Sendable and cannot be passed across concurrency domains")
+        case .end(let end):
+            self = .end(end)
+        }
+    }
+}
+
+/// A helper handler to transform a Sendable request into a
+/// non-Sendable one, to manage warnings.
+private final class TransformerHandler: ChannelOutboundHandler {
+    typealias OutboundIn = SendableRequestPart
+    typealias OutboundOut = HTTPClientRequestPart
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let response = self.unwrapOutboundIn(data)
+        context.write(self.wrapOutboundOut(.init(response)), promise: nil)
+    }
+}
+
 class NIOHTTP1TestServerTest: XCTestCase {
     private var group: EventLoopGroup!
     private let allocator = ByteBufferAllocator()
@@ -42,6 +84,8 @@ class NIOHTTP1TestServerTest: XCTestCase {
                     channel.pipeline.addHandler(AggregateBodyHandler())
                 }.flatMap {
                     channel.pipeline.addHandler(TestHTTPHandler(responsePromise: responsePromise))
+                }.flatMap {
+                    channel.pipeline.addHandler(TransformerHandler())
                 }
             }
         return bootstrap.connect(host: "127.0.0.1", port: serverPort)
@@ -60,9 +104,9 @@ class NIOHTTP1TestServerTest: XCTestCase {
             headers: headers
         )
 
-        channel.write(NIOAny(HTTPClientRequestPart.head(requestHead)), promise: nil)
-        channel.write(NIOAny(HTTPClientRequestPart.body(.byteBuffer(requestBuffer))), promise: nil)
-        channel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: nil)
+        channel.write(SendableRequestPart.head(requestHead), promise: nil)
+        channel.write(SendableRequestPart.body(requestBuffer), promise: nil)
+        channel.writeAndFlush(SendableRequestPart.end(nil), promise: nil)
     }
 
     private func sendRequestTo(_ url: URL, body: String) throws -> EventLoopFuture<String> {
@@ -381,7 +425,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
         let requestHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/uri", headers: headers)
-        channel.writeAndFlush(NIOAny(HTTPClientRequestPart.head(requestHead)), promise: nil)
+        channel.writeAndFlush(SendableRequestPart.head(requestHead), promise: nil)
         XCTAssertNoThrow(
             try testServer.receiveHeadAndVerify { head in
                 XCTAssertEqual(head.uri, "/uri")
@@ -392,7 +436,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
 
         for _ in 0..<10 {
             channel.writeAndFlush(
-                NIOAny(HTTPClientRequestPart.body(.byteBuffer(ByteBuffer(string: "ping")))),
+                SendableRequestPart.body(ByteBuffer(string: "ping")),
                 promise: nil
             )
             XCTAssertNoThrow(
@@ -403,7 +447,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
             XCTAssertNoThrow(try testServer.writeOutbound(.body(.byteBuffer(ByteBuffer(string: "pong")))))
         }
 
-        channel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: nil)
+        channel.writeAndFlush(SendableRequestPart.end(nil), promise: nil)
         XCTAssertNoThrow(
             try testServer.receiveEndAndVerify { trailers in
                 XCTAssertNil(trailers)

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -41,7 +41,9 @@ extension SendableRequestPart {
         case .body(.byteBuffer(let body)):
             self = .body(body)
         case .body(.fileRegion):
-            throw NIOHTTP1TestServerError(reason: "FileRegion is not Sendable and cannot be passed across concurrency domains")
+            throw NIOHTTP1TestServerError(
+                reason: "FileRegion is not Sendable and cannot be passed across concurrency domains"
+            )
         case .end(let end):
             self = .end(end)
         }


### PR DESCRIPTION
Motivation:

The ChannelInvoker protocols are an awkward beast. They aren't really something that people can do generic programming against. Instead, they were designed to do API sharing. Of course, they didn't do that very well, and the strict concurrency checking world has revealed this.

Much of the API surface on ChannelInvoker is confused. There are NIOAnys, which aren't Sendable. We allow sending user events without requiring Sendable. And our two main conforming types are ChannelPipeline and ChannelHandlerContext, two types with wildly differing thread-safety semantics.

This PR aims to clean that up.

Modifications:

- Deprecated all API surface on ChannelInvoker protocols that uses NIOAny.

    ChannelInvoker has to be assumed to be a cross-thread protocol,
    and that requires that it only use Sendable types. NIOAny isn't,
    so these methods are no longer sound.

- Re-add non-deprecated versions on ChannelHandlerContext.

    While it's not safe to use the NIOAny methods on Channel or
    ChannelPipeline, it's totally safe to use them on
    ChannelHandlerContext. So we keep those available and
    undeprecated.

- Provide typed generic replacements on ChannelPipeline and on Channel

    To replace the NIOAny methods on ChannelPipeline and Channel
    we can use some typed generic ones instead. These are not
    defined on ChannelInvoker, as the methods are useless on
    ChannelHandlerContext. This begins the acknowledgement that
    ChannelHandlerContext should not have conformed to these
    protocols at all.

- Add Sendable constraints to the user event witnesses on ChannelInvoker

    Again, these were missing, but must be there for Channel and
    ChannelPipeline.

- Provide non-Sendable overloads on ChannelHandlerContext

    ChannelHandlerContext is thread-bound, and so may safely pass
    non-Sendable user events.

Result:

One step closer to strict concurrency cleanliness for NIOCore.