### PR TITLE
Make NonBlockingFileIO strict-concurrency clean

### DIFF
--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -205,6 +205,7 @@ public struct NonBlockingFileIO: Sendable {
 
         let promise = eventLoop.makePromise(of: Void.self)
 
+        @Sendable
         func _read(remainingReads: Int, bytesReadSoFar: Int64) {
             if remainingReads > 1 || (remainingReads == 1 && lastReadSize > 0) {
                 let readSize = remainingReads > 1 ? chunkSize : lastReadSize
@@ -843,7 +844,7 @@ public struct NonBlockingFileIO: Sendable {
 
 #if !os(Windows)
 /// A `NIODirectoryEntry` represents a single directory entry.
-public struct NIODirectoryEntry: Hashable {
+public struct NIODirectoryEntry: Hashable, Sendable {
     // File number of entry
     public var ino: UInt64
     // File type


### PR DESCRIPTION
### Motivation:

NonBlockingFileIO is now mostly in a good state, but there are some missed Sendable annotations. Let's clean that up.

### Modifications:

Mark an inner function as `@Sendable`
Add `Sendable` to `NIODirectoryEntry`.

### Result:

The road continues
