### PR TITLE
Update generate matrix stript to use nightly_next

### DIFF
--- a/scripts/generate_matrix.sh
+++ b/scripts/generate_matrix.sh
@@ -22,8 +22,8 @@ linux_5_10_enabled="${MATRIX_LINUX_5_10_ENABLED:=true}"
 linux_5_10_command_arguments="$MATRIX_LINUX_5_10_COMMAND_ARGUMENTS"
 linux_6_0_enabled="${MATRIX_LINUX_6_0_ENABLED:=true}"
 linux_6_0_command_arguments="$MATRIX_LINUX_6_0_COMMAND_ARGUMENTS"
-linux_nightly_6_1_enabled="${MATRIX_LINUX_NIGHTLY_6_1_ENABLED:=true}"
-linux_nightly_6_1_command_arguments="$MATRIX_LINUX_NIGHTLY_6_1_COMMAND_ARGUMENTS"
+linux_nightly_next_enabled="${MATRIX_LINUX_NIGHTLY_NEXT_ENABLED:=${MATRIX_LINUX_NIGHTLY_6_1_ENABLED:=true}}"
+linux_nightly_next_command_arguments="${MATRIX_LINUX_NIGHTLY_NEXT_COMMAND_ARGUMENTS:=${MATRIX_LINUX_NIGHTLY_6_1_COMMAND_ARGUMENTS}}"
 linux_nightly_main_enabled="${MATRIX_LINUX_NIGHTLY_MAIN_ENABLED:=true}"
 linux_nightly_main_command_arguments="$MATRIX_LINUX_NIGHTLY_MAIN_COMMAND_ARGUMENTS"
 
@@ -31,8 +31,8 @@ windows_command="$MATRIX_WINDOWS_COMMAND"  # required if any Windows pipeline is
 windows_setup_command="$MATRIX_WINDOWS_SETUP_COMMAND"
 windows_6_0_enabled="${MATRIX_WINDOWS_6_0_ENABLED:=false}"
 windows_6_0_command_arguments="$MATRIX_WINDOWS_6_0_COMMAND_ARGUMENTS"
-windows_nightly_6_1_enabled="${MATRIX_WINDOWS_NIGHTLY_6_1_ENABLED:=false}"
-windows_nightly_6_1_command_arguments="$MATRIX_WINDOWS_NIGHTLY_6_1_COMMAND_ARGUMENTS"
+windows_nightly_next_enabled="${MATRIX_WINDOWS_NIGHTLY_NEXT_ENABLED:=${MATRIX_WINDOWS_NIGHTLY_6_1_ENABLED:=false}}"
+windows_nightly_next_command_arguments="${MATRIX_WINDOWS_NIGHTLY_NEXT_COMMAND_ARGUMENTS:=${MATRIX_WINDOWS_NIGHTLY_6_1_COMMAND_ARGUMENTS}}"
 windows_nightly_main_enabled="${MATRIX_WINDOWS_NIGHTLY_MAIN_ENABLED:=false}"
 windows_nightly_main_command_arguments="$MATRIX_WINDOWS_NIGHTLY_MAIN_COMMAND_ARGUMENTS"
 
@@ -41,13 +41,13 @@ linux_runner="ubuntu-latest"
 linux_5_9_container_image="swift:5.9-jammy"
 linux_5_10_container_image="swift:5.10-jammy"
 linux_6_0_container_image="swift:6.0-jammy"
-linux_nightly_6_1_container_image="swiftlang/swift:nightly-6.1-jammy"
+linux_nightly_next_container_image="swiftlang/swift:nightly-6.1-jammy"
 linux_nightly_main_container_image="swiftlang/swift:nightly-main-jammy"
 
 windows_6_0_runner="windows-2022"
 windows_6_0_container_image="swift:6.0-windowsservercore-ltsc2022"
-windows_nightly_6_1_runner="windows-2019"
-windows_nightly_6_1_container_image="swiftlang/swift:nightly-6.1-windowsservercore-1809"
+windows_nightly_next_runner="windows-2019"
+windows_nightly_next_container_image="swiftlang/swift:nightly-6.1-windowsservercore-1809"
 windows_nightly_main_runner="windows-2019"
 windows_nightly_main_container_image="swiftlang/swift:nightly-main-windowsservercore-1809"
 
