### PR TITLE
Make NIOPosix strict-concurrency clean

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -120,7 +120,8 @@ let package = Package(
                 swiftAtomics,
             ],
             exclude: includePrivacyManifest ? [] : ["PrivacyInfo.xcprivacy"],
-            resources: includePrivacyManifest ? [.copy("PrivacyInfo.xcprivacy")] : []
+            resources: includePrivacyManifest ? [.copy("PrivacyInfo.xcprivacy")] : [],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "NIO",

--- a/Sources/NIOPosix/GetaddrinfoResolver.swift
+++ b/Sources/NIOPosix/GetaddrinfoResolver.swift
@@ -217,7 +217,7 @@ internal final class GetaddrinfoResolver: Resolver, Sendable {
 
         // Ensure that both futures are succeeded in the same tick
         // to avoid racing and potentially leaking a promise
-        self.loop.execute {
+        self.loop.execute { [v4Results, v6Results] in
             self.v6Future.succeed(v6Results)
             self.v4Future.succeed(v4Results)
         }

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -351,7 +351,7 @@ internal final class SelectableEventLoop: EventLoop, @unchecked Sendable {
             id: self.scheduledTaskCounter.loadThenWrappingIncrement(ordering: .relaxed),
             {
                 do {
-                    promise.succeed(try task())
+                    promise.assumeIsolatedUnsafeUnchecked().succeed(try task())
                 } catch let err {
                     promise.fail(err)
                 }


### PR DESCRIPTION
Motivation

NIOPosix should be clean under strict concurrency

Modifications

- Fix newly-added issue in GetaddrinfoResolver
- Fix newly-added issue in SEL
- Lock in the win in Package.swift

Result

We did it!
