### PR TITLE
CMake Updater: Output difference in expectations

### DIFF
--- a/scripts/update-cmake-lists.sh
+++ b/scripts/update-cmake-lists.sh
@@ -129,7 +129,7 @@ done
 
 if [[ "${fail_on_changes}" == true ]]; then
     if [ -n "$(git status --untracked-files=no --porcelain)" ]; then
-        fatal "Changes in the cmake files detected. Please update."
+        fatal "Changes in the cmake files detected. Please update. -- $(git diff)"
     else
         log "✅ CMake files are up-to-date."
     fi


### PR DESCRIPTION
Teach the script to indicate what is different on failure rather than keeping quiet. This helps when the script is failing in CI but not locally.

### Motivation:

The script is reporting that there are missing changes in CI on swift-crypto, but I am unable to reproduce them locally. This is to get immediate insight on why the check fails rather than keeping quiet.

### Modifications:

Include the diff in the update-cmake-lists script.

### Result:

update-cmake-lists script outputs the difference between what is in a PR vs what it expects to see instead of shrugging and leaving it as an exercise to the user.
