### PR TITLE
check-matrix-job.sh should tolerate unset 6.1 vars

### DIFF
--- a/scripts/check-matrix-job.ps1
+++ b/scripts/check-matrix-job.ps1
@@ -64,8 +64,8 @@ if ($swift_version -eq "5.9" -and $command_5_9) {
 } elseif ($swift_version -eq "6.0" -and $command_6_0) {
     Log "Running 6.0 command override"
     Invoke-Expression $command_6_0
-} elseif ($swift_version -eq "nightly-6.0" -and $command_nightly_6_1) {
-    Log "Running nightly 6.0 command override"
+} elseif ($swift_version -eq "nightly-6.1" -and $command_nightly_6_1) {
+    Log "Running nightly 6.1 command override"
     Invoke-Expression $command_nightly_6_1
 } elseif ($swift_version -eq "nightly-main" -and $command_nightly_main) {
     Log "Running nightly main command override"

--- a/scripts/check-matrix-job.sh
+++ b/scripts/check-matrix-job.sh
@@ -25,7 +25,7 @@ command="$COMMAND"
 command_5_9="$COMMAND_OVERRIDE_5_9"
 command_5_10="$COMMAND_OVERRIDE_5_10"
 command_6_0="$COMMAND_OVERRIDE_6_0"
-command_nightly_6_1="$COMMAND_OVERRIDE_NIGHTLY_6_1"
+command_nightly_6_1="${COMMAND_OVERRIDE_NIGHTLY_6_1:=""}"
 command_nightly_main="$COMMAND_OVERRIDE_NIGHTLY_MAIN"
 
 if [[ "$swift_version" == "5.9" ]] && [[ -n "$command_5_9" ]]; then
@@ -37,8 +37,8 @@ elif [[ "$swift_version" == "5.10" ]] && [[ -n "$command_5_10" ]]; then
 elif [[ "$swift_version" == "6.0" ]] && [[ -n "$command_6_0" ]]; then
   log "Running 6.0 command override"
   eval "$command_6_0"
-elif [[ "$swift_version" == "nightly-6.0" ]] && [[ -n "$command_nightly_6_1" ]]; then
-  log "Running nightly 6.0 command override"
+elif [[ "$swift_version" == "nightly-6.1" ]] && [[ -n "$command_nightly_6_1" ]]; then
+  log "Running nightly 6.1 command override"
   eval "$command_nightly_6_1"
 elif [[ "$swift_version" == "nightly-main" ]] && [[ -n "$command_nightly_main" ]]; then
   log "Running nightly main command override"


### PR DESCRIPTION
### Motivation:

We recently added support for nightly 6.1 Swift and old scripts making use of `check-matrix-job.sh` do not set `COMMAND_OVERRIDE_NIGHTLY_6_1` which causes the script to fail. We should tolerate this.

### Modifications:

Add a default case for `COMMAND_OVERRIDE_NIGHTLY_6_1`.

### Result:

No failures if a caller doesn't specify `COMMAND_OVERRIDE_NIGHTLY_6_1`.

```
❯ SWIFT_VERSION=nightly-6.1 COMMAND="echo foo" COMMAND_OVERRIDE_5_9="" COMMAND_OVERRIDE_5_10="" COMMAND_OVERRIDE_6_0="" COMMAND_OVERRIDE_NIGHTLY_MAIN="" ./scripts/check-matrix-job.sh
** Running default command
foo
❯ SWIFT_VERSION=nightly-6.1 COMMAND="echo foo" COMMAND_OVERRIDE_5_9="" COMMAND_OVERRIDE_5_10="" COMMAND_OVERRIDE_6_0="" COMMAND_OVERRIDE_NIGHTLY_MAIN="" COMMAND_OVERRIDE_NIGHTLY_6_1="echo bar" ./scripts/check-matrix-job.sh
** Running nightly 6.1 command override
bar
```