### PR TITLE
fix: Fix NIOCore build for wasm targets

### DIFF
--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -67,7 +67,7 @@ extension UInt64 {
         }
     }
 }
-#elseif arch(arm) || arch(i386) || arch(arm64_32)
+#elseif arch(arm) || arch(i386) || arch(arm64_32) || arch(wasm32)
 // 32 bit architectures
 // Note: for testing purposes you can also use these defines for 64 bit platforms, they'll just consume twice as
 // much space, nothing else will go bad.


### PR DESCRIPTION
Fixes NIOCore compiler errors for the `wasm32` architecture.

### Motivation:

When compiling NIOCore for a SwiftWasm target, several compilation errors such as the following occur:

```
> swift build --swift-sdk wasm32-unknown-wasi --target NIOCore

.../swift-nio/Sources/NIOCore/FileHandle.swift:151:42: error: cannot find type 'TwoUInt32s' in scope
149 | public final class NIOFileHandle: FileDescriptor & Sendable {
150 |     private static let descriptorClosed: CInt = CInt.min
151 |     private let descriptor: UnsafeAtomic<TwoUInt32s>
    |                                          `- error: cannot find type 'TwoUInt32s' in scope
152 | 
153 |     public var isOpen: Bool {
.../swift-nio/Sources/NIOCore/FileHandle.swift:77:8: error: Unknown architecture
 75 | typealias TwoUInt32s = DoubleWord
 76 | #else
 77 | #error("Unknown architecture")
    |        `- error: Unknown architecture
 78 | #endif
 79 | 
 
…
```
The compilation errors were introduced with the following change: 

https://github.com/apple/swift-nio/pull/2598/files#diff-a041d0c0d50a8f4fcda2020eeb4450ea994920ef61653cc06014457ccdb3ba0cR70

### Modifications:

The fix is straight-forward and unlikely to affect any existing compilation targets other than the `wasm32` target.

We simply need to add `arch(wasm32)` to compiler architecture condtions for a new typedef on line, then NIOCore compiles to wasm32 again.

### Result:

Before: NIOCore wasm build fails ❌ 

After: NIOCore wasm build succeeds ✅ 
