### PR TITLE
Correct allocation test script

### DIFF
--- a/IntegrationTests/tests_04_performance/test_01_allocation_counts.sh
+++ b/IntegrationTests/tests_04_performance/test_01_allocation_counts.sh
@@ -63,5 +63,5 @@ for test in "${all_tests[@]}"; do
             assert_less_than_or_equal "$total_allocations" "$max_allowed"
             assert_greater_than "$total_allocations" "$(( max_allowed - 1000))"
         fi
-    done < <(grep "^test_${test[^\W]}*.total_allocations:" "$tmp/output" | cut -d: -f1 | cut -d. -f1 | sort | uniq)
+    done < <(grep "^test_${test}[^\W]*.total_allocations:" "$tmp/output" | cut -d: -f1 | cut -d. -f1 | sort | uniq)
 done


### PR DESCRIPTION
Motivation:

Unfortunately the current script has a bug meaning it can never fail.

Modifications:

Change bracketing for output search.

Result:

Allocation tests will flag when failing