### PR TITLE
Fix typo in code comment

### DIFF
--- a/Sources/CNIOAtomics/src/cpp_magic.h
+++ b/Sources/CNIOAtomics/src/cpp_magic.h
@@ -219,7 +219,7 @@
  *
  * 1. The preprocessor expands the arguments to _IF casting the condition to '0'
  *    or '1'.
- * 2. The casted condition is concatencated with _IF_ giving _IF_0 or _IF_1.
+ * 2. The casted condition is concatenated with _IF giving _IF_0 or _IF_1.
  * 3. The _IF_0 and _IF_1 macros either returns the argument or doesn't (e.g.
  *    they implement the "choice selection" part of the macro).
  * 4. Note that the "true" clause is in the extra set of brackets; thus these

--- a/Sources/CNIOLLHTTP/include/c_nio_llhttp.h
+++ b/Sources/CNIOLLHTTP/include/c_nio_llhttp.h
@@ -675,7 +675,7 @@ llhttp_errno_t c_nio_llhttp_execute(llhttp_t* parser, const char* data, size_t l
  * Requests without `Content-Length` and other messages might require treating
  * all incoming bytes as the part of the body, up to the last byte of the
  * connection. This method will invoke `on_message_complete()` callback if the
- * request was terminated safely. Otherwise a error code would be returned.
+ * request was terminated safely. Otherwise an error code would be returned.
  */
 LLHTTP_EXPORT
 llhttp_errno_t c_nio_llhttp_finish(llhttp_t* parser);


### PR DESCRIPTION
_[Fix typos in code comments]_

### Motivation:

_To correct minor typographical errors in code comments for better readability and understanding._

### Modifications:

_Fixed typos in comments within the following files:  
- Sources/CNIOAtomics/src/cpp_magic.h  
- Sources/CNIOLLHTTP/include/c_nio_llhttp.h_

### Result:

_Improved clarity and accuracy of code comments. No functional changes to the code._

N/A