### PR TITLE
Static SDK installation script improvements

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -88,4 +88,4 @@ jobs:
   static-sdk:
     name: Static SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/static_sdk.yml@install_static_sdk_resiliance
+    uses: apple/swift-nio/.github/workflows/static_sdk.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -88,4 +88,4 @@ jobs:
   static-sdk:
     name: Static SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+    uses: apple/swift-nio/.github/workflows/static_sdk.yml@install_static_sdk_resiliance

--- a/.github/workflows/static_sdk.yml
+++ b/.github/workflows/static_sdk.yml
@@ -19,7 +19,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             },
@@ -29,7 +29,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt-get update -y -q && apt-get install -y -q curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             }

--- a/.github/workflows/static_sdk.yml
+++ b/.github/workflows/static_sdk.yml
@@ -19,7 +19,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/install_static_sdk_resiliance/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/install_static_sdk_resiliance/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             },
@@ -29,7 +29,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/install_static_sdk_resiliance/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/install_static_sdk_resiliance/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             }

--- a/.github/workflows/static_sdk.yml
+++ b/.github/workflows/static_sdk.yml
@@ -19,7 +19,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/install_static_sdk_resiliance/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/install_static_sdk_resiliance/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_VERSION=latest INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             },
@@ -29,7 +29,7 @@ jobs:
               "platform":"Linux",
               "runner":"ubuntu-latest",
               "image":"ubuntu:jammy",
-              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
+              "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s https://raw.githubusercontent.com/apple/swift-nio/install_static_sdk_resiliance/scripts/install_swift_prerequisites.sh | bash && curl -s https://raw.githubusercontent.com/apple/swift-nio/install_static_sdk_resiliance/scripts/install_static_sdk.sh | INSTALL_SWIFT_STATIC_SDK_BRANCH=main INSTALL_SWIFT_STATIC_SDK_ARCH=x86_64 bash && hash -r",
               "command":"swift build",
               "command_arguments":"--swift-sdk x86_64-swift-linux-musl"
             }

