### PR TITLE
rename top matrix workflow object 'swift'->'config'

### DIFF
--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -19,8 +19,8 @@ concurrency:
 
 jobs:
   execute-matrix:
-    name: ${{ matrix.swift.platform }} (${{ matrix.swift.name }})
-    runs-on: ${{ matrix.swift.runner }}
+    name: ${{ matrix.config.platform }} (${{ matrix.config.name }})
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.matrix_string) }}
@@ -31,37 +31,37 @@ jobs:
           persist-credentials: false
           submodules: true
       - name: Pull Docker image
-        run: docker pull ${{ matrix.swift.image }}
+        run: docker pull ${{ matrix.config.image }}
       - name: Run matrix job
-        if: ${{ matrix.swift.platform != 'Windows' }}
+        if: ${{ matrix.config.platform != 'Windows' }}
         run: |
-          if [[ -n "${{ matrix.swift.setup_command }}" ]]; then
-            setup_command_expression="${{ matrix.swift.setup_command }} &&"
+          if [[ -n "${{ matrix.config.setup_command }}" ]]; then
+            setup_command_expression="${{ matrix.config.setup_command }} &&"
           else
             setup_command_expression=""
           fi
           workspace="/$(basename ${{ github.workspace }})"
           docker run -v ${{ github.workspace }}:"$workspace" \
             -w "$workspace" \
-            -e SWIFT_VERSION="${{ matrix.swift.swift_version }}" \
+            -e SWIFT_VERSION="${{ matrix.config.swift_version }}" \
             -e setup_command_expression="$setup_command_expression" \
             -e workspace="$workspace" \
-            ${{ matrix.swift.image }} \
-            bash -c "swift --version && git config --global --add safe.directory \"$workspace\" && $setup_command_expression ${{ matrix.swift.command }} ${{ matrix.swift.command_arguments }}"
+            ${{ matrix.config.image }} \
+            bash -c "swift --version && git config --global --add safe.directory \"$workspace\" && $setup_command_expression ${{ matrix.config.command }} ${{ matrix.config.command_arguments }}"
       - name: Run matrix job (Windows)
-        if: ${{ matrix.swift.platform == 'Windows' }}
+        if: ${{ matrix.config.platform == 'Windows' }}
         run: |
