### PR TITLE
Add helpers for working with loop bound values

### DIFF
--- a/Sources/NIOCore/NIOLoopBound.swift
+++ b/Sources/NIOCore/NIOLoopBound.swift
@@ -58,6 +58,56 @@ public struct NIOLoopBound<Value>: @unchecked Sendable {
             yield &self._value
         }
     }
+
+    /// Executes the closure on the event loop the value is bound to.
+    @inlinable
+    public func execute(_ task: @escaping @Sendable (Value) -> Void) {
+        if self.eventLoop.inEventLoop {
+            task(self._value)
+        } else {
+            self.eventLoop.execute {
+                task(self._value)
+            }
+        }
+    }
+
+    /// Executes the closure on the event loop the value is bound to and returns the result in
+    /// a future.
+    ///
+    /// - Parameter task: The task to execute on the event loop with the loop bound value.
+    /// - Returns: A future containing the result of the task.
+    @inlinable
+    public func submit<Result: Sendable>(
+        _ task: @escaping @Sendable (Value) throws -> Result
+    ) -> EventLoopFuture<Result> {
+        if self.eventLoop.inEventLoop {
+            self.eventLoop.makeCompletedFuture {
+                try task(self._value)
+            }
+        } else {
+            self.eventLoop.submit {
+                try task(self._value)
+            }
+        }
+    }
+
+    /// Executes the closure on the event loop the value is bound to and returns the result in
+    /// a future.
+    ///
+    /// - Parameter task: The task to execute on the event loop with the loop bound value.
+    /// - Returns: A future containing the result of the task.
+    @inlinable
+    public func flatSubmit<Result: Sendable>(
+        _ task: @escaping @Sendable (Value) -> EventLoopFuture<Result>
+    ) -> EventLoopFuture<Result> {
+        if self.eventLoop.inEventLoop {
+            task(self._value)
+        } else {
+            self.eventLoop.flatSubmit {
+                task(self._value)
+            }
+        }
+    }
 }
 
 /// ``NIOLoopBoundBox`` is an always-`Sendable`, reference-typed container allowing you access to ``value`` if and
@@ -175,4 +225,55 @@ public final class NIOLoopBoundBox<Value>: @unchecked Sendable {
             yield &self._value
         }
     }
+
+    /// Executes the closure on the event loop the value is bound to.
+    @inlinable
+    public func execute(_ task: @escaping @Sendable (Value) -> Void) {
+        if self.eventLoop.inEventLoop {
+            task(self._value)
+        } else {
+            self.eventLoop.execute {
+                task(self._value)
+            }
+        }
+    }
+
+    /// Executes the closure on the event loop the value is bound to and returns the result in
+    /// a future.
+    ///
+    /// - Parameter task: The task to execute on the event loop with the loop bound value.
+    /// - Returns: A future containing the result of the task.
+    @inlinable
+    public func submit<Result: Sendable>(
+        _ task: @escaping @Sendable (Value) throws -> Result
+    ) -> EventLoopFuture<Result> {
+        if self.eventLoop.inEventLoop {
+            self.eventLoop.makeCompletedFuture {
+                try task(self._value)
+            }
+        } else {
+            self.eventLoop.submit {
+                try task(self._value)
+            }
+        }
+    }
+
+    /// Executes the closure on the event loop the value is bound to and returns the result in
+    /// a future.
+    ///
+    /// - Parameter task: The task to execute on the event loop with the loop bound value.
+    /// - Returns: A future containing the result of the task.
+    @inlinable
+    public func flatSubmit<Result: Sendable>(
+        _ task: @escaping @Sendable (Value) -> EventLoopFuture<Result>
+    ) -> EventLoopFuture<Result> {
+        if self.eventLoop.inEventLoop {
+            task(self._value)
+        } else {
+            self.eventLoop.flatSubmit {
+                task(self._value)
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Motivation:

Isolating state to a given event loop is quite a common pattern. These types often provide sendable view APIs which do the event-loop dance for you. Writing these wrappers is somewhat repetitive (each method needs to do the dance) and requires a precondition.

We can make this simpler by providing helper methods on the loop bound types which do the event-loop dance.

Modifications:

Add three methods to NIOLoopBound and NIOLoopBoundBox:
1. `execute` to execute a task with the loop bound value on the event loop
2. `submit` to execute a task with the loop bound value on the event loop which returns a sendable value
3. `flatSubmit` to execute a task with the loop bound value on the event loop which returns a future holding a sendable value

Result:

Easier to build sendable views of non-sendable types which are isolated to a given event loop.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
