### PR TITLE
Add netstat -s to nio-diagnose

### DIFF
--- a/scripts/nio-diagnose
+++ b/scripts/nio-diagnose
@@ -366,6 +366,16 @@ function analyse_process() {
     analyse_syscalls "$pid"
 }
 
+function produce_network_stats() {
+    declare -a command
+
+    command=( netstat -s )
+
+    output "### System-wide network statistics"
+    output
+    run_and_print "${command[@]}"
+}
+
 number_of_nio_pids=0
 
 output "# NIO diagnose ($(shasum "${BASH_SOURCE[0]}"))"
@@ -378,6 +388,7 @@ analyse_system_versions
 analyse_tcp_conns
 analyse_udp
 analyse_uds
+produce_network_stats
 analyse_procs
 analyse_ulimit
 


### PR DESCRIPTION
Motivation:

netstat -s can identify many system-wide issues that may be useful extra data. There's no reason not to collect it.

Modifications:

Add netstat -s to the nio-diagnose script.

Result:

Better diagnostics
