### PR TITLE
feat: Support non-Sendable types in `EventLoopFuture.get`

### DIFF
--- a/Sources/NIOCore/EventLoopFuture.swift
+++ b/Sources/NIOCore/EventLoopFuture.swift
@@ -869,7 +869,21 @@ extension EventLoopFuture {
             return CallbackList()
         }
     }
-
+    #if compiler(>=6)
+    /// Adds an observer callback to this `EventLoopFuture` that is called when the
+    /// `EventLoopFuture` has any result.
+    ///
+    /// - Parameters:
+    ///   - callback: The callback that is called when the `EventLoopFuture` is fulfilled.
+    @inlinable
+    @preconcurrency
+    public func whenComplete(_ callback: @escaping @Sendable (sending Result<Value, Error>) -> Void) {
+        self._whenComplete {
+            callback(self._value!)
+            return CallbackList()
+        }
+    }
+    #else
     /// Adds an observer callback to this `EventLoopFuture` that is called when the
     /// `EventLoopFuture` has any result.
     ///
@@ -883,6 +897,7 @@ extension EventLoopFuture {
             return CallbackList()
         }
     }
+    #endif
 
     /// Internal: Set the value and return a list of callbacks that should be invoked as a result.
     @inlinable


### PR DESCRIPTION
Enable using `EventLoopFuture.get()` for non-Sendable `Value` on compilers that support `sending` keyword.

### Motivation:
I am using NIO to prepare non-Sendable reference types. The EventLoop does not maintain ownership of these types after they are prepared and returned to the caller - so there's no reason that they should have to be Sendable.

### Modifications:
Gate use of the `sending` keyword (instead of Sendable) behind an appropriate if-def.

### Result:

Swift compilers >=6 will be able to use `EventLoopFuture.get()` on non-Sendable Value types.
