### PR TITLE
POSIX: don't force-unwrap result of fdopendir(3)

### DIFF
--- a/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
@@ -191,7 +191,7 @@ extension FileDescriptor {
     ///     caller should not modify the descriptor or close the descriptor via `close()`. Once
     ///     directory iteration has been completed then `Libc.closdir(_:)` must be called.
     internal func opendir() -> Result<CInterop.DirPointer, Errno> {
-        valueOrErrno(retryOnInterrupt: false) {
+        unwrapValueOrErrno(retryOnInterrupt: false) {
             libc_fdopendir(self.rawValue)
         }
     }

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -368,8 +368,8 @@ internal func system_futimens(
 /// fdopendir(3): Opens a directory stream for the file descriptor
 internal func libc_fdopendir(
     _ fd: FileDescriptor.RawValue
-) -> CInterop.DirPointer {
-    fdopendir(fd)!
+) -> CInterop.DirPointer? {
+    fdopendir(fd)
 }
 
 /// readdir(3): Returns a pointer to the next directory entry


### PR DESCRIPTION
Motivation:

It's possible for fdopendir(3) to return 0 if the file descriptor's backing filesystem is force-unmounted. This should return an error, but instead crashes the library.

Result:

If fdopendir fails, FileDescriptor.opendir will return the error contained in errno (set by the stat(2) call in libc fdopendir).