### PR TITLE
Clarify test server error code

### DIFF
--- a/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
+++ b/Sources/NIOTestUtils/NIOHTTP1TestServer.swift
@@ -272,7 +272,9 @@ public final class NIOHTTP1TestServer {
             try channel.pipeline.syncOperations.addHandler(TransformerHandler())
             _ = try channel.syncOptions!.setOption(.autoRead, value: true)
         } catch {
-            print("Channel initialization failed with: \(error)")
+            // This happens when the channel has been closed while it was waiting in
+            // the pipeline. It's benign: the closure passed to the close future above will
+            // have executed already, and started working on getting the next channel.
             channel.close(promise: nil)
         }
     }

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -474,7 +474,7 @@ class NIOHTTP1TestServerTest: XCTestCase {
             }
         )
 
-        // Create a second channel now, and again send a request head. We can't wait for the test server to receive it, because it hasn't yet.
+        // Create a second channel now.
         let secondResponsePromise = self.group.next().makePromise(of: String.self)
         let secondChannel = try self.connect(serverPort: testServer.serverPort, responsePromise: secondResponsePromise)
             .wait()

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -462,7 +462,8 @@ class NIOHTTP1TestServerTest: XCTestCase {
     func testCloseChannelWhileItIsWaiting() throws {
         let testServer = NIOHTTP1TestServer(group: self.group, aggregateBody: false)
         let firstResponsePromise = self.group.next().makePromise(of: String.self)
-        let firstChannel = try self.connect(serverPort: testServer.serverPort, responsePromise: firstResponsePromise).wait()
+        let firstChannel = try self.connect(serverPort: testServer.serverPort, responsePromise: firstResponsePromise)
+            .wait()
 
         // Send a request head and wait for it to be sent, and received at the test server so we know the connection is well underway.
         let requestHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/uri")
@@ -475,7 +476,8 @@ class NIOHTTP1TestServerTest: XCTestCase {
 
         // Create a second channel now, and again send a request head. We can't wait for the test server to receive it, because it hasn't yet.
         let secondResponsePromise = self.group.next().makePromise(of: String.self)
-        let secondChannel = try self.connect(serverPort: testServer.serverPort, responsePromise: secondResponsePromise).wait()
+        let secondChannel = try self.connect(serverPort: testServer.serverPort, responsePromise: secondResponsePromise)
+            .wait()
 
         // To burn a little time and convince ourselves that things are going fairly well, we can send a body payload on the first channel
         // and confirm it comes through.

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -458,6 +458,53 @@ class NIOHTTP1TestServerTest: XCTestCase {
         XCTAssertNotNil(channel)
         XCTAssertNoThrow(try channel.closeFuture.wait())
     }
+
+    func testCloseChannelWhileItIsWaiting() throws {
+        let testServer = NIOHTTP1TestServer(group: self.group, aggregateBody: false)
+        let firstResponsePromise = self.group.next().makePromise(of: String.self)
+        let firstChannel = try self.connect(serverPort: testServer.serverPort, responsePromise: firstResponsePromise).wait()
+
+        // Send a request head and wait for it to be sent, and received at the test server so we know the connection is well underway.
+        let requestHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/uri")
+        firstChannel.writeAndFlush(SendableRequestPart.head(requestHead), promise: nil)
+        XCTAssertNoThrow(
+            try testServer.receiveHeadAndVerify { head in
+                XCTAssertEqual(head.uri, "/uri")
+            }
+        )
+
+        // Create a second channel now, and again send a request head. We can't wait for the test server to receive it, because it hasn't yet.
+        let secondResponsePromise = self.group.next().makePromise(of: String.self)
+        let secondChannel = try self.connect(serverPort: testServer.serverPort, responsePromise: secondResponsePromise).wait()
+
+        // To burn a little time and convince ourselves that things are going fairly well, we can send a body payload on the first channel
+        // and confirm it comes through.
+        firstChannel.writeAndFlush(
+            SendableRequestPart.body(ByteBuffer(string: "ping")),
+            promise: nil
+        )
+        XCTAssertNoThrow(
+            try testServer.receiveBodyAndVerify { buffer in
+                XCTAssertEqual(String(buffer: buffer), "ping")
+            }
+        )
+
+        // Now, close the second channel.
+        try secondChannel.close().wait()
+
+        // Now we can complete the transaction.
+        firstChannel.writeAndFlush(SendableRequestPart.end(nil), promise: nil)
+        XCTAssertNoThrow(
+            try testServer.receiveEndAndVerify { trailers in
+                XCTAssertNil(trailers)
+            }
+        )
+        XCTAssertNoThrow(try testServer.writeOutbound(.head(.init(version: .http1_1, status: .ok))))
+        XCTAssertNoThrow(try testServer.writeOutbound(.end(nil)))
+
+        // The promise for the second should error.
+        XCTAssertThrowsError(try secondResponsePromise.futureResult.wait())
+    }
 }
 
 private final class TestHTTPHandler: ChannelInboundHandler {


### PR DESCRIPTION
Motivation

The NIOHTTP1TestServer had a weird codepath where we could hit errors configuring the channel pipeline, but we weren't sure why. I've investigated, and this happens because a Channel that had been accepted earlier was closed while we were waiting to start handling it. This is totally benign: the code works just fine in that situation.

To be clear, though, let's document the behaviour and add a test.

Modifications

- Code comment to explain the behaviour
- Added a regression test

Result

More confidence.