### PR TITLE
Add some trivial Sendable annotations

### DIFF
--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -64,7 +64,7 @@ public typealias ConnectTimeoutOption = ChannelOptions.Types.ConnectTimeoutOptio
 public typealias AllowRemoteHalfClosureOption = ChannelOptions.Types.AllowRemoteHalfClosureOption
 
 extension ChannelOptions {
-    public enum Types {
+    public enum Types: Sendable {
 
         /// `SocketOption` allows users to specify configuration settings that are directly applied to the underlying socket file descriptor.
         ///

--- a/Sources/NIOPosix/BSDSocketAPICommon.swift
+++ b/Sources/NIOPosix/BSDSocketAPICommon.swift
@@ -32,7 +32,7 @@ protocol _SocketShutdownProtocol {
 }
 
 @usableFromInline
-internal enum Shutdown: _SocketShutdownProtocol {
+internal enum Shutdown: _SocketShutdownProtocol, Sendable {
     case RD
     case WR
     case RDWR
@@ -49,7 +49,7 @@ extension NIOBSDSocket {
 extension NIOBSDSocket {
     /// Specifies the type of socket.
     @usableFromInline
-    internal struct SocketType: RawRepresentable {
+    internal struct SocketType: RawRepresentable, Sendable {
         public typealias RawValue = CInt
         public var rawValue: RawValue
         public init(rawValue: RawValue) {
@@ -144,7 +144,7 @@ extension NIOBSDSocket {
     /// They aren't necessarily protocols in their own right: for example, ``mptcp``
     /// is not. They act to modify the socket type instead: thus, ``mptcp`` acts
     /// to modify `SOCK_STREAM` to ask for ``mptcp`` support.
-    public struct ProtocolSubtype: RawRepresentable, Hashable {
+    public struct ProtocolSubtype: RawRepresentable, Hashable, Sendable {
         public typealias RawValue = CInt
 
         /// The underlying value of the protocol subtype.

--- a/Sources/NIOPosix/IntegerTypes.swift
+++ b/Sources/NIOPosix/IntegerTypes.swift
@@ -16,7 +16,7 @@
 
 /// A 24-bit unsigned integer value type.
 @usableFromInline
-struct _UInt24 {
+struct _UInt24: Sendable {
     @usableFromInline var _backing: (UInt16, UInt8)
 
     @inlinable
@@ -65,7 +65,7 @@ extension _UInt24: CustomStringConvertible {
 // MARK: _UInt56
 
 /// A 56-bit unsigned integer value type.
-struct _UInt56 {
+struct _UInt56: Sendable {
     @usableFromInline var _backing: (UInt32, UInt16, UInt8)
 
     @inlinable init(_ value: UInt64) {


### PR DESCRIPTION
Motivation

We have a few types lying around that can trivially be Sendable, and that `-require-explicit-sendable` needs to be `Sendable`. Let's add those annotations.

Modifications

Made a few types Sendable

Result

One step closer to our strict concurrency goal