### PR TITLE
feat: add homeDirectory accessor to FileSystem

### DIFF
--- a/Sources/NIOFS/Docs.docc/Extensions/FileSystemProtocol.md
+++ b/Sources/NIOFS/Docs.docc/Extensions/FileSystemProtocol.md
@@ -42,5 +42,6 @@ closing it to avoid leaking resources.
 ### System directories
 
 - ``currentWorkingDirectory``
+- ``homeDirectory``
 - ``temporaryDirectory``
 - ``withTemporaryDirectory(prefix:options:execute:)``

--- a/Sources/NIOFS/FileSystem.swift
+++ b/Sources/NIOFS/FileSystem.swift
@@ -636,6 +636,18 @@ public struct FileSystem: Sendable, FileSystemProtocol {
         }
     }
 
+    /// Returns the path of the current user's home directory.
+    public var homeDirectory: NIOFilePath {
+        get async throws {
+            let result = try await self.threadPool.runIfActive {
+                try Libc.homeDirectoryForCurrentUser().mapError { errno in
+                    FileSystemError.homeDirectory(errno: errno, location: .here())
+                }.get()
+            }
+            return .init(result)
+        }
+    }
+
     /// Returns a path to a temporary directory.
     ///
     /// #### Implementation details

--- a/Sources/NIOFS/FileSystemError+Syscall.swift
+++ b/Sources/NIOFS/FileSystemError+Syscall.swift
@@ -975,6 +975,17 @@ extension FileSystemError {
     }
 
     @_spi(Testing)
