### PR TITLE
Only apply standard swift settings on valid targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -598,11 +598,16 @@ if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
 
 // ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
 for target in package.targets {
-    if target.type != .plugin {
+    switch target.type {
+    case .regular, .test, .executable:
         var settings = target.swiftSettings ?? []
         // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
         settings.append(.enableUpcomingFeature("MemberImportVisibility"))
         target.swiftSettings = settings
+    case .macro, .plugin, .system, .binary:
+        ()  // not applicable
+    @unknown default:
+        ()  // we don't know what to do here, do nothing
     }
 }
 // --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //


### PR DESCRIPTION
Only apply standard swift settings on valid targets. The current check ignores plugins but that is not comprehensive enough.