### PR TITLE
Enable strict concurrency checking for NIOWebSocket

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -207,7 +207,8 @@ let package = Package(
                 "NIOHTTP1",
                 "CNIOSHA1",
                 "_NIOBase64",
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "CNIOLLHTTP",

--- a/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketClientUpgrader.swift
@@ -186,7 +186,7 @@ private func _shouldAllowUpgrade(upgradeResponse: HTTPResponseHead, requestKey: 
 
 /// Called when the upgrade response has been flushed and it is safe to mutate the channel
 /// pipeline. Adds channel handlers for websocket frame encoding, decoding and errors.
-private func _upgrade<UpgradeResult>(
+private func _upgrade<UpgradeResult: Sendable>(
     channel: Channel,
     upgradeResponse: HTTPResponseHead,
     maxFrameSize: Int,

--- a/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
+++ b/Sources/NIOWebSocket/NIOWebSocketServerUpgrader.swift
@@ -312,7 +312,7 @@ private func _buildUpgradeResponse(
         }
 }
 
-private func _upgrade<UpgradeResult>(
+private func _upgrade<UpgradeResult: Sendable>(
     channel: Channel,
     upgradeRequest: HTTPRequestHead,
     maxFrameSize: Int,

--- a/Sources/NIOWebSocket/WebSocketOpcode.swift
+++ b/Sources/NIOWebSocket/WebSocketOpcode.swift
@@ -57,7 +57,24 @@ extension WebSocketOpcode: Equatable {}
 extension WebSocketOpcode: Hashable {}
 
 extension WebSocketOpcode: CaseIterable {
-    public static var allCases = (0..<0x10).map { WebSocketOpcode(rawValue: $0) }
+    public static let allCases: [WebSocketOpcode] = [
+        .init(rawValue: 0x0),
+        .init(rawValue: 0x1),
+        .init(rawValue: 0x2),
+        .init(rawValue: 0x3),
+        .init(rawValue: 0x4),
+        .init(rawValue: 0x5),
+        .init(rawValue: 0x6),
+        .init(rawValue: 0x7),
+        .init(rawValue: 0x8),
+        .init(rawValue: 0x9),
+        .init(rawValue: 0xA),
+        .init(rawValue: 0xB),
+        .init(rawValue: 0xC),
+        .init(rawValue: 0xD),
+        .init(rawValue: 0xE),
+        .init(rawValue: 0xF),
+    ]
 }
 
 extension WebSocketOpcode: CustomStringConvertible {

--- a/Sources/NIOWebSocket/WebSocketOpcode.swift
+++ b/Sources/NIOWebSocket/WebSocketOpcode.swift
@@ -57,24 +57,12 @@ extension WebSocketOpcode: Equatable {}
 extension WebSocketOpcode: Hashable {}
 
 extension WebSocketOpcode: CaseIterable {
-    public static let allCases: [WebSocketOpcode] = [
-        .init(rawValue: 0x0),
-        .init(rawValue: 0x1),
-        .init(rawValue: 0x2),
-        .init(rawValue: 0x3),
-        .init(rawValue: 0x4),
-        .init(rawValue: 0x5),
-        .init(rawValue: 0x6),
-        .init(rawValue: 0x7),
-        .init(rawValue: 0x8),
-        .init(rawValue: 0x9),
-        .init(rawValue: 0xA),
-        .init(rawValue: 0xB),
-        .init(rawValue: 0xC),
-        .init(rawValue: 0xD),
-        .init(rawValue: 0xE),
-        .init(rawValue: 0xF),
-    ]
+    public static var allCases: [WebSocketOpcode] {
+        get { (0..<0x10).map { WebSocketOpcode(rawValue: $0) } }
+
+        @available(*, deprecated)
+        set {}
+    }
 }
 
 extension WebSocketOpcode: CustomStringConvertible {


### PR DESCRIPTION
Enable strict concurrency checking for NIOWebSocket

### Motivation:

To ensure NIOWebSocket concurrency safety.

### Modifications:

* Enable strict concurrency checking in the package manifest.
* `NIOWebSocketClientUpgrader._upgrade` private function generic return
type is marked as `Sendable` in line with the only method which calls
it.
* `NIOWebSocketServerUpgrader._upgrade` private function generic return
type is marked as `Sendable` in line with the only method which calls
it.
* `WebSocketOpcode.allCases` public computed variable is replaced with a
`let` which manually enumerates the cases instead

### Result:

`NIOWebSocket` does not warn of concurrency issues, builds will warn and CI will fail if regressions are introduced.