### PR TITLE
Avoid using stderr explicitly

### DIFF
--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -20,20 +20,20 @@ import NIOCore
 import _NIODataStructures
 
 private func printError(_ string: StaticString) {
-     string.withUTF8Buffer { buf in
-         var buf = buf
-         while buf.count > 0 {
-             // 2 is stderr
-             let rc = write(2, buf.baseAddress, buf.count)
-             if rc < 0 {
-                 let err = errno
-                 if err == EINTR { continue }
-                 fatalError("Unexpected error writing: \(err)")
-             }
-             buf = .init(rebasing: buf.dropFirst(Int(rc)))
-         }
-     }
- }
+    string.withUTF8Buffer { buf in
+        var buf = buf
+        while buf.count > 0 {
+            // 2 is stderr
+            let rc = write(2, buf.baseAddress, buf.count)
+            if rc < 0 {
+                let err = errno
+                if err == EINTR { continue }
+                fatalError("Unexpected error writing: \(err)")
+            }
+            buf = .init(rebasing: buf.dropFirst(Int(rc)))
+        }
+    }
+}
 
 /// Execute the given closure and ensure we release all auto pools if needed.
 @inlinable


### PR DESCRIPTION
Motivation

It's tempting for us to use the FILE * for stderr whenever we want to print to it. However, the Linux libc modules aren't appropriately annotated to call that field constant, and indeed it isn't. This causes Swift to throw a fit if we even touch it.

Modifications

Introduce an awkward function that issues direct writes to stderr instead of using the FILE *.

Result

Swift is happier.