### PR TITLE
Deprecate _NIOFileSystem types

### DIFF
--- a/Sources/_NIOFileSystem/Array+FileSystem.swift
+++ b/Sources/_NIOFileSystem/Array+FileSystem.swift
@@ -21,7 +21,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/Array+FileSystem.swift
+++ b/Sources/_NIOFileSystem/Array+FileSystem.swift
@@ -21,7 +21,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/Array+FileSystem.swift
+++ b/Sources/_NIOFileSystem/Array+FileSystem.swift
@@ -16,6 +16,20 @@
 import NIOCore
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension Array where Element == UInt8 {
     /// Reads the contents of the file at the path.
     ///

--- a/Sources/_NIOFileSystem/ArraySlice+FileSystem.swift
+++ b/Sources/_NIOFileSystem/ArraySlice+FileSystem.swift
@@ -16,6 +16,20 @@
 import NIOCore
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension ArraySlice where Element == UInt8 {
     /// Reads the contents of the file at the path.
     ///

--- a/Sources/_NIOFileSystem/ArraySlice+FileSystem.swift
+++ b/Sources/_NIOFileSystem/ArraySlice+FileSystem.swift
@@ -21,7 +21,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/ArraySlice+FileSystem.swift
+++ b/Sources/_NIOFileSystem/ArraySlice+FileSystem.swift
@@ -21,7 +21,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/ByteBuffer+FileSystem.swift
+++ b/Sources/_NIOFileSystem/ByteBuffer+FileSystem.swift
@@ -20,7 +20,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/ByteBuffer+FileSystem.swift
+++ b/Sources/_NIOFileSystem/ByteBuffer+FileSystem.swift
@@ -15,6 +15,20 @@
 import NIOCore
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension ByteBuffer {
     /// Reads the contents of the file at the path.
     ///

--- a/Sources/_NIOFileSystem/ByteBuffer+FileSystem.swift
+++ b/Sources/_NIOFileSystem/ByteBuffer+FileSystem.swift
@@ -20,7 +20,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/Convenience.swift
+++ b/Sources/_NIOFileSystem/Convenience.swift
@@ -19,7 +19,7 @@ import SystemPackage
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -81,7 +81,7 @@ extension String {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -141,7 +141,7 @@ extension Sequence<UInt8> where Self: Sendable {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -202,7 +202,7 @@ extension AsyncSequence where Self.Element: Sequence<UInt8>, Self: Sendable {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/Convenience.swift
+++ b/Sources/_NIOFileSystem/Convenience.swift
@@ -19,7 +19,7 @@ import SystemPackage
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -81,7 +81,7 @@ extension String {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -141,7 +141,7 @@ extension Sequence<UInt8> where Self: Sendable {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -202,7 +202,7 @@ extension AsyncSequence where Self.Element: Sequence<UInt8>, Self: Sendable {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/Convenience.swift
+++ b/Sources/_NIOFileSystem/Convenience.swift
@@ -14,6 +14,20 @@
 
 import SystemPackage
 
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension String {
     /// Writes the UTF8 encoded `String` to a file.
     ///
@@ -62,6 +76,20 @@ extension String {
     }
 }
 
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension Sequence<UInt8> where Self: Sendable {
     /// Writes the contents of the `Sequence` to a file.
     ///
@@ -108,6 +136,20 @@ extension Sequence<UInt8> where Self: Sendable {
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension AsyncSequence where Self.Element: Sequence<UInt8>, Self: Sendable {
     /// Writes the contents of the `AsyncSequence` to a file.
     ///
@@ -155,6 +197,20 @@ extension AsyncSequence where Self.Element: Sequence<UInt8>, Self: Sendable {
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension AsyncSequence where Self.Element == UInt8, Self: Sendable {
     /// Writes the contents of the `AsyncSequence` to a file.
     ///

--- a/Sources/_NIOFileSystem/FileSystem.swift
+++ b/Sources/_NIOFileSystem/FileSystem.swift
@@ -49,6 +49,20 @@ import Darwin
 /// more information about the error by calling ``FileSystemError/detailedDescription()`` which
 /// returns a structured multi-line string containing information about the error.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 public struct FileSystem: Sendable, FileSystemProtocol {
     /// Returns a shared global instance of the ``FileSystem``.
     ///
@@ -689,6 +703,20 @@ extension NIOSingletons {
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 private let globalFileSystem: FileSystem = {
     guard NIOSingletons.singletonsEnabledSuggestion else {
         fatalError(
@@ -702,15 +730,44 @@ private let globalFileSystem: FileSystem = {
 }()
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+
 extension NIOSingletons {
     /// Returns a shared global instance of the ``FileSystem``.
     ///
     /// The file system executes blocking work in a thread pool. See
     /// `blockingPoolThreadCountSuggestion` for the default behaviour and ways to control it.
+    @available(
+        *,
+        deprecated,
+        message: """
+            The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+            on or after January 1st 2026.
+
+            You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+            and is both API stable and supported by the SwiftNIO maintainers.
+
+            The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+            has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+            """
+    )
     public static var fileSystem: FileSystem { globalFileSystem }
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension FileSystemProtocol where Self == FileSystem {
     /// A global shared instance of ``FileSystem``.
     public static var shared: FileSystem {
@@ -720,6 +777,21 @@ extension FileSystemProtocol where Self == FileSystem {
 
 /// Provides temporary scoped access to a ``FileSystem`` with the given number of threads.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that usage of \
+        the 'FilePath' type has been replaced with 'NIOFilePath'. Each type offers an init to \
+        convert from the other.
+        """
+)
 public func withFileSystem<Result>(
     numberOfThreads: Int,
     _ body: (FileSystem) async throws -> Result
@@ -733,6 +805,20 @@ public func withFileSystem<Result>(
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension FileSystem {
     /// Opens `path` for reading and returns ``ReadFileHandle`` or ``FileSystemError``.
     private func _openFile(

--- a/Sources/_NIOFileSystem/FileSystem.swift
+++ b/Sources/_NIOFileSystem/FileSystem.swift
@@ -54,7 +54,7 @@ import Darwin
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -708,7 +708,7 @@ extension NIOSingletons {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -741,7 +741,7 @@ extension NIOSingletons {
         deprecated,
         message: """
             The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-            on or after April 1st 2026.
+            on or after January 1st 2026.
 
             You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
             and is both API stable and supported by the SwiftNIO maintainers.
@@ -759,7 +759,7 @@ extension NIOSingletons {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -782,7 +782,7 @@ extension FileSystemProtocol where Self == FileSystem {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -810,7 +810,7 @@ public func withFileSystem<Result>(
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/FileSystem.swift
+++ b/Sources/_NIOFileSystem/FileSystem.swift
@@ -54,7 +54,7 @@ import Darwin
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -708,7 +708,7 @@ extension NIOSingletons {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -741,7 +741,7 @@ extension NIOSingletons {
         deprecated,
         message: """
             The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-            on or after January 1st 2026.
+            on or after April 1st 2026.
 
             You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
             and is both API stable and supported by the SwiftNIO maintainers.
@@ -759,7 +759,7 @@ extension NIOSingletons {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -782,7 +782,7 @@ extension FileSystemProtocol where Self == FileSystem {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -810,7 +810,7 @@ public func withFileSystem<Result>(
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/_NIOFileSystem/FileSystemProtocol.swift
@@ -16,6 +16,20 @@ import SystemPackage
 
 /// The interface for interacting with a file system.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 public protocol FileSystemProtocol: Sendable {
     /// The type of ``ReadableFileHandleProtocol`` to return when opening files for reading.
     associatedtype ReadFileHandle: ReadableFileHandleProtocol
@@ -308,6 +322,20 @@ public protocol FileSystemProtocol: Sendable {
 // MARK: - Open existing files/directories
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension FileSystemProtocol {
     /// Opens the file at the given path and provides scoped read-only access to it.
     ///
@@ -418,6 +446,20 @@ extension FileSystemProtocol {
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension FileSystemProtocol {
     /// Opens the file at `path` for reading and returns a handle to it.
     ///

--- a/Sources/_NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/_NIOFileSystem/FileSystemProtocol.swift
@@ -21,7 +21,7 @@ import SystemPackage
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -327,7 +327,7 @@ public protocol FileSystemProtocol: Sendable {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -451,7 +451,7 @@ extension FileSystemProtocol {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/_NIOFileSystem/FileSystemProtocol.swift
@@ -21,7 +21,7 @@ import SystemPackage
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -327,7 +327,7 @@ public protocol FileSystemProtocol: Sendable {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.
@@ -451,7 +451,7 @@ extension FileSystemProtocol {
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/Internal/ParallelDirCopy.swift
+++ b/Sources/_NIOFileSystem/Internal/ParallelDirCopy.swift
@@ -20,7 +20,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/Internal/ParallelDirCopy.swift
+++ b/Sources/_NIOFileSystem/Internal/ParallelDirCopy.swift
@@ -20,7 +20,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/Internal/ParallelDirCopy.swift
+++ b/Sources/_NIOFileSystem/Internal/ParallelDirCopy.swift
@@ -15,6 +15,20 @@
 import NIOCore
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension FileSystem {
     /// Iterative implementation of a recursive parallel copy of the directory from `sourcePath` to
     /// `destinationPath`.

--- a/Sources/_NIOFileSystem/Internal/ParallelRemoval.swift
+++ b/Sources/_NIOFileSystem/Internal/ParallelRemoval.swift
@@ -20,7 +20,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/Internal/ParallelRemoval.swift
+++ b/Sources/_NIOFileSystem/Internal/ParallelRemoval.swift
@@ -15,6 +15,20 @@
 import NIOCore
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension FileSystem {
     /// Recursively walk all objects found in `path`. Call ourselves recursively
     /// on each directory that we find, as soon as the file descriptor for

--- a/Sources/_NIOFileSystem/Internal/ParallelRemoval.swift
+++ b/Sources/_NIOFileSystem/Internal/ParallelRemoval.swift
@@ -20,7 +20,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/String+FileSystem.swift
+++ b/Sources/_NIOFileSystem/String+FileSystem.swift
@@ -20,7 +20,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after April 1st 2026.
+        on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/String+FileSystem.swift
+++ b/Sources/_NIOFileSystem/String+FileSystem.swift
@@ -20,7 +20,7 @@ import NIOCore
     deprecated,
     message: """
         The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
-        on or after January 1st 2026.
+        on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
         and is both API stable and supported by the SwiftNIO maintainers.

--- a/Sources/_NIOFileSystem/String+FileSystem.swift
+++ b/Sources/_NIOFileSystem/String+FileSystem.swift
@@ -15,6 +15,20 @@
 import NIOCore
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystem' module has been deprecated and will be removed from SwiftNIO \
+        on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystem' module which replaces '_NIOFileSystem' \
+        and is both API stable and supported by the SwiftNIO maintainers.
+
+        The most notable change between '_NIOFileSystem' and 'NIOFileSystem' is that 'FilePath' \
+        has been replaced with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension String {
     /// Reads the contents of the file at the path into a String.
     ///

--- a/Sources/_NIOFileSystemFoundationCompat/Data+FileSystem.swift
+++ b/Sources/_NIOFileSystemFoundationCompat/Data+FileSystem.swift
@@ -24,7 +24,7 @@ import struct Foundation.Data
     deprecated,
     message: """
         The '_NIOFileSystemFoundationCompat' module has been deprecated and will be removed from \
-        SwiftNIO on or after January 1st 2026.
+        SwiftNIO on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystemFoundationCompat' module which replaces \
         '_NIOFileSystemFoundationCompat' and is both API stable and supported by the SwiftNIO \

--- a/Sources/_NIOFileSystemFoundationCompat/Data+FileSystem.swift
+++ b/Sources/_NIOFileSystemFoundationCompat/Data+FileSystem.swift
@@ -24,7 +24,7 @@ import struct Foundation.Data
     deprecated,
     message: """
         The '_NIOFileSystemFoundationCompat' module has been deprecated and will be removed from \
-        SwiftNIO on or after April 1st 2026.
+        SwiftNIO on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystemFoundationCompat' module which replaces \
         '_NIOFileSystemFoundationCompat' and is both API stable and supported by the SwiftNIO \

--- a/Sources/_NIOFileSystemFoundationCompat/Data+FileSystem.swift
+++ b/Sources/_NIOFileSystemFoundationCompat/Data+FileSystem.swift
@@ -19,6 +19,22 @@ import NIOFoundationCompat
 import struct Foundation.Data
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystemFoundationCompat' module has been deprecated and will be removed from \
+        SwiftNIO on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystemFoundationCompat' module which replaces \
+        '_NIOFileSystemFoundationCompat' and is both API stable and supported by the SwiftNIO \
+        maintainers.
+
+        The most notable change between '_NIOFileSystemFoundationCompat' and \
+        'NIOFileSystemFoundationCompat' is that usage of the 'FilePath' type has been replaced \
+        with 'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension Data {
     /// Reads the contents of the file at the path.
     ///

--- a/Sources/_NIOFileSystemFoundationCompat/Date+FileInfo.swift
+++ b/Sources/_NIOFileSystemFoundationCompat/Date+FileInfo.swift
@@ -21,7 +21,7 @@ import struct Foundation.Date
     deprecated,
     message: """
         The '_NIOFileSystemFoundationCompat' module has been deprecated and will be removed from \
-        SwiftNIO on or after January 1st 2026.
+        SwiftNIO on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystemFoundationCompat' module which replaces \
         '_NIOFileSystemFoundationCompat' and is both API stable and supported by the SwiftNIO \
@@ -44,7 +44,7 @@ extension Date {
     deprecated,
     message: """
         The '_NIOFileSystemFoundationCompat' module has been deprecated and will be removed from \
-        SwiftNIO on or after January 1st 2026.
+        SwiftNIO on or after April 1st 2026.
 
         You should switch to using the 'NIOFileSystemFoundationCompat' module which replaces \
         '_NIOFileSystemFoundationCompat' and is both API stable and supported by the SwiftNIO \

--- a/Sources/_NIOFileSystemFoundationCompat/Date+FileInfo.swift
+++ b/Sources/_NIOFileSystemFoundationCompat/Date+FileInfo.swift
@@ -21,7 +21,7 @@ import struct Foundation.Date
     deprecated,
     message: """
         The '_NIOFileSystemFoundationCompat' module has been deprecated and will be removed from \
-        SwiftNIO on or after April 1st 2026.
+        SwiftNIO on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystemFoundationCompat' module which replaces \
         '_NIOFileSystemFoundationCompat' and is both API stable and supported by the SwiftNIO \
@@ -44,7 +44,7 @@ extension Date {
     deprecated,
     message: """
         The '_NIOFileSystemFoundationCompat' module has been deprecated and will be removed from \
-        SwiftNIO on or after April 1st 2026.
+        SwiftNIO on or after January 1st 2026.
 
         You should switch to using the 'NIOFileSystemFoundationCompat' module which replaces \
         '_NIOFileSystemFoundationCompat' and is both API stable and supported by the SwiftNIO \

--- a/Sources/_NIOFileSystemFoundationCompat/Date+FileInfo.swift
+++ b/Sources/_NIOFileSystemFoundationCompat/Date+FileInfo.swift
@@ -16,6 +16,22 @@ import _NIOFileSystem
 
 import struct Foundation.Date
 
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystemFoundationCompat' module has been deprecated and will be removed from \
+        SwiftNIO on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystemFoundationCompat' module which replaces \
+        '_NIOFileSystemFoundationCompat' and is both API stable and supported by the SwiftNIO \
+        maintainers.
+
+        The most notable change between '_NIOFileSystemFoundationCompat' and \
+        'NIOFileSystemFoundationCompat' is that 'FilePath' has been replaced with \
+        'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension Date {
     public init(timespec: FileInfo.Timespec) {
         let timeInterval = Double(timespec.seconds) + Double(timespec.nanoseconds) / 1_000_000_000
@@ -23,6 +39,22 @@ extension Date {
     }
 }
 
+@available(
+    *,
+    deprecated,
+    message: """
+        The '_NIOFileSystemFoundationCompat' module has been deprecated and will be removed from \
+        SwiftNIO on or after January 1st 2026.
+
+        You should switch to using the 'NIOFileSystemFoundationCompat' module which replaces \
+        '_NIOFileSystemFoundationCompat' and is both API stable and supported by the SwiftNIO \
+        maintainers.
+
+        The most notable change between '_NIOFileSystemFoundationCompat' and \
+        'NIOFileSystemFoundationCompat' is that 'FilePath' has been replaced with \
+        'NIOFilePath'. Each type offers an init to convert from the other.
+        """
+)
 extension FileInfo.Timespec {
     /// The UTC time of the timestamp.
     public var date: Date {


### PR DESCRIPTION
Motivation:

_NIOFileSystem and _NIOFileSystemFoundationCompat will be removed after some period of time in favour of their non-underscored counterparts. We need to tell users to migrate.

Modifications:

- Deprecate types in `_NIOFileSystem` and `_NIOFileSystemFoundationCompat` telling users to migrate and that they'll be removed after 1st Jan 2026

Result:

Timeline set for removal of _NIOFileSystem and _NIOFileSystemFoundationCompat