### PR TITLE
Fixed issue with macOS CI when overrides are being used.

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -295,7 +295,7 @@ jobs:
       - name: Swift build
         run: |
           if [ -n "${{ matrix.config.build_arguments_override }}" ]; then
-            swift build "${{ matrix.config.build_arguments_override }}"
+            swift build ${{ matrix.config.build_arguments_override }}
           else
             swift build --build-tests
           fi
@@ -303,7 +303,7 @@ jobs:
         if: 'inputs.swift_test_enabled'
         run: |
           if [ -n "${{ matrix.config.test_arguments_override }}" ]; then
-            swift test "${{ matrix.config.test_arguments_override }}"
+            swift test ${{ matrix.config.test_arguments_override }}
           else
             swift test
           fi


### PR DESCRIPTION
Fixed issue with macOS CI when overrides are being used.

### Motivation:

When we use Xcode_XX_X_build_arguments_override, the CI fails because of an extra double quotes ("") making its way to the final command.

### Modifications:

Remove the extra double quote from the Yaml file defining macOS tests.

### Result:

We are able to run `swift build` with extra arguments.
