### PR TITLE
Fast-path isolated view for EmbeddedEventLoop

### DIFF
--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -381,6 +381,7 @@ public final class EmbeddedEventLoop: EventLoop, CustomStringConvertible {
         in delay: TimeAmount,
         _ task: @escaping () throws -> T
     ) -> Scheduled<T> {
+        // Because of the way EmbeddedEL works, we can delegate this directly to schedule.
         self.scheduleTask(in: delay, task)
     }
 

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -355,6 +355,35 @@ public final class EmbeddedEventLoop: EventLoop, CustomStringConvertible {
         return
     }
 
+    public func _executeIsolatedUnsafeUnchecked(_ task: @escaping () -> Void) {
+        // Because of the way EmbeddedEL works, we can just delegate this directly
+        // to execute.
+        self.execute(task)
+    }
+
+    public func _submitIsolatedUnsafeUnchecked<T>(_ task: @escaping () throws -> T) -> EventLoopFuture<T> {
+        // Because of the way EmbeddedEL works, we can delegate this directly to schedule. Note that I didn't
+        // say submit: we don't have an override of submit here.
+        self.scheduleTask(deadline: self._now, task).futureResult
+    }
+
+    @discardableResult
+    public func _scheduleTaskIsolatedUnsafeUnchecked<T>(
+        deadline: NIODeadline,
+        _ task: @escaping () throws -> T
+    ) -> Scheduled<T> {
+        // Because of the way EmbeddedEL works, we can delegate this directly to schedule.
+        self.scheduleTask(deadline: deadline, task)
+    }
+
+    @discardableResult
+    public func _scheduleTaskIsolatedUnsafeUnchecked<T>(
+        in delay: TimeAmount,
+        _ task: @escaping () throws -> T
+    ) -> Scheduled<T> {
+        self.scheduleTask(in: delay, task)
+    }
+
     deinit {
         self.checkCorrectThread()
         precondition(scheduledTasks.isEmpty, "Embedded event loop freed with unexecuted scheduled tasks!")


### PR DESCRIPTION
Motivation:

This patch takes advantage of the fast-path for isolated views on EmbeddedEventLoop, reducing overhead when using EmbeddedEL.

Modifications:

- Implement the new witnesses in EmbeddedEL

Result:

EmbeddedEL is faster when using isolated views.
