### PR TITLE
Make the FileSystem world strict concurrency clean

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -256,7 +256,8 @@ let package = Package(
             dependencies: [
                 "_NIOFileSystem"
             ],
-            path: "Sources/_NIOFileSystemExported"
+            path: "Sources/_NIOFileSystemExported",
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "_NIOFileSystemFoundationCompat",
@@ -264,7 +265,8 @@ let package = Package(
                 "_NIOFileSystem",
                 "NIOFoundationCompat",
             ],
-            path: "Sources/NIOFileSystemFoundationCompat"
+            path: "Sources/NIOFileSystemFoundationCompat",
+            swiftSettings: strictConcurrencySettings
         ),
 
         // MARK: - Examples
@@ -543,7 +545,7 @@ let package = Package(
                 swiftCollections,
                 swiftSystem,
             ],
-            swiftSettings: [
+            swiftSettings: strictConcurrencySettings + [
                 .define("ENABLE_MOCKING", .when(configuration: .debug))
             ]
         ),
@@ -560,14 +562,16 @@ let package = Package(
                 // for the integration tests. Exclude the whole tree from
                 // the build.
                 "Test Data"
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .testTarget(
             name: "NIOFileSystemFoundationCompatTests",
             dependencies: [
                 "_NIOFileSystem",
                 "_NIOFileSystemFoundationCompat",
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
     ]
 )

--- a/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFileSystemIntegrationTests/FileSystemTests.swift
@@ -585,9 +585,9 @@ final class FileSystemTests: XCTestCase {
     func testCopyLargeFile() async throws {
         let sourcePath = try await self.fs.temporaryFilePath()
         let destPath = try await self.fs.temporaryFilePath()
-        self.addTeardownBlock {
-            _ = try? await self.fs.removeItem(at: sourcePath, strategy: .platformDefault)
-            _ = try? await self.fs.removeItem(at: destPath, strategy: .platformDefault)
+        self.addTeardownBlock { [fs] in
+            _ = try? await fs.removeItem(at: sourcePath, strategy: .platformDefault)
+            _ = try? await fs.removeItem(at: destPath, strategy: .platformDefault)
         }
 
         let sourceInfo = try await self.fs.withFileHandle(
@@ -854,7 +854,7 @@ final class FileSystemTests: XCTestCase {
         _ copyStrategy: CopyStrategy,
         _ description: String,
         _ path: FilePath,
-        triggerCancel: @escaping (DirectoryEntry) -> Bool,
+        triggerCancel: @escaping @Sendable (DirectoryEntry) -> Bool,
         line: UInt = #line
     ) async throws {
 
@@ -863,8 +863,8 @@ final class FileSystemTests: XCTestCase {
         let requestedCancel = NIOLockedValueBox<Bool>(false)
         let cancelRequested = expectation(description: "cancel requested")
 
-        let task = Task {
-            try await self.fs.copyItem(at: path, to: copyPath, strategy: copyStrategy) { _, error in
+        let task = Task { [fs] in
+            try await fs.copyItem(at: path, to: copyPath, strategy: copyStrategy) { _, error in
                 throw error
             } shouldCopyItem: { source, destination in
                 // Abuse shouldCopy to trigger the cancellation after getting some way in.


### PR DESCRIPTION
Motivation:

We have a few other file system modules with a small amount of code, and a lot of tests. Most of these require no changes for strict concurrency, so let's tackle them all.

Modifications:

Strict concurrency for filesystem targets enabled. Fixed a few incorrect test case captures.

Result:

Strict concurrency clean filesystem bits.
