### PR TITLE
Fix leaking technique

### DIFF
--- a/Sources/NIOPosix/PosixSingletons.swift
+++ b/Sources/NIOPosix/PosixSingletons.swift
@@ -117,6 +117,6 @@ private let globalPosixBlockingPool: NIOThreadPool = {
         numberOfThreads: NIOSingletons.blockingPoolThreadCountSuggestion,
         threadNamePrefix: "SGLTN-TP-#"
     )
-    _ = Unmanaged.passUnretained(pool).retain()  // never gonna let you down.
+    _ = Unmanaged.passRetained(pool)  // never gonna let you down.
     return pool
 }()


### PR DESCRIPTION
Using `Unmanaged.passRetained` is correct and therefore safe under all compiler optimizations