### PR TITLE
Remove side effect from assertion in IPHeaderRemoverHandler

### DIFF
--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -25,7 +25,8 @@ private final class IPHeaderRemoverHandler: ChannelInboundHandler {
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         var data = Self.unwrapInboundIn(data)
-        assert(data.data.readIPv4Header() != nil)
+        let header = data.data.readIPv4Header()
+        assert(header != nil)
         context.fireChannelRead(Self.wrapInboundOut(data))
     }
 }


### PR DESCRIPTION
Motivation:

The 'testRawSocketBootstrap_withProtocolNegotiation' test times out when run in release mode. This is because 'IPHeaderRemoverHandler' removes the IPv4 headers as a side effect of an assertion. This means that the headers are only removed when compiled in debug mode.

Modifications:

Always remove the headers.

Result:

The test passes in release mode.