### PR TITLE
fix remaining warnings & enable -warnings-as-errors in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_nightly_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   cxx-interop:

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -377,15 +377,9 @@ extension ByteBufferAllocator {
 }
 
 // MARK: - Conformances
-#if compiler(>=6.0)
-extension ByteBufferView: @retroactive ContiguousBytes {}
-extension ByteBufferView: @retroactive DataProtocol {}
-extension ByteBufferView: @retroactive MutableDataProtocol {}
-#else
 extension ByteBufferView: ContiguousBytes {}
 extension ByteBufferView: DataProtocol {}
 extension ByteBufferView: MutableDataProtocol {}
-#endif
 
 extension ByteBufferView {
     public typealias Regions = CollectionOfOne<ByteBufferView>

--- a/Tests/NIOPosixTests/EchoServerClientTest.swift
+++ b/Tests/NIOPosixTests/EchoServerClientTest.swift
@@ -224,7 +224,7 @@ class EchoServerClientTest: XCTestCase {
 
         try withTemporaryUnixDomainSocketPathName { udsPath in
             // Bootstrap should not overwrite an existing file unless it is a socket
-            FileManager.default.createFile(atPath: udsPath, contents: nil, attributes: nil)
+            _ = FileManager.default.createFile(atPath: udsPath, contents: nil, attributes: nil)
             let bootstrap = ServerBootstrap(group: group)
 
             XCTAssertThrowsError(

--- a/Tests/NIOPosixTests/SALEventLoopTests.swift
+++ b/Tests/NIOPosixTests/SALEventLoopTests.swift
@@ -59,16 +59,12 @@ final class SALEventLoopTests: XCTestCase, SALTest {
                 }
 
                 // Now execute 10 tasks.
-                var i = 0
                 for _ in 0..<10 {
-                    thisLoop.execute {
-                        i &+= 1
-                    }
+                    thisLoop.execute {}
                 }
 
                 // Now enqueue a "last" task.
                 thisLoop.execute {
-                    i &+= 1
                     promise.succeed(())
                 }
 

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -127,7 +127,7 @@ func withTemporaryUnixDomainSocketPathName<T>(
         shortEnoughPath = path
         restoreSavedCWD = false
     } catch SocketAddressError.unixDomainSocketPathTooLong {
-        FileManager.default.changeCurrentDirectoryPath(
+        _ = FileManager.default.changeCurrentDirectoryPath(
             URL(fileURLWithPath: path).deletingLastPathComponent().absoluteString
         )
         shortEnoughPath = URL(fileURLWithPath: path).lastPathComponent
@@ -141,7 +141,7 @@ func withTemporaryUnixDomainSocketPathName<T>(
             try? FileManager.default.removeItem(atPath: path)
         }
         if restoreSavedCWD {
-            FileManager.default.changeCurrentDirectoryPath(saveCurrentDirectory)
+            _ = FileManager.default.changeCurrentDirectoryPath(saveCurrentDirectory)
         }
     }
     return try body(shortEnoughPath)


### PR DESCRIPTION
### Motivation:

Warnings are annoying.

### Modifications:

- Remove unnecessary use of `Foundation.Thread` which isn't Sendable.
- Remove now unnecessary `@retroactive`s.
- Enable `-warnings-as-errors` in CI

### Result:

- Warnings can't sneak in as easily anymore
- No more warnings left in `swift-nio`

```
$ rm -rf .build/arm64-apple-macosx/ && swift build --build-tests -Xswiftc -warnings-as-errors > /dev/null
echo $?
$ echo $?
0
```