### PR TITLE
Equatable SocketAddressError

### DIFF
--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -59,7 +59,7 @@ import WASILibc
 #endif
 
 /// Special `Error` that may be thrown if we fail to create a `SocketAddress`.
-public enum SocketAddressError: Error, Equatable {
+public enum SocketAddressError: Error, Equatable, Hashable {
     /// The host is unknown (could not be resolved).
     case unknown(host: String, port: Int)
     /// The requested `SocketAddress` is not supported.

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -59,7 +59,7 @@ import WASILibc
 #endif
 
 /// Special `Error` that may be thrown if we fail to create a `SocketAddress`.
-public enum SocketAddressError: Error {
+public enum SocketAddressError: Error, Equatable {
     /// The host is unknown (could not be resolved).
     case unknown(host: String, port: Int)
     /// The requested `SocketAddress` is not supported.


### PR DESCRIPTION
Make `SocketAddressError` `Equatable`. This is useful when running tests that you expect to throw this error as it allows you to write for example
```swift
await #expect(throws: SocketAddressError.unknown(host: "127.0.0.1", port: Int.max)) {
    try await app.startup()
}
```