### PR TITLE
always @preconcurrency import Glibc/Musl/Android/Bionic/WASILibc

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -18,13 +18,13 @@ import Darwin
 import ucrt
 import WinSDK
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #if canImport(wasi_pthread)
 import wasi_pthread
 #endif

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -27,13 +27,13 @@ private func sys_sched_yield() {
 }
 #else
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #else
 #error("The concurrency atomics module was unable to identify your C library.")
 #endif

--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -18,13 +18,13 @@ import Darwin
 import ucrt
 import WinSDK
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #if canImport(wasi_pthread)
 import wasi_pthread
 #endif

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -65,11 +65,11 @@ import func WinSDK.WSAGetLastError
 internal typealias socklen_t = ucrt.size_t
 #elseif os(Linux) || os(Android)
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 #endif
 import CNIOLinux
 
@@ -91,7 +91,7 @@ private let sysInet_ntop:
         inet_ntop
 private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> CInt = inet_pton
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 
 private let sysInet_ntop:
     @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? =

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -17,13 +17,13 @@ import ucrt
 #elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #else
 #error("The Byte Buffer module was unable to identify your C library.")
 #endif

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -19,7 +19,7 @@ import Dispatch
 #endif
 
 #if canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 import CNIOWASI
 #endif
 

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -19,13 +19,13 @@ import ucrt
 #elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 import CNIOWASI
 #else
 #error("The File Handle module was unable to identify your C library.")

--- a/Sources/NIOCore/FileRegion.swift
+++ b/Sources/NIOCore/FileRegion.swift
@@ -16,13 +16,13 @@ import ucrt
 #elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #else
 #error("The File Region module was unable to identify your C library.")
 #endif

--- a/Sources/NIOCore/GlobalSingletons.swift
+++ b/Sources/NIOCore/GlobalSingletons.swift
@@ -20,13 +20,13 @@ import Darwin
 import ucrt
 import WinSDK
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #else
 #error("Unsupported C library")
 #endif

--- a/Sources/NIOCore/IO.swift
+++ b/Sources/NIOCore/IO.swift
@@ -29,13 +29,13 @@ internal func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
     DWORD((s << 10) | p)
 }
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #elseif canImport(Darwin)
 import Darwin
 #else

--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -13,17 +13,17 @@
 //===----------------------------------------------------------------------===//
 #if os(Linux) || os(FreeBSD) || os(Android)
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #endif
 import CNIOLinux
 #elseif canImport(Darwin)
 import Darwin
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #elseif os(Windows)
 import let WinSDK.AF_INET
 import let WinSDK.AF_INET6

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -45,15 +45,15 @@ private typealias sa_family_t = WinSDK.ADDRESS_FAMILY
 import Darwin
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 #endif
 import CNIOLinux
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #else
 #error("The Socket Addresses module was unable to identify your C library.")
 #endif

--- a/Sources/NIOCore/SocketOptionProvider.swift
+++ b/Sources/NIOCore/SocketOptionProvider.swift
@@ -15,17 +15,17 @@
 import Darwin
 #elseif os(Linux) || os(Android)
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #endif
 import CNIOLinux
 #elseif os(Windows)
 import WinSDK
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #else
 #error("The Socket Option provider module was unable to identify your C library.")
 #endif

--- a/Sources/NIOCore/SystemCallHelpers.swift
+++ b/Sources/NIOCore/SystemCallHelpers.swift
@@ -22,15 +22,15 @@
 #if canImport(Darwin)
 import Darwin.C
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #elseif os(Windows)
 import CNIOWindows
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 #else
 #error("The system call helpers module was unable to identify your C library.")
 #endif

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -14,11 +14,11 @@
 #if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 #endif
 #elseif os(Windows)
 import let WinSDK.RelationProcessorCore
@@ -39,7 +39,7 @@ import typealias WinSDK.DWORD
 #elseif canImport(Darwin)
 import Darwin
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #else
 #error("The Core utilities module was unable to identify your C library.")
 #endif

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -25,13 +25,13 @@ import Dispatch
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #else
 #error("Unknown C library.")
 #endif

--- a/Sources/NIOFileSystem/FileInfo.swift
+++ b/Sources/NIOFileSystem/FileInfo.swift
@@ -17,13 +17,13 @@ import SystemPackage
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 import CNIOLinux
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 import CNIOLinux
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 import CNIOLinux
 #endif
 

