### PR TITLE
[Windows] Add shims to make string from `GetLastError` using `FormatMessage`

### DIFF
--- a/Sources/CNIOWindows/include/CNIOWindows.h
+++ b/Sources/CNIOWindows/include/CNIOWindows.h
@@ -109,6 +109,8 @@ size_t NIO(CMSG_SPACE)(size_t);
 
 int NIO(errno)(void);
 
+DWORD NIO(FormatGetLastError)(DWORD errorCode, LPSTR errorMsg);
+
 #undef NIO
 
 #endif

--- a/Sources/CNIOWindows/shim.c
+++ b/Sources/CNIOWindows/shim.c
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <winbase.h>
 
 int CNIOWindows_sendmmsg(SOCKET s, CNIOWindows_mmsghdr *msgvec, unsigned int vlen,
                          int flags) {
@@ -58,6 +59,18 @@ size_t CNIOWindows_CMSG_SPACE(size_t length) {
 
 int CNIOWindows_errno(void) {
     return errno;
+}
+
+DWORD CNIOWindows_FormatGetLastError(DWORD errorCode, LPSTR errorMsg) {
+  return FormatMessage(
+    FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+    NULL,
+    errorCode,
+    0, // Default language
+    errorMsg,
+    0,
+    NULL
+  );
 }
 
 #endif

--- a/Sources/NIOPosix/Windows.swift
+++ b/Sources/NIOPosix/Windows.swift
@@ -30,7 +30,8 @@ var errno: Int32 {
 }
 
 extension NIOCore.Windows {
-    static func FormatLastError(_ errorCode: DWORD) -> String? {
+    /// Call this to get a string representation from an error code that was returned from `GetLastError`.
+    static func makeErrorMessageFromCode(_ errorCode: DWORD) -> String? {
         var errorMsg = UnsafeMutablePointer<CHAR>?.none
         CNIOWindows_FormatGetLastError(errorCode, &errorMsg)
 

--- a/Sources/NIOPosix/Windows.swift
+++ b/Sources/NIOPosix/Windows.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Windows)
+import NIOCore
 import WinSDK
 import CNIOWindows
 
@@ -26,6 +27,22 @@ func write(_ fd: Int32, _ ptr: UnsafeRawPointer?, _ count: Int) -> Int32 {
 
 var errno: Int32 {
     CNIOWindows_errno()
+}
+
+extension NIOCore.Windows {
+    static func FormatLastError(_ errorCode: DWORD) -> String? {
+        var errorMsg = UnsafeMutablePointer<CHAR>?.none
+        CNIOWindows_FormatGetLastError(errorCode, &errorMsg)
+
+        if let errorMsg {
+            let result = String(cString: errorMsg)
+            LocalFree(errorMsg)
+            return result
+        } else {
+            // we could check GetLastError here again. But that feels quite recursive.
+            return nil
+        }
+    }
 }
 
 #endif


### PR DESCRIPTION
If we receive a functions error via `GetLastError`, we can stringify it via `FormatMessage`. Sadly `FormatMessage` isn't auto imported into Swift, which is why we need to use the shim layer.