### PR TITLE
[Windows] Use WSASend as writev equivalent

### DIFF
--- a/Sources/NIOPosix/BSDSocketAPIPosix.swift
+++ b/Sources/NIOPosix/BSDSocketAPIPosix.swift
@@ -130,6 +130,13 @@ extension NIOBSDSocket {
         try Posix.write(descriptor: s, pointer: buf, size: len)
     }
 
+    static func writev(
+        socket s: NIOBSDSocket.Handle,
+        iovecs: UnsafeBufferPointer<IOVector>
+    ) -> IOResult<Int> {
+        try Posix.writev(descriptor: s, iovecs: iovecs)
+    }
+
     static func setsockopt(
         socket: NIOBSDSocket.Handle,
         level: NIOBSDSocket.OptionLevel,

--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -89,6 +89,7 @@ import func WinSDK.TransmitFile
 import func WinSDK.WriteFile
 import func WinSDK.WSAGetLastError
 import func WinSDK.WSAIoctl
+import func WinSDK.WSASend
 
 import struct WinSDK.socklen_t
 import struct WinSDK.u_long
@@ -391,6 +392,20 @@ extension NIOBSDSocket {
             throw IOError(winsock: WSAGetLastError(), reason: "send")
         }
         return .processed(size_t(iResult))
+    }
+
+    @inline(never)
+    static func writev(
+        socket s: NIOBSDSocket.Handle,
+        iovecs: UnsafeBufferPointer<IOVector>
+    ) throws -> IOResult<Int> {
+        var bytesSent: DWORD = 0
+        let ptr = UnsafeMutablePointer(mutating: iovecs.baseAddress)
+        let result = WSASend(s, ptr, UInt32(iovecs.count), &bytesSent, 0, nil, nil)
+        if result == SOCKET_ERROR {
+            throw IOError(winsock: WSAGetLastError(), reason: "wsasend")
+        }
+        return .processed(Int(bytesSent))
     }
 
     @inline(never)

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -175,7 +175,7 @@ class Socket: BaseSocket, SocketProtocol {
     /// - Throws: An `IOError` if the operation failed.
     func writev(iovecs: UnsafeBufferPointer<IOVector>) throws -> IOResult<Int> {
         try withUnsafeHandle {
-            try Posix.writev(descriptor: $0, iovecs: iovecs)
+            try NIOBSDSocket.writev(socket: $0, iovecs: iovecs)
         }
     }
 


### PR DESCRIPTION
See title. `writev` does not exist in Windows land.
