### PR TITLE
fix: Fix compiler error found on latest main that breaks wasip1 (wasm) compilation

### DIFF
--- a/Sources/NIOCore/Channel.swift
+++ b/Sources/NIOCore/Channel.swift
@@ -458,8 +458,10 @@ extension ChannelError: CustomStringConvertible {
             "Bad interface address family"
         case let .illegalMulticastAddress(address):
             "Illegal multicast address \(address)"
+        #if !os(WASI)
         case let .multicastNotSupported(interface):
             "Multicast not supported on interface \(interface)"
+        #endif
         case .inappropriateOperationForState:
             "Inappropriate operation for state"
         case .unremovableHandler:


### PR DESCRIPTION
This is a quick simple fix for compiling NIOCore to wasm using the command `swift build --swift-sdk wasm32-unknown-wasip1-threads --target NIOCore`.

This fixes all errors for `wasip1`, however there are other errors remaining in `main` when compiling for `wasi` using the command `swift build --swift-sdk wasm32-unknown-wasi --target NIOCore`. Those issues are out of scope for this PR. 

### Motivation:

I am working to enable wasm compilation for a wide range of repositories which depend on NIOCore. See [here](https://github.com/PassiveLogic/swift-web-examples/issues/1) for a sneak peak. This change is required to enable several compiling several respositories.

### Modifications:

`.multicastNotSupported` is elided for `os(WASI)` builds in Channel.swift, however some new code referenced that case without proper `WASI` guards.

This modification simply adds the appropriate elision guard to fix wasip1 builds for NIOCore.

### Result:

After making this change, `swift build --swift-sdk wasm32-unknown-wasip1-threads --target NIOCore` builds again (assuming you have the appropriate wasm sdk installed).
