### PR TITLE
inEventLoop benchmark

### DIFF
--- a/Sources/NIOPerformanceTester/TCPThroughputBenchmark.swift
+++ b/Sources/NIOPerformanceTester/TCPThroughputBenchmark.swift
@@ -128,8 +128,6 @@ final class TCPThroughputBenchmark: Benchmark {
             .bind(host: "127.0.0.1", port: 0)
             .wait()
 
-        self.serverHandler = try promise.futureResult.wait()
-
         self.clientChannel = try ClientBootstrap(group: group)
             .channelInitializer { channel in
                 channel.eventLoop.makeCompletedFuture {
@@ -139,6 +137,8 @@ final class TCPThroughputBenchmark: Benchmark {
             }
             .connect(to: serverChannel.localAddress!)
             .wait()
+
+        self.serverHandler = try promise.futureResult.wait()
 
         var message = self.serverChannel.allocator.buffer(capacity: self.messageSize)
         message.writeInteger(UInt16(messageSize), as: UInt16.self)

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -838,6 +838,31 @@ measureAndPrint(desc: "future_reduce_into_10k_futures") {
     return try! EventLoopFuture<Int>.reduce(into: 0, futures, on: el1, { $0 += $1 }).wait()
 }
 
+try measureAndPrint(desc: "el_in_eventloop_100M") {
+    let el1 = group.next()
+
+    let inEL = try el1.submit {
+        var inEL = 0
+        for _ in 0..<100_000_000 {
+            inEL = inEL &+ (el1.inEventLoop ? 1 : 0)
+        }
+        return inEL
+    }.wait()
+    precondition(inEL == 100_000_000)
+    return inEL
+}
+
+measureAndPrint(desc: "el_not_in_eventloop_100M") {
+    let el1 = group.next()
+
+    var inEL = 0
+    for _ in 0..<100_000_000 {
+        inEL = inEL &+ (el1.inEventLoop ? 1 : 0)
+    }
+    precondition(inEL == 0)
+    return inEL
+}
+
 try measureAndPrint(desc: "channel_pipeline_1m_events", benchmark: ChannelPipelineBenchmark(runCount: 1_000_000))
 
 try measureAndPrint(


### PR DESCRIPTION
### Motivation:

PR #3297 is changing `inEventLoop` and `inEventLoop` is very much on the perf path. So let's add a benchmark

### Modifications:

- Add `(!)inEventLoop` benchmark
- Fix a guaranteed deadlock in `TCPThroughputBenchmark` to make the benchmarks runnable

### Result:

- More benchmarks
- Fewer hangs