### PR TITLE
Return response when header validation fails

### DIFF
--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -913,12 +913,65 @@ extension ChannelPipeline.SynchronousOperations {
         )
     }
 
+    /// Configure a `ChannelPipeline` for use as a HTTP server.
+    ///
+    /// This function knows how to set up all first-party HTTP channel handlers appropriately
+    /// for server use. It supports the following features:
+    ///
+    /// 1. Providing assistance handling clients that pipeline HTTP requests, using the
+    ///     `HTTPServerPipelineHandler`.
+    /// 2. Supporting HTTP upgrade, using the `HTTPServerUpgradeHandler`.
+    /// 3. Providing assistance handling protocol errors.
+    /// 4. Validating outbound header fields to protect against response splitting attacks.
+    /// 5. Specifying whether the header validation should return a response
+    ///
+    /// This method will likely be extended in future with more support for other first-party
+    /// features.
+    ///
+    /// - important: This **must** be called on the Channel's event loop.
+    /// - Parameters:
+    ///   - position: Where in the pipeline to add the HTTP server handlers, defaults to `.last`.
+    ///   - pipelining: Whether to provide assistance handling HTTP clients that pipeline
+    ///         their requests. Defaults to `true`. If `false`, users will need to handle
+    ///         clients that pipeline themselves.
+    ///   - upgrade: Whether to add a `HTTPServerUpgradeHandler` to the pipeline, configured for
+    ///         HTTP upgrade. Defaults to `nil`, which will not add the handler to the pipeline. If
+    ///         provided should be a tuple of an array of `HTTPServerProtocolUpgrader` and the upgrade
+    ///         completion handler. See the documentation on `HTTPServerUpgradeHandler` for more
+    ///         details.
+    ///   - errorHandling: Whether to provide assistance handling protocol errors (e.g.
+    ///         failure to parse the HTTP request) by sending 400 errors. Defaults to `true`.
+    ///   - headerValidation: Whether to validate outbound request headers to confirm that they meet
+    ///         spec compliance. Defaults to `true`.
+    ///   - encoderConfiguration: The configuration for the ``HTTPRequestEncoder``.
+    ///   - headerValidationResponse: Whether to return a response when the header validation fails.
+    /// - Throws: If the pipeline could not be configured.
+    public func configureHTTPServerPipeline(
+        position: ChannelPipeline.SynchronousOperations.Position = .last,
+        withPipeliningAssistance pipelining: Bool = true,
+        withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
+        withErrorHandling errorHandling: Bool = true,
+        withOutboundHeaderValidation headerValidation: Bool = true,
+        withEncoderConfiguration encoderConfiguration: HTTPResponseEncoder.Configuration = .init(),
+        withOutboundHeaderValidationRepsonse headerValidationResponse: Bool
+    ) throws {
+        try self._configureHTTPServerPipeline(
+            position: position,
+            withPipeliningAssistance: pipelining,
+            withServerUpgrade: upgrade,
+            withErrorHandling: errorHandling,
+            withOutboundHeaderValidation: headerValidation,
+            withOutboundHeaderValidationRepsonse: headerValidationResponse, withEncoderConfiguration: encoderConfiguration
+        )
+    }
+
     private func _configureHTTPServerPipeline(
         position: ChannelPipeline.SynchronousOperations.Position = .last,
         withPipeliningAssistance pipelining: Bool = true,
         withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
         withErrorHandling errorHandling: Bool = true,
         withOutboundHeaderValidation headerValidation: Bool = true,
+        withOutboundHeaderValidationRepsonse headerValidationResponse: Bool = true,
         withEncoderConfiguration encoderConfiguration: HTTPResponseEncoder.Configuration = .init()
     ) throws {
         self.eventLoop.assertInEventLoop()

--- a/Sources/NIOHTTP1/HTTPPipelineSetup.swift
+++ b/Sources/NIOHTTP1/HTTPPipelineSetup.swift
@@ -971,7 +971,7 @@ extension ChannelPipeline.SynchronousOperations {
         withServerUpgrade upgrade: NIOHTTPServerUpgradeConfiguration? = nil,
         withErrorHandling errorHandling: Bool = true,
         withOutboundHeaderValidation headerValidation: Bool = true,
-        withOutboundHeaderValidationRepsonse headerValidationResponse: Bool = true,
+        withOutboundHeaderValidationRepsonse headerValidationResponse: Bool = false,
         withEncoderConfiguration encoderConfiguration: HTTPResponseEncoder.Configuration = .init()
     ) throws {
         self.eventLoop.assertInEventLoop()
@@ -986,7 +986,7 @@ extension ChannelPipeline.SynchronousOperations {
         }
 
         if headerValidation {
-            handlers.append(NIOHTTPResponseHeadersValidator())
+            handlers.append(NIOHTTPResponseHeadersValidator(sendResponseOnInvalidHeader: headerValidationResponse))
         }
 
         if errorHandling {

--- a/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
@@ -635,6 +635,43 @@ final class HTTPHeaderValidationTests: XCTestCase {
         XCTAssertEqual(maybeReceivedHeadBytes, toleratedRequestBytes)
         XCTAssertEqual(maybeReceivedTrailerBytes, toleratedTrailerBytes)
     }
+
+    func testBadRequestResponseIsReturnedIfHeadersInvalidAndConfiguredToDoSo() throws {
+        let channel = EmbeddedChannel()
+        try channel.pipeline.syncOperations.configureHTTPServerPipeline(withOutboundHeaderValidationRepsonse: true)
+        try channel.primeForResponse()
+
+        func assertReadHead(from channel: EmbeddedChannel) throws {
+            if case .head = try channel.readInbound(as: HTTPServerRequestPart.self) {
+                ()
+            } else {
+                XCTFail("Expected 'head'")
+            }
+        }
+
+        func assertReadEnd(from channel: EmbeddedChannel) throws {
+            if case .end = try channel.readInbound(as: HTTPServerRequestPart.self) {
+                ()
+            } else {
+                XCTFail("Expected 'end'")
+            }
+        }
+
+        // Read the first request.
+        try assertReadHead(from: channel)
+        try assertReadEnd(from: channel)
+        XCTAssertNil(try channel.readInbound(as: HTTPServerRequestPart.self))
+
+        // Respond with bad headers; they should cause an error and result in the rest of the
+        // response being dropped.
+        let head = HTTPResponseHead(version: .http1_1, status: .ok, headers: [":pseudo-header": "not-here"])
+        XCTAssertThrowsError(try channel.writeOutbound(HTTPServerResponsePart.head(head)))
+        XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self))
+        XCTAssertThrowsError(try channel.writeOutbound(HTTPServerResponsePart.body(.byteBuffer(ByteBuffer()))))
+        XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self))
+        XCTAssertThrowsError(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
+        XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self))
+    }
 }
 
 extension EmbeddedChannel {

--- a/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
@@ -663,7 +663,7 @@ final class HTTPHeaderValidationTests: XCTestCase {
         XCTAssertNil(try channel.readInbound(as: HTTPServerRequestPart.self))
 
         // Respond with bad headers; they should cause an error and result in the rest of the
-        // response being dropped.
+        // response being dropped, but a fallback response being sent
         let head = HTTPResponseHead(version: .http1_1, status: .ok, headers: [":pseudo-header": "not-here"])
         XCTAssertThrowsError(try channel.writeOutbound(HTTPServerResponsePart.head(head)))
 
@@ -685,6 +685,8 @@ final class HTTPHeaderValidationTests: XCTestCase {
         XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self))
         XCTAssertThrowsError(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
         XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self))
