### PR TITLE
Revert "Enable MemberImportVisibility check on all targets"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -566,14 +566,3 @@ if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-system"),
     ]
 }
-
-// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
-for target in package.targets {
-    if target.type != .plugin {
-        var settings = target.swiftSettings ?? []
-        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
-        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
-        target.swiftSettings = settings
-    }
-}
-// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //


### PR DESCRIPTION
Reverts apple/swift-nio#3021