### PR TITLE
Deprecate not-actually-public Base64 APIs

### DIFF
--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -733,13 +733,13 @@ extension ByteBuffer: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let base64String = try container.decode(String.self)
-        self = try ByteBuffer(bytes: base64String.decodeBase64())
+        self = try ByteBuffer(bytes: base64String._base64Decoded())
     }
 
     /// Encodes this buffer as a base64 string in a single value container.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        let base64String = String(encodingAsBase64: self.readableBytesView)
+        let base64String = String(_base64Encoding: self.readableBytesView)
         try container.encode(base64String)
     }
 }

--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -733,13 +733,13 @@ extension ByteBuffer: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let base64String = try container.decode(String.self)
-        self = try ByteBuffer(bytes: base64String.base64Decoded())
+        self = try ByteBuffer(bytes: base64String.decodeBase64())
     }
 
     /// Encodes this buffer as a base64 string in a single value container.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        let base64String = String(base64Encoding: self.readableBytesView)
+        let base64String = String(encodingAsBase64: self.readableBytesView)
         try container.encode(base64String)
     }
 }

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -149,7 +149,7 @@ extension NIOWebSocketClientUpgrader {
             UInt64.random(in: UInt64.min...UInt64.max, using: &generator),
             UInt64.random(in: UInt64.min...UInt64.max, using: &generator)
         )
-        return String(base64Encoding: buffer.readableBytesView)
+        return String(encodingAsBase64: buffer.readableBytesView)
     }
     /// Generates a random WebSocket Request Key by generating 16 bytes randomly using the `SystemRandomNumberGenerator` and encoding them as a base64 string as defined in RFC6455 https://tools.ietf.org/html/rfc6455#section-4.1.
     /// - Returns: base64 encoded request key
@@ -179,7 +179,7 @@ private func _shouldAllowUpgrade(upgradeResponse: HTTPResponseHead, requestKey: 
     var hasher = SHA1()
     hasher.update(string: requestKey)
     hasher.update(string: magicWebSocketGUID)
-    let expectedAcceptValue = String(base64Encoding: hasher.finish())
+    let expectedAcceptValue = String(encodingAsBase64: hasher.finish())
 
     return expectedAcceptValue == acceptValueHeader[0]
 }

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -149,7 +149,7 @@ extension NIOWebSocketClientUpgrader {
             UInt64.random(in: UInt64.min...UInt64.max, using: &generator),
             UInt64.random(in: UInt64.min...UInt64.max, using: &generator)
         )
-        return String(encodingAsBase64: buffer.readableBytesView)
+        return String(_base64Encoding: buffer.readableBytesView)
     }
     /// Generates a random WebSocket Request Key by generating 16 bytes randomly using the `SystemRandomNumberGenerator` and encoding them as a base64 string as defined in RFC6455 https://tools.ietf.org/html/rfc6455#section-4.1.
     /// - Returns: base64 encoded request key
@@ -179,7 +179,7 @@ private func _shouldAllowUpgrade(upgradeResponse: HTTPResponseHead, requestKey: 
     var hasher = SHA1()
     hasher.update(string: requestKey)
     hasher.update(string: magicWebSocketGUID)
-    let expectedAcceptValue = String(encodingAsBase64: hasher.finish())
+    let expectedAcceptValue = String(_base64Encoding: hasher.finish())
 
     return expectedAcceptValue == acceptValueHeader[0]
 }

--- a/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
@@ -303,7 +303,7 @@ private func _buildUpgradeResponse(
                 var hasher = SHA1()
                 hasher.update(string: key)
                 hasher.update(string: magicWebSocketGUID)
-                acceptValue = String(base64Encoding: hasher.finish())
+                acceptValue = String(encodingAsBase64: hasher.finish())
             }
 
             extraHeaders.replaceOrAdd(name: "Upgrade", value: "websocket")

--- a/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
@@ -15,6 +15,7 @@
 import CNIOSHA1
 import NIOCore
 import NIOHTTP1
+import _NIOBase64
 
 let magicWebSocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
@@ -303,7 +304,7 @@ private func _buildUpgradeResponse(
                 var hasher = SHA1()
                 hasher.update(string: key)
                 hasher.update(string: magicWebSocketGUID)
-                acceptValue = String(encodingAsBase64: hasher.finish())
+                acceptValue = String(_base64Encoding: hasher.finish())
             }
 
             extraHeaders.replaceOrAdd(name: "Upgrade", value: "websocket")

