### PR TITLE
Enable release mode builds for pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,11 +22,6 @@ jobs:
       linux_nightly_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
-  release-builds:
-    name: Release builds
-    # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/release_builds.yml@release-builds
-
   benchmarks:
     name: Benchmarks
     # Workaround https://github.com/nektos/act/issues/1875

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,11 @@ jobs:
       linux_nightly_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
+  release-builds:
+    name: Release builds
+    # Workaround https://github.com/nektos/act/issues/1875
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+
   benchmarks:
     name: Benchmarks
     # Workaround https://github.com/nektos/act/issues/1875

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
   release-builds:
     name: Release builds
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@release-builds
 
   benchmarks:
     name: Benchmarks

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -3,14 +3,6 @@ name: Release builds
 on:
   workflow_call:
     inputs:
-      linux_5_9_enabled:
-        type: boolean
-        description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to false."
-        default: false
-      linux_5_9_arguments_override:
-        type: string
-        description: "The arguments passed to swift test in the Linux 5.9 Swift version matrix job."
-        default: ""
       linux_5_10_enabled:
         type: boolean
         description: "Boolean to enable the Linux 5.10 Swift version matrix job. Defaults to true."
@@ -34,22 +26,6 @@ on:
       linux_6_1_arguments_override:
         type: string
         description: "The arguments passed to swift test in the Linux 6.1 Swift version matrix job."
-        default: ""
-      linux_nightly_6_0_enabled:
-        type: boolean
-        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
-        default: true
-      linux_nightly_6_0_arguments_override:
-        type: string
-        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
-        default: ""
-      linux_nightly_6_1_enabled:
-        type: boolean
-        description: "⚠️  Deprecated, use linux_nightly_next_enabled."
-        default: true
-      linux_nightly_6_1_arguments_override:
-        type: string
-        description: "⚠️  Deprecated, use linux_nightly_next_arguments_override."
         default: ""
       linux_nightly_next_enabled:
         type: boolean
@@ -84,22 +60,6 @@ on:
         type: string
         description: "The arguments passed to swift test in the Windows 6.1 Swift version matrix job."
         default: ""
-      windows_nightly_6_0_enabled:
-        type: boolean
-        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
-        default: false
-      windows_nightly_6_0_arguments_override:
-        type: string
-        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
-        default: ""
-      windows_nightly_6_1_enabled:
-        type: boolean
-        description: "⚠️  Deprecated, use windows_nightly_next_enabled."
-        default: false
-      windows_nightly_6_1_arguments_override:
-        type: string
-        description: "⚠️  Deprecated, use windows_nightly_next_arguments_override."
-        default: ""
       windows_nightly_next_enabled:
         type: boolean
         description: "Boolean to enable the Windows matrix job using the nightly build for the next Swift version. Defaults to true."
@@ -133,16 +93,14 @@ jobs:
         env:
           MATRIX_LINUX_SETUP_COMMAND: "swift --version"
           MATRIX_LINUX_COMMAND: "swift build -c release"
-          MATRIX_LINUX_5_9_ENABLED: ${{ inputs.linux_5_9_enabled }}
-          MATRIX_LINUX_5_9_COMMAND_ARGUMENTS: ${{ inputs.linux_5_9_arguments_override }}
           MATRIX_LINUX_5_10_ENABLED: ${{ inputs.linux_5_10_enabled }}
           MATRIX_LINUX_5_10_COMMAND_ARGUMENTS: ${{ inputs.linux_5_10_arguments_override }}
           MATRIX_LINUX_6_0_ENABLED: ${{ inputs.linux_6_0_enabled }}
           MATRIX_LINUX_6_0_COMMAND_ARGUMENTS: ${{ inputs.linux_6_0_arguments_override }}
           MATRIX_LINUX_6_1_ENABLED: ${{ inputs.linux_6_1_enabled }}
           MATRIX_LINUX_6_1_COMMAND_ARGUMENTS: ${{ inputs.linux_6_1_arguments_override }}
