### PR TITLE
[Windows] Ensure WSAStartup is correctly called.

### DIFF
--- a/Sources/CNIOWindows/WSAStartup.c
+++ b/Sources/CNIOWindows/WSAStartup.c
@@ -18,18 +18,20 @@
 
 #include <stdlib.h>
 
-#pragma section(".CRT$XCU", read)
-
-static void __cdecl
-NIOWSAStartup(void) {
+void NIOWSAStartup(void) {
     WSADATA wsa;
     WORD wVersionRequested = MAKEWORD(2, 2);
-    if (!WSAStartup(wVersionRequested, &wsa)) {
+    int startup = WSAStartup(wVersionRequested, &wsa);
+    if (startup != 0) {
         _exit(EXIT_FAILURE);
     }
 }
 
-__declspec(allocate(".CRT$XCU"))
-static void (*pNIOWSAStartup)(void) = &NIOWSAStartup;
+// The function pointer type for C initializers
+typedef void (__cdecl *NIOWindowsStartup)(void);
+
+// Declare a function pointer to your function, and put it in the .CRT$XCU section
+#pragma section(".CRT$XCU", read)
+__declspec(allocate(".CRT$XCU")) NIOWindowsStartup NIOWSAStartup_ptr = NIOWSAStartup;
 
 #endif

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -474,7 +474,8 @@ public enum SocketAddress: CustomStringConvertible, Sendable {
             try String(port).withCString(encodedAs: UTF16.self) { wszPort in
                 var pResult: UnsafeMutablePointer<ADDRINFOW>?
 
-                guard GetAddrInfoW(wszHost, wszPort, nil, &pResult) == 0 else {
+                let result = GetAddrInfoW(wszHost, wszPort, nil, &pResult)
+                guard result == 0 else {
                     throw SocketAddressError.unknown(host: host, port: port)
                 }
 


### PR DESCRIPTION
### Motivation

- `WSAStartup` isn't called

### Changes

- Change stuff that I have very little idea about until it works

### Result

WSAStartup is now emitted at the correct location for the linker to be picked up.