--- a/Sources/_NIOBase64/Base64.swift
+++ b/Sources/_NIOBase64/Base64.swift
@@ -16,15 +16,28 @@
 // https://github.com/fabianfett/swift-base64-kit
 
 extension String {
+    /// Base64 encode a collection of UInt8 to a string, without the use of Foundation.
+    @available(*, deprecated, message: "This API was unintentionally made public.")
+    @inlinable
+    public init<Buffer: Collection>(base64Encoding bytes: Buffer) where Buffer.Element == UInt8 {
+        self.init(encodingAsBase64: bytes)
+    }
+
+
+    @available(*, deprecated, message: "This API was unintentionally made public.")
+    @inlinable
+    public func base64Decoded() throws -> [UInt8] {
+        try self.decodeBase64()
+    }
 
     /// Base64 encode a collection of UInt8 to a string, without the use of Foundation.
     @inlinable
-    public init<Buffer: Collection>(base64Encoding bytes: Buffer) where Buffer.Element == UInt8 {
+    package init<Buffer: Collection>(encodingAsBase64 bytes: Buffer) where Buffer.Element == UInt8 {
         self = Base64.encode(bytes: bytes)
     }
 
     @inlinable
-    public func base64Decoded() throws -> [UInt8] {
+    package func decodeBase64() throws -> [UInt8] {
         try Base64.decode(string: self)
     }
 }

--- a/Sources/_NIOBase64/Base64.swift
+++ b/Sources/_NIOBase64/Base64.swift
@@ -20,23 +20,23 @@ extension String {
     @available(*, deprecated, message: "This API was unintentionally made public.")
     @inlinable
     public init<Buffer: Collection>(base64Encoding bytes: Buffer) where Buffer.Element == UInt8 {
-        self.init(encodingAsBase64: bytes)
+        self.init(_base64Encoding: bytes)
     }
 
     @available(*, deprecated, message: "This API was unintentionally made public.")
     @inlinable
     public func base64Decoded() throws -> [UInt8] {
-        try self.decodeBase64()
+        try self._base64Decoded()
     }
 
     /// Base64 encode a collection of UInt8 to a string, without the use of Foundation.
     @inlinable
-    package init<Buffer: Collection>(encodingAsBase64 bytes: Buffer) where Buffer.Element == UInt8 {
+    public init<Buffer: Collection>(_base64Encoding bytes: Buffer) where Buffer.Element == UInt8 {
         self = Base64.encode(bytes: bytes)
     }
 
     @inlinable
-    package func decodeBase64() throws -> [UInt8] {
+    public func _base64Decoded() throws -> [UInt8] {
         try Base64.decode(string: self)
     }
 }

--- a/Sources/_NIOBase64/Base64.swift
+++ b/Sources/_NIOBase64/Base64.swift
@@ -23,7 +23,6 @@ extension String {
         self.init(encodingAsBase64: bytes)
     }
 
-
     @available(*, deprecated, message: "This API was unintentionally made public.")
     @inlinable
     public func base64Decoded() throws -> [UInt8] {

--- a/Tests/NIOBase64Tests/Base64Test.swift
+++ b/Tests/NIOBase64Tests/Base64Test.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-
 import _NIOBase64
 
 class Base64Test: XCTestCase {

--- a/Tests/NIOBase64Tests/Base64Test.swift
+++ b/Tests/NIOBase64Tests/Base64Test.swift
@@ -13,8 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-
-@_spi(Package)
 import _NIOBase64
 
 class Base64Test: XCTestCase {

--- a/Tests/NIOBase64Tests/Base64Test.swift
+++ b/Tests/NIOBase64Tests/Base64Test.swift
@@ -13,58 +13,60 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+
+@_spi(Package)
 import _NIOBase64
 
 class Base64Test: XCTestCase {
     func testEncodeEmptyData() throws {
         let data = [UInt8]()
-        let encodedData = String(encodingAsBase64: data)
+        let encodedData = String(_base64Encoding: data)
         XCTAssertEqual(encodedData.count, 0)
     }
 
     func testBase64EncodingOfEmptyString() throws {
         let string = ""
-        let encoded = String(encodingAsBase64: string.utf8)
+        let encoded = String(_base64Encoding: string.utf8)
         XCTAssertEqual(encoded, "")
     }
 
     func testBase64DecodingOfEmptyString() throws {
         let encoded = ""
         XCTAssertNoThrow {
-            let decoded = try encoded.decodeBase64()
+            let decoded = try encoded._base64Decoded()
             XCTAssertEqual(decoded, [UInt8]())
         }
     }
 
     func testBase64EncodingArrayOfNulls() throws {
         let data = Array(repeating: UInt8(0), count: 10)
-        let encodedData = String(encodingAsBase64: data)
+        let encodedData = String(_base64Encoding: data)
         XCTAssertEqual(encodedData, "AAAAAAAAAAAAAA==")
     }
 
     func testBase64DecodeArrayOfNulls() throws {
         let encoded = "AAAAAAAAAAAAAA=="
-        let decoded = try! encoded.decodeBase64()
+        let decoded = try! encoded._base64Decoded()
         let expected = Array(repeating: UInt8(0), count: 10)
         XCTAssertEqual(decoded, expected)
     }
 
     func testBase64EncodeingHelloWorld() throws {
         let string = "Hello, world!"
-        let encoded = String(encodingAsBase64: string.utf8)
+        let encoded = String(_base64Encoding: string.utf8)
         let expected = "SGVsbG8sIHdvcmxkIQ=="
         XCTAssertEqual(encoded, expected)
     }
 
     func testBase64DecodeHelloWorld() throws {
         let encoded = "SGVsbG8sIHdvcmxkIQ=="
-        let decoded = try! encoded.decodeBase64()
+        let decoded = try! encoded._base64Decoded()
         XCTAssertEqual(decoded, "Hello, world!".utf8.map { UInt8($0) })
     }
 
     func testBase64EncodingAllTheBytesSequentially() throws {
         let data = Array(UInt8(0)...UInt8(255))
-        let encodedData = String(encodingAsBase64: data)
+        let encodedData = String(_base64Encoding: data)
         XCTAssertEqual(
             encodedData,
             "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w=="
@@ -73,14 +75,14 @@ class Base64Test: XCTestCase {
 
     func testBase64DecodingWithInvalidLength() {
         let encoded = "dGVzbA!=="
-        XCTAssertThrowsError(try encoded.decodeBase64()) { error in
+        XCTAssertThrowsError(try encoded._base64Decoded()) { error in
             XCTAssertEqual(error as? Base64Error, .invalidLength)
         }
     }
 
     func testBase64DecodeWithInvalidCharacter() throws {
         let encoded = "SGVsbG8sI_dvcmxkIQ=="
-        XCTAssertThrowsError(try encoded.decodeBase64()) { error in
+        XCTAssertThrowsError(try encoded._base64Decoded()) { error in
             XCTAssertEqual(error as? Base64Error, .invalidCharacter)
         }
     }

--- a/Tests/NIOBase64Tests/Base64Test.swift
+++ b/Tests/NIOBase64Tests/Base64Test.swift
@@ -14,58 +14,58 @@
 
 import XCTest
 
-@testable import _NIOBase64
+import _NIOBase64
 
 class Base64Test: XCTestCase {
     func testEncodeEmptyData() throws {
         let data = [UInt8]()
-        let encodedData = String(base64Encoding: data)
+        let encodedData = String(encodingAsBase64: data)
         XCTAssertEqual(encodedData.count, 0)
     }
 
     func testBase64EncodingOfEmptyString() throws {
         let string = ""
-        let encoded = String(base64Encoding: string.utf8)
+        let encoded = String(encodingAsBase64: string.utf8)
         XCTAssertEqual(encoded, "")
     }
 
     func testBase64DecodingOfEmptyString() throws {
         let encoded = ""
         XCTAssertNoThrow {
-            let decoded = try encoded.base64Decoded()
+            let decoded = try encoded.decodeBase64()
             XCTAssertEqual(decoded, [UInt8]())
         }
     }
 
     func testBase64EncodingArrayOfNulls() throws {
         let data = Array(repeating: UInt8(0), count: 10)
-        let encodedData = String(base64Encoding: data)
+        let encodedData = String(encodingAsBase64: data)
         XCTAssertEqual(encodedData, "AAAAAAAAAAAAAA==")
     }
 
     func testBase64DecodeArrayOfNulls() throws {
         let encoded = "AAAAAAAAAAAAAA=="
-        let decoded = try! encoded.base64Decoded()
+        let decoded = try! encoded.decodeBase64()
         let expected = Array(repeating: UInt8(0), count: 10)
         XCTAssertEqual(decoded, expected)
     }
 
     func testBase64EncodeingHelloWorld() throws {
         let string = "Hello, world!"
-        let encoded = String(base64Encoding: string.utf8)
+        let encoded = String(encodingAsBase64: string.utf8)
         let expected = "SGVsbG8sIHdvcmxkIQ=="
         XCTAssertEqual(encoded, expected)
     }
 
     func testBase64DecodeHelloWorld() throws {
         let encoded = "SGVsbG8sIHdvcmxkIQ=="
-        let decoded = try! encoded.base64Decoded()
+        let decoded = try! encoded.decodeBase64()
         XCTAssertEqual(decoded, "Hello, world!".utf8.map { UInt8($0) })
     }
 
     func testBase64EncodingAllTheBytesSequentially() throws {
         let data = Array(UInt8(0)...UInt8(255))
-        let encodedData = String(base64Encoding: data)
+        let encodedData = String(encodingAsBase64: data)
         XCTAssertEqual(
             encodedData,
             "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w=="
@@ -74,14 +74,14 @@ class Base64Test: XCTestCase {
 
     func testBase64DecodingWithInvalidLength() {
         let encoded = "dGVzbA!=="
-        XCTAssertThrowsError(try encoded.base64Decoded()) { error in
+        XCTAssertThrowsError(try encoded.decodeBase64()) { error in
             XCTAssertEqual(error as? Base64Error, .invalidLength)
         }
     }
 
     func testBase64DecodeWithInvalidCharacter() throws {
         let encoded = "SGVsbG8sI_dvcmxkIQ=="
-        XCTAssertThrowsError(try encoded.base64Decoded()) { error in
+        XCTAssertThrowsError(try encoded.decodeBase64()) { error in
             XCTAssertEqual(error as? Base64Error, .invalidCharacter)
         }
     }


### PR DESCRIPTION
Motivation:

The not-actually-public `_NIOBase64` module has public extensions on `String`. These are visible when transitively depending on `_NIOBase64` but shouldn't be.

Modifications:

- Add underscored variants
- Deprecate public variants

Result:

Stricter API