### PR TITLE
Add stale action to mark issues and PRs as stale and close them

### DIFF
--- a/.github/workflows/stale_issues_prs.yml
+++ b/.github/workflows/stale_issues_prs.yml
@@ -1,0 +1,27 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          days-before-issue-close: 7
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          days-before-pr-stale: 45
+          stale-pr-label: 'stale'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          days-before-pr-close: 10
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          operations-per-run: 1000


### PR DESCRIPTION
### Motivation:

To keep good repo hygiene, it would be good to have old issues/PRs automatically commented on after a period of inactivity, and if still inactive after this, subsequently closed.
For this we can use the `stale` GH action. We can try out a first integration here before potentially moving it to other repos too.

### Modifications:

- Issues will be marked as stale after 30 days of inactivity, and subsequently closed after 7 more days of inactivity.
- PRs will be marked as stale after 45 days of inactivity, and subsequently closed after 10 more days of inactivity.
- A label `stale` will be added to issues and PRs marked as stale, and a comment will be left.

All of these things can be changed if we think the durations, the message, or the label name (if any) should be different.

### Result:

Hopefully better responsiveness in issues/PRs and cleaner repos.
