### PR TITLE
BaseStreamSocketChannel half-close allows outstanding writes to complete

### DIFF
--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -601,9 +601,10 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
                 case .open, .pending:
                     ()
                 case .readyForClose(let eventLoopPromise):
-                    self.close0(error: ChannelError.outputClosed, mode: .output, promise: eventLoopPromise)  // TODO: it doesn't seem right that I have to pass an error in here)
+                    // TODO: it doesn't seem right that I have to pass an error in here)
+                    self.close0(error: ChannelError.outputClosed, mode: .output, promise: eventLoopPromise)
                 case .closed:
-                    () // we can be flushed before becoming active
+                    ()  // we can be flushed before becoming active
                 }
             }
 

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -603,7 +603,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
                 case .readyForClose(let eventLoopPromise):
                     self.close0(error: ChannelError.outputClosed, mode: .output, promise: eventLoopPromise)  // TODO: it doesn't seem right that I have to pass an error in here)
                 case .closed:
-                    assertionFailure("Write result has the channel already closed, but we did not close it.")
+                    () // we can be flushed before becoming active
                 }
             }
 

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -600,9 +600,9 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
                 switch closeState {
                 case .open, .pending:
                     ()
-                case .readyForClose(let eventLoopPromise):
+                case .readyForClose(let closePromise):
                     // TODO: it doesn't seem right that I have to pass an error in here)
-                    self.close0(error: ChannelError.outputClosed, mode: .output, promise: eventLoopPromise)
+                    self.close0(error: ChannelError.outputClosed, mode: .output, promise: closePromise)
                 case .closed:
                     ()  // we can be flushed before becoming active
                 }

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -601,7 +601,6 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
                 case .open, .pending:
                     ()
                 case .readyForClose(let closePromise):
-                    // TODO: it doesn't seem right that I have to pass an error in here)
                     self.close0(error: ChannelError.outputClosed, mode: .output, promise: closePromise)
                 case .closed:
                     ()  // we can be flushed before becoming active

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -600,8 +600,8 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
                 switch closeState {
                 case .open, .pending:
                     ()
-                case .readyForClose(let closePromise):
-                    self.close0(error: ChannelError.outputClosed, mode: .output, promise: closePromise)
+                case .readyForClose:
+                    self.close0(error: ChannelError.outputClosed, mode: .output, promise: nil)
                 case .closed:
                     ()  // we can be flushed before becoming active
                 }

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -598,7 +598,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
             case .writtenCompletely(let closeState):
                 newWriteRegistrationState = .unregister
                 switch closeState {
-                case .open, .pending:
+                case .open:
                     ()
                 case .readyForClose:
                     self.close0(error: ChannelError.outputClosed, mode: .output, promise: nil)

--- a/Sources/NIOPosix/BaseStreamSocketChannel.swift
+++ b/Sources/NIOPosix/BaseStreamSocketChannel.swift
@@ -201,7 +201,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
                 case .open:
                     preconditionFailure("Close resulted in an open state, this should never happen")
                 case .pending:
-                    () // nothing to do
+                    ()  // nothing to do
                 case .readyForClose(let closePromise):
                     assert(promise == closePromise)
                     // Shutdown the socket only when the pending writes are dealt with
@@ -213,7 +213,7 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
                     }
                     self.pendingWrites.outboundCloseState = .closed
                 case .closed:
-                    () // nothing to do
+                    ()  // nothing to do
                 }
 
                 self.pipeline.fireUserInboundEventTriggered(ChannelEvent.outputClosed)

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -268,7 +268,8 @@ private struct PendingDatagramWritesState {
         // When we've hit an error we treat it like fully writing the first datagram. We aren't going to try to
         // send it again.
         let promiseFiller = self.wroteFirst(error: error)
-        let result: OneWriteOperationResult = self.pendingWrites.hasMark ? .writtenPartially : .writtenCompletely
+        let result: OneWriteOperationResult =
+            self.pendingWrites.hasMark ? .writtenPartially : .writtenCompletely(closePromise: nil)
 
         return (promiseFiller, result)
     }
@@ -305,7 +306,8 @@ private struct PendingDatagramWritesState {
         }
 
         // If we no longer have a mark, we wrote everything.
-        let result: OneWriteOperationResult = self.pendingWrites.hasMark ? .writtenPartially : .writtenCompletely
+        let result: OneWriteOperationResult =
+            self.pendingWrites.hasMark ? .writtenPartially : .writtenCompletely(closePromise: nil)
         return (promiseFiller, result)
     }
 
