### PR TITLE
Ensuring NIOAsyncChannel flushes all writes before closing

### DIFF
--- a/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
@@ -302,6 +302,7 @@ public struct NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Sendable {
             }
         }
 
+        // ensure everything written to outbound is written to channel
         try await self._outbound.flush()
         self._outbound.finish()
         // We ignore errors from close, since all we care about is that the channel has been closed

--- a/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
@@ -302,8 +302,6 @@ public struct NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Sendable {
             }
         }
 
-        // ensure everything written to outbound is written to channel
-        try await self._outbound.flush()
         self._outbound.finish()
         // We ignore errors from close, since all we care about is that the channel has been closed
         // at this point.

--- a/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannel.swift
@@ -293,6 +293,7 @@ public struct NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Sendable {
             result = try await body(self._inbound, self._outbound)
         } catch let bodyError {
             do {
+                try await self._outbound.flush()
                 self._outbound.finish()
                 try await self.channel.close().get()
                 throw bodyError
@@ -301,6 +302,7 @@ public struct NIOAsyncChannel<Inbound: Sendable, Outbound: Sendable>: Sendable {
             }
         }
 
+        try await self._outbound.flush()
         self._outbound.finish()
         // We ignore errors from close, since all we care about is that the channel has been closed
         // at this point.

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
@@ -130,7 +130,7 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
 
     /// Send a write into the ``ChannelPipeline`` and flush it right away.
     ///
-    /// This method suspends if the underlying channel is not writable and will resume once the it becomes writable again.
+    /// This method suspends until the write has been written and flushed.
     @inlinable
     public func writeAndFlush(_ data: OutboundOut) async throws {
         switch self._backing {
@@ -175,6 +175,7 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
         }
     }
 
+    /// Ensure all writes to the writer have been read
     @inlinable
     public func flush() async throws {
         if case .writer(let writer) = self._backing,


### PR DESCRIPTION
Currently NIOAsyncChannel can close the channel without having flushed all the writes it has made. 

### Motivation:

I believe there are two situations where writes are not getting written. At the point the NIOAsyncChannel starts the channel close procedure it calls `finish` on the writer which will resume all the pending continuations but then closes the channel immediately so those writes are never written. The second situation is related to the fact that there is no way to wait on a write actually making it all the way through the channel pipeline.

These proposed changes are more to start a discussion and this PR is still very much a draft. 

### Modifications:

Instead of passing Values through the NIOAsyncWriter we pass actions. There are currently three actions 
- `write`: write value to channel
- `writeAndFlush`: write value to channel and flush the pipeline (returning when write promise either fails or succeeds).
- `flush`: Ensure all previous writes have been written. 

### Result:

As long as the last write a user makes is with `writeAndFlush` everything will get written out before the channel is closed.
