### PR TITLE
Expose GITHUB_ACTIONS env var to docker containers

### DIFF
--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -43,6 +43,7 @@ jobs:
           workspace="/$(basename ${{ github.workspace }})"
           docker run -v ${{ github.workspace }}:"$workspace" \
             -w "$workspace" \
+            -e GITHUB_ACTIONS="$GITHUB_ACTIONS" \
             -e SWIFT_VERSION="${{ matrix.config.swift_version }}" \
             -e setup_command_expression="$setup_command_expression" \
             -e workspace="$workspace" \
@@ -59,6 +60,7 @@ jobs:
           $workspace = "C:\" + (Split-Path ${{ github.workspace }} -Leaf)
           docker run -v ${{ github.workspace }}:$($workspace) `
             -w $($workspace) `
+            -e GITHUB_ACTIONS=%GITHUB_ACTIONS% `
             -e SWIFT_VERSION="${{ matrix.config.swift_version }}" `
             -e setup_command_expression=%setup_command_expression% `
             ${{ matrix.config.image }} `


### PR DESCRIPTION
### Motivation:

It can be useful for scripts to be able to check if they are being run in CI. Because we invoke docker on the CI runners, the env var which people may use to do this isn't present.

### Modifications:

Expose `GITHUB_ACTIONS` env var to docker containers in the matrix workflow

### Result:

Adopters of the matrix workflow or downstream workflows will be able to check if they are running in CI
