### PR TITLE
Replace almost all public static lets with computed vars

### DIFF
--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -134,6 +134,8 @@ extension NIOBSDSocket {
     public struct AddressFamily: RawRepresentable, Sendable {
         public typealias RawValue = CInt
         public var rawValue: RawValue
+
+        @inlinable
         public init(rawValue: RawValue) {
             self.rawValue = rawValue
         }
@@ -151,6 +153,8 @@ extension NIOBSDSocket {
     public struct ProtocolFamily: RawRepresentable, Sendable {
         public typealias RawValue = CInt
         public var rawValue: RawValue
+
+        @inlinable
         public init(rawValue: RawValue) {
             self.rawValue = rawValue
         }
@@ -168,6 +172,8 @@ extension NIOBSDSocket {
     public struct OptionLevel: RawRepresentable, Sendable {
         public typealias RawValue = CInt
         public var rawValue: RawValue
+
+        @inlinable
         public init(rawValue: RawValue) {
             self.rawValue = rawValue
         }
@@ -185,6 +191,8 @@ extension NIOBSDSocket {
     public struct Option: RawRepresentable, Sendable {
         public typealias RawValue = CInt
         public var rawValue: RawValue
+
+        @inlinable
         public init(rawValue: RawValue) {
             self.rawValue = rawValue
         }
@@ -200,40 +208,54 @@ extension NIOBSDSocket.Option: Hashable {
 // Address Family
 extension NIOBSDSocket.AddressFamily {
     /// Address for IP version 4.
-    public static let inet: NIOBSDSocket.AddressFamily =
+    @inlinable
+    public static var inet: NIOBSDSocket.AddressFamily {
         NIOBSDSocket.AddressFamily(rawValue: AF_INET)
+    }
 
     /// Address for IP version 6.
-    public static let inet6: NIOBSDSocket.AddressFamily =
+    @inlinable
+    public static var inet6: NIOBSDSocket.AddressFamily {
         NIOBSDSocket.AddressFamily(rawValue: AF_INET6)
+    }
 
     /// Unix local to host address.
-    public static let unix: NIOBSDSocket.AddressFamily =
+    @inlinable
+    public static var unix: NIOBSDSocket.AddressFamily {
         NIOBSDSocket.AddressFamily(rawValue: AF_UNIX)
+    }
 }
 
 // Protocol Family
 extension NIOBSDSocket.ProtocolFamily {
     /// IP network 4 protocol.
-    public static let inet: NIOBSDSocket.ProtocolFamily =
+    @inlinable
+    public static var inet: NIOBSDSocket.ProtocolFamily {
         NIOBSDSocket.ProtocolFamily(rawValue: PF_INET)
+    }
 
     /// IP network 6 protocol.
-    public static let inet6: NIOBSDSocket.ProtocolFamily =
+    @inlinable
+    public static var inet6: NIOBSDSocket.ProtocolFamily {
         NIOBSDSocket.ProtocolFamily(rawValue: PF_INET6)
+    }
 
     #if !os(WASI)
     /// UNIX local to the host.
-    public static let unix: NIOBSDSocket.ProtocolFamily =
+    @inlinable
+    public static var unix: NIOBSDSocket.ProtocolFamily {
         NIOBSDSocket.ProtocolFamily(rawValue: PF_UNIX)
+    }
     #endif
 }
 
 #if !os(Windows) && !os(WASI)
 extension NIOBSDSocket.ProtocolFamily {
     /// UNIX local to the host, alias for `PF_UNIX` (`.unix`)
-    public static let local: NIOBSDSocket.ProtocolFamily =
+    @inlinable
+    public static var local: NIOBSDSocket.ProtocolFamily {
         NIOBSDSocket.ProtocolFamily(rawValue: PF_LOCAL)
+    }
 }
 #endif
 
@@ -241,137 +263,194 @@ extension NIOBSDSocket.ProtocolFamily {
 extension NIOBSDSocket.OptionLevel {
     /// Socket options that apply only to IP sockets.
     #if os(Linux) || os(Android)
-    public static let ip: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var ip: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_IP))
+    }
     #else
-    public static let ip: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var ip: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: IPPROTO_IP)
+    }
     #endif
 
     /// Socket options that apply only to IPv6 sockets.
     #if os(Linux) || os(Android)
-    public static let ipv6: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var ipv6: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_IPV6))
+    }
     #elseif os(Windows)
-    public static let ipv6: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var ipv6: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: IPPROTO_IPV6.rawValue)
+    }
     #else
-    public static let ipv6: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var ipv6: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: IPPROTO_IPV6)
+    }
     #endif
 
     /// Socket options that apply only to TCP sockets.
     #if os(Linux) || os(Android)
-    public static let tcp: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var tcp: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_TCP))
+    }
     #elseif os(Windows)
-    public static let tcp: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var tcp: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: IPPROTO_TCP.rawValue)
+    }
     #else
-    public static let tcp: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var tcp: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: IPPROTO_TCP)
+    }
     #endif
 
     /// Socket options that apply to MPTCP sockets.
     ///
     /// These only work on Linux currently.
-    public static let mptcp = NIOBSDSocket.OptionLevel(rawValue: 284)
+    @inlinable
+    public static var mptcp: NIOBSDSocket.OptionLevel {
+        NIOBSDSocket.OptionLevel(rawValue: 284)
+    }
 
     /// Socket options that apply to all sockets.
-    public static let socket: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var socket: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: SOL_SOCKET)
+    }
 
     /// Socket options that apply only to UDP sockets.
     #if os(Linux) || os(Android)
-    public static let udp: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var udp: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: CInt(IPPROTO_UDP))
+    }
     #elseif os(Windows)
-    public static let udp: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var udp: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: IPPROTO_UDP.rawValue)
+    }
     #else
