### PR TITLE
Delete Thresholds/nightly-6.1 symlinks

### DIFF
--- a/Benchmarks/Thresholds/nightly-6.1
+++ b/Benchmarks/Thresholds/nightly-6.1
@@ -1,1 +1,0 @@
-./nightly-next

--- a/IntegrationTests/tests_04_performance/Thresholds/nightly-6.1.json
+++ b/IntegrationTests/tests_04_performance/Thresholds/nightly-6.1.json
@@ -1,1 +1,0 @@
-./nightly-next.json


### PR DESCRIPTION
Following on from https://github.com/apple/swift-nio/pull/3126 delete `Benchmarks/Thresholds/nightly-6.1` and `IntegrationTests/tests_04_performance/Thresholds/nightly-6.1.json` which is no longer needed now that the shared benchmarks workflow has been updated.