### PR TITLE
Add peekInteger API to ByteBuffer

### DIFF
--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -114,9 +114,9 @@ extension ByteBuffer {
         }
     }
 
-    /// Peeks at the integer at the current reader index without advancing it.
+    /// Returns the integer at the current reader index without advancing it.
     ///
-    /// This method is equivalent to calling `getInteger(at: readerIndex, ...)
+    /// This method is equivalent to calling `getInteger(at: readerIndex, ...)`
     ///
     /// - Parameters:
     ///   - endianness: The endianness of the integer (defaults to big endian).

--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -126,7 +126,7 @@ extension ByteBuffer {
     public func peekInteger<T: FixedWidthInteger>(
         endianness: Endianness = .big,
         as: T.Type = T.self
-    ) -> T?  {
+    ) -> T? {
         self.getInteger(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 }

--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -126,11 +126,8 @@ extension ByteBuffer {
     public func peekInteger<T: FixedWidthInteger>(
         endianness: Endianness = .big,
         as: T.Type = T.self
-    ) -> T? {
-        guard let result = self.getInteger(at: self.readerIndex, endianness: endianness, as: T.self) else {
-            return nil
-        }
-        return result
+    ) -> T?  {
+        self.getInteger(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 }
 

--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -127,7 +127,10 @@ extension ByteBuffer {
         endianness: Endianness = .big,
         as: T.Type = T.self
     ) -> T? {
-        return self.getInteger(at: self.readerIndex, endianness: endianness, as: `as`)
+        guard let result = self.getInteger(at: self.readerIndex, endianness: endianness, as: T.self) else {
+            return nil
+        }
+        return result
     }
 }
 

--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -113,6 +113,22 @@ extension ByteBuffer {
             self.setBytes(ptr, at: index)
         }
     }
+
+    /// Peeks at the integer at the current reader index without advancing it.
+    ///
+    /// This method is equivalent to calling `getInteger(at: readerIndex, ...)
+    ///
+    /// - Parameters:
+    ///   - endianness: The endianness of the integer (defaults to big endian).
+    ///   - as: The desired `FixedWidthInteger` type (optional parameter).
+    /// - Returns: An integer value deserialized from this `ByteBuffer` or `nil` if the bytes are not readable.
+    @inlinable
+    public func peekInteger<T: FixedWidthInteger>(
+        endianness: Endianness = .big,
+        as: T.Type = T.self
+    ) -> T? {
+        return self.getInteger(at: self.readerIndex, endianness: endianness, as: `as`)
+    }
 }
 
 extension FixedWidthInteger {

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -3876,7 +3876,7 @@ extension ByteBufferTest {
         let second: UInt8 = 0x34
         _ = buffer.writeInteger(first)
         _ = buffer.writeInteger(second)
-        
+
         // First peek to check the first integer.
         guard let peeked1: UInt8 = buffer.peekInteger(as: UInt8.self) else {
             XCTFail("peekInteger failed to return a value on first call")
@@ -3884,7 +3884,7 @@ extension ByteBufferTest {
         }
         XCTAssertEqual(peeked1, first)
         XCTAssertEqual(buffer.readerIndex, 0)
-        
+
         // Second peek should return the same value, confirming readerIndex is unchanged.
         guard let peeked2: UInt8 = buffer.peekInteger(as: UInt8.self) else {
             XCTFail("peekInteger failed to return a value on second call")

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -3831,4 +3831,66 @@ extension ByteBufferTest {
 
         XCTAssertEqual(buffer.description, buffer.debugDescription)
     }
+
+    // Test that peekInteger correctly reads a UInt8.
+    func testPeekIntegerUInt8() {
+        var buffer: ByteBuffer = ByteBuffer()
+        let value: UInt8 = 0xAB
+        _ = buffer.writeInteger(value)
+
+        // Use peekInteger to get the value at readerIndex.
+        guard let peeked: UInt8 = buffer.peekInteger(as: UInt8.self) else {
+            XCTFail("peekInteger failed to return a value")
+            return
+        }
+        XCTAssertEqual(peeked, value)
+        XCTAssertEqual(buffer.readerIndex, 0)
+    }
+
+    // Test that peekInteger correctly reads a UInt16.
+    func testPeekIntegerUInt16() {
+        var buffer: ByteBuffer = ByteBuffer()
+        let value: UInt16 = 0xABCD
+        _ = buffer.writeInteger(value)
+
+        guard let peeked: UInt16 = buffer.peekInteger(as: UInt16.self) else {
+            XCTFail("peekInteger failed to return a value")
+            return
+        }
+        XCTAssertEqual(peeked, value)
+        XCTAssertEqual(buffer.readerIndex, 0)
+    }
+
+    // Test that peekInteger returns nil when there are not enough bytes for a UInt32.
+    func testPeekIntegerNotEnoughBytes() {
+        let buffer: ByteBuffer = ByteBuffer()
+        // Do not write any bytes, so there are not enough bytes for a UInt32.
+        let peeked: UInt32? = buffer.peekInteger(as: UInt32.self)
+        XCTAssertNil(peeked, "Expected nil when there are not enough bytes")
+    }
+
+    // Test that after writing multiple values, peekInteger always returns the first integer.
+    func testPeekIntegerAfterMultipleWrites() {
+        var buffer: ByteBuffer = ByteBuffer()
+        let first: UInt8 = 0x12
+        let second: UInt8 = 0x34
+        _ = buffer.writeInteger(first)
+        _ = buffer.writeInteger(second)
+        
+        // First peek to check the first integer.
+        guard let peeked1: UInt8 = buffer.peekInteger(as: UInt8.self) else {
+            XCTFail("peekInteger failed to return a value on first call")
+            return
+        }
+        XCTAssertEqual(peeked1, first)
+        XCTAssertEqual(buffer.readerIndex, 0)
+        
+        // Second peek should return the same value, confirming readerIndex is unchanged.
+        guard let peeked2: UInt8 = buffer.peekInteger(as: UInt8.self) else {
+            XCTFail("peekInteger failed to return a value on second call")
+            return
+        }
+        XCTAssertEqual(peeked2, first)
+        XCTAssertEqual(buffer.readerIndex, 0)
+    }
 }


### PR DESCRIPTION
### Motivation:

The existing getInteger API is often used incorrectly, leading to verbose or error-prone code as mentioned in https://github.com/apple/swift-nio/issues/2034 and https://github.com/apple/swift-nio/issues/2736. Users may unintentionally access data without correctly managing the reader index. To address this, I added a peekInteger API that reads integers using the current readerIndex without modifying it.

### Modifications:

* Added a peekInteger method to ByteBuffer, which provides a nonmutating way to read integers using the current readerIndex.
* Implemented peekInteger using the existing getInteger function.
* Added comprehensive unit tests to validate correct behavior, including scenarios for different integer types, insufficient bytes, and multi-write scenarios.

### Result:

* Users now have access to a safer API for inspecting integers in a buffer without modifying state.
* Added tests for integer reading scenarios.