### PR TITLE
Call channel initializer when using async methods on pipe bootstrap

### DIFF
--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2635,9 +2635,9 @@ extension NIOPipeBootstrap {
             return channelOptions.applyAllChannelOptions(to: channel).flatMap {
                 if let bootstrapChannelInitializer {
                     bootstrapChannelInitializer(channel)
-                 } else {
+                } else {
                     channel.eventLoop.makeSucceededVoidFuture()
-                 }
+                }
             }
             .flatMap {
                 _ -> EventLoopFuture<ChannelInitializerResult> in

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2600,6 +2600,7 @@ extension NIOPipeBootstrap {
         let pipeChannelOutput: SelectablePipeHandle?
         let hasNoInputPipe: Bool
         let hasNoOutputPipe: Bool
+        let bootstrapChannelInitializer = self.channelInitializer
         do {
             if let input = input {
                 try self.validateFileDescriptorIsNotAFile(input)
@@ -2632,6 +2633,13 @@ extension NIOPipeBootstrap {
         func setupChannel() -> EventLoopFuture<ChannelInitializerResult> {
             eventLoop.assertInEventLoop()
             return channelOptions.applyAllChannelOptions(to: channel).flatMap {
+                if let bootstrapChannelInitializer {
+                    bootstrapChannelInitializer(channel)
+                 } else {
+                    channel.eventLoop.makeSucceededVoidFuture()
+                 }
+            }
+            .flatMap {
                 _ -> EventLoopFuture<ChannelInitializerResult> in
                 channelInitializer(channel)
             }.flatMap { result in


### PR DESCRIPTION
Motivation:

For our async initializers on bootstraps, it's imortant that _both_ channel initializers are called, not only the one that comes as an argument on the bind function.

Modifications:

Fix the takeOwnershipOfDescriptor async functions to call the initializer from the bootstrap, and add regression tests.

Result:

Better behaved code.