### PR TITLE
Clean up concurrency in NIOEchoClient

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -300,7 +300,8 @@ let package = Package(
                 "NIOCore",
                 "NIOConcurrencyHelpers",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOHTTP1Server",

--- a/Sources/NIOEchoClient/main.swift
+++ b/Sources/NIOEchoClient/main.swift
@@ -58,7 +58,9 @@ let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
     .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
-        channel.pipeline.addHandler(EchoHandler())
+        channel.eventLoop.makeCompletedFuture {
+            try channel.pipeline.syncOperations.addHandler(EchoHandler())
+        }
     }
 defer {
     try! group.syncShutdownGracefully()


### PR DESCRIPTION
Motivation:

We're getting to the examples now! This patch updates NIOEchoClient to be clean under strict concurrency.

Modifications:

Use the sync operations to add echo handler.

Result:

Another strict concurrency module.