### PR TITLE
Better handle ECONNRESET on connected datagram sockets.

### DIFF
--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -1091,7 +1091,8 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
                 let result: Int32 = try self.socket.getOption(level: .socket, name: .so_error)
                 if result != 0 {
                     // we have a socket error, let's forward
-                    // this path will be executed on Linux (EPOLLERR) & Darwin (ev.fflags != 0)
+                    // this path will be executed on Linux (EPOLLERR) & Darwin (ev.fflags != 0) for
+                    // stream sockets, and most (but not all) errors on datagram sockets
                     error = IOError(errnoCode: result, reason: "connection reset (error set)")
                 } else {
                     // we don't have a socket error, this must be connection reset without an error then
@@ -1207,6 +1208,14 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
     /// - Returns: `true` if the `Channel` should be closed, `false` otherwise.
     func shouldCloseOnReadError(_ err: Error) -> Bool {
         true
+    }
+
+    /// Handles an error reported by the selector.
+    ///
+    /// Default behaviour is to treat this as if it were a reset.
+    func error() -> ErrorResult {
+        self.reset()
+        return .fatal
     }
 
     internal final func updateCachedAddressesFromSocket(updateLocal: Bool = true, updateRemote: Bool = true) {
@@ -1331,7 +1340,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         // The initial set of interested events must not contain `.readEOF` because when connect doesn't return
         // synchronously, kevent might send us a `readEOF` because the `writable` event that marks the connect as completed.
         // See SocketChannelTest.testServerClosesTheConnectionImmediately for a regression test.
-        try self.safeRegister(interested: [.reset])
+        try self.safeRegister(interested: [.reset, .error])
         self.lifecycleManager.finishRegistration()(nil, self.pipeline)
     }
 

--- a/Sources/NIOPosix/PipeChannel.swift
+++ b/Sources/NIOPosix/PipeChannel.swift
@@ -68,7 +68,7 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
         if let inputFD = self.pipePair.inputFD {
             try selector.register(
                 selectable: inputFD,
-                interested: interested.intersection([.read, .reset]),
+                interested: interested.intersection([.read, .reset, .error]),
                 makeRegistration: self.registrationForInput
             )
         }
@@ -76,7 +76,7 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
         if let outputFD = self.pipePair.outputFD {
             try selector.register(
                 selectable: outputFD,
-                interested: interested.intersection([.write, .reset]),
+                interested: interested.intersection([.write, .reset, .error]),
                 makeRegistration: self.registrationForOutput
             )
         }
@@ -95,13 +95,13 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair> {
         if let inputFD = self.pipePair.inputFD, inputFD.isOpen {
             try selector.reregister(
                 selectable: inputFD,
-                interested: interested.intersection([.read, .reset])
+                interested: interested.intersection([.read, .reset, .error])
             )
         }
         if let outputFD = self.pipePair.outputFD, outputFD.isOpen {
             try selector.reregister(
                 selectable: outputFD,
-                interested: interested.intersection([.write, .reset])
+                interested: interested.intersection([.write, .reset, .error])
             )
         }
     }

--- a/Sources/NIOPosix/SelectableChannel.swift
+++ b/Sources/NIOPosix/SelectableChannel.swift
@@ -44,9 +44,17 @@ internal protocol SelectableChannel: Channel {
     /// Called when the `SelectableChannel` was reset (ie. is now unusable)
     func reset()
 
+    /// Called when the `SelectableChannel` had an error reported on the selector.
+    func error() -> ErrorResult
+
     func register(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws
 
     func deregister(selector: Selector<NIORegistration>, mode: CloseMode) throws
 
     func reregister(selector: Selector<NIORegistration>, interested: SelectorEventSet) throws
+}
+
+internal enum ErrorResult {
+    case fatal
+    case nonFatal
 }

--- a/Sources/NIOPosix/SelectorEpoll.swift
+++ b/Sources/NIOPosix/SelectorEpoll.swift
@@ -90,7 +90,10 @@ extension SelectorEventSet {
         if epollEvent.events & Epoll.EPOLLRDHUP != 0 {
             selectorEventSet.formUnion(.readEOF)
         }
-        if epollEvent.events & Epoll.EPOLLHUP != 0 || epollEvent.events & Epoll.EPOLLERR != 0 {
+        if epollEvent.events & Epoll.EPOLLERR != 0 {
+            selectorEventSet.formUnion(.error)
+        }
+        if epollEvent.events & Epoll.EPOLLHUP != 0 {
             selectorEventSet.formUnion(.reset)
         }
         self = selectorEventSet

--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -52,7 +52,7 @@ extension timespec {
 /// receives a connection reset, express interest with `[.read, .write, .reset]`.
 /// If then suddenly the socket becomes both readable and writable, the eventing mechanism will tell you about that
 /// fact using `[.read, .write]`.
-struct SelectorEventSet: OptionSet, Equatable {
+struct SelectorEventSet: OptionSet, Equatable, CustomStringConvertible {
 
     typealias RawValue = UInt8
 
@@ -62,7 +62,7 @@ struct SelectorEventSet: OptionSet, Equatable {
     /// of flags or to compare against spurious wakeups.
     static let _none = SelectorEventSet([])
 
-    /// Connection reset or other errors.
+    /// Connection reset.
     static let reset = SelectorEventSet(rawValue: 1 << 0)
 
     /// EOF at the read/input end of a `Selectable`.
@@ -79,8 +79,41 @@ struct SelectorEventSet: OptionSet, Equatable {
     /// - Note: This is rarely used because in many cases, there is no signal that this happened.
     static let writeEOF = SelectorEventSet(rawValue: 1 << 4)
 
+    /// Error encountered.
+    static let error = SelectorEventSet(rawValue: 1 << 5)
+
     init(rawValue: SelectorEventSet.RawValue) {
         self.rawValue = rawValue
+    }
+
+    var description: String {
+        var values: [String] = []
+        if self.contains(.reset) {
+            values.append("reset")
+        }
+
+        if self.contains(.readEOF) {
+            values.append("readEOF")
+        }
+
+        if self.contains(.read) {
+            values.append("read")
+        }
+
+        if self.contains(.write) {
+            values.append("write")
+        }
+
+        if self.contains(.writeEOF) {
+            values.append("writeEOF")
+        }
+
+        let remaining = self.subtracting([.reset, .readEOF, .read, .write, .writeEOF])
+        if remaining.rawValue != 0 {
+            values.append("unknown(0x\(String(remaining.rawValue, radix: 16)))")
+        }
+
+        return "[\(values.joined(separator: ", "))]"
     }
 }
 
@@ -237,7 +270,7 @@ internal class Selector<R: Registration> {
         makeRegistration: (SelectorEventSet, SelectorRegistrationID) -> R
     ) throws {
         assert(self.myThread == NIOThread.current)
-        assert(interested.contains(.reset))
+        assert(interested.contains([.reset, .error]))
         guard self.lifecycleState == .open else {
             throw IOError(errnoCode: EBADF, reason: "can't register on selector as it's \(self.lifecycleState).")
         }
@@ -265,7 +298,7 @@ internal class Selector<R: Registration> {
         guard self.lifecycleState == .open else {
             throw IOError(errnoCode: EBADF, reason: "can't re-register on selector as it's \(self.lifecycleState).")
         }
-        assert(interested.contains(.reset), "must register for at least .reset but tried registering for \(interested)")
+        assert(interested.contains([.reset, .error]), "must register for at least .reset & .error but tried registering for \(interested)")
         try selectable.withUnsafeHandle { fd in
             var reg = registrations[Int(fd)]!
             try self.reregister0(

--- a/Sources/NIOPosix/SelectorKqueue.swift
+++ b/Sources/NIOPosix/SelectorKqueue.swift
@@ -240,7 +240,7 @@ extension Selector: _SelectorBackendProtocol {
     ) throws {
         try kqueueUpdateEventNotifications(
             selectable: selectable,
-            interested: .reset,
+            interested: [.reset, .error],
             oldInterested: oldInterested,
             registrationID: registrationID
         )

--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -34,6 +34,17 @@ extension Channel {
         }.wait()
     }
 
+    func waitForErrors(count: Int) throws -> [any Error] {
+        try self.pipeline.context(name: "ByteReadRecorder").flatMap { context in
+            if let future = (context.handler as? DatagramReadRecorder<ByteBuffer>)?.notifyForErrors(count) {
+                return future
+            }
+
+            XCTFail("Could not wait for errors")
+            return self.eventLoop.makeSucceededFuture([])
+        }.wait()
+    }
+
     func readCompleteCount() throws -> Int {
         try self.pipeline.context(name: "ByteReadRecorder").map { context in
             (context.handler as! DatagramReadRecorder<ByteBuffer>).readCompleteCount
@@ -66,10 +77,12 @@ final class DatagramReadRecorder<DataType>: ChannelInboundHandler {
     }
 
     var reads: [AddressedEnvelope<DataType>] = []
+    var errors: [any Error] = []
     var loop: EventLoop? = nil
     var state: State = .fresh
 
     var readWaiters: [Int: EventLoopPromise<[AddressedEnvelope<DataType>]>] = [:]
+    var errorWaiters: [Int: EventLoopPromise<[any Error]>] = [:]
     var readCompleteCount = 0
 
     func channelRegistered(context: ChannelHandlerContext) {
@@ -95,6 +108,16 @@ final class DatagramReadRecorder<DataType>: ChannelInboundHandler {
         context.fireChannelRead(Self.wrapInboundOut(data))
     }
 
+    func errorCaught(context: ChannelHandlerContext, error: any Error) {
+        self.errors.append(error)
+
+        if let promise = self.errorWaiters.removeValue(forKey: self.errors.count) {
+            promise.succeed(self.errors)
+        }
+
+        context.fireErrorCaught(error)
+    }
+
     func channelReadComplete(context: ChannelHandlerContext) {
         self.readCompleteCount += 1
         context.fireChannelReadComplete()
@@ -107,6 +130,15 @@ final class DatagramReadRecorder<DataType>: ChannelInboundHandler {
 
         readWaiters[count] = loop!.makePromise()
         return readWaiters[count]!.futureResult
+    }
+
+    func notifyForErrors(_ count: Int) -> EventLoopFuture<[any Error]> {
+        guard self.errors.count < count else {
+            return self.loop!.makeSucceededFuture(.init(self.errors.prefix(count)))
+        }
+
+        self.errorWaiters[count] = self.loop!.makePromise()
+        return self.errorWaiters[count]!.futureResult
     }
 }
 
@@ -1710,6 +1742,29 @@ class DatagramChannelTests: XCTestCase {
         for datagram in datagrams {
             XCTAssertEqual(datagram.data.readableBytes, buffer.readableBytes)
         }
+    }
+
+    func testShutdownReadOnConnectedUDP() throws {
+        var buffer = self.firstChannel.allocator.buffer(capacity: 256)
+        buffer.writeStaticString("hello, world!")
+
+        // Connect and write
+        XCTAssertNoThrow(try self.firstChannel.connect(to: self.secondChannel.localAddress!).wait())
+
+        let writeData = AddressedEnvelope(remoteAddress: self.secondChannel.localAddress!, data: buffer)
+        XCTAssertNoThrow(try self.firstChannel.writeAndFlush(writeData).wait())
+        _ = try self.secondChannel.waitForDatagrams(count: 1)
+
+        // Ok, close on the second channel.
+        XCTAssertNoThrow(try self.secondChannel.close(mode: .all).wait())
+        print("closed")
+
+        // Write again.
+        XCTAssertNoThrow(try self.firstChannel.writeAndFlush(writeData).wait())
+
+        // This should trigger an error.
+        let errors = try self.firstChannel.waitForErrors(count: 1)
+        XCTAssertEqual((errors[0] as? IOError)?.errnoCode, ECONNREFUSED)
     }
 
     private func hasGoodGROSupport() throws -> Bool {

--- a/Tests/NIOPosixTests/SALChannelTests.swift
+++ b/Tests/NIOPosixTests/SALChannelTests.swift
@@ -149,7 +149,7 @@ final class SALChannelTest: XCTestCase, SALTest {
                 // Next, we expect a reregistration which adds the `.write` notification
                 try self.assertReregister { selectable, eventSet in
                     XCTAssert(selectable as? Socket === channel.socket)
-                    XCTAssertEqual([.read, .reset, .readEOF, .write], eventSet)
+                    XCTAssertEqual([.read, .reset, .error, .readEOF, .write], eventSet)
                     return true
                 }
 
@@ -201,7 +201,7 @@ final class SALChannelTest: XCTestCase, SALTest {
                 // And lastly, after having written everything, we'd expect to unregister for write
                 try self.assertReregister { selectable, eventSet in
                     XCTAssert(selectable as? Socket === channel.socket)
-                    XCTAssertEqual([.read, .reset, .readEOF], eventSet)
+                    XCTAssertEqual([.read, .reset, .error, .readEOF], eventSet)
                     return true
                 }
 
@@ -315,11 +315,11 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertLocalAddress(address: localAddress)
                 try self.assertRemoteAddress(address: localAddress)
                 try self.assertRegister { selectable, event, Registration in
-                    XCTAssertEqual([.reset], event)
+                    XCTAssertEqual([.reset, .error], event)
                     return true
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF], event)
+                    XCTAssertEqual([.reset, .error, .readEOF], event)
                     return true
                 }
                 try self.assertDeregister { selectable in
@@ -360,11 +360,11 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertLocalAddress(address: localAddress)
                 try self.assertRemoteAddress(address: localAddress)
                 try self.assertRegister { selectable, event, Registration in
-                    XCTAssertEqual([.reset], event)
+                    XCTAssertEqual([.reset, .error], event)
                     return true
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF], event)
+                    XCTAssertEqual([.reset, .error, .readEOF], event)
                     return true
                 }
                 try self.assertDeregister { selectable in
@@ -431,19 +431,19 @@ final class SALChannelTest: XCTestCase, SALTest {
                         XCTAssertEqual(localAddress, channel.localAddress)
                         XCTAssertEqual(remoteAddress, channel.remoteAddress)
                         XCTAssertEqual(eventSet, registrationEventSet)
-                        XCTAssertEqual(.reset, eventSet)
+                        XCTAssertEqual([.reset, .error], eventSet)
                         return true
                     } else {
                         return false
                     }
                 }
                 try self.assertReregister { selectable, eventSet in
-                    XCTAssertEqual([.reset, .readEOF], eventSet)
+                    XCTAssertEqual([.reset, .error, .readEOF], eventSet)
                     return true
                 }
                 // because autoRead is on by default
                 try self.assertReregister { selectable, eventSet in
-                    XCTAssertEqual([.reset, .readEOF, .read], eventSet)
+                    XCTAssertEqual([.reset, .error, .readEOF, .read], eventSet)
                     return true
                 }
 
@@ -504,19 +504,19 @@ final class SALChannelTest: XCTestCase, SALTest {
                         XCTAssertEqual(localAddress, channel.localAddress)
                         XCTAssertEqual(remoteAddress, channel.remoteAddress)
                         XCTAssertEqual(eventSet, registrationEventSet)
-                        XCTAssertEqual(.reset, eventSet)
+                        XCTAssertEqual([.reset, .error], eventSet)
                         return true
                     } else {
                         return false
                     }
                 }
                 try self.assertReregister { selectable, eventSet in
-                    XCTAssertEqual([.reset, .readEOF], eventSet)
+                    XCTAssertEqual([.reset, .error, .readEOF], eventSet)
                     return true
                 }
                 // because autoRead is on by default
                 try self.assertReregister { selectable, eventSet in
-                    XCTAssertEqual([.reset, .readEOF, .read], eventSet)
+                    XCTAssertEqual([.reset, .error, .readEOF, .read], eventSet)
                     return true
                 }
 
@@ -549,11 +549,11 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertConnect(expectedAddress: serverAddress, result: false)
                 try self.assertLocalAddress(address: localAddress)
                 try self.assertRegister { selectable, event, Registration in
-                    XCTAssertEqual([.reset], event)
+                    XCTAssertEqual([.reset, .error], event)
                     return true
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .write], event)
+                    XCTAssertEqual([.reset, .error, .write], event)
                     return true
                 }
 
@@ -570,7 +570,7 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertRemoteAddress(address: serverAddress)
 
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF, .write], event)
+                    XCTAssertEqual([.reset, .error, .readEOF, .write], event)
                     return true
                 }
                 try self.assertWritev(
@@ -621,11 +621,11 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertLocalAddress(address: localAddress)
                 try self.assertRemoteAddress(address: serverAddress)
                 try self.assertRegister { selectable, event, Registration in
-                    XCTAssertEqual([.reset], event)
+                    XCTAssertEqual([.reset, .error], event)
                     return true
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF], event)
+                    XCTAssertEqual([.reset, .error, .readEOF], event)
                     return true
                 }
                 try self.assertWritev(
@@ -676,11 +676,11 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertLocalAddress(address: localAddress)
                 try self.assertRemoteAddress(address: serverAddress)
                 try self.assertRegister { selectable, event, Registration in
-                    XCTAssertEqual([.reset], event)
+                    XCTAssertEqual([.reset, .error], event)
                     return true
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF], event)
+                    XCTAssertEqual([.reset, .error, .readEOF], event)
                     return true
                 }
                 try self.assertWritev(
@@ -690,7 +690,7 @@ final class SALChannelTest: XCTestCase, SALTest {
                 )
                 try self.assertWrite(expectedFD: .max, expectedBytes: secondWrite, return: .wouldBlock(0))
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF, .write], event)
+                    XCTAssertEqual([.reset, .error, .readEOF, .write], event)
                     return true
                 }
 
@@ -741,11 +741,11 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertLocalAddress(address: localAddress)
                 try self.assertRemoteAddress(address: serverAddress)
                 try self.assertRegister { selectable, event, Registration in
-                    XCTAssertEqual([.reset], event)
+                    XCTAssertEqual([.reset, .error], event)
                     return true
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF], event)
+                    XCTAssertEqual([.reset, .error, .readEOF], event)
                     return true
                 }
                 try self.assertWritev(
@@ -815,14 +815,14 @@ final class SALChannelTest: XCTestCase, SALTest {
                         XCTAssertEqual(localAddress, channel.localAddress)
                         XCTAssertEqual(remoteAddress, channel.remoteAddress)
                         XCTAssertEqual(eventSet, registrationEventSet)
-                        XCTAssertEqual(.reset, eventSet)
+                        XCTAssertEqual([.reset, .error], eventSet)
                         return true
                     } else {
                         return false
                     }
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF], event)
+                    XCTAssertEqual([.reset, .error, .readEOF], event)
                     return true
                 }
 
@@ -895,14 +895,14 @@ final class SALChannelTest: XCTestCase, SALTest {
                         XCTAssertEqual(localAddress, channel.localAddress)
                         XCTAssertEqual(remoteAddress, channel.remoteAddress)
                         XCTAssertEqual(eventSet, registrationEventSet)
-                        XCTAssertEqual(.reset, eventSet)
+                        XCTAssertEqual([.reset, .error], eventSet)
                         return true
                     } else {
                         return false
                     }
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF], event)
+                    XCTAssertEqual([.reset, .error, .readEOF], event)
                     return true
                 }
 
