### PR TITLE
[Windows] Disable Pipelines for now (fatalError)

### DIFF
--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2353,6 +2353,9 @@ public final class NIOPipeBootstrap {
     ///   - inputOutput: The _Unix file descriptor_ for the input & output.
     /// - Returns: an `EventLoopFuture<Channel>` to deliver the `Channel`.
     public func takingOwnershipOfDescriptor(inputOutput: CInt) -> EventLoopFuture<Channel> {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         let inputFD = inputOutput
         let outputFD = try! Posix.dup(descriptor: inputOutput)
 
@@ -2360,6 +2363,7 @@ public final class NIOPipeBootstrap {
             try! Posix.close(descriptor: outputFD)
             throw error
         }
+        #endif
     }
 
     /// Create the `PipeChannel` with the provided input and output file descriptors.
@@ -2460,6 +2464,9 @@ extension NIOPipeBootstrap {
         inputOutput: CInt,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
     ) async throws -> Output {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         let inputFD = inputOutput
         let outputFD = try! Posix.dup(descriptor: inputOutput)
 
@@ -2473,6 +2480,7 @@ extension NIOPipeBootstrap {
             try! Posix.close(descriptor: outputFD)
             throw error
         }
+        #endif
     }
 
     /// Create the `PipeChannel` with the provided input and output file descriptors.
@@ -2574,6 +2582,9 @@ extension NIOPipeBootstrap {
         output: CInt?,
         channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<ChannelInitializerResult>
     ) -> EventLoopFuture<ChannelInitializerResult> {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         precondition(
             input ?? 0 >= 0 && output ?? 0 >= 0 && input != output,
             "illegal file descriptor pair. The file descriptors \(String(describing: input)), \(String(describing: output)) "
@@ -2656,6 +2667,7 @@ extension NIOPipeBootstrap {
                 setupChannel()
             }
         }
+        #endif
     }
 }
 

--- a/Sources/NIOPosix/PipePair.swift
+++ b/Sources/NIOPosix/PipePair.swift
@@ -19,23 +19,30 @@ import struct WinSDK.socklen_t
 #endif
 
 final class SelectablePipeHandle {
-    var fileDescriptor: CInt
+    var fileDescriptor: NIOBSDSocket.Handle
 
     var isOpen: Bool {
         self.fileDescriptor >= 0
     }
 
-    init(takingOwnershipOfDescriptor fd: CInt) {
+    init(takingOwnershipOfDescriptor fd: NIOBSDSocket.Handle) {
         precondition(fd >= 0)
         self.fileDescriptor = fd
     }
 
     func close() throws {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         let fd = try self.takeDescriptorOwnership()
         try Posix.close(descriptor: fd)
+        #endif
     }
 
-    func takeDescriptorOwnership() throws -> CInt {
+    func takeDescriptorOwnership() throws -> NIOBSDSocket.Handle {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         guard self.isOpen else {
             throw IOError(errnoCode: EBADF, reason: "SelectablePipeHandle already closed [in close]")
         }
@@ -43,6 +50,7 @@ final class SelectablePipeHandle {
             self.fileDescriptor = -1
         }
         return self.fileDescriptor
+        #endif
     }
 
     deinit {
@@ -51,7 +59,7 @@ final class SelectablePipeHandle {
 }
 
 extension SelectablePipeHandle: Selectable {
-    func withUnsafeHandle<T>(_ body: (CInt) throws -> T) throws -> T {
+    func withUnsafeHandle<T>(_ body: (NIOBSDSocket.Handle) throws -> T) throws -> T {
         guard self.isOpen else {
             throw IOError(errnoCode: EBADF, reason: "SelectablePipeHandle already closed [in wUH]")
         }
@@ -72,6 +80,9 @@ final class PipePair: SocketProtocol {
     let output: SelectablePipeHandle?
 
     init(input: SelectablePipeHandle?, output: SelectablePipeHandle?) throws {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         self.input = input
         self.output = output
         try self.ignoreSIGPIPE()
@@ -80,14 +91,19 @@ final class PipePair: SocketProtocol {
                 try NIOFileHandle.setNonBlocking(fileDescriptor: fd)
             }
         }
+        #endif
     }
 
     func ignoreSIGPIPE() throws {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         for fileHandle in [self.input, self.output].compactMap({ $0 }) {
             try fileHandle.withUnsafeHandle {
                 try PipePair.ignoreSIGPIPE(descriptor: $0)
             }
         }
+        #endif
     }
 
     var description: String {
@@ -103,30 +119,42 @@ final class PipePair: SocketProtocol {
     }
 
     func write(pointer: UnsafeRawBufferPointer) throws -> IOResult<Int> {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         guard let outputSPH = self.output else {
             fatalError("Internal inconsistency inside NIO: outputSPH closed on write. Please file a bug")
         }
         return try outputSPH.withUnsafeHandle {
             try Posix.write(descriptor: $0, pointer: pointer.baseAddress!, size: pointer.count)
         }
+        #endif
     }
 
     func writev(iovecs: UnsafeBufferPointer<IOVector>) throws -> IOResult<Int> {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         guard let outputSPH = self.output else {
             fatalError("Internal inconsistency inside NIO: outputSPH closed on writev. Please file a bug")
         }
         return try outputSPH.withUnsafeHandle {
             try Posix.writev(descriptor: $0, iovecs: iovecs)
         }
+        #endif
     }
 
     func read(pointer: UnsafeMutableRawBufferPointer) throws -> IOResult<Int> {
+        #if os(Windows)
+        fatalError(missingPipeSupportWindows)
+        #else
         guard let inputSPH = self.input else {
             fatalError("Internal inconsistency inside NIO: inputSPH closed on read. Please file a bug")
         }
         return try inputSPH.withUnsafeHandle {
             try Posix.read(descriptor: $0, pointer: pointer.baseAddress!, size: pointer.count)
         }
+        #endif
     }
 
     func recvmsg(

--- a/Sources/NIOPosix/Windows.swift
+++ b/Sources/NIOPosix/Windows.swift
@@ -19,6 +19,8 @@ import CNIOWindows
 
 typealias ssize_t = SSIZE_T
 
+let missingPipeSupportWindows = "Unimplemented: NIOPosix does not support PipeChannel on Windows"
+
 // overwrite the windows write method, as the one without underscore is deprecated.
 // also we can use this to downcast the count Int to UInt32
 func write(_ fd: Int32, _ ptr: UnsafeRawPointer?, _ count: Int) -> Int32 {


### PR DESCRIPTION
### Motivation

In Linux we can use `epoll` to observe sockets and pipes. WSAPoll sadly only works for sockets. To observe pipes in Windows we can use `WaitForMultipleObjects`. However we should try to get to a place where we can start to fix tests first.

### Changes

- fatalError all pipe functions that do not compile right now.