### PR TITLE
Import Android instead for NIOEmbedded

### DIFF
--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -28,8 +28,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #elseif canImport(WASILibc)
 import WASILibc
 #else
@@ -130,7 +130,7 @@ public final class EmbeddedEventLoop: EventLoop, CustomStringConvertible {
 
     public let description = "EmbeddedEventLoop"
 
-    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Android)
     private let myThread: pthread_t = pthread_self()
 
     func isCorrectThread() -> Bool {


### PR DESCRIPTION
Pull #3030 invokes C APIs that aren't in the extremely limited Bionic module, so import the much larger Android overlay instead.

This [just broke my daily Android CI](https://github.com/finagolfin/swift-android-sdk/actions/runs/12389744616/job/34583381415#step:19:239).