### PR TITLE
[Windows] Windows has endianess too

### DIFF
--- a/Sources/CNIOSHA1/c_nio_sha1.c
+++ b/Sources/CNIOSHA1/c_nio_sha1.c
@@ -56,6 +56,16 @@
 #include <sys/endian.h>
 #elif defined(__linux__) || defined(__APPLE__) || defined(__wasm32__)
 #include <sys/types.h>
+#elif defined(_WIN32) || defined(_WIN64)
+	#ifndef LITTLE_ENDIAN
+	#define LITTLE_ENDIAN 1234
+	#endif
+	#ifndef BIG_ENDIAN
+	#define BIG_ENDIAN 4321
+	#endif
+	#ifndef BYTE_ORDER
+	#define BYTE_ORDER LITTLE_ENDIAN
+	#endif
 #endif
 
 


### PR DESCRIPTION
TIL there is an `endian.h` on Linux and macOS that is imported through `<sys/types.h>` on Linux and Apple platforms. Apparently such a header file does not exist in Windows land. For this reason we need to define the macros that we need here ourselves.