### PR TITLE
Embedded channels should set local and remote address always

### DIFF
--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -617,7 +617,8 @@ public final class NIOAsyncTestingChannel: Channel {
     ///   - address: The address to fake-bind to.
     ///   - promise: The `EventLoopPromise` which will be fulfilled when the fake-bind operation has been done.
     public func bind(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.futureResult.whenSuccess {
+        let promise = promise ?? self.testingEventLoop.makePromise()
+        promise.futureResult.whenSuccess {
             self.localAddress = address
         }
         if self.eventLoop.inEventLoop {
@@ -637,7 +638,8 @@ public final class NIOAsyncTestingChannel: Channel {
     ///   - address: The address to fake-bind to.
     ///   - promise: The `EventLoopPromise` which will be fulfilled when the fake-bind operation has been done.
     public func connect(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
-        promise?.futureResult.whenSuccess {
+        let promise = promise ?? self.testingEventLoop.makePromise()
+        promise.futureResult.whenSuccess {
             self.remoteAddress = address
         }
         if self.eventLoop.inEventLoop {

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -1060,7 +1060,8 @@ public final class EmbeddedChannel: Channel {
     ///   - promise: The `EventLoopPromise` which will be fulfilled when the fake-bind operation has been done.
     public func bind(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         self.embeddedEventLoop.checkCorrectThread()
-        promise?.futureResult.whenSuccess {
+        let promise = promise ?? self.embeddedEventLoop.makePromise()
+        promise.futureResult.whenSuccess {
             self.localAddress = address
         }
         self.pipeline.bind(to: address, promise: promise)
@@ -1075,7 +1076,8 @@ public final class EmbeddedChannel: Channel {
     ///   - promise: The `EventLoopPromise` which will be fulfilled when the fake-bind operation has been done.
     public func connect(to address: SocketAddress, promise: EventLoopPromise<Void>?) {
         self.embeddedEventLoop.checkCorrectThread()
-        promise?.futureResult.whenSuccess {
+        let promise = promise ?? self.embeddedEventLoop.makePromise()
+        promise.futureResult.whenSuccess {
             self.remoteAddress = address
         }
         self.pipeline.connect(to: address, promise: promise)

--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -445,7 +445,6 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testSetLocalAddressAfterSuccessfulBind() throws {
-
         let channel = NIOAsyncTestingChannel()
         let bindPromise = channel.eventLoop.makePromise(of: Void.self)
         let socketAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
@@ -454,11 +453,19 @@ class AsyncTestingChannelTests: XCTestCase {
             XCTAssertEqual(channel.localAddress, socketAddress)
         }
         try bindPromise.futureResult.wait()
+    }
 
+    func testSetLocalAddressAfterSuccessfulBindWithoutPromise() throws {
+        let channel = NIOAsyncTestingChannel()
+        let socketAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
+        // Call bind on-loop so we know when to expect the result
+        try channel.testingEventLoop.submit {
+            channel.bind(to: socketAddress, promise: nil)
+        }.wait()
+        XCTAssertEqual(channel.localAddress, socketAddress)
     }
 
     func testSetRemoteAddressAfterSuccessfulConnect() throws {
-
         let channel = NIOAsyncTestingChannel()
         let connectPromise = channel.eventLoop.makePromise(of: Void.self)
         let socketAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
@@ -467,7 +474,16 @@ class AsyncTestingChannelTests: XCTestCase {
             XCTAssertEqual(channel.remoteAddress, socketAddress)
         }
         try connectPromise.futureResult.wait()
+    }
 
+    func testSetRemoteAddressAfterSuccessfulConnectWithoutPromise() throws {
+        let channel = NIOAsyncTestingChannel()
+        let socketAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
+        // Call connect on-loop so we know when to expect the result
+        try channel.testingEventLoop.submit {
+            channel.connect(to: socketAddress, promise: nil)
+        }.wait()
+        XCTAssertEqual(channel.remoteAddress, socketAddress)
     }
 
     func testUnprocessedOutboundUserEventFailsOnEmbeddedChannel() throws {

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
@@ -463,6 +463,13 @@ class EmbeddedChannelTest: XCTestCase {
         try bindPromise.futureResult.wait()
     }
 
+    func testSetLocalAddressAfterSuccessfulBindWithoutPromise() throws {
+        let channel = EmbeddedChannel()
+        let socketAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
+        channel.bind(to: socketAddress, promise: nil)
+        XCTAssertEqual(channel.localAddress, socketAddress)
+    }
+
     func testSetRemoteAddressAfterSuccessfulConnect() throws {
         let channel = EmbeddedChannel()
         let connectPromise = channel.eventLoop.makePromise(of: Void.self)
@@ -472,6 +479,13 @@ class EmbeddedChannelTest: XCTestCase {
             XCTAssertEqual(channel.remoteAddress, socketAddress)
         }
         try connectPromise.futureResult.wait()
+    }
+
+    func testSetRemoteAddressAfterSuccessfulConnectWithoutPromise() throws {
+        let channel = EmbeddedChannel()
+        let socketAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
+        channel.connect(to: socketAddress, promise: nil)
+        XCTAssertEqual(channel.remoteAddress, socketAddress)
     }
 
     func testUnprocessedOutboundUserEventFailsOnEmbeddedChannel() {


### PR DESCRIPTION
Embedded channels should set local and remote address always

### Motivation:

Currently, if connect or bind are called without a promise, the remote/local address does not get set because those were getting set in the whenSuccess of the promise.

### Modifications:

If the user didn't provide a promise, create one ourselves, so we have something to listen for.

### Result:

Calling connect/bind will always result in remote/local address getting set, regardless of whether you pass a promise
