### PR TITLE
Adds `Int(buffer:)` initializer to `FixedWidthInteger` types

### DIFF
--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -134,6 +134,22 @@ extension FixedWidthInteger {
 
         return 1 << ((Self.bitWidth - 1) - self.leadingZeroBitCount)
     }
+
+    /// Initialize an integer from a ByteBuffer. The buffer must contain enough bytes to represent the integer.
+    /// The bytes will be read using the host system's endianness.
+    ///
+    /// - Parameters:
+    ///   - buffer: The ByteBuffer to read from
+    ///
+    /// - Returns: The integer value read from the buffer, or nil if the value could not be read.
+    @inlinable
+    public init?(buffer: ByteBuffer) {
+        var buffer = buffer
+        guard let value = buffer.readInteger(endianness: .host, as: Self.self) else {
+            return nil
+        }
+        self = value
+    }
 }
 
 extension UInt32 {

--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -137,18 +137,16 @@ extension FixedWidthInteger {
 
     /// Initialize an integer from a ByteBuffer. The buffer must contain enough bytes to represent the integer.
     /// The bytes will be read using the host system's endianness.
+    /// If the buffer doesn't contain enough bytes to represent the integer, the program will crash.
     ///
     /// - Parameters:
     ///   - buffer: The ByteBuffer to read from
     ///
-    /// - Returns: The integer value read from the buffer, or nil if the value could not be read.
+    /// - Returns: The integer value read from the buffer
     @inlinable
-    public init?(buffer: ByteBuffer) {
+    public init(buffer: ByteBuffer) {
         var buffer = buffer
-        guard let value = buffer.readInteger(endianness: .host, as: Self.self) else {
-            return nil
-        }
-        self = value
+        self = buffer.readInteger(endianness: .host, as: Self.self)!
     }
 }
 

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -3499,6 +3499,43 @@ extension ByteBufferTest {
 
 }
 
+// MARK: - Int / FixedWidthInteger init
+extension ByteBufferTest {
+    func testCreateInt32From3BytesFails() {
+        let bytes: [UInt8] = [0, 1, 2]
+        let buffer = ByteBuffer(bytes: bytes)
+
+        XCTAssertNil(UInt32(buffer: buffer))
+    }
+
+    func testCreateIntegersFromByteBuffer() {
+        // 8-bit
+        let uint8Buffer = ByteBuffer(bytes: [42])
+        XCTAssertEqual(UInt8(buffer: uint8Buffer), 42)
+        XCTAssertEqual(Int8(buffer: uint8Buffer), 42)
+
+        // 16-bit
+        let uint16Bytes: [UInt8] = Endianness.host == .little ? [0x02, 0x01] : [0x01, 0x02]
+        let uint16Buffer = ByteBuffer(bytes: uint16Bytes)
+        XCTAssertEqual(UInt16(buffer: uint16Buffer), 0x0102)
+        XCTAssertEqual(Int16(buffer: uint16Buffer), 0x0102)
+
+        // 32-bit
+        let uint32Bytes: [UInt8] = Endianness.host == .little ? [0x04, 0x03, 0x02, 0x01] : [0x01, 0x02, 0x03, 0x04]
+        let uint32Buffer = ByteBuffer(bytes: uint32Bytes)
+        XCTAssertEqual(UInt32(buffer: uint32Buffer), 0x01020304)
+        XCTAssertEqual(Int32(buffer: uint32Buffer), 0x01020304)
+
+        // 64-bit
+        let uint64Bytes: [UInt8] = Endianness.host == .little ?
+        [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01] :
+        [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        let uint64Buffer = ByteBuffer(bytes: uint64Bytes)
+        XCTAssertEqual(UInt64(buffer: uint64Buffer), 0x0102030405060708)
+        XCTAssertEqual(Int64(buffer: uint64Buffer), 0x0102030405060708)
+    }
+}
+
 // MARK: - DispatchData init
 extension ByteBufferTest {
 

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -3501,13 +3501,6 @@ extension ByteBufferTest {
 
 // MARK: - Int / FixedWidthInteger init
 extension ByteBufferTest {
-    func testCreateInt32From3BytesFails() {
-        let bytes: [UInt8] = [0, 1, 2]
-        let buffer = ByteBuffer(bytes: bytes)
-
-        XCTAssertNil(UInt32(buffer: buffer))
-    }
-
     func testCreateIntegersFromByteBuffer() {
         // 8-bit
         let uint8Buffer = ByteBuffer(bytes: [42])


### PR DESCRIPTION
### Motivation:

Makes it possible to make integers out of ByteBuffers directly with an initializer. I.e. `UInt32(buffer: ByteBuffer(bytes: [0, 1, 2, 3]))`.

### Modifications:

- Adds the `Int(buffer:)` initializer in `ByteBuffer-int.swift`
- Adds tests in `ByteBufferTest.swift`. _Holy hell this file is huge._
- Note that `Int(buffer:)` will crash if the buffer does not have enough bytes in it to represent the desired integer type.
- It also does _not_ expose endianness and uses `Endianness.host`, to keep the public API clean and simple. It's a convenience initializer, so I thought keeping it minimal is a good idea.

### Result:

Nicer direct initializer for integers from ByteBuffers.