### PR TITLE
Print the swift version in Linux matrix jobs

### DIFF
--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -49,7 +49,7 @@ jobs:
             -e setup_command_expression="$setup_command_expression" \
             -e workspace="$workspace" \
             ${{ matrix.config.image }} \
-            bash -c "$setup_command_expression ${{ matrix.config.command }} ${{ matrix.config.command_arguments }}"
+            bash -c "swift --version && $setup_command_expression ${{ matrix.config.command }} ${{ matrix.config.command_arguments }}"
       - name: Run matrix job (Windows)
         if: ${{ matrix.config.platform == 'Windows' }}
         run: |


### PR DESCRIPTION
Print the output of `swift --version` in Linux matrix jobs before we do any other work to aid in debugging
