### PR TITLE
Fix API documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The core SwiftNIO repository will contain a few extremely important protocol imp
 
 ## Documentation
 
- - [API documentation](https://swiftpackageindex.com/apple/swift-nio/main/documentation/nio)
+ - [API documentation](https://swiftpackageindex.com/apple/swift-nio/documentation/nio)
 
 ## Example Usage
 
@@ -346,26 +346,26 @@ swift package benchmark
 
 For more information please refer to `swift package benchmark --help` or the [documentation of `package-benchmark`](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark).
 
-[ch]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/channelhandler
-[c]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/channel
-[chc]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/channelhandlercontext
-[ec]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/nioembedded/embeddedchannel
-[el]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/eventloop
-[eel]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/nioembedded/embeddedeventloop
-[elg]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/eventloopgroup
-[bb]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/bytebuffer
-[elf]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/eventloopfuture
-[elp]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/eventlooppromise
-[cp]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/channelpipeline
-[sbootstrap]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/nioposix/serverbootstrap
-[cbootstrap]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/nioposix/clientbootstrap
-[dbootstrap]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/nioposix/datagrambootstrap
-[mtelg]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/nioposix/multithreadedeventloopgroup
-[nioh1]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niohttp1
-[nioh2]: https://swiftpackageindex.com/apple/swift-nio-http2/main/documentation/niohttp2
-[niows]: https://swiftpackageindex.com/apple/swift-nio/main/documentation/niowebsocket
-[niossl]: https://swiftpackageindex.com/apple/swift-nio-ssl/main/documentation/niossl
-[niossh]: https://swiftpackageindex.com/apple/swift-nio-ssh/main/documentation/niossh
+[ch]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/channelhandler
+[c]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/channel
+[chc]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/channelhandlercontext
+[ec]: https://swiftpackageindex.com/apple/swift-nio/documentation/nioembedded/embeddedchannel
+[el]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/eventloop
+[eel]: https://swiftpackageindex.com/apple/swift-nio/documentation/nioembedded/embeddedeventloop
+[elg]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/eventloopgroup
+[bb]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/bytebuffer
+[elf]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/eventloopfuture
+[elp]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/eventlooppromise
+[cp]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/channelpipeline
+[sbootstrap]: https://swiftpackageindex.com/apple/swift-nio/documentation/nioposix/serverbootstrap
+[cbootstrap]: https://swiftpackageindex.com/apple/swift-nio/documentation/nioposix/clientbootstrap
+[dbootstrap]: https://swiftpackageindex.com/apple/swift-nio/documentation/nioposix/datagrambootstrap
+[mtelg]: https://swiftpackageindex.com/apple/swift-nio/documentation/nioposix/multithreadedeventloopgroup
+[nioh1]: https://swiftpackageindex.com/apple/swift-nio/documentation/niohttp1
+[nioh2]: https://swiftpackageindex.com/apple/swift-nio-http2/documentation/niohttp2
+[niows]: https://swiftpackageindex.com/apple/swift-nio/documentation/niowebsocket
+[niossl]: https://swiftpackageindex.com/apple/swift-nio-ssl/documentation/niossl
+[niossh]: https://swiftpackageindex.com/apple/swift-nio-ssh/documentation/niossh
 [pthreads]: https://en.wikipedia.org/wiki/POSIX_Threads
 [kqueue]: https://en.wikipedia.org/wiki/Kqueue
 [epoll]: https://en.wikipedia.org/wiki/Epoll


### PR DESCRIPTION
Point API docs URLs to the latest stable version instead of the unstable main branch.

### Motivation:

For most of developers this README.md is the main entry point when searching online or installing the library, so pointing them to API docs for the latest stable release makes more sense then the main branch, which may contain not-yet-released API or breaking changes.

### Modifications:

This PR removes `main` branch name from API docs URLs, making them always point to the latest stable release instead of the main branch.

### Result:

API docs URLs in README.md point to the latest stable release.
