### PR TITLE
unchecked Sendable for the Channels

### DIFF
--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -223,7 +223,7 @@ private struct SocketChannelLifecycleManager {
 /// For this reason, `BaseSocketChannel` exists to provide a common core implementation of
 /// the `SelectableChannel` protocol. It uses a number of private functions to provide hooks
 /// for subclasses to implement the specific logic to handle their writes and reads.
-class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, ChannelCore {
+class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, ChannelCore, @unchecked Sendable {
     typealias SelectableType = SocketType.SelectableType
 
     struct AddressCache {
@@ -1419,7 +1419,7 @@ extension BaseSocketChannel {
 }
 
 /// Execute the given function and synchronously complete the given `EventLoopPromise` (if not `nil`).
-func executeAndComplete<Value>(_ promise: EventLoopPromise<Value>?, _ body: () throws -> Value) {
+func executeAndComplete<Value: Sendable>(_ promise: EventLoopPromise<Value>?, _ body: () throws -> Value) {
     do {
         let result = try body()
         promise?.succeed(result)

--- a/Sources/NIOPosix/BaseStreamSocketChannel.swift
+++ b/Sources/NIOPosix/BaseStreamSocketChannel.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIOCore
 
-class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket> {
+class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>, @unchecked Sendable {
     internal var connectTimeoutScheduled: Optional<Scheduled<Void>>
     private var allowRemoteHalfClosure: Bool = false
     private var inputShutdown: Bool = false

--- a/Sources/NIOPosix/PipeChannel.swift
+++ b/Sources/NIOPosix/PipeChannel.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIOCore
 
-final class PipeChannel: BaseStreamSocketChannel<PipePair> {
+final class PipeChannel: BaseStreamSocketChannel<PipePair>, @unchecked Sendable {
     private let pipePair: PipePair
 
     internal enum Direction {

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -50,7 +50,7 @@ extension ByteBuffer {
 /// A `Channel` for a client socket.
 ///
 /// - Note: All operations on `SocketChannel` are thread-safe.
-final class SocketChannel: BaseStreamSocketChannel<Socket> {
+final class SocketChannel: BaseStreamSocketChannel<Socket>, @unchecked Sendable {
     private var connectTimeout: TimeAmount? = nil
 
     init(eventLoop: SelectableEventLoop, protocolFamily: NIOBSDSocket.ProtocolFamily, enableMPTCP: Bool = false) throws
@@ -192,7 +192,7 @@ final class SocketChannel: BaseStreamSocketChannel<Socket> {
 /// A `Channel` for a server socket.
 ///
 /// - Note: All operations on `ServerSocketChannel` are thread-safe.
-final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
+final class ServerSocketChannel: BaseSocketChannel<ServerSocket>, @unchecked Sendable {
 
     private var backlog: Int32 = 128
     private let group: EventLoopGroup
@@ -451,7 +451,7 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket> {
 /// A channel used with datagram sockets.
 ///
 /// Currently, it does not support connected mode which is well worth adding.
-final class DatagramChannel: BaseSocketChannel<Socket> {
+final class DatagramChannel: BaseSocketChannel<Socket>, @unchecked Sendable {
     private var reportExplicitCongestionNotifications = false
     private var receivePacketInfo = false
 


### PR DESCRIPTION
### Motivation:

All of NIO's channels are thread-safe, and that includes the NIOPosix ones. In an ideal world we'd have written these in such a way that they rely on very small, easily-verified types to enforce this constraint. We will migrate towards that in time, but for expediency we can mark these as they are, which is `@unchecked Sendable`.

### Modifications:

Mark the core NIOPosix channel types `@unchecked Sendable`.

### Result:

Fewer warnings.
