### PR TITLE
Update re-usable workflows to use nightly_next

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,7 +28,11 @@ on:
         default: false
       linux_nightly_6_1_enabled:
         type: boolean
-        description: "Boolean to enable the Linux nightly 6.1 Swift version matrix job. Defaults to true."
+        description: "⚠️  Deprecated, use linux_nightly_next_enabled."
+        default: true
+      linux_nightly_next_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux nightly matrix job for the next Swift version. Defaults to true."
         default: true
       linux_nightly_main_enabled:
         type: boolean
@@ -67,7 +71,7 @@ jobs:
           MATRIX_LINUX_5_9_ENABLED: ${{ inputs.linux_5_9_enabled }}
           MATRIX_LINUX_5_10_ENABLED: ${{ inputs.linux_5_10_enabled }}
           MATRIX_LINUX_6_0_ENABLED: ${{ inputs.linux_6_0_enabled }}
-          MATRIX_LINUX_NIGHTLY_6_1_ENABLED: ${{ inputs.linux_nightly_6_1_enabled }}
+          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: ${{ inputs.linux_nightly_6_1_enabled && inputs.linux_nightly_next_enabled  }}
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: ${{ inputs.linux_nightly_main_enabled }}
 
   benchmarks:

--- a/.github/workflows/cxx_interop.yml
+++ b/.github/workflows/cxx_interop.yml
@@ -21,7 +21,11 @@ on:
         default: false
       linux_nightly_6_1_enabled:
         type: boolean
-        description: "Boolean to enable the Linux nightly 6.0 Swift version matrix job. Defaults to true."
+        description: "⚠️  Deprecated, use linux_nightly_next_enabled."
+        default: true
+      linux_nightly_next_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux matrix job using the nightly build for the next Swift version. Defaults to true."
         default: true
       linux_nightly_main_enabled:
         type: boolean
@@ -60,7 +64,7 @@ jobs:
           MATRIX_LINUX_5_9_ENABLED: ${{ inputs.linux_5_9_enabled }}
           MATRIX_LINUX_5_10_ENABLED: ${{ inputs.linux_5_10_enabled }}
           MATRIX_LINUX_6_0_ENABLED: ${{ inputs.linux_6_0_enabled }}
-          MATRIX_LINUX_NIGHTLY_6_1_ENABLED: ${{ inputs.linux_nightly_6_1_enabled }}
+          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: ${{ inputs.linux_nightly_6_1_enabled && inputs.linux_nightly_next_enabled }}
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: ${{ inputs.linux_nightly_main_enabled }}
 
   cxx-interop:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,25 +14,25 @@ jobs:
   unit-tests:
     name: Unit tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+    uses: apple/swift-nio/.github/workflows/unit_tests.yml@nightly_next
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_nightly_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   benchmarks:
     name: Benchmarks
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/benchmarks.yml@main
+    uses: apple/swift-nio/.github/workflows/benchmarks.yml@nightly_next
     with:
       benchmark_package_path: "Benchmarks"
 
   cxx-interop:
     name: Cxx interop
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@nightly_next
 
   construct-integration-test-matrix:
     name: Construct integration test matrix
@@ -45,7 +45,7 @@ jobs:
         with:
           persist-credentials: false
       - id: generate-matrix
-        run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/nightly_next/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq"
           MATRIX_LINUX_COMMAND: "./scripts/integration_tests.sh"
@@ -54,7 +54,7 @@ jobs:
     name: Integration tests
     needs: construct-integration-test-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@nightly_next
     with:
       name: "Integration tests"
       matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,25 +14,25 @@ jobs:
   unit-tests:
     name: Unit tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/unit_tests.yml@nightly_next
+    uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_nightly_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   benchmarks:
     name: Benchmarks
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/benchmarks.yml@nightly_next
+    uses: apple/swift-nio/.github/workflows/benchmarks.yml@main
     with:
       benchmark_package_path: "Benchmarks"
 
   cxx-interop:
     name: Cxx interop
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@nightly_next
+    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
 
   construct-integration-test-matrix:
     name: Construct integration test matrix
@@ -45,7 +45,7 @@ jobs:
         with:
           persist-credentials: false
       - id: generate-matrix
-        run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/nightly_next/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq"
           MATRIX_LINUX_COMMAND: "./scripts/integration_tests.sh"
@@ -54,7 +54,7 @@ jobs:
     name: Integration tests
     needs: construct-integration-test-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@nightly_next
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Integration tests"
       matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,11 +37,19 @@ on:
         default: ""
       linux_nightly_6_1_enabled:
         type: boolean
