### PR TITLE
Add More Peek API Variants for ByteBuffer

### DIFF
--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -857,6 +857,21 @@ public struct ByteBuffer {
         return new
     }
 
+    /// Returns a slice of size `length` bytes, starting at the current `readerIndex`. The `ByteBuffer` this is invoked on
+    /// and the `ByteBuffer` returned will share the same underlying storage. However, the byte at `readerIndex` in this
+    /// `ByteBuffer` will correspond to index `0` in the returned `ByteBuffer`.
+    /// The `readerIndex` of the returned `ByteBuffer` will be `0`, the `writerIndex` will be `length`.
+    ///
+    /// This method is equivalent to calling `getSlice(at: readerIndex, length: length)`.
+    ///
+    /// - Parameter length: The length of the requested slice.
+    /// - Returns: A `ByteBuffer` containing the selected bytes as readable bytes or `nil` if the selected bytes were not
+    ///            readable in the initial `ByteBuffer`.
+    @inlinable
+    public func peekSlice(length: Int) -> ByteBuffer? {
+        self.getSlice(at: self.readerIndex, length: length)
+    }
+
     /// Discard the bytes before the reader index. The byte at index `readerIndex` before calling this method will be
     /// at index `0` after the call returns.
     ///

--- a/Sources/NIOCore/ByteBuffer-lengthPrefix.swift
+++ b/Sources/NIOCore/ByteBuffer-lengthPrefix.swift
@@ -165,15 +165,6 @@ extension ByteBuffer {
         endianness: Endianness = .big,
         as integer: Integer.Type
     ) -> ByteBuffer? where Integer: FixedWidthInteger {
-        guard let lengthPrefix = self.getInteger(at: self.readerIndex, endianness: endianness, as: Integer.self),
-            let messageLength = Int(exactly: lengthPrefix),
-            let messageBuffer = self.getSlice(
-                at: self.readerIndex + MemoryLayout<Integer>.size,
-                length: messageLength
-            )
-        else {
-            return nil
-        }
-        return messageBuffer
+        self.getLengthPrefixedSlice(at: self.readerIndex, endianness: endianness, as: integer)
     }
 }

--- a/Sources/NIOCore/ByteBuffer-lengthPrefix.swift
+++ b/Sources/NIOCore/ByteBuffer-lengthPrefix.swift
@@ -149,4 +149,31 @@ extension ByteBuffer {
 
         return messageBuffer
     }
+
+    /// Reads an integer length prefix at the current `readerIndex`, then returns a `ByteBuffer` slice of that length
+    /// without advancing the reader index.
+    ///
+    /// This method is equivalent to calling `getLengthPrefixedSlice(at: readerIndex, ...)`.
+    ///
+    /// - Parameters:
+    ///   - endianness: The endianness of the length prefix (defaults to big endian).
+    ///   - integer: The `FixedWidthInteger` type for the length prefix.
+    /// - Returns: `nil` if the length prefix could not be read, the length prefix is negative, or if there aren't enough
+    ///            bytes for the message after the prefix. Otherwise, a slice of the requested length.
+    @inlinable
+    public func peekLengthPrefixedSlice<Integer>(
+        endianness: Endianness = .big,
+        as integer: Integer.Type
+    ) -> ByteBuffer? where Integer: FixedWidthInteger {
+        guard let lengthPrefix = self.getInteger(at: self.readerIndex, endianness: endianness, as: Integer.self),
+            let messageLength = Int(exactly: lengthPrefix),
+            let messageBuffer = self.getSlice(
+                at: self.readerIndex + MemoryLayout<Integer>.size,
+                length: messageLength
+            )
+        else {
+            return nil
+        }
+        return messageBuffer
+    }
 }

--- a/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
+++ b/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift
@@ -136,6 +136,23 @@ extension ByteBuffer {
         }
     }
 
+    /// Return `length` bytes starting at the current `readerIndex` as `Data`. This will not change the reader index.
+    ///
+    /// This method is equivalent to calling `getData(at: readerIndex, length: length, byteTransferStrategy: ...)`.
+    ///
+    /// - Parameters:
+    ///   - length: The number of bytes of interest.
+    ///   - byteTransferStrategy: Controls how to transfer the bytes (see `ByteTransferStrategy`).
+    /// - Returns: A `Data` value containing the bytes of interest or `nil` if the selected bytes are not readable.
+    @inlinable
+    public func peekData(length: Int, byteTransferStrategy: ByteTransferStrategy) -> Data? {
+        self.getData(
+            at: self.readerIndex,
+            length: length,
+            byteTransferStrategy: byteTransferStrategy
+        )
+    }
+
     // MARK: - Foundation String APIs
 
     /// Get a `String` decoding `length` bytes starting at `index` with `encoding`. This will not change the reader index.
