### PR TITLE
Support for 64-bit timespec seconds on 32-bit platforms

### DIFF
--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -253,11 +253,7 @@ public final class ConditionLock<T: Equatable> {
         gettimeofday(&curTime, nil)
 
         let allNSecs: Int64 = timeoutNS + Int64(curTime.tv_usec) * 1000
-        #if canImport(wasi_pthread)
-        let tvSec = curTime.tv_sec + (allNSecs / nsecPerSec)
-        #else
-        let tvSec = curTime.tv_sec + Int((allNSecs / nsecPerSec))
-        #endif
+        let tvSec = curTime.tv_sec + time_t((allNSecs / nsecPerSec))
 
         var timeoutAbs = timespec(
             tv_sec: tvSec,

--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -46,7 +46,7 @@ extension timespec {
         let nsecPerSec: Int64 = 1_000_000_000
         let ns = amount.nanoseconds
         let sec = ns / nsecPerSec
-        self = timespec(tv_sec: Int(sec), tv_nsec: Int(ns - sec * nsecPerSec))
+        self = timespec(tv_sec: time_t(sec), tv_nsec: Int(ns - sec * nsecPerSec))
     }
 }
 #endif


### PR DESCRIPTION
Modern 32-bit platforms (such as embedded Linux builds) support 64-bit timestamps in `time_t` and `timespec`. Accommodate this.