### PR TITLE
Enable strict concurrency checking for NIOHTTP1Client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -329,7 +329,8 @@ let package = Package(
                 "NIOHTTP1",
                 "NIOConcurrencyHelpers",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOChatServer",

--- a/Sources/NIOHTTP1Client/main.swift
+++ b/Sources/NIOHTTP1Client/main.swift
@@ -81,11 +81,12 @@ let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
     .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
-        channel.pipeline.addHTTPClientHandlers(
-            position: .first,
-            leftOverBytesStrategy: .fireError
-        ).flatMap {
-            channel.pipeline.addHandler(HTTPEchoHandler())
+        channel.eventLoop.makeCompletedFuture {
+            try channel.pipeline.syncOperations.addHTTPClientHandlers(
+                position: .first,
+                leftOverBytesStrategy: .fireError
+            )
+            try channel.pipeline.syncOperations.addHandler(HTTPEchoHandler())
         }
     }
 defer {


### PR DESCRIPTION
### Motivation:

To ensure `NIOHTTP1Client` concurrency safety.

### Modifications:

* Enable strict concurrency checking in the package manifest.

### Result:

Builds will warn and CI will fail if regressions are introduced.