@@ -361,6 +378,18 @@ extension ByteBuffer {
         let written = self.setUUIDBytes(uuid, at: self.writerIndex)
         self.moveWriterIndex(forwardBy: written)
         return written
+    }
+
+    /// Get a `UUID` from the 16 bytes starting at the current `readerIndex`. Does not move the reader index.
+    ///
+    /// If there are fewer than 16 bytes starting at `readerIndex` then `nil` will be returned.
+    ///
+    /// This method is equivalent to calling `getUUIDBytes(at: readerIndex)`.
+    ///
+    /// - Returns: A `UUID` value containing the bytes of interest or `nil` if the selected bytes are not readable.
+    @inlinable
+    public func peekUUIDBytes() -> UUID? {
+        self.getUUIDBytes(at: self.readerIndex)
     }
 }
 

--- a/Sources/NIOWebSocket/WebSocketErrorCodes.swift
+++ b/Sources/NIOWebSocket/WebSocketErrorCodes.swift
@@ -154,6 +154,16 @@ extension ByteBuffer {
     public mutating func write(webSocketErrorCode code: WebSocketErrorCode) {
         self.writeInteger(UInt16(webSocketErrorCode: code))
     }
+
+    /// Read a `WebSocketErrorCode` from 2 bytes at the current `readerIndex`. Does not move the reader index.
+    ///
+    /// This method is equivalent to calling `getWebSocketErrorCode(at: readerIndex)`.
+    ///
+    /// - Returns: The error code, or `nil` if there are not enough bytes to read the code.
+    @inlinable
+    public func peekWebSocketErrorCode() -> WebSocketErrorCode? {
+        self.getWebSocketErrorCode(at: self.readerIndex)
+    }
 }
 
 extension UInt16 {

--- a/Tests/NIOWebSocketTests/ByteBufferWebSocketTests.swift
+++ b/Tests/NIOWebSocketTests/ByteBufferWebSocketTests.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOWebSocket
+import XCTest
+
+final class ByteBufferWebSocketTests: XCTestCase {
+    private var buffer = ByteBuffer()
+    
+    func testPeekWebSocketErrorCode_Normal() {
+        var buffer = ByteBuffer()
+        let errorCode = WebSocketErrorCode(codeNumber: 1002)
+        buffer.write(webSocketErrorCode: errorCode)
+
+        guard let webSocketCode = buffer.peekWebSocketErrorCode() else {
+            XCTFail("Expected to read a valid WebSocketErrorCode.")
+            return
+        }
+        XCTAssertEqual(webSocketCode, errorCode, "Should match the written error code.")
+        XCTAssertEqual(buffer.readerIndex, 0, "peekWebSocketErrorCode() should not advance the reader index.")
+    }
+
+    func testPeekWebSocketErrorCode_NotEnoughBytes() {
+        var buffer = ByteBuffer()
+        // Only write a single byte, insufficient for a UInt16.
+        buffer.writeInteger(UInt8(0x03))
+        let code = buffer.peekWebSocketErrorCode()
+        XCTAssertNil(code, "Should return nil if not enough bytes to form an error code.")
+    }
+
+    func testPeekWebSocketErrorCode_Repeated() {
+        var buffer = ByteBuffer()
+        let errorCode = WebSocketErrorCode(codeNumber: 1011)
+        buffer.write(webSocketErrorCode: errorCode)
+
+        let firstPeek = buffer.peekWebSocketErrorCode()
+        let secondPeek = buffer.peekWebSocketErrorCode()
+        XCTAssertEqual(firstPeek, secondPeek, "Repeated peeks should yield the same code.")
+        XCTAssertEqual(buffer.readerIndex, 0, "peekWebSocketErrorCode() should not advance reader index.")
+    }
+}

--- a/Tests/NIOWebSocketTests/ByteBufferWebSocketTests.swift
+++ b/Tests/NIOWebSocketTests/ByteBufferWebSocketTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 final class ByteBufferWebSocketTests: XCTestCase {
     private var buffer = ByteBuffer()
-    
+
     func testPeekWebSocketErrorCode_Normal() {
         var buffer = ByteBuffer()
         let errorCode = WebSocketErrorCode(codeNumber: 1002)


### PR DESCRIPTION
### Motivation:

Existing get APIs require passing an explicit index and can be misused, leading to verbose and error-prone code. Adding peek variants that automatically use the current readerIndex improves safety and clarity. This aims to address issue #2034 and issue #2736, and is a continuation of PR #3157

### Modifications:

    Introduced peekSlice(), peekLengthPrefixedSlice(), peekData(), peekUUIDBytes() and peekWebSocketErrorCode().
    Added tests for each peek API covering normal, empty and repeated peek scenarios.

### Result:

Developers can now use nonmutating peek APIs to inspect ByteBuffer contents without altering the reader index.