### PR TITLE
[Windows] fatalError concurrency takeover

### DIFF
--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -126,7 +126,7 @@ extension NIOSingletons {
         #else
         return false
         #endif
-        #endif // windows unimplemented
+        #endif  // windows unimplemented
     }
 }
 


### PR DESCRIPTION
To make further progress, let's disable the concurrency takeover feature for now.