-          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: ${{ inputs.linux_nightly_6_1_enabled && inputs.linux_nightly_next_enabled }}
-          MATRIX_LINUX_NIGHTLY_NEXT_COMMAND_ARGUMENTS: ${{ inputs.linux_nightly_6_1_arguments_override }} ${{ inputs.linux_nightly_next_arguments_override }}
+          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: ${{ inputs.linux_nightly_next_enabled }}
+          MATRIX_LINUX_NIGHTLY_NEXT_COMMAND_ARGUMENTS: ${{ inputs.linux_nightly_next_arguments_override }}
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: ${{ inputs.linux_nightly_main_enabled }}
           MATRIX_LINUX_NIGHTLY_MAIN_COMMAND_ARGUMENTS: ${{ inputs.linux_nightly_main_arguments_override }}
           MATRIX_WINDOWS_COMMAND: "swift build -c release"
@@ -150,8 +108,8 @@ jobs:
           MATRIX_WINDOWS_6_0_COMMAND_ARGUMENTS: ${{ inputs.windows_6_0_arguments_override }}
           MATRIX_WINDOWS_6_1_ENABLED: ${{ inputs.windows_6_1_enabled }}
           MATRIX_WINDOWS_6_1_COMMAND_ARGUMENTS: ${{ inputs.windows_6_1_arguments_override }}
