### PR TITLE
Opt NIO module into Strict Concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -129,7 +129,8 @@ let package = Package(
                 "NIOCore",
                 "NIOEmbedded",
                 "NIOPosix",
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "_NIOConcurrency",


### PR DESCRIPTION
Motivation:

Honestly these little modules are pretty mechanical now.

Modifications:

Add the strict concurrency flags to a module with nothing in it.

Result:

Become even more automatic from way downtown.