### PR TITLE
Backport: Fix broken swift format link (#2948)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Try to keep your lines less than 120 characters long so github can correctly dis
 
 SwiftNIO uses the [swift-format](https://github.com/swiftlang/swift-format) tool to bring consistency to code formatting.  There is a specific [.swift-format](./.swift-format) configuration file.  This will be checked and enforced on PRs.  Note that the check will run on the current most recent stable version target which may not match that in your own local development environment.
 
-If you want to apply the formatting to your local repo before you commit then you can either run [check-swift-format.sh](./scripts/check-swift-format.sh) which will use your current toolchain, or to match the CI checks exactly you can use `act` (see [act section](#act)):
+If you want to apply the formatting to your local repo before you commit then you can either run [check-swift-format.sh](https://github.com/swiftlang/github-workflows/blob/main/.github/workflows/scripts/check-swift-format.sh) which will use your current toolchain, or to match the CI checks exactly you can use `act` (see [act section](#act)):
 ```
 act --action-offline-mode --bind workflow_call -j format-check --input format_check_enabled=true
 ```


### PR DESCRIPTION
Trying to fix swift format link in contributions.md

Someone please let me know what the process is for running `swift format` locally now that the script has been moved out of the repo.

Co-authored-by: Franz Busch <f.busch@apple.com>
(cherry picked from commit 08af85ae4bf55f056128078685e0fe4bc647ed8f)