### PR TITLE
Add Xcode 26.0, 16.4 CI, remove 16.2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,7 +80,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@update_macos_ci_xcode_26
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       runner_pool: general
       build_scheme: swift-nio-Package


### PR DESCRIPTION
### Motivation:

New Xcodes are out so we should test with them.

### Modifications:

Update the macOS matrix generation script

### Result:

Add Xcode 26.0, 16.4 CI, remove 16.2 jobs by default.

CI with the new Xcodes working (except 26.0 which will come online as nodes recycle https://github.com/apple/swift-nio/actions/runs/17834807139/job/50709176060?pr=3375)