### PR TITLE
[Windows] Make SelectableEventLoop compile

### DIFF
--- a/Sources/CNIOWindows/include/CNIOWindows.h
+++ b/Sources/CNIOWindows/include/CNIOWindows.h
@@ -107,6 +107,8 @@ WSACMSGHDR *NIO(CMSG_NXTHDR)(const WSAMSG *, LPWSACMSGHDR);
 size_t NIO(CMSG_LEN)(size_t);
 size_t NIO(CMSG_SPACE)(size_t);
 
+int NIO(errno)(void);
+
 #undef NIO
 
 #endif

--- a/Sources/CNIOWindows/shim.c
+++ b/Sources/CNIOWindows/shim.c
@@ -17,6 +17,7 @@
 #include "CNIOWindows.h"
 
 #include <assert.h>
+#include <errno.h>
 
 int CNIOWindows_sendmmsg(SOCKET s, CNIOWindows_mmsghdr *msgvec, unsigned int vlen,
                          int flags) {
@@ -53,6 +54,10 @@ size_t CNIOWindows_CMSG_LEN(size_t length) {
 
 size_t CNIOWindows_CMSG_SPACE(size_t length) {
   return WSA_CMSG_SPACE(length);
+}
+
+int CNIOWindows_errno(void) {
+    return errno;
 }
 
 #endif

--- a/Sources/NIOPosix/Windows.swift
+++ b/Sources/NIOPosix/Windows.swift
@@ -14,7 +14,18 @@
 
 #if os(Windows)
 import WinSDK
+import CNIOWindows
 
 typealias ssize_t = SSIZE_T
+
+// overwrite the windows write method, as the one without underscore is deprecated.
+// also we can use this to downcast the count Int to UInt32
+func write(_ fd: Int32, _ ptr: UnsafeRawPointer?, _ count: Int) -> Int32 {
+    _write(fd, ptr, UInt32(clamping: count))
+}
+
+var errno: Int32 {
+    CNIOWindows_errno()
+}
 
 #endif


### PR DESCRIPTION
- Add overwrite for `write` method that calls undeprecated `_write`
- Add errno global readonly variable