-          if (-not [string]::IsNullOrEmpty("${{ matrix.swift.setup_command }}")) {
-              $setup_command_expression = "${{ matrix.swift.setup_command }} &"
+          if (-not [string]::IsNullOrEmpty("${{ matrix.config.setup_command }}")) {
+              $setup_command_expression = "${{ matrix.config.setup_command }} &"
           } else {
               $setup_command_expression = ""
           }
           $workspace = "C:\" + (Split-Path ${{ github.workspace }} -Leaf)
           docker run -v ${{ github.workspace }}:$($workspace) `
             -w $($workspace) `
-            -e SWIFT_VERSION="${{ matrix.swift.swift_version }}" `
+            -e SWIFT_VERSION="${{ matrix.config.swift_version }}" `
             -e setup_command_expression=%setup_command_expression% `
-            ${{ matrix.swift.image }} `
-            cmd /s /c  "swift --version & powershell Invoke-Expression ""$($setup_command_expression) ${{ matrix.swift.command }} ${{ matrix.swift.command_arguments }}"""
+            ${{ matrix.config.image }} `
+            cmd /s /c  "swift --version & powershell Invoke-Expression ""$($setup_command_expression) ${{ matrix.config.command }} ${{ matrix.config.command_arguments }}"""
     env:
-      SWIFT_VERSION: ${{ matrix.swift.swift_version }}
+      SWIFT_VERSION: ${{ matrix.config.swift_version }}

--- a/scripts/generate_matrix.sh
+++ b/scripts/generate_matrix.sh
@@ -52,7 +52,7 @@ windows_nightly_main_runner="windows-2019"
 windows_nightly_main_container_image="swiftlang/swift:nightly-main-windowsservercore-1809"
 
 # Create matrix from inputs
-matrix='{"swift": []}'
+matrix='{"config": []}'
 
 ## Linux
 if [[ "$linux_5_9_enabled" == "true" || "$linux_5_10_enabled" == "true" || "$linux_6_0_enabled" == "true" || \
@@ -70,7 +70,7 @@ if [[ "$linux_5_9_enabled" == "true" ]]; then
     --arg command_arguments "$linux_5_9_command_arguments" \
     --arg container_image "$linux_5_9_container_image" \
     --arg runner "$linux_runner" \
-    '.swift[.swift| length] |= . + { "name": "5.9", "image": $container_image, "swift_version": "5.9", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
+    '.config[.config| length] |= . + { "name": "5.9", "image": $container_image, "swift_version": "5.9", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
 fi
 
 if [[ "$linux_5_10_enabled" == "true" ]]; then
@@ -80,7 +80,7 @@ if [[ "$linux_5_10_enabled" == "true" ]]; then
     --arg command_arguments "$linux_5_10_command_arguments" \
     --arg container_image "$linux_5_10_container_image" \
     --arg runner "$linux_runner" \
-    '.swift[.swift| length] |= . + { "name": "5.10", "image": $container_image, "swift_version": "5.10", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
+    '.config[.config| length] |= . + { "name": "5.10", "image": $container_image, "swift_version": "5.10", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
 fi
 
 if [[ "$linux_6_0_enabled" == "true" ]]; then
@@ -90,7 +90,7 @@ if [[ "$linux_6_0_enabled" == "true" ]]; then
     --arg command_arguments "$linux_6_0_command_arguments" \
     --arg container_image "$linux_6_0_container_image" \
     --arg runner "$linux_runner" \
-    '.swift[.swift| length] |= . + { "name": "6.0", "image": $container_image, "swift_version": "6.0", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
+    '.config[.config| length] |= . + { "name": "6.0", "image": $container_image, "swift_version": "6.0", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
 fi
 
 if [[ "$linux_nightly_6_0_enabled" == "true" ]]; then
@@ -100,7 +100,7 @@ if [[ "$linux_nightly_6_0_enabled" == "true" ]]; then
     --arg command_arguments "$linux_nightly_6_0_command_arguments" \
     --arg container_image "$linux_nightly_6_0_container_image" \
     --arg runner "$linux_runner" \
-    '.swift[.swift| length] |= . + { "name": "nightly-6.0", "image": $container_image, "swift_version": "nightly-6.0", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
+    '.config[.config| length] |= . + { "name": "nightly-6.0", "image": $container_image, "swift_version": "nightly-6.0", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
 fi
 
 if [[ "$linux_nightly_main_enabled" == "true" ]]; then
@@ -110,7 +110,7 @@ if [[ "$linux_nightly_main_enabled" == "true" ]]; then
     --arg command_arguments "$linux_nightly_main_command_arguments" \
     --arg container_image "$linux_nightly_main_container_image" \
     --arg runner "$linux_runner" \
-    '.swift[.swift| length] |= . + { "name": "nightly-main", "image": $container_image, "swift_version": "nightly-main", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
+    '.config[.config| length] |= . + { "name": "nightly-main", "image": $container_image, "swift_version": "nightly-main", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
 fi
 
 ## Windows
@@ -127,7 +127,7 @@ if [[ "$windows_6_0_enabled" == "true" ]]; then
     --arg command_arguments "$windows_6_0_command_arguments" \
     --arg container_image "$windows_6_0_container_image" \
     --arg runner "$windows_6_0_runner" \
-    '.swift[.swift| length] |= . + { "name": "6.0", "image": $container_image, "swift_version": "6.0", "platform": "Windows", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner }')
+    '.config[.config| length] |= . + { "name": "6.0", "image": $container_image, "swift_version": "6.0", "platform": "Windows", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner }')
 fi
 
 if [[ "$windows_nightly_6_0_enabled" == "true" ]]; then
@@ -137,7 +137,7 @@ if [[ "$windows_nightly_6_0_enabled" == "true" ]]; then
     --arg command_arguments "$windows_nightly_6_0_command_arguments" \
     --arg container_image "$windows_nightly_6_0_container_image" \
     --arg runner "$windows_nightly_6_0_runner" \
-    '.swift[.swift| length] |= . + { "name": "nightly-6.0", "image": $container_image, "swift_version": "nightly-6.0", "platform": "Windows", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner }')
+    '.config[.config| length] |= . + { "name": "nightly-6.0", "image": $container_image, "swift_version": "nightly-6.0", "platform": "Windows", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner }')
 fi
 
 if [[ "$windows_nightly_main_enabled" == "true" ]]; then
@@ -147,7 +147,7 @@ if [[ "$windows_nightly_main_enabled" == "true" ]]; then
     --arg command_arguments "$windows_nightly_main_command_arguments" \
     --arg container_image "$windows_nightly_main_container_image" \
     --arg runner "$windows_nightly_main_runner" \
-    '.swift[.swift| length] |= . + { "name": "nightly-main", "image": $container_image, "swift_version": "nightly-main", "platform": "Windows", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner }')
+    '.config[.config| length] |= . + { "name": "nightly-main", "image": $container_image, "swift_version": "nightly-main", "platform": "Windows", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner }')
 fi
 
 echo "$matrix" | jq -c


### PR DESCRIPTION
### Motivation:

The use of 'swift' here is very arbitrary and adds no value. The object is only there at all because GitHub Actions seems to require it.

### Modifications:

Rename the top-level object from 'swift' to 'config' to maybe add value to the intent of the object and hopefully be less cryptic.

### Result:

Everything should just keep working.