### PR TITLE
Remove macOS CI shim

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,6 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@macos_ci  # TODO: change to @main
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       build_scheme: swift-nio-Package

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,6 +80,6 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@macos_ci  # TODO: change to @main
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       build_scheme: swift-nio-Package


### PR DESCRIPTION
Remove macOS CI shim which was needed so that the PR yaml would parse and execute tests.