### PR TITLE
Make isolated execute on async testing eventloop actually run

### DIFF
--- a/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
+++ b/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
@@ -146,7 +146,8 @@ public final class NIOAsyncTestingEventLoop: EventLoop, @unchecked Sendable {
             task: {
                 do {
                     // UnsafeUnchecked is acceptable because we know we're in the loop here.
-                    promise?.assumeIsolatedUnsafeUnchecked().succeed(try task())
+                    let result = try task()
+                    promise?.assumeIsolatedUnsafeUnchecked().succeed(result)
                 } catch let err {
                     promise?.fail(err)
                 }

--- a/Tests/NIOPosixTests/EventLoopFutureIsolatedTests.swift
+++ b/Tests/NIOPosixTests/EventLoopFutureIsolatedTests.swift
@@ -318,13 +318,15 @@ final class EventLoopFutureIsolatedTest: XCTestCase {
     func _eventLoopIsolated(loop: any EventLoop) throws {
         let f = loop.flatSubmit {
             let value = SuperNotSendable()
+            value.x = 4
 
             // Again, all of these need to close over value. In addition,
             // many need to return it as well.
             let isolated = loop.assumeIsolated()
             XCTAssertIdentical(isolated.nonisolated(), loop)
             isolated.execute {
-                XCTAssertEqual(value.x, 5)
+                XCTAssertEqual(value.x, 4)
+                value.x = 5
             }
             let firstFuture = isolated.submit {
                 let val = SuperNotSendable()


### PR DESCRIPTION
Motivation:

The isolated execute on async testing event loop wouldn't execute tasks in the case of promise being nil

Modifications:

Rewrite the execute logic slightly.

Result:

Correct execution