### PR TITLE
Remove unnecessary 'FIXME' comment

### DIFF
--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift
@@ -623,7 +623,6 @@ final class NIOAsyncWriterTests: XCTestCase {
         self.delegate.didYieldHandler = { _ in
             if self.delegate.didYieldCallCount == 1 {
                 // Delay this yield until the other yield is suspended again.
-                // FIXME: This will never finish if no other thread is handling the other yield.
                 suspendedAgain.lock(whenValue: true)
                 suspendedAgain.unlock()
             }


### PR DESCRIPTION
This was left in when pull request #3044 was merged, but as discussed on that pull request, this doesn't need to be fixed.