### PR TITLE
Strict concurrency for TCP examples

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -275,7 +275,8 @@ let package = Package(
                 "NIOPosix",
                 "NIOCore",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOTCPEchoClient",
@@ -283,7 +284,8 @@ let package = Package(
                 "NIOPosix",
                 "NIOCore",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOEchoServer",


### PR DESCRIPTION
Motivation:

Two more examples with no changes required.

Modifications:

Lock in strict concurrency for NIOTCPEchoClient and NIOTCPEchoServer.

Result:

Even more stricter concurrencier.