### PR TITLE
macOS CI pools

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -134,23 +134,35 @@ jobs:
             matrix='{"config": []}'
 
             if [[ "$xcode_15_4_enabled" == "true" ]]; then
-              matrix=$(echo "$matrix" | jq -c \
-                '.config[.config| length] |= . + { "name": "Xcode 15.4", "xcode_version": "15.4", "build_arguments_override": "${xcode_15_4_build_arguments_override}", "test_arguments_override": "${xcode_15_4_test_arguments_override}", "os": "sequoia", "arch": "ARM64", "pool": "${runner_pool}" }')
+                matrix=$(echo "$matrix" | jq -c \
+                --arg build_arguments_override "$xcode_15_4_build_arguments_override"  \
+                --arg test_arguments_override "$xcode_15_4_test_arguments_override"  \
+                --arg runner_pool "$runner_pool"  \
+                '.config[.config| length] |= . + { "name": "Xcode 15.4", "xcode_version": "15.4", "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
             if [[ "$xcode_16_0_enabled" == "true" ]]; then
-              matrix=$(echo "$matrix" | jq -c \
-                '.config[.config| length] |= . + { "name": "Xcode 16.0", "xcode_version": "16.0", "build_arguments_override": "${xcode_16_0_build_arguments_override}", "test_arguments_override": "${xcode_16_0_test_arguments_override}", "os": "sequoia", "arch": "ARM64", "pool": "${runner_pool}" }')
+                matrix=$(echo "$matrix" | jq -c \
+                --arg build_arguments_override "$xcode_16_0_build_arguments_override"  \
+                --arg test_arguments_override "$xcode_16_0_test_arguments_override"  \
+                --arg runner_pool "$runner_pool"  \
+                '.config[.config| length] |= . + { "name": "Xcode 16.0", "xcode_version": "16.0", "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
             if [[ "$xcode_16_1_enabled" == "true" ]]; then
-              matrix=$(echo "$matrix" | jq -c \
-                '.config[.config| length] |= . + { "name": "Xcode 16.1", "xcode_version": "16.1", "build_arguments_override": "${xcode_16_1_build_arguments_override}", "test_arguments_override": "${xcode_16_1_test_arguments_override}", "os": "sequoia", "arch": "ARM64", "pool": "${runner_pool}" }')
+                matrix=$(echo "$matrix" | jq -c \
+                --arg build_arguments_override "$xcode_16_1_build_arguments_override"  \
+                --arg test_arguments_override "$xcode_16_1_test_arguments_override"  \
+                --arg runner_pool "$runner_pool"  \
+                '.config[.config| length] |= . + { "name": "Xcode 16.1", "xcode_version": "16.1", "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
             if [[ "$xcode_16_2_enabled" == "true" ]]; then
-              matrix=$(echo "$matrix" | jq -c \
-                '.config[.config| length] |= . + { "name": "Xcode 16.2", "xcode_version": "16.2", "build_arguments_override": "${xcode_16_2_build_arguments_override}", "test_arguments_override": "${xcode_16_2_test_arguments_override}", "os": "sequoia", "arch": "ARM64", "pool": "${runner_pool}" }')
+                matrix=$(echo "$matrix" | jq -c \
+                --arg build_arguments_override "$xcode_16_2_build_arguments_override"  \
+                --arg test_arguments_override "$xcode_16_2_test_arguments_override"  \
+                --arg runner_pool "$runner_pool"  \
+                '.config[.config| length] |= . + { "name": "Xcode 16.2", "xcode_version": "16.2", "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
             echo "$matrix" | jq -c

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -96,6 +96,11 @@ on:
         description: "Boolean to enable the Xcode test targeting visionOS. Defaults to false."
         default: false
 
+      runner_pool:
+        type: string
+        description: "The runner pool which will be requested."
+        default: "nightly"
+
 jobs:
   construct-matrix:
     name: Construct Darwin matrix
@@ -111,6 +116,7 @@ jobs:
         run: |
           cat >> "$GITHUB_OUTPUT" << EOM
           darwin-matrix=$(
+            runner_pool="${MATRIX_RUNNER_POOL:="nightly"}"
             xcode_15_4_enabled="${MATRIX_MACOS_15_4_ENABLED:=true}"
             xcode_15_4_build_arguments_override="${MATRIX_MACOS_15_4_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_15_4_test_arguments_override="${MATRIX_MACOS_15_4_TEST_ARGUMENTS_OVERRIDE:=""}"
@@ -129,28 +135,29 @@ jobs:
 
             if [[ "$xcode_15_4_enabled" == "true" ]]; then
               matrix=$(echo "$matrix" | jq -c \
-                '.config[.config| length] |= . + { "name": "Xcode 15.4", "xcode_version": "15.4", "build_arguments_override": "${xcode_15_4_build_arguments_override}", "test_arguments_override": "${xcode_15_4_test_arguments_override}", "os": "sequoia", "arch": "ARM64"}')
+                '.config[.config| length] |= . + { "name": "Xcode 15.4", "xcode_version": "15.4", "build_arguments_override": "${xcode_15_4_build_arguments_override}", "test_arguments_override": "${xcode_15_4_test_arguments_override}", "os": "sequoia", "arch": "ARM64", "pool": "${runner_pool}" }')
             fi
 
             if [[ "$xcode_16_0_enabled" == "true" ]]; then
               matrix=$(echo "$matrix" | jq -c \
-                '.config[.config| length] |= . + { "name": "Xcode 16.0", "xcode_version": "16.0", "build_arguments_override": "${xcode_16_0_build_arguments_override}", "test_arguments_override": "${xcode_16_0_test_arguments_override}", "os": "sequoia", "arch": "ARM64"}')
+                '.config[.config| length] |= . + { "name": "Xcode 16.0", "xcode_version": "16.0", "build_arguments_override": "${xcode_16_0_build_arguments_override}", "test_arguments_override": "${xcode_16_0_test_arguments_override}", "os": "sequoia", "arch": "ARM64", "pool": "${runner_pool}" }')
             fi
 
             if [[ "$xcode_16_1_enabled" == "true" ]]; then
               matrix=$(echo "$matrix" | jq -c \
-                '.config[.config| length] |= . + { "name": "Xcode 16.1", "xcode_version": "16.1", "build_arguments_override": "${xcode_16_1_build_arguments_override}", "test_arguments_override": "${xcode_16_1_test_arguments_override}", "os": "sequoia", "arch": "ARM64"}')
+                '.config[.config| length] |= . + { "name": "Xcode 16.1", "xcode_version": "16.1", "build_arguments_override": "${xcode_16_1_build_arguments_override}", "test_arguments_override": "${xcode_16_1_test_arguments_override}", "os": "sequoia", "arch": "ARM64", "pool": "${runner_pool}" }')
             fi
 
             if [[ "$xcode_16_2_enabled" == "true" ]]; then
               matrix=$(echo "$matrix" | jq -c \
-                '.config[.config| length] |= . + { "name": "Xcode 16.2", "xcode_version": "16.2", "build_arguments_override": "${xcode_16_2_build_arguments_override}", "test_arguments_override": "${xcode_16_2_test_arguments_override}", "os": "sequoia", "arch": "ARM64"}')
+                '.config[.config| length] |= . + { "name": "Xcode 16.2", "xcode_version": "16.2", "build_arguments_override": "${xcode_16_2_build_arguments_override}", "test_arguments_override": "${xcode_16_2_test_arguments_override}", "os": "sequoia", "arch": "ARM64", "pool": "${runner_pool}" }')
             fi
 
             echo "$matrix" | jq -c
           )"
           EOM
         env:
