### PR TITLE
Enable strict concurrency checking for NIOTLS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -221,7 +221,8 @@ let package = Package(
                 .target(name: "NIO", condition: .when(platforms: historicalNIOPosixDependencyRequired)),
                 "NIOCore",
                 swiftCollections,
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "NIOTestUtils",

--- a/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
+++ b/Sources/NIOTLS/NIOTypedApplicationProtocolNegotiationHandler.swift
@@ -39,7 +39,8 @@ import NIOCore
 /// specify a type that must be returned from the supplied closure. The result will then be used to succeed the ``NIOTypedApplicationProtocolNegotiationHandler/protocolNegotiationResult``
 /// promise. This allows us to construct pipelines that include protocol negotiation handlers and be able to bridge them into `NIOAsyncChannel`
 /// based bootstraps.
-public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>: ChannelInboundHandler,
+@preconcurrency
+public final class NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult: Sendable>: ChannelInboundHandler,
     RemovableChannelHandler
 {
     public typealias InboundIn = Any


### PR DESCRIPTION
### Motivation:

To ensure NIOTLS concurrency safety.

### Modifications:

* Enable strict concurrency checking in the package manifest.
* Require `NegotiationResult` to be `Sendable`
  * In `NIOTypedApplicationProtocolNegotiationHandler<NegotiationResult>` the
result is used to fulfil promises and perform hops so we need it to be
sendable when accessed from these other concurrency domains.

### Result:

Builds will warn and CI will fail if regressions are introduced.