### PR TITLE
Don't double-initialize Pipe Bootstraps

### DIFF
--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2419,7 +2419,7 @@ public final class NIOPipeBootstrap {
     }
 
     private func _takingOwnershipOfDescriptors(input: CInt?, output: CInt?) -> EventLoopFuture<Channel> {
-        return self._takingOwnershipOfDescriptors(
+        self._takingOwnershipOfDescriptors(
             input: input,
             output: output
         ) { channel in

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2419,23 +2419,12 @@ public final class NIOPipeBootstrap {
     }
 
     private func _takingOwnershipOfDescriptors(input: CInt?, output: CInt?) -> EventLoopFuture<Channel> {
-        let channelInitializer: @Sendable (Channel) -> EventLoopFuture<Channel> = {
-            let eventLoop = self.group.next()
-            let channelInitializer = self.channelInitializer
-            return { channel in
-                if let channelInitializer = channelInitializer {
-                    return channelInitializer(channel).map { channel }
-                } else {
-                    return eventLoop.makeSucceededFuture(channel)
-                }
-            }
-
-        }()
         return self._takingOwnershipOfDescriptors(
             input: input,
-            output: output,
-            channelInitializer: channelInitializer
-        )
+            output: output
+        ) { channel in
+            channel.eventLoop.makeSucceededFuture(channel)
+        }
     }
 
     @available(*, deprecated, renamed: "takingOwnershipOfDescriptor(inputOutput:)")

--- a/Tests/NIOPosixTests/BootstrapTest.swift
+++ b/Tests/NIOPosixTests/BootstrapTest.swift
@@ -868,34 +868,34 @@ class BootstrapTest: XCTestCase {
     func testNoDoubleAddOnPipeBootstrapTakingOwnership_inputOutput() throws {
         try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
             $0.takingOwnershipOfDescriptor(inputOutput: $1)
-         }
+        }
     }
 
     func testNoDoubleAddOnPipeBootstrapTakingOwnership_input() throws {
         try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
             $0.takingOwnershipOfDescriptor(input: $1)
-         }
+        }
     }
 
     func testNoDoubleAddOnPipeBootstrapTakingOwnership_output() throws {
         try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
             $0.takingOwnershipOfDescriptor(output: $1)
-         }
+        }
     }
 
     func testNoDoubleAddOnPipeBootstrapTakingOwnership_inputOutputSeparate() throws {
         try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
             $0.takingOwnershipOfDescriptors(input: $1, output: dup($1))
-         }
+        }
     }
 }
 
 private final class AddOnceHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = Any
-    
+
     let added = NIOLockedValueBox(0)
 
-    init() { }
+    init() {}
 
     func handlerAdded(context: ChannelHandlerContext) {
         self.added.withLockedValue { $0 += 1 }

--- a/Tests/NIOPosixTests/BootstrapTest.swift
+++ b/Tests/NIOPosixTests/BootstrapTest.swift
@@ -823,6 +823,83 @@ class BootstrapTest: XCTestCase {
         let channelFuture = bootstrap?.takingOwnershipOfDescriptor(inputOutput: sock)
         XCTAssertThrowsError(try channelFuture?.wait())
     }
+
+    private func doTestNoDoubleAddOnPipeBootstrapTakingOwnership(
+        _ method: (NIOPipeBootstrap, CInt) -> EventLoopFuture<Channel>
+    ) throws {
+        var socketPair: [CInt] = [-1, -1]
+        XCTAssertNoThrow(
+            try socketPair.withUnsafeMutableBufferPointer { socketPairPtr in
+                precondition(socketPairPtr.count == 2)
+                try Posix.socketpair(
+                    domain: .local,
+                    type: .stream,
+                    protocolSubtype: .default,
+                    socketVector: socketPairPtr.baseAddress
+                )
+            }
+        )
+        defer {
+            XCTAssertNoThrow(try socketPair.filter { $0 > 0 }.forEach(Posix.close(descriptor:)))
+        }
+
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try elg.syncShutdownGracefully())
+        }
+
+        let handler = AddOnceHandler()
+        let bootstrap = NIOPipeBootstrap(group: elg)
+            .channelInitializer { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    try channel.pipeline.syncOperations.addHandler(handler)
+                }
+            }
+
+        let channel = try method(bootstrap, dup(socketPair[0])).wait()
+
+        defer {
+            try! channel.close().wait()
+        }
+
+        XCTAssertEqual(handler.added.withLockedValue { $0 }, 1)
+    }
+
+    func testNoDoubleAddOnPipeBootstrapTakingOwnership_inputOutput() throws {
+        try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
+            $0.takingOwnershipOfDescriptor(inputOutput: $1)
+         }
+    }
+
+    func testNoDoubleAddOnPipeBootstrapTakingOwnership_input() throws {
+        try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
+            $0.takingOwnershipOfDescriptor(input: $1)
+         }
+    }
+
+    func testNoDoubleAddOnPipeBootstrapTakingOwnership_output() throws {
+        try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
+            $0.takingOwnershipOfDescriptor(output: $1)
+         }
+    }
+
+    func testNoDoubleAddOnPipeBootstrapTakingOwnership_inputOutputSeparate() throws {
+        try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
+            $0.takingOwnershipOfDescriptors(input: $1, output: dup($1))
+         }
+    }
+}
+
+private final class AddOnceHandler: ChannelInboundHandler, Sendable {
+    typealias InboundIn = Any
+    
+    let added = NIOLockedValueBox(0)
+
+    init() { }
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        self.added.withLockedValue { $0 += 1 }
+    }
 }
 
 private final class WriteStringOnChannelActive: ChannelInboundHandler {


### PR DESCRIPTION
Motivation:

In #3309 I fixed an issue where the channel initializer would not be called in some PipeBootstrap paths. Unfortunately, that introduced a new bug where the initializer was now called twice on some other paths.

Modifications:

Get the number of calls back to 1 on the non-async paths. Add some tests

Result:

Better pipe bootstrap behaviour.
