### PR TITLE
Make static SDK curl for setup script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
   static-sdk:
     name: Static SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/static_sdk.yml@static_sdk_script
+    uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
 
   macos-tests:
     name: macOS tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
   static-sdk:
     name: Static SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+    uses: apple/swift-nio/.github/workflows/static_sdk.yml@static_sdk_script
 
   macos-tests:
     name: macOS tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,3 +83,8 @@ jobs:
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       build_scheme: swift-nio-Package
+
+  static-sdk:
+    name: Static SDK
+    # Workaround https://github.com/nektos/act/issues/1875
+    uses: apple/swift-nio/.github/workflows/static_sdk.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -87,4 +87,4 @@ jobs:
   static-sdk:
     name: Static SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+    uses: apple/swift-nio/.github/workflows/static_sdk.yml@static_sdk_script

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -87,4 +87,4 @@ jobs:
   static-sdk:
     name: Static SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/static_sdk.yml@static_sdk_script
+    uses: apple/swift-nio/.github/workflows/static_sdk.yml@main

--- a/.github/workflows/static_sdk.yml
+++ b/.github/workflows/static_sdk.yml
@@ -19,7 +19,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/static_sdk_script/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             },
@@ -29,7 +29,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/static_sdk_script/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             }

--- a/.github/workflows/static_sdk.yml
+++ b/.github/workflows/static_sdk.yml
@@ -19,7 +19,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/static_sdk_script/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             },
@@ -29,7 +29,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/static_sdk_script/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             }

--- a/.github/workflows/static_sdk.yml
+++ b/.github/workflows/static_sdk.yml
@@ -19,7 +19,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 ./scripts/install_static_sdk.sh",
+              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             },
@@ -29,7 +29,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 ./scripts/install_static_sdk.sh",
+              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             }

--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Run matrix job
         if: ${{ matrix.config.platform != 'Windows' }}
         run: |
-          if [[ -n "${{ matrix.config.setup_command }}" ]]; then
-            setup_command_expression="${{ matrix.config.setup_command }} &&"
+          if [[ -n '${{ matrix.config.setup_command }}' ]]; then
+            setup_command_expression='${{ matrix.config.setup_command }} &&'
           else
             setup_command_expression=""
           fi

--- a/scripts/install_static_sdk.sh
+++ b/scripts/install_static_sdk.sh
@@ -125,5 +125,11 @@ log "Static SDK URL: $static_sdk_url"
 static_sdk_path="/tmp/$(basename "$static_sdk_url")"
 curl -sL "$static_sdk_url" -o "$static_sdk_path"
 
+log "Looking for swift"
+which swift
+
+log "Checking swift"
+swift --version
+
 log "Installing Static SDK"
 swift sdk install "$static_sdk_path"


### PR DESCRIPTION
### Motivation:

The static SDK workflow currently assumes a local setup script which isn't true for external adopters.

### Modifications:

* The static SDK workflow now curls for the setup script.
* Run Static SDK checks on PR commits

### Result:

External adopters should be unblocked.
