### PR TITLE
fix bogus "unleakable promise leaked" error message (#2855)

### DIFF
--- a/Sources/NIOCore/EventLoopFuture.swift
+++ b/Sources/NIOCore/EventLoopFuture.swift
@@ -163,7 +163,12 @@ public struct EventLoopPromise<Value> {
     internal static func makeUnleakablePromise(eventLoop: EventLoop, line: UInt = #line) -> EventLoopPromise<Value> {
         EventLoopPromise<Value>(
             eventLoop: eventLoop,
-            file: "BUG in SwiftNIO (please report), unleakable promise leaked.",
+            file: """
+                EventLoopGroup shut down with unfulfilled promises remaining. \
+                This suggests that the EventLoopGroup was shut down with unfinished work outstanding which is \
+                illegal. Either switch to using the singleton EventLoopGroups or fix the issue by only shutting down \
+                the EventLoopGroups when all the work associated with them has finished.
+                """,
             line: line
         )
     }


### PR DESCRIPTION
### Motivation:

SwiftNIO contained a bogus error message:

```
BUG in SwiftNIO (please report), unleakable promise leaked.:486: Fatal error: leaking promise created at (file: "BUG in SwiftNIO (please report), unleakable promise leaked.", line: 486)
```

The actual meaning is that the ELG was shut down prematurely.

### Modifications:

- Replace the message with an accurate one

### Result:

- Users less confused
- fixes #2855
- fixes #2201 