### PR TITLE
Use the new Android overlay in the tests and update some Bionic declarations

### DIFF
--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -452,21 +452,12 @@ internal func libc_confstr(
 #endif
 
 /// fts(3)
-#if os(Android)
-internal func libc_fts_open(
-    _ path: [UnsafeMutablePointer<CInterop.PlatformChar>],
-    _ options: CInt
-) -> UnsafeMutablePointer<CInterop.FTS> {
-    fts_open(path, options, nil)!
-}
-#else
 internal func libc_fts_open(
     _ path: [UnsafeMutablePointer<CInterop.PlatformChar>?],
     _ options: CInt
 ) -> UnsafeMutablePointer<CInterop.FTS> {
-    fts_open(path, options, nil)
+    fts_open(path, options, nil)!
 }
-#endif
 
 /// fts(3)
 internal func libc_fts_read(

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -124,12 +124,20 @@ private let sysWritev = sysWritev_wrapper
 #elseif !os(Windows)
 private let sysWritev: @convention(c) (Int32, UnsafePointer<iovec>?, CInt) -> CLong = writev
 #endif
-#if !os(Windows)
+#if canImport(Android)
+private let sysRecvMsg: @convention(c) (CInt, UnsafeMutablePointer<msghdr>, CInt) -> ssize_t = recvmsg
+private let sysSendMsg: @convention(c) (CInt, UnsafePointer<msghdr>, CInt) -> ssize_t = sendmsg
+#elseif !os(Windows)
 private let sysRecvMsg: @convention(c) (CInt, UnsafeMutablePointer<msghdr>?, CInt) -> ssize_t = recvmsg
 private let sysSendMsg: @convention(c) (CInt, UnsafePointer<msghdr>?, CInt) -> ssize_t = sendmsg
 #endif
 private let sysDup: @convention(c) (CInt) -> CInt = dup
-#if !os(Windows)
+#if canImport(Android)
+private let sysGetpeername:
+    @convention(c) (CInt, UnsafeMutablePointer<sockaddr>, UnsafeMutablePointer<socklen_t>) -> CInt = getpeername
+private let sysGetsockname:
+    @convention(c) (CInt, UnsafeMutablePointer<sockaddr>, UnsafeMutablePointer<socklen_t>) -> CInt = getsockname
+#elseif !os(Windows)
 private let sysGetpeername:
     @convention(c) (CInt, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> CInt = getpeername
 private let sysGetsockname:
@@ -141,7 +149,9 @@ private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>) -> CUnsigned
 #else
 private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsignedInt = if_nametoindex
 #endif
-#if !os(Windows)
+#if canImport(Android)
+private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>) -> CInt = socketpair
+#elseif !os(Windows)
 private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>?) -> CInt = socketpair
 #endif
 
@@ -1000,7 +1010,7 @@ internal enum Posix {
         socketVector: UnsafeMutablePointer<CInt>?
     ) throws {
         _ = try syscall(blocking: false) {
-            sysSocketpair(domain.rawValue, type.rawValue, protocolSubtype.rawValue, socketVector)
+            sysSocketpair(domain.rawValue, type.rawValue, protocolSubtype.rawValue, socketVector!)
         }
     }
     #endif

--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
@@ -22,8 +22,8 @@ import XCTest
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 #error("The Concurrency helpers test module was unable to identify your C library.")
 #endif

--- a/Tests/NIOCoreTests/XCTest+Extensions.swift
+++ b/Tests/NIOCoreTests/XCTest+Extensions.swift
@@ -15,6 +15,10 @@
 import NIOCore
 import XCTest
 
+#if canImport(Android)
+import Android
+#endif
+
 func assert(
     _ condition: @autoclosure () -> Bool,
     within time: TimeAmount,

--- a/Tests/NIOEmbeddedTests/TestUtils.swift
+++ b/Tests/NIOEmbeddedTests/TestUtils.swift
@@ -17,6 +17,10 @@ import NIOConcurrencyHelpers
 import NIOCore
 import XCTest
 
+#if canImport(Android)
+import Android
+#endif
+
 // FIXME: Duplicated with NIO
 func assert(
     _ condition: @autoclosure () -> Bool,

--- a/Tests/NIOFileSystemTests/FileInfoTests.swift
+++ b/Tests/NIOFileSystemTests/FileInfoTests.swift
@@ -19,8 +19,8 @@ import _NIOFileSystem
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #endif
 
 final class FileInfoTests: XCTestCase {
@@ -44,7 +44,7 @@ final class FileInfoTests: XCTestCase {
         status.st_birthtimespec = timespec(tv_sec: 3, tv_nsec: 0)
         status.st_flags = 11
         status.st_gen = 12
-        #elseif canImport(Glibc) || canImport(Bionic)
+        #elseif canImport(Glibc) || canImport(Android)
         status.st_atim = timespec(tv_sec: 0, tv_nsec: 0)
         status.st_mtim = timespec(tv_sec: 1, tv_nsec: 0)
         status.st_ctim = timespec(tv_sec: 2, tv_nsec: 0)
@@ -98,7 +98,7 @@ final class FileInfoTests: XCTestCase {
         assertNotEqualAfterMutation { $0.platformSpecificStatus!.st_birthtimespec.tv_sec += 1 }
         assertNotEqualAfterMutation { $0.platformSpecificStatus!.st_flags += 1 }
         assertNotEqualAfterMutation { $0.platformSpecificStatus!.st_gen += 1 }
-        #elseif canImport(Glibc) || canImport(Bionic)
+        #elseif canImport(Glibc) || canImport(Android)
         assertNotEqualAfterMutation { $0.platformSpecificStatus!.st_atim.tv_sec += 1 }
         assertNotEqualAfterMutation { $0.platformSpecificStatus!.st_mtim.tv_sec += 1 }
         assertNotEqualAfterMutation { $0.platformSpecificStatus!.st_ctim.tv_sec += 1 }
@@ -151,7 +151,7 @@ final class FileInfoTests: XCTestCase {
         }
         assertDifferentHashValueAfterMutation { $0.platformSpecificStatus!.st_flags += 1 }
         assertDifferentHashValueAfterMutation { $0.platformSpecificStatus!.st_gen += 1 }
-        #elseif canImport(Glibc) || canImport(Bionic)
+        #elseif canImport(Glibc) || canImport(Android)
         assertDifferentHashValueAfterMutation { $0.platformSpecificStatus!.st_atim.tv_sec += 1 }
         assertDifferentHashValueAfterMutation { $0.platformSpecificStatus!.st_mtim.tv_sec += 1 }
         assertDifferentHashValueAfterMutation { $0.platformSpecificStatus!.st_ctim.tv_sec += 1 }

--- a/Tests/NIOFileSystemTests/FileTypeTests.swift
+++ b/Tests/NIOFileSystemTests/FileTypeTests.swift
@@ -19,6 +19,8 @@ import XCTest
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #endif
 
 final class FileTypeTests: XCTestCase {


### PR DESCRIPTION
### Motivation:

Get this repo building again for Android with NDK 27

### Modifications:

- Update some networking declarations for newly added nullability annotations
- Import the new Android overlay instead in some tests
- Add two force-unwraps on all platforms, that are needed for Android

### Result:

This repo and its tests build for Android again

I've been [using these patches on my Android CI](https://github.com/finagolfin/swift-android-sdk/blob/main/swift-nio-ndk27.patch) and natively on Android for a couple months now. I didn't bother keeping this patch building for Android with Swift 5 anymore, as my Android CI no longer tests Swift 5.

I built this pull and ran the tests on linux x86_64 to make sure there was no regression.