-    public static let udp: NIOBSDSocket.OptionLevel =
+    @inlinable
+    public static var udp: NIOBSDSocket.OptionLevel {
         NIOBSDSocket.OptionLevel(rawValue: IPPROTO_UDP)
+    }
     #endif
 }
 
 // IPv4 Options
 extension NIOBSDSocket.Option {
     /// Add a multicast group membership.
-    public static let ip_add_membership: NIOBSDSocket.Option =
+    @inlinable
+    public static var ip_add_membership: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IP_ADD_MEMBERSHIP)
+    }
 
     /// Drop a multicast group membership.
-    public static let ip_drop_membership: NIOBSDSocket.Option =
+    @inlinable
+    public static var ip_drop_membership: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IP_DROP_MEMBERSHIP)
+    }
 
     /// Set the interface for outgoing multicast packets.
-    public static let ip_multicast_if: NIOBSDSocket.Option =
+    @inlinable
+    public static var ip_multicast_if: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IP_MULTICAST_IF)
+    }
 
     /// Control multicast loopback.
-    public static let ip_multicast_loop: NIOBSDSocket.Option =
+    @inlinable
+    public static var ip_multicast_loop: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IP_MULTICAST_LOOP)
+    }
 
     /// Control multicast time-to-live.
-    public static let ip_multicast_ttl: NIOBSDSocket.Option =
+    @inlinable
+    public static var ip_multicast_ttl: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IP_MULTICAST_TTL)
+    }
 
     /// The IPv4 layer generates an IP header when sending a packet
     /// unless the ``ip_hdrincl`` socket option is enabled on the socket.
     /// When it is enabled, the packet must contain an IP header.  For
     /// receiving, the IP header is always included in the packet.
-    public static let ip_hdrincl: NIOBSDSocket.Option =
+    @inlinable
+    public static var ip_hdrincl: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IP_HDRINCL)
+    }
 }
 
 // IPv6 Options
 extension NIOBSDSocket.Option {
     /// Add an IPv6 group membership.
-    public static let ipv6_join_group: NIOBSDSocket.Option =
+    @inlinable
+    public static var ipv6_join_group: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IPV6_JOIN_GROUP)
+    }
 
     /// Drop an IPv6 group membership.
-    public static let ipv6_leave_group: NIOBSDSocket.Option =
+    @inlinable
+    public static var ipv6_leave_group: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IPV6_LEAVE_GROUP)
+    }
 
     /// Specify the maximum number of router hops for an IPv6 packet.
-    public static let ipv6_multicast_hops: NIOBSDSocket.Option =
+    @inlinable
+    public static var ipv6_multicast_hops: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IPV6_MULTICAST_HOPS)
+    }
 
     /// Set the interface for outgoing multicast packets.
-    public static let ipv6_multicast_if: NIOBSDSocket.Option =
+    @inlinable
+    public static var ipv6_multicast_if: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IPV6_MULTICAST_IF)
+    }
 
     /// Control multicast loopback.
-    public static let ipv6_multicast_loop: NIOBSDSocket.Option =
+    @inlinable
+    public static var ipv6_multicast_loop: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IPV6_MULTICAST_LOOP)
+    }
 
     /// Indicates if a socket created for the `AF_INET6` address family is
     /// restricted to IPv6 only.
-    public static let ipv6_v6only: NIOBSDSocket.Option =
+    @inlinable
+    public static var ipv6_v6only: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: IPV6_V6ONLY)
+    }
 }
 
 // TCP Options
 extension NIOBSDSocket.Option {
     /// Disables the Nagle algorithm for send coalescing.
-    public static let tcp_nodelay: NIOBSDSocket.Option =
+    @inlinable
+    public static var tcp_nodelay: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: TCP_NODELAY)
+    }
 }
 
 #if os(Linux) || os(FreeBSD) || os(Android)
 extension NIOBSDSocket.Option {
     /// Get information about the TCP connection.
-    public static let tcp_info: NIOBSDSocket.Option =
+    @inlinable
+    public static var tcp_info: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: TCP_INFO)
+    }
 }
 #endif
 
 #if canImport(Darwin)
 extension NIOBSDSocket.Option {
     /// Get information about the TCP connection.
-    public static let tcp_connection_info: NIOBSDSocket.Option =
+    @inlinable
+    public static var tcp_connection_info: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: TCP_CONNECTION_INFO)
+    }
 }
 #endif
 
@@ -381,10 +460,16 @@ extension NIOBSDSocket.Option {
     // hardcoded.
 
     /// Use UDP segmentation offload (UDP_SEGMENT, or 'GSO'). Only available on Linux.
-    public static let udp_segment = NIOBSDSocket.Option(rawValue: 103)
+    @inlinable
+    public static var udp_segment: NIOBSDSocket.Option {
+        NIOBSDSocket.Option(rawValue: 103)
+    }
 
     /// Use UDP generic receive offload (GRO). Only available on Linux.
-    public static let udp_gro = NIOBSDSocket.Option(rawValue: 104)
+    @inlinable
+    public static var udp_gro: NIOBSDSocket.Option {
+        NIOBSDSocket.Option(rawValue: 104)
+    }
 }
 #endif
 
