### PR TITLE
Opt _NIOConcurrency into Strict Concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -136,7 +136,8 @@ let package = Package(
             dependencies: [
                 .target(name: "NIO", condition: .when(platforms: historicalNIOPosixDependencyRequired)),
                 "NIOCore",
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "NIOFoundationCompat",


### PR DESCRIPTION
Motivation:

We intend to have this package be completely strict-concurrency clean, so every target needs to be opted in, even those that currently have no code.

Modifications:

Opt in this empty target to strict concurrency.

Result:

One more database entry.