### PR TITLE
uncomment visionOS CI tasks

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -101,8 +101,8 @@ on:
         default: false
       visionos_xcode_build_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode build targeting visionOS. Defaults to true."
-        default: true
+        description: "Boolean to enable the Xcode build targeting visionOS. Defaults to false."
+        default: false
       visionos_xcode_test_enabled:
         type: boolean
         description: "Boolean to enable the Xcode test targeting visionOS. Defaults to false."
@@ -268,12 +268,12 @@ jobs:
       - name: tvOS test
         if: '!cancelled() && inputs.tvos_xcode_test_enabled'
         run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "name=Apple TV 4K (3rd generation)" test
-        # - name: visionOS build  # arm only  # TODO: disabled due to issue
-        #   if: '!cancelled() && inputs.visionos_xcode_build_enabled'
-        #   run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "generic/platform=visionos" build
-        # - name: visionOS test  # arm only  # TODO: disabled due to issue
-        #   if: '!cancelled() && inputs.visionos_xcode_test_enabled'
-        #   run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "name=Apple Vision Pro" test
+      - name: visionOS build  # arm only
+        if: '!cancelled() && inputs.visionos_xcode_build_enabled'
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "generic/platform=visionos" build
+      - name: visionOS test  # arm only
+        if: '!cancelled() && inputs.visionos_xcode_test_enabled'
+        run: /usr/bin/xcodebuild -quiet -scheme ${BUILD_SCHEME} -destination "name=Apple Vision Pro" test
     env:
       XCODE_VERSION: ${{ matrix.config.xcode_version }}
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.config.xcode_version }}.app"


### PR DESCRIPTION
### Motivation:

These don't work on all versions but we should allow people to opt-in if they know they do work

### Modifications:

Uncomment the steps and make the step default to off

### Result:

People can choose to run visionOS builds and tests