### PR TITLE
Support concurrency take over in 6.2

### DIFF
--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -40,7 +40,7 @@ extension NIOSingletons {
     @discardableResult
     public static func unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor() -> Bool {
         // Guard between the minimum and maximum supported version for the hook
-        #if compiler(>=5.9) && compiler(<6.2)
+        #if compiler(>=5.9) && compiler(<6.3)
         guard #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) else {
             return false
         }


### PR DESCRIPTION
Motivation:

The compiler now self-presents as 6.2 on the nightlies, and the executor takeover still works. Lift the guard.

Modifications:

Lift the guard on compiler version.

Result:

Integration tests pass again.
