### PR TITLE
Add perf test for EL as SerialExecutor

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version:5.9
 
 import PackageDescription
 


### PR DESCRIPTION
This PR adds two benchmarks:

- Jumping 1k times from the global executor to a NIO EL and back using `el.execute {}` and an `UncheckedContinuation`
- Jumping 1k times from the global executor to a NIO EL and back using an actor that has a custom executor