+
+        _ = try? channel.finish()
     }
 }
 


### PR DESCRIPTION
- **Validate missing imports in CI (#2245)**
- **Conform `NIOTooManyBytesError` to `Hashable` (#2246)**
- **Define `Array` element type explicitly to fix nightly CI (#2250)**
- **Functions passed to non-`Sendable` `ChannelHandler`s do *not* need to be `Sendable` (#2249)**
- **Add EventLoopFuture.makeCompletedFuture(withResultOf:) (#2253)**
- **Small changes for the `NIOAsyncSequenceProducer` (#2254)**
- **HTTPResponseStatus should print code and reason (#2257)**
- **Call finish once the Source is deinited (#2258)**
- **Widen the tolerance on testSystemCallWrapperPerformance in debug mode (#2259)**
- **Fix typo in the name of a constant (#2262)**
- **helpful error message when compiling without test discovery on >= Swift 5.5 (#2264)**
- **Update HTTP parser to LLHTTP (#2263)**
- **Add support for newer LLHTTP status codes (#2269)**
- **NIOConcurrency: add NIOLockedValueBox (#2265)**
- **Implement a `NIOAsyncWriter` (#2251)**
- **Fixup docs for the `NIOAsyncWriter` (#2271)**
- **rename class Lock to struct NIOLock (#2266)**
- **address additional NIOLockedValueBox review comments (#2270)**
- **Merge pull request from GHSA-7fj7-39wj-c64f**
- **Update allocation limits (#2272)**
- **Raise minimum supported Swift version from 5.4 to 5.5 (#2267)**
- **Move ISSUE_TEMPLATE.md to ISSUE_TEMPLATE/bug-report.md (#2273)**
- **add `withLockVoid(_:)` to NIOLock (#2276)**
- **Correctly manage Content-Length on HEAD responses (#2277)**
- **Fixed compile errors on windows (#2278)**
- **Remove wrong comment about performance (#2281)**
- **Ensure fatalError for the NIOAsyncSequenceProducer when finished (#2282)**
- **Get NIO compiling with GM Xcode (#2284)**
- **Improve diagnostics for depracted `Lock`. (#2285)**
- **Improve `NIOAsyncSequenceProducer` docs (#2287)**
- **Mark types explicitly non sendable (#2290)**
- **Fix Nightly Build to work with new Swift versions (#2288)**
- **Remove `#if compiler(>=5.5)` (#2292)**
- **Replace `NIOSendable` with `Sendable` (#2291)**
- **We only support 5.5.2+ (#2293)**
- **Implements additional file operation in NonBlockingFileIO (#2244)**
- **adds create directory method (#2296)**
- **Add support for removing channel options (#2297)**
- **Move 5.7 beta APIs to NIOCore (#2300)**
- **Add correct C directory function declarations for Android (#2302)**
- **Add benchmarks for `NIOAsyncWriter` and `NIOAsyncSequenceProducer` (#2301)**
- **Don't unconditionally remove the HTTPServerUpgradeHandler (#2303)**
- **Make `NIOWebSocketServerUpgrader` `Sendable` (#2304)**
- **Add utilties for reading and writing UUIDs (#2045)**
- **Add missing `Sendable` requirements (#2305)**
- **Use #fileID/#filePath instead of #file (#2306)**
- **Add `NIOAsyncTestingChannel.waitForOut/InboundWrite()` (#2307)**
- **MPTCP support on Linux (#2308)**
- **add witnesses for ByteBufferView.reserveCapacity(_:), append(_:), and append(contentsOf:) (#2309)**
- **Fix `testTaskCancel_whenStreaming_andNotSuspended` flakiness (#2314)**
- **Fix failing build on MacOS (#2313)**
- **Correctly include netinet/in.h (#2315)**
- **Make `NIOHTTP1TestServer` Sendable (#2318)**
- **Remove _NIOBeta (#2319)**
- **Add `NIOBSDSocket.ProtocolSubtype` (#2317)**
- **Remove obsolete information from the README (#2321)**
- **cap read+pread POSIX read sizes at Int32.max (#2323)**
- **Add `RawSocketBootstrap` (#2320)**
- **Add .spi.yml for Swift Package Index DocC support (#2324)**
- **Fix non Darwin/Linux builds (#2328)**
- **Expand 'documentation_targets' list to fix missing docs (#2329)**
- **Remove implicit ByteBuffer copy in copyMemory (#2330)**
- **Make EventLoopFuture.wait() unavailable from async (#2331)**
- **Measure allocations applying WS mask (#2333)**
- **add easier async to future conversion (#2334)**
- **Improve performance of tests (#2336)**
- **Remove useless instance variables in the SelectableEventLoop (#2338)**
- **NIOCore: repair the Windows build of NIOCore (#2339)**
- **2023 is real, we should support it (#2342)**
- **Allow writing and reading empty datagrams (#2341)**
- **Fix main nightly CI (#2337)**
- **Avoid actually allocating a giant buffer (#2347)**
- **Implement `remoteAddress0` and `localAddress0` on `EmbeddedChannel` (#2345)**
- **Prepare mmsghdr structure properly. (#2346)**
- **Avoid integer literals that won't fit. (#2348)**
- **Tail allocate mutex and a generic value using ManagedBuffer (#2349)**
- **Add Swift 5.8 CI and update nightly CI to Ubuntu 22.04 (#2350)**
- **Special case EventLoopPromise.succeed() when Value is Void (#2311)**
- **Lift alloc counter Package.swift to 5.1 and add platforms (#2352)**
- **Point docs to Swift Package Index (#2353)**
- **Fix flaky testTaskCancel_whenStreaming_andNotSuspended (#2355)**
- **Remove unused array (#2361)**
- **Add UDP performance tests (#2360)**
- **Pool buffers for ivecs and storage refs in the event loop. (#2358)**
- **Make PooledBuffer safer. (#2363)**
- **NIOAsyncWriter: Provide a fast path for single element writes (#2365)**
- **Clarify on EL semantics (#2366)**
- **TCP channel throughput benchmark. (#2367)**
- **Add availability requirements to TCPThroughputBenchmark (#2368)**
- **Building swift-nio with Swift 5.7 for iOS using Xcode 14.0 at 2.48.0. (#2369)**
- **Don't retain a task when all we want is a time (#2373)**
- **Add a pooled recv buffer allocator (#2362)**
- **Make our time types transparent (#2374)**
- **Not Holding OnToRunClosure() test updates (#2375)**
- **Add support for UDP_SEGMENT (#2372)**
- **OnLoopSendable: Sendable containers if on EventLoop (#2370)**
- **Fix an upcoming compiler warning on implicit raw pointer casts. (#2377)**
- **Fix memory binding. (#2376)**
- **Lower the max segment count in tests (#2382)**
- **Rebuild the channel when retrying testWriteBufferAtGSOSegmentCountLimit (#2383)**
- **Remove redundant availability guard (#2379)**
- **mark syncShutdownGracefully noasync (#2381)**
- **Add support for UDP_GRO (#2385)**
- **Rework the `NIOAsyncSequenceProducer` tests to rely less on timings (#2386)**
- **Buffer pool for message headers and addresses. (#2378)**
- **Allow UDP GRO tests to fail in some circumstances (#2387)**
- **Work around the SwiftPM layout change. (#2389)**
- **Always populate utsname (#2391)**
- **Mildly rework the NIOLock storage (#2395)**
- **Update links in NIO docs index (#2396)**
- **Throw `CancellationError` if `NIOThrowingAsyncSequenceProducer.AsyncIterator.next()` is cancelled instead of returning `nil` (#2399)**
- **Land `NIOAsyncChannel` as SPI (#2397)**
- **Clean up and regression check the docs. (#2400)**
- **Throw `CancellationError` instead of returning `nil` during early cancellation. (#2401)**
- **Fix broken docs. (#2405)**
- **Add docker-compose file for Swift 5.9 (#2404)**
- **Handle reentranct reads in ALPNHandler (#2402)**
- **Drop Swift 5.5 (#2406)**
- **Close accepted FDs if we fail to create Socket (#2407)**
- **Don't have channels stop reading on errors they tolerate. (#2408)**
- **Avoid double-closing on fcntl failures (#2409)**
- **Add `AsyncChannel` based `ServerBootstrap.bind()` methods (#2403)**
- **Extend the integration test harness to track FDs (#2411)**
- **AsyncChannelBootstrapTests bind to 0 instead (#2412)**
- **Bind to port 0 in a few more places (#2413)**
- **Handle close(output) in the pipeline handler. (#2414)**
- **NIOThrowingAsyncSequenceProducer throws when cancelled (#2415)**
- **Make ByteBuffer CustomDebugStringConvertible (#2418)**
- **Add unprocessedBytes property on NIOSingleStepByteToMessageProcessor (#2419)**
- **addition of assertSuccess() and assertFailure() on EventLoopFuture (#2417)**
- **Tolerate sending data after close(mode: .output) (#2421)**
- **include relevant versions (kernel & Swift) in test output (#2425)**
- **Update update-alloc-limits script (#2430)**
- **`Embedded`: `getOption(ChannelOptions.allowRemoteHalfClosure)` should not `fatalError` (#2429)**
- **Add narrative documentation for NIO's concurrency bridges (#2423)**
- **Add test coverage of WebSocketMaskingKey.random() (#2433)**
- **Fix flaky test in NIOAsyncWriter (#2431)**
- **Fix happy eyeballs races with custom resolver (#2436)**
- **Pooled control message storage. (#2422)**
- **Add NIOAsyncChannel based connect methods to ClientBootstrap (#2437)**
- **Adopt the Swift CoC (#2440)**
- **Add NIOAsyncChannel based connect and bind methods to DatagramBootstrap (#2439)**
- **Update RediStack URL in README.md (#2445)**
- **Use #if canImport(Darwin) where possible (#2446)**
- **Align ServerBootstrap bind methods with the initializer style (#2443)**
- **Add support for Musl libc (#2449)**
- **Correct a few Musl additions from #2449 for Android, plus error if libc not found (#2451)**
- **Allow opt-out of PII in CONTRIBUTORS.txt (#2453)**
- **Update mailmap to unify my (Gwynne's) email addresses. (#2454)**
- **Close Channel when input & output are closed (#2450)**
- **Fix several minor typos in comments found in various files (#2455)**
- **Allocations regressed in 5.9 (#2456)**
- **Make `NIO[Throwing]AsyncSequenceProducer.Source` `Sendable` (#2459)**
- **Fix last remaining test on Android (#2457)**
- **Async support NIOPipeBootstrap (#2458)**
- **Async methods for `NIORawSocketBootstrap` (#2460)**
- **Restructure `Package.swift` (#2462)**
- **Remove `XCTAsyncTest` usage (#2461)**
- **Add configuration for `NIOAsyncChannel` (#2464)**
- **Throw SocketAddressError (cf. fatalError) in SocketAddress.convert for unknown address family (#2477)**
- **Skip TCP_NODELAY on sockets that NIO doesn't explicitly support (#2476)**
- **Reduce the amount of bootstrap async methods (#2474)**
- **Make `NIOAsyncChannel.Configuration` Sendable (#2466)**
- **update contributor email address (#2481)**
- **Fix huge compile time of setUUIDBytes (#2482)**
- **NIOSingletons: Use NIO in easy mode (#2471)**
- **correct malformed codelink (#2484)**
- **Fix 5.9 and nightly allocation limits (#2485)**
- **Fix 5.9 and nightly allocation limits (#2485) (#2487)**
- **Add async TCP echo example (#2463)**
- **Rename the `waitForFinalResult()` methods and provide an `ELF` convenience (#2483)**
- **Add testing interfaces for the stream and writer of the `NIOAsyncChannel` (#2488)**
- **Don't lose or delay writes before channelActive (#2486)**
- **Make System.coreCount aware of cgroup2 (#2394)**
- **Initial PoC of Custom Actor Executor support (#2388)**
- **Fix leaked promise in `NIOTypedApplicationProtocolNegotiationHandler` (#2489)**
- **Add bootstrap APIs for VSOCK sockets (#2479)**
- **Get Android building again after #2479 (#2490)**
- **AsyncChannel: Provide throwing finish method on test stream (#2493)**
- **Avoid using deinit to fulfil the protocol negotiation promise (#2497)**
- **EventLoopFuture/Promise: only Sendable if Value is Sendable (#2496)**
- **match casing of reference links to the casing of the actual referenced declaration/module (#2500)**
- **Update nightly allocation limits (#2502)**
- **Adding ByteBuffer.hexDump in xxd and hexdump -C formats (#2475)**
- **Docs: explain the basic safe usage of ByteBuffer (#2499)**
- **make public NIOThreadPoolError init (#2503)**
- **Support users opting-out of us setting framing headers. (#2508)**
- **Make `ByteBuffer` Codable (#2509)**
- **update CNIOLLHTTP to latest nodejs/llhttp (#2512)**
- **Simplify header separator and crlf (#2513)**
- **Support for custom protocols in DatagramBootstrap (#2516)**
- **Remove `ProtocolNegotiationHandler` protocol (#2519)**
- **Fix failed c++ compile of CNIOAtomics.h (#2518)**
- **Update CNIOSHA1.h to support C++ mode (#2523)**
- **Bump minimum Swift version to 5.7 (#2524)**
- **Introduce new typed `HTTPServerUpgrader` and `WebSocketServerUpgrader` (#2517)**
- **Fix Sendable warning in `NIOPipeBoostrap` (#2530)**
- **Breaking SPI(AsyncChannel): Align back pressure naming (#2527)**
- **SPI(AsyncChannel): Make `NIOAsyncChannel` a struct (#2528)**
- **Tolerate empty HTTP response body parts (#2531)**
- **SPI(AsyncChannel): Update the concurrency documentation (#2529)**
- **Fix test availability for tests (#2533)**
- **Introduce new typed `HTTPClientUpgrader` and `WebSocketClientUpgrader` (#2526)**
- **Adopt `package-benchmark` (#2534)**
- **Fix missing whitespace in `README.md` (#2535)**
- **Add `NIOAsyncChannel` benchmark (#2536)**
- **Add customization point for scheduling `ExecutorJob`s on `EventLoop`s (#2538)**
- **Improve performance of `NIOAsyncChannel` (#2539)**
- **perf tests: reset BB indices after every iteration (#2544)**
- **measureRunTime use DispatchTime (#2545)**
- **Fix overflow (#2543)**
- **Call `NIOAsyncWriterSinkDelegate` outside of the lock (#2547)**
- **Add jitter support to recurring tasks (#2542)**
- **Fix flaky `testRemovesAllHTTPRelatedHandlersAfterUpgrade` test (#2552)**
- **Fix `Sendable` conformance for `Lock` (#2556)**
- **Remove `NIOProtocolNegotiationResult` (#2554)**
- **Add docs for the async NIO APIs (#2549)**
- **Remove SPI from `NIOAsyncChannel`, new bootstrap methods, protocol negotiation and HTTP upgrade. (#2548)**
- **Remove continuation resumption inside locks (#2558)**
- **waitForUpgraderToBeRemoved availability guard (#2559)**
- **Avoid terminating when a precondition is not met in HTTPServerPipelineHandler (#2550)**
- **Fix flakiness in testDelayedUpgradeBehaviour (#2557)**
- **NonBlockingFileIO: tolerate chunk handlers from other ELs (#2562)**
- **Support disabling body aggregation in NIOHTTP1TestServer (#2563)**
- **Add autogenerated files from VSCode to .gitignore (#2567)**
- **Mark retroactive conformances appropriately. (#2569)**
- **Mention file length in bytes in `readFileSize` explicitly (#2572)**
- **Add support for async VSock bootstrap methods (#2561)**
- **Add support for unidirectional `NIOPipeBootstrap` (#2560)**
- **Fix thread-safety issues in TCPThroughputBenchmark (#2537)**
- **Add async version of NIOThreadPool.runIfActive (#2566)**
- **Fix concurrency doc APIs (#2575)**
- **Back out new typed HTTP protocol upgrader (#2579)**
- **Fix exclusive access violation in `NIOAsyncChannelOutboundWriterHandler` (#2580)**
- **use feature-specific guard for @retroactive (#2581)**
- **Fix spelling of retroactive guard (#2586)**
- **Fix reordering/reentrancy bug in `NIOAsyncWriter` + `NIOAsyncChannel` (#2587)**
- **Fixing an issue with CNIOSHA1 missing an #include for the BYTE_ORDER define. (#2584)**
- **Add `withInboundOutboud` to `NIOAsyncChannel` and deprecate deinit ba… (#2589)**
- **Add `closeOnDeinit` to the `NIOAsyncChannel` init (#2592)**
- **Revert "Back out new typed HTTP protocol upgrader (#2579)" (#2593)**
- **Fix the typed HTTP upgrade compiler guards (#2594)**
- **Async apis for NonBlockingFileIO (#2576)**
- **Remove precondition on result of IOCTL_VM_SOCKETS_GET_LOCAL_CID (#2588)**
- **Add missing availability guards in tests (#2596)**
- **Build for Android with NDK 26, by accounting for the new nullability annotations (#2600)**
- **Update README.md (#2602)**
- **Changes to support building with Musl (#2595)**
- **Add tests to validate the behaviour when requests/response content-length headers are wrong in HTTP1 (#2601)**
- **Add NIOAsyncWriterSinkDelegate._didSuspend hook for testing (#2597)**
- **Fix warnings caused by not defining the feature macros. (#2606)**
- **Fix test availability annotations (#2607)**
- **Fix building tests on Swift 5.9.2 Linux (#2610)**
- **Set `SWIFT_VERSION` environment variable to resolve to the correct benchmarks thresholds path (#2613)**
- **Add cxx interop build pipeline (#2614)**
- **allow setting MTELG.singleton as Swift Concurrency executor (#2564)**
- **Fix the broken performance test binary (#2619)**
- **Suppress the performance checker warning by being sneaky (#2620)**
- **Fix broken tests (#2621)**
- **Fix `NIOAsyncChannel` allocation benchmarks (#2622)**
- **Add NIOFilesystem (#2615)**
- **Add additional guards in tests for mocking (#2624)**
- **Avoid overflow in tests where Int is 32-bit (#2626)**
- **[arch] Add arm64_32 to the 32-bit platform check (#2625)**
- **More changes to support building with Musl. (#2628)**
- **no confstr on Android (#2627)**
- **Only compile FileSystem on some platforms (#2636)**
- **Pass initial offset to BufferedReader.init (#2642)**
- **fix: conditionally define RENAME_* macros (#2643)**
- **Remove `@unchecked Sendable` conformance from `ChannelOptions.Storage` (#2638)**
- **Don't drop bytes from the buffered reader when reading short (#2646)**
- **Fix up the markdown output generated by `scripts/analyze_performance_results.rb` (#2651)**
- **Conform `NIOIPProtocol` to `Sendable` (#2655)**
- **Add some more `Sendable` annotations to `NIOCore` (#2656)**
- **Remove large temp file after FS tests (#2658)**
- **Introduce `assumeIsolated()` methods on `EventLoop`, `EventLoopPromise` and `EventLoopFuture` (#2657)**
- **Fix CoW performance bug in `NIOThreadPool` work queue (#2669)**
- **Remove unreliable `SchedulingBenchmark` (#2650)**
- **Migrate to `syncOperations` in more places (#2661)**
- **Build the new FileSystem module for Android (#2660)**
- **Track `execute()` and `enqueue()` tasks separately from scheduled tasks. (#2645)**
- **Fix memory allocations counters on macOS. (#2673)**
- **Raise minimum Swift version to 5.8 (#2675)**
- **Expose `NIOThreadPool.numberOfThreads` publicly. (#2676)**
- **Add NIOBSDSocket.Option for SO_BROADCAST (#2678)**
- **Prevent BufferedWriter from producing empty files (#2677)**
- **Update issue template link in SECURITY.md (#2680)**
- **Underscore the NIOFileSystem module (#2683)**
- **Handle 'atomically' created files more gracefully when detached (#2682)**
- **Remove DispatchGroup and replace with condvar (#2687)**
- **Change BufferedReader.read(while:) signature (#2688)**
- **Add a NIOFileSystem shim (#2689)**
- **Remove temp directories after tests (#2690)**
- **Add cancellation to NIOThreadPool's async runIfActive (#2679)**
- **Clarify Client/Server column headers (#2691)**
- **Use NIOThreadPool in NIOFileSystem (#2692)**
- **Added file and line to NIOAsyncWriterError description (#2693)**
- **Add delegate for collecting eventloop tick metrics (#2608)**
- **Add a helper for setting or cascading optional promises (#2697)**
- **Add support for `SWIFTCI_USE_LOCAL_DEPS` convention (#2699)**
- **Add privacy manifest (#2695)**
- **Tolerate IPv6 address resolution failure (#2704)**
- **Retain a ref to NIOAsyncWriter until channel active (#2703)**
- **Remove surplus Sendable requirements from FileSystem with methods (#2706)**
- **Add `ByteBuffer` support to `BufferedWriter` (#2707)**
- **Add 'withTemporaryDirectory' (#2708)**
- **Replace 'R' with 'Result' (#2709)**
- **concurrency takeover safe for 6.0 (#2710)**
- **No longer need test discovery command line. (#2717)**
- **clean up @retroactive conformances (#2719)**
- **Document unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor (#2721)**
- **Add slack to rst allocation tests (#2722)**
- **Exclude unused privacy manifests. (#2716)**
- **Fix race in TCPThroughputBenchmark (#2724)**
- **testSimpleMPTCP should not fail for ENOPROTOOPT (#2725)**
- **Remove storage indirection for FileSystemError (#2726)**
- **Imrprove rename error (#2731)**
- **Add a version of 'write' for 'ByteBuffer' (#2730)**
- **Release file handles back to caller on failure to take ownership (#2715)**
- **Add a fallback path if renameat2 fails (#2733)**
- **Add API for setting last accessed and last modified file times (#2735)**
- **Update availability guard (#2739)**
- **Correctly mark 304 as not having a response body (#2737)**
- **Silence warning about missing include in macOS builds (#2741)**
- **convert the NIOFileSystem example code to a Snippet (#2746)**
- **fix link to NIOFileSystem from NIO index page (#2747)**
- **put snippet code inside @available function (#2750)**
- **Throw an appropriate error from the writer when the channel closed (#2744)**
- **NIOSendableBox: allow off-loop initialisation iff Value is Sendable (#2753)**
- **[GHA] Introduce the first GitHub Action (#2760)**
- **[GHA] Fix docker images (#2762)**
- **[GHA] Add API breaking check (#2763)**
- **[GHA] Documentation check (#2764)**
- **[GHA] Create reusable workflow (#2767)**
- **Pre-box some errors to reduce allocations (#2765)**
- **Allow in-place mutation of `NIOLoopBoundBox.value` (#2771)**
- **[GHA] Unacceptable language check (#2766)**
- **Avoid creating a yield ID counter per async writer (#2768)**
- **Add benchmark for creating NIOAsyncChannel (#2774)**
- **[GHA] Move docs check to script (#2776)**
- **[GHA] Benchmark job (#2780)**
- **Combine the two NIOAsyncChannel channel handlers (#2779)**
- **[GHA] Download the scripts to make workflow reusable (#2785)**
- **Improved documentation for HTTP Parts to clarify how often each part is received (#2775)**
- **[GHA] Add license header check (#2781)**
- **[GHA] Broken symlink and format check (#2787)**
- **Fix benchmark thresholds update script (#2783)**
- **[GHA] Introduce reusable matrix workflow (#2789)**
- **[GHA] Cxx interoperability compatibility and integration tests check (#2790)**
- **Add manual control to NIOLockedValueBox (#2786)**
- **ChannelHandler: provide static (un)wrap(In|Out)bound(In|Out) (#2791)**
- **Disable warnings as errors on Swift 6 and main (#2793)**
- **Adopt swift-format (#2794)**
- **Ignore format commit from git blame (#2796)**
- **[GHA] Only format Swift files that are in Git index (#2797)**
- **Use the new Android overlay and Bionic module from Swift 6 (#2784)**
- **Change `unsafeDownCast` to `as!` (#2802)**
- **[GHA] Make unit tests, benchmarks and cxx interop easier to reuse (#2801)**
- **[CI] Add format ignore file (#2803)**
- **Add release.yml for automatic release note generation (#2805)**
- **Fix compose file used in update-benchmark-thresholds script (#2808)**
- **Remove advice to generate linux tests. (#2807)**
- **Make testInstantTCPConnectionResetThrowsError more reliable (#2810)**
- **Better align shutdown semantics of testing event loops (#2800)**
- **[CI] Add `shellcheck` and fix up warnings (#2809)**
- **[CI] Fix docs check (#2811)**
- **[CI] Add Swift 6 language mode workflow (#2812)**
- **FileSystem.copyItem can parallelise directory copy (#2806)**
- **Fix test compilation on non-macOS Darwin platforms (#2817)**
- **ChannelOption: Allow types to be accessed with leading dot syntax (#2816)**
- **Add `.index-build` to `.gitignore` (#2819)**
- **Make EventLoopPromise conform to Equatable (#2714)**
- **[CI] Add action and workflow to check for semver label (#2814)**
- **Provide a default CopyStrategy overload for copyItem. (#2818)**
- **Update repository docs for swift-version support and recent CI check changes (#2815)**
- **Fix failing build for test (#2824)**
- **Fix typo in comment in WebSocketErrorCodes.swift (#2604)**
- **Clone files on Darwin rather than copying them (#2823)**
- **[CI] Add a scheduled workflow for tests and benchmarks (#2822)**
- **[CI] Fix label check (#2827)**
- **Update wording from `ubuntu` to `Ubuntu` at README.md (#2830)**
- **Adopt strict concurrency and Sendable in NIOConcurrencyHelpers (#2832)**
- **Update the triggers for the Semantic Version label check (#2833)**
- **Add `.editorconfig` file (#2829)**
- **Adopt strict concurrency in _NIODataStructures (#2835)**
- **Fix text availability (#2836)**
- **Adopt strict concurrency in _NIOBase64 (#2838)**
- **Strict concurrency the early tests (#2840)**
- **Remove symlinks from resources (#2841)**
- **Fix `NIOFileSystem` flaky tests (#2842)**
- **Improve testTasksScheduledDuringShutdownAreAutomaticallyCancelled (#2843)**
- **Align benchmark scaling and minimum samples (#2839)**
- **Explain why TSV isn't Sendable. (#2845)**
- **[CI] Don't persist git credentials in CI (#2847)**
- **[CI] Mark the workspace as safe for the matrix job (#2848)**
- **Pin DocC to below 1.4 (#2854)**
- **Provide documentation and context information for NIOTooManyBytesError (#2831)**
- **[CI] Make container images configurable in soundness and matrix jobs … (#2851)**
- **Fix global concurrency hook integration test (#2857)**
- **Update release.yml (#2850)**
- **Add .compact format to ByteBuffer's hexdump method (#2856)**
- **Make `assumeIsolated` work with SerialExecutors that are backed by EventLoops (#2865)**
- **Making ByteBuffer's description more useful (#2864)**
- **Adding a nicer description for `WebSocketFrame`. (#2862)**
- **[CI] Run tests on push to main (#2868)**
- **[CI] License header support `.in` and `.cmake` files (#2870)**
- **Include nanoseconds in assertion of timestamp for NIOFileSystem tests (#2869)**
- **Correct the link of sswg-security at SECURITY.md (#2872)**
- **Improving `description` and adding `debugDescription` to `NIOAny` (#2866)**
- **Make `FileChunks` `Sendable` (#2871)**
- **Make `ByteBuffer.debugDescription` suitable for structural display (#2495)**
- **Speculative fix for flakey AsyncTestingEventLoop test (#2873)**
- **Add support for WASILibc (#2671)**
- **NIOSingleStepByteToMessageDecoder reentrancy safety (#2881)**
- **Adopt `NIOThrowingAsyncSequenceProducer` (#2879)**
- **ci: Install shellcheck if not present in CI runner (#2882)**
- **ci: Use ${GITHUB_BASE_REF} as treeish for checking API break (#2883)**
- **Issue-2734 - Clamp buffer to maximum upon large write operation (#2745)**
- **Expose UDP_MAX_SEGMENTS via System (#2891)**
- **Revert "Adopt `NIOThrowingAsyncSequenceProducer` (#2879)" (#2892)**
- **Add concrete description for `EmbeddedEventLoop` (#2890)**
- **ci: Refer to nested reusable workflows using remote variant (#2884)**
- **Conditionally include linux/udp.h (#2894)**
- **Add new ChannelOption to get the amount of buffered outbound data in the Channel (#2849)**
- **[CI] Fix pull request label workflow (#2885)**
- **Add an `AcceptBackoffHandler` to the async server bootstraps (#2782)**
- **Work around a type checking error when using the Static Linux SDK (#2898)**
- **Issue-2748 - Add ByteBuffer Hex init & write (#2837)**
- **Add functions for reading and writing length-prefixed data with customizable encodings for the length (#2867)**
- **ConditionLock deallocs its pthread_cond_t in more cases (#2901)**
- **Add EventLoop APIs for simpler scheduling of callbacks (#2759)**
- **A DatagramChannelTest now waits for writes (#2905)**
- **Make ByteBufferQUICBinaryEncodingStrategyTests compatible with 32-bit systems (#2904)**
- **Fix broken link to swift-server performance documentation (#2907)**
- **Add convenience conformances to `ByteCount` (#2909)**
- **Throw error when the max read amount is greater than `ByteBuffer` can tolerate (#2911)**
- **Add `removeHandler(context: ChannelHandlerContext)` to SynchronousOperations of ChannelPipeline (#2912)**
- **[NIOFileSystem] Provide an API to specify allowing unlimited sized reads (#2914)**
- **[CI] Switch to reusable soundness (#2913)**
- **[CI] Fix unit test yaml file (#2915)**
- **[CI] Add back matrix CI script (#2916)**
- **Re-add CXX compat check script (#2919)**
- **[CI] Migrate to Swift 6.0 and drop 5.8 (#2920)**
- **Adopt NIOThrowingAsyncSequenceProducer 2nd try (#2917)**
- **Disable semver label check locally (#2928)**
- **[CI] Fix python lint (#2925)**
- **Add future wait benchmark to catch memory leaks (#2931)**
- **Drop support for Swift 5.8 (#2924)**
- **clean up 5.8 thresholds (#2932)**
- **Fix `EventLoopFuture` and `EventLoopPromise` under strict concurrency checking (#2654)**
- **Fix Windows build break. (#2935)**
- **Provide APIs to read file into more data types (#2923)**
- **Fix withConnectedSocket in async mode (#2937)**
- **Fix Windows build for NIOCore. (#2938)**
- **[CI] Add Windows matrix build (#2929)**
- **[CI] Small adjustments to the Windows actions (#2939)**
- **[CI] Enable benchmarks & cxx Windows CI (#2940)**
- **[CI] Fix the Windows 6.0 check name (#2941)**
- **NIOPosix on Darwin: inherit main thread QoS (#2944)**
- **workaround Xcode 15.4 bug with swift build --arch x86_64 --arch arm64 (#2945)**
- **Checkout any submodules when running Actions (#2946)**
- **Issue-2900 - Add VisionOS support (#2947)**
- **EmbeddedEventLoop/Channel: check correct thread (#2951)**
- **Fix `NIOAsyncSequenceProducer` watermark strategy. (#2952)**
- **Handle Sendability of RemovableChannelHandler (#2953)**
- **BaseSocketChannel flushNow IONotificationState changes (#2954)**
- **Add new protocol for ChannelHandler to get buffered bytes in the channel handler (#2918)**
- **Clean up Sendability for ChannelInvoker (#2955)**
- **Fix broken swift format link (#2948)**
- **Correct allocation test script (#2956)**
- **Remove unused dockerfiles and allocation limit scripts (#2957)**
- **Complete NIOCore strict concurrency (#2959)**
- **Fix leaking technique (#2963)**
- **Improve docs around running act for formatting (#2965)**
- **Use Swift 6.0 docs pipeline (#2966)**
- **Remove sendable checking from NIOLock and NIOLockedValueBox (#2968)**
- **Fix SemVer major label check (#2970)**
- **Close channel during upgrade, if client closes input (#2756)**
- **unify scheduled and main yamls (#2972)**
- **remove unused Swift 6 language mode workflow (#2976)**
- **Swift 6ify NIOHTTP1Server demo (#2974)**
- **Add WebSocketFrame.reservedBits OptionSet (#2971)**
- **Add netstat -s to nio-diagnose (#2977)**
- **Use condition variable in NIOThreadPool (#2964)**
- **Better handle ECONNRESET on connected datagram sockets. (#2979)**
- **tests: Remove asserts on the value of local Vsock CID (#2975)**
- **Add back alloc limits script with JSON mode (#2987)**
- **Add ByteBuffer methods getUTF8ValidatedString and readUTF8ValidatedString (#2973)**
- **EventLoopFuture.waitSpinningRunLoop() (#2985)**
- **give common blocking functions a clear name (#2984)**
- **fix warnings: syncShutdownGracefully not available in async contexts (#2995)**
- **Only toggle production state when above/below watermark (#2996)**
- **Make NIOFileDescriptor/FileRegion/IOData Sendable & soft-deprecated (#2598)**
- **Add Cxx interop swift settings to CI (#2999)**
- **fix almost all Sendable warnings (#2994)**
- **deprecate NIOEventLoopGroupProvider.createNew (#2480)**
- **ByteBuffer: one fewer allocs to go to Data (#1839)**
- **Update documentation comments (#2998)**
- **Cxx interop CI appends swiftSettings (#3002)**
- **fix remaining warnings & enable -warnings-as-errors in CI (#3000)**
- **Prevent crash in Happy Eyeballs Resolver (#3003)**
- **Remove noasync from NIOFileHandle (#3001)**
- **Avoid converting array holding existentials (#3006)**
- **Aligning semantic version label check name (#3007)**
- **Use the new Android overlay in the tests and update some Bionic declarations (#3009)**
- **Revert `fastRebase` implementation (#3014)**
- **Introduce JSON matrix workflow (#3013)**
- **Matrix workflows refer to main branch (#3016)**
- **Re-usable workflows curl scripts (#3017)**
- **GHA: Separate matrix input handling (#3018)**
- **Add EventLoop.now API for getting the current time (#3015)**
- **Add parallel removal of items (#3008)**
- **Remove outdated documentation (#3023)**
- **Deprecate not-actually-public Base64 APIs (#3022)**
- **rename top matrix workflow object 'swift'->'config' (#3024)**
- **Fix new warnings (#3026)**
- **Remove now unneeded fts_open bitcast for Android (#3025)**
- **fix bogus "unleakable promise leaked" error message (#2855) (#3027)**
- **Enable MemberImportVisibility check on all targets (#3021)**
- **Revert "Enable MemberImportVisibility check on all targets" (#3028)**
- **Add isolated views to EventLoop, Promise, and Future (#2969)**
- **Fix now-racy scheduled callback tests (#3031)**
- **Get NIOEmbedded clean under strict concurrency (#3030)**
- **Enable MemberImportVisibility check - attempt 2 (#3029)**
- **Wait for `closeFuture` instead of close promise in `NIOAsyncChannel`'s `executeThenClose` (#3032)**
- **Import Android instead for NIOEmbedded (#3033)**
- **Update release.yml and label action (#3035)**
- **Fix flaky test testTasksScheduledDuringShutdownAreAutomaticallyCancel… (#3036)**
- **Print alloc-limits-from-test-output usage when no args (#3041)**
- **Support concurrency take over in 6.2 (#3043)**
- **GetaddrinfoResolver succeeds futures on eventLoop (#3042)**
- **Add Sendability annotations on SocketOptionProvider (#3034)**
- **unchecked Sendable for the Channels (#3050)**
- **Add channel initializer closure to NIOAsyncTestingChannel.init (#3053)**
- **Test allocations of isolated ELF views (#3054)**
- **Avoid abstraction overheads on isolated ELF (#3055)**
- **Clarify docs on EventLoopFuture/assumeIsolatedUnsafeUnchecked (#3058)**
- **NIOAsyncWriter: Fix suspending yield when writer is finished (#3044)**
- **Fix compiling on 6.1 (#3057)**
- **Remove unnecessary 'FIXME' comment (#3059)**
- **Clean up sendability in the bootstraps (#3051)**
- **Add some trivial Sendable annotations (#3060)**
- **Fix WebSocketProtocolErrorHandler sending the close frame with appropriate masking key (#3040)**
- **feat: Add `String(contentsOf: FilePath ...)` (#3048)**
- **feat: NIO.TimeAmount(string:) and TimeAmount.description (#3046)**
- **Add allocation counter tests for isolated EL operations (#3068)**
- **Improve coverage of isolated views (#3069)**
- **Adds `Int(buffer:)` initializer to `FixedWidthInteger` types (#3047)**
- **Move Isolated EL operations to EL protocol (#3070)**
- **Ensure we test the isolated fallback methods (#3072)**
- **Improve HTTPHeaders description performance (#3063)**
- **Fast-path isolated view for EmbeddedEventLoop (#3073)**
- **Enable optimized Isolated view path for AsyncTestingEL (#3074)**
- **Adopt optimized isolated path for SelectableEL (#3075)**
- **Update nightly CI pipelines to 6.1 instead of 6.0 (#3076)**
- **more 6.0 nightly to 6.1 nightly CI changes (#3078)**
- **check-matrix-job.sh should tolerate unset 6.1 vars (#3080)**
- **Improve `flatScheduleTask` (#3079)**
- **Fix the HappyEyeballsResolver and core Bootstraps under strict concurrency (#3062)**
- **Clean up Sendability in Thread and ThreadPool (#3081)**
- **Make NonBlockingFileIO strict-concurrency clean (#3082)**
- **Sendability clean up for RawSocketBootstrap (#3083)**
- **Strict concurrency for SelectableEventLoop & MTELG (#3084)**
- **Add Sendable annotations to SelectorGeneric (#3085)**
- **Remove accidental static var (#3086)**
- **Add simple Sendable conformance to AsyncSequenceFromIterator (#3088)**
- **Add Sendable annotations to the syscall wrappers (#3087)**
- **Avoid using stderr explicitly (#3089)**
- **Make NIOPosix strict-concurrency clean (#3090)**
- **`NIOFileSystem`: Try ${TMPDIR} first for temporary directory (#3067)**
- **undo Xcode 13 GM workaround (#3092)**
- **Update the legacy CI matrix for 6.1 nightly (#3094)**
- **Opt _NIOConcurrency into Strict Concurrency (#3095)**
- **Opt NIOFoundationCompat into strict concurrency (#3096)**
- **Opt NIO module into Strict Concurrency (#3097)**
- **Clean up concurrency in NIOEchoClient (#3099)**
- **Add strict concurrency to NIOUDPEchoServer (#3101)**
- **Lock in strict concurrency in NIOEchoServer (#3100)**
- **Update NIOUDPEchoClient for strict concurrency (#3102)**
- **Strict concurrency for TCP examples (#3103)**
- **Strict concurrency for the chat examples (#3104)**
- **Strict concurrency enablement for some test targets (#3105)**
- **Strict concurrency for NIOTests (#3106)**
- **Make _NIOFileSystem strict concurrency compatible (#3098)**
- **Add ChannelPipeline.SynchronousOperations.Position (#3065)**
- **Make the FileSystem world strict concurrency clean (#3107)**
- **document known Structured Concurrency violations (#3108)**
- **Enable strict concurrency checking for NIOTLS (#3112)**
- **Add more methods to work with Isolated futures (#3117)**
- **Simplify Windows matrix command invocation (#3118)**
- **Make isolated execute on async testing eventloop actually run (#3116)**
- **Enable strict concurrency checking for NIOHTTP1 (#3115)**
- **Hashable SocketAddressError (#3119)**
- **Update generate matrix stript to use nightly_next (#3120)**
- **Expose GITHUB_ACTIONS env var to docker containers (#3123)**
- **Update re-usable workflows to use nightly_next (#3122)**
- **Populate CI env var in swift_test_matrix.yml (#3125)**
- **rename nightly 6 1 to nightly next (#3126)**
- **NIOSingletons docs: Clarify the set once-ness (#3128)**
- **Remove side effect from assertion in IPHeaderRemoverHandler (#3129)**
- **Enable strict concurrency checking for NIOHTTP1Server (#3132)**
- **Enable strict concurrency checking for NIOHTTP1Client (#3131)**
- **Enable strict concurrency checking for NIOWebSocket (#3127)**
- **Enable strict concurrency checking for NIOTestUtils (#3130)**
- **Delete Thresholds/nightly-6.1 symlinks (#3133)**
- **Only apply standard swift settings on valid targets (#3134)**
- **A re-usable static SDK compilation workflow (#3019)**
- **Downgrade NIOHTTP1TestServer handleChannel failure (#3137)**
- **Add a missing import to CNIOLinux (#3140)**
- **Allow NIOLoopBoundBox to be initialized by sending in a value (#3138)**
- **Experimental macOS CI (#3141)**
- **Remove macOS CI shim (#3143)**
- **Make static SDK curl for setup script (#3142)**
- **A re-usable CMake check workflow (#3144)**
- **install jq, use correct quotes (#3145)**
- **Update macOS CI workflow (#3150)**
- **Add make*Future methods to isolated event loop (#3152)**
- **always @preconcurrency import Glibc/Musl/Android/Bionic/WASILibc (#3153)**
- **A script for updating benchmark thresholds from CI output (#3151)**
- **Changed NIOAsyncChannel.executeThenClose to accept actor-isolated parameter (#3121)**
- **fix: Fix NIOCore build for wasm targets (#3156)**
- **Add peekInteger API to ByteBuffer (#3157)**
- **Use overflow addition in tests to avoid compilation failures (#3155)**
- **Add Peek API variants for ByteBuffer (#3160)**
- **Separate build and test steps in `macos_tests.yml` (#3162)**
- **macOS CI pools (#3163)**
- **Update install_static_sdk.sh to cope with versions with no patch (#3166)**
- **Strict concurrency for websocket client/server demo and async demo (#3161)**
- **Document supported versions consistently (#3168)**
- **Add support for Xcode 16.3 (#3171)**
- **Improve alloc tests failure messages (#3173)**
- **uncomment visionOS CI tasks (#3176)**
- **Strict concurrency for NIOHTTP1Tests (#3169)**
- **Strict concurrency for NIOPerformanceTester and NIOCrashTester (#3167)**
- **Update nightly main benchmark thresholds (#3187)**
- **Ignore return value of signal() on Android (#3181)**
- **Strict concurrency for NIOPosix BootstrapTest (#3183)**
- **Strict concurrency NIOPosix EventLoopTest (#3185)**
- **Static SDK installation script improvements (#3186)**
- **Strict concurrency for NIOPosix AcceptBackoffHandlerTests (#3182)**
- **Strict concurrency for NIOPosix ChannelPipelineTests (#3184)**
- **Strict concurrency for NIOPosix SelectorTest (#3190)**
- **Strict concurrency for NIOPosix NonBlockingFileIOTest (#3188)**
- **Strict concurrency for NIOPosix StreamChannelsTest (#3189)**
- **Add perf test for EL as SerialExecutor (#3178)**
- **Strict concurrency for NIOPosix ChannelTests (#3191)**
- **Expose the event loop from the loop bound boxes (#3179)**
- **Remove unchecked from SelectorTest (#3192)**
- **Add Peek API for Multiple Integers (#3175)**
- **Strict concurrency for NIOPosixTests, EL and ELF (#3193)**
- **Add More Peek API Variants for ByteBuffer (#3174)**
- **Strict concurrency for NIOPosixTests EchoServerClient (#3195)**
- **Add and enable Swift 6.1 workflows (#3196)**
- **Update matrix job script for 6.1 (#3201)**
- **Add Tests for WebSocketErrorCode Get, Read and Write APIs in ByteBuffer (#3198)**
- **Strict concurrency for a handful more NIOPosixTests (#3199)**
- **Swift concurrency for NIOWebSocketTests (#3208)**
- **Strict concurrency for NIOTestUtilsTests (#3206)**
- **Strict concurrency for NIOTLSTests (#3207)**
- **Strict concurrency for SAL tests (#3205)**
- **Enable strict concurrency for NIOPosixTests (#3211)**
- **Add errorCaught to NIOTypedHTTPClientUpgradeHandler (#3210)**
- **Clarify test server error code (#3212)**
- **Fix ByteBufferTests when compiling with Swift 6 but running on macOS 14. (#3217)**
- **Update LLHTTP and apply patch to support C++ interop (#3216)**
- **Fix compiler issues on 5.10 x86 Ubuntu Noble. (#3224)**
- **BaseStreamSocketChannel half-close allows outstanding writes to complete (#3148)**
- **Replace almost all public static lets with computed vars (#3229)**
- **Removed Docker references as repo moved to Github actions (#3227)**
- **Update SECURITY.md (#3232)**
- **Make ChannelError and NIOConnectionError conform to CustomStringConvertible (#3230)**
- **Drop Swift 5.9 (#3228)**
- **Moving `PooledRecvBufferAllocator` from NIOPosix to NIOCore (#3110)**
- **Update Array+FileSystem.swift to add visionOS (#3220)**
- **Remove assertions on PWM failAll and closeOutbound (#3231)**
- **Disable Swift 5.9 CI jobs by default (#3233)**
- **Enable visionOS xcodebuilds by default in CI (#3234)**
- **Revert "Enable visionOS xcodebuilds by default in CI" (#3235)**
- **Fix NIOAsyncWriter test on concurrency thread pool with single thread (#3135)**
- **Macos setup command (#3236)**
- **Update check-matrix-job.sh to default swift commands (#3237)**
- **Enable visionOS xcodebuilds by default in CI - attempt 2 (#3238)**
- **Update macos_tests.yml to limit run time to 30 minutes (#3240)**
- **Print the swift version in Linux matrix jobs (#3241)**
- **Remove default setup command for Xcode 16.2 (#3242)**
- **Revert "Remove default setup command for Xcode 16.2 (#3242)" (#3244)**
- **Revert "Print the swift version in Linux matrix jobs" (#3245)**
- **Execute swift --version in shared workflows (#3247)**
- **Revert "Revert "Remove default setup command for Xcode 16.2 (#3242)" (#3244)" (#3248)**
- **Update the matrix nightly-next to point to 6.2 (#3250)**
- **`NIOThrowingAsyncSequenceProducer` make more funcs `@inlinable` (#3243)**
- **Handle different ThreadDestructor signatures between Android NDK 27 and NDK 28 (#3249)**
- **Make CNIOAtomics and CNIODarwin compatible with C++ interop (#3251)**
- **Retry curl operations in CI scripts (#3256)**
- **Benchmarks workflow prints diff when changes found (#3258)**
- **a couple grammar fixes (#3259)**
- **Embedded channels should set local and remote address always (#3254)**
- **Add Xcode 26 beta 1 to macOS CI (#3267)**
- **Adjust for SendableMetatype (#3266)**
- **Extend NIOEventLoopTickInfo with end-time and loop sleep time (#3268)**
- **Adding RawSpan support to writeBytes in ByteBuffer (#3269)**
- **Add `scheduleCallback` APIs to `NIOIsolatedEventLoop` (#3263)**
- **Fixed issue with macOS CI when overrides are being used. (#3270)**
- **fix: Fix compiler error found on latest main that breaks wasip1 (wasm) compilation (#3271)**
- **Add assembly files for Windows (#3275)**
- **Fix API documentation links in README.md (#3276)**
- **Support for 64-bit timespec seconds on 32-bit platforms (#3277)**
- **Work around Android nullability errors (#3279)**
- **Widen the allocation limit on nightlies (#3280)**
- **Functions that return values should return those values (#3283)**
- **Update generate_matrix.sh for windows nightlies to 2022 images (#3284)**
- **Make use of symlink to latest Xcode beta  (#3285)**
- **Add internals for stackdiff tool (#3286)**
- **Add diffing to the stackdiff tool (#3287)**
- **Add dtrace parsing (#3288)**
- **Add stackdiff dump (#3289)**
- **Add stackdiff merging (#3290)**
- **chore: avoid spurious xcodebuild warning (#3291)**
- **Add DocC docs for running alloc tests and debugging them (#3293)**
- **Add bpftrace allocations script (#3113)**
- **Run update_and_patch_llhttp.sh script to update to 9.3.0 (#3298)**
- **ensure <stddef.h> is not imported within extern "C" (#3299)**
- **inEventLoop benchmark (#3301)**
- **improve inEventLoop checks (#3302)**
- **Wrap closures stored in the CallbackList (#3303)**
- **NIOThread refactor: pthread_t lifetimes (#3297)**
- **Structured Concurrency compliant MTELG create/shutdown (#3296)**
- **Make file handle sendable (#3300)**
- **NIOThread: remove the detached threads functionality (#3304)**
- **Pick visionOS version for Xcode 16.2 (#3307)**
- **Call channel initializer when using async methods on pipe bootstrap (#3309)**
- **Remove Foundation import (#3310)**
- **Fixes a small mistake in the NIOTCPEchoServer README file (#3311)**
- **CMake Updater: Output difference in expectations (#3314)**
- **Move conditional setup logic from bash to actions (#3313)**
- **Fix docc (#3315)**
- **[Windows] Windows has endianess too (#3317)**
- **[Windows] Ensure NIOEmbedded compiles (#3319)**
- **Fix typo in `HTTPServerClientTest.swift` comments (#3323)**
- **[Windows] IOVector is WSABUF on Windows (#3324)**
- **Add workflow for release mode builds(#3321)**
- **Do not run windows nightly CI by default (#3325)**
- **Enable release mode builds (#3327)**
- **Fixes all warnings when `-require-explicit-sendable` flag is enabled (#3320)**
- **Add a new file path type, NIOFilePath, backed by SystemPackage's FilePath type (#3322)**
- **Add bpftrace support to stackdiff (#3329)**
- **Don't double-initialize Pipe Bootstraps (#3330)**
- **[wasm][1/2] Add reusable WebAssembly workflow (#3331)**
- **Support options on AsyncTestingChannel and EmbeddedChannel (#3308)**
- **Add Android imports for some new tests in #3308 that require it (#3334)**
- **Make testMetricsDelegateTickInfo less flaky (#3335)**
- **[wasm][2/2] Include WebAssembly SDK checks in PR and main workflows (#3332)**
- **[Windows] Ensure ssize_t and socklen_t are available (#3337)**
- **[Windows] Add msghdr extension for Windows (#3336)**
- **Update FilePath references to NIOFilePath (#3333)**
- **[Windows] Ensure NIOHTTP1 compiles (#3338)**
- **Drop all server response parts after an invalid header (#3339)**
- **[Windows] Make Thread.swift compile (#3341)**
- **[Windows] Make ControlMessage.swift compile (#3342)**
- **[Windows] Map naming conventions Windows -> Posix (ssize_t) (#3343)**
- **[Windows] Make SelectableEventLoop compile (#3344)**
- **Add test for desired behaviour**
- **Get test passing**
- **Close the channel**
