### PR TITLE
SelectableEventLoop.debugDescription: fix debugDescription deadlock

### DIFF
--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -1060,28 +1060,31 @@ extension SelectableEventLoop: CustomStringConvertible, CustomDebugStringConvert
 
     @usableFromInline
     var debugDescription: String {
-        self._tasksLock.withLock {
-            if self.inEventLoop {
-                return """
-                    SelectableEventLoop { \
-                    selector = \(self._selector), \
-                    scheduledTasks = \(self._scheduledTasks.description), \
-                    thread = \(self.thread), \
-                    state = \(self.internalState) \
-                    }
-                    """
-            } else {
-                return self.externalStateLock.withLock {
-                    """
-                    SelectableEventLoop { \
-                    selector = \(self._selector), \
-                    scheduledTasks = \(self._scheduledTasks.description), \
-                    thread = \(self.thread), \
-                    state = \(self.externalState) \
-                    }
-                    """
+        let scheduledTasks = self._tasksLock.withLock {
+            self._scheduledTasks.description
+        }
+
+        if self.inEventLoop {
+            return """
+                SelectableEventLoop { \
+                selector = \(self._selector), \
+                scheduledTasks = \(scheduledTasks), \
+                thread = \(self.thread), \
+                state = \(self.internalState) \
                 }
+                """
+        } else {
+            let externalState = self.externalStateLock.withLock {
+                self.externalState
             }
+            return """
+                SelectableEventLoop { \
+                selector = \(self._selector), \
+                scheduledTasks = \(scheduledTasks), \
+                thread = \(self.thread), \
+                state = \(externalState) \
+                }
+                """
         }
     }
 }


### PR DESCRIPTION
### Motivation:

In #3297, I introduced a deadlock involving `SelectableEventLoop`'s `debugDescription`. I was under the impression that it's not possible to call this from outside the `NIO` module so I deemed it safe. That was a mistake :).

### Modifications:

- Make it impossible to deadlock around `SelectableEventLoop.debugDescription`.

### Result:

- Fewer deadlocks