### PR TITLE
Speed up allocation counting tests

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
+++ b/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh
@@ -296,8 +296,9 @@ build_package \
 set -eu
 cd "$working_dir"
 swift build "${build_opts[@]}"
+build_dir=$(swift build "${build_opts[@]}" --show-bin-path)
 for f in "${files[@]}"; do
     echo "- $f"
-    swift run "${build_opts[@]}" "$(module_name_from_path "$f")"
+    "${build_dir}/$(module_name_from_path "$f")"
 done
 )

--- a/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
+++ b/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AtomicCounter
+import Dispatch
 import Foundation
 
 #if canImport(Darwin)
@@ -139,7 +140,14 @@ func measureAll(trackFDs: Bool, _ fn: () -> Int) -> [Measurement] {
 }
 
 func measureAndPrint(desc: String, trackFDs: Bool, fn: () -> Int) {
+    let start = DispatchTime.now()
     let measurements = measureAll(trackFDs: trackFDs, fn)
+
+    let end = DispatchTime.now()
+    let durationNanos = end.uptimeNanoseconds - start.uptimeNanoseconds
+    let durationSeconds = Double(durationNanos) / 1e9
+    print("\(desc).duration: \(durationSeconds) (s)")
+
     measurements.printTotalAllocations(description: desc)
     measurements.printRemainingAllocations(description: desc)
     measurements.printTotalAllocatedBytes(description: desc)

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet_sync.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_autoReadGetAndSet_sync.swift
@@ -16,6 +16,7 @@ import NIOCore
 import NIOPosix
 
 func run(identifier: String) {
+    let group = MultiThreadedEventLoopGroup.preheatedSingleton
     MultiThreadedEventLoopGroup.withCurrentThreadAsEventLoop { loop in
         ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).map { server in
             measure(identifier: identifier) {

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_1000_rst_connections.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_1000_rst_connections.swift
@@ -27,10 +27,7 @@ private final class CloseAfterTimeoutHandler: ChannelInboundHandler {
 }
 
 func run(identifier: String) {
-    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-    defer {
-        try! group.syncShutdownGracefully()
-    }
+    let group = MultiThreadedEventLoopGroup.preheatedSingleton.next()
 
     let serverConnection = try! ServerBootstrap(group: group)
         .bind(host: "localhost", port: 0)

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_assume_isolated_scheduling_10000_executions.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_assume_isolated_scheduling_10000_executions.swift
@@ -17,7 +17,7 @@ import NIOPosix
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let group = MultiThreadedEventLoopGroup.preheatedSingleton.next()
         let loop = group.next()
         let dg = DispatchGroup()
 
@@ -28,7 +28,6 @@ func run(identifier: String) {
             }
         }.wait()
         dg.wait()
-        try! group.syncShutdownGracefully()
         return 10_000
     }
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_flat_schedule_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_flat_schedule_10000_tasks.swift
@@ -18,24 +18,32 @@ import NIOPosix
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let group = MultiThreadedEventLoopGroup.preheatedSingleton
         let loop = group.next()
-        let counter = try! loop.submit { () -> Int in
+        let (counter, tasks) = try! loop.submit { () -> (Int, [Scheduled<Int>]) in
+            let iterations = 10_000
+
             var counter: Int = 0
+            var tasks: [Scheduled<Int>] = []
+            tasks.reserveCapacity(iterations)
 
             let deadline = NIODeadline.now() + .hours(1)
 
-            for _ in 0..<10000 {
-                loop.flatScheduleTask(deadline: deadline) {
+            for _ in 0..<iterations {
+                let task = loop.assumeIsolated().flatScheduleTask(deadline: deadline) {
                     counter &+= 1
                     return loop.makeSucceededFuture(counter)
                 }
+                tasks.append(task)
             }
 
-            return counter
+            return (counter, tasks)
         }.wait()
 
-        try! group.syncShutdownGracefully()
+        for task in tasks {
+            task.cancel()
+        }
+
         return counter
     }
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_flat_schedule_assume_isolated_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_flat_schedule_assume_isolated_10000_tasks.swift
@@ -18,24 +18,32 @@ import NIOPosix
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let group = MultiThreadedEventLoopGroup.preheatedSingleton
         let loop = group.next()
-        let counter = try! loop.submit { () -> Int in
+        let (counter, tasks) = try! loop.submit { () -> (Int, [Scheduled<Int>]) in
+            let iterations = 10_000
+
             var counter: Int = 0
+            var tasks: [Scheduled<Int>] = []
+            tasks.reserveCapacity(iterations)
 
             let deadline = NIODeadline.now() + .hours(1)
 
-            for _ in 0..<10000 {
-                loop.assumeIsolated().flatScheduleTask(deadline: deadline) {
+            for _ in 0..<iterations {
+                let task = loop.assumeIsolated().flatScheduleTask(deadline: deadline) {
                     counter &+= 1
                     return loop.makeSucceededFuture(counter)
                 }
+                tasks.append(task)
             }
 
-            return counter
+            return (counter, tasks)
         }.wait()
 
-        try! group.syncShutdownGracefully()
+        for task in tasks {
+            task.cancel()
+        }
+
         return counter
     }
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_10000_tasks.swift
@@ -13,25 +13,33 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
+import NIOCore
 import NIOPosix
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let group = MultiThreadedEventLoopGroup.preheatedSingleton
         let loop = group.next()
-        let counter = try! loop.submit { () -> Int in
+        let (counter, tasks) = try! loop.submit { () -> (Int, [Scheduled<Void>]) in
+            let iterations = 10_000
             var counter: Int = 0
+            var tasks = [Scheduled<Void>]()
+            tasks.reserveCapacity(iterations)
 
-            for _ in 0..<10000 {
-                loop.scheduleTask(in: .hours(1)) {
+            for _ in 0..<iterations {
+                let task = loop.scheduleTask(in: .hours(1)) {
                     counter &+= 1
                 }
+                tasks.append(task)
             }
 
-            return counter
+            return (counter, tasks)
         }.wait()
 
-        try! group.syncShutdownGracefully()
+        for task in tasks {
+            task.cancel()
+        }
+
         return counter
     }
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_and_run_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_and_run_10000_tasks.swift
@@ -13,10 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
+import NIOCore
 import NIOPosix
 
 func run(identifier: String) {
-    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let group = MultiThreadedEventLoopGroup.preheatedSingleton
     let loop = group.next()
     let dg = DispatchGroup()
 
@@ -27,7 +28,7 @@ func run(identifier: String) {
             for _ in 0..<10000 {
                 dg.enter()
 
-                loop.scheduleTask(in: .nanoseconds(0)) {
+                let task = loop.scheduleTask(in: .nanoseconds(0)) {
                     counter &+= 1
                     dg.leave()
                 }
@@ -37,6 +38,4 @@ func run(identifier: String) {
 
         return counter
     }
-
-    try! group.syncShutdownGracefully()
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_with_deadline_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_with_deadline_10000_tasks.swift
@@ -18,23 +18,31 @@ import NIOPosix
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let group = MultiThreadedEventLoopGroup.preheatedSingleton
         let loop = group.next()
-        let counter = try! loop.submit { () -> Int in
+        let (counter, tasks) = try! loop.submit { () -> (Int, [Scheduled<Void>]) in
+            let iterations = 10_000
             var counter: Int = 0
+
+            var tasks = [Scheduled<Void>]()
+            tasks.reserveCapacity(iterations)
 
             let deadline = NIODeadline.now() + .hours(1)
 
-            for _ in 0..<10000 {
-                loop.scheduleTask(deadline: deadline) {
+            for _ in 0..<iterations {
+                let task = loop.scheduleTask(deadline: deadline) {
                     counter &+= 1
                 }
+                tasks.append(task)
             }
 
-            return counter
+            return (counter, tasks)
         }.wait()
 
-        try! group.syncShutdownGracefully()
+        for task in tasks {
+            task.cancel()
+        }
+
         return counter
     }
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_with_deadline_assume_isolated_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_schedule_with_deadline_assume_isolated_10000_tasks.swift
@@ -18,24 +18,31 @@ import NIOPosix
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let group = MultiThreadedEventLoopGroup.preheatedSingleton
         let loop = group.next()
-        let counter = try! loop.submit { () -> Int in
+        let (counter, tasks) = try! loop.submit { () -> (Int, [Scheduled<Int>]) in
+            let iterations = 10_000
             var counter: Int = 0
+            var tasks = [Scheduled<Int>]()
+            tasks.reserveCapacity(iterations)
 
             let deadline = NIODeadline.now() + .hours(1)
 
-            for _ in 0..<10000 {
-                loop.assumeIsolated().scheduleTask(deadline: deadline) {
+            for _ in 0..<iterations {
+                let task = loop.assumeIsolated().scheduleTask(deadline: deadline) {
                     counter &+= 1
                     return counter
                 }
+                tasks.append(task)
             }
 
-            return counter
+            return (counter, tasks)
         }.wait()
 
-        try! group.syncShutdownGracefully()
+        for task in tasks {
+            task.cancel()
+        }
+
         return counter
     }
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_scheduling_10000_executions.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_scheduling_10000_executions.swift
@@ -17,7 +17,7 @@ import NIOPosix
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let group = MultiThreadedEventLoopGroup.preheatedSingleton
         let loop = group.next()
         let dg = DispatchGroup()
 
@@ -28,7 +28,6 @@ func run(identifier: String) {
             }
         }.wait()
         dg.wait()
-        try! group.syncShutdownGracefully()
         return 10_000
     }
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_submit_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_submit_10000_tasks.swift
@@ -17,7 +17,7 @@ import NIOPosix
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let group = MultiThreadedEventLoopGroup.preheatedSingleton
         let loop = group.next()
         let counter = try! loop.submit { () -> Int in
             var counter: Int = 0
@@ -32,7 +32,6 @@ func run(identifier: String) {
             return counter
         }.wait()
 
-        try! group.syncShutdownGracefully()
         return counter
     }
 }

--- a/IntegrationTests/tests_04_performance/test_01_resources/test_submit_assume_isolated_10000_tasks.swift
+++ b/IntegrationTests/tests_04_performance/test_01_resources/test_submit_assume_isolated_10000_tasks.swift
@@ -17,7 +17,7 @@ import NIOPosix
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let group = MultiThreadedEventLoopGroup.preheatedSingleton
         let loop = group.next()
         let counter = try! loop.submit { () -> Int in
             var counter: Int = 0
@@ -32,7 +32,6 @@ func run(identifier: String) {
             return counter
         }.wait()
 
-        try! group.syncShutdownGracefully()
         return counter
     }
 }


### PR DESCRIPTION
Motivation:

The allocation counting tests take around 18 minutes in CI, which is quite a while! The tests themselves don't take nearly so long, however each test is run 11 times but between each time the framework waits for allocations to become rebalanced (i.e. everything we allocated should be freed). The framework will wait up to 5 seconds between each iteration for this. About 15 or so tests take 55 seconds, meaning they're just waiting for the allocs to quiece. It turns out that dispatch doesn't always free blocks from `async` work items immediately. This is relevant because a number of tests create their own MTELGs, and so when they are shutdown we see allocations from the shutdown flow lingering for more than 5 seconds.

Not only does this slow the tests down, if the allocations don't quiece, the framework ignores the result, so we lose some coverage too.

Modifiications:

- Add a pre-warmed singleton MTELG which tests can use, this ensures it has plenty of space in its queues so that intermediate allocs from running tests aren't seen as leaks
- Cancel tasks which are scheduled to run after the test to avoid 'leaks'.
- Avoid using `swift run` and just execute the test binary, this shaves off a few seconds for each test.
- Print out how long each test run takes to make debugging easier

Result:

- Faster alloc tests

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
