### PR TITLE
Add DocC docs for running alloc tests and debugging them

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,19 +333,6 @@ apt-get install -y git curl libatomic1 libxml2 netcat-openbsd lsof perl
 dnf install swift-lang /usr/bin/nc /usr/bin/lsof /usr/bin/shasum
 ```
 
-### Benchmarks
-
-Benchmarks for `swift-nio` are in a separate Swift Package in the `Benchmarks` subfolder of this repository.
-They use the [`package-benchmark`](https://github.com/ordo-one/package-benchmark) plugin.
-Benchmarks depends on the [`jemalloc`](https://jemalloc.net) memory allocation library, which is used by `package-benchmark` to capture memory allocation statistics.
-An installation guide can be found in the [Getting Started article](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark/gettingstarted#Installing-Prerequisites-and-Platform-Support) of `package-benchmark`.
-Afterwards you can run the benchmarks from CLI by going to the `Benchmarks` subfolder (e.g. `cd Benchmarks`) and invoking:
-```
-swift package benchmark
-```
-
-For more information please refer to `swift package benchmark --help` or the [documentation of `package-benchmark`](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark).
-
 [ch]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/channelhandler
 [c]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/channel
 [chc]: https://swiftpackageindex.com/apple/swift-nio/documentation/niocore/channelhandlercontext

--- a/Sources/NIO/Docs.docc/Articles/Debugging Allocation Regressions.md
+++ b/Sources/NIO/Docs.docc/Articles/Debugging Allocation Regressions.md
@@ -1,0 +1,407 @@
+# Debugging Allocation Regressions
+
+This document explains different approaches to debugging allocation regressions.
+
+## Overview
+
+If you're not familiar with running SwiftNIO's allocation counting tests then
+take a look at <doc:Running-Alloction-Counting-Tests> first.
+
+The exact allocation counts are _not_ directly comparable between different
+operating systems and even different versions of the same operating system.
+Every new Swift version will also introduce differences (hopefully decreasing
+over time).
+
+This means that if you get hit by a CI failure, you will have to first reproduce
+the regression locally by running the allocation counter tests once on `main`
+and then again on your failing branch. Sometimes the allocation will be platform
+specific and you may have to reproduce it in a container.
+
+How you diagnose regressions depends on the nature of the change. It may be
+possible to diagnose regressions from inspection; did the change introduce any
+unnecessary allocations? Are there any intermediate allocations (such as from a
+collection resizing where capacity could've been reserved) which could be
+avoided?
+
+Most cases aren't so straightforward and require a different approach, such as:
+- Looking at the allocation traces in Instruments (macOS only)
+- Diffing allocation traces
+
+## Instruments
+
+To look at allocation traces in Instruments:
+
+1. Start Instruments
+2. Choose the "Allocations" instrument
+3. Tap the executable selector in the toolbar
+4. Click "Choose Target..."
+5. Select the binary for the test
+6. Click "Choose"
+7. Press the record button
+
+Now you should have a full Instruments allocations trace of the test run. To
+make sense of what's going on, switch the allocation lifespan from "Created &
+Persisted" to "Created & Destroyed". After that you should be able to see the
+type of the allocation and how many times it got allocated. Clicking on the
+little arrow next to the type name will reveal each individual allocation of
+this type and the responsible stack trace.
+
+## Collecting allocation traces
+
+As you're looking for an allocation regression you should have two versions of
+the binary you're debugging: a before and an after. A useful way to find the
+regression is to collect and compare all of the allocation stacks for each
+version of the program.
+
+How you collect the stacks depends on the platform you're investigating.
+SwiftNIO provides scripts for `dtrace` (macOS) and `bpftrace` (Linux) to collect
+stacks that lead to allocations. You can also use `heaptrack` on Linux where
+`bpftrace` isn't available. The following sections explain how to collection
+allocation traces using each tool.
+
+### DTrace (macOS)
+
+On macOS you can use `dtrace`. SwiftNIO provides the `malloc-aggregation.d`
+script in the `dev` directory for collecting stacks. You can run it with:
+
+```
+sudo ./malloc-aggregation.d -c your-executable
+```
+
+To make analysis easier you can demangle the symbols with `swift demangle`:
+
+```
+sudo ./malloc-aggregation.d -c your-executable | swift demangle
+```
+
+### BFPTrace (Linux)
+
+On Linux, and where available, you can use `bpftrace`. SwiftNIO provides the
+`malloc-aggregation.bt` script in the `dev` directory for collecting stacks.
+
+You'll need to install `bpftrace` first, on Ubuntu you can run:
+
+```
+apt-get update && apt-get install -y bpftrace
+```
+
+The script is very similar to the DTrace script and you can run it by passing
+your executable as an argument, for example:
+
+```
+sudo ./malloc-aggregation.bt -c your-executable
+```
+
+However, `bpftrace` tends to work better if PID-based tracing is used instead.
+This is because `bpftrace` has a [known limitation where symbolication fails if
+the process being traced has existed before `bpftrace`
+does](https://github.com/bpftrace/bpftrace/issues/2118#issuecomment-1008694821).
+This can still be resolved using tools like `llvm-symbolizer`, but it's
+trickier.
+
+You can pass the PID of your program to the script via the `-p` option, for
+example:
+
+```
+sudo ./malloc-aggregation.bt -p <PID>
+```
+
+You can start your executable in the background and capture the PID to pass
+to `malloc-aggreation.bt` using:
+
+```
+your-executable & PID=$! && sudo ./malloc-aggregation.bt -p $PID
+```
+
+### Heaptrack (Linux)
+
+In some cases we don't have access to Linux kernel headers, which prevents us
+from using `bpftrace`, but there is the
+[heaptrack](https://github.com/KDE/heaptrack) tool which can also capture
+allocation stacks.
+
+To install heaptrack on Ubuntu run:
+
+```
+apt-get update && apt-get install -y heaptrack
+```
+
+Getting allocation stacks from `heaptrack` is a two-step process. First you need
+to run your binary with `heaptrack`:
+
+```
+heaptrack /path/to/executable_to_test
+```
+
+This will produce a `.gz` file which `heaptrack_print` can analyze:
+
+```
+heaptrack_print \
+    --print-allocators yes \
+    --print-peaks no \
+    --print-temporary no \
+    --peak-limit 1000 \
+    --sub-peak-limit 1000 \
+    heaptrack_capture.gz
+```
+
+There are many options for `heaptrack_print`, the command above will print out
+the top allocating stacks. Note `--peak-limit` and `--sub-peak-limit`, these
+default to quite low values so raising them is important to avoid information
+loss that can make analysis more difficult.
+
+You can also pipe the result of `heaptrack_print` through `swift demangle` to
+make analysis easier.
+
+## Diffing allocation traces
+
+Once you've captured two allocation traces for your program you can diff them to
+work out where any regression was introduced. Each of the tools outlined
+previously produce output in different formats although they are broadly similar
+to:
+
+
+```
+...
+      libsystem_malloc.dylib`malloc
+      libswiftCore.dylib`swift_slowAlloc+0x19
+      libswiftCore.dylib`swift_allocObject+0x27
+      test_1_reqs_1000_conn`SelectableEventLoop.run()+0x231
+      test_1_reqs_1000_conn`closure #1 in static MultiThreadedEventLoopGroup.setupThreadAndEventLoop(name:selectorFactory:initializer:)+0x106
+      test_1_reqs_1000_conn`partial apply for closure #1 in static MultiThreadedEventLoopGroup.setupThreadAndEventLoop(name:selectorFactory:initializer:)+0x2d
+      test_1_reqs_1000_conn`thunk for @escaping @callee_guaranteed (@guaranteed NIOThread) -> ()+0xf
+      test_1_reqs_1000_conn`partial apply for thunk for @escaping @callee_guaranteed (@guaranteed NIOThread) -> ()+0x11
+      test_1_reqs_1000_conn`closure #1 in static ThreadOpsPosix.run(handle:args:detachThread:)+0x1e4
+      libsystem_pthread.dylib`_pthread_start+0x94
+      libsystem_pthread.dylib`thread_start+0xf
+   231000
+...
+```
+
+The output will contain many blocks like this. Each block means that the
+specific stack trace is responsible for some number of allocations: in the
+example above, 231000 allocations.
+
+The output from `bpftrace` and `heaptrack` will differ slightly to this. To make
+analysis easier we built a tool to parse and analyze the stacks.
+
+### stackdiff
+
+The `stackdiff` tool is a CLI tool for parsing and analyzing stack traces
+collected by `dtrace`, `bpftrace`, and `heaptrack`. It's available in the
+`dev/stackdiff` directory of the `swift-nio` repository. You can build it from
+the `stackdiff` directiroy with `swift build -c release`. The tool has three
+subcommands:
+
+1. `dump`,
+2. `diff`, and
+3. `merge`.
+
+#### stackdiff dump
+
+The `dump` subcommand parses and prints stacks collected via `dtrace`,
+`bpftrace`, or `heaptrack`. You must provide the stack traces as an argument
+along with the format of the input. For example, if you collected the allocation
+traces using DTrace into `allocs.txt` you should run:
+
+```
+stackdiff dump --format dtrace allocs.txt
+```
+
+By default only stacks with 1000 allocations or more are included. You can
+change this with `--min-allocations`:
+
+```
+stackdiff dump --format dtrace --min-allocations 10000 allocs.txt
+```
+
+You can also filter traces so that only stacks containing a given string are
+included:
+
+```
+stackdiff dump --format dtrace --filter swift_slowAlloc allocs.txt
+```
+
+See the help with `stackdiff dump --help` to learn about other options.
+
+#### stackdiff diff
+
+The `diff` subcommand parses stacks from two input files and prints the stacks
+which are unique to each input file as well as the stacks which are common to
+both input files but have differing allocation counts. You can apply the same
+options as the `dump` command.
+
+To print the diff between two `heaptrack` outputs use:
+
+```
+stackdiff diff --format heaptrack before.txt after.txt
+```
+
+This will print out a few different sections:
+1. Allocation traces present only in "before.txt",
+2. Allocation traces present only in "after.txt",
+3. Allocation traces present only in "before.txt" and "after.txt" but with
+   differing allocation counts.
+4. A summary of the allactions.
+
+Using this information can help you to narrow down where the allocation was
+introduced. In some cases there will be many stacks which are unique to each
+file but are subtly different. These often hide the true cause of the
+regression. The `merge` command makes finding these differences easier.
+
+#### stackdiff merge
+
+The `merge` subcommand is much like `diff` but interactively allows you to pair
+up unique stacks from one file with those from another. This is done by
+computing a textual similarity between stacks and offering them to you to either
+accept or reject. Once you've matched analyzed the unique traces across the
+files you should be left with the _actual_ difference.
+
+You can call `merge` like you do for `diff`:
+
+```
+stackdiff merge --format heaptrack before.txt after.txt
+```
+
+You'll first be presented with a summary of the differences between the two
+inputs:
+
+```
+Input A
+- File: before.txt
+- Allocations: 623000
+- Stacks: 373
+- Stacks only in A: 22
+
+Input B
+- File: after.txt
+- Allocations: 624000
+- Stacks: 374
+- Stacks only in B: 23
+
+Allocation delta (A-B): -1000
+
+About to start merging stacks, hit enter to continue ...
+```
+
+The tool refers to inputs `A` and `B` when merging, these correspond to the
+files printed in the summary (i.e. the first and second positional arguments
+passed to `merge`.) For each it prints the total number of allocations which
+haven't been filtered out in each file, the number of stacks in each file, and
+the unique stacks in each. In this case there are 22 stacks in `A` which aren't
+present in `B`, and `23` stacks in `B` which aren't in `A`. It's likely that 22
+of the stacks are the practically speaking the same with one additional stack in
+`B`. You can also see that the allocation delta is -1000, meaning that `B` has
+1000 allocations more than `A`.
+
+You'll then need to hit enter to start merging stacks. When you do, you'll be
+presented with output like this:
+
+```
+Finding candidates for stack 1 of 22 (S1) from A only ...
+Looking at candidate stack 1 of 23 (S2) ...
+
+Allocations:
+       |     A |      B |    Net
+    S1 | 10000 |      0 |  10000
+    S2 |     0 | -10000 | -10000
+ Total | 10000 | -10000 |      0
+
+Stack similarity: 0.7441860465116279
+
+S1| ...skipping 3 common lines...
+S1| libswiftCore.dylib`_ContiguousArrayBuffer.init(_uninitializedCount:minimumCapacity:)
+S1| ...skipping 3 common lines...
+
+S2| ...skipping 3 common lines...
+S2| libswiftCore.dylib`_allocateStringStorage(codeUnitCapacity:)
+S2| libswiftCore.dylib`_StringGuts.reserveCapacity(_:)
+S2| libswiftCore.dylib`String.init(repeating:count:)
+S2| ...skipping 3 common lines...
+
+Accept ([y]es/no/skip/expand)?:
+```
+
+The first two lines tell you your progress, in this case that you're looking at
+the first stack which is only present in `A` and evaluating it against the first
+candidate stack:
+
+```
+Finding candidates for stack 1 of 22 (S1) from A only ...
+Looking at candidate stack 1 of 23 (S2) ...
+```
+
+After this is a table indicating the allocations and where they come from:
+
+```
+Allocations:
+       |     A |      B |    Net
+    S1 | 10000 |      0 |  10000
+    S2 |     0 | -10000 | -10000
+ Total | 10000 | -10000 |      0
+```
+
+The `S1` and `S2` labels apply to the two stacks we're looking at and the two
+`A` and `B` columns indicate how many allocations from that stack are associated
+with the two input files. Allocations from `B` are always treated as negative
+(we're diffing `A` and `B` so conceptually subtracting `B` from `A`.)
+
+Below the table you can see the similarity score of 0.74:
+
+```
+Stack similarity: 0.7441860465116279
+```
+
+Scores above 0.9 are considered strong matches, below 0.55 are weak.
+
+The two stacks `S1` and `S2` are printed next:
+
+```
+S1| ...skipping 3 common lines...
+S1| libswiftCore.dylib`_ContiguousArrayBuffer.init(_uninitializedCount:minimumCapacity:)
+S1| ...skipping 3 common lines...
+
+S2| ...skipping 3 common lines...
+S2| libswiftCore.dylib`_allocateStringStorage(codeUnitCapacity:)
+S2| libswiftCore.dylib`_StringGuts.reserveCapacity(_:)
+S2| libswiftCore.dylib`String.init(repeating:count:)
+S2| ...skipping 3 common lines...
+```
+
+Their common prefix and suffix are hidden to make their differences more
+obvious. Finally you're asked for input:
+
+```
+Accept ([y]es/no/skip/expand)?:
+```
+
+If you think the stacks are effectively the same then enter `y` or `yes` and hit
+enter (or just hit enter, as this is the default option). If you don't think the
+stacks match up then enter `n` or `no` and hit enter, you'll then be presented
+with a similar output but with a different candidate for `S2`. If there are no
+candidates remaining or you enter `s` or `skip` then `S1` will not be paired and
+you'll be presented with the next stack for `S1`. Finally, you can else enter
+`e` or `expand` to expand out the common lines.
+
+Once you've finished merging stacks you'll be presented with all the unmerged
+stacks, in other words, those which haven't been paired up between `A` and `B`
+and common stacks which have a non-zero allocation count:
+
+```
+Finished merging stacks, removing stacks with net zero allocations.
+Stacks remaining: 1
+Net allocations: -1000
+
+ALLOCATIONS: -1000
+libsystem_malloc.dylib`malloc_type_malloc
+libswiftCore.dylib`swift::swift_slowAllocTyped(unsigned long, unsigned long, unsigned long long)
+libswiftCore.dylib`swift_allocObject
+libswiftCore.dylib`_allocateStringStorage(codeUnitCapacity:)
+libswiftCore.dylib`_StringGuts.reserveCapacity(_:)
+libswiftCore.dylib`String.init(repeating:count:)
+do-some-allocs`specialized static do_some_allocs.main()
+do-some-allocs`do_some_allocs_main
+dyld`start
+```
+
+This means that the one remaining stack was from `B` and has 1000 allocations.

--- a/Sources/NIO/Docs.docc/Articles/Running Alloction Counting Tests.md
+++ b/Sources/NIO/Docs.docc/Articles/Running Alloction Counting Tests.md
@@ -1,0 +1,180 @@
+# Running Allocation Counting Tests
+
+This document explains the different type of allocation counting tests and how
+to run them.
+
+## Overview
+
+Allocations are expensive so are often a good proxy for measuring performance in
+an application: reducing unnecessary allocations _typically_ leads to an
+increase in performance. SwiftNIO has a number of tests which record allocations
+and check the results against a threshold. These are run as part of CI and help
+us to avoid introducing allocation regressions.
+
+SwiftNIO uses two frameworks for running allocation tests:
+
+1. The [`package-benchmark`](https://github.com/ordo-one/package-benchmark)
+   package.
+2. A homegrown allocation counting framework.
+
+## Running package-benchmark benchmarks
+
+The `package-benchmark` benchmarks live in the `Benchmarks` directory of the
+`swift-nio` repository. To run the benchmarks you'll need to install `jemalloc`,
+refer to the instructions in the `package-benchmark` [Getting
+Started](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark/gettingstarted#Installing-Prerequisites-and-Platform-Support)
+guide to do this.
+
+To run all the benchmarks without checking against the thresholds run the
+following command from the `Benchmarks` directory:
+
+```sh
+$ swift package benchmark
+```
+
+To list the available benchmarks run:
+
+```sh
+$ swift package benchmark list
+```
+
+To run a subset of benchmarks you can provide a regular expression to the
+`--filter` option. For example to run just the "WaitOnPromise" benchmark:
+
+
+```sh
+$ swift package benchmark --filter WaitOnPromise
+```
+
+Each benchmark has a threshold associated with it. These are stored in the
+`Benchmarks/Thresholds` directory. There are thresholds for each version of
+Swift that SwiftNIO supports.
+
+To run the benchmarks and check against the thresholds, in this case the nightly
+builds of Swift's `main` branch you can run:
+
+```sh
+$ swift package benchmark threshold check --path Thresholds/nightly-main
+```
+
+Sometimes you'll need to run a benchmark _without_ invoking it via `swift
+package benchmark`. The easiest way to do this is to first invoke `swift
+package benchmark` and then run the benchmark binary which was built as a
+side effect:
+
+```sh
+$ ./.build/release/NIOCoreBenchmarks --filter WaitOnPromise
+```
+
+## Running the homegrown benchmarks
+
+Most of SwiftNIO's allocation counting tests are written using its own framework
+which predates `package-benchmark`. The source for the framework lives in
+`IntegrationTests/allocation-counter-tests-framework` and is used across the
+various `swift-nio-*` repositories and more besides. In the `swift-nio`
+repository the tests live in
+`IntegrationTests/tests_04_performance/test_01_resources`.
+
+The following commands assume your current working directory is
+`IntegrationTests/tests_04_performance/test_01_resources`.
+
+To run all tests written for this framework:
+
+```sh
+$ ./run-nio-alloc-counter-tests.sh
+```
+
+The invocation of this script will take a while because it has to build all of
+SwiftNIO in release mode first, then it compiles the integration tests and runs
+them all, multiple times.
+
+To run a single test specify the file containing it as an argument to the
+script:
+
+```sh
+$ ./run-nio-alloc-counter-tests.sh test_future_lots_of_callbacks.swift
+```
+
+You'll notice that when you run the script that it builds SwiftNIO and
+the test each time. In the output you should see some lines like:
+
+```
+...
+Fetching /private/tmp/.nio_alloc_counter_tests_5jMMhk/swift-nio
+Fetching /private/tmp/.nio_alloc_counter_tests_5jMMhk/HookedFunctions
+Fetching /private/tmp/.nio_alloc_counter_tests_5jMMhk/AtomicCounter
+...
+```
+
+The `/private/tmp/.nio_alloc_counter_tests_5jMMhk` directory contains
+a regular Swift package which you can modify to iterate more quickly, 
+just don't forget to build it whith `-c release`!
+
+### Understanding the output
+
+The output of the script will look something like:
+
+```
+- /Users/johannes/devel/swift-nio/IntegrationTests/tests_04_performance/test_01_resources/test_future_lots_of_callbacks.swift
+test_future_lots_of_callbacks.remaining_allocations: 0
+test_future_lots_of_callbacks.total_allocations: 75001
+test_future_lots_of_callbacks.total_allocated_bytes: 4138056
+DEBUG: [["remaining_allocations": 0, "total_allocations": 75001, "total_allocated_bytes": 4138056], ["total_allocations": 75001, "remaining_allocations": 0, "total_allocated_bytes": 4138056], ["total_allocated_bytes": 4138056, "total_allocations": 75001, "remaining_allocations": 0], ["total_allocated_bytes": 4138056, "total_allocations": 75001, "remaining_allocations": 0], ["remaining_allocations": 0, "total_allocations": 75001, "total_allocated_bytes": 4138056], ["total_allocations": 75001, "remaining_allocations": 0, "total_allocated_bytes": 4138056], ["total_allocated_bytes": 4138056, "total_allocations": 75001, "remaining_allocations": 0], ["total_allocations": 75001, "total_allocated_bytes": 4138056, "remaining_allocations": 0], ["remaining_allocations": 0, "total_allocations": 75001, "total_allocated_bytes": 4138056], ["total_allocations": 75001, "total_allocated_bytes": 4138056, "remaining_allocations": 0]]
+```
+
+with this kind of block repeated for each allocation counter test. Let's go
+through and understand each line. The first line is the name of the specific
+allocation test. The most relevant part is the file name
+(`test_future_lots_of_callbacks.swift`). For this test, we seem to be testing
+how many allocations futures with many callbacks are doing.
+
+```
+- /Users/johannes/devel/swift-nio/IntegrationTests/tests_04_performance/test_01_resources/test_future_lots_of_callbacks.swift
+```
+
+Next, we see
+
+```
+test_future_lots_of_callbacks.remaining_allocations: 0
+test_future_lots_of_callbacks.total_allocations: 75001
+test_future_lots_of_callbacks.total_allocated_bytes: 4138056
+```
+
+which are the aggregate values. The first line says `remaining_allocations: 0`,
+which means that this allocation test didn't leak, which is good! Then, we see
+
+```
+test_future_lots_of_callbacks.total_allocations: 75001
+```
+
+which means that by the end of the test, we saw 75001 allocations in total. As a
+rule, we usually run the workload of every allocation test 1000 times. That
+means you want to divide 75001 by the 1000 runs to get the number of allocations
+per run. In other words: each iteration of this allocation test allocated 75
+times. The extra one allocation is just some noise that we have to ignore: these
+are usually inserted by operations in the Swift runtime that need to initialize
+some state. In many (especially multi-threaded test cases) there is some noise,
+which is why we run the workload repeatedly, which makes it easy to tell the
+signal from the noise.
+
+Finally, we see
+
+```
+test_future_lots_of_callbacks.total_allocated_bytes: 4138056
+```
+
+Which is the total number of bytes allocated by this test.
+
+Last of all, we see
+
+```
+DEBUG: [["remaining_allocations": 0, "total_allocations": 75001, "total_allocated_bytes": 4138056], ["total_allocations": 75001, "remaining_allocations": 0, "total_allocated_bytes": 4138056], ["total_allocated_bytes": 4138056, "total_allocations": 75001, "remaining_allocations": 0], ["total_allocated_bytes": 4138056, "total_allocations": 75001, "remaining_allocations": 0], ["remaining_allocations": 0, "total_allocations": 75001, "total_allocated_bytes": 4138056], ["total_allocations": 75001, "remaining_allocations": 0, "total_allocated_bytes": 4138056], ["total_allocated_bytes": 4138056, "total_allocations": 75001, "remaining_allocations": 0], ["total_allocations": 75001, "total_allocated_bytes": 4138056, "remaining_allocations": 0], ["remaining_allocations": 0, "total_allocations": 75001, "total_allocated_bytes": 4138056], ["total_allocations": 75001, "total_allocated_bytes": 4138056, "remaining_allocations": 0]]
+```
+
+which are just the exact numbers of each of the 10 runs we considered.
+Note, the lines are prefixed with `DEBUG:` to make analysis of the output
+easier, it does _not_ mean we're running in debug mode. If you see a lot of
+fluctuation between the runs, then the allocation test doesn't allocate
+deterministically which would be something you want to fix. In the example
+above, we're totally stable to the last byte of allocated memory, so we have
+nothing to worry about with this test.

--- a/Sources/NIO/Docs.docc/index.md
+++ b/Sources/NIO/Docs.docc/index.md
@@ -142,6 +142,13 @@ Applications that need extremely high performance from their networking stack ma
 
 The core SwiftNIO repository will contain a few extremely important protocol implementations, such as HTTP, directly in tree. However, we believe that most protocol implementations should be decoupled from the release cycle of the underlying networking stack, as the release cadence is likely to be very different (either much faster or much slower). For this reason, we actively encourage the community to develop and maintain their protocol implementations out-of-tree. Indeed, some first-party SwiftNIO protocol implementations, including our TLS and HTTP/2 bindings, are developed out-of-tree!
 
+## Topics
+
+### Allocation Tests
+
+- <doc:Running-Alloction-Counting-Tests>
+- <doc:Debugging-Allocation-Regressions>
+
 
 <!-- links -->
 


### PR DESCRIPTION
Motivation:

Our docs for running alloc counting benchmarks are scattered between a few places, and our info about debugging allocations is also a bit outdated.

Modifiactions:

- Add a doc on running the two different flavours of allocation counting test. Remove the entry about bencharks from the README.
- Add a doc on debugging allocations

Most of the content comes from the original
`docs/debugging-allocations.md` doc but has been updated a little and includes info about the new stackdiff tool.

Result:

Better docs