### PR TITLE
fix almost all Sendable warnings

### DIFF
--- a/Sources/NIOCore/ChannelPipeline.swift
+++ b/Sources/NIOCore/ChannelPipeline.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -2130,6 +2130,23 @@ extension ChannelHandlerContext {
         let promise = self.eventLoop.makePromise(of: Void.self, file: file, line: line)
         self.writeAndFlush(data, promise: promise)
         return promise.futureResult
+    }
+
+    /// Returns this `ChannelHandlerContext` as a `NIOLoopBound`, bound to `self.eventLoop`.
+    ///
+    /// This is a shorthand for `NIOLoopBound(self, eventLoop: self.eventLoop)`.
+    ///
+    /// Being able to capture `ChannelHandlerContext`s in `EventLoopFuture` callbacks is important in SwiftNIO programs.
+    /// Of course, this is not always safe because the `EventLoopFuture` callbacks may run on other threads. SwiftNIO
+    /// programmers therefore always had to manually arrange for those callbacks to run on the correct `EventLoop`
+    /// (i.e. `context.eventLoop`) which then made that construction safe.
+    ///
+    /// Newer Swift versions contain a static feature to automatically detect data races which of course can't detect
+    /// the only _dynamically_ ``EventLoop`` a ``EventLoopFuture`` callback is running on. ``NIOLoopBound`` can be used
+    /// to prove to the compiler that this is safe and in case it is not, ``NIOLoopBound`` will trap at runtime. This is
+    /// therefore dynamically enforce the correct behaviour.
+    public var loopBound: NIOLoopBound<ChannelHandlerContext> {
+        NIOLoopBound(self, eventLoop: self.eventLoop)
     }
 }
 

--- a/Sources/NIOFileSystem/Internal/BufferedStream.swift
+++ b/Sources/NIOFileSystem/Internal/BufferedStream.swift
@@ -243,7 +243,6 @@ extension BufferedStream {
         }
 
         /// A type that indicates the result of writing elements to the source.
-        @frozen
         internal enum WriteResult: Sendable {
             /// A token that is returned when the asynchronous stream's backpressure strategy indicated that production should
             /// be suspended. Use this token to enqueue a callback by  calling the ``enqueueCallback(_:)`` method.

--- a/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerPipelineHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -439,9 +439,11 @@ public final class HTTPServerPipelineHandler: ChannelDuplexHandler, RemovableCha
                 // we just received the .end that we're missing so we can fall through to closing the connection
                 fallthrough
             case .quiescingLastRequestEndReceived:
+                let loopBoundContext = context.loopBound
                 self.lifecycleState = .quiescingCompleted
                 context.write(data).flatMap {
-                    context.close()
+                    let context = loopBoundContext.value
+                    return context.close()
                 }.cascade(to: promise)
             case .acceptingEvents, .quiescingWaitingForRequestEnd:
                 context.write(data, promise: promise)

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2023-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -174,6 +174,7 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
     }
 
     private func channelRead(context: ChannelHandlerContext, requestPart: HTTPServerRequestPart) {
+        let loopBoundContext = context.loopBound
         switch self.stateMachine.channelReadRequestPart(requestPart) {
         case .failUpgradePromise(let error):
             self.upgradeResultPromise.fail(error)
@@ -182,6 +183,7 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
             self.notUpgradingCompletionHandler(context.channel)
                 .hop(to: context.eventLoop)
                 .whenComplete { result in
+                    let context = loopBoundContext.value
                     self.upgradingHandlerCompleted(context: context, result, requestHeadAndProtocol: nil)
                 }
 
@@ -194,6 +196,7 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
                 allHeaderNames: allHeaderNames,
                 connectionHeader: connectionHeader
             ).whenComplete { result in
+                let context = loopBoundContext.value
                 context.eventLoop.assertInEventLoop()
                 self.findingUpgradeCompleted(context: context, requestHead: head, result)
             }
@@ -297,6 +300,7 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
             )
         }
 
