### PR TITLE
Simplify Windows matrix command invocation

### DIFF
--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -62,6 +62,6 @@ jobs:
             -e SWIFT_VERSION="${{ matrix.config.swift_version }}" `
             -e setup_command_expression=%setup_command_expression% `
             ${{ matrix.config.image }} `
-            cmd /s /c  "swift --version & powershell Invoke-Expression ""$($setup_command_expression) ${{ matrix.config.command }} ${{ matrix.config.command_arguments }}"""
+            cmd /s /c  "swift --version & $($setup_command_expression) ${{ matrix.config.command }} ${{ matrix.config.command_arguments }}"
     env:
       SWIFT_VERSION: ${{ matrix.config.swift_version }}


### PR DESCRIPTION
Simplify Windows matrix command invocation

### Motivation:

The existing invocation hid command execution failures.

### Modifications:

Removed the powershell invocation layer.

### Result:

Failing commands result in workflow failures as expected.

I tested this by pointing CI pipelines to this branch.
* Example of a workflow expected to pass passing: https://github.com/apple/swift-log/actions/runs/13331113564/job/37235228530?pr=350 
* Example of a workflow expected to fail failing: https://github.com/apple/swift-nio/actions/runs/13331079601/job/37235122359?pr=3118