### PR TITLE
Remove Foundation import

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,6 @@
 
 import PackageDescription
 
-// Used only for environment variables, does not make its way
-// into the product code.
-import class Foundation.ProcessInfo
-
 let swiftAtomics: PackageDescription.Target.Dependency = .product(name: "Atomics", package: "swift-atomics")
 let swiftCollections: PackageDescription.Target.Dependency = .product(name: "DequeModule", package: "swift-collections")
 let swiftSystem: PackageDescription.Target.Dependency = .product(name: "SystemPackage", package: "swift-system")


### PR DESCRIPTION
Motivation:

The package manifest imports Foundation.ProcessInfo to read environment variables ... but doesn't.

Modifications:

- Remove unused import

Result:

- Fewer Foundation imports