+        let loopBoundContext = context.loopBound
         let responseHeaders = self.buildUpgradeHeaders(protocol: proto)
         return upgrader.buildUpgradeResponse(
             channel: context.channel,
@@ -307,6 +311,7 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
         .map { (upgrader, $0, proto) }
         .flatMapError { error in
             // No upgrade here. We want to fire the error down the pipeline, and then try another loop iteration.
+            let context = loopBoundContext.value
             context.fireErrorCaught(error)
             return self.handleUpgradeForProtocol(
                 context: context,
@@ -339,9 +344,11 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
             )
 
         case .runNotUpgradingInitializer:
+            let loopBoundContext = context.loopBound
             self.notUpgradingCompletionHandler(context.channel)
                 .hop(to: context.eventLoop)
                 .whenComplete { result in
+                    let context = loopBoundContext.value
                     self.upgradingHandlerCompleted(context: context, result, requestHeadAndProtocol: nil)
                 }
 
@@ -376,14 +383,19 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
         // internal handler, then call the user code, and then finally when the user code is done we do
         // our final cleanup steps, namely we replay the received data we buffered in the meantime and
         // then remove ourselves from the pipeline.
-        self.removeExtraHandlers(context: context).flatMap {
-            self.sendUpgradeResponse(context: context, responseHeaders: responseHeaders)
+        let channel = context.channel
+        let pipeline = context.pipeline
+        let loopBoundContext = context.loopBound
+        self.removeExtraHandlers(pipeline: pipeline).flatMap {
+            let context = loopBoundContext.value
+            return self.sendUpgradeResponse(context: context, responseHeaders: responseHeaders)
         }.flatMap {
-            context.pipeline.syncOperations.removeHandler(self.httpEncoder)
+            pipeline.syncOperations.removeHandler(self.httpEncoder)
         }.flatMap { () -> EventLoopFuture<UpgradeResult> in
-            upgrader.upgrade(channel: context.channel, upgradeRequest: requestHead)
+            upgrader.upgrade(channel: channel, upgradeRequest: requestHead)
         }.hop(to: context.eventLoop)
             .whenComplete { result in
+                let context = loopBoundContext.value
                 self.upgradingHandlerCompleted(context: context, result, requestHeadAndProtocol: (requestHead, proto))
             }
     }
@@ -404,14 +416,14 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
     }
 
     /// Removes any extra HTTP-related handlers from the channel pipeline.
-    private func removeExtraHandlers(context: ChannelHandlerContext) -> EventLoopFuture<Void> {
+    private func removeExtraHandlers(pipeline: ChannelPipeline) -> EventLoopFuture<Void> {
         guard self.extraHTTPHandlers.count > 0 else {
-            return context.eventLoop.makeSucceededFuture(())
+            return pipeline.eventLoop.makeSucceededFuture(())
         }
 
         return .andAllSucceed(
-            self.extraHTTPHandlers.map { context.pipeline.removeHandler($0) },
-            on: context.eventLoop
+            self.extraHTTPHandlers.map { pipeline.removeHandler($0) },
+            on: pipeline.eventLoop
         )
     }
 

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -207,7 +207,7 @@ private final class HTTPHandler: ChannelInboundHandler {
             ()
         case .end:
             self.state.requestComplete()
-            let loopBoundContext = NIOLoopBound(context, eventLoop: context.eventLoop)
+            let loopBoundContext = context.loopBound
             let loopBoundSelf = NIOLoopBound(self, eventLoop: context.eventLoop)
             context.eventLoop.scheduleTask(in: delay) { () -> Void in
                 let `self` = loopBoundSelf.value
@@ -501,7 +501,7 @@ private final class HTTPHandler: ChannelInboundHandler {
         promise: EventLoopPromise<Void>?
     ) {
         self.state.responseComplete()
-        let loopBoundContext = NIOLoopBound(context, eventLoop: context.eventLoop)
+        let loopBoundContext = context.loopBound
 
         let promise = self.keepAlive ? promise : (promise ?? context.eventLoop.makePromise())
         if !self.keepAlive {

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -431,6 +431,7 @@ public final class ServerBootstrap {
 
     final class AcceptHandler: ChannelInboundHandler {
         public typealias InboundIn = SocketChannel
+        public typealias InboundOut = SocketChannel
 
         private let childChannelInit: ((Channel) -> EventLoopFuture<Void>)?
         private let childChannelOptions: ChannelOptions.Storage
@@ -445,7 +446,9 @@ public final class ServerBootstrap {
 
         func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
             if event is ChannelShouldQuiesceEvent {
+                let loopBoundContext = context.loopBound
                 context.channel.close().whenFailure { error in
+                    let context = loopBoundContext.value
                     context.fireErrorCaught(error)
                 }
             }
@@ -467,28 +470,33 @@ public final class ServerBootstrap {
             }
 
             @inline(__always)
-            func fireThroughPipeline(_ future: EventLoopFuture<Void>) {
+            func fireThroughPipeline(_ future: EventLoopFuture<Void>, context: ChannelHandlerContext) {
                 ctxEventLoop.assertInEventLoop()
+                assert(ctxEventLoop === context.eventLoop)
+                let loopBoundContext = context.loopBound
                 future.flatMap { (_) -> EventLoopFuture<Void> in
+                    let context = loopBoundContext.value
                     ctxEventLoop.assertInEventLoop()
                     guard context.channel.isActive else {
-                        return context.eventLoop.makeFailedFuture(ChannelError._ioOnClosedChannel)
+                        return ctxEventLoop.makeFailedFuture(ChannelError._ioOnClosedChannel)
                     }
-                    context.fireChannelRead(data)
+                    context.fireChannelRead(Self.wrapInboundOut(accepted))
                     return context.eventLoop.makeSucceededFuture(())
                 }.whenFailure { error in
+                    let context = loopBoundContext.value
                     ctxEventLoop.assertInEventLoop()
                     self.closeAndFire(context: context, accepted: accepted, err: error)
                 }
             }
 
             if childEventLoop === ctxEventLoop {
-                fireThroughPipeline(setupChildChannel())
+                fireThroughPipeline(setupChildChannel(), context: context)
             } else {
                 fireThroughPipeline(
                     childEventLoop.flatSubmit {
                         setupChildChannel()
-                    }.hop(to: ctxEventLoop)
+                    }.hop(to: ctxEventLoop),
+                    context: context
                 )
             }
         }
@@ -498,7 +506,9 @@ public final class ServerBootstrap {
             if context.eventLoop.inEventLoop {
                 context.fireErrorCaught(err)
             } else {
+                let loopBoundContext = context.loopBound
                 context.eventLoop.execute {
+                    let context = loopBoundContext.value
                     context.fireErrorCaught(err)
                 }
             }
@@ -998,7 +1008,8 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         let connectPromise = channel.eventLoop.makePromise(of: Void.self)
         channel.connect(to: address, promise: connectPromise)
         let cancelTask = channel.eventLoop.scheduleTask(in: self.connectTimeout) {
-            connectPromise.fail(ChannelError.connectTimeout(self.connectTimeout))
+            [connectTimeout = self.connectTimeout] in
+            connectPromise.fail(ChannelError.connectTimeout(connectTimeout))
             channel.close(promise: nil)
         }
 
@@ -1147,8 +1158,8 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         @inline(__always)
         func setupChannel() -> EventLoopFuture<Channel> {
             eventLoop.assertInEventLoop()
-            return channelOptions.applyAllChannelOptions(to: channel).flatMap {
-                if let bindTarget = self.bindTarget {
+            return channelOptions.applyAllChannelOptions(to: channel).flatMap { [bindTarget = self.bindTarget] in
+                if let bindTarget = bindTarget {
                     return channel.bind(to: bindTarget).flatMap {
                         channelInitializer(channel)
                     }

--- a/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -119,10 +119,12 @@ public final class ApplicationProtocolNegotiationHandler: ChannelInboundHandler,
 
     private func invokeUserClosure(context: ChannelHandlerContext, result: ALPNResult) {
         let switchFuture = self.completionHandler(result, context.channel)
+        let loopBoundSelfAndContext = NIOLoopBound((self, context), eventLoop: context.eventLoop)
 
         switchFuture
             .hop(to: context.eventLoop)
             .whenComplete { result in
+                let (`self`, context) = loopBoundSelfAndContext.value
                 self.userFutureCompleted(context: context, result: result)
             }
     }

--- a/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2023-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -125,10 +125,12 @@ public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResu
 
     private func invokeUserClosure(context: ChannelHandlerContext, result: ALPNResult) {
         let switchFuture = self.completionHandler(result, context.channel)
+        let loopBoundSelfAndContext = NIOLoopBound((self, context), eventLoop: context.eventLoop)
 
         switchFuture
             .hop(to: context.eventLoop)
             .whenComplete { result in
+                let (`self`, context) = loopBoundSelfAndContext.value
                 self.userFutureCompleted(context: context, result: result)
             }
     }

--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -118,6 +118,7 @@ private final class WebServerHandler: ChannelDuplexHandler {
     }
 
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let loopBoundContext = context.loopBound
         switch Self.unwrapOutboundIn(data) {
         case .head(var head):
             head.headers.replaceOrAdd(name: "connection", value: "close")
@@ -127,6 +128,7 @@ private final class WebServerHandler: ChannelDuplexHandler {
             context.write(data, promise: promise)
         case .end:
             context.write(data).map {
+                let context = loopBoundContext.value
                 context.close(promise: nil)
             }.cascade(to: promise)
         }

--- a/Sources/NIOWebSocket/WebSocketProtocolErrorHandler.swift
+++ b/Sources/NIOWebSocket/WebSocketProtocolErrorHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -25,6 +25,7 @@ public final class WebSocketProtocolErrorHandler: ChannelInboundHandler {
     public init() {}
 
     public func errorCaught(context: ChannelHandlerContext, error: Error) {
+        let loopBoundContext = context.loopBound
         if let error = error as? NIOWebSocketError {
             var data = context.channel.allocator.buffer(capacity: 2)
             data.write(webSocketErrorCode: WebSocketErrorCode(error))
@@ -34,6 +35,7 @@ public final class WebSocketProtocolErrorHandler: ChannelInboundHandler {
                 data: data
             )
             context.writeAndFlush(Self.wrapOutboundOut(frame)).whenComplete { (_: Result<Void, Error>) in
+                let context = loopBoundContext.value
                 context.close(promise: nil)
             }
         }

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -200,8 +200,8 @@ private final class UpgradeDelayClientUpgrader: TypedAndUntypedHTTPClientProtoco
     fileprivate func upgrade(context: ChannelHandlerContext, upgradeResponse: HTTPResponseHead) -> EventLoopFuture<Void>
     {
         self.upgradePromise = context.eventLoop.makePromise()
-        return self.upgradePromise!.futureResult.flatMap {
-            context.pipeline.addHandler(self.upgradedHandler)
+        return self.upgradePromise!.futureResult.flatMap { [pipeline = context.pipeline] in
+            pipeline.addHandler(self.upgradedHandler)
         }
     }
 
@@ -1104,10 +1104,12 @@ final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
             handlerType: NIOTypedHTTPClientUpgradeHandler<Bool>.self
         )
 
+        let loopBoundContext = context.loopBound
         try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0))
             .wait()
         upgradeResult.whenSuccess { result in
             if result {
+                let context = loopBoundContext.value
                 upgradeCompletionHandler(context)
             }
         }

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -251,8 +251,8 @@ class HTTPDecoderTest: XCTestCase {
                 let part = Self.unwrapInboundIn(data)
                 switch part {
                 case .end:
-                    _ = context.pipeline.removeHandler(self).flatMap { _ in
-                        context.pipeline.addHandler(self.collector)
+                    _ = context.pipeline.removeHandler(self).flatMap { [pipeline = context.pipeline] _ in
+                        pipeline.addHandler(self.collector)
                     }
                 default:
                     // ignore
@@ -324,8 +324,8 @@ class HTTPDecoderTest: XCTestCase {
                 let part = Self.unwrapInboundIn(data)
                 switch part {
                 case .end:
-                    _ = context.pipeline.removeHandler(self).flatMap { _ in
-                        context.pipeline.addHandler(ByteCollector())
+                    _ = context.pipeline.removeHandler(self).flatMap { [pipeline = context.pipeline] _ in
+                        pipeline.addHandler(ByteCollector())
                     }
                     break
                 default:

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -109,6 +109,7 @@ class HTTPServerClientTest: XCTestCase {
         }
 
         public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            let loopBoundContext = context.loopBound
             switch Self.unwrapInboundIn(data) {
             case .head(let req):
                 switch req.uri {
@@ -129,6 +130,7 @@ class HTTPServerClientTest: XCTestCase {
                     context.write(Self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
+                        let context = loopBoundContext.value
                         self.sentEnd = true
                         self.maybeClose(context: context)
                     }
@@ -154,6 +156,7 @@ class HTTPServerClientTest: XCTestCase {
                     context.write(Self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
+                        let context = loopBoundContext.value
                         self.sentEnd = true
                         self.maybeClose(context: context)
                     }
@@ -184,6 +187,7 @@ class HTTPServerClientTest: XCTestCase {
                     context.write(Self.wrapOutboundOut(.end(trailers))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
+                        let context = loopBoundContext.value
                         self.sentEnd = true
                         self.maybeClose(context: context)
                     }
@@ -208,6 +212,7 @@ class HTTPServerClientTest: XCTestCase {
                     context.write(Self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
+                        let context = loopBoundContext.value
                         self.sentEnd = true
                         self.maybeClose(context: context)
                     }
@@ -221,6 +226,7 @@ class HTTPServerClientTest: XCTestCase {
                     context.write(Self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
+                        let context = loopBoundContext.value
                         self.sentEnd = true
                         self.maybeClose(context: context)
                     }
@@ -233,6 +239,7 @@ class HTTPServerClientTest: XCTestCase {
                     context.write(Self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
+                        let context = loopBoundContext.value
                         self.sentEnd = true
                         self.maybeClose(context: context)
                     }
@@ -251,6 +258,7 @@ class HTTPServerClientTest: XCTestCase {
                     context.write(Self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
+                        let context = loopBoundContext.value
                         self.sentEnd = true
                         self.maybeClose(context: context)
                     }
@@ -271,6 +279,7 @@ class HTTPServerClientTest: XCTestCase {
                     context.write(Self.wrapOutboundOut(.end(nil))).recover { error in
                         XCTFail("unexpected error \(error)")
                     }.whenComplete { (_: Result<Void, Error>) in
+                        let context = loopBoundContext.value
                         self.sentEnd = true
                         self.maybeClose(context: context)
                     }

--- a/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerPipelineHandlerTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -912,11 +912,13 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
             }
 
             func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+                let loopBoundContext = context.loopBound
                 switch Self.unwrapInboundIn(data) {
                 case .head:
                     // We dispatch this to the event loop so that it doesn't happen immediately but rather can be
                     // run from the driving test code whenever it wants by running the EmbeddedEventLoop.
                     context.eventLoop.execute {
+                        let context = loopBoundContext.value
                         context.writeAndFlush(
                             Self.wrapOutboundOut(
                                 .head(
@@ -937,6 +939,7 @@ class HTTPServerPipelineHandlerTest: XCTestCase {
                     // We dispatch this to the event loop so that it doesn't happen immediately but rather can be
                     // run from the driving test code whenever it wants by running the EmbeddedEventLoop.
                     context.eventLoop.execute {
+                        let context = loopBoundContext.value
                         context.writeAndFlush(Self.wrapOutboundOut(.end(nil)), promise: nil)
                     }
                     XCTAssertEqual(.reqEndExpected, self.state)

--- a/Tests/NIOPosixTests/ChannelNotificationTest.swift
+++ b/Tests/NIOPosixTests/ChannelNotificationTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -138,8 +138,8 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNil(self.connectPromise)
             XCTAssertNil(self.closePromise)
 
-            promise!.futureResult.whenSuccess {
-                XCTAssertFalse(context.channel.isActive)
+            promise!.futureResult.whenSuccess { [channel = context.channel] in
+                XCTAssertFalse(channel.isActive)
             }
 
             self.registerPromise = promise
@@ -157,8 +157,8 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNil(self.connectPromise)
             XCTAssertNil(self.closePromise)
 
-            promise!.futureResult.whenSuccess {
-                XCTAssertTrue(context.channel.isActive)
+            promise!.futureResult.whenSuccess { [channel = context.channel] in
+                XCTAssertTrue(channel.isActive)
             }
 
             self.connectPromise = promise
@@ -170,8 +170,8 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNotNil(self.connectPromise)
             XCTAssertNil(self.closePromise)
 
-            promise!.futureResult.whenSuccess {
-                XCTAssertFalse(context.channel.isActive)
+            promise!.futureResult.whenSuccess { [channel = context.channel] in
+                XCTAssertFalse(channel.isActive)
             }
 
             self.closePromise = promise
@@ -248,8 +248,8 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNil(self.registerPromise)
 
             let p = promise ?? context.eventLoop.makePromise()
-            p.futureResult.whenSuccess {
-                XCTAssertFalse(context.channel.isActive)
+            p.futureResult.whenSuccess { [channel = context.channel] in
+                XCTAssertFalse(channel.isActive)
             }
 
             self.registerPromise = p
@@ -354,8 +354,8 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNil(self.closePromise)
 
             let p = promise ?? context.eventLoop.makePromise()
-            p.futureResult.whenSuccess {
-                XCTAssertFalse(context.channel.isActive)
+            p.futureResult.whenSuccess { [channel = context.channel] in
+                XCTAssertFalse(channel.isActive)
             }
 
             self.registerPromise = p
@@ -373,8 +373,8 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNil(self.bindPromise)
             XCTAssertNil(self.closePromise)
 
-            promise?.futureResult.whenSuccess {
-                XCTAssertTrue(context.channel.isActive)
+            promise?.futureResult.whenSuccess { [channel = context.channel] in
+                XCTAssertTrue(channel.isActive)
             }
 
             self.bindPromise = promise
@@ -387,8 +387,8 @@ class ChannelNotificationTest: XCTestCase {
             XCTAssertNil(self.closePromise)
 
             let p = promise ?? context.eventLoop.makePromise()
-            p.futureResult.whenSuccess {
-                XCTAssertFalse(context.channel.isActive)
+            p.futureResult.whenSuccess { [channel = context.channel] in
+                XCTAssertFalse(channel.isActive)
             }
 
             self.closePromise = p

--- a/Tests/NIOPosixTests/ChannelPipelineTest.swift
+++ b/Tests/NIOPosixTests/ChannelPipelineTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -803,7 +803,9 @@ class ChannelPipelineTest: XCTestCase {
         buffer.writeStaticString("Hello, world!")
 
         let removalPromise = channel.eventLoop.makePromise(of: Void.self)
+        let loopBoundContext = context.loopBound
         removalPromise.futureResult.whenSuccess {
+            let context = loopBoundContext.value
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
         }
@@ -845,7 +847,9 @@ class ChannelPipelineTest: XCTestCase {
 
         XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
         XCTAssertNoThrow(try channel.throwIfErrorCaught())
+        let loopBoundContext = context.loopBound
         channel.pipeline.syncOperations.removeHandler(context: context).whenSuccess {
+            let context = loopBoundContext.value
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
         }
@@ -873,7 +877,9 @@ class ChannelPipelineTest: XCTestCase {
         buffer.writeStaticString("Hello, world!")
 
         let removalPromise = channel.eventLoop.makePromise(of: Void.self)
+        let loopBoundContext = context.loopBound
         removalPromise.futureResult.map {
+            let context = loopBoundContext._value
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
         }.whenFailure {
@@ -912,7 +918,9 @@ class ChannelPipelineTest: XCTestCase {
 
         XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
         XCTAssertNoThrow(try channel.throwIfErrorCaught())
+        let loopBoundContext = context.loopBound
         channel.pipeline.removeHandler(name: "TestHandler").whenSuccess {
+            let context = loopBoundContext.value
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
         }
@@ -941,7 +949,9 @@ class ChannelPipelineTest: XCTestCase {
         buffer.writeStaticString("Hello, world!")
 
         let removalPromise = channel.eventLoop.makePromise(of: Void.self)
+        let loopBoundContext = context.loopBound
         removalPromise.futureResult.whenSuccess {
+            let context = loopBoundContext.value
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
         }
@@ -979,7 +989,9 @@ class ChannelPipelineTest: XCTestCase {
 
         XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
         XCTAssertNoThrow(try channel.throwIfErrorCaught())
+        let loopBoundContext = context.loopBound
         channel.pipeline.removeHandler(handler).whenSuccess {
+            let context = loopBoundContext.value
             context.writeAndFlush(NIOAny(buffer), promise: nil)
             context.fireErrorCaught(DummyError())
         }
@@ -1403,7 +1415,9 @@ class ChannelPipelineTest: XCTestCase {
                 self.removeHandlerCalls += 1
                 XCTAssertEqual(1, self.removeHandlerCalls)
                 self.removalTriggeredPromise.succeed(())
+                let loopBoundContext = context.loopBound
                 self.continueRemovalFuture.whenSuccess {
+                    let context = loopBoundContext.value
                     context.leavePipeline(removalToken: removalToken)
                 }
             }

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -542,7 +542,9 @@ public final class EventLoopTest: XCTestCase {
                 }
                 XCTAssertTrue(context.channel.isActive)
                 self.closePromise = context.eventLoop.makePromise()
+                let loopBoundContext = context.loopBound
                 self.closePromise!.futureResult.whenSuccess {
+                    let context = loopBoundContext.value
                     context.close(mode: mode, promise: promise)
                 }
                 promiseRegisterCallback(self.closePromise!)

--- a/Tests/NIOPosixTests/IdleStateHandlerTest.swift
+++ b/Tests/NIOPosixTests/IdleStateHandlerTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -37,7 +37,7 @@ class IdleStateHandlerTest: XCTestCase {
     }
 
     private func testIdle(
-        _ handler: IdleStateHandler,
+        _ handler: @escaping @Sendable @autoclosure () -> IdleStateHandler,
         _ writeToChannel: Bool,
         _ assertEventFn: @escaping (IdleStateHandler.IdleStateEvent) -> Bool
     ) throws {
@@ -86,6 +86,7 @@ class IdleStateHandlerTest: XCTestCase {
                 .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
                     channel.eventLoop.makeCompletedFuture {
+                        let handler = handler()
                         try channel.pipeline.syncOperations.addHandler(handler)
                         try channel.pipeline.syncOperations.addHandler(TestWriteHandler(writeToChannel, assertEventFn))
                     }

--- a/Tests/NIOPosixTests/SocketChannelTest.swift
+++ b/Tests/NIOPosixTests/SocketChannelTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -550,7 +550,9 @@ public final class SocketChannelTest: XCTestCase {
                 XCTAssertEqual(.inactive, state)
                 state = .removed
 
+                let loopBoundContext = context.loopBound
                 context.channel.closeFuture.whenComplete { (_: Result<Void, Error>) in
+                    let context = loopBoundContext.value
                     XCTAssertNil(context.localAddress)
                     XCTAssertNil(context.remoteAddress)
 

--- a/Tests/NIOPosixTests/StreamChannelsTest.swift
+++ b/Tests/NIOPosixTests/StreamChannelsTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2024 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -486,9 +486,11 @@ class StreamChannelTest: XCTestCase {
                     // raise the high water mark so we don't get another call straight away.
                     var buffer = context.channel.allocator.buffer(capacity: 5)
                     buffer.writeString("hello")
+                    let loopBoundContext = context.loopBound
                     context.channel.setOption(.writeBufferWaterMark, value: .init(low: 1024, high: 1024))
                         .flatMap {
-                            context.writeAndFlush(Self.wrapOutboundOut(buffer))
+                            let context = loopBoundContext.value
+                            return context.writeAndFlush(Self.wrapOutboundOut(buffer))
                         }.whenFailure { error in
                             XCTFail("unexpected error: \(error)")
                         }
@@ -638,7 +640,9 @@ class StreamChannelTest: XCTestCase {
                     XCTFail("unexpected error \(error)")
                 }
 
+                let loopBoundContext = context.loopBound
                 context.eventLoop.execute {
+                    let context = loopBoundContext.value
                     self.kickOff(context: context)
                 }
             }
@@ -648,26 +652,34 @@ class StreamChannelTest: XCTestCase {
             }
 
             func kickOff(context: ChannelHandlerContext) {
-                var buffer = context.channel.allocator.buffer(capacity: self.chunkSize)
-                buffer.writeBytes(Array(repeating: UInt8(ascii: "0"), count: chunkSize))
+                let buffer = NIOLoopBoundBox(
+                    context.channel.allocator.buffer(capacity: self.chunkSize),
+                    eventLoop: context.eventLoop
+                )
+                buffer.value.writeBytes(Array(repeating: UInt8(ascii: "0"), count: chunkSize))
 
+                let loopBoundContext = context.loopBound
+                let loopBoundSelf = NIOLoopBound(self, eventLoop: context.eventLoop)
                 func writeOneMore() {
-                    self.bytesWritten += buffer.readableBytes
-                    context.writeAndFlush(Self.wrapOutboundOut(buffer)).whenFailure { error in
+                    let context = loopBoundContext.value
+                    self.bytesWritten += buffer.value.readableBytes
+                    context.writeAndFlush(Self.wrapOutboundOut(buffer.value)).whenFailure { error in
                         XCTFail("unexpected error \(error)")
                     }
                     context.eventLoop.scheduleTask(in: .microseconds(100)) {
+                        let context = loopBoundContext.value
                         switch self.state {
                         case .writingUntilFull:
                             // We're just enqueuing another chunk.
                             writeOneMore()
                         case .writeSentinel:
+                            let `self` = loopBoundSelf.value
                             // We've seen the notification that the channel is unwritable, let's write one more byte.
-                            buffer.clear()
-                            buffer.writeString("1")
+                            buffer.value.clear()
+                            buffer.value.writeString("1")
                             self.state = .done
                             self.bytesWritten += 1
-                            context.writeAndFlush(Self.wrapOutboundOut(buffer)).whenFailure { error in
+                            context.writeAndFlush(Self.wrapOutboundOut(buffer.value)).whenFailure { error in
                                 XCTFail("unexpected error \(error)")
                             }
                             self.wroteEnoughToBeStuckPromise.succeed(self.bytesWritten)
@@ -692,7 +704,9 @@ class StreamChannelTest: XCTestCase {
                     ()  // ignored, we're done
                 }
                 context.fireChannelWritabilityChanged()
+                let loopBoundContext = context.loopBound
                 self.wroteEnoughToBeStuckPromise.futureResult.whenSuccess { _ in
+                    let context = loopBoundContext.value
                     context.pipeline.removeHandler(self).whenFailure { error in
                         XCTFail("unexpected error \(error)")
                     }


### PR DESCRIPTION
### Motivation:

Opening the `swift-nio` repository made me warning blind because there were always so many trivially fixable warnings about things that were correct but cannot be understood by the compiler.

### Modifications:

Fix all the sendable warnings that popped up, except for one test where `NIOLockedValueBox<Thread?>` isn't sendable because `Foundation.Thread` seemingly isn't `Sendable` which is odd. Guessing that'll be fixed on their end.

### Result:

- Fewer warnings
- Less warning-blindness
- More checks