### PR TITLE
Lock in strict concurrency in NIOEchoServer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -291,7 +291,8 @@ let package = Package(
                 "NIOCore",
                 "NIOConcurrencyHelpers",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOEchoClient",


### PR DESCRIPTION
Motivation:

Prior patches actually removed all the issues in NIOEchoServer, so let's bank the win.

Modifications:

Added strict concurrency checking to NIOEchoServer

Result:

More stricter.