@@ -56,7 +56,7 @@ matrix='{"config": []}'
 
 ## Linux
 if [[ "$linux_5_9_enabled" == "true" || "$linux_5_10_enabled" == "true" || "$linux_6_0_enabled" == "true" || \
-  "$linux_nightly_6_1_enabled" == "true" || "$linux_nightly_main_enabled" == "true" ]]; then
+  "$linux_nightly_next_enabled" == "true" || "$linux_nightly_main_enabled" == "true" ]]; then
   if [[ -z "$linux_command" ]]; then
     echo "No linux command defined"; exit 1
   fi
@@ -93,14 +93,14 @@ if [[ "$linux_6_0_enabled" == "true" ]]; then
     '.config[.config| length] |= . + { "name": "6.0", "image": $container_image, "swift_version": "6.0", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
 fi
 
-if [[ "$linux_nightly_6_1_enabled" == "true" ]]; then
+if [[ "$linux_nightly_next_enabled" == "true" ]]; then
   matrix=$(echo "$matrix" | jq -c \
     --arg setup_command "$linux_setup_command"  \
     --arg command "$linux_command"  \
-    --arg command_arguments "$linux_nightly_6_1_command_arguments" \
-    --arg container_image "$linux_nightly_6_1_container_image" \
+    --arg command_arguments "$linux_nightly_next_command_arguments" \
+    --arg container_image "$linux_nightly_next_container_image" \
     --arg runner "$linux_runner" \
-    '.config[.config| length] |= . + { "name": "nightly-6.1", "image": $container_image, "swift_version": "nightly-6.1", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
+    '.config[.config| length] |= . + { "name": "nightly-next", "image": $container_image, "swift_version": "nightly-6.1", "platform": "Linux", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner}')
 fi
 
 if [[ "$linux_nightly_main_enabled" == "true" ]]; then
@@ -114,7 +114,7 @@ if [[ "$linux_nightly_main_enabled" == "true" ]]; then
 fi
 
 ## Windows
-if [[ "$windows_6_0_enabled" == "true" || "$windows_nightly_6_1_enabled" == "true" || "$windows_nightly_main_enabled" == "true" ]]; then
+if [[ "$windows_6_0_enabled" == "true" || "$windows_nightly_next_enabled" == "true" || "$windows_nightly_main_enabled" == "true" ]]; then
   if [[ -z "$windows_command" ]]; then
     echo "No windows command defined"; exit 1
   fi
@@ -130,14 +130,14 @@ if [[ "$windows_6_0_enabled" == "true" ]]; then
     '.config[.config| length] |= . + { "name": "6.0", "image": $container_image, "swift_version": "6.0", "platform": "Windows", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner }')
 fi
 
-if [[ "$windows_nightly_6_1_enabled" == "true" ]]; then
+if [[ "$windows_nightly_next_enabled" == "true" ]]; then
   matrix=$(echo "$matrix" | jq -c \
     --arg setup_command "$windows_setup_command"  \
     --arg command "$windows_command"  \
-    --arg command_arguments "$windows_nightly_6_1_command_arguments" \
-    --arg container_image "$windows_nightly_6_1_container_image" \
-    --arg runner "$windows_nightly_6_1_runner" \
-    '.config[.config| length] |= . + { "name": "nightly-6.1", "image": $container_image, "swift_version": "nightly-6.1", "platform": "Windows", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner }')
+    --arg command_arguments "$windows_nightly_next_command_arguments" \
+    --arg container_image "$windows_nightly_next_container_image" \
+    --arg runner "$windows_nightly_next_runner" \
+    '.config[.config| length] |= . + { "name": "nightly-next", "image": $container_image, "swift_version": "nightly-6.1", "platform": "Windows", "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner }')
 fi
 
 if [[ "$windows_nightly_main_enabled" == "true" ]]; then


### PR DESCRIPTION
Update generate matrix stript to use nightly_next

### Motivation:

Updating the CI parameters for changing nightly job targets with each new Swift version (6.0, 6.1, ...) is onerous. Whilst this gives us some value in the non-nightly pipelines by forcing adopters to apply thought to what is applied to each supported version, the nightlies arguably deliver less value in this regard as they tend to be non-required.

### Modifications:

Change flags to refer to nightly_next rather than nightly_6_1, implement a shim so that the old environment variables still work.

### Result:

We will be able to modify adopter workflows to use nightly_next terminology.

Example of a job where workflows are using the new matrix https://github.com/apple/swift-nio/actions/runs/13520016728