### PR TITLE
Move Isolated EL operations to EL protocol

### DIFF
--- a/IntegrationTests/tests_04_performance/Thresholds/5.10.json
+++ b/IntegrationTests/tests_04_performance/Thresholds/5.10.json
@@ -34,7 +34,7 @@
     "encode_1000_ws_frames_new_buffer_with_space_with_mask": 5050,
     "execute_hop_10000_tasks": 0,
     "flat_schedule_10000_tasks": 130100,
-    "flat_schedule_assume_isolated_10000_tasks": 150100,
+    "flat_schedule_assume_isolated_10000_tasks": 110100,
     "future_assume_isolated_lots_of_callbacks": 74050,
     "future_erase_result": 4050,
     "future_lots_of_callbacks": 74050,

--- a/IntegrationTests/tests_04_performance/Thresholds/5.9.json
+++ b/IntegrationTests/tests_04_performance/Thresholds/5.9.json
@@ -34,7 +34,7 @@
     "encode_1000_ws_frames_new_buffer_with_space_with_mask": 5050,
     "execute_hop_10000_tasks": 0,
     "flat_schedule_10000_tasks": 130100,
-    "flat_schedule_assume_isolated_10000_tasks": 150100,
+    "flat_schedule_assume_isolated_10000_tasks": 110100,
     "future_assume_isolated_lots_of_callbacks": 74050,
     "future_erase_result": 4050,
     "future_lots_of_callbacks": 74050,

--- a/IntegrationTests/tests_04_performance/Thresholds/6.0.json
+++ b/IntegrationTests/tests_04_performance/Thresholds/6.0.json
@@ -34,7 +34,7 @@
     "encode_1000_ws_frames_new_buffer_with_space_with_mask": 5050,
     "execute_hop_10000_tasks": 0,
     "flat_schedule_10000_tasks": 130100,
-    "flat_schedule_assume_isolated_10000_tasks": 150100,
+    "flat_schedule_assume_isolated_10000_tasks": 110100,
     "future_assume_isolated_lots_of_callbacks": 74050,
     "future_erase_result": 4050,
     "future_lots_of_callbacks": 74050,

--- a/IntegrationTests/tests_04_performance/Thresholds/nightly-6.0.json
+++ b/IntegrationTests/tests_04_performance/Thresholds/nightly-6.0.json
@@ -34,7 +34,7 @@
     "encode_1000_ws_frames_new_buffer_with_space_with_mask": 5050,
     "execute_hop_10000_tasks": 0,
     "flat_schedule_10000_tasks": 130100,
-    "flat_schedule_assume_isolated_10000_tasks": 150100,
+    "flat_schedule_assume_isolated_10000_tasks": 110100,
     "future_assume_isolated_lots_of_callbacks": 74050,
     "future_erase_result": 4050,
     "future_lots_of_callbacks": 74050,

--- a/IntegrationTests/tests_04_performance/Thresholds/nightly-main.json
+++ b/IntegrationTests/tests_04_performance/Thresholds/nightly-main.json
@@ -34,7 +34,7 @@
     "encode_1000_ws_frames_new_buffer_with_space_with_mask": 5050,
     "execute_hop_10000_tasks": 0,
     "flat_schedule_10000_tasks": 130100,
