### PR TITLE
improve inEventLoop checks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -117,6 +117,7 @@ let package = Package(
                 "NIOConcurrencyHelpers",
                 "NIOCore",
                 "_NIODataStructures",
+                "CNIOPosix",
                 swiftAtomics,
             ],
             exclude: includePrivacyManifest ? [] : ["PrivacyInfo.xcprivacy"],
@@ -150,6 +151,13 @@ let package = Package(
         ),
         .target(
             name: "CNIOAtomics",
+            dependencies: [],
+            cSettings: [
+                .define("_GNU_SOURCE")
+            ]
+        ),
+        .target(
+            name: "CNIOPosix",
             dependencies: [],
             cSettings: [
                 .define("_GNU_SOURCE")

--- a/Sources/CNIOPosix/event_loop_id.c
+++ b/Sources/CNIOPosix/event_loop_id.c
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "include/CNIOPosix.h"
+
+// Once we support C23, this should become `thread_local`.
+// DO NOT TOUCH DIRECTLY, use `c_nio_posix_{get,set}_el_id`
+_Thread_local uintptr_t _c_nio_posix_thread_local_el_id;

--- a/Sources/CNIOPosix/include/CNIOPosix.h
+++ b/Sources/CNIOPosix/include/CNIOPosix.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <inttypes.h>
+
+extern _Thread_local uintptr_t _c_nio_posix_thread_local_el_id;
+
+static inline uintptr_t c_nio_posix_get_el_id(void) {
+    return _c_nio_posix_thread_local_el_id;
+}
+
+static inline void c_nio_posix_set_el_id(uintptr_t id) {
+    _c_nio_posix_thread_local_el_id = id;
+}

--- a/Sources/NIOCore/ByteBuffer-int.swift
+++ b/Sources/NIOCore/ByteBuffer-int.swift
@@ -180,7 +180,7 @@ extension UInt32 {
 
         var n = self
 
-        #if arch(arm) || arch(i386) || arch(arm64_32)
+        #if arch(arm) || arch(i386) || arch(arm64_32) || arch(wasm32)
         // on 32-bit platforms we can't make use of a whole UInt32.max (as it doesn't fit in an Int)
         let max = UInt32(Int.max)
         #else

--- a/Sources/NIOFileSystem/ByteCount.swift
+++ b/Sources/NIOFileSystem/ByteCount.swift
@@ -81,7 +81,7 @@ public struct ByteCount: Hashable, Sendable {
 extension ByteCount {
     /// A ``ByteCount`` for the maximum amount of bytes that can be written to `ByteBuffer`.
     internal static var byteBufferCapacity: ByteCount {
-        #if arch(arm) || arch(i386) || arch(arm64_32)
+        #if arch(arm) || arch(i386) || arch(arm64_32) || arch(wasm32)
         // on 32-bit platforms we can't make use of a whole UInt32.max (as it doesn't fit in an Int)
         let byteBufferMaxIndex = UInt32(Int.max)
         #else

--- a/Sources/NIOPosix/IntegerBitPacking.swift
+++ b/Sources/NIOPosix/IntegerBitPacking.swift
@@ -106,4 +106,26 @@ extension IntegerBitPacking {
         let unpacked = _IntegerBitPacking.unpackUU(value, leftType: UInt32.self, rightType: UInt32.self)
         return (unpacked.0, CInt(truncatingIfNeeded: unpacked.1))
     }
+
+    @inlinable
+    static func packUInt32UInt32(_ left: UInt32, _ right: UInt32) -> UInt64 {
+        _IntegerBitPacking.packUU(left, right)
+    }
+
+    @inlinable
+    static func unpackUInt32UInt32(_ value: UInt64) -> (UInt32, UInt32) {
+        let unpacked = _IntegerBitPacking.unpackUU(value, leftType: UInt32.self, rightType: UInt32.self)
+        return (unpacked.0, unpacked.1)
+    }
+
+    @inlinable
+    static func packUInt16UInt16(_ left: UInt16, _ right: UInt16) -> UInt32 {
+        _IntegerBitPacking.packUU(left, right)
+    }
+
+    @inlinable
+    static func unpackUInt16UInt16(_ value: UInt32) -> (UInt16, UInt16) {
+        let unpacked = _IntegerBitPacking.unpackUU(value, leftType: UInt16.self, rightType: UInt16.self)
+        return (unpacked.0, unpacked.1)
+    }
 }

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Atomics
+import CNIOPosix
 import DequeModule
 import Dispatch
 import NIOConcurrencyHelpers
@@ -134,6 +135,8 @@ internal final class SelectableEventLoop: EventLoop, @unchecked Sendable {
     internal var _scheduledTasks = PriorityQueue<ScheduledTask>()
     @usableFromInline
     internal var _immediateTasks = Deque<UnderlyingTask>()
+    @usableFromInline
+    internal let _uniqueID: SelectableEventLoopUniqueID
 
     // We only need the ScheduledTask's task closure. However, an `Array<() -> Void>` allocates
     // for every appended closure. https://bugs.swift.org/browse/SR-15872
@@ -247,12 +250,14 @@ internal final class SelectableEventLoop: EventLoop, @unchecked Sendable {
 
     internal init(
         thread: NIOThread,
+        uniqueID: SelectableEventLoopUniqueID,
         parentGroup: MultiThreadedEventLoopGroup?,  // nil iff thread take-over
         selector: NIOPosix.Selector<NIORegistration>,
         canBeShutdownIndividually: Bool,
         metricsDelegate: NIOEventLoopMetricsDelegate?
     ) {
         self.metricsDelegate = metricsDelegate
+        self._uniqueID = uniqueID
         self._parentGroup = parentGroup
         self._selector = selector
         self.thread = thread
@@ -267,6 +272,8 @@ internal final class SelectableEventLoop: EventLoop, @unchecked Sendable {
         let voidPromise = self.makePromise(of: Void.self)
         voidPromise.succeed(())
         self._succeededVoidFuture = voidPromise.futureResult
+        preconditionInEventLoop()
+        precondition(self._uniqueID.matchesCurrentThread)
     }
 
     deinit {
@@ -326,7 +333,7 @@ internal final class SelectableEventLoop: EventLoop, @unchecked Sendable {
     /// - see: `EventLoop.inEventLoop`
     @usableFromInline
     internal var inEventLoop: Bool {
-        thread.isCurrent
+        self._uniqueID.matchesCurrentThread
     }
 
     /// - see: `EventLoop.now`
@@ -809,6 +816,7 @@ internal final class SelectableEventLoop: EventLoop, @unchecked Sendable {
     /// Start processing I/O and tasks for this `SelectableEventLoop`. This method will continue running (and so block) until the `SelectableEventLoop` is closed.
     internal func run() throws {
         self.preconditionInEventLoop()
+
         defer {
             var iterations = 0
             var drained = false
@@ -1096,5 +1104,84 @@ extension SelectableEventLoop {
             }
             handler.didCancelScheduledCallback(eventLoop: self)
         }
+    }
+}
+
+@usableFromInline
+struct SelectableEventLoopUniqueID: Sendable {
+    @usableFromInline
+    static let _nextGroupID = ManagedAtomic<UInt64>(1)  // DO NOT MAKE THIS 0.
+
+    @usableFromInline
+    var _loopID: UInt32
+
+    @usableFromInline
+    let _groupID: UInt32
+
+    @inlinable
+    var groupID: Int {
+        Int(self._groupID)
+    }
+
+    @inlinable
+    var loopID: Int {
+        Int(self._loopID)
+    }
+
+    @inlinable
+    init(_loopID: UInt32, groupID: UInt32) {
+        self._loopID = _loopID
+        self._groupID = groupID
+    }
+
+    static func makeNextGroup() -> Self {
+        let groupID = Self._nextGroupID.loadThenWrappingIncrement(ordering: .relaxed)
+
+        // If we're crashing just below, we created more 2^32 ELGs -- unlikely.
+        return Self(_loopID: 1, groupID: UInt32(groupID))
+    }
+
+    mutating func nextLoop() {
+        self._loopID += 1
+    }
+
+    @inlinable
+    internal var matchesCurrentThread: Bool {
+        let threadUniqueID = c_nio_posix_get_el_id()
+        return threadUniqueID == self.packedEventLoopID
+    }
+
+    @inlinable
+    internal var packedEventLoopID: UInt {
+        #if arch(arm) || arch(i386) || arch(arm64_32) || arch(wasm32)
+        // 32 bit
+        // If we're crashing below, we created more than 2^16 (64ki) ELGs which is unsupported.
+        precondition(self._groupID < UInt32(UInt16.max), "too many event loops created")
+        precondition(self._loopID < UInt32(UInt16.max), "event loop group with too many event loops created")
+        let packedID = IntegerBitPacking.packUInt16UInt16(
+            UInt16(self._groupID),
+            UInt16(self._loopID)
+        )
+        #else
+        // 64 bit
+        let packedID = IntegerBitPacking.packUInt32UInt32(self._groupID, self._loopID)
+        #endif
+        assert(MemoryLayout<UInt>.size == MemoryLayout.size(ofValue: packedID))
+        return UInt(packedID)
+    }
+
+    internal func attachToCurrentThread() {
+        let existingPackedID = c_nio_posix_get_el_id()
+        precondition(existingPackedID == 0, "weird, current thread ID \(existingPackedID), expected 0")
+
+        let packedID = self.packedEventLoopID
+        c_nio_posix_set_el_id(UInt(packedID))
+    }
+
+    internal func detachFromCurrentThread() {
+        let existingPackedID = c_nio_posix_get_el_id()
+        precondition(existingPackedID == self.packedEventLoopID)
+
+        c_nio_posix_set_el_id(0)
     }
 }

--- a/Sources/NIOWebSocket/WebSocketFrameEncoder.swift
+++ b/Sources/NIOWebSocket/WebSocketFrameEncoder.swift
@@ -16,7 +16,7 @@ import NIOCore
 
 private let maxOneByteSize = 125
 private let maxTwoByteSize = Int(UInt16.max)
-#if arch(arm) || arch(i386) || arch(arm64_32)
+#if arch(arm) || arch(i386) || arch(arm64_32) || arch(wasm32)
 // on 32-bit platforms we can't put a whole UInt32 in an Int
 private let maxNIOFrameSize = Int(UInt32.max / 2)
 #else

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -1409,7 +1409,7 @@ class ByteBufferTest: XCTestCase {
     }
 
     func testAllocationOfReallyBigByteBuffer() throws {
-        #if arch(arm) || arch(i386) || arch(arm64_32)
+        #if arch(arm) || arch(i386) || arch(arm64_32) || arch(wasm32)
         // this test doesn't work on 32-bit platforms because the address space is only 4GB large and we're trying
         // to make a 4GB ByteBuffer which just won't fit. Even going down to 2GB won't make it better.
         return


### PR DESCRIPTION
### Motivation:

`inEventLoop` is very much in the performance path of SwiftNIO, especially these days with Concurrency, `NIOLoopBound` and friends. Previously, we relied on `pthread_equal(pthread_self(), myPthread)`, however, this could cause a number of issues.

1. Holding onto a `pthread_t` after `.join` is actually illegal (fixed in #3297)
2. ABA issues when `pthread_t` pointer are re-used for new pthreads
3. Fix would require a lock around `myPthread` which makes things (2x slower, even without contention)

### Modifications:

- New type `SelectableEventLoopUniqueID` which can be packed into a `UInt`
- Attach them into a C thread local
- Added `testInEventLoopABAProblem()` which does some basic testing (passes now, failed before this PR)

### Result:

- Even faster than the old, incorrect version
  - old: `measuring: el_in_eventloop_100M: 0.257395375, 0.241049208, 0.243188792, 0.259125916, 0.24843225, 0.229690125, 0.244281541, 0.225078834, 0.236395, 0.233305167` 
  - new: `measuring: el_in_eventloop_100M: 0.175561125, 0.187225625, 0.199269375, 0.19740975, 0.1922695, 0.179850958, 0.177612458, 0.17665125, 0.17897475, 0.18038775`
- More correct
- Groundwork to make #3297 not make things slower