@@ -913,7 +913,7 @@ final class SALChannelTest: XCTestCase, SALTest {
                 )
                 try self.assertWrite(expectedFD: .max, expectedBytes: secondWrite, return: .wouldBlock(0))
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF, .write], event)
+                    XCTAssertEqual([.reset, .error, .readEOF, .write], event)
                     return true
                 }
 
@@ -983,14 +983,14 @@ final class SALChannelTest: XCTestCase, SALTest {
                         XCTAssertEqual(localAddress, channel.localAddress)
                         XCTAssertEqual(remoteAddress, channel.remoteAddress)
                         XCTAssertEqual(eventSet, registrationEventSet)
-                        XCTAssertEqual(.reset, eventSet)
+                        XCTAssertEqual([.reset, .error], eventSet)
                         return true
                     } else {
                         return false
                     }
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF], event)
+                    XCTAssertEqual([.reset, .error, .readEOF], event)
                     return true
                 }
 
@@ -1064,11 +1064,11 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertConnect(expectedAddress: serverAddress, result: false)
                 try self.assertLocalAddress(address: localAddress)
                 try self.assertRegister { selectable, event, Registration in
-                    XCTAssertEqual([.reset], event)
+                    XCTAssertEqual([.reset, .error], event)
                     return true
                 }
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .write], event)
+                    XCTAssertEqual([.reset, .error, .write], event)
                     return true
                 }
 
