### PR TITLE
Add Android imports for some new tests in #3308 that require it

### DIFF
--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -18,6 +18,10 @@ import XCTest
 
 @testable import NIOEmbedded
 
+#if canImport(Android)
+import Android
+#endif
+
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class AsyncTestingChannelTests: XCTestCase {
     func testSingleHandlerInit() async throws {

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
@@ -19,6 +19,10 @@ import XCTest
 
 @testable import NIOEmbedded
 
+#if canImport(Android)
+import Android
+#endif
+
 final class ChannelLifecycleHandler: ChannelInboundHandler, Sendable {
     public typealias InboundIn = Any
 


### PR DESCRIPTION
My Android CI [just broke because it couldn't find these newly used C symbols in the NIO tests](https://github.com/finagolfin/swift-android-sdk/actions/runs/16768316992/job/47477878652#step:19:242), this patch [fixed it again](https://github.com/finagolfin/swift-android-sdk/actions/runs/16787226279/job/47540691932). Unsure why this only affects Android, likely the module leaks postulated before.