### PR TITLE
Macos setup command

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -58,7 +58,7 @@ on:
       xcode_16_2_setup_command:
         type: string
         description: "The command(s) to be executed before all other work."
-        default: ""
+        default: "xcrun simctl runtime match set iphoneos18.2 22D8075 && xcrun simctl runtime match set xros2.2 22N895"
       xcode_16_3_enabled:
         type: boolean
         description: "Boolean to enable the Xcode version 16.3 jobs. Defaults to true."

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -23,6 +23,10 @@ on:
         type: string
         description: "The arguments passed to swift test in the macOS 5.10 Swift version matrix job."
         default: ""
+      xcode_16_0_setup_command:
+        type: string
+        description: "The command(s) to be executed before all other work."
+        default: ""
       xcode_16_1_enabled:
         type: boolean
         description: "Boolean to enable the Xcode version 16.1 jobs. Defaults to true."
@@ -34,6 +38,10 @@ on:
       xcode_16_1_test_arguments_override:
         type: string
         description: "The arguments passed to swift test in the Xcode version 16.1 job."
+        default: ""
+      xcode_16_1_setup_command:
+        type: string
+        description: "The command(s) to be executed before all other work."
         default: ""
       xcode_16_2_enabled:
         type: boolean
@@ -47,6 +55,10 @@ on:
         type: string
         description: "The arguments passed to swift test in the Xcode version 16.2 job."
         default: ""
+      xcode_16_2_setup_command:
+        type: string
+        description: "The command(s) to be executed before all other work."
+        default: ""
       xcode_16_3_enabled:
         type: boolean
         description: "Boolean to enable the Xcode version 16.3 jobs. Defaults to true."
@@ -58,6 +70,10 @@ on:
       xcode_16_3_test_arguments_override:
         type: string
         description: "The arguments passed to swift test in the Xcode version 16.3 job."
+        default: ""
+      xcode_16_3_setup_command:
+        type: string
+        description: "The command(s) to be executed before all other work."
         default: ""
 
       build_scheme:
@@ -132,60 +148,70 @@ jobs:
             xcode_15_4_enabled="${MATRIX_MACOS_15_4_ENABLED:=true}"
             xcode_15_4_build_arguments_override="${MATRIX_MACOS_15_4_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_15_4_test_arguments_override="${MATRIX_MACOS_15_4_TEST_ARGUMENTS_OVERRIDE:=""}"
+            xcode_15_4_setup_command="${MATRIX_MACOS_15_4_SETUP_COMMAND:=""}"
             xcode_16_0_enabled="${MATRIX_MACOS_16_0_ENABLED:=true}"
             xcode_16_0_build_arguments_override="${MATRIX_MACOS_16_0_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_16_0_test_arguments_override="${MATRIX_MACOS_16_0_TEST_ARGUMENTS_OVERRIDE:=""}"
+            xcode_16_0_setup_command="${MATRIX_MACOS_16_0_SETUP_COMMAND:=""}"
             xcode_16_1_enabled="${MATRIX_MACOS_16_1_ENABLED:=true}"
             xcode_16_1_build_arguments_override="${MATRIX_MACOS_16_1_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_16_1_test_arguments_override="${MATRIX_MACOS_16_1_TEST_ARGUMENTS_OVERRIDE:=""}"
+            xcode_16_1_setup_command="${MATRIX_MACOS_16_1_SETUP_COMMAND:=""}"
             xcode_16_2_enabled="${MATRIX_MACOS_16_2_ENABLED:=true}"
             xcode_16_2_build_arguments_override="${MATRIX_MACOS_16_2_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_16_2_test_arguments_override="${MATRIX_MACOS_16_2_TEST_ARGUMENTS_OVERRIDE:=""}"
+            xcode_16_2_setup_command="${MATRIX_MACOS_16_2_SETUP_COMMAND:=""}"
             xcode_16_3_enabled="${MATRIX_MACOS_16_3_ENABLED:=true}"
             xcode_16_3_build_arguments_override="${MATRIX_MACOS_16_3_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_16_3_test_arguments_override="${MATRIX_MACOS_16_3_TEST_ARGUMENTS_OVERRIDE:=""}"
