### PR TITLE
Enable strict concurrency checking for NIOTestUtils

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -233,7 +233,8 @@ let package = Package(
                 "NIOEmbedded",
                 "NIOHTTP1",
                 swiftAtomics,
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "_NIOFileSystem",

--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -263,18 +263,16 @@ public final class NIOHTTP1TestServer {
             self.handleChannels()
             return
         }
-        channel.pipeline.configureHTTPServerPipeline().flatMap {
+        do {
+            try channel.pipeline.syncOperations.configureHTTPServerPipeline()
             if self.aggregateBody {
-                return channel.pipeline.addHandler(AggregateBodyHandler())
-            } else {
-                return self.eventLoop.makeSucceededVoidFuture()
+                try channel.pipeline.syncOperations.addHandler(AggregateBodyHandler())
             }
-        }.flatMap {
-            channel.pipeline.addHandler(WebServerHandler(webServer: self))
-        }.flatMap {
-            channel.pipeline.addHandler(TransformerHandler())
-        }.whenSuccess {
-            _ = channel.setOption(.autoRead, value: true)
+            try channel.pipeline.syncOperations.addHandler(WebServerHandler(webServer: self))
+            try channel.pipeline.syncOperations.addHandler(TransformerHandler())
+            _ = try channel.syncOptions!.setOption(.autoRead, value: true)
+        } catch {
+            assertionFailure("Channel initialization failed with: \(error)")
         }
     }
 

--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -272,7 +272,7 @@ public final class NIOHTTP1TestServer {
             try channel.pipeline.syncOperations.addHandler(TransformerHandler())
             _ = try channel.syncOptions!.setOption(.autoRead, value: true)
         } catch {
-            assertionFailure("Channel initialization failed with: \(error)")
+            fatalError("Channel initialization failed with: \(error)")
         }
     }
 


### PR DESCRIPTION
### Motivation:

To ensure `NIOTestUtils` concurrency safety.

### Modifications:

* Enable strict concurrency checking in the package manifest.
* `NIOHTTP1TestServer` does pipeline configuration as synchronous operations.

### Result:

`NIOTestUtils` does not warn of concurrency issues, builds will warn and CI will fail if regressions are introduced.
