### PR TITLE
Add strict concurrency to NIOUDPEchoServer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -374,7 +374,8 @@ let package = Package(
                 "NIOPosix",
                 "NIOCore",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOUDPEchoClient",

--- a/Sources/NIOUDPEchoServer/main.swift
+++ b/Sources/NIOUDPEchoServer/main.swift
@@ -47,8 +47,9 @@ var bootstrap = DatagramBootstrap(group: group)
 
     // Set the handlers that are applied to the bound channel
     .channelInitializer { channel in
-        // Ensure we don't read faster than we can write by adding the BackPressureHandler into the pipeline.
-        channel.pipeline.addHandler(EchoHandler())
+        channel.eventLoop.makeCompletedFuture {
+            try channel.pipeline.syncOperations.addHandler(EchoHandler())
+        }
     }
 
 defer {


### PR DESCRIPTION
Motivation:

Another strict concurrency change, another echo handler.

Modifications:

Move to sync operations.

Result:

Another step on strict concurrency.