-        description: "Boolean to enable the Linux nightly 6.1 Swift version matrix job. Defaults to true."
+        description: "⚠️  Deprecated, use linux_nightly_next_enabled."
         default: true
       linux_nightly_6_1_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Linux nightly 6.1 Swift version matrix job."
+        description: "⚠️  Deprecated, use linux_nightly_next_arguments_override."
+        default: ""
+      linux_nightly_next_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux matrix job using the nightly build for the next Swift version. Defaults to true."
+        default: true
+      linux_nightly_next_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux matrix job using the nightly build for the next Swift version."
         default: ""
       linux_nightly_main_enabled:
         type: boolean
@@ -70,11 +78,19 @@ on:
         default: ""
       windows_nightly_6_1_enabled:
         type: boolean
-        description: "Boolean to enable the Windows nightly 6.1 Swift version matrix job. Defaults to false."
+        description: "⚠️  Deprecated, use windows_nightly_next_enabled."
         default: false
       windows_nightly_6_1_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Windows nightly 6.1 Swift version matrix job."
+        description: "⚠️  Deprecated, use windows_nightly_next_arguments_override."
+        default: ""
+      windows_nightly_next_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows matrix job using the nightly build for the next Swift version. Defaults to true."
+        default: true
+      windows_nightly_next_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Windows matrix job using the nightly build for the next Swift version."
         default: ""
       windows_nightly_main_enabled:
         type: boolean
@@ -106,15 +122,15 @@ jobs:
           MATRIX_LINUX_5_10_COMMAND_ARGUMENTS: ${{ inputs.linux_5_10_arguments_override }}
           MATRIX_LINUX_6_0_ENABLED: ${{ inputs.linux_6_0_enabled }}
           MATRIX_LINUX_6_0_COMMAND_ARGUMENTS: ${{ inputs.linux_6_0_arguments_override }}
-          MATRIX_LINUX_NIGHTLY_6_1_ENABLED: ${{ inputs.linux_nightly_6_1_enabled }}
-          MATRIX_LINUX_NIGHTLY_6_1_COMMAND_ARGUMENTS: ${{ inputs.linux_nightly_6_1_arguments_override }}
+          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: ${{ inputs.linux_nightly_6_1_enabled && inputs.linux_nightly_next_enabled }}
+          MATRIX_LINUX_NIGHTLY_NEXT_COMMAND_ARGUMENTS: ${{ inputs.linux_nightly_6_1_arguments_override }} ${{ inputs.linux_nightly_next_arguments_override }}
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: ${{ inputs.linux_nightly_main_enabled }}
           MATRIX_LINUX_NIGHTLY_MAIN_COMMAND_ARGUMENTS: ${{ inputs.linux_nightly_main_arguments_override }}
           MATRIX_WINDOWS_COMMAND: "swift test"
           MATRIX_WINDOWS_6_0_ENABLED: ${{ inputs.windows_6_0_enabled }}
           MATRIX_WINDOWS_6_0_COMMAND_ARGUMENTS: ${{ inputs.windows_6_0_arguments_override }}
-          MATRIX_WINDOWS_NIGHTLY_6_1_ENABLED: ${{ inputs.windows_nightly_6_1_enabled }}
-          MATRIX_WINDOWS_NIGHTLY_6_1_COMMAND_ARGUMENTS: ${{ inputs.windows_nightly_6_1_arguments_override }}
+          MATRIX_WINDOWS_NIGHTLY_NEXT_ENABLED: ${{ inputs.windows_nightly_6_1_enabled && inputs.windows_nightly_next_enabled }}
+          MATRIX_WINDOWS_NIGHTLY_NEXT_COMMAND_ARGUMENTS: ${{ inputs.windows_nightly_6_1_arguments_override }} ${{ inputs.windows_nightly_next_arguments_override }}
           MATRIX_WINDOWS_NIGHTLY_MAIN_ENABLED: ${{ inputs.windows_nightly_main_enabled }}
           MATRIX_WINDOWS_NIGHTLY_MAIN_COMMAND_ARGUMENTS: ${{ inputs.windows_nightly_main_arguments_override }}
 


### PR DESCRIPTION
### Motivation:

Updating the CI parameters for changing nightly job targets with each
new Swift version (6.0, 6.1, ...) is onerous. Whilst this gives us some
value in the non-nightly pipelines by forcing adopters to apply thought
to what is applied to each supported version, the nightlies arguably
deliver less value in this regard as they tend to be non-required.

### Modifications:

Change parameters to refer to nightly_next rather than nightly_6_1, implement
a shim so that the old parameter names still work.

### Result:

We will be able to modify top-level workflows to use nightly_next
terminology.

Test run with an additional commit opting in to use these changes at the top level https://github.com/apple/swift-nio/actions/runs/13524774485/job/37792437713?pr=3122