### PR TITLE
Remove sendable checking from NIOLock and NIOLockedValueBox

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -185,8 +185,6 @@ final class LockStorage<Value>: ManagedBuffer<Value, LockPrimitive> {
     }
 }
 
-extension LockStorage: @unchecked Sendable {}
-
 /// A threading lock based on `libpthread` instead of `libdispatch`.
 ///
 /// - Note: ``NIOLock`` has reference semantics.
@@ -253,7 +251,7 @@ extension NIOLock {
     }
 }
 
-extension NIOLock: Sendable {}
+extension NIOLock: @unchecked Sendable {}
 
 extension UnsafeMutablePointer {
     @inlinable

--- a/Sources/NIOConcurrencyHelpers/NIOLockedValueBox.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLockedValueBox.swift
@@ -79,4 +79,4 @@ public struct NIOLockedValueBox<Value> {
     }
 }
 
-extension NIOLockedValueBox: Sendable where Value: Sendable {}
+extension NIOLockedValueBox: @unchecked Sendable where Value: Sendable {}


### PR DESCRIPTION
Motivation:

ManagedBuffer is marked as explicitly not sendable on Swift nightly builds. NIOLock and NIOLockedValueBox used a type derived from ManagedBuffer and must be Sendable. Currently the derived type is marked as `@unchecked Sendable`. However on nightly toolchains this now conflicts with being explicitly not Sendable.

Modifications:

- Remove Sendable checking on NIOLock and NIOLockedValueBox

Result:

Fewer warnings