@@ -394,43 +479,72 @@ extension NIOBSDSocket.Option {
 // header files yet.
 extension NIOBSDSocket.Option {
     /// Get info about an MPTCP connection
-    public static let mptcp_info = NIOBSDSocket.Option(rawValue: 1)
+    @inlinable
+    public static var mptcp_info: NIOBSDSocket.Option {
+        NIOBSDSocket.Option(rawValue: 1)
+    }
 }
 
 #if !os(WASI)
 // Socket Options
 extension NIOBSDSocket.Option {
     /// Get the error status and clear.
-    public static let so_error = Self(rawValue: SO_ERROR)
+    @inlinable
+    public static var so_error: NIOBSDSocket.Option {
+        Self(rawValue: SO_ERROR)
+    }
 
     /// Use keep-alives.
-    public static let so_keepalive = Self(rawValue: SO_KEEPALIVE)
+    @inlinable
+    public static var so_keepalive: NIOBSDSocket.Option {
+        Self(rawValue: SO_KEEPALIVE)
+    }
 
     /// Linger on close if unsent data is present.
-    public static let so_linger = Self(rawValue: SO_LINGER)
+    @inlinable
+    public static var so_linger: NIOBSDSocket.Option {
+        Self(rawValue: SO_LINGER)
+    }
 
     /// Specifies the total per-socket buffer space reserved for receives.
-    public static let so_rcvbuf = Self(rawValue: SO_RCVBUF)
+    @inlinable
+    public static var so_rcvbuf: NIOBSDSocket.Option {
+        Self(rawValue: SO_RCVBUF)
+    }
 
     /// Specifies the total per-socket buffer space reserved for sends.
-    public static let so_sndbuf = Self(rawValue: SO_SNDBUF)
+    @inlinable
+    public static var so_sndbuf: NIOBSDSocket.Option {
+        Self(rawValue: SO_SNDBUF)
+    }
 
     /// Specifies the receive timeout.
-    public static let so_rcvtimeo = Self(rawValue: SO_RCVTIMEO)
+    @inlinable
+    public static var so_rcvtimeo: NIOBSDSocket.Option {
+        Self(rawValue: SO_RCVTIMEO)
+    }
 
     /// Allows the socket to be bound to an address that is already in use.
-    public static let so_reuseaddr = Self(rawValue: SO_REUSEADDR)
+    @inlinable
+    public static var so_reuseaddr: NIOBSDSocket.Option {
+        Self(rawValue: SO_REUSEADDR)
+    }
 
     /// Allows the socket to send broadcast messages.
-    public static let so_broadcast = Self(rawValue: SO_BROADCAST)
+    @inlinable
+    public static var so_broadcast: NIOBSDSocket.Option {
+        Self(rawValue: SO_BROADCAST)
+    }
 }
 #endif
 
 #if !os(Windows) && !os(WASI)
 extension NIOBSDSocket.Option {
     /// Indicate when to generate timestamps.
-    public static let so_timestamp: NIOBSDSocket.Option =
+    @inlinable
+    public static var so_timestamp: NIOBSDSocket.Option {
         NIOBSDSocket.Option(rawValue: SO_TIMESTAMP)
+    }
 }
 #endif
 

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -103,22 +103,22 @@ private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMut
 
 #if os(Android)
 #if compiler(>=6.0)
-let IFF_BROADCAST: CUnsignedInt = numericCast(Android.IFF_BROADCAST.rawValue)
-let IFF_POINTOPOINT: CUnsignedInt = numericCast(Android.IFF_POINTOPOINT.rawValue)
-let IFF_MULTICAST: CUnsignedInt = numericCast(Android.IFF_MULTICAST.rawValue)
+@usableFromInline let IFF_BROADCAST: CUnsignedInt = numericCast(Android.IFF_BROADCAST.rawValue)
+@usableFromInline let IFF_POINTOPOINT: CUnsignedInt = numericCast(Android.IFF_POINTOPOINT.rawValue)
+@usableFromInline let IFF_MULTICAST: CUnsignedInt = numericCast(Android.IFF_MULTICAST.rawValue)
 #else
-let IFF_BROADCAST: CUnsignedInt = numericCast(SwiftGlibc.IFF_BROADCAST.rawValue)
-let IFF_POINTOPOINT: CUnsignedInt = numericCast(SwiftGlibc.IFF_POINTOPOINT.rawValue)
-let IFF_MULTICAST: CUnsignedInt = numericCast(SwiftGlibc.IFF_MULTICAST.rawValue)
+@usableFromInline let IFF_BROADCAST: CUnsignedInt = numericCast(SwiftGlibc.IFF_BROADCAST.rawValue)
+@usableFromInline let IFF_POINTOPOINT: CUnsignedInt = numericCast(SwiftGlibc.IFF_POINTOPOINT.rawValue)
+@usableFromInline let IFF_MULTICAST: CUnsignedInt = numericCast(SwiftGlibc.IFF_MULTICAST.rawValue)
 #endif
 #if arch(arm)
-let SO_RCVTIMEO = SO_RCVTIMEO_OLD
-let SO_TIMESTAMP = SO_TIMESTAMP_OLD
+@usableFromInline let SO_RCVTIMEO = SO_RCVTIMEO_OLD
+@usableFromInline let SO_TIMESTAMP = SO_TIMESTAMP_OLD
 #endif
 #elseif os(Linux)
 // Work around SO_TIMESTAMP/SO_RCVTIMEO being awkwardly defined in glibc.
-let SO_TIMESTAMP = CNIOLinux_SO_TIMESTAMP
-let SO_RCVTIMEO = CNIOLinux_SO_RCVTIMEO
+@usableFromInline let SO_TIMESTAMP = CNIOLinux_SO_TIMESTAMP
+@usableFromInline let SO_RCVTIMEO = CNIOLinux_SO_RCVTIMEO
 #endif
 
 public enum NIOBSDSocket: Sendable {

--- a/Sources/NIOCore/ByteBuffer-hex.swift
+++ b/Sources/NIOCore/ByteBuffer-hex.swift
@@ -32,23 +32,29 @@ extension ByteBuffer {
     /// Can be either xxd output compatible, or hexdump compatible.
     public struct HexDumpFormat: Hashable, Sendable {
 
-        enum Value: Hashable {
+        @usableFromInline
+        enum Value: Hashable, Sendable {
             case plain(maxBytes: Int? = nil)
             case detailed(maxBytes: Int? = nil)
             case compact(maxBytes: Int? = nil)
         }
 
+        @usableFromInline
         let value: Value
+
+        @inlinable
         init(_ value: Value) { self.value = value }
 
         /// A plain hex dump format compatible with `xxd` CLI utility.
-        public static let plain = Self(.plain(maxBytes: nil))
+        @inlinable
+        public static var plain: HexDumpFormat { Self(.plain(maxBytes: nil)) }
 
         /// A hex dump format compatible with `hexdump` command line utility.
-        public static let detailed = Self(.detailed(maxBytes: nil))
+        @inlinable
+        public static var detailed: HexDumpFormat { Self(.detailed(maxBytes: nil)) }
 
         /// A hex dump analog to `plain` format  but without whitespaces.
-        public static let compact = Self(.compact(maxBytes: nil))
+        public static var compact: HexDumpFormat { Self(.compact(maxBytes: nil)) }
 
         /// A detailed hex dump format compatible with `xxd`, clipped to `maxBytes` bytes dumped.
         /// This format will dump first `maxBytes / 2` bytes, and the last `maxBytes / 2` bytes, replacing the rest with " ... ".

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -823,8 +823,11 @@ public struct NIODeadline: Equatable, Hashable, Sendable {
         .init(self._uptimeNanoseconds)
     }
 
-    public static let distantPast = NIODeadline(0)
-    public static let distantFuture = NIODeadline(.init(Int64.max))
+    @inlinable
+    public static var distantPast: NIODeadline { NIODeadline(0) }
+
+    @inlinable
+    public static var distantFuture: NIODeadline { NIODeadline(.init(Int64.max)) }
 
     @inlinable init(_ nanoseconds: Int64) {
         precondition(nanoseconds >= 0)

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -297,6 +297,7 @@ extension NIOFileHandle {
     public struct Mode: OptionSet, Sendable {
         public let rawValue: UInt8
 
+        @inlinable
         public init(rawValue: UInt8) {
             self.rawValue = rawValue
         }
@@ -315,17 +316,28 @@ extension NIOFileHandle {
         }
 
         /// Opens file for reading
-        public static let read = Mode(rawValue: 1 << 0)
+        @inlinable
+        public static var read: Mode { Mode(rawValue: 1 << 0) }
         /// Opens file for writing
-        public static let write = Mode(rawValue: 1 << 1)
+        @inlinable
+        public static var write: NIOFileHandle.Mode { Mode(rawValue: 1 << 1) }
     }
 
     /// `Flags` allows to specify additional flags to `Mode`, such as permission for file creation.
     public struct Flags: Sendable {
+        @usableFromInline
         internal var posixMode: NIOPOSIXFileMode
+
+        @usableFromInline
         internal var posixFlags: CInt
 
-        public static let `default` = Flags(posixMode: 0, posixFlags: 0)
+        @inlinable
+        internal init(posixMode: NIOPOSIXFileMode, posixFlags: CInt) {
+            self.posixMode = posixMode
+            self.posixFlags = posixFlags
+        }
+
+        public static var `default`: Flags { Flags(posixMode: 0, posixFlags: 0) }
 
         #if os(Windows)
         public static let defaultPermissions = _S_IREAD | _S_IWRITE

--- a/Sources/NIOCore/IPProtocol.swift
+++ b/Sources/NIOCore/IPProtocol.swift
@@ -36,89 +36,215 @@ extension NIOIPProtocol {
 // Subset of https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml with an RFC
 extension NIOIPProtocol {
     /// IPv6 Hop-by-Hop Option - [RFC8200]
-    public static let hopopt = Self(rawValue: 0)
+    @inlinable
+    public static var hopopt: NIOIPProtocol {
+        Self(rawValue: 0)
+    }
     /// Internet Control Message - [RFC792]
-    public static let icmp = Self(rawValue: 1)
+    @inlinable
+    public static var icmp: NIOIPProtocol {
+        Self(rawValue: 1)
+    }
     /// Internet Group Management - [RFC1112]
-    public static let igmp = Self(rawValue: 2)
+    @inlinable
+    public static var igmp: NIOIPProtocol {
+        Self(rawValue: 2)
+    }
     /// Gateway-to-Gateway - [RFC823]
-    public static let ggp = Self(rawValue: 3)
+    @inlinable
+    public static var ggp: NIOIPProtocol {
+        Self(rawValue: 3)
+    }
     /// IPv4 encapsulation - [RFC2003]
-    public static let ipv4 = Self(rawValue: 4)
+    @inlinable
+    public static var ipv4: NIOIPProtocol {
+        Self(rawValue: 4)
+    }
     /// Stream - [RFC1190][RFC1819]
-    public static let st = Self(rawValue: 5)
+    @inlinable
+    public static var st: NIOIPProtocol {
+        Self(rawValue: 5)
+    }
     /// Transmission Control - [RFC9293]
-    public static let tcp = Self(rawValue: 6)
+    @inlinable
+    public static var tcp: NIOIPProtocol {
+        Self(rawValue: 6)
+    }
     /// Exterior Gateway Protocol - [RFC888][David_Mills]
-    public static let egp = Self(rawValue: 8)
+    @inlinable
+    public static var egp: NIOIPProtocol {
+        Self(rawValue: 8)
+    }
     /// Network Voice Protocol - [RFC741][Steve_Casner]
-    public static let nvpIi = Self(rawValue: 11)
+    @inlinable
+    public static var nvpIi: NIOIPProtocol {
+        Self(rawValue: 11)
+    }
     /// User Datagram - [RFC768][Jon_Postel]
-    public static let udp = Self(rawValue: 17)
+    @inlinable
+    public static var udp: NIOIPProtocol {
+        Self(rawValue: 17)
+    }
     /// Host Monitoring - [RFC869][Bob_Hinden]
-    public static let hmp = Self(rawValue: 20)
+    @inlinable
+    public static var hmp: NIOIPProtocol {
+        Self(rawValue: 20)
+    }
     /// Reliable Data Protocol - [RFC908][Bob_Hinden]
-    public static let rdp = Self(rawValue: 27)
+    @inlinable
+    public static var rdp: NIOIPProtocol {
+        Self(rawValue: 27)
+    }
     /// Internet Reliable Transaction - [RFC938][Trudy_Miller]
-    public static let irtp = Self(rawValue: 28)
+    @inlinable
+    public static var irtp: NIOIPProtocol {
+        Self(rawValue: 28)
+    }
     /// ISO Transport Protocol Class 4 - [RFC905][<mystery contact>]
-    public static let isoTp4 = Self(rawValue: 29)
+    @inlinable
+    public static var isoTp4: NIOIPProtocol {
+        Self(rawValue: 29)
+    }
     /// Bulk Data Transfer Protocol - [RFC969][David_Clark]
-    public static let netblt = Self(rawValue: 30)
+    @inlinable
+    public static var netblt: NIOIPProtocol {
+        Self(rawValue: 30)
+    }
     /// Datagram Congestion Control Protocol - [RFC4340]
-    public static let dccp = Self(rawValue: 33)
+    @inlinable
+    public static var dccp: NIOIPProtocol {
+        Self(rawValue: 33)
+    }
     /// IPv6 encapsulation - [RFC2473]
-    public static let ipv6 = Self(rawValue: 41)
+    @inlinable
+    public static var ipv6: NIOIPProtocol {
+        Self(rawValue: 41)
+    }
     /// Reservation Protocol - [RFC2205][RFC3209][Bob_Braden]
-    public static let rsvp = Self(rawValue: 46)
+    @inlinable
+    public static var rsvp: NIOIPProtocol {
+        Self(rawValue: 46)
+    }
     /// Generic Routing Encapsulation - [RFC2784][Tony_Li]
-    public static let gre = Self(rawValue: 47)
+    @inlinable
+    public static var gre: NIOIPProtocol {
+        Self(rawValue: 47)
+    }
     /// Dynamic Source Routing Protocol - [RFC4728]
-    public static let dsr = Self(rawValue: 48)
+    @inlinable
+    public static var dsr: NIOIPProtocol {
+        Self(rawValue: 48)
+    }
     /// Encap Security Payload - [RFC4303]
-    public static let esp = Self(rawValue: 50)
+    @inlinable
+    public static var esp: NIOIPProtocol {
+        Self(rawValue: 50)
+    }
     /// Authentication Header - [RFC4302]
-    public static let ah = Self(rawValue: 51)
+    @inlinable
+    public static var ah: NIOIPProtocol {
+        Self(rawValue: 51)
+    }
     /// NBMA Address Resolution Protocol - [RFC1735]
-    public static let narp = Self(rawValue: 54)
+    @inlinable
+    public static var narp: NIOIPProtocol {
+        Self(rawValue: 54)
+    }
     /// ICMP for IPv6 - [RFC8200]
-    public static let ipv6Icmp = Self(rawValue: 58)
+    @inlinable
+    public static var ipv6Icmp: NIOIPProtocol {
+        Self(rawValue: 58)
+    }
     /// No Next Header for IPv6 - [RFC8200]
-    public static let ipv6Nonxt = Self(rawValue: 59)
+    @inlinable
+    public static var ipv6Nonxt: NIOIPProtocol {
+        Self(rawValue: 59)
+    }
     /// Destination Options for IPv6 - [RFC8200]
-    public static let ipv6Opts = Self(rawValue: 60)
+    @inlinable
+    public static var ipv6Opts: NIOIPProtocol {
+        Self(rawValue: 60)
+    }
     /// EIGRP - [RFC7868]
-    public static let eigrp = Self(rawValue: 88)
+    @inlinable
+    public static var eigrp: NIOIPProtocol {
+        Self(rawValue: 88)
+    }
     /// OSPFIGP - [RFC1583][RFC2328][RFC5340][John_Moy]
-    public static let ospfigp = Self(rawValue: 89)
+    @inlinable
+    public static var ospfigp: NIOIPProtocol {
+        Self(rawValue: 89)
+    }
     /// Ethernet-within-IP Encapsulation - [RFC3378]
-    public static let etherip = Self(rawValue: 97)
+    @inlinable
+    public static var etherip: NIOIPProtocol {
+        Self(rawValue: 97)
+    }
     /// Encapsulation Header - [RFC1241][Robert_Woodburn]
-    public static let encap = Self(rawValue: 98)
+    @inlinable
+    public static var encap: NIOIPProtocol {
+        Self(rawValue: 98)
+    }
     /// Protocol Independent Multicast - [RFC7761][Dino_Farinacci]
-    public static let pim = Self(rawValue: 103)
+    @inlinable
+    public static var pim: NIOIPProtocol {
+        Self(rawValue: 103)
+    }
     /// IP Payload Compression Protocol - [RFC2393]
-    public static let ipcomp = Self(rawValue: 108)
+    @inlinable
+    public static var ipcomp: NIOIPProtocol {
+        Self(rawValue: 108)
+    }
     /// Virtual Router Redundancy Protocol - [RFC5798]
-    public static let vrrp = Self(rawValue: 112)
+    @inlinable
+    public static var vrrp: NIOIPProtocol {
+        Self(rawValue: 112)
+    }
     /// Layer Two Tunneling Protocol - [RFC3931][Bernard_Aboba]
-    public static let l2tp = Self(rawValue: 115)
+    @inlinable
+    public static var l2tp: NIOIPProtocol {
+        Self(rawValue: 115)
+    }
     /// Fibre Channel - [Murali_Rajagopal][RFC6172]
-    public static let fc = Self(rawValue: 133)
+    @inlinable
+    public static var fc: NIOIPProtocol {
+        Self(rawValue: 133)
+    }
     /// MANET Protocols - [RFC5498]
-    public static let manet = Self(rawValue: 138)
+    @inlinable
+    public static var manet: NIOIPProtocol {
+        Self(rawValue: 138)
+    }
     /// Host Identity Protocol - [RFC7401]
-    public static let hip = Self(rawValue: 139)
+    @inlinable
+    public static var hip: NIOIPProtocol {
+        Self(rawValue: 139)
+    }
     /// Shim6 Protocol - [RFC5533]
-    public static let shim6 = Self(rawValue: 140)
+    @inlinable
+    public static var shim6: NIOIPProtocol {
+        Self(rawValue: 140)
+    }
     /// Wrapped Encapsulating Security Payload - [RFC5840]
-    public static let wesp = Self(rawValue: 141)
+    @inlinable
+    public static var wesp: NIOIPProtocol {
+        Self(rawValue: 141)
+    }
     /// Robust Header Compression - [RFC5858]
-    public static let rohc = Self(rawValue: 142)
+    @inlinable
+    public static var rohc: NIOIPProtocol {
+        Self(rawValue: 142)
+    }
     /// Ethernet - [RFC8986]
-    public static let ethernet = Self(rawValue: 143)
+    @inlinable
+    public static var ethernet: NIOIPProtocol {
+        Self(rawValue: 143)
+    }
     /// AGGFRAG encapsulation payload for ESP - [RFC-ietf-ipsecme-iptfs-19]
-    public static let aggfrag = Self(rawValue: 144)
+    @inlinable
+    public static var aggfrag: NIOIPProtocol {
+        Self(rawValue: 144)
+    }
 }
 
 extension NIOIPProtocol: CustomStringConvertible {

--- a/Sources/NIOCore/IntegerTypes.swift
+++ b/Sources/NIOCore/IntegerTypes.swift
@@ -27,13 +27,14 @@ struct _UInt24: Sendable {
         self._backing = IntegerBitPacking.unpackUInt16UInt8(value)
     }
 
-    static let bitWidth: Int = 24
+    @inlinable
+    static var bitWidth: Int { 24 }
 
-    @usableFromInline
-    static let max: _UInt24 = .init((UInt32(1) << 24) - 1)
+    @inlinable
+    static var max: _UInt24 { .init((UInt32(1) << 24) - 1) }
 
-    @usableFromInline
-    static let min: _UInt24 = .init(0)
+    @inlinable
+    static var min: _UInt24 { .init(0) }
 }
 
 extension UInt32 {
@@ -74,11 +75,15 @@ struct _UInt56: Sendable {
         self._backing = IntegerBitPacking.unpackUInt32UInt16UInt8(value)
     }
 
-    static let bitWidth: Int = 56
+    @inlinable
+    static var bitWidth: Int { 56 }
 
-    private static let initializeUInt64: UInt64 = (1 << 56) - 1
-    static let max: _UInt56 = .init(initializeUInt64)
-    static let min: _UInt56 = .init(0)
+    @inlinable
+    static var initializeUInt64: UInt64 { (1 << 56) - 1 }
+    @inlinable
+    static var max: _UInt56 { .init(initializeUInt64) }
+    @inlinable
+    static var min: _UInt56 { .init(0) }
 }
 
 extension _UInt56 {

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -797,21 +797,31 @@ public enum RemoveAfterUpgradeStrategy: Sendable {
 
 /// Strategy to use when a HTTPDecoder receives an informational HTTP response (1xx except 101)
 public struct NIOInformationalResponseStrategy: Hashable, Sendable {
-    enum Base {
+    @usableFromInline
+    enum Base: Sendable {
         case drop
         case forward
     }
 
+    @usableFromInline
     var base: Base
-    private init(_ base: Base) {
+
+    @inlinable
+    init(_ base: Base) {
         self.base = base
     }
 
     /// Drop the informational response and only forward the "real" response
-    public static let drop = Self(.drop)
+    @inlinable
+    public static var drop: NIOInformationalResponseStrategy {
+        Self(.drop)
+    }
     /// Forward the informational response and then forward the "real" response. This will result in
     /// multiple `head` before an `end` is emitted.
-    public static let forward = Self(.forward)
+    @inlinable
+    public static var forward: NIOInformationalResponseStrategy {
+        Self(.forward)
+    }
 }
 
 extension HTTPParserError {

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -691,15 +691,17 @@ public struct HTTPVersion: Equatable, Sendable {
     ///
     /// - Parameter major: The major version number.
     /// - Parameter minor: The minor version number.
+    @inlinable
     public init(major: Int, minor: Int) {
         self._major = UInt16(major)
         self._minor = UInt16(minor)
     }
 
-    private var _minor: UInt16
-    private var _major: UInt16
+    /* private but */ @usableFromInline var _minor: UInt16
+    /* private but */ @usableFromInline var _major: UInt16
 
     /// The major version number.
+    @inlinable
     public var major: Int {
         get {
             Int(self._major)
@@ -710,6 +712,7 @@ public struct HTTPVersion: Equatable, Sendable {
     }
 
     /// The minor version number.
+    @inlinable
     public var minor: Int {
         get {
             Int(self._minor)
@@ -720,19 +723,34 @@ public struct HTTPVersion: Equatable, Sendable {
     }
 
     /// HTTP/3
-    public static let http3 = HTTPVersion(major: 3, minor: 0)
+    @inlinable
+    public static var http3: HTTPVersion {
+        HTTPVersion(major: 3, minor: 0)
+    }
 
     /// HTTP/2
-    public static let http2 = HTTPVersion(major: 2, minor: 0)
+    @inlinable
+    public static var http2: HTTPVersion {
+        HTTPVersion(major: 2, minor: 0)
+    }
 
     /// HTTP/1.1
-    public static let http1_1 = HTTPVersion(major: 1, minor: 1)
+    @inlinable
+    public static var http1_1: HTTPVersion {
+        HTTPVersion(major: 1, minor: 1)
+    }
 
     /// HTTP/1.0
-    public static let http1_0 = HTTPVersion(major: 1, minor: 0)
+    @inlinable
+    public static var http1_0: HTTPVersion {
+        HTTPVersion(major: 1, minor: 0)
+    }
 
     /// HTTP/0.9 (not supported by SwiftNIO)
-    public static let http0_9 = HTTPVersion(major: 0, minor: 9)
+    @inlinable
+    public static var http0_9: HTTPVersion {
+        HTTPVersion(major: 0, minor: 9)
+    }
 }
 
 extension HTTPParserError: CustomDebugStringConvertible {

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -697,8 +697,8 @@ public struct HTTPVersion: Equatable, Sendable {
         self._minor = UInt16(minor)
     }
 
-    /* private but */ @usableFromInline var _minor: UInt16
-    /* private but */ @usableFromInline var _major: UInt16
+    @usableFromInline var _minor: UInt16
+    @usableFromInline var _major: UInt16
 
     /// The major version number.
     @inlinable

--- a/Sources/NIOPosix/BSDSocketAPICommon.swift
+++ b/Sources/NIOPosix/BSDSocketAPICommon.swift
@@ -151,6 +151,7 @@ extension NIOBSDSocket {
         public var rawValue: RawValue
 
         /// Construct a protocol subtype from its underlying value.
+        @inlinable
         public init(rawValue: RawValue) {
             self.rawValue = rawValue
         }
@@ -159,11 +160,14 @@ extension NIOBSDSocket {
 
 extension NIOBSDSocket.ProtocolSubtype {
     /// Refers to the "default" protocol subtype for a given socket type.
-    public static let `default` = Self(rawValue: 0)
+    public static var `default`: NIOBSDSocket.ProtocolSubtype {
+        Self(rawValue: 0)
+    }
 
     /// The protocol subtype for MPTCP.
     ///
     /// - Returns: nil if MPTCP is not supported.
+    @inlinable
     public static var mptcp: Self? {
         #if os(Linux)
         // Defined by the linux kernel, this is IPPROTO_MPTCP.
@@ -176,6 +180,7 @@ extension NIOBSDSocket.ProtocolSubtype {
 
 extension NIOBSDSocket.ProtocolSubtype {
     /// Construct a protocol subtype from an IP protocol.
+    @inlinable
     public init(_ protocol: NIOIPProtocol) {
         self.rawValue = CInt(`protocol`.rawValue)
     }

--- a/Sources/NIOPosix/IntegerTypes.swift
+++ b/Sources/NIOPosix/IntegerTypes.swift
@@ -25,13 +25,20 @@ struct _UInt24: Sendable {
         self._backing = IntegerBitPacking.unpackUInt16UInt8(value)
     }
 
-    static let bitWidth: Int = 24
+    @inlinable
+    static var bitWidth: Int {
+        24
+    }
 
-    @usableFromInline
-    static let max: _UInt24 = .init((UInt32(1) << 24) - 1)
+    @inlinable
+    static var max: _UInt24 {
+        .init((UInt32(1) << 24) - 1)
+    }
 
-    @usableFromInline
-    static let min: _UInt24 = .init(0)
+    @inlinable
+    static var min: _UInt24 {
+        .init(0)
+    }
 }
 
 extension UInt32 {
@@ -72,11 +79,23 @@ struct _UInt56: Sendable {
         self._backing = IntegerBitPacking.unpackUInt32UInt16UInt8(value)
     }
 
-    static let bitWidth: Int = 56
+    @inlinable
+    static var bitWidth: Int {
+        56
+    }
 
-    private static let initializeUInt64: UInt64 = (1 << 56) - 1
-    static let max: _UInt56 = .init(initializeUInt64)
-    static let min: _UInt56 = .init(0)
+    @inlinable
+    static var _initializeUInt64: UInt64 {
+        (1 << 56) - 1
+    }
+    @inlinable
+    static var max: _UInt56 {
+        .init(_initializeUInt64)
+    }
+    @inlinable
+    static var min: _UInt56 {
+        .init(0)
+    }
 }
 
 extension _UInt56 {

--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -35,10 +35,12 @@ import NIOCore
 /// of blocking.
 public struct NonBlockingFileIO: Sendable {
     /// The default and recommended size for ``NonBlockingFileIO``'s thread pool.
-    public static let defaultThreadPoolSize = 2
+    @inlinable
+    public static var defaultThreadPoolSize: Int { 2 }
 
     /// The default and recommended chunk size.
-    public static let defaultChunkSize = 128 * 1024
+    @inlinable
+    public static var defaultChunkSize: Int { 128 * 1024 }
 
     /// ``NonBlockingFileIO`` errors.
     public enum Error: Swift.Error {

--- a/Sources/NIOPosix/VsockAddress.swift
+++ b/Sources/NIOPosix/VsockAddress.swift
@@ -58,14 +58,17 @@ public struct VsockAddress: Hashable, Sendable {
     public struct ContextID: RawRepresentable, ExpressibleByIntegerLiteral, Hashable, Sendable {
         public var rawValue: UInt32
 
+        @inlinable
         public init(rawValue: UInt32) {
             self.rawValue = rawValue
         }
 
+        @inlinable
         public init(integerLiteral value: UInt32) {
             self.init(rawValue: value)
         }
 
+        @inlinable
         public init(_ value: Int) {
             self.init(rawValue: UInt32(bitPattern: Int32(truncatingIfNeeded: value)))
         }
@@ -77,17 +80,20 @@ public struct VsockAddress: Hashable, Sendable {
         /// On Darwin platforms, the man page states this can be used with `connect(2)` to mean "this host".
         ///
         /// This is equal to `VMADDR_CID_ANY (-1U)`.
-        public static let any: Self = Self(rawValue: UInt32(bitPattern: -1))
+        @inlinable
+        public static var any: Self { Self(rawValue: UInt32(bitPattern: -1)) }
 
         /// The address of the hypervisor.
         ///
         /// This is equal to `VMADDR_CID_HYPERVISOR (0)`.
-        public static let hypervisor: Self = Self(rawValue: 0)
+        @inlinable
+        public static var hypervisor: Self { Self(rawValue: 0) }
 
         /// The address of the host.
         ///
         /// This is equal to `VMADDR_CID_HOST (2)`.
-        public static let host: Self = Self(rawValue: 2)
+        @inlinable
+        public static var host: Self { Self(rawValue: 2) }
 
         /// The address for local communication (loopback).
         ///
@@ -103,7 +109,8 @@ public struct VsockAddress: Hashable, Sendable {
         /// other platforms.
         ///
         /// - SeeAlso: https://man7.org/linux/man-pages/man7/vsock.7.html
-        public static let local: Self = Self(rawValue: 1)
+        @inlinable
+        public static var local: Self { Self(rawValue: 1) }
 
     }
 
@@ -113,14 +120,17 @@ public struct VsockAddress: Hashable, Sendable {
     public struct Port: RawRepresentable, ExpressibleByIntegerLiteral, Hashable, Sendable {
         public var rawValue: UInt32
 
+        @inlinable
         public init(rawValue: UInt32) {
             self.rawValue = rawValue
         }
 
+        @inlinable
         public init(integerLiteral value: UInt32) {
             self.init(rawValue: value)
         }
 
+        @inlinable
         public init(_ value: Int) {
             self.init(rawValue: UInt32(bitPattern: Int32(truncatingIfNeeded: value)))
         }
@@ -128,7 +138,8 @@ public struct VsockAddress: Hashable, Sendable {
         /// Used to bind to any port number.
         ///
         /// This is equal to `VMADDR_PORT_ANY (-1U)`.
-        public static let any: Self = Self(rawValue: UInt32(bitPattern: -1))
+        @inlinable
+        public static var any: Self { Self(rawValue: UInt32(bitPattern: -1)) }
     }
 }
 

--- a/Sources/NIOWebSocket/WebSocketOpcode.swift
+++ b/Sources/NIOWebSocket/WebSocketOpcode.swift
@@ -16,20 +16,45 @@ import NIOCore
 
 /// An operation code for a websocket frame.
 public struct WebSocketOpcode: Sendable {
-    fileprivate let networkRepresentation: UInt8
+    @usableFromInline
+    let networkRepresentation: UInt8
 
-    public static let continuation = WebSocketOpcode(rawValue: 0x0)
-    public static let text = WebSocketOpcode(rawValue: 0x1)
-    public static let binary = WebSocketOpcode(rawValue: 0x2)
-    public static let connectionClose = WebSocketOpcode(rawValue: 0x8)
-    public static let ping = WebSocketOpcode(rawValue: 0x9)
-    public static let pong = WebSocketOpcode(rawValue: 0xA)
+    @inlinable
+    public static var continuation: WebSocketOpcode {
+        WebSocketOpcode(rawValue: 0x0)
+    }
+
+    @inlinable
+    public static var text: WebSocketOpcode {
+        WebSocketOpcode(rawValue: 0x1)
+    }
+
+    @inlinable
+    public static var binary: WebSocketOpcode {
+        WebSocketOpcode(rawValue: 0x2)
+    }
+
+    @inlinable
+    public static var connectionClose: WebSocketOpcode {
+        WebSocketOpcode(rawValue: 0x8)
+    }
+
+    @inlinable
+    public static var ping: WebSocketOpcode {
+        WebSocketOpcode(rawValue: 0x9)
+    }
+
+    @inlinable
+    public static var pong: WebSocketOpcode {
+        WebSocketOpcode(rawValue: 0xA)
+    }
 
     /// Create an opcode from the encoded representation.
     ///
     /// - Parameters
     ///   - encoded: The encoded representation of the opcode as an 8-bit integer.
     ///          Must be no more than 4 bits large.
+    @inlinable
     public init?(encodedWebSocketOpcode encoded: UInt8) {
         guard encoded < 0x10 else {
             return nil
@@ -40,13 +65,15 @@ public struct WebSocketOpcode: Sendable {
 
     /// Create an opcode directly with no validation.
     ///
-    /// Used only to create the static lets on this structure.
-    private init(rawValue: UInt8) {
+    /// Used only to create the static vars on this structure.
+    @inlinable
+    init(rawValue: UInt8) {
         self.networkRepresentation = rawValue
     }
 
     /// Whether the opcode is in the control range: that is, if the
     /// high bit of the opcode nibble is `1`.
+    @inlinable
     public var isControlOpcode: Bool {
         self.networkRepresentation & 0x8 == 0x8
     }
@@ -57,6 +84,7 @@ extension WebSocketOpcode: Equatable {}
 extension WebSocketOpcode: Hashable {}
 
 extension WebSocketOpcode: CaseIterable {
+    @inlinable
     public static var allCases: [WebSocketOpcode] {
         get { (0..<0x10).map { WebSocketOpcode(rawValue: $0) } }
 
@@ -96,6 +124,7 @@ extension UInt8 {
     ///
     /// - Parameters:
     ///   - opcode: The `WebSocketOpcode`.
+    @inlinable
     public init(webSocketOpcode opcode: WebSocketOpcode) {
         precondition(opcode.networkRepresentation < 0x10)
         self = opcode.networkRepresentation
@@ -107,6 +136,7 @@ extension Int {
     ///
     /// - Parameters:
     ///   - opcode: The `WebSocketOpcode`.
+    @inlinable
     public init(webSocketOpcode opcode: WebSocketOpcode) {
         precondition(opcode.networkRepresentation < 0x10)
         self = Int(opcode.networkRepresentation)

--- a/Sources/_NIOBase64/Base64.swift
+++ b/Sources/_NIOBase64/Base64.swift
@@ -153,8 +153,8 @@ internal enum Base64: Sendable {
         UInt8(ascii: "8"), UInt8(ascii: "9"), UInt8(ascii: "+"), UInt8(ascii: "/"),
     ]
 
-    @usableFromInline
-    static let encodePaddingCharacter: UInt8 = UInt8(ascii: "=")
+    @inlinable
+    static var encodePaddingCharacter: UInt8 { UInt8(ascii: "=") }
 
     @usableFromInline
     static func encode(alphabet: [UInt8], firstByte: UInt8) -> UInt8 {


### PR DESCRIPTION
Motivation:

Public static lets can serve a bunch of roles, but one of them is to store simple constants: integers, and other trivial types, for example. This is a nice pattern and for internal and private static lets it works well, but for public ones it produces some inefficient code.

In particular, it has two downsides. First, it allocates storage for that value. We don't actually need to allocate a few hundred extra megabytes for the various integers we want to store.

Secondly, it forces calling code to access the address and call the dispatch_once code in order to get hold of the value. For trivial types we don't need that cost: they can just know what the value is directly.

Inlinable computed vars avoid all of these costs: they have no size overhead for storage, and they are visible to all clients so their values can be directly assembled.

While I'm here, I added a bunch of other inlinable annotations for a few trivial data types I stumbled onto.

Modifications:

- Added loads of inlinables. Like, loads.
- Swapped many static lets to static vars.

Result:

Better codegen, smaller memory footprints, more attributes.