@@ -1085,7 +1085,7 @@ final class SALChannelTest: XCTestCase, SALTest {
                 try self.assertRemoteAddress(address: serverAddress)
 
                 try self.assertReregister { selectable, event in
-                    XCTAssertEqual([.reset, .readEOF, .write], event)
+                    XCTAssertEqual([.reset, .error, .readEOF, .write], event)
                     return true
                 }
                 try self.assertWritev(

--- a/Tests/NIOPosixTests/SelectorTest.swift
+++ b/Tests/NIOPosixTests/SelectorTest.swift
@@ -82,7 +82,7 @@ class SelectorTest: XCTestCase {
         // Register both sockets with .write. This will ensure both are ready when calling selector.whenReady.
         try selector.register(
             selectable: socket1,
-            interested: [.reset, .write],
+            interested: [.reset, .error, .write],
             makeRegistration: { ev, regID in
                 TestRegistration(socket: socket1, interested: ev, registrationID: regID)
             }
@@ -90,7 +90,7 @@ class SelectorTest: XCTestCase {
 
         try selector.register(
             selectable: socket2,
-            interested: [.reset, .write],
+            interested: [.reset, .error, .write],
             makeRegistration: { ev, regID in
                 TestRegistration(socket: socket2, interested: ev, registrationID: regID)
             }
@@ -477,7 +477,7 @@ class SelectorTest: XCTestCase {
                             + " This should really only ever happen in very bizarre conditions."
                     )
                 }
-                channel.interestedEvent = [.readEOF, .reset]
+                channel.interestedEvent = [.readEOF, .reset, .error]
                 func workaroundSR9815() {
                     channel.registerAlreadyConfigured0(promise: nil)
                 }

--- a/Tests/NIOPosixTests/SyscallAbstractionLayer.swift
+++ b/Tests/NIOPosixTests/SyscallAbstractionLayer.swift
@@ -753,19 +753,19 @@ extension SALTest {
                     XCTAssertEqual(localAddress, channel.localAddress)
                     XCTAssertEqual(remoteAddress, channel.remoteAddress)
                     XCTAssertEqual(eventSet, registrationEventSet)
-                    XCTAssertEqual(.reset, eventSet)
+                    XCTAssertEqual([.reset, .error], eventSet)
                     return true
                 } else {
                     return false
                 }
             }
             try self.assertReregister { selectable, eventSet in
-                XCTAssertEqual([.reset, .readEOF], eventSet)
+                XCTAssertEqual([.reset, .error, .readEOF], eventSet)
                 return true
             }
             // because autoRead is on by default
             try self.assertReregister { selectable, eventSet in
-                XCTAssertEqual([.reset, .readEOF, .read], eventSet)
+                XCTAssertEqual([.reset, .error, .readEOF, .read], eventSet)
                 return true
             }
         } _: {
@@ -795,19 +795,19 @@ extension SALTest {
                     XCTAssertEqual(localAddress, channel.localAddress)
                     XCTAssertEqual(nil, channel.remoteAddress)
                     XCTAssertEqual(eventSet, registrationEventSet)
-                    XCTAssertEqual(.reset, eventSet)
+                    XCTAssertEqual([.reset, .error], eventSet)
                     return true
                 } else {
                     return false
                 }
             }
             try self.assertReregister { selectable, eventSet in
-                XCTAssertEqual([.reset, .readEOF], eventSet)
+                XCTAssertEqual([.reset, .error, .readEOF], eventSet)
                 return true
             }
             // because autoRead is on by default
             try self.assertReregister { selectable, eventSet in
-                XCTAssertEqual([.reset, .readEOF, .read], eventSet)
+                XCTAssertEqual([.reset, .error, .readEOF, .read], eventSet)
                 return true
             }
         } _: {


### PR DESCRIPTION
Motivation:

When a connected datagram socket sends a datagram to a port or host that is not listening, an ICMP Destination Unreachable message may be returned. That message triggers an ECONNRESET to be produced at the socket layer.

On Darwin we handled this well, but on Linux it turned out that this would push us into connection teardown and, eventually, into a crash. Not so good.

To better handle this, we need to distinguish EPOLLERR from EPOLLHUP on datagram sockets. In these cases, we should check whether the socket error was fatal and, if it was not, we should continue our execution having fired the error down the pipeline.

Modifications:

Modify the selector code to distinguish reset and error. Add support for our channels to handle errors.
Have most channels handle errors as resets.
Override the logic for datagram channels to duplicate the logic in readable.
Add a unit test.

Result:

Better datagrams for all.
