### PR TITLE
Update macos_tests.yml to limit run time to 30 minutes

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -244,6 +244,7 @@ jobs:
     name: ${{ matrix.config.name }}
     needs: construct-matrix
     runs-on: [self-hosted, macos, "${{ matrix.config.os }}", "${{ matrix.config.arch }}", "${{ matrix.config.pool }}"]
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.construct-matrix.outputs.darwin-matrix) }}


### PR DESCRIPTION
Update macos_tests.yml to limit run time to 30 minutes - in the future this should be configurable
