### PR TITLE
Enable strict concurrency checking for NIOHTTP1Server

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -319,7 +319,8 @@ let package = Package(
                 "NIOHTTP1",
                 "NIOConcurrencyHelpers",
             ],
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOHTTP1Client",

--- a/Sources/NIOHTTP1Client/main.swift
+++ b/Sources/NIOHTTP1Client/main.swift
@@ -81,11 +81,12 @@ let bootstrap = ClientBootstrap(group: group)
     // Enable SO_REUSEADDR.
     .channelOption(.socketOption(.so_reuseaddr), value: 1)
     .channelInitializer { channel in
-        channel.pipeline.addHTTPClientHandlers(
-            position: .first,
-            leftOverBytesStrategy: .fireError
-        ).flatMap {
-            channel.pipeline.addHandler(HTTPEchoHandler())
+        channel.eventLoop.makeCompletedFuture {
+            try channel.pipeline.syncOperations.addHTTPClientHandlers(
+                position: .first,
+                leftOverBytesStrategy: .fireError
+            )
+            try channel.pipeline.syncOperations.addHandler(HTTPEchoHandler())
         }
     }
 defer {

--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -631,8 +631,8 @@ default:
 }
 
 func childChannelInitializer(channel: Channel) -> EventLoopFuture<Void> {
-    channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
-        channel.pipeline.addHandler(HTTPHandler(fileIO: fileIO, htdocsPath: htdocs))
+    channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMapThrowing {
+        try channel.pipeline.syncOperations.addHandler(HTTPHandler(fileIO: fileIO, htdocsPath: htdocs))
     }
 }
 


### PR DESCRIPTION
### Motivation:

To ensure `NIOHTTP1Server` concurrency safety.

### Modifications:

* Enable strict concurrency checking in the package manifest.
* User synchronous operations in pipeline configurations

### Result:

Builds will warn and CI will fail if regressions are introduced.