### PR TITLE
Update the legacy CI matrix for 6.1 nightly

### DIFF
--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -46,15 +46,26 @@ on:
         description: "The command of the 6.0 Swift version linux matrix job to execute."
       matrix_linux_nightly_6_0_enabled:
         type: boolean
-        description: "Boolean to enable the nightly 6.0 Swift version matrix job. Defaults to true."
+        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
         default: true
       matrix_linux_nightly_6_0_container_image:
         type: string
-        description: "Container image for the nightly 6.0 Swift version matrix job. Defaults to matching Swift Ubuntu image."
+        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
         default: "swiftlang/swift:nightly-6.0-jammy"
       matrix_linux_nightly_6_0_command_override:
         type: string
-        description: "The command of the nightly 6.0 Swift version linux matrix job to execute."
+        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
+      matrix_linux_nightly_6_1_enabled:
+        type: boolean
+        description: "Boolean to enable the nightly 6.1 Swift version matrix job. Defaults to true."
+        default: true
+      matrix_linux_nightly_6_1_container_image:
+        type: string
+        description: "Container image for the nightly 6.1 Swift version matrix job. Defaults to matching Swift Ubuntu image."
+        default: "swiftlang/swift:nightly-6.1-jammy"
+      matrix_linux_nightly_6_1_command_override:
+        type: string
+        description: "The command of the nightly 6.1 Swift version linux matrix job to execute."
       matrix_linux_nightly_main_enabled:
         type: boolean
         description: "Boolean to enable the nightly main Swift version matrix job. Defaults to true."
@@ -80,11 +91,18 @@ on:
         description: "The command of the 6.0 Swift version windows matrix job to execute."
       matrix_windows_nightly_6_0_enabled:
         type: boolean
-        description: "Boolean to enable the nightly 6.0 Swift version matrix job. Defaults to true."
+        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
         default: false
       matrix_windows_nightly_6_0_command_override:
         type: string
-        description: "The command of the nightly 6.0 Swift version windows matrix job to execute."
+        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
+      matrix_windows_nightly_6_1_enabled:
+        type: boolean
+        description: "Boolean to enable the nightly 6.1 Swift version matrix job. Defaults to true."
+        default: false
+      matrix_windows_nightly_6_1_command_override:
+        type: string
+        description: "The command of the nightly 6.1 Swift version windows matrix job to execute."
       matrix_windows_nightly_main_enabled:
         type: boolean
         description: "Boolean to enable the nightly main Swift version matrix job. Defaults to true."
@@ -116,9 +134,9 @@ jobs:
           - image: ${{ inputs.matrix_linux_6_0_container_image }}
             swift_version: "6.0"
             enabled: ${{ inputs.matrix_linux_6_0_enabled }}
-          - image: ${{ inputs.matrix_linux_nightly_6_0_container_image }}
-            swift_version: "nightly-6.0"
-            enabled: ${{ inputs.matrix_linux_nightly_6_0_enabled }}
+          - image: ${{ inputs.matrix_linux_nightly_6_1_container_image }}
+            swift_version: "nightly-6.1"
+            enabled: ${{ inputs.matrix_linux_nightly_6_1_enabled }}
           - image: ${{ inputs.matrix_linux_nightly_main_container_image }}
             swift_version: "nightly-main"
             enabled: ${{ inputs.matrix_linux_nightly_main_enabled }}
@@ -143,7 +161,7 @@ jobs:
           COMMAND_OVERRIDE_5_9: ${{ inputs.matrix_linux_5_9_command_override }}
           COMMAND_OVERRIDE_5_10: ${{ inputs.matrix_linux_5_10_command_override }}
           COMMAND_OVERRIDE_6_0: ${{ inputs.matrix_linux_6_0_command_override }}
-          COMMAND_OVERRIDE_NIGHTLY_6_0: ${{ inputs.matrix_linux_nightly_6_0_command_override }}
+          COMMAND_OVERRIDE_NIGHTLY_6_1: ${{ inputs.matrix_linux_nightly_6_1_command_override }}
           COMMAND_OVERRIDE_NIGHTLY_MAIN: ${{ inputs.matrix_linux_nightly_main_command_override }}
         run: |
           apt-get -qq update && apt-get -qq -y install curl
@@ -185,9 +203,9 @@ jobs:
       matrix:
         # We are specifying only the major and minor of the docker images to automatically pick up the latest patch release
         swift:
-          - image: swiftlang/swift:nightly-6.0-windowsservercore-1809
-            swift_version: "nightly-6.0"
-            enabled: ${{ inputs.matrix_windows_nightly_6_0_enabled }}
+          - image: swiftlang/swift:nightly-6.1-windowsservercore-1809
+            swift_version: "nightly-6.1"
+            enabled: ${{ inputs.matrix_windows_nightly_6_1_enabled }}
           - image: swiftlang/swift:nightly-main-windowsservercore-1809
             swift_version: "nightly-main"
             enabled: ${{ inputs.matrix_windows_nightly_main_enabled }}
@@ -207,4 +225,4 @@ jobs:
       - name: Run matrix job
         if: ${{ matrix.swift.enabled }}
         run: |
-          docker run --env SWIFT_VERSION="${{ matrix.swift.swift_version }}" --env COMMAND="${{ inputs.matrix_windows_command }}" --env COMMAND_OVERRIDE_NIGHTLY_6_0="${{ inputs.matrix_windows_nightly_6_0_command_override }}" --env COMMAND_OVERRIDE_NIGHTLY_MAIN="${{ inputs.matrix_windows_nightly_main_command_override }}" -v ${{ github.workspace }}:C:\source ${{ matrix.swift.image }} cmd /s /c  "swift --version & cd C:\source\ & powershell -File __check-matrix-job.ps1"
+          docker run --env SWIFT_VERSION="${{ matrix.swift.swift_version }}" --env COMMAND="${{ inputs.matrix_windows_command }}" --env COMMAND_OVERRIDE_NIGHTLY_6_1="${{ inputs.matrix_windows_nightly_6_1_command_override }}" --env COMMAND_OVERRIDE_NIGHTLY_MAIN="${{ inputs.matrix_windows_nightly_main_command_override }}" -v ${{ github.workspace }}:C:\source ${{ matrix.swift.image }} cmd /s /c  "swift --version & cd C:\source\ & powershell -File __check-matrix-job.ps1"


### PR DESCRIPTION
### Motivation:

Some repositories still use the older CI Swift matrix directly so we need to update it to handle 6.1 nightlies.

### Modifications:

Replace 6.0 nightly with 6.1 nightly.

### Result:

External CI should use 6.1 nightly.