### PR TITLE
Support options on AsyncTestingChannel and EmbeddedChannel

### DIFF
--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -617,7 +617,7 @@ public final class NIOAsyncTestingChannel: Channel {
             return result as! Option.Value
         }
 
-        guard let value = optionValue(for: option) else {
+        guard let value = self.optionValue(for: option) else {
             fatalError("option \(option) not supported")
         }
 
@@ -632,7 +632,7 @@ public final class NIOAsyncTestingChannel: Channel {
     @inlinable
     internal func addOption<Option: ChannelOption>(_ option: Option, value: Option.Value) {
         // override the option if it exists
-        _stateLock.withLockedValue { state in
+        self._stateLock.withLockedValue { state in
             var options = state.options
             let optionIndex = options.firstIndex(where: { $0.option is Option })
             if let optionIndex = optionIndex {

--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -636,7 +636,7 @@ public final class NIOAsyncTestingChannel: Channel {
             var options = state.options
             let optionIndex = options.firstIndex(where: { $0.option is Option })
             if let optionIndex = optionIndex {
-               options[optionIndex] = (option, value)
+                options[optionIndex] = (option, value)
             } else {
                 options.append((option, value))
             }

--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -264,6 +264,11 @@ public final class NIOAsyncTestingChannel: Channel {
     }
 
     public var options: [(option: any ChannelOption, value: any Sendable)] {
+        _options
+    }
+
+    @usableFromInline
+    internal var _options: [(option: any ChannelOption, value: any Sendable)] {
         get {
             self.stateLock.withLockedValue { $0.options }
         }
@@ -634,9 +639,9 @@ public final class NIOAsyncTestingChannel: Channel {
         // override the option if it exists
         let optionIndex = options.firstIndex(where: { $0.option is Option })
         if let optionIndex = optionIndex {
-            self.options[optionIndex] = (option, value)
+            self._options[optionIndex] = (option, value)
         } else {
-            self.options.append((option, value))
+            self._options.append((option, value))
         }
     }
 

--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -267,6 +267,8 @@ public final class NIOAsyncTestingChannel: Channel {
         }
     }
 
+    /// The `ChannelOption`s set on this channel.
+    /// - see: `NIOAsyncTestingChannel.setOption`
     public var options: [(option: any ChannelOption, value: any Sendable)] {
         self._stateLock.withLockedValue { $0.options }
     }

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -788,12 +788,13 @@ public final class EmbeddedChannel: Channel {
     /// - see: `Channel.isWritable`
     public var isWritable: Bool = true
 
-    public var options: [(option: any ChannelOption, value: any Sendable)] {
-        _options
-    }
 
     @usableFromInline
     internal var _options: [(option: any ChannelOption, value: any Sendable)] = []
+
+    /// The `ChannelOption`s set on this channel.
+    /// - see: `Embedded.setOption`
+    public var options: [(option: any ChannelOption, value: any Sendable)] { _options }
 
     /// Synchronously closes the `EmbeddedChannel`.
     ///

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -788,7 +788,6 @@ public final class EmbeddedChannel: Channel {
     /// - see: `Channel.isWritable`
     public var isWritable: Bool = true
 
-
     @usableFromInline
     internal var _options: [(option: any ChannelOption, value: any Sendable)] = []
 

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -794,7 +794,7 @@ public final class EmbeddedChannel: Channel {
 
     /// The `ChannelOption`s set on this channel.
     /// - see: `Embedded.setOption`
-    public var options: [(option: any ChannelOption, value: any Sendable)] { _options }
+    public var options: [(option: any ChannelOption, value: any Sendable)] { self._options }
 
     /// Synchronously closes the `EmbeddedChannel`.
     ///
@@ -1067,7 +1067,7 @@ public final class EmbeddedChannel: Channel {
 
     @inlinable
     internal func addOption<Option: ChannelOption>(_ option: Option, value: Option.Value) {
-        if let optionIndex = self.options.firstIndex(where: { $0.option is Option }) {
+        if let optionIndex = self._options.firstIndex(where: { $0.option is Option }) {
             self._options[optionIndex] = (option: option, value: value)
         } else {
             self._options.append((option: option, value: value))

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -788,8 +788,12 @@ public final class EmbeddedChannel: Channel {
     /// - see: `Channel.isWritable`
     public var isWritable: Bool = true
 
+    public var options: [(option: any ChannelOption, value: any Sendable)] {
+        _options
+    }
+
     @usableFromInline
-    internal var options: [(option: any ChannelOption, value: any Sendable)] = []
+    internal var _options: [(option: any ChannelOption, value: any Sendable)] = []
 
     /// Synchronously closes the `EmbeddedChannel`.
     ///
@@ -1063,9 +1067,9 @@ public final class EmbeddedChannel: Channel {
     @inlinable
     internal func addOption<Option: ChannelOption>(_ option: Option, value: Option.Value) {
         if let optionIndex = self.options.firstIndex(where: { $0.option is Option }) {
-            self.options[optionIndex] = (option: option, value: value)
+            self._options[optionIndex] = (option: option, value: value)
         } else {
-            self.options.append((option: option, value: value))
+            self._options.append((option: option, value: value))
         }
     }
 

--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -685,12 +685,12 @@ class AsyncTestingChannelTests: XCTestCase {
     func testGetSetOption() async throws {
         let channel = NIOAsyncTestingChannel()
         let option = ChannelOptions.socket(IPPROTO_IP, IP_TTL)
-        let _ = channel.setOption(option, value: 1)
+        let _ = try await channel.setOption(option, value: 1).get()
 
         let optionValue1 = try await channel.getOption(option).get()
         XCTAssertEqual(1, optionValue1)
 
-        let _ = channel.setOption(option, value: 2)
+        let _ = try await channel.setOption(option, value: 2).get()
         let optionValue2 = try await channel.getOption(option).get()
         XCTAssertEqual(2, optionValue2)
     }

--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -681,6 +681,19 @@ class AsyncTestingChannelTests: XCTestCase {
         try await XCTAsyncAssertEqual(buf, try await channel.waitForOutboundWrite(as: ByteBuffer.self))
         try await XCTAsyncAssertTrue(try await channel.finish().isClean)
     }
+
+    func testGetSetOption() async throws {
+        let channel = NIOAsyncTestingChannel()
+        let option = ChannelOptions.socket(IPPROTO_IP, IP_TTL)
+        let _ = channel.setOption(option, value: 1)
+
+        let optionValue1 = try await channel.getOption(option).get()
+        XCTAssertEqual(1, optionValue1)
+
+        let _ = channel.setOption(option, value: 2)
+        let optionValue2 = try await channel.getOption(option).get()
+        XCTAssertEqual(2, optionValue2)
+    }
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
@@ -692,4 +692,17 @@ class EmbeddedChannelTest: XCTestCase {
         XCTAssertEqual(buf, try channel.readOutbound(as: ByteBuffer.self))
         XCTAssertTrue(try channel.finish().isClean)
     }
+
+    func testGetSetOption() async throws {
+        let channel = EmbeddedChannel()
+        let option = ChannelOptions.socket(IPPROTO_IP, IP_TTL)
+        let _ = channel.setOption(option, value: 1)
+
+        let optionValue1 = try await channel.getOption(option).get()
+        XCTAssertEqual(1, optionValue1)
+
+        let _ = channel.setOption(option, value: 2)
+        let optionValue2 = try await channel.getOption(option).get()
+        XCTAssertEqual(2, optionValue2)
+    }
 }

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
@@ -693,16 +693,16 @@ class EmbeddedChannelTest: XCTestCase {
         XCTAssertTrue(try channel.finish().isClean)
     }
 
-    func testGetSetOption() async throws {
+    func testGetSetOption() throws {
         let channel = EmbeddedChannel()
         let option = ChannelOptions.socket(IPPROTO_IP, IP_TTL)
         let _ = channel.setOption(option, value: 1)
 
-        let optionValue1 = try await channel.getOption(option).get()
+        let optionValue1 = try channel.getOption(option).wait()
         XCTAssertEqual(1, optionValue1)
 
         let _ = channel.setOption(option, value: 2)
-        let optionValue2 = try await channel.getOption(option).get()
+        let optionValue2 = try channel.getOption(option).wait()
         XCTAssertEqual(2, optionValue2)
     }
 }


### PR DESCRIPTION
Support options on AsyncTestingChannel and EmbeddedChannel

Fixes #3305 

### Motivation:

The channels are intended for testing purposes so while most options have no practical use setting and getting them can be useful for testing.

For example a traceroute implementation will set TTL to the current hop number. Testing such an implementation requires the channels to pretend to support the TTL option.

### Modifications:

Added option storage to AsyncTestingChannel and EmbedededChannel and made `getOptionSync` and `setOptionSync` read and write from that storage.

### Result:

EmbeddedChannel and AsyncTestingChannel support changing their options.
