### PR TITLE
Fix flaky test testTasksScheduledDuringShutdownAreAutomaticallyCancel…

### DIFF
--- a/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingEventLoopTests.swift
@@ -480,7 +480,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
         }
     }
 
-    func testTasksScheduledDuringShutdownAreAutomaticallyCancelled() async throws {
+    func testTasksScheduledDuringShutdownAreAutomaticallyCancelledOrNotScheduled() async throws {
         let eventLoop = NIOAsyncTestingEventLoop()
         let tasksRun = ManagedAtomic(0)
 
@@ -511,7 +511,7 @@ final class NIOAsyncTestingEventLoopTests: XCTestCase {
         }
 
         try await eventLoop.executeInContext {
-            XCTAssertGreaterThan(tasksRun.load(ordering: .acquiring), 1)
+            XCTAssertGreaterThan(tasksRun.load(ordering: .acquiring), 0)
         }
     }
 


### PR DESCRIPTION
…ledOrNotScheduledAnymore

# Motivation

This task was flaky and hit the assertion with the count being 1

# Modification

This changes the expectation to greater than 0 since we can always guarantee that one scheduled task is run but due to timing windows it might be that we shutdown the EL before the second task is enqueued which meant it was immediately failed.

# Result

One less flaky test