@@ -322,7 +324,8 @@ private struct PendingDatagramWritesState {
         )
         let writeFiller = self.wroteFirst()
         // If we no longer have a mark, we wrote everything.
-        let result: OneWriteOperationResult = self.pendingWrites.hasMark ? .writtenPartially : .writtenCompletely
+        let result: OneWriteOperationResult =
+            self.pendingWrites.hasMark ? .writtenPartially : .writtenCompletely(closePromise: nil)
         return (writeFiller, result)
     }
 
@@ -565,7 +568,7 @@ final class PendingDatagramWritesManager: PendingWritesManager {
                 preconditionFailure("PendingDatagramWritesManager was handed a file write")
             case .nothingToBeWritten:
                 assertionFailure("called \(#function) with nothing available to be written")
-                return OneWriteOperationResult.writtenCompletely
+                return OneWriteOperationResult.writtenCompletely(closePromise: nil)
             }
         }
     }

--- a/Sources/NIOPosix/PendingWritesManager.swift
+++ b/Sources/NIOPosix/PendingWritesManager.swift
@@ -646,12 +646,13 @@ extension PendingWritesManager {
             var oneResult: OneWriteOperationResult
             repeat {
                 guard self.isOpen && self.isFlushPending else {
-                    let closeResult: CloseResult = switch self.outboundCloseState {
-                    case .open: .open
-                    case .pending: .pending
-                    case .readyForClose(let closePromise): .readyForClose(closePromise)
-                    case .closed: .closed(nil)
-                    }
+                    let closeResult: CloseResult =
+                        switch self.outboundCloseState {
+                        case .open: .open
+                        case .pending: .pending
+                        case .readyForClose(let closePromise): .readyForClose(closePromise)
+                        case .closed: .closed(nil)
+                        }
                     result.writeResult = .writtenCompletely(closeResult)
                     break writeSpinLoop
                 }

--- a/Sources/NIOPosix/PendingWritesManager.swift
+++ b/Sources/NIOPosix/PendingWritesManager.swift
@@ -509,7 +509,7 @@ final class PendingStreamWritesManager: PendingWritesManager {
             switch self.outboundCloseState {
             case .open:
                 self.outboundCloseState = .readyForClose(promise)
-            case  .readyForClose:
+            case .readyForClose:
                 ()
             case .pending, .closed:
                 preconditionFailure("close called on channel in unexpected state: \(self.outboundCloseState)")
@@ -547,8 +547,8 @@ final class PendingStreamWritesManager: PendingWritesManager {
 
 internal enum CloseState {
     case open
-    case pending(Optional<EventLoopPromise<Void>>)
-    case readyForClose(Optional<EventLoopPromise<Void>>)
+    case pending(EventLoopPromise<Void>?)
+    case readyForClose(EventLoopPromise<Void>?)
     case closed
 }
 

--- a/Sources/NIOPosix/PendingWritesManager.swift
+++ b/Sources/NIOPosix/PendingWritesManager.swift
@@ -541,9 +541,13 @@ final class PendingStreamWritesManager: PendingWritesManager {
                 closePromise.setOrCascade(to: promise)
                 self.outboundCloseState = .pending(closePromise)
             case .readyForClose:
-                preconditionFailure("We are in .readyForClose state but we still have pending writes. This should never happen.")
+                preconditionFailure(
+                    "We are in .readyForClose state but we still have pending writes. This should never happen."
+                )
             case .closed:
-                preconditionFailure("We are in .closed state but we still have pending writes. This should never happen.")
+                preconditionFailure(
+                    "We are in .closed state but we still have pending writes. This should never happen."
+                )
             }
 
         }

--- a/Sources/NIOPosix/PendingWritesManager.swift
+++ b/Sources/NIOPosix/PendingWritesManager.swift
@@ -119,7 +119,6 @@ internal struct OverallWriteResult {
         /// is expected to fulfill it
         internal enum WrittenCompletelyResult: Equatable {
             case open
-            case pending
             case readyForClose(EventLoopPromise<Void>?)
             case closed(EventLoopPromise<Void>?)
 

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -1273,7 +1273,7 @@ final class ChannelTests: XCTestCase {
             )
 
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.closed), result.writeResult)
             XCTAssertNoThrow(try ps[0].futureResult.wait())
             XCTAssertThrowsError(try ps[1].futureResult.wait())
             XCTAssertThrowsError(try ps[2].futureResult.wait())

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -528,7 +528,7 @@ final class ChannelTests: XCTestCase {
             XCTAssertFalse(pwm.isEmpty)
             XCTAssertFalse(pwm.isFlushPending)
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
 
             result = try assertExpectedWritability(
                 pendingWritesManager: pwm,
@@ -539,7 +539,7 @@ final class ChannelTests: XCTestCase {
                 returns: [],
                 promiseStates: [[true, false]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
 
             pwm.markFlushCheckpoint()
@@ -554,7 +554,7 @@ final class ChannelTests: XCTestCase {
                 promiseStates: [[true, true]]
             )
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
         }
     }
 
@@ -584,7 +584,7 @@ final class ChannelTests: XCTestCase {
                 returns: [.processed(8)],
                 promiseStates: [[true, true, false]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
 
             pwm.markFlushCheckpoint()
@@ -598,7 +598,7 @@ final class ChannelTests: XCTestCase {
                 returns: [.processed(0)],
                 promiseStates: [[true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -655,7 +655,7 @@ final class ChannelTests: XCTestCase {
                 returns: [.processed(8)],
                 promiseStates: [[true, true, true, true], [true, true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(totalBytes - 1 - 7 - 8, pwm.bufferedBytes)
         }
     }
@@ -704,7 +704,7 @@ final class ChannelTests: XCTestCase {
                 returns: [.processed(1)],
                 promiseStates: [[true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -768,7 +768,7 @@ final class ChannelTests: XCTestCase {
                 returns: [.processed(1)],
                 promiseStates: [Array(repeating: true, count: numberOfBytes)]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -819,7 +819,7 @@ final class ChannelTests: XCTestCase {
             )
 
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
         }
     }
 
@@ -892,7 +892,7 @@ final class ChannelTests: XCTestCase {
                 returns: [.processed(2 * halfTheWriteVLimit), .processed(halfTheWriteVLimit)],
                 promiseStates: [[true, true, false], [true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -962,7 +962,7 @@ final class ChannelTests: XCTestCase {
                     [true, true, true],
                 ]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
             pwm.markFlushCheckpoint()
         }
@@ -1000,7 +1000,7 @@ final class ChannelTests: XCTestCase {
                 returns: [.processed(2)],
                 promiseStates: [[true, false]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             totalBytes -= Int64(fr1.readableBytes)
             XCTAssertEqual(totalBytes, pwm.bufferedBytes)
 
@@ -1013,7 +1013,7 @@ final class ChannelTests: XCTestCase {
                 returns: [],
                 promiseStates: [[true, false]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(totalBytes, pwm.bufferedBytes)
             pwm.markFlushCheckpoint()
 
@@ -1029,7 +1029,7 @@ final class ChannelTests: XCTestCase {
 
             totalBytes -= Int64(fr2.readableBytes)
             XCTAssertEqual(totalBytes, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
         }
     }
 
@@ -1059,7 +1059,7 @@ final class ChannelTests: XCTestCase {
             )
 
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
         }
     }
 
@@ -1134,7 +1134,7 @@ final class ChannelTests: XCTestCase {
 
             totalBytes -= 4
             XCTAssertEqual(totalBytes, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
         }
     }
 
@@ -1180,7 +1180,7 @@ final class ChannelTests: XCTestCase {
                 returns: [.processed(8)],
                 promiseStates: [[true, true, false]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
 
             pwm.markFlushCheckpoint()
@@ -1196,7 +1196,7 @@ final class ChannelTests: XCTestCase {
             )
 
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
         }
     }
 
@@ -1223,7 +1223,7 @@ final class ChannelTests: XCTestCase {
                 returns: [.processed(0)],
                 promiseStates: [[true, true, false]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
 
             pwm.markFlushCheckpoint()
@@ -1239,7 +1239,7 @@ final class ChannelTests: XCTestCase {
             )
 
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
         }
     }
 
@@ -1273,7 +1273,7 @@ final class ChannelTests: XCTestCase {
             )
 
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertNoThrow(try ps[0].futureResult.wait())
             XCTAssertThrowsError(try ps[1].futureResult.wait())
             XCTAssertThrowsError(try ps[2].futureResult.wait())
@@ -1322,7 +1322,7 @@ final class ChannelTests: XCTestCase {
                 promiseStates: [Array(repeating: true, count: Socket.writevLimitIOVectors + 1)]
             )
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
         }
     }
 
@@ -1353,7 +1353,7 @@ final class ChannelTests: XCTestCase {
             )
 
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
         }
     }
 

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -853,8 +853,7 @@ final class ChannelTests: XCTestCase {
             XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
             XCTAssertEqual(totalBytes - 2, pwm.bufferedBytes)
 
-            let closeResult = pwm.failAll(error: ChannelError.operationUnsupported, close: true)
-            XCTAssertEqual(closeResult, .closed(nil))
+            _ = pwm.failAll(error: ChannelError.operationUnsupported)
 
             XCTAssertTrue(ps.map { $0.futureResult.isFulfilled }.allSatisfy { $0 })
         }
@@ -1260,8 +1259,7 @@ final class ChannelTests: XCTestCase {
             XCTAssertEqual(Int64(buffer.readableBytes * 3), pwm.bufferedBytes)
 
             ps[0].futureResult.assumeIsolated().whenComplete { (_: Result<Void, Error>) in
-                let closeResult = pwm.failAll(error: ChannelError.inputClosed, close: true)
-                XCTAssertEqual(closeResult, .closed(nil))
+                _ = pwm.failAll(error: ChannelError.inputClosed)
             }
 
             let result = try assertExpectedWritability(

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -853,7 +853,8 @@ final class ChannelTests: XCTestCase {
             XCTAssertEqual(.couldNotWriteEverything, result.writeResult)
             XCTAssertEqual(totalBytes - 2, pwm.bufferedBytes)
 
-            pwm.failAll(error: ChannelError.operationUnsupported, close: true)
+            let closeResult = pwm.failAll(error: ChannelError.operationUnsupported, close: true)
+            XCTAssertEqual(closeResult, .closed(nil))
 
             XCTAssertTrue(ps.map { $0.futureResult.isFulfilled }.allSatisfy { $0 })
         }
@@ -1259,7 +1260,8 @@ final class ChannelTests: XCTestCase {
             XCTAssertEqual(Int64(buffer.readableBytes * 3), pwm.bufferedBytes)
 
             ps[0].futureResult.assumeIsolated().whenComplete { (_: Result<Void, Error>) in
-                pwm.failAll(error: ChannelError.inputClosed, close: true)
+                let closeResult = pwm.failAll(error: ChannelError.inputClosed, close: true)
+                XCTAssertEqual(closeResult, .closed(nil))
             }
 
             let result = try assertExpectedWritability(
@@ -1273,7 +1275,7 @@ final class ChannelTests: XCTestCase {
             )
 
             XCTAssertEqual(0, pwm.bufferedBytes)
-            XCTAssertEqual(.writtenCompletely(.closed), result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.closed(nil)), result.writeResult)
             XCTAssertNoThrow(try ps[0].futureResult.wait())
             XCTAssertThrowsError(try ps[1].futureResult.wait())
             XCTAssertThrowsError(try ps[2].futureResult.wait())

--- a/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
@@ -739,7 +739,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(1))],
                 promiseStates: [[true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.closed), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
             XCTAssertNoThrow(try ps[0].futureResult.wait())
             XCTAssertThrowsError(try ps[1].futureResult.wait())

--- a/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
@@ -346,7 +346,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
 
             XCTAssertFalse(pwm.isEmpty)
             XCTAssertFalse(pwm.isFlushPending)
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
 
             result = try assertExpectedWritability(
                 pendingWritesManager: pwm,
@@ -356,7 +356,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [],
                 promiseStates: [[true, false]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(Int64(buffer.readableBytes), pwm.bufferedBytes)
 
             pwm.markFlushCheckpoint()
@@ -369,7 +369,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(0))],
                 promiseStates: [[true, true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(Int64(buffer.readableBytes), pwm.bufferedBytes)
         }
     }
@@ -401,7 +401,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(2))],
                 promiseStates: [[true, true, false]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
 
             pwm.markFlushCheckpoint()
@@ -414,7 +414,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(0))],
                 promiseStates: [[true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -474,7 +474,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(4))],
                 promiseStates: [[true, true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -527,7 +527,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(12))],
                 promiseStates: [Array(repeating: true, count: ps.count - 1) + [true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -600,7 +600,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(2)), .success(.processed(1))],
                 promiseStates: [[true, true, false], [true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -653,7 +653,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 promiseStates: [[true, false, false], [true, true, false], [true, true, true]]
             )
 
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
 
             XCTAssertNoThrow(try ps[1].futureResult.wait())
@@ -693,7 +693,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(2))],
                 promiseStates: [[true, true, false]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
 
             pwm.markFlushCheckpoint()
@@ -706,7 +706,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(0))],
                 promiseStates: [[true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -739,7 +739,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(1))],
                 promiseStates: [[true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
             XCTAssertNoThrow(try ps[0].futureResult.wait())
             XCTAssertThrowsError(try ps[1].futureResult.wait())
@@ -784,7 +784,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(4))],
                 promiseStates: [Array(repeating: true, count: Socket.writevLimitIOVectors + 1)]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }
@@ -845,7 +845,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(1))],
                 promiseStates: [Array(repeating: true, count: 5)]
             )
-            XCTAssertEqual(.writtenCompletely, result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.open), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
         }
     }

--- a/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
+++ b/Tests/NIOPosixTests/PendingDatagramWritesManagerTests.swift
@@ -739,7 +739,7 @@ class PendingDatagramWritesManagerTests: XCTestCase {
                 returns: [.success(.processed(1))],
                 promiseStates: [[true, true, true]]
             )
-            XCTAssertEqual(.writtenCompletely(.closed), result.writeResult)
+            XCTAssertEqual(.writtenCompletely(.closed(nil)), result.writeResult)
             XCTAssertEqual(0, pwm.bufferedBytes)
             XCTAssertNoThrow(try ps[0].futureResult.wait())
             XCTAssertThrowsError(try ps[1].futureResult.wait())

--- a/Tests/NIOPosixTests/StreamChannelsTest.swift
+++ b/Tests/NIOPosixTests/StreamChannelsTest.swift
@@ -261,6 +261,46 @@ class StreamChannelTest: XCTestCase {
         XCTAssertNoThrow(try forEachCrossConnectedStreamChannelPair(runTest))
     }
 
+    func testHalfCloseOwnOutputWithPopulatedBuffer() throws {
+        func runTest(chan1: Channel, chan2: Channel) throws {
+            let readPromise = chan2.eventLoop.makePromise(of: Void.self)
+
+            XCTAssertNoThrow(try chan1.setOption(.allowRemoteHalfClosure, value: true).wait())
+
+            self.buffer.writeString("X")
+            XCTAssertNoThrow(
+                try chan2.pipeline.addHandler(FulfillOnFirstEventHandler(channelReadPromise: readPromise)).wait()
+            )
+
+            // let's write a byte from chan1 to chan2 which we leave in the buffer.
+            let writeFuture = chan1.write(self.buffer)
+
+            // close chan1's output, this shouldn't take effect until the buffer is empty
+            let closeFuture = chan1.close(mode: .output)
+
+            // flush chan1's output
+            chan1.flush()
+
+            // Attempt to write a byte from chan1 to chan2 which should be refused after the close
+            XCTAssertThrowsError(try chan1.write(self.buffer).wait()) { error in
+                XCTAssertEqual(ChannelError.outputClosed, error as? ChannelError, "\(chan1)")
+            }
+
+            // wait for the write to complete
+            XCTAssertNoThrow(try writeFuture.wait(), "chan1 write failed")
+
+            // and wait for it to arrive
+            XCTAssertNoThrow(try readPromise.futureResult.wait())
+
+            // wait for the close to complete
+            XCTAssertNoThrow(try closeFuture.wait(), "chan1 close failed")
+
+            XCTAssertNoThrow(try chan1.syncCloseAcceptingAlreadyClosed())
+            XCTAssertNoThrow(try chan2.syncCloseAcceptingAlreadyClosed())
+        }
+        XCTAssertNoThrow(try forEachCrossConnectedStreamChannelPair(runTest))
+    }
+
     func testHalfCloseOwnInput() {
         func runTest(chan1: Channel, chan2: Channel) throws {
 


### PR DESCRIPTION
### Motivation:

At the moment half-closes are actioned immediately and fails all outstanding writes. We should refuse new writes but allow these writes to complete before completing the close.

### Modifications:

Modify the PendingWritesManager internal buffer to hold an enum of either writes or close events. We use this to store the close and only action it when the preceding writes have been handled.

### Result:

Outbound close should no longer fail outstanding writes

Should resolve https://github.com/apple/swift-nio/issues/3139
