### PR TITLE
Allow NIOLoopBoundBox to be initialized by sending in a value

### DIFF
--- a/Sources/NIOCore/NIOLoopBound.swift
+++ b/Sources/NIOCore/NIOLoopBound.swift
@@ -127,6 +127,28 @@ public final class NIOLoopBoundBox<Value>: @unchecked Sendable {
         .init(_value: value, uncheckedEventLoop: eventLoop)
     }
 
+    #if compiler(>=6.0)
+    /// Initialise a ``NIOLoopBoundBox`` by sending a  value, validly callable off `eventLoop`.
+    ///
+    /// Contrary to ``init(_:eventLoop:)``, this method can be called off `eventLoop` because `value` is moved into the box and can no longer be accessed outside the box.
+    /// So we don't need to protect `value` itself, we just need to protect the ``NIOLoopBoundBox`` against mutations which we do because the ``value``
+    /// accessors are checking that we're on `eventLoop`.
+    public static func makeBoxTakingValue(
+        _ value: sending Value,
+        as: Value.Type = Value.self,
+        eventLoop: EventLoop
+    ) -> NIOLoopBoundBox<Value> {
+        // Here, we -- possibly surprisingly -- do not precondition being on the EventLoop. This is okay for a few
+        // reasons:
+        // - This function takes its value as `sending` so we don't need to worry about somebody
+        //   still holding a reference to this.
+        // - Because of Swift's Definitive Initialisation (DI), we know that we did write `self._value` before `init`
+        //   returns.
+        // - The only way to ever write (or read indeed) `self._value` is by proving to be inside the `EventLoop`.
+        .init(_value: value, uncheckedEventLoop: eventLoop)
+    }
+    #endif
+
     /// Access the `value` with the precondition that the code is running on `eventLoop`.
     ///
     /// - Note: ``NIOLoopBoundBox`` itself is reference-typed, so any writes will affect anybody sharing this reference.

--- a/Tests/NIOPosixTests/NIOLoopBoundTests.swift
+++ b/Tests/NIOPosixTests/NIOLoopBoundTests.swift
@@ -75,6 +75,39 @@ final class NIOLoopBoundTests: XCTestCase {
         )
     }
 
+    #if compiler(>=6.0)
+    func testLoopBoundBoxCanBeInitialisedWithTakingValueOffLoopAndLaterSetToValue() {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        let loop = group.any()
+
+        class NonSendableIntBox {
+            var value: Int
+
+            init(value: Int) {
+                self.value = value
+            }
+        }
+
+        let instance = NonSendableIntBox(value: 15)
+        let sendableBox = NIOLoopBoundBox.makeBoxTakingValue(instance, as: NonSendableIntBox.self, eventLoop: loop)
+        for _ in 0..<(100 - 15) {
+            loop.execute {
+                sendableBox.value.value += 1
+            }
+        }
+        XCTAssertEqual(
+            100,
+            try loop.submit {
+                sendableBox.value.value
+            }.wait()
+        )
+    }
+    #endif
+
     func testInPlaceMutation() {
         var loopBound = NIOLoopBound(CoWValue(), eventLoop: loop)
         XCTAssertTrue(loopBound.value.mutateInPlace())


### PR DESCRIPTION
Allow NIOLoopBoundBox to be initialized by sending in a value
### Motivation:

It should be possible to initialize a loopbound box off-loop if the initial value of the box is being moved onto the loop.

### Modifications:

Add another static function, to create a loopboundbox by `sending` a value. This is safe because the compiler will not let the caller use the value after putting it into the box. Only the box (or rather, the el which the box is bound to) will be able to access the value thereafter.