### PR TITLE
Add channel initializer closure to NIOAsyncTestingChannel.init

### DIFF
--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -65,6 +65,17 @@ class AsyncTestingChannelTests: XCTestCase {
         XCTAssertNoThrow(try channel.pipeline.removeHandler(name: "handler2").wait())
     }
 
+    func testClosureInit() async throws {
+        final class Handler: ChannelInboundHandler, Sendable {
+            typealias InboundIn = Never
+        }
+
+        let channel = try await NIOAsyncTestingChannel {
+            try $0.pipeline.syncOperations.addHandler(Handler())
+        }
+        XCTAssertNoThrow(try channel.pipeline.handler(type: Handler.self).wait())
+    }
+
     func testWaitForInboundWrite() async throws {
         let channel = NIOAsyncTestingChannel()
         let task = Task {


### PR DESCRIPTION
Since nio 2.78, adding handlers to a pipeline requires the handlers to be sendable. 

That makes the [NIOAsyncTestingChannel.init(handlers:loop:)](https://swiftpackageindex.com/apple/swift-nio/2.78.0/documentation/nioembedded/nioasynctestingchannel/init(handlers:loop:)) function cumbersome, because you cannot create handlers and then call the function (unless your handlers are Sendable) even if you never use the handlers elsewhere.

This PR adds a new initializer which takes a closure. The closure is run on-loop before the channel is registered. This means we can do:

```swift
let channel = try await NIOAsyncTestingChannel {
    let handler = MyUnsendableHandler()
    try $0.pipeline.syncOperations.addHandler(handler)
}
```