### PR TITLE
Downgrade NIOHTTP1TestServer handleChannel failure

### DIFF
--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -272,7 +272,8 @@ public final class NIOHTTP1TestServer {
             try channel.pipeline.syncOperations.addHandler(TransformerHandler())
             _ = try channel.syncOptions!.setOption(.autoRead, value: true)
         } catch {
-            fatalError("Channel initialization failed with: \(error)")
+            print("Channel initialization failed with: \(error)")
+            channel.close(promise: nil)
         }
     }
 


### PR DESCRIPTION
### Motivation:

We added a fatalError to report NIOHTTP1TestServer handleChannel failures when doing the strict concurrency work which are now being hit.

We don't know if these failures are actually new or not because the previous code just swallowed such errors.

### Modifications:

Print the errors but limp-on to see if the test goes on to pass, if so this might not be a new error.

### Result:

Less severe response to NIOHTTP1TestServer handleChannel failure.