### PR TITLE
[Windows] Use recv instead of read

### DIFF
--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -720,7 +720,7 @@ extension NIOBSDSocket {
 extension IOVector {
     // An initializer thats maps `ByteBuffer`` derived pointers to WSABUF. This allows us to use the
     // same initializer, that we use for iovecs on Windows.
-    init(iov_base: UnsafeMutableRawPointer, iov_len: UInt32) {
+    init(iov_base: UnsafeMutableRawPointer!, iov_len: UInt32) {
         self = WSABUF(
             len: iov_len,
             buf: iov_base.assumingMemoryBound(to: Int8.self)

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -224,7 +224,7 @@ class Socket: BaseSocket, SocketProtocol {
     /// - Returns: The `IOResult` which indicates how much data could be read and if the operation returned before all could be read (because the socket is in non-blocking mode).
     /// - Throws: An `IOError` if the operation failed.
     func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
-        try withUnsafeHandle {(handle) -> IOResult<Int> in
+        try withUnsafeHandle { (handle) -> IOResult<Int> in
             #if os(Windows)
             try Windows.recv(socket: handle, pointer: pointer.baseAddress!, size: Int32(pointer.count), flags: 0)
             #else

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -224,8 +224,12 @@ class Socket: BaseSocket, SocketProtocol {
     /// - Returns: The `IOResult` which indicates how much data could be read and if the operation returned before all could be read (because the socket is in non-blocking mode).
     /// - Throws: An `IOError` if the operation failed.
     func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
-        try withUnsafeHandle {
-            try Posix.read(descriptor: $0, pointer: pointer.baseAddress!, size: pointer.count)
+        try withUnsafeHandle {(handle) -> IOResult<Int> in
+            #if os(Windows)
+            try Windows.recv(socket: handle, pointer: pointer.baseAddress!, size: Int32(pointer.count), flags: 0)
+            #else
+            try Posix.read(descriptor: handle, pointer: pointer.baseAddress!, size: pointer.count)
+            #endif
         }
     }
 

--- a/Sources/NIOPosix/Windows.swift
+++ b/Sources/NIOPosix/Windows.swift
@@ -44,6 +44,14 @@ extension NIOCore.Windows {
             return nil
         }
     }
+
+    static func recv(socket: SOCKET, pointer: UnsafeMutableRawPointer, size: Int32, flags: Int32) throws -> IOResult<Int> {
+        let result = WinSDK.recv(socket, pointer.assumingMemoryBound(to: CChar.self), size, flags)
+        if result == WinSDK.SOCKET_ERROR {
+            throw IOError(winsock: WSAGetLastError(), reason: "accept")
+        }
+        return .processed(Int(result))
+    }
 }
 
 #endif

--- a/Sources/NIOPosix/Windows.swift
+++ b/Sources/NIOPosix/Windows.swift
@@ -46,9 +46,9 @@ extension NIOCore.Windows {
     }
 
     static func recv(
-        socket: SOCKET, 
-        pointer: UnsafeMutableRawPointer, 
-        size: Int32, 
+        socket: SOCKET,
+        pointer: UnsafeMutableRawPointer,
+        size: Int32,
         flags: Int32
     ) throws -> IOResult<Int> {
         let result = WinSDK.recv(socket, pointer.assumingMemoryBound(to: CChar.self), size, flags)

--- a/Sources/NIOPosix/Windows.swift
+++ b/Sources/NIOPosix/Windows.swift
@@ -45,7 +45,12 @@ extension NIOCore.Windows {
         }
     }
 
-    static func recv(socket: SOCKET, pointer: UnsafeMutableRawPointer, size: Int32, flags: Int32) throws -> IOResult<Int> {
+    static func recv(
+        socket: SOCKET, 
+        pointer: UnsafeMutableRawPointer, 
+        size: Int32, 
+        flags: Int32
+    ) throws -> IOResult<Int> {
         let result = WinSDK.recv(socket, pointer.assumingMemoryBound(to: CChar.self), size, flags)
         if result == WinSDK.SOCKET_ERROR {
             throw IOError(winsock: WSAGetLastError(), reason: "accept")


### PR DESCRIPTION
There is no read in Windows land. Instead we have recv.