### PR TITLE
Enable visionOS xcodebuilds by default in CI - attempt 2

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -117,8 +117,8 @@ on:
         default: false
       visionos_xcode_build_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode build targeting visionOS. Defaults to false."
-        default: false
+        description: "Boolean to enable the Xcode build targeting visionOS. Defaults to true."
+        default: true
       visionos_xcode_test_enabled:
         type: boolean
         description: "Boolean to enable the Xcode test targeting visionOS. Defaults to false."


### PR DESCRIPTION
### Motivation:

Building for visionOS no longer seems to be having issues on the runners, we should enable it to increase our test coverage.

### Modifications:

Enable visionOS xcodebuilds by default in CI

### Result:

NIO and downstream repositories will see their *existing* macOS CI workflows now build for visionOS.

They can be disabled if necessary by passing `visionos_xcode_build_enabled: false`


See apple/swift-nio#3234, apple/swift-nio#3235