### PR TITLE
Fix leaking technique (#2963)

### DIFF
--- a/Sources/NIOPosix/PosixSingletons.swift
+++ b/Sources/NIOPosix/PosixSingletons.swift
@@ -117,6 +117,6 @@ private let globalPosixBlockingPool: NIOThreadPool = {
         numberOfThreads: NIOSingletons.blockingPoolThreadCountSuggestion,
         threadNamePrefix: "SGLTN-TP-#"
     )
-    _ = Unmanaged.passUnretained(pool).retain()  // never gonna let you down.
+    _ = Unmanaged.passRetained(pool)  // never gonna let you down.
     return pool
 }()


### PR DESCRIPTION
Using `Unmanaged.passRetained` is correct and therefore safe under all compiler optimizations

(cherry picked from commit 3fda9430aa47942930126bbbf8982ef762feb7cf)