--- a/Sources/NIOFileSystem/FileSystem.swift
+++ b/Sources/NIOFileSystem/FileSystem.swift
@@ -20,11 +20,11 @@ import SystemPackage
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #endif
 
 /// A file system which interacts with the local system. The file system uses a thread pool to

--- a/Sources/NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/NIOFileSystem/FileSystemError+Syscall.swift
@@ -17,9 +17,9 @@ import SystemPackage
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #endif
 
 extension FileSystemError {

--- a/Sources/NIOFileSystem/FileType.swift
+++ b/Sources/NIOFileSystem/FileType.swift
@@ -17,11 +17,11 @@ import SystemPackage
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 #endif
 
 /// The type of a file system object.

--- a/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
@@ -18,13 +18,13 @@ import SystemPackage
 import Darwin
 import CNIODarwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 import CNIOLinux
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 import CNIOLinux
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 import CNIOLinux
 #endif
 

--- a/Sources/NIOFileSystem/Internal/System Calls/Errno.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Errno.swift
@@ -17,11 +17,11 @@ import SystemPackage
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 #endif
 
 extension Errno {

--- a/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
@@ -18,13 +18,13 @@ import SystemPackage
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 import CNIOLinux
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 import CNIOLinux
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 import CNIOLinux
 #endif
 

--- a/Sources/NIOFileSystem/Internal/System Calls/Mocking.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Mocking.swift
@@ -22,13 +22,13 @@ import SystemPackage
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 import CNIOLinux
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 import CNIOLinux
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 import CNIOLinux
 #endif
 

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -18,13 +18,13 @@ import SystemPackage
 import Darwin
 import CNIODarwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 import CNIOLinux
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 import CNIOLinux
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 import CNIOLinux
 #endif
 

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -18,13 +18,13 @@ import SystemPackage
 import Darwin
 import CNIODarwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 import CNIOLinux
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 import CNIOLinux
 #elseif canImport(Android)
-import Android
+@preconcurrency import Android
 import CNIOLinux
 #endif
 

--- a/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFileSystem/Internal/SystemFileHandle.swift
@@ -20,13 +20,13 @@ import SystemPackage
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 import CNIOLinux
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 import CNIOLinux
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #endif
 
 /// An implementation of ``FileHandleProtocol`` which is backed by system calls and a file

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -23,11 +23,11 @@ import CNIODarwin
 internal typealias MMsgHdr = CNIODarwin_mmsghdr
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 #if canImport(Glibc)
-@_exported import Glibc
+@_exported @preconcurrency import Glibc
 #elseif canImport(Musl)
-@_exported import Musl
+@_exported @preconcurrency import Musl
 #elseif canImport(Android)
-@_exported import Android
+@_exported @preconcurrency import Android
 #endif
 import CNIOLinux
 internal typealias MMsgHdr = CNIOLinux_mmsghdr

--- a/Sources/NIOPosix/VsockAddress.swift
+++ b/Sources/NIOPosix/VsockAddress.swift
@@ -18,9 +18,9 @@ import NIOCore
 import CNIODarwin
 #elseif os(Linux) || os(Android)
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #endif
 import CNIOLinux
 #endif

--- a/Sources/_NIODataStructures/Heap.swift
+++ b/Sources/_NIODataStructures/Heap.swift
@@ -14,15 +14,15 @@
 #if canImport(Darwin)
 import Darwin.C
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(WASILibc)
-import WASILibc
+@preconcurrency import WASILibc
 #elseif os(Windows)
 import ucrt
 #elseif canImport(Bionic)
-import Bionic
+@preconcurrency import Bionic
 #else
 #error("The Heap module was unable to identify your C library.")
 #endif


### PR DESCRIPTION
### Motivation:

The non-`Darwin` libcs don't have the correct concurrency annotations. But due to these Swift bugs, it's important that the _first_ importer uses `@preconcurrency`:

- https://github.com/swiftlang/swift/issues/79414
- https://github.com/swiftlang/swift/issues/77866

### Modifications:

Much like the Foundation (& corelibs) PRs such as https://github.com/swiftlang/swift-foundation/pull/1175 , use `@preconcurrency import` for the non-`Darwin` libcs.

### Result:

Fewer bad warnings/errors in user code.