### PR TITLE
Fix now-racy scheduled callback tests

### DIFF
--- a/Tests/NIOPosixTests/NIOScheduledCallbackTests.swift
+++ b/Tests/NIOPosixTests/NIOScheduledCallbackTests.swift
@@ -45,7 +45,7 @@ final class MTELGScheduledCallbackTests: _BaseScheduledCallbackTests {
         }
 
         func waitForLoopTick() async throws {
-            try await self.loop.submit { }.get()
+            try await self.loop.submit {}.get()
         }
     }
 
@@ -68,7 +68,7 @@ final class NIOAsyncTestingEventLoopScheduledCallbackTests: _BaseScheduledCallba
         }
 
         func waitForLoopTick() async throws {
-            try await self._loop.executeInContext { }
+            try await self._loop.executeInContext {}
         }
     }
 


### PR DESCRIPTION
Motivation:

In PR 3026 we I fixed some warnings, but as part of doing so I eliminated some complexity in the scheduled callback tests. Apparently I did that a bit hard, as I lost a few synchronization edges that made the tests lightly flaky.

Modifications:

- Re-add synchronization edges between the EL and the test when we advance time
- Re-add synchronization edges after cancellation calls.

Result:

More reliable tests
