### PR TITLE
Cxx interop CI appends swiftSettings

### DIFF
--- a/scripts/check-cxx-interop-compatibility.sh
+++ b/scripts/check-cxx-interop-compatibility.sh
@@ -33,7 +33,7 @@ swift package init
 
 {
   echo "let swiftSettings: [SwiftSetting] = [.interoperabilityMode(.Cxx)]"
-  echo "for target in package.targets { target.swiftSettings = swiftSettings }"
+  echo "for target in package.targets { target.swiftSettings = (target.swiftSettings ?? []) + swiftSettings }"
 } >> Package.swift
 
 echo "package.dependencies.append(.package(path: \"$source_dir\"))" >> Package.swift


### PR DESCRIPTION
Cxx interop CI appends `swiftSettings` to any existing settings rather than overriding them.

### Motivation:

This better accommodates workflows for example which use Swift 5 language mode on a per-target basis.

### Modifications:
Cxx interop CI appends `swiftSettings` to any existing settings rather than overriding them.

### Result:

Cxx interop CI jobs don't cause unexpected build configurations.
