### PR TITLE
Enable strict concurrency checking for NIOHTTP1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -196,7 +196,8 @@ let package = Package(
                 "NIOConcurrencyHelpers",
                 "CNIOLLHTTP",
                 swiftCollections,
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "NIOWebSocket",

--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -22,6 +22,10 @@ public typealias NIOHTTPClientUpgradeConfiguration = (
     upgraders: [NIOHTTPClientProtocolUpgrader], completionHandler: @Sendable (ChannelHandlerContext) -> Void
 )
 
+public typealias NIOHTTPClientUpgradeSendableConfiguration = (
+    upgraders: [NIOHTTPClientProtocolUpgrader & Sendable], completionHandler: @Sendable (ChannelHandlerContext) -> Void
+)
+
 /// Configuration required to configure a HTTP server pipeline for upgrade.
 ///
 /// See the documentation for `HTTPServerUpgradeHandler` for details on these
@@ -31,6 +35,10 @@ public typealias HTTPUpgradeConfiguration = NIOHTTPServerUpgradeConfiguration
 
 public typealias NIOHTTPServerUpgradeConfiguration = (
     upgraders: [HTTPServerProtocolUpgrader], completionHandler: @Sendable (ChannelHandlerContext) -> Void
+)
+
+public typealias NIOHTTPServerUpgradeSendableConfiguration = (
+    upgraders: [HTTPServerProtocolUpgrader & Sendable], completionHandler: @Sendable (ChannelHandlerContext) -> Void
 )
 
 extension ChannelPipeline {
@@ -67,7 +75,7 @@ extension ChannelPipeline {
     public func addHTTPClientHandlers(
         position: Position = .last,
         leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
-        withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration?
+        withClientUpgrade upgrade: NIOHTTPClientUpgradeSendableConfiguration?
     ) -> EventLoopFuture<Void> {
         self._addHTTPClientHandlers(
             position: position,
@@ -79,7 +87,7 @@ extension ChannelPipeline {
     private func _addHTTPClientHandlers(
         position: Position = .last,
         leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
-        withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration?
+        withClientUpgrade upgrade: NIOHTTPClientUpgradeSendableConfiguration?
     ) -> EventLoopFuture<Void> {
         let future: EventLoopFuture<Void>
 
@@ -120,11 +128,12 @@ extension ChannelPipeline {
     ///         the upgrade completion handler. See the documentation on ``NIOHTTPClientUpgradeHandler``
     ///         for more details.
     /// - Returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    @preconcurrency
     public func addHTTPClientHandlers(
         position: Position = .last,
         leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
         enableOutboundHeaderValidation: Bool = true,
-        withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration? = nil
+        withClientUpgrade upgrade: NIOHTTPClientUpgradeSendableConfiguration? = nil
     ) -> EventLoopFuture<Void> {
         let future: EventLoopFuture<Void>
 
@@ -168,12 +177,13 @@ extension ChannelPipeline {
     ///         the upgrade completion handler. See the documentation on ``NIOHTTPClientUpgradeHandler``
     ///         for more details.
     /// - Returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    @preconcurrency
     public func addHTTPClientHandlers(
         position: Position = .last,
         leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
         enableOutboundHeaderValidation: Bool = true,
         encoderConfiguration: HTTPRequestEncoder.Configuration = .init(),
-        withClientUpgrade upgrade: NIOHTTPClientUpgradeConfiguration? = nil
+        withClientUpgrade upgrade: NIOHTTPClientUpgradeSendableConfiguration? = nil
     ) -> EventLoopFuture<Void> {
         let future: EventLoopFuture<Void>
 
@@ -234,7 +244,7 @@ extension ChannelPipeline {
     public func configureHTTPServerPipeline(
         position: ChannelPipeline.Position = .last,
         withPipeliningAssistance pipelining: Bool = true,
-        withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
+        withServerUpgrade upgrade: NIOHTTPServerUpgradeSendableConfiguration? = nil,
         withErrorHandling errorHandling: Bool = true
     ) -> EventLoopFuture<Void> {
         self._configureHTTPServerPipeline(
@@ -274,10 +284,11 @@ extension ChannelPipeline {
     ///   - headerValidation: Whether to validate outbound request headers to confirm that they meet
     ///         spec compliance. Defaults to `true`.
     /// - Returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    @preconcurrency
     public func configureHTTPServerPipeline(
         position: ChannelPipeline.Position = .last,
         withPipeliningAssistance pipelining: Bool = true,
-        withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
+        withServerUpgrade upgrade: NIOHTTPServerUpgradeSendableConfiguration? = nil,
         withErrorHandling errorHandling: Bool = true,
         withOutboundHeaderValidation headerValidation: Bool = true
     ) -> EventLoopFuture<Void> {
@@ -320,10 +331,11 @@ extension ChannelPipeline {
     ///         spec compliance. Defaults to `true`.
     ///   - encoderConfiguration: The configuration for the ``HTTPResponseEncoder``.
     /// - Returns: An `EventLoopFuture` that will fire when the pipeline is configured.
+    @preconcurrency
     public func configureHTTPServerPipeline(
         position: ChannelPipeline.Position = .last,
         withPipeliningAssistance pipelining: Bool = true,
-        withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
+        withServerUpgrade upgrade: NIOHTTPServerUpgradeSendableConfiguration? = nil,
         withErrorHandling errorHandling: Bool = true,
         withOutboundHeaderValidation headerValidation: Bool = true,
         withEncoderConfiguration encoderConfiguration: HTTPResponseEncoder.Configuration = .init()
@@ -341,7 +353,7 @@ extension ChannelPipeline {
     private func _configureHTTPServerPipeline(
         position: ChannelPipeline.Position = .last,
         withPipeliningAssistance pipelining: Bool = true,
-        withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
+        withServerUpgrade upgrade: NIOHTTPServerUpgradeSendableConfiguration? = nil,
         withErrorHandling errorHandling: Bool = true,
         withOutboundHeaderValidation headerValidation: Bool = true,
         withEncoderConfiguration encoderConfiguration: HTTPResponseEncoder.Configuration = .init()

--- a/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/HTTPServerUpgradeHandler.swift
@@ -194,7 +194,6 @@ public final class HTTPServerUpgradeHandler: ChannelInboundHandler, RemovableCha
     ///
     /// - Returns: An isolated `EventLoopFuture` that will contain a callback to invoke if upgrade is requested,
     /// or nil if upgrade has failed. Never returns a failed future.
-    /// The `NIOLoopBound` is safe because it's only called after the hop in firstRequestHeadReceived
     private func handleUpgrade(
         context: ChannelHandlerContext,
         request: HTTPRequestHead,

--- a/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
@@ -18,7 +18,8 @@ import NIOCore
 
 /// Configuration for an upgradable HTTP pipeline.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-public struct NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult: Sendable> {
+@preconcurrency
+public struct NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult: Sendable>: Sendable {
     /// Whether to provide assistance handling HTTP clients that pipeline
     /// their requests. Defaults to `true`. If `false`, users will need to handle clients that pipeline themselves.
     public var enablePipelining = true
@@ -146,7 +147,8 @@ extension ChannelPipeline.SynchronousOperations {
 
 /// Configuration for an upgradable HTTP pipeline.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-public struct NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult: Sendable> {
+@preconcurrency
+public struct NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult: Sendable>: Sendable {
     /// The strategy to use when dealing with leftover bytes after removing the ``HTTPDecoder`` from the pipeline.
     public var leftOverBytesStrategy = RemoveAfterUpgradeStrategy.dropBytes
 

--- a/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPTypedPipelineSetup.swift
@@ -18,7 +18,6 @@ import NIOCore
 
 /// Configuration for an upgradable HTTP pipeline.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@preconcurrency
 public struct NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult: Sendable>: Sendable {
     /// Whether to provide assistance handling HTTP clients that pipeline
     /// their requests. Defaults to `true`. If `false`, users will need to handle clients that pipeline themselves.
@@ -147,7 +146,6 @@ extension ChannelPipeline.SynchronousOperations {
 
 /// Configuration for an upgradable HTTP pipeline.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@preconcurrency
 public struct NIOUpgradableHTTPClientPipelineConfiguration<UpgradeResult: Sendable>: Sendable {
     /// The strategy to use when dealing with leftover bytes after removing the ``HTTPDecoder`` from the pipeline.
     public var leftOverBytesStrategy = RemoveAfterUpgradeStrategy.dropBytes

--- a/Sources/NIOHTTP1/NIOHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOHTTPClientUpgradeHandler.swift
@@ -59,7 +59,8 @@ extension NIOHTTPClientUpgradeError: CustomStringConvertible {
 /// An object that implements `NIOHTTPClientProtocolUpgrader` knows how to handle HTTP upgrade to
 /// a protocol on a client-side channel.
 /// It has the option of denying this upgrade based upon the server response.
-public protocol NIOHTTPClientProtocolUpgrader {
+@preconcurrency
+public protocol NIOHTTPClientProtocolUpgrader: Sendable {
 
     /// The protocol this upgrader knows how to support.
     var supportedProtocol: String { get }
@@ -371,7 +372,7 @@ public final class NIOHTTPClientUpgradeHandler: ChannelDuplexHandler, RemovableC
             return pipeline.eventLoop.makeSucceededFuture(())
         }
 
-        let removeFutures = self.httpHandlers.map { pipeline.removeHandler($0) }
+        let removeFutures = self.httpHandlers.map { pipeline.syncOperations.removeHandler($0) }
         return .andAllSucceed(removeFutures, on: pipeline.eventLoop)
     }
 

--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
@@ -43,7 +43,6 @@ public protocol NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>: Sendable {
 
 /// The upgrade configuration for the ``NIOTypedHTTPClientUpgradeHandler``.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@preconcurrency
 public struct NIOTypedHTTPClientUpgradeConfiguration<UpgradeResult: Sendable>: Sendable {
     /// The initial request head that is sent out once the channel becomes active.
     public var upgradeRequestHead: HTTPRequestHead

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -269,9 +269,14 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
         request: HTTPRequestHead,
         allHeaderNames: Set<String>,
         connectionHeader: Set<String>
-    ) -> EventLoopFuture<
-        (upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders, proto: String)?
-    >.Isolated {
+    )
+        -> EventLoopFuture<
+            (
+                upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders,
+                proto: String
+            )?
+        >.Isolated
+    {
         // We want a local copy of the protocol iterator. We'll pass it to the next invocation of the function.
         var protocolIterator = protocolIterator
         guard let proto = protocolIterator.next() else {
@@ -387,12 +392,12 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
         self.removeExtraHandlers(pipeline: pipeline)
             .assumeIsolated()
             .flatMap {
-            return self.sendUpgradeResponse(context: context, responseHeaders: responseHeaders)
-        }.flatMap {
-            return pipeline.syncOperations.removeHandler(self.httpEncoder)
-        }.flatMap { () -> EventLoopFuture<UpgradeResult> in
-            upgrader.upgrade(channel: channel, upgradeRequest: requestHead)
-        }.nonisolated().hop(to: context.eventLoop)
+                self.sendUpgradeResponse(context: context, responseHeaders: responseHeaders)
+            }.flatMap {
+                pipeline.syncOperations.removeHandler(self.httpEncoder)
+            }.flatMap { () -> EventLoopFuture<UpgradeResult> in
+                upgrader.upgrade(channel: channel, upgradeRequest: requestHead)
+            }.nonisolated().hop(to: context.eventLoop)
             .assumeIsolated()
             .whenComplete { result in
                 self.upgradingHandlerCompleted(context: context, result, requestHeadAndProtocol: (requestHead, proto))

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -48,7 +48,6 @@ public protocol NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>: Sendable {
 
 /// The upgrade configuration for the ``NIOTypedHTTPServerUpgradeHandler``.
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-@preconcurrency
 public struct NIOTypedHTTPServerUpgradeConfiguration<UpgradeResult: Sendable>: Sendable {
     /// The array of potential upgraders.
     public var upgraders: [any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>]
@@ -400,8 +399,7 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
                 pipeline.syncOperations.removeHandler(self.httpEncoder)
             }.flatMap { () -> EventLoopFuture<UpgradeResult> in
                 upgrader.upgrade(channel: channel, upgradeRequest: requestHead)
-            }.nonisolated().hop(to: context.eventLoop)
-            .assumeIsolated()
+            }
             .whenComplete { result in
                 self.upgradingHandlerCompleted(context: context, result, requestHeadAndProtocol: (requestHead, proto))
             }

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -272,7 +272,8 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
     )
         -> EventLoopFuture<
             (
-                upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders,
+                upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>,
+                responseHeaders: HTTPHeaders,
                 proto: String
             )?
         >.Isolated
@@ -332,7 +333,8 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
         requestHead: HTTPRequestHead,
         _ result: Result<
             (
-                upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders,
+                upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>,
+                responseHeaders: HTTPHeaders,
                 proto: String
             )?,
             Error

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgradeHandler.swift
@@ -334,7 +334,8 @@ public final class NIOTypedHTTPServerUpgradeHandler<UpgradeResult: Sendable>: Ch
             (
                 upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders,
                 proto: String
-            )?, Error
+            )?,
+            Error
         >
     ) {
         switch self.stateMachine.findingUpgraderCompleted(requestHead: requestHead, result) {

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
@@ -313,9 +313,11 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
         requestHead: HTTPRequestHead,
         _ result: Result<
             (
-                upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>, responseHeaders: HTTPHeaders,
+                upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>,
+                responseHeaders: HTTPHeaders,
                 proto: String
-            )?, Error
+            )?,
+            Error
         >
     ) -> FindingUpgraderCompletedAction? {
         switch self.state {

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -325,7 +325,7 @@ class HTTPClientUpgradeTestCase: XCTestCase {
 
         let channel = EmbeddedChannel()
 
-        let config: NIOHTTPClientUpgradeConfiguration = (
+        let config: NIOHTTPClientUpgradeSendableConfiguration = (
             upgraders: clientUpgraders,
             completionHandler: { context in
                 channel.pipeline.removeHandler(clientHTTPHandler, promise: nil)

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -61,7 +61,7 @@ private func setUpClientChannel(
 
     let channel = EmbeddedChannel()
 
-    let config: NIOHTTPClientUpgradeConfiguration = (
+    let config: NIOHTTPClientUpgradeSendableConfiguration = (
         upgraders: clientUpgraders,
         completionHandler: { context in
             channel.pipeline.removeHandler(clientHTTPHandler, promise: nil)


### PR DESCRIPTION
### Motivation:

To ensure NIOHTTP1 concurrency safety.

### Modifications:

* Enable strict concurrency checking in the package manifest.
* Mark several objects `Sendable` with `@preconcurrency` annotations where they are returned in futures which may execute in arbitrary concurrency domains.
  * `NIOTypedHTTPClientProtocolUpgrader`
  * `NIOTypedHTTPClientUpgradeConfiguration`
  * `NIOUpgradableHTTPServerPipelineConfiguration`
  * `NIOUpgradableHTTPClientPipelineConfiguration`
  * `NIOTypedHTTPServerProtocolUpgrader`
  * `NIOTypedHTTPServerUpgradeConfiguration`
* Mark handlers as explicitly not sendable
  * `NIOTypedHTTPClientUpgradeHandler`
  * `NIOTypedHTTPServerUpgradeHandler`
* Added new Sendable type aliases:
  * `NIOHTTPClientUpgradeSendableConfiguration`
  * `NIOHTTPServerUpgradeSendableConfiguration`

### Result:

No more concurrency warnings. Builds will warn and CI will fail if regressions are introduced.