### PR TITLE
Print alloc-limits-from-test-output usage when no args

### DIFF
--- a/dev/alloc-limits-from-test-output
+++ b/dev/alloc-limits-from-test-output
@@ -49,6 +49,12 @@ case "$mode_flag" in
         ;;
 esac
 
+# stdin is coming from a terminal, i.e. nothing is being piped in.
+if [[ -t 0 ]]; then
+    usage
+    exit 1
+fi
+
 function allow_slack() {
     raw="$1"
     if [[ ! "$raw" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
Motivation:

The alloc-limits-from-test-output doesn't print usage if you don't pass in a format arg, it just sits and waits for stdin.

Modifications:

Print usage if running interactively

Result:

Easier to get usage