### PR TITLE
Update NIOUDPEchoClient for strict concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -382,7 +382,8 @@ let package = Package(
                 "NIOPosix",
                 "NIOCore",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOAsyncAwaitDemo",


### PR DESCRIPTION
Motivation:

NIOUDPEchoClient should be strict concurrency clean.

Modifications:

Annotate one closure @Sendable to convince Swift it's ok.

Result:

Strict concurrency clean in NIOUDPEchoClient.