--- a/scripts/install_static_sdk.sh
+++ b/scripts/install_static_sdk.sh
@@ -29,10 +29,10 @@ if [[ ! ( -n "$branch" && -z "$version" ) && ! ( -z "$branch" && -n "$version") 
   fatal "Exactly one of build or version must be defined."
 fi
 
-CURL_BIN="${CURL_BIN:-$(which curl)}" || fatal "CURL_BIN unset and no curl on PATH"
-TAR_BIN="${TAR_BIN:-$(which tar)}" || fatal "TAR_BIN unset and no tar on PATH"
-JQ_BIN="${JQ_BIN:-$(which jq)}" || fatal "JQ_BIN unset and no jq on PATH"
-SED_BIN="${SED_BIN:-$(which sed)}" || fatal "SED_BIN unset and no sed on PATH"
+CURL_BIN="${CURL_BIN:-$(which curl 2> /dev/null)}" && test -n "$CURL_BIN" || fatal "CURL_BIN unset and no curl on PATH"
+TAR_BIN="${TAR_BIN:-$(which tar 2> /dev/null)}" && test -n "$TAR_BIN" || fatal "TAR_BIN unset and no tar on PATH"
+JQ_BIN="${JQ_BIN:-$(which jq 2> /dev/null)}" && test -n "$JQ_BIN" || fatal "JQ_BIN unset and no jq on PATH"
+SED_BIN="${SED_BIN:-$(which sed 2> /dev/null)}" && test -n "$SED_BIN" || fatal "SED_BIN unset and no sed on PATH"
 
 case "$arch" in
   "aarch64")

--- a/scripts/install_static_sdk.sh
+++ b/scripts/install_static_sdk.sh
@@ -29,17 +29,11 @@ if [[ ! ( -n "$branch" && -z "$version" ) && ! ( -z "$branch" && -n "$version") 
   fatal "Exactly one of build or version must be defined."
 fi
 
-log "Installing tools for this script"
-if command -v apt-get >/dev/null; then
-  package_manager="apt-get"
-  apt-get update > /dev/null
-elif command -v yum >/dev/null; then
-  package_manager="yum"
-else
-  fatal "Cannot find either 'apt' or 'yum'"
-fi
+CURL_BIN="${CURL_BIN:-$(which curl)}" || fatal "CURL_BIN unset and no curl on PATH"
+TAR_BIN="${TAR_BIN:-$(which tar)}" || fatal "TAR_BIN unset and no tar on PATH"
+JQ_BIN="${JQ_BIN:-$(which jq)}" || fatal "JQ_BIN unset and no jq on PATH"
+SED_BIN="${SED_BIN:-$(which sed)}" || fatal "SED_BIN unset and no sed on PATH"
 
-"$package_manager" install -y curl rsync jq tar > /dev/null
 case "$arch" in
   "aarch64")
     arch_suffix="-$arch" ;;
@@ -54,14 +48,17 @@ os_image_sanitized="${os_image//./}"
 if [[ -n "$branch" ]]; then
   # Some snapshots may not have all the artefacts we require
   log "Discovering branch snapshot for branch $branch"
-  snapshots="$(curl -s "https://www.swift.org/api/v1/install/dev/main/${os_image_sanitized}.json" | jq -r --arg arch "$arch" '.[$arch] | unique | reverse | .[].dir')"
+
+  # shellcheck disable=SC2016  # Our use of JQ_BIN means that shellcheck can't tell this is a `jq` invocation
+  snapshots="$("$CURL_BIN" -s "https://www.swift.org/api/v1/install/dev/main/${os_image_sanitized}.json" | "$JQ_BIN" -r --arg arch "$arch" '.[$arch] | unique | reverse | .[].dir')"
+
   for snapshot in $snapshots; do
     snapshot_url="https://download.swift.org/development/${os_image_sanitized}${arch_suffix}/${snapshot}/${snapshot}-${os_image}${arch_suffix}.tar.gz"
     static_sdk_url="https://download.swift.org/development/static-sdk/${snapshot}/${snapshot}_static-linux-0.0.1.artifactbundle.tar.gz"
     
     # check that the files exist
-    curl -sILXGET --fail "$snapshot_url" > /dev/null; snapshot_return_code=$?
-    curl -sILXGET --fail "$static_sdk_url" > /dev/null; static_sdk_return_code=$?
+    "$CURL_BIN" -sILXGET --fail "$snapshot_url" > /dev/null; snapshot_return_code=$?
+    "$CURL_BIN" -sILXGET --fail "$static_sdk_url" > /dev/null; static_sdk_return_code=$?
     
     if [[ ("$snapshot_return_code" -eq 0) && ("$static_sdk_return_code" -eq 0) ]]; then
       log "Discovered branch snapshot: $snapshot"
@@ -78,7 +75,7 @@ if [[ -n "$branch" ]]; then
 elif [[ -n "$version" ]]; then
   if [[ "$version" == "latest" ]]; then
     log "Discovering latest version"
-    version=$(curl -s https://www.swift.org/api/v1/install/releases.json | jq -r '.[-1].tag' | sed -E 's/swift-([0-9]+\.[0-9]+\.?[0-9]*)-RELEASE/\1/')
+    version=$("$CURL_BIN" -s https://www.swift.org/api/v1/install/releases.json | "$JQ_BIN" -r '.[-1].tag' | "$SED_BIN" -E 's/swift-([0-9]+\.[0-9]+\.?[0-9]*)-RELEASE/\1/')
     if [[ -z "$version" ]]; then
       fatal "Failed to discover latest Swift version"
     fi
@@ -89,44 +86,22 @@ elif [[ -n "$version" ]]; then
   static_sdk_url="https://download.swift.org/swift-${version}-release/static-sdk/swift-${version}-RELEASE/swift-${version}-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz"
 fi
 
-log "Installing standard Swift pre-requisites"  # pre-reqs list taken from swift.org
-DEBIAN_FRONTEND=noninteractive "$package_manager" install -y\
-    binutils\
-    git\
-    gnupg2\
-    libc6-dev\
-    libcurl4-openssl-dev\
-    libedit2\
-    libgcc-11-dev\
-    libpython3-dev\
-    libsqlite3-0\
-    libstdc++-11-dev\
-    libxml2-dev\
-    libz3-dev\
-    pkg-config\
-    python3-lldb-13\
-    tzdata\
-    unzip\
-    zlib1g-dev\
-    > /dev/null
-
 log "Obtaining Swift toolchain"
 log "Snapshot URL: $snapshot_url"
 snapshot_path="/tmp/$(basename "$snapshot_url")"
-curl -sL "$snapshot_url" -o "$snapshot_path"
+"$CURL_BIN" -sfL "$snapshot_url" -o "$snapshot_path" || fatal "Failed to download Swift toolchain"
 
 log "Installing Swift toolchain"
 mkdir -p /tmp/snapshot
-tar xfz "$snapshot_path" --strip-components 1 -C /tmp/snapshot
-rsync -a /tmp/snapshot/* /
+"$TAR_BIN" xfz "$snapshot_path" --strip-components 1 -C /
 
 log "Obtaining Static SDK"
 log "Static SDK URL: $static_sdk_url"
 static_sdk_path="/tmp/$(basename "$static_sdk_url")"
-curl -sL "$static_sdk_url" -o "$static_sdk_path"
+"$CURL_BIN" -sfL "$static_sdk_url" -o "$static_sdk_path" || fatal "Failed to download Static SDK"
 
 log "Looking for swift"
-which swift
+which swift || fatal "Failed to locate installed Swift"
 
 log "Checking swift"
 swift --version

--- a/scripts/install_static_sdk.sh
+++ b/scripts/install_static_sdk.sh
@@ -29,10 +29,10 @@ if [[ ! ( -n "$branch" && -z "$version" ) && ! ( -z "$branch" && -n "$version") 
   fatal "Exactly one of build or version must be defined."
 fi
 
-CURL_BIN="${CURL_BIN:-$(which curl 2> /dev/null)}" && test -n "$CURL_BIN" || fatal "CURL_BIN unset and no curl on PATH"
-TAR_BIN="${TAR_BIN:-$(which tar 2> /dev/null)}" && test -n "$TAR_BIN" || fatal "TAR_BIN unset and no tar on PATH"
-JQ_BIN="${JQ_BIN:-$(which jq 2> /dev/null)}" && test -n "$JQ_BIN" || fatal "JQ_BIN unset and no jq on PATH"
-SED_BIN="${SED_BIN:-$(which sed 2> /dev/null)}" && test -n "$SED_BIN" || fatal "SED_BIN unset and no sed on PATH"
+CURL_BIN="${CURL_BIN:-$(which curl 2> /dev/null)}"; test -n "$CURL_BIN" || fatal "CURL_BIN unset and no curl on PATH"
+TAR_BIN="${TAR_BIN:-$(which tar 2> /dev/null)}"; test -n "$TAR_BIN" || fatal "TAR_BIN unset and no tar on PATH"
+JQ_BIN="${JQ_BIN:-$(which jq 2> /dev/null)}"; test -n "$JQ_BIN" || fatal "JQ_BIN unset and no jq on PATH"
+SED_BIN="${SED_BIN:-$(which sed 2> /dev/null)}"; test -n "$SED_BIN" || fatal "SED_BIN unset and no sed on PATH"
 
 case "$arch" in
   "aarch64")

--- a/scripts/install_swift_prerequisites.sh
+++ b/scripts/install_swift_prerequisites.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -uo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+if command -v apt-get >/dev/null; then
+  PACKAGE_MANAGER_BIN="apt"
+  apt-get update > /dev/null
+elif command -v yum >/dev/null; then
+  PACKAGE_MANAGER_BIN="yum"
+else
+  fatal "Cannot find either 'apt' or 'yum'"
+fi
+
+log "Installing standard Swift pre-requisites"  # pre-reqs list taken from swift.org
+DEBIAN_FRONTEND=noninteractive "$PACKAGE_MANAGER_BIN" install -y\
+    binutils\
+    git\
+    gnupg2\
+    libc6-dev\
+    libcurl4-openssl-dev\
+    libedit2\
+    libgcc-11-dev\
+    libpython3-dev\
+    libsqlite3-0\
+    libstdc++-11-dev\
+    libxml2-dev\
+    libz3-dev\
+    pkg-config\
+    python3-lldb-13\
+    tzdata\
+    unzip\
+    zlib1g-dev\
+    > /dev/null


### PR DESCRIPTION
Static SDK installation script improvements

### Motivation:

Make static SDK installation scripts more modular and make
failures easier to diagnose.

### Modifications:

- Allow specification of binaries from outside the installation script
- Remove script dependency installation from the script
- Separate the Swift dependency installation into its own script
- Fatal error explicitly if the installed Swift can't be found
- Make curl operations for downloading artifacts explicitly fail

### Result:

Scripts which are easier to maintain and operate.

An example CI run with this in operation https://github.com/apple/swift-nio/actions/runs/14329482180/job/40162003318?pr=3186