### PR TITLE
Remove NIOFileSystem from products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,8 +64,6 @@ let package = Package(
         .library(name: "NIOFoundationCompat", targets: ["NIOFoundationCompat"]),
         .library(name: "NIOWebSocket", targets: ["NIOWebSocket"]),
         .library(name: "NIOTestUtils", targets: ["NIOTestUtils"]),
-        .library(name: "NIOFileSystem", targets: ["NIOFileSystem"]),
-        .library(name: "NIOFileSystemFoundationCompat", targets: ["NIOFileSystemFoundationCompat"]),
         .library(name: "_NIOFileSystem", targets: ["_NIOFileSystem"]),
         .library(name: "_NIOFileSystemFoundationCompat", targets: ["_NIOFileSystemFoundationCompat"]),
     ],

--- a/Snippets/NIOFileSystemTour.swift
+++ b/Snippets/NIOFileSystemTour.swift
@@ -1,7 +1,7 @@
 // snippet.hide
 
 import NIOCore
-import NIOFileSystem
+import _NIOFileSystem
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func main() async throws {
@@ -48,7 +48,7 @@ func main() async throws {
 
     // Directories can be opened like regular files but they cannot be read from or
     // written to. However, their contents can be listed:
-    let path: NIOFilePath? = try await fileSystem.withDirectoryHandle(atPath: "/Users/hal9000/Music") { directory in
+    let path: FilePath? = try await fileSystem.withDirectoryHandle(atPath: "/Users/hal9000/Music") { directory in
         for try await entry in directory.listContents() {
             if entry.name == "daisy.mp3" {
                 // Found it!


### PR DESCRIPTION
Motivation:

NIOFileSystem has a few APIs which expose swift-system. We'll need to replace those before making this API stable.

Modifications:

- Remove NIOFileSystem product
- Modify snippet so that it still builds

Result:

NIOFileSystem isn't yet public API