+            xcode_16_3_setup_command="${MATRIX_MACOS_16_3_SETUP_COMMAND:=""}"
 
             # Create matrix from inputs
             matrix='{"config": []}'
 
             if [[ "$xcode_15_4_enabled" == "true" ]]; then
                 matrix=$(echo "$matrix" | jq -c \
+                --arg setup_command "$xcode_15_4_setup_command"  \
                 --arg build_arguments_override "$xcode_15_4_build_arguments_override"  \
                 --arg test_arguments_override "$xcode_15_4_test_arguments_override"  \
                 --arg runner_pool "$runner_pool"  \
-                '.config[.config| length] |= . + { "name": "Xcode 15.4", "xcode_version": "15.4", "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
+                '.config[.config| length] |= . + { "name": "Xcode 15.4", "xcode_version": "15.4", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
             if [[ "$xcode_16_0_enabled" == "true" ]]; then
                 matrix=$(echo "$matrix" | jq -c \
+                --arg setup_command "$xcode_16_0_setup_command"  \
                 --arg build_arguments_override "$xcode_16_0_build_arguments_override"  \
                 --arg test_arguments_override "$xcode_16_0_test_arguments_override"  \
                 --arg runner_pool "$runner_pool"  \
-                '.config[.config| length] |= . + { "name": "Xcode 16.0", "xcode_version": "16.0", "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
+                '.config[.config| length] |= . + { "name": "Xcode 16.0", "xcode_version": "16.0", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
             if [[ "$xcode_16_1_enabled" == "true" ]]; then
                 matrix=$(echo "$matrix" | jq -c \
+                --arg setup_command "$xcode_16_1_setup_command"  \
                 --arg build_arguments_override "$xcode_16_1_build_arguments_override"  \
                 --arg test_arguments_override "$xcode_16_1_test_arguments_override"  \
                 --arg runner_pool "$runner_pool"  \
-                '.config[.config| length] |= . + { "name": "Xcode 16.1", "xcode_version": "16.1", "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
+                '.config[.config| length] |= . + { "name": "Xcode 16.1", "xcode_version": "16.1", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
             if [[ "$xcode_16_2_enabled" == "true" ]]; then
                 matrix=$(echo "$matrix" | jq -c \
+                --arg setup_command "$xcode_16_2_setup_command"  \
                 --arg build_arguments_override "$xcode_16_2_build_arguments_override"  \
                 --arg test_arguments_override "$xcode_16_2_test_arguments_override"  \
                 --arg runner_pool "$runner_pool"  \
-                '.config[.config| length] |= . + { "name": "Xcode 16.2", "xcode_version": "16.2", "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
+                '.config[.config| length] |= . + { "name": "Xcode 16.2", "xcode_version": "16.2", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
             if [[ "$xcode_16_3_enabled" == "true" ]]; then
                 matrix=$(echo "$matrix" | jq -c \
+                --arg setup_command "$xcode_16_3_setup_command"  \
                 --arg build_arguments_override "$xcode_16_3_build_arguments_override"  \
                 --arg test_arguments_override "$xcode_16_3_test_arguments_override"  \
                 --arg runner_pool "$runner_pool"  \
-                '.config[.config| length] |= . + { "name": "Xcode 16.3", "xcode_version": "16.3", "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
+                '.config[.config| length] |= . + { "name": "Xcode 16.3", "xcode_version": "16.3", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
             echo "$matrix" | jq -c
@@ -196,18 +222,23 @@ jobs:
           MATRIX_MACOS_15_4_ENABLED: ${{ inputs.xcode_15_4_enabled }}
           MATRIX_MACOS_15_4_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_15_4_build_arguments_override }}
           MATRIX_MACOS_15_4_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_15_4_test_arguments_override }}
+          MATRIX_MACOS_15_4_SETUP_COMMAND: ${{ inputs.xcode_15_4_setup_command }}
           MATRIX_MACOS_16_0_ENABLED: ${{ inputs.xcode_16_0_enabled }}
           MATRIX_MACOS_16_0_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_0_build_arguments_override }}
           MATRIX_MACOS_16_0_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_0_test_arguments_override }}
+          MATRIX_MACOS_16_0_SETUP_COMMAND: ${{ inputs.xcode_16_0_setup_command }}
           MATRIX_MACOS_16_1_ENABLED: ${{ inputs.xcode_16_1_enabled }}
           MATRIX_MACOS_16_1_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_1_build_arguments_override }}
           MATRIX_MACOS_16_1_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_1_test_arguments_override }}
+          MATRIX_MACOS_16_1_SETUP_COMMAND: ${{ inputs.xcode_16_1_setup_command }}
           MATRIX_MACOS_16_2_ENABLED: ${{ inputs.xcode_16_2_enabled }}
           MATRIX_MACOS_16_2_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_2_build_arguments_override }}
           MATRIX_MACOS_16_2_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_2_test_arguments_override }}
+          MATRIX_MACOS_16_2_SETUP_COMMAND: ${{ inputs.xcode_16_2_setup_command }}
           MATRIX_MACOS_16_3_ENABLED: ${{ inputs.xcode_16_3_enabled }}
           MATRIX_MACOS_16_3_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_3_build_arguments_override }}
           MATRIX_MACOS_16_3_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_3_test_arguments_override }}
+          MATRIX_MACOS_16_3_SETUP_COMMAND: ${{ inputs.xcode_16_3_setup_command }}
 
   darwin-job:
     name: ${{ matrix.config.name }}
@@ -222,6 +253,11 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+      - name: Setup command
+        run: |
+          if [ -n "${{ matrix.config.setup_command }}" ]; then
+            bash -c "${{ matrix.config.setup_command }}"
+          fi
       - name: Swift build
         run: |
           if [ -n "${{ matrix.config.build_arguments_override }}" ]; then

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,7 +80,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@macos_setup_command  # TODO: test shim
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       runner_pool: general
       build_scheme: swift-nio-Package

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,7 +80,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@macos_setup_command  # TODO: test shim
     with:
       runner_pool: general
       build_scheme: swift-nio-Package


### PR DESCRIPTION
Add per-xcode setup command

###  Motivation:

Sometimes individual Xcodes require different steps to fixup simulator
configuration.

### Modifications:

* Allow the config to define custom setup steps
* Add some `simctl` commands to Xcode 16.2 by default to workaround issues

### Result:

Adopters can specify their own setup steps

Example of this working with a test shim in place https://github.com/apple/swift-nio/actions/runs/14992683747/job/42119567309?pr=3236