### PR TITLE
Document supported versions consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It's like [Netty](https://netty.io), but written for Swift.
 
 The SwiftNIO project is split across multiple repositories:
 
-Repository | NIO 2 (Swift 5.7+)
+Repository | NIO 2
 --- | ---
 [https://github.com/apple/swift-nio][repo-nio] <br> SwiftNIO core | `from: "2.0.0"`
 [https://github.com/apple/swift-nio-ssl][repo-nio-ssl] <br> TLS (SSL) support | `from: "2.0.0"`
@@ -19,8 +19,6 @@ Repository | NIO 2 (Swift 5.7+)
 [https://github.com/apple/swift-nio-extras][repo-nio-extras] <br>useful additions around SwiftNIO | `from: "1.0.0"`
 [https://github.com/apple/swift-nio-transport-services][repo-nio-transport-services] <br> first-class support for macOS, iOS, tvOS, and watchOS | `from: "1.0.0"`
 [https://github.com/apple/swift-nio-ssh][repo-nio-ssh] <br> SSH support | `.upToNextMinor(from: "0.2.0")`
-
-NIO 2.29.0 and older support Swift 5.0+, NIO 2.39.0 and older support Swift 5.2+.
 
 Within this repository we have a number of products that provide different functionality. This package contains the following products:
 
@@ -73,10 +71,10 @@ This is the current version of SwiftNIO and will be supported for the foreseeabl
 
 ### Swift Versions
 
-We commit to support the most recently released swift version (currently 5.10) and the last two minor releases before that unless this is impossible to do in one codebase.
-In addition checks are run against the latest beta release (if any) as well as the nightly swift builds and the intent is that these should pass.
+We commit to support the most recently released Swift version and the last two minor releases before that unless this is impossible to do in one codebase.
+In addition checks are run against the latest beta release (if any) as well as the nightly Swift builds and the intent is that these should pass.
 
-The most recent versions of SwiftNIO support Swift 5.9 and newer. The minimum Swift version supported by SwiftNIO releases are detailed below:
+The minimum Swift version supported by SwiftNIO releases are detailed below:
 
 SwiftNIO            | Minimum Swift Version
 --------------------|----------------------


### PR DESCRIPTION
Motivation:

The README mentions indicates the supported Swift versions in a few places which over time have gotten out of sync.

Modifications:

- Only document the supported Swift version in the 'supported versions' section of the README

Result:

- Resolves #3158