### PR TITLE
ensure <stddef.h> is not imported within extern "C"

### DIFF
--- a/Sources/CNIOLLHTTP/include/c_nio_llhttp.h
+++ b/Sources/CNIOLLHTTP/include/c_nio_llhttp.h
@@ -553,10 +553,10 @@ typedef enum llhttp_status llhttp_status_t;
 
 #ifndef INCLUDE_LLHTTP_API_H_
 #define INCLUDE_LLHTTP_API_H_
+#include <stddef.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include <stddef.h>
 
 #if defined(__wasm__)
 #define LLHTTP_EXPORT __attribute__((visibility("default")))

--- a/Sources/CNIOLLHTTP/update_and_patch_llhttp.sh
+++ b/Sources/CNIOLLHTTP/update_and_patch_llhttp.sh
@@ -142,6 +142,25 @@ index 071e828c6..1e5d99cec 100644
  struct c_nio_llhttp__internal_s {
 EOF
 
+patch -p1 -V none << 'EOF'
+diff --git a/include/c_nio_llhttp.h b/include/c_nio_llhttp.h
+index 1e5d99ce..39cf110a 100644
+--- a/include/c_nio_llhttp.h
++++ b/include/c_nio_llhttp.h
+@@ -553,10 +553,10 @@ typedef enum llhttp_status llhttp_status_t;
+ 
+ #ifndef INCLUDE_LLHTTP_API_H_
+ #define INCLUDE_LLHTTP_API_H_
++#include <stddef.h>
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-#include <stddef.h>
+ 
+ #if defined(__wasm__)
+ #define LLHTTP_EXPORT __attribute__((visibility("default")))
+EOF
+
 rm -rf "$compiletmp"
 rm -rf "$tmpdir"
 


### PR DESCRIPTION
Add patch for `<stddef.h>` being included inside of extern "C" section which is invalid in C++.

### Motivation:

When building with C++ interop enabled on Linux, `<stddef.h>` fails to import because the C++ module `_Builtin_stddef.max_align_t` (which it includes) is re-imported with C language linkage.

```
<module-includes>:1:10: note: in file included from <module-includes>:1:
1 | #include "/home/xtremek/Programming/xavgru12/meta-swift-project/poky/build-qemuarm64/tmp-glibc/work/cortexa57-oe-linux/swift-hello-world/1.0/build/checkouts/swift-nio/Sources/CNIOLLHTTP/include/CNIOLLHTTP.h"
  |          `- note: in file included from <module-includes>:1:
2 | 

/home/xtremek/Programming/xavgru12/meta-swift-project/poky/build-qemuarm64/tmp-glibc/work/cortexa57-oe-linux/swift-hello-world/1.0/build/checkouts/swift-nio/Sources/CNIOLLHTTP/include/CNIOLLHTTP.h:20:10: note: in file included from /home/xtremek/Programming/xavgru12/meta-swift-project/poky/build-qemuarm64/tmp-glibc/work/cortexa57-oe-linux/swift-hello-world/1.0/build/checkouts/swift-nio/Sources/CNIOLLHTTP/include/CNIOLLHTTP.h:20:
18 | #define C_NIO_LLHTTP_SWIFT
19 | 
20 | #include "c_nio_llhttp.h"
   |          `- note: in file included from /home/xtremek/Programming/xavgru12/meta-swift-project/poky/build-qemuarm64/tmp-glibc/work/cortexa57-oe-linux/swift-hello-world/1.0/build/checkouts/swift-nio/Sources/CNIOLLHTTP/include/CNIOLLHTTP.h:20:
21 | 
22 | static inline llhttp_errno_t c_nio_llhttp_execute_swift(llhttp_t *parser,

/home/xtremek/Programming/xavgru12/meta-swift-project/poky/build-qemuarm64/tmp-glibc/work/cortexa57-oe-linux/swift-hello-world/1.0/build/checkouts/swift-nio/Sources/CNIOLLHTTP/include/c_nio_llhttp.h:559:10: note: in file included from /home/xtremek/Programming/xavgru12/meta-swift-project/poky/build-qemuarm64/tmp-glibc/work/cortexa57-oe-linux/swift-hello-world/1.0/build/checkouts/swift-nio/Sources/CNIOLLHTTP/include/c_nio_llhttp.h:559:
557 | extern "C" { 
558 | #endif
559 | #include <stddef.h>
    |          `- note: in file included from /home/xtremek/Programming/xavgru12/meta-swift-project/poky/build-qemuarm64/tmp-glibc/work/cortexa57-oe-linux/swift-hello-world/1.0/build/checkouts/swift-nio/Sources/CNIOLLHTTP/include/c_nio_llhttp.h:559:
560 | 
561 | #if defined(__wasm__)

<unknown>:0: error: could not build C module 'CNIOLLHTTP'
/home/xtremek/Programming/xavgru12/meta-swift-project/poky/build-qemuarm64/tmp-glibc/work/cortexa57-oe-linux/swift-hello-world/1.0/recipe-sysroot-native/usr/lib/clang/17/include/stddef.h:128:1: error: import of C++ module '_Builtin_stddef.max_align_t' appears within extern "C" language linkage specification
126 | 
127 | #if defined(__need_max_align_t)
128 | #include <__stddef_max_align_t.h>
    | `- error: import of C++ module '_Builtin_stddef.max_align_t' appears within extern "C" language linkage specification
129 | #undef __need_max_align_t
130 | #endif /* defined(__need_max_align_t) */

/home/xtremek/Programming/xavgru12/meta-swift-project/poky/build-qemuarm64/tmp-glibc/work/cortexa57-oe-linux/swift-hello-world/1.0/build/checkouts/swift-nio/Sources/CNIOLLHTTP/include/c_nio_llhttp.h:557:1: note: extern "C" language linkage specification begins here
555 | #define INCLUDE_LLHTTP_API_H_
556 | #ifdef __cplusplus
557 | extern "C" { 
    | `- note: extern "C" language linkage specification begins here
558 | #endif
```

### Modifications:

Added a patch to the `update_and_patch_llhttp.sh` file to move this include to the correct location, and ran the script to actually apply it to the included `c_nio_llhttp.h` file in the `CNIOLLHTTP` target.

### Result:

swift-nio compiles properly on a package with C++ interop (`.interoperabilityMode(.Cxx)`) enabled in Linux.

@lhoward @Lukasa 