### PR TITLE
[Issue-3274] - Add Request and Response to notUpgradingHandler

### DIFF
--- a/Sources/NIOHTTP1/NIOTypedHTTPClientUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPClientUpgraderStateMachine.swift
@@ -160,7 +160,7 @@ struct NIOTypedHTTPClientUpgraderStateMachine<UpgradeResult> {
     @usableFromInline
     enum ChannelReadResponsePartAction {
         case fireErrorCaughtAndRemoveHandler(Error)
-        case runNotUpgradingInitializer
+        case runNotUpgradingInitializer(HTTPResponseHead)
         case startUpgrading(
             upgrader: any NIOTypedHTTPClientProtocolUpgrader<UpgradeResult>,
             responseHeaders: HTTPResponseHead
@@ -187,7 +187,7 @@ struct NIOTypedHTTPClientUpgraderStateMachine<UpgradeResult> {
                 var buffer = Deque<NIOAny>()
                 buffer.append(.init(responsePart))
                 self.state = .upgrading(.init(buffer: buffer))
-                return .runNotUpgradingInitializer
+                return .runNotUpgradingInitializer(response)
             }
 
             // Ok, we have a HTTP response. Check if it's an upgrade confirmation.

--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
@@ -137,7 +137,7 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
     @usableFromInline
     enum ChannelReadRequestPartAction {
         case failUpgradePromise(Error)
-        case runNotUpgradingInitializer
+        case runNotUpgradingInitializer(HTTPRequestHead)
         case startUpgrading(
             upgrader: any NIOTypedHTTPServerProtocolUpgrader<UpgradeResult>,
             requestHead: HTTPRequestHead,
@@ -170,7 +170,7 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
                 var buffer = Deque<NIOAny>()
                 buffer.append(NIOAny(requestPart))
                 self.state = .upgrading(.init(buffer: buffer))
-                return .runNotUpgradingInitializer
+                return .runNotUpgradingInitializer(head)
             }
 
             // We can now transition to awaiting the upgrader. This means that we are trying to
@@ -298,7 +298,7 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
             responseHeaders: HTTPHeaders,
             proto: String
         )
-        case runNotUpgradingInitializer
+        case runNotUpgradingInitializer(HTTPRequestHead)
         case fireErrorCaughtAndStartUnbuffering(Error)
         case fireErrorCaughtAndRemoveHandler(Error)
     }
@@ -342,7 +342,7 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
                 // There was no upgrader to handle the request. We just run the not upgrading
                 // initializer now.
                 self.state = .upgrading(.init(buffer: awaitingUpgrader.buffer))
-                return .runNotUpgradingInitializer
+                return .runNotUpgradingInitializer(requestHead)
 
             case .failure(let error):
                 if !awaitingUpgrader.buffer.isEmpty {

--- a/Sources/NIOWebSocketClient/Client.swift
+++ b/Sources/NIOWebSocketClient/Client.swift
@@ -75,7 +75,7 @@ struct Client {
                     let clientUpgradeConfiguration = NIOTypedHTTPClientUpgradeConfiguration(
                         upgradeRequestHead: requestHead,
                         upgraders: [upgrader],
-                        notUpgradingCompletionHandler: { channel in
+                        notUpgradingCompletionHandler: { channel, _ in
                             channel.eventLoop.makeCompletedFuture {
                                 UpgradeResult.notUpgraded
                             }

--- a/Sources/NIOWebSocketServer/Server.swift
+++ b/Sources/NIOWebSocketServer/Server.swift
@@ -95,7 +95,7 @@ struct Server {
 
                 let serverUpgradeConfiguration = NIOTypedHTTPServerUpgradeConfiguration(
                     upgraders: [upgrader],
-                    notUpgradingCompletionHandler: { channel in
+                    notUpgradingCompletionHandler: { channel, requestHead in
                         channel.eventLoop.makeCompletedFuture {
                             try channel.pipeline.syncOperations.addHandler(HTTPByteBufferResponsePartHandler())
                             let asyncChannel = try NIOAsyncChannel<

--- a/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPClientUpgradeTests.swift
@@ -1088,7 +1088,7 @@ final class TypedHTTPClientUpgradeTestCase: HTTPClientUpgradeTestCase {
         let config = NIOTypedHTTPClientUpgradeConfiguration<Bool>(
             upgradeRequestHead: requestHead,
             upgraders: upgraders
-        ) { channel in
+        ) { channel, _ in
             channel.eventLoop.makeCompletedFuture {
                 try channel.pipeline.syncOperations.addHandler(clientHTTPHandler)
             }.map { _ in

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -1781,8 +1781,8 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
                     var configuration = NIOUpgradableHTTPServerPipelineConfiguration(
                         upgradeConfiguration: .init(
                             upgraders: upgraders.map { $0 as! any NIOTypedHTTPServerProtocolUpgrader<Bool> },
-                            notUpgradingCompletionHandler: {
-                                notUpgradingHandler?($0) ?? $0.eventLoop.makeSucceededFuture(false)
+                            notUpgradingCompletionHandler: { channel, _ in
+                                notUpgradingHandler?(channel) ?? channel.eventLoop.makeSucceededFuture(false)
                             }
                         )
                     )

--- a/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketClientEndToEndTests.swift
@@ -462,7 +462,7 @@ class WebSocketClientEndToEndTests: XCTestCase {
 final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
     func setUpClientChannel(
         clientUpgraders: [any NIOTypedHTTPClientProtocolUpgrader<Void>],
-        notUpgradingCompletionHandler: @Sendable @escaping (Channel) -> EventLoopFuture<Void>
+        notUpgradingCompletionHandler: @Sendable @escaping (Channel, HTTPResponseHead) -> EventLoopFuture<Void>
     ) throws -> (EmbeddedChannel, EventLoopFuture<Void>) {
 
         let channel = EmbeddedChannel()
@@ -508,7 +508,7 @@ final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
         // The process should kick-off independently by sending the upgrade request to the server.
         let (clientChannel, upgradeResult) = try setUpClientChannel(
             clientUpgraders: [basicUpgrader],
-            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+            notUpgradingCompletionHandler: { channel, _ in channel.eventLoop.makeSucceededVoidFuture() }
         )
 
         // Read the server request.
@@ -577,7 +577,7 @@ final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
         // The process should kick-off independently by sending the upgrade request to the server.
         let (clientChannel, upgradeResult) = try setUpClientChannel(
             clientUpgraders: [basicUpgrader],
-            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+            notUpgradingCompletionHandler: { channel, _ in channel.eventLoop.makeSucceededVoidFuture() }
         )
 
         // Push the successful server response but with a missing accept key.
@@ -610,7 +610,7 @@ final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
         // The process should kick-off independently by sending the upgrade request to the server.
         let (clientChannel, upgradeResult) = try setUpClientChannel(
             clientUpgraders: [basicUpgrader],
-            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+            notUpgradingCompletionHandler: { channel, _ in channel.eventLoop.makeSucceededVoidFuture() }
         )
 
         // Push the successful server response but with an incorrect response key.
@@ -644,7 +644,7 @@ final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
         // The process should kick-off independently by sending the upgrade request to the server.
         let (clientChannel, upgradeResult) = try setUpClientChannel(
             clientUpgraders: [basicUpgrader],
-            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+            notUpgradingCompletionHandler: { channel, _ in channel.eventLoop.makeSucceededVoidFuture() }
         )
 
         // Push the successful server response with an incorrect protocol.
@@ -677,7 +677,7 @@ final class TypedWebSocketClientEndToEndTests: WebSocketClientEndToEndTests {
         // The process should kick-off independently by sending the upgrade request to the server.
         let (clientChannel, upgradeResult) = try setUpClientChannel(
             clientUpgraders: [basicUpgrader],
-            notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+            notUpgradingCompletionHandler: { channel, _ in channel.eventLoop.makeSucceededVoidFuture() }
         )
 
         // Push the successful server response.

--- a/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
+++ b/Tests/NIOWebSocketTests/WebSocketServerEndToEndTests.swift
@@ -672,7 +672,7 @@ final class TypedWebSocketServerEndToEndTests: WebSocketServerEndToEndTests {
                 configuration: .init(
                     upgradeConfiguration: NIOTypedHTTPServerUpgradeConfiguration<Void>(
                         upgraders: upgraders,
-                        notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededVoidFuture() }
+                        notUpgradingCompletionHandler: { channel, _ in channel.eventLoop.makeSucceededVoidFuture() }
                     )
                 )
             )


### PR DESCRIPTION
Motivation:

Solve Issue 3274

Modifications:
Allow HTTPResponseHead and HTTPRequestHead to be sent via the notUpgradingCOmpletionHandler

Result:

You can access the request or response when configuring the not upgrading completion handler

