### PR TITLE
Strict concurrency for the chat examples

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -331,7 +331,8 @@ let package = Package(
                 "NIOCore",
                 "NIOConcurrencyHelpers",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOChatClient",
@@ -340,7 +341,8 @@ let package = Package(
                 "NIOCore",
                 "NIOConcurrencyHelpers",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOWebSocketServer",
@@ -367,7 +369,8 @@ let package = Package(
             dependencies: [
                 "NIOPosix",
                 "NIOCore",
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOUDPEchoServer",

--- a/Sources/NIOChatClient/main.swift
+++ b/Sources/NIOChatClient/main.swift
@@ -47,7 +47,9 @@ let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
     .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
-        channel.pipeline.addHandler(ChatHandler())
+        channel.eventLoop.makeCompletedFuture {
+            try channel.pipeline.syncOperations.addHandler(ChatHandler())
+        }
     }
 defer {
     try! group.syncShutdownGracefully()

--- a/Sources/NIOChatClient/main.swift
+++ b/Sources/NIOChatClient/main.swift
@@ -18,19 +18,9 @@ private final class ChatHandler: ChannelInboundHandler {
     public typealias InboundIn = ByteBuffer
     public typealias OutboundOut = ByteBuffer
 
-    private func printByte(_ byte: UInt8) {
-        #if os(Android)
-        print(Character(UnicodeScalar(byte)), terminator: "")
-        #else
-        fputc(Int32(byte), stdout)
-        #endif
-    }
-
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        var buffer = Self.unwrapInboundIn(data)
-        while let byte: UInt8 = buffer.readInteger() {
-            printByte(byte)
-        }
+        let buffer = Self.unwrapInboundIn(data)
+        print(String(buffer: buffer))
     }
 
     public func errorCaught(context: ChannelHandlerContext, error: Error) {

--- a/Sources/NIOMulticastChat/main.swift
+++ b/Sources/NIOMulticastChat/main.swift
@@ -72,8 +72,8 @@ let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 var datagramBootstrap = DatagramBootstrap(group: group)
     .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
-        channel.pipeline.addHandler(ChatMessageEncoder()).flatMap {
-            channel.pipeline.addHandler(ChatMessageDecoder())
+        channel.eventLoop.makeCompletedFuture {
+            try channel.pipeline.syncOperations.addHandlers(ChatMessageEncoder(), ChatMessageDecoder())
         }
     }
 


### PR DESCRIPTION
Motivation:

Our next suite of examples for strict concurrency are the chat ones. These are very similar to the rest: either no violation at all, or just a need to use the sync operations on pipeline setup.

Modifications:

- Use sync operations
- Lock in strict concurrency checking

Result:

We continue our march.