-          MATRIX_WINDOWS_NIGHTLY_NEXT_ENABLED: ${{ inputs.windows_nightly_6_1_enabled && inputs.windows_nightly_next_enabled }}
-          MATRIX_WINDOWS_NIGHTLY_NEXT_COMMAND_ARGUMENTS: ${{ inputs.windows_nightly_6_1_arguments_override }} ${{ inputs.windows_nightly_next_arguments_override }}
+          MATRIX_WINDOWS_NIGHTLY_NEXT_ENABLED: ${{ inputs.windows_nightly_next_enabled }}
+          MATRIX_WINDOWS_NIGHTLY_NEXT_COMMAND_ARGUMENTS: ${{ inputs.windows_nightly_next_arguments_override }}
           MATRIX_WINDOWS_NIGHTLY_MAIN_ENABLED: ${{ inputs.windows_nightly_main_enabled }}
           MATRIX_WINDOWS_NIGHTLY_MAIN_COMMAND_ARGUMENTS: ${{ inputs.windows_nightly_main_arguments_override }}
 

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -1,0 +1,165 @@
+name: Release builds
+
+on:
+  workflow_call:
+    inputs:
+      linux_5_9_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to false."
+        default: false
+      linux_5_9_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux 5.9 Swift version matrix job."
+        default: ""
+      linux_5_10_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 5.10 Swift version matrix job. Defaults to true."
+        default: true
+      linux_5_10_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux 5.10 Swift version matrix job."
+        default: ""
+      linux_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 6.0 Swift version matrix job. Defaults to true."
+        default: true
+      linux_6_0_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux 6.0 Swift version matrix job."
+        default: ""
+      linux_6_1_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 6.1 Swift version matrix job. Defaults to true."
+        default: true
+      linux_6_1_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux 6.1 Swift version matrix job."
+        default: ""
+      linux_nightly_6_0_enabled:
+        type: boolean
+        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
+        default: true
+      linux_nightly_6_0_arguments_override:
+        type: string
+        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
+        default: ""
+      linux_nightly_6_1_enabled:
+        type: boolean
+        description: "⚠️  Deprecated, use linux_nightly_next_enabled."
+        default: true
+      linux_nightly_6_1_arguments_override:
+        type: string
+        description: "⚠️  Deprecated, use linux_nightly_next_arguments_override."
+        default: ""
+      linux_nightly_next_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux matrix job using the nightly build for the next Swift version. Defaults to true."
+        default: true
+      linux_nightly_next_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux matrix job using the nightly build for the next Swift version."
+        default: ""
+      linux_nightly_main_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux nightly main Swift version matrix job. Defaults to true."
+        default: true
+      linux_nightly_main_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux nightly main Swift version matrix job."
+        default: ""
+
+      windows_6_0_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows 6.0 Swift version matrix job. Defaults to false."
+        default: false
+      windows_6_0_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Windows 6.0 Swift version matrix job."
+        default: ""
+      windows_6_1_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows 6.1 Swift version matrix job. Defaults to false."
+        default: false
+      windows_6_1_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Windows 6.1 Swift version matrix job."
+        default: ""
+      windows_nightly_6_0_enabled:
+        type: boolean
+        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
+        default: false
+      windows_nightly_6_0_arguments_override:
+        type: string
+        description: "⚠️  Deprecated, we no longer run against 6.0 nightly."
+        default: ""
+      windows_nightly_6_1_enabled:
+        type: boolean
+        description: "⚠️  Deprecated, use windows_nightly_next_enabled."
+        default: false
+      windows_nightly_6_1_arguments_override:
+        type: string
+        description: "⚠️  Deprecated, use windows_nightly_next_arguments_override."
+        default: ""
+      windows_nightly_next_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows matrix job using the nightly build for the next Swift version. Defaults to true."
+        default: true
+      windows_nightly_next_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Windows matrix job using the nightly build for the next Swift version."
+        default: ""
+      windows_nightly_main_enabled:
+        type: boolean
+        description: "Boolean to enable the Windows nightly main Swift version matrix job. Defaults to false."
+        default: false
+      windows_nightly_main_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Windows nightly main Swift version matrix job."
+        default: ""
+
+jobs:
+  construct-matrix:
+    name: Construct release build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      release-build-matrix: '${{ steps.generate-matrix.outputs.release-build-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "release-build-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: "swift --version"
+          MATRIX_LINUX_COMMAND: "swift build -c release"
+          MATRIX_LINUX_5_9_ENABLED: ${{ inputs.linux_5_9_enabled }}
+          MATRIX_LINUX_5_9_COMMAND_ARGUMENTS: ${{ inputs.linux_5_9_arguments_override }}
+          MATRIX_LINUX_5_10_ENABLED: ${{ inputs.linux_5_10_enabled }}
+          MATRIX_LINUX_5_10_COMMAND_ARGUMENTS: ${{ inputs.linux_5_10_arguments_override }}
+          MATRIX_LINUX_6_0_ENABLED: ${{ inputs.linux_6_0_enabled }}
+          MATRIX_LINUX_6_0_COMMAND_ARGUMENTS: ${{ inputs.linux_6_0_arguments_override }}
+          MATRIX_LINUX_6_1_ENABLED: ${{ inputs.linux_6_1_enabled }}
+          MATRIX_LINUX_6_1_COMMAND_ARGUMENTS: ${{ inputs.linux_6_1_arguments_override }}
+          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: ${{ inputs.linux_nightly_6_1_enabled && inputs.linux_nightly_next_enabled }}
+          MATRIX_LINUX_NIGHTLY_NEXT_COMMAND_ARGUMENTS: ${{ inputs.linux_nightly_6_1_arguments_override }} ${{ inputs.linux_nightly_next_arguments_override }}
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: ${{ inputs.linux_nightly_main_enabled }}
+          MATRIX_LINUX_NIGHTLY_MAIN_COMMAND_ARGUMENTS: ${{ inputs.linux_nightly_main_arguments_override }}
+          MATRIX_WINDOWS_COMMAND: "swift build -c release"
+          MATRIX_WINDOWS_6_0_ENABLED: ${{ inputs.windows_6_0_enabled }}
+          MATRIX_WINDOWS_6_0_COMMAND_ARGUMENTS: ${{ inputs.windows_6_0_arguments_override }}
+          MATRIX_WINDOWS_6_1_ENABLED: ${{ inputs.windows_6_1_enabled }}
+          MATRIX_WINDOWS_6_1_COMMAND_ARGUMENTS: ${{ inputs.windows_6_1_arguments_override }}
+          MATRIX_WINDOWS_NIGHTLY_NEXT_ENABLED: ${{ inputs.windows_nightly_6_1_enabled && inputs.windows_nightly_next_enabled }}
+          MATRIX_WINDOWS_NIGHTLY_NEXT_COMMAND_ARGUMENTS: ${{ inputs.windows_nightly_6_1_arguments_override }} ${{ inputs.windows_nightly_next_arguments_override }}
+          MATRIX_WINDOWS_NIGHTLY_MAIN_ENABLED: ${{ inputs.windows_nightly_main_enabled }}
+          MATRIX_WINDOWS_NIGHTLY_MAIN_COMMAND_ARGUMENTS: ${{ inputs.windows_nightly_main_arguments_override }}
+
+  release-builds:
+    name: Release builds
+    needs: construct-matrix
+    # Workaround https://github.com/nektos/act/issues/1875
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: "Release builds"
+      matrix_string: '${{ needs.construct-matrix.outputs.release-build-matrix }}'


### PR DESCRIPTION
Add workflow to release mode build

### Motivation:

Some errors do not show up in debug builds. Running release mode builds improves the CI coverage.

### Modifications:

Add a new workflow for release mode builds.

### Result:

The CI can perform release mode builds.
