### PR TITLE
Update macOS CI workflow

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -5,11 +5,11 @@ on:
     inputs:
       xcode_15_4_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode version 15.4 jobs. Defaults to true."
-        default: true
+        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        default: false
       xcode_15_4_test_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Xcode version 15.4 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_16_0_enabled:
         type: boolean
@@ -41,24 +41,44 @@ on:
         description: "The build scheme used in the Xcode builds."
       macos_xcode_build_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode build targetting macOS. Defaults to true."
+        description: "Boolean to enable the Xcode build targeting macOS. Defaults to true."
         default: true
+      macos_xcode_test_enabled:
+        type: boolean
+        description: "Boolean to enable the Xcode test targeting macOS. Defaults to false."
+        default: false
       ios_xcode_build_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode build targetting iOS. Defaults to true."
+        description: "Boolean to enable the Xcode build targeting iOS. Defaults to true."
         default: true
+      ios_xcode_test_enabled:
+        type: boolean
+        description: "Boolean to enable the Xcode test targeting iOS. Defaults to false."
+        default: false
       watchos_xcode_build_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode build targetting watchOS. Defaults to true."
+        description: "Boolean to enable the Xcode build targeting watchOS. Defaults to true."
         default: true
+      watchos_xcode_test_enabled:
+        type: boolean
+        description: "Boolean to enable the Xcode test targeting watchOS. Defaults to false."
+        default: false
       tvos_xcode_build_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode build targetting tvOS. Defaults to true."
+        description: "Boolean to enable the Xcode build targeting tvOS. Defaults to true."
         default: true
+      tvos_xcode_test_enabled:
+        type: boolean
+        description: "Boolean to enable the Xcode test targeting tvOS. Defaults to false."
+        default: false
       visionos_xcode_build_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode build targetting visionOS. Defaults to true."
+        description: "Boolean to enable the Xcode build targeting visionOS. Defaults to true."
         default: true
+      visionos_xcode_test_enabled:
+        type: boolean
+        description: "Boolean to enable the Xcode test targeting visionOS. Defaults to false."
+        default: false
 
 jobs:
   construct-matrix:
@@ -140,24 +160,43 @@ jobs:
           else
             swift test
           fi
+        # see `xcodebuild -list` for schemes, `simctl list` for destinations
       - name: macOS build
         if: '!cancelled() && inputs.macos_xcode_build_enabled'
-        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination generic/platform=macos build
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "generic/platform=macos" build
+      - name: macOS test
+        if: '!cancelled() && inputs.macos_xcode_test_enabled'
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "name=My Mac" test
       - name: macOS Catalyst build
         if: '!cancelled() && inputs.macos_xcode_build_enabled'
         run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "generic/platform=macos,variant=Mac Catalyst" build
+      - name: macOS Catalyst test
+        if: '!cancelled() && inputs.macos_xcode_test_enabled'
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "name=My Mac,variant=Mac Catalyst" test
       - name: iOS build
         if: '!cancelled() && inputs.ios_xcode_build_enabled'
-        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination generic/platform=ios build
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "generic/platform=ios" build
+      - name: iOS test
+        if: '!cancelled() && inputs.ios_xcode_test_enabled'
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "name=iPhone 16 Pro" test
       - name: watchOS build
         if: '!cancelled() && inputs.watchos_xcode_build_enabled'
-        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination generic/platform=watchos build
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "generic/platform=watchos" build
+      - name: watchOS test
+        if: '!cancelled() && inputs.watchos_xcode_test_enabled'
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "name=Apple Watch Series 10 (46mm)" test
       - name: tvOS build
         if: '!cancelled() && inputs.tvos_xcode_build_enabled'
-        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination generic/platform=tvos build
-        # - name: visionOS build  # arm only  # TODO: temporarily disabled due to issue
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "generic/platform=tvos" build
+      - name: tvOS test
+        if: '!cancelled() && inputs.tvos_xcode_test_enabled'
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "name=Apple TV 4K (3rd generation)" test
+        # - name: visionOS build  # arm only  # TODO: disabled due to issue
         #   if: '!cancelled() && inputs.visionos_xcode_build_enabled'
-        #   run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination generic/platform=visionos build
+        #   run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "generic/platform=visionos" build
+        # - name: visionOS test  # arm only  # TODO: disabled due to issue
+        #   if: '!cancelled() && inputs.visionos_xcode_test_enabled'
+        #   run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "name=Apple Vision Pro" test
     env:
       XCODE_VERSION: ${{ matrix.config.xcode_version }}
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.config.xcode_version }}.app"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,3 +66,8 @@ jobs:
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       build_scheme: swift-nio-Package
+      macos_xcode_test_enabled: false  # Disabled because of an issue
+      ios_xcode_test_enabled: true
+      watchos_xcode_test_enabled: true
+      tvos_xcode_test_enabled: true
+      visionos_xcode_test_enabled: true


### PR DESCRIPTION
### Motivation:

We are still exploring the shape of macOS CI and exploring the system's capabilities.

### Modifications:

* Add visionOS jobs
* Remove Xcode 15.4 as it is no longer on the runners
* Add support for running tests targetting other platforms
* Enable test targeting other platforms on daily jobs to increase coverage without bloating PR runtimes.

###  Result:

More macOS CI coverage

CI run with this enabled https://github.com/apple/swift-nio/actions/runs/13944231147/job/39027647470?pr=3150 - the iOS failure is unrelated to this change