-    "flat_schedule_assume_isolated_10000_tasks": 150100,
+    "flat_schedule_assume_isolated_10000_tasks": 110100,
     "future_assume_isolated_lots_of_callbacks": 74050,
     "future_erase_result": 4050,
     "future_lots_of_callbacks": 74050,

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -395,6 +395,69 @@ public protocol EventLoop: EventLoopGroup {
     ///
     /// - NOTE: Event loops only need to implemented this if they provide a custom scheduled callback implementation.
     func cancelScheduledCallback(_ scheduledCallback: NIOScheduledCallback)
+
+    /// Submit a given task to be executed by the ``EventLoop``, from a context where the caller
+    /// statically knows that the context is isolated.
+    ///
+    /// This is an optional performance hook. ``EventLoop`` implementers are not required to implement
+    /// this witness, but may choose to do so to enable better performance of the isolated EL views. If
+    /// they do so, ``EventLoop/Isolated/execute`` will perform better.
+    func _executeIsolatedUnsafeUnchecked(_ task: @escaping () -> Void)
+
+    /// Submit a given task to be executed by the ``EventLoop```, from a context where the caller
+    /// statically knows that the context is isolated.
+    ///
+    /// Once the execution is complete the returned ``EventLoopFuture`` is notified.
+    ///
+    /// This is an optional performance hook. ``EventLoop`` implementers are not required to implement
+    /// this witness, but may choose to do so to enable better performance of the isolated EL views. If
+    /// they do so, ``EventLoop/Isolated/submit`` will perform better.
+    ///
+    /// - Parameters:
+    ///   - task: The closure that will be submitted to the ``EventLoop`` for execution.
+    /// - Returns: ``EventLoopFuture`` that is notified once the task was executed.
+    func _submitIsolatedUnsafeUnchecked<T>(_ task: @escaping () throws -> T) -> EventLoopFuture<T>
+
+    /// Schedule a `task` that is executed by this ``EventLoop`` at the given time, from a context where the caller
+    /// statically knows that the context is isolated.
+    ///
+    /// This is an optional performance hook. ``EventLoop`` implementers are not required to implement
+    /// this witness, but may choose to do so to enable better performance of the isolated EL views. If
+    /// they do so, ``EventLoop/Isolated/scheduleTask(deadline:_:)`` will perform better.
+    ///
+    /// - Parameters:
+    ///   - deadline: The instant in time before which the task will not execute.
+    ///   - task: The synchronous task to run. As with everything that runs on the ``EventLoop```, it must not block.
+    /// - Returns: A ``Scheduled``` object which may be used to cancel the task if it has not yet run, or to wait
+    ///            on the completion of the task.
+    ///
+    /// - Note: You can only cancel a task before it has started executing.
+    @discardableResult
+    func _scheduleTaskIsolatedUnsafeUnchecked<T>(
+        deadline: NIODeadline,
+        _ task: @escaping () throws -> T
+    ) -> Scheduled<T>
+
+    /// Schedule a `task` that is executed by this ``EventLoop`` after the given amount of time, from a context where the caller
+    /// statically knows that the context is isolated.
+    ///
+    /// This is an optional performance hook. ``EventLoop`` implementers are not required to implement
+    /// this witness, but may choose to do so to enable better performance of the isolated EL views. If
+    /// they do so, ``EventLoop/Isolated/scheduleTask(in:_:)`` will perform better.
+    ///
+    /// - Parameters:
+    ///   - in: The amount of time before which the task will not execute.
+    ///   - task: The synchronous task to run. As with everything that runs on the ``EventLoop``, it must not block.
+    /// - Returns: A ``Scheduled`` object which may be used to cancel the task if it has not yet run, or to wait
+    ///            on the completion of the task.
+    ///
+    /// - Note: You can only cancel a task before it has started executing.
+    /// - Note: The `in` value is clamped to a maximum when running on a Darwin-kernel.
+    @discardableResult
+    func _scheduleTaskIsolatedUnsafeUnchecked<T>(
+        in: TimeAmount,
+        _ task: @escaping () throws -> T
+    ) -> Scheduled<T>
 }
 
 extension EventLoop {
@@ -421,6 +484,50 @@ extension EventLoop {
     public func _promiseCompleted(futureIdentifier: _NIOEventLoopFutureIdentifier) -> (file: StaticString, line: UInt)?
     {
         nil
+    }
+
+    /// Default implementation: wraps the task in an UnsafeTransfer.
+    public func _executeIsolatedUnsafeUnchecked(_ task: @escaping () -> Void) {
+        self.assertInEventLoop()
+        let unsafeTransfer = UnsafeTransfer(task)
+        self.execute {
+            unsafeTransfer.wrappedValue()
+        }
+    }
+
+    /// Default implementation: wraps the task in an UnsafeTransfer.
+    public func _submitIsolatedUnsafeUnchecked<T>(_ task: @escaping () throws -> T) -> EventLoopFuture<T> {
+        self.assertInEventLoop()
+        let unsafeTransfer = UnsafeTransfer(task)
+        return self.submit {
+            try unsafeTransfer.wrappedValue()
+        }
+    }
+
+    /// Default implementation: wraps the task in an UnsafeTransfer.
+    @discardableResult
+    public func _scheduleTaskIsolatedUnsafeUnchecked<T>(
+        deadline: NIODeadline,
+        _ task: @escaping () throws -> T
+    ) -> Scheduled<T> {
+        self.assertInEventLoop()
+        let unsafeTransfer = UnsafeTransfer(task)
+        return self.scheduleTask(deadline: deadline) {
+            try unsafeTransfer.wrappedValue()
+        }
+    }
+
+    /// Default implementation: wraps the task in an UnsafeTransfer.
+    @discardableResult
+    public func _scheduleTaskIsolatedUnsafeUnchecked<T>(
+        in delay: TimeAmount,
+        _ task: @escaping () throws -> T
+    ) -> Scheduled<T> {
+        self.assertInEventLoop()
+        let unsafeTransfer = UnsafeTransfer(task)
+        return self.scheduleTask(in: delay) {
+            try unsafeTransfer.wrappedValue()
+        }
     }
 }
 

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -487,6 +487,7 @@ extension EventLoop {
     }
 
     /// Default implementation: wraps the task in an UnsafeTransfer.
+    @inlinable
     public func _executeIsolatedUnsafeUnchecked(_ task: @escaping () -> Void) {
         self.assertInEventLoop()
         let unsafeTransfer = UnsafeTransfer(task)
@@ -496,6 +497,7 @@ extension EventLoop {
     }
 
     /// Default implementation: wraps the task in an UnsafeTransfer.
+    @inlinable
     public func _submitIsolatedUnsafeUnchecked<T>(_ task: @escaping () throws -> T) -> EventLoopFuture<T> {
         self.assertInEventLoop()
         let unsafeTransfer = UnsafeTransfer(task)
@@ -505,6 +507,7 @@ extension EventLoop {
     }
 
     /// Default implementation: wraps the task in an UnsafeTransfer.
+    @inlinable
     @discardableResult
     public func _scheduleTaskIsolatedUnsafeUnchecked<T>(
         deadline: NIODeadline,
@@ -518,6 +521,7 @@ extension EventLoop {
     }
 
     /// Default implementation: wraps the task in an UnsafeTransfer.
+    @inlinable
     @discardableResult
     public func _scheduleTaskIsolatedUnsafeUnchecked<T>(
         in delay: TimeAmount,

--- a/Sources/NIOCore/EventLoopFuture+AssumeIsolated.swift
+++ b/Sources/NIOCore/EventLoopFuture+AssumeIsolated.swift
@@ -34,10 +34,7 @@ public struct NIOIsolatedEventLoop {
     @available(*, noasync)
     @inlinable
     public func execute(_ task: @escaping () -> Void) {
-        let unsafeTransfer = UnsafeTransfer(task)
-        self._wrapped.execute {
-            unsafeTransfer.wrappedValue()
-        }
+        self._wrapped._executeIsolatedUnsafeUnchecked(task)
     }
 
     /// Submit a given task to be executed by the `EventLoop`. Once the execution is complete the returned `EventLoopFuture` is notified.
@@ -48,10 +45,7 @@ public struct NIOIsolatedEventLoop {
     @available(*, noasync)
     @inlinable
     public func submit<T>(_ task: @escaping () throws -> T) -> EventLoopFuture<T> {
-        let unsafeTransfer = UnsafeTransfer(task)
-        return self._wrapped.submit {
-            try unsafeTransfer.wrappedValue()
-        }
+        self._wrapped._submitIsolatedUnsafeUnchecked(task)
     }
 
     /// Schedule a `task` that is executed by this `EventLoop` at the given time.
@@ -70,10 +64,7 @@ public struct NIOIsolatedEventLoop {
         deadline: NIODeadline,
         _ task: @escaping () throws -> T
     ) -> Scheduled<T> {
-        let unsafeTransfer = UnsafeTransfer(task)
-        return self._wrapped.scheduleTask(deadline: deadline) {
-            try unsafeTransfer.wrappedValue()
-        }
+        self._wrapped._scheduleTaskIsolatedUnsafeUnchecked(deadline: deadline, task)
     }
 
     /// Schedule a `task` that is executed by this `EventLoop` after the given amount of time.
@@ -93,10 +84,7 @@ public struct NIOIsolatedEventLoop {
         in delay: TimeAmount,
         _ task: @escaping () throws -> T
     ) -> Scheduled<T> {
-        let unsafeTransfer = UnsafeTransfer(task)
-        return self._wrapped.scheduleTask(in: delay) {
-            try unsafeTransfer.wrappedValue()
-        }
+        self._wrapped._scheduleTaskIsolatedUnsafeUnchecked(in: delay, task)
     }
 
     /// Schedule a `task` that is executed by this `EventLoop` at the given time.
@@ -122,10 +110,11 @@ public struct NIOIsolatedEventLoop {
         line: UInt = #line,
         _ task: @escaping () throws -> EventLoopFuture<T>
     ) -> Scheduled<T> {
-        let unsafeTransfer = UnsafeTransfer(task)
-        return self._wrapped.flatScheduleTask(deadline: deadline, file: file, line: line) {
-            try unsafeTransfer.wrappedValue()
-        }
+        let promise: EventLoopPromise<T> = self._wrapped.makePromise(file: file, line: line)
+        let scheduled = self.scheduleTask(deadline: deadline, task)
+
+        scheduled.futureResult.flatMap { $0 }.cascade(to: promise)
+        return .init(promise: promise, cancellationTask: { scheduled.cancel() })
     }
 
     /// Returns the wrapped event loop.


### PR DESCRIPTION
Motivation

Right now the isolated view on the EventLoop has to implement its interface in terms of UnsafeTransfer, because there are no non-Sendable operations it can use.

That hurts us because we have to allocate an extra closure for all these operations, making them slower than they need to be. This is unavoidable in some contexts, but most EventLoops would be able to offer a fast-path that avoids this extra allocation.

To achieve that, we need to move this logic into a customisation point on the EventLoop protocol. Our fallback default implementation can be the same as we do today.

Modifications

- Add customisation points for EventLoop for each of its operations that has a protocol witness already.
- Add default implementations of these, using the implementation from EventLoop.Isolated.

Results

No behavioural changes, but the code has moved.