### PR TITLE
Disable Swift 5.9 CI jobs by default

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,8 +12,8 @@ on:
         description: "Arguments to the switch package command invocation e.g. `--disable-sandbox`"
       linux_5_9_enabled:
         type: boolean
-        description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to true."
-        default: true
+        description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to false."
+        default: false
       linux_5_10_enabled:
         type: boolean
         description: "Boolean to enable the Linux 5.10 Swift version matrix job. Defaults to true."

--- a/.github/workflows/cxx_interop.yml
+++ b/.github/workflows/cxx_interop.yml
@@ -5,8 +5,8 @@ on:
     inputs:
       linux_5_9_enabled:
         type: boolean
-        description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to true."
-        default: true
+        description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to false."
+        default: false
       linux_5_10_enabled:
         type: boolean
         description: "Boolean to enable the Linux 5.10 Swift version matrix job. Defaults to true."

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -13,8 +13,8 @@ on:
         required: true
       matrix_linux_5_9_enabled:
         type: boolean
-        description: "Boolean to enable the 5.9 Swift version matrix job. Defaults to true."
-        default: true
+        description: "Boolean to enable the 5.9 Swift version matrix job. Defaults to false."
+        default: false
       matrix_linux_5_9_container_image:
         type: string
         description: "Container image for the 5.9 Swift version matrix job. Defaults to matching Swift Ubuntu image."

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,8 +5,8 @@ on:
     inputs:
       linux_5_9_enabled:
         type: boolean
-        description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to true."
-        default: true
+        description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to false."
+        default: false
       linux_5_9_arguments_override:
         type: string
         description: "The arguments passed to swift test in the Linux 5.9 Swift version matrix job."

--- a/scripts/generate_matrix.sh
+++ b/scripts/generate_matrix.sh
@@ -16,7 +16,7 @@
 # Parameters
 linux_command="$MATRIX_LINUX_COMMAND"  # required if any Linux pipeline is enabled
 linux_setup_command="$MATRIX_LINUX_SETUP_COMMAND"
-linux_5_9_enabled="${MATRIX_LINUX_5_9_ENABLED:=true}"
+linux_5_9_enabled="${MATRIX_LINUX_5_9_ENABLED:=false}"
 linux_5_9_command_arguments="$MATRIX_LINUX_5_9_COMMAND_ARGUMENTS"
 linux_5_10_enabled="${MATRIX_LINUX_5_10_ENABLED:=true}"
 linux_5_10_command_arguments="$MATRIX_LINUX_5_10_COMMAND_ARGUMENTS"


### PR DESCRIPTION
### Motivation:

Swift 5.9 is no longer supported and CI has been updated to no longer require it, we should disable it by default.

### Modifications:

* Default Swift 5.9 CI jobs to disabled

### Result:

Swift 5.9 CI jobs will not run unless opted-in
