### PR TITLE
Remove now unneeded fts_open bitcast for Android

### DIFF
--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -400,14 +400,7 @@ public enum Libc {
         return valueOrErrno {
             pathBytes.withUnsafeMutableBufferPointer { pointer in
                 // The array must be terminated with a nil.
-                #if os(Android)
-                libc_fts_open(
-                    [pointer.baseAddress!, unsafeBitCast(0, to: UnsafeMutablePointer<CInterop.PlatformChar>.self)],
-                    options.rawValue
-                )
-                #else
                 libc_fts_open([pointer.baseAddress, nil], options.rawValue)
-                #endif
             }
         }
     }


### PR DESCRIPTION
I added this changed function call for Android in #2660 earlier this year, because of [an incorrect Bionic function signature as explained recently](https://github.com/apple/swift-nio/pull/3009#discussion_r1864807270), but now that it has been worked around through a new API note as mentioned there, this change is no longer needed.

I simply did not notice this earlier because it still compiles and merely gives a warning, which removing this call now silences.