### PR TITLE
Remove accidental static var

### DIFF
--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -23,7 +23,7 @@ class Socket: BaseSocket, SocketProtocol {
     typealias SocketType = Socket
 
     /// The maximum number of bytes to write per `writev` call.
-    static var writevLimitBytes = Int(Int32.max)
+    static let writevLimitBytes = Int(Int32.max)
 
     /// The maximum number of `IOVector`s to write per `writev` call.
     static let writevLimitIOVectors: Int = Posix.UIO_MAXIOV


### PR DESCRIPTION
This was never written to, so we don't need it, and it's a Sendable violation.
