### PR TITLE
Use overflow addition in tests to avoid compilation failures

### DIFF
--- a/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
@@ -323,7 +323,9 @@ class NonBlockingFileIOTest: XCTestCase {
             { (filehandle, path) -> Void in
                 let content = try self.fileIO.read(
                     fileHandle: filehandle,
-                    byteCount: Int(Int32.max) + 10,
+                    // There's a runtime check above, use overflow addition to stop the compilation
+                    // from failing on 32-bit platforms.
+                    byteCount: Int(Int32.max) &+ 10,
                     allocator: .init(),
                     eventLoop: self.eventLoop
                 ).wait()
@@ -1404,7 +1406,9 @@ extension NonBlockingFileIOTest {
             { (filehandle, path) -> Void in
                 let content = try await self.fileIO.read(
                     fileHandle: filehandle,
-                    byteCount: Int(Int32.max) + 10,
+                    // There's a runtime check above, use overflow addition to stop the compilation
+                    // from failing on 32-bit platforms.
+                    byteCount: Int(Int32.max) &+ 10,
                     allocator: .init()
                 )
                 XCTAssertEqual(String(buffer: content), "some-dummy-content")


### PR DESCRIPTION
Motivation:

A few tests are failing to compiler on 32-bit platforms with recently nightly toolchains. These tests are skipped if `Int` is 32 bits wide but the compiler doesn't know that.

Modifications:

- Use overflow addition to stop the compiler from complaining; the addition won't ever actually overflow because of the runtime check done ahead of time.

Result:

- Tests compile again
- Resolves #3154