### PR TITLE
[Windows] Ensure NIOHTTP1 compiles

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -110,7 +110,7 @@ private class BetterHTTPParser {
                 versionMinor: Int(opaque!.pointee.http_minor),
                 statusCode: Int(opaque!.pointee.status_code),
                 isUpgrade: opaque!.pointee.upgrade != 0,
-                method: llhttp_method(rawValue: CUnsignedInt(opaque!.pointee.method)),
+                method: llhttp_method(rawValue: numericCast(opaque!.pointee.method)),
                 keepAliveState: opaque!.keepAliveState
             ) {
             case .normal:


### PR DESCRIPTION
This only needs one `numericCast`.

Previous error:
```
C:\Users\fat\Developer\apple\swift-nio\Sources\NIOHTTP1\HTTPDecoder.swift:113:49: error: cannot convert value of type 'CUnsignedInt' (aka 'UInt32') to expected argument type 'Int32'
 111 |                 statusCode: Int(opaque!.pointee.status_code),
 112 |                 isUpgrade: opaque!.pointee.upgrade != 0,
 113 |                 method: llhttp_method(rawValue: CUnsignedInt(opaque!.pointee.method)),
     |                                                 `- error: cannot convert value of type 'CUnsignedInt' (aka 'UInt32') to expected argument type 'Int32'
 114 |                 keepAliveState: opaque!.keepAliveState
 115 |             ) {
```