### PR TITLE
Add simple Sendable conformance to AsyncSequenceFromIterator

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -424,7 +424,7 @@ struct AsyncSequenceFromIterator<AsyncIterator: AsyncIteratorProtocol>: AsyncSeq
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension AsyncSequenceFromIterator: Sendable where AsyncIterator: Sendable { }
+extension AsyncSequenceFromIterator: Sendable where AsyncIterator: Sendable {}
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension EventLoop {

--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -424,6 +424,9 @@ struct AsyncSequenceFromIterator<AsyncIterator: AsyncIteratorProtocol>: AsyncSeq
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension AsyncSequenceFromIterator: Sendable where AsyncIterator: Sendable { }
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension EventLoop {
     @preconcurrency
     @inlinable


### PR DESCRIPTION
usableFromInline types need explicit Sendable conformances, so let's add one here. This type is a trivial wrapper, so let's express that