### PR TITLE
Rename public product to NIOFileSystem; keep implementation target _N…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,7 @@ let package = Package(
         .library(name: "NIOFoundationCompat", targets: ["NIOFoundationCompat"]),
         .library(name: "NIOWebSocket", targets: ["NIOWebSocket"]),
         .library(name: "NIOTestUtils", targets: ["NIOTestUtils"]),
-        .library(name: "_NIOFileSystem", targets: ["_NIOFileSystem", "NIOFileSystem"]),
+        .library(name: "NIOFileSystem",  targets: ["_NIOFileSystem", "NIOFileSystem"]),
         .library(name: "_NIOFileSystemFoundationCompat", targets: ["_NIOFileSystemFoundationCompat"]),
     ],
     targets: [
@@ -556,7 +556,7 @@ let package = Package(
             name: "NIOFileSystemTests",
             dependencies: [
                 "NIOCore",
-                "_NIOFileSystem",
+                "NIOFileSystem",
                 swiftAtomics,
                 swiftCollections,
                 swiftSystem,
@@ -570,7 +570,7 @@ let package = Package(
             dependencies: [
                 "NIOCore",
                 "NIOPosix",
-                "_NIOFileSystem",
+                "NIOFileSystem",
                 "NIOFoundationCompat",
             ],
             exclude: [
@@ -584,7 +584,7 @@ let package = Package(
         .testTarget(
             name: "NIOFileSystemFoundationCompatTests",
             dependencies: [
-                "_NIOFileSystem",
+                "NIOFileSystem",
                 "_NIOFileSystemFoundationCompat",
             ],
             swiftSettings: strictConcurrencySettings


### PR DESCRIPTION
NIOFileSystem

Remove leading underscore from the public NIOFileSystem product

### Motivation:

The `_NIOFileSystem` module has been stable long enough to be considered public API.  Consumers should import it without a leading underscore.  This makes the library name consistent with other SwiftNIO modules and marks it as a stable, supported API.

### Modifications:

- Renamed the library product in `Package.swift` from `_NIOFileSystem` to `NIOFileSystem`.  
- Updated three test targets in `Package.swift` to depend on `NIOFileSystem` instead of `_NIOFileSystem`.  
- Left implementation target name and shim target intact.  The shim (`Sources/_NIOFileSystemExported/Exports.swift`) continues to `@_exported import _NIOFileSystem` so that the public module re-exports the implementation.

