### PR TITLE
Opt NIOFoundationCompat into strict concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -143,7 +143,8 @@ let package = Package(
             dependencies: [
                 .target(name: "NIO", condition: .when(platforms: historicalNIOPosixDependencyRequired)),
                 "NIOCore",
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "CNIOAtomics",


### PR DESCRIPTION
Motivation:

I continue to grab the low-hanging fruit. This time I've opted a purely data-processing module into strict concurrency. Truly, I am the hero Gotham deserves.

Modifications:

Set some build flags.

Result:

Stricter concurrency.
