### PR TITLE
Add errorCaught to NIOTypedHTTPClientUpgradeHandler

### DIFF
--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
@@ -193,6 +193,7 @@ public final class NIOTypedHTTPClientUpgradeHandler<UpgradeResult: Sendable>: Ch
 
     public func errorCaught(context: ChannelHandlerContext, error: any Error) {
         self.upgradeResultPromise.fail(error)
+        context.fireErrorCaught(error)
     }
 
     private func channelRead(context: ChannelHandlerContext, responsePart: HTTPClientResponsePart) {

--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgradeHandler.swift
@@ -191,6 +191,10 @@ public final class NIOTypedHTTPClientUpgradeHandler<UpgradeResult: Sendable>: Ch
         }
     }
 
+    public func errorCaught(context: ChannelHandlerContext, error: any Error) {
+        self.upgradeResultPromise.fail(error)
+    }
+
     private func channelRead(context: ChannelHandlerContext, responsePart: HTTPClientResponsePart) {
         switch self.stateMachine.channelReadResponsePart(responsePart) {
         case .fireErrorCaughtAndRemoveHandler(let error):

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -1217,56 +1217,6 @@ final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
                 break
             }
         }
-        /*let channel = EmbeddedChannel()
-        
-        if let previousHTTPHandler {
-            try channel.pipeline.syncOperations.addHandler(previousHTTPHandler)
-        }
-        var headers = HTTPHeaders()
-        headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
-        headers.add(name: "Content-Length", value: "\(0)")
-        
-        let requestHead = HTTPRequestHead(
-            version: .http1_1,
-            method: .GET,
-            uri: "/",
-            headers: headers
-        )
-        
-        let upgraders: [any NIOTypedHTTPClientProtocolUpgrader<Bool>] = Array(
-            clientUpgraders.map { $0 as! any NIOTypedHTTPClientProtocolUpgrader<Bool> }
-        )
-        
-        let config = NIOTypedHTTPClientUpgradeConfiguration<Bool>(
-            upgradeRequestHead: requestHead,
-            upgraders: upgraders
-        ) { channel in
-            channel.eventLoop.makeCompletedFuture {
-                try channel.pipeline.syncOperations.addHandler(clientHTTPHandler)
-            }.map { _ in
-                false
-            }
-        }
-        var configuration = NIOUpgradableHTTPClientPipelineConfiguration(upgradeConfiguration: config)
-        configuration.leftOverBytesStrategy = .forwardBytes
-        let upgradeResult = try channel.pipeline.syncOperations.configureUpgradableHTTPClientPipeline(
-            configuration: configuration
-        )
-        let context = try channel.pipeline.syncOperations.context(
-            handlerType: NIOTypedHTTPClientUpgradeHandler<Bool>.self
-        )
-        
-        let loopBoundContext = context.loopBound
-        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0))
-            .wait()
-        upgradeResult.whenSuccess { result in
-            if result {
-                let context = loopBoundContext.value
-                upgradeCompletionHandler(context)
-            }
-        }
-        
-        return channel*/
     }
 
     // - MARK: The following tests are all overridden from the base class since they slightly differ in behaviour

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -1372,7 +1372,7 @@ final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
 
     func testReturnsErrorsFromPriorChannelHandlers() throws {
         struct FailedError: Error {}
-        final class FailingChannelHandler: ChannelInboundHandler, RemovableChannelHandler {
+        final class FailingChannelHandler: ChannelInboundHandler, RemovableChannelHandler, Sendable {
             typealias InboundIn = Any
             typealias InboundOut = Any
             func channelRead(context: ChannelHandlerContext, data: NIOAny) {

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -390,6 +390,7 @@ private func assertPipelineContainsUpgradeHandler(channel: Channel) {
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 class HTTPClientUpgradeTestCase: XCTestCase {
     func setUpClientChannel(
+        previousHTTPHandler: (RemovableChannelHandler & Sendable)? = nil,
         clientHTTPHandler: RemovableChannelHandler & Sendable,
         clientUpgraders: [any TypedAndUntypedHTTPClientProtocolUpgrader],
         _ upgradeCompletionHandler: @escaping @Sendable (ChannelHandlerContext) -> Void
@@ -1141,14 +1142,19 @@ class HTTPClientUpgradeTestCase: XCTestCase {
 #if !canImport(Darwin) || swift(>=5.10)
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
-    override func setUpClientChannel(
+
+    func setUpClientChannel(
+        previousHTTPHandler: (RemovableChannelHandler & Sendable)? = nil,
         clientHTTPHandler: RemovableChannelHandler & Sendable,
         clientUpgraders: [any TypedAndUntypedHTTPClientProtocolUpgrader],
-        _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void
+        _ upgradeCompletionHandler: @escaping (ChannelHandlerContext, Result<Bool, Error>) -> Void
     ) throws -> EmbeddedChannel {
 
         let channel = EmbeddedChannel()
 
+        if let previousHTTPHandler {
+            try channel.pipeline.syncOperations.addHandler(previousHTTPHandler)
+        }
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
         headers.add(name: "Content-Length", value: "\(0)")
@@ -1186,14 +1192,81 @@ final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
         let loopBoundContext = context.loopBound
         try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0))
             .wait()
-        upgradeResult.assumeIsolated().whenSuccess { result in
+        upgradeResult.assumeIsolated().whenComplete { result in
+            upgradeCompletionHandler(loopBoundContext.value, result)
+        }
+
+        return channel
+    }
+
+    override func setUpClientChannel(
+        previousHTTPHandler: (RemovableChannelHandler & Sendable)? = nil,
+        clientHTTPHandler: RemovableChannelHandler & Sendable,
+        clientUpgraders: [any TypedAndUntypedHTTPClientProtocolUpgrader],
+        _ upgradeCompletionHandler: @escaping (ChannelHandlerContext) -> Void
+    ) throws -> EmbeddedChannel {
+        try setUpClientChannel(
+            previousHTTPHandler: previousHTTPHandler,
+            clientHTTPHandler: clientHTTPHandler,
+            clientUpgraders: clientUpgraders
+        ) { context, result in
+            switch result {
+            case .success(true):
+                upgradeCompletionHandler(context)
+            default:
+                break
+            }
+        }
+        /*let channel = EmbeddedChannel()
+        
+        if let previousHTTPHandler {
+            try channel.pipeline.syncOperations.addHandler(previousHTTPHandler)
+        }
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
+        headers.add(name: "Content-Length", value: "\(0)")
+        
+        let requestHead = HTTPRequestHead(
+            version: .http1_1,
+            method: .GET,
+            uri: "/",
+            headers: headers
+        )
+        
+        let upgraders: [any NIOTypedHTTPClientProtocolUpgrader<Bool>] = Array(
+            clientUpgraders.map { $0 as! any NIOTypedHTTPClientProtocolUpgrader<Bool> }
+        )
+        
+        let config = NIOTypedHTTPClientUpgradeConfiguration<Bool>(
+            upgradeRequestHead: requestHead,
+            upgraders: upgraders
+        ) { channel in
+            channel.eventLoop.makeCompletedFuture {
+                try channel.pipeline.syncOperations.addHandler(clientHTTPHandler)
+            }.map { _ in
+                false
+            }
+        }
+        var configuration = NIOUpgradableHTTPClientPipelineConfiguration(upgradeConfiguration: config)
+        configuration.leftOverBytesStrategy = .forwardBytes
+        let upgradeResult = try channel.pipeline.syncOperations.configureUpgradableHTTPClientPipeline(
+            configuration: configuration
+        )
+        let context = try channel.pipeline.syncOperations.context(
+            handlerType: NIOTypedHTTPClientUpgradeHandler<Bool>.self
+        )
+        
+        let loopBoundContext = context.loopBound
+        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0))
+            .wait()
+        upgradeResult.whenSuccess { result in
             if result {
                 let context = loopBoundContext.value
                 upgradeCompletionHandler(context)
             }
         }
-
-        return channel
+        
+        return channel*/
     }
 
     // - MARK: The following tests are all overridden from the base class since they slightly differ in behaviour
@@ -1345,6 +1418,44 @@ final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
         // Check that the upgrade was still successful, despite the interruption.
         XCTAssert(upgradeHandlerCallbackFired.withLockedValue { $0 })
         XCTAssertEqual(1, clientUpgrader.upgradedHandler.handlerAddedContextCallCount)
+    }
+
+    func testReturnsErrorsFromPriorChannelHandlers() throws {
+        struct FailedError: Error {}
+        final class FailingChannelHandler: ChannelInboundHandler, RemovableChannelHandler {
+            typealias InboundIn = Any
+            typealias InboundOut = Any
+            func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+                context.fireErrorCaught(FailedError())
+                context.close(promise: nil)
+            }
+        }
+        var upgradeResult: Result<Bool, Error>?
+
+        let clientUpgrader = ExplodingClientUpgrader(forProtocol: "myProto")
+        let clientHandler = RecordingHTTPHandler()
+
+        let clientChannel = try setUpClientChannel(
+            previousHTTPHandler: FailingChannelHandler(),
+            clientHTTPHandler: clientHandler,
+            clientUpgraders: [clientUpgrader]
+        ) { _, result in
+            upgradeResult = result
+        }
+
+        let response = "HTTP/1.1 101 Switching Protocols\r\nConnection: upgrade\r\nUpgrade: myProto\r\n\r\n"
+        XCTAssertNoThrow(try clientChannel.writeInbound(clientChannel.allocator.buffer(string: response)))
+
+        clientChannel.flush()
+        clientChannel.embeddedEventLoop.run()
+
+        let result = try XCTUnwrap(upgradeResult)
+        switch result {
+        case .failure(is FailedError):
+            break
+        default:
+            XCTFail("Wrong result \(result)")
+        }
     }
 
     override func testUpgradeResponseMissingAllProtocols() throws {


### PR DESCRIPTION
To handle errors fired by previous ChannelHandlers. eg NIOSSLClientHandler

### Motivation:

Otherwise if a ChannelHandler previous to the upgrade ChannelHandler fails the error returned is `inappropriateOperationForState` and the error fired by the original ChannelHandler is lost.

Added `testReturnsErrorsFromPriorChannelHandlers`. Also had to reorganise `setUpClientChannel` slightly so I could get the result of the upgrade.