### PR TITLE
Remove default setup command for Xcode 16.2

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -58,7 +58,7 @@ on:
       xcode_16_2_setup_command:
         type: string
         description: "The command(s) to be executed before all other work."
-        default: "xcrun simctl runtime match set iphoneos18.2 22D8075 && xcrun simctl runtime match set xros2.2 22N895"
+        default: ""
       xcode_16_3_enabled:
         type: boolean
         description: "Boolean to enable the Xcode version 16.3 jobs. Defaults to true."


### PR DESCRIPTION
Motivation:

A setup command for 16.2 was added as a workaround for an infra issue. This should now be resolved.

Modifications:

- Remove the default setup command

Result:

CI should still work.