### PR TITLE
GHA: Separate matrix input handling

### DIFF
--- a/.github/workflows/swift_load_test_matrix.yml
+++ b/.github/workflows/swift_load_test_matrix.yml
@@ -1,0 +1,40 @@
+name: Matrix Load
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        type: string
+        description: "The name of the workflow used for the concurrency group."
+        required: true
+      matrix_path:
+        type: string
+        description: "The path of the test matrix definition."
+        default: ""
+
+jobs:
+  load-matrix:
+    name: Prepare matrices
+    runs-on: ubuntu-latest
+    outputs:
+      swift-matrix: ${{ steps.load-matrix.outputs.swift-matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Mark the workspace as safe
+        # https://github.com/actions/checkout/issues/766
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - id: load-matrix
+        run: |
+            printf "swift-matrix=%s" "$(jq -c '.' ${{ inputs.matrix_path }})" >> "$GITHUB_OUTPUT"
+
+  execute-matrix:
+    name: Execute matrix
+    needs: load-matrix
+    # Workaround https://github.com/nektos/act/issues/1875
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: ${{ inputs.name }}
+      matrix_string: '${{ needs.load-matrix.outputs.swift-matrix }}'

--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -7,14 +7,10 @@ on:
         type: string
         description: "The name of the workflow used for the concurrency group."
         required: true
-      matrix_path:
-        type: string
-        description: "The path of the test matrix definition."
-        default: ""
       matrix_string:
         type: string
         description: "The test matrix definition."
-        default: ""
+        required: true
 
 # We will cancel previously triggered workflow runs
 concurrency:
@@ -22,34 +18,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  generate-matrix:
-    name: Prepare matrices
-    runs-on: ubuntu-latest
-    outputs:
-      swift-matrix: ${{ steps.load-matrix.outputs.swift-matrix }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Mark the workspace as safe
-        # https://github.com/actions/checkout/issues/766
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-      - id: load-matrix
-        run: |
-          if [ -n '${{ inputs.matrix_string }}' ]; then
-            printf "swift-matrix=%s" "$(echo '${{ inputs.matrix_string }}' | jq -c '.')" >> "$GITHUB_OUTPUT"
-          else
-            printf "swift-matrix=%s" "$(jq -c '.' ${{ inputs.matrix_path }})" >> "$GITHUB_OUTPUT"
-          fi
-
   execute-matrix:
     name: ${{ matrix.swift.platform }} (${{ matrix.swift.name }})
-    needs: generate-matrix
     runs-on: ${{ matrix.swift.runner }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.swift-matrix) }}
+      matrix: ${{ fromJson(inputs.matrix_string) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation:

The new test matrix workflow is quite verbose in the most common case, unit tests, outputting two workflow entries for handling and preparing the matrix inputs.

In addition to this, it appeared that when running in `act` the matrix preparation step would run multiple times.

### Modifications:

* Prioritize the current most common case, string inputs, and skip the matrix preparation step in this case reducing the number of workflows run.
* Separate the path for loading the JSON matrix from a file into its own workflow.

### Result:

* Less noise in the output
* More reliable and efficient local matrix runs