### PR TITLE
[Windows] Allow `_SelectorBackendProtocol` to work with Windows Handles

### DIFF
--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -123,21 +123,21 @@ protocol _SelectorBackendProtocol {
     func initialiseState0() throws
     func deinitAssertions0()  // allows actual implementation to run some assertions as part of the class deinit
     func register0(
-        selectableFD: CInt,
-        fileDescriptor: CInt,
+        selectableFD: NIOBSDSocket.Handle,
+        fileDescriptor: NIOBSDSocket.Handle,
         interested: SelectorEventSet,
         registrationID: SelectorRegistrationID
     ) throws
     func reregister0(
-        selectableFD: CInt,
-        fileDescriptor: CInt,
+        selectableFD: NIOBSDSocket.Handle,
+        fileDescriptor: NIOBSDSocket.Handle,
         oldInterested: SelectorEventSet,
         newInterested: SelectorEventSet,
         registrationID: SelectorRegistrationID
     ) throws
     func deregister0(
-        selectableFD: CInt,
-        fileDescriptor: CInt,
+        selectableFD: NIOBSDSocket.Handle,
+        fileDescriptor: NIOBSDSocket.Handle,
         oldInterested: SelectorEventSet,
         registrationID: SelectorRegistrationID
     ) throws


### PR DESCRIPTION
`_SelectorBackendProtocol` currently requires the file descriptors to be of `CInt` (aka Int32). However Windows HANDLES are pointers therefore `UInt64`s. Let's use the typealias that we already have `NIOBSDSocket.Handle`.