### PR TITLE
Add a missing import to CNIOLinux

### DIFF
--- a/Tests/NIOPosixTests/ChannelPipelineTest.swift
+++ b/Tests/NIOPosixTests/ChannelPipelineTest.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Atomics
+import CNIOLinux
 import NIOEmbedded
 import NIOPosix
 import NIOTestUtils


### PR DESCRIPTION
### Motivation:

Same as https://github.com/apple/swift-nio-extras/pull/251, just for swift-nio.

### Modifications:

Added the missing import.

### Result:

Fixes a CI diagnostic.