+          MATRIX_RUNNER_POOL: ${{ inputs.runner_pool }}
           MATRIX_MACOS_15_4_ENABLED: ${{ inputs.xcode_15_4_enabled }}
           MATRIX_MACOS_15_4_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_15_4_build_arguments_override }}
           MATRIX_MACOS_15_4_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_15_4_test_arguments_override }}
@@ -167,7 +174,7 @@ jobs:
   darwin-job:
     name: ${{ matrix.config.name }}
     needs: construct-matrix
-    runs-on: [self-hosted, macos, "${{ matrix.config.os }}", "${{ matrix.config.arch }}"]
+    runs-on: [self-hosted, macos, "${{ matrix.config.os }}", "${{ matrix.config.arch }}", "${{ matrix.config.pool }}"]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.construct-matrix.outputs.darwin-matrix) }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@macos_ci_pools  # TODO: testing
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       runner_pool: nightly
       build_scheme: swift-nio-Package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@macos_ci_pools  # TODO: testing
     with:
       runner_pool: nightly
       build_scheme: swift-nio-Package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,7 @@ jobs:
     # Workaround https://github.com/nektos/act/issues/1875
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
+      runner_pool: nightly
       build_scheme: swift-nio-Package
       macos_xcode_test_enabled: false  # Disabled because of an issue
       ios_xcode_test_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,7 +80,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@macos_ci_pools  # TODO: testing
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       runner_pool: general
       build_scheme: swift-nio-Package

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,7 +80,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@macos_ci_pools  # TODO: testing
     with:
       runner_pool: general
       build_scheme: swift-nio-Package

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -82,6 +82,7 @@ jobs:
     # Workaround https://github.com/nektos/act/issues/1875
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
+      runner_pool: general
       build_scheme: swift-nio-Package
 
   static-sdk:


### PR DESCRIPTION
Add support for macOS CI runner pools

### Motivation:

With new runners coming online we are separating the runners into pools.
* "nightly" runners are to be targeted for asynchronous work which users
aren't waiting on such as overnight work.
* "general" runners can be used for either synchronoous or asynchronous
work.
* At the moment all runers are "general" runners, a subset are "nightly"
runners.

The aim here is to prioritize work which users are waiting for such as
on PRs. Asynchronous work prioritizing the "nightly" runners will likely
end up queuing for the contended runners but synchronous work will claim
any available node.

### Modifications:

* Add a `runner_pool` input for the macOS workflow
* Default the `runner_pool` to `nightly` since the vast majority of
existing workflows are specifying asynchronous work.
* Specify the runner pool in NIO's use of macOS CI.

### Result:

Support for runner pools.

An example of this in action: https://github.com/apple/swift-nio/actions/runs/14188573697/job/39748250001