### PR TITLE
Add Xcode 26 beta 1 to macOS CI

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -29,8 +29,8 @@ on:
         default: ""
       xcode_16_1_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode version 16.1 jobs. Defaults to true."
-        default: true
+        description: "Boolean to enable the Xcode version 16.1 jobs. Defaults to false."
+        default: false
       xcode_16_1_build_arguments_override:
         type: string
         description: "The arguments passed to swift build in the Xcode version 16.1 job."

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -75,6 +75,22 @@ on:
         type: string
         description: "The command(s) to be executed before all other work."
         default: ""
+      xcode_26_beta_enabled:
+        type: boolean
+        description: "Boolean to enable the Xcode version 26 beta 1 jobs. Defaults to true."
+        default: true
+      xcode_26_beta_1_build_arguments_override:
+        type: string
+        description: "The arguments passed to swift build in the Xcode version 26 beta 1 job."
+        default: ""
+      xcode_26_beta_1_test_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Xcode version 26 beta 1 job."
+        default: ""
+      xcode_26_beta_1_setup_command:
+        type: string
+        description: "The command(s) to be executed before all other work."
+        default: ""
 
       build_scheme:
         type: string
@@ -165,6 +181,10 @@ jobs:
             xcode_16_3_build_arguments_override="${MATRIX_MACOS_16_3_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_16_3_test_arguments_override="${MATRIX_MACOS_16_3_TEST_ARGUMENTS_OVERRIDE:=""}"
             xcode_16_3_setup_command="${MATRIX_MACOS_16_3_SETUP_COMMAND:=""}"
+            xcode_26_beta_1_enabled="${MATRIX_MACOS_26_BETA_1_ENABLED:=true}"
+            xcode_26_beta_1_build_arguments_override="${MATRIX_MACOS_26_BETA_1_BUILD_ARGUMENTS_OVERRIDE:=""}"
+            xcode_26_beta_1_test_arguments_override="${MATRIX_MACOS_26_BETA_1_TEST_ARGUMENTS_OVERRIDE:=""}"
+            xcode_26_beta_1_setup_command="${MATRIX_MACOS_26_BETA_1_SETUP_COMMAND:=""}"
 
             # Create matrix from inputs
             matrix='{"config": []}'
@@ -214,6 +234,15 @@ jobs:
                 '.config[.config| length] |= . + { "name": "Xcode 16.3", "xcode_version": "16.3", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
             fi
 
+            if [[ "$xcode_26_beta_1_enabled" == "true" ]]; then
+                matrix=$(echo "$matrix" | jq -c \
+                --arg setup_command "$xcode_26_beta_1_setup_command"  \
+                --arg build_arguments_override "$xcode_26_beta_1_build_arguments_override"  \
+                --arg test_arguments_override "$xcode_26_beta_1_test_arguments_override"  \
+                --arg runner_pool "$runner_pool"  \
+                '.config[.config| length] |= . + { "name": "Xcode 26 beta 1", "xcode_version": "26.b1", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "sequoia", "arch": "ARM64", "pool": $runner_pool }')
+            fi
+
             echo "$matrix" | jq -c
           )"
           EOM
@@ -239,6 +268,10 @@ jobs:
           MATRIX_MACOS_16_3_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_3_build_arguments_override }}
           MATRIX_MACOS_16_3_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_3_test_arguments_override }}
           MATRIX_MACOS_16_3_SETUP_COMMAND: ${{ inputs.xcode_16_3_setup_command }}
+          MATRIX_MACOS_26_BETA_1_ENABLED: ${{ inputs.xcode_26_beta_1_enabled }}
+          MATRIX_MACOS_26_BETA_1_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_beta_1_build_arguments_override }}
+          MATRIX_MACOS_26_BETA_1_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_beta_1_test_arguments_override }}
+          MATRIX_MACOS_26_BETA_1_SETUP_COMMAND: ${{ inputs.xcode_26_beta_1_setup_command }}
 
   darwin-job:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,7 +80,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@add_xcode_26_b1_to_macos_ci
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       runner_pool: general
       build_scheme: swift-nio-Package

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,7 +80,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@add_xcode_26_b1_to_macos_ci
     with:
       runner_pool: general
       build_scheme: swift-nio-Package


### PR DESCRIPTION
Add Xcode 26 beta 1 to macOS CI and disable Xcode 16.1 jobs by default

### Motivation:

* Xcode 26 beta 1 is now released, we should test our code on it.
* We should drop 16.1 to conserve the number of jobs. 16.1 isn't offering much coverage anyway since it has the same Swift minor version (6.0) as Xcode 16.2.

### Modifications:

* Enable use of Xcode 26 beta 1 by default.
* Disable Xcode 16.1 jobs by default

### Result:

* This and downstream repos will run Xcode builds on Xcode 26 beta 1.
* Xcode 16.1 jobs won't run by default on this or downstream repos but will run if explicitly requested.

An example of this working https://github.com/apple/swift-nio/actions/runs/15614383580/job/43983277904?pr=3267