+    public static func homeDirectory(errno: Errno, location: SourceLocation) -> Self {
+        FileSystemError(
+            code: .unavailable,
+            message: "Can't get home directory for current user.",
+            systemCall: "getpwuid_r",
+            errno: errno,
+            location: location
+        )
+    }
+
+    @_spi(Testing)
     public static func confstr(name: String, errno: Errno, location: SourceLocation) -> Self {
         FileSystemError(
             code: .unavailable,

--- a/Sources/NIOFS/FileSystemProtocol.swift
+++ b/Sources/NIOFS/FileSystemProtocol.swift
@@ -108,6 +108,9 @@ public protocol FileSystemProtocol: Sendable {
     /// Returns the current working directory.
     var currentWorkingDirectory: NIOFilePath { get async throws }
 
+    /// Returns the current user's home directory.
+    var homeDirectory: NIOFilePath { get async throws }
+
     /// Returns the path of the temporary directory.
     var temporaryDirectory: NIOFilePath { get async throws }
 

--- a/Sources/NIOFS/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFS/Internal/System Calls/Syscall.swift
@@ -362,6 +362,67 @@ public enum Libc: Sendable {
         }
     }
 
+    static func homeDirectoryForCurrentUser() -> Result<FilePath, Errno> {
+        if let home = getenv("HOME"), home.pointee != 0 {
+            return .success(FilePath(String(cString: home)))
+        }
+
+        #if os(Windows)
+        if let profile = getenv("USERPROFILE"), profile.pointee != 0 {
+            return .success(FilePath(String(cString: profile)))
+        }
+        return .failure(.noSuchFileOrDirectory)
+        #else
+        return self._homeDirectoryFromPasswordDatabase()
+        #endif
+    }
+
+    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Android)
+    private static func _homeDirectoryFromPasswordDatabase() -> Result<FilePath, Errno> {
+        var pwd = passwd()
+        var result: UnsafeMutablePointer<passwd>? = nil
+        var buffer = [CChar](repeating: 0, count: 256)
+
+        let uid: uid_t = {
+            #if canImport(Darwin)
+            return Darwin.getuid()
+            #elseif canImport(Glibc)
+            return Glibc.getuid()
+            #elseif canImport(Musl)
+            return Musl.getuid()
+            #else
+            return 0
+            #endif
+        }()
+
+        while true {
+            let error: CInt = buffer.withUnsafeMutableBufferPointer { pointer in
+                guard let baseAddress = pointer.baseAddress else {
+                    return CInt(ERANGE)
+                }
+
+                return withUnsafeMutablePointer(to: &result) { resultPointer in
+                    libc_getpwuid_r(uid, &pwd, baseAddress, pointer.count, resultPointer)
+                }
+            }
+
+            if error == 0 {
+                guard result != nil, let directoryPointer = pwd.pw_dir else {
+                    return .failure(.noSuchFileOrDirectory)
+                }
+                return .success(FilePath(String(cString: directoryPointer)))
+            }
+
+            if error == ERANGE {
+                buffer.append(contentsOf: repeatElement(0, count: buffer.count))
+                continue
+            }
+
+            return .failure(Errno(rawValue: error))
+        }
+    }
+    #endif
+
     #if !os(Android)
     static func constr(_ name: CInt) -> Result<String, Errno> {
         var buffer = [CInterop.PlatformChar](repeating: 0, count: 128)

--- a/Sources/NIOFS/Internal/System Calls/Syscalls.swift
+++ b/Sources/NIOFS/Internal/System Calls/Syscalls.swift
@@ -440,6 +440,17 @@ internal func libc_getcwd(
     getcwd(buffer, size)
 }
 
+/// getpwuid_r(3): Get password file entry
+internal func libc_getpwuid_r(
+    _ uid: uid_t,
+    _ pwd: UnsafeMutablePointer<passwd>,
+    _ buffer: UnsafeMutablePointer<CChar>,
+    _ bufferSize: Int,
+    _ result: UnsafeMutablePointer<UnsafeMutablePointer<passwd>?>
+) -> CInt {
+    getpwuid_r(uid, pwd, buffer, bufferSize, result)
+}
+
 /// confstr(3)
 #if !os(Android)
 internal func libc_confstr(

--- a/Sources/_NIOFileSystem/FileSystem.swift
+++ b/Sources/_NIOFileSystem/FileSystem.swift
@@ -636,6 +636,17 @@ public struct FileSystem: Sendable, FileSystemProtocol {
         }
     }
 
+    /// Returns the path of the current user's home directory.
+    public var homeDirectory: FilePath {
+        get async throws {
+            try await self.threadPool.runIfActive {
+                try Libc.homeDirectoryForCurrentUser().mapError { errno in
+                    FileSystemError.homeDirectory(errno: errno, location: .here())
+                }.get()
+            }
+        }
+    }
+
     /// Returns a path to a temporary directory.
     ///
     /// #### Implementation details

--- a/Sources/_NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/_NIOFileSystem/FileSystemError+Syscall.swift
@@ -975,6 +975,17 @@ extension FileSystemError {
     }
 
     @_spi(Testing)
+    public static func homeDirectory(errno: Errno, location: SourceLocation) -> Self {
+        FileSystemError(
+            code: .unavailable,
+            message: "Can't get home directory for current user.",
+            systemCall: "getpwuid_r",
+            errno: errno,
+            location: location
+        )
+    }
+
+    @_spi(Testing)
     public static func confstr(name: String, errno: Errno, location: SourceLocation) -> Self {
         FileSystemError(
             code: .unavailable,

--- a/Sources/_NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/_NIOFileSystem/FileSystemProtocol.swift
@@ -108,6 +108,9 @@ public protocol FileSystemProtocol: Sendable {
     /// Returns the current working directory.
     var currentWorkingDirectory: FilePath { get async throws }
 
+    /// Returns the current user's home directory.
+    var homeDirectory: FilePath { get async throws }
+
     /// Returns the path of the temporary directory.
     var temporaryDirectory: FilePath { get async throws }
 

--- a/Sources/_NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/_NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -362,6 +362,67 @@ public enum Libc: Sendable {
         }
     }
 
+    static func homeDirectoryForCurrentUser() -> Result<FilePath, Errno> {
+        if let home = getenv("HOME"), home.pointee != 0 {
+            return .success(FilePath(String(cString: home)))
+        }
+
+        #if os(Windows)
+        if let profile = getenv("USERPROFILE"), profile.pointee != 0 {
+            return .success(FilePath(String(cString: profile)))
+        }
+        return .failure(.noSuchFileOrDirectory)
+        #else
+        return self._homeDirectoryFromPasswordDatabase()
+        #endif
+    }
+
+    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Android)
+    private static func _homeDirectoryFromPasswordDatabase() -> Result<FilePath, Errno> {
+        var pwd = passwd()
+        var result: UnsafeMutablePointer<passwd>? = nil
+        var buffer = [CChar](repeating: 0, count: 256)
+
+        let uid: uid_t = {
+            #if canImport(Darwin)
+            return Darwin.getuid()
+            #elseif canImport(Glibc)
+            return Glibc.getuid()
+            #elseif canImport(Musl)
+            return Musl.getuid()
+            #else
+            return 0
+            #endif
+        }()
+
+        while true {
+            let error: CInt = buffer.withUnsafeMutableBufferPointer { pointer in
+                guard let baseAddress = pointer.baseAddress else {
+                    return CInt(ERANGE)
+                }
+
+                return withUnsafeMutablePointer(to: &result) { resultPointer in
+                    libc_getpwuid_r(uid, &pwd, baseAddress, pointer.count, resultPointer)
+                }
+            }
+
+            if error == 0 {
+                guard result != nil, let directoryPointer = pwd.pw_dir else {
+                    return .failure(.noSuchFileOrDirectory)
+                }
+                return .success(FilePath(String(cString: directoryPointer)))
+            }
+
+            if error == ERANGE {
+                buffer.append(contentsOf: repeatElement(0, count: buffer.count))
+                continue
+            }
+
+            return .failure(Errno(rawValue: error))
+        }
+    }
+    #endif
+
     #if !os(Android)
     static func constr(_ name: CInt) -> Result<String, Errno> {
         var buffer = [CInterop.PlatformChar](repeating: 0, count: 128)

--- a/Sources/_NIOFileSystem/Internal/System Calls/Syscalls.swift
+++ b/Sources/_NIOFileSystem/Internal/System Calls/Syscalls.swift
@@ -440,6 +440,17 @@ internal func libc_getcwd(
     getcwd(buffer, size)
 }
 
+/// getpwuid_r(3): Get password file entry
+internal func libc_getpwuid_r(
+    _ uid: uid_t,
+    _ pwd: UnsafeMutablePointer<passwd>,
+    _ buffer: UnsafeMutablePointer<CChar>,
+    _ bufferSize: Int,
+    _ result: UnsafeMutablePointer<UnsafeMutablePointer<passwd>?>
+) -> CInt {
+    getpwuid_r(uid, pwd, buffer, bufferSize, result)
+}
+
 /// confstr(3)
 #if !os(Android)
 internal func libc_confstr(

--- a/Tests/NIOFSIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileSystemTests.swift
@@ -511,6 +511,15 @@ final class FileSystemTests: XCTestCase {
         XCTAssert(directory.underlying.isAbsolute)
     }
 
+    func testHomeDirectory() async throws {
+        let directory = try await self.fs.homeDirectory
+        XCTAssert(!directory.underlying.isEmpty)
+        XCTAssert(directory.underlying.isAbsolute)
+
+        let info = try await self.fs.info(forFileAt: directory, infoAboutSymbolicLink: false)
+        XCTAssertEqual(info?.type, .directory)
+    }
+
     func testTemporaryDirectory() async throws {
         let directory = try await self.fs.temporaryDirectory
         XCTAssert(!directory.underlying.isEmpty)


### PR DESCRIPTION
## Summary
- surface a `homeDirectory` property on `FileSystemProtocol` and the concrete file system implementation
- resolve the current user's home directory via environment variables with a `getpwuid_r` fallback

## Rationale
- fixes #3381 by providing an async API to retrieve the current user's home directory

## Changes
- add protocol requirements and implementations for `homeDirectory`
- extend syscall helpers and error mapping to support `getpwuid_r`
- document the new API and add an integration test covering the returned path

Fixes #3381
