### PR TITLE
re-vendor sha1 & update script location

### DIFF
--- a/Sources/CNIOSHA1/c_nio_sha1.c
+++ b/Sources/CNIOSHA1/c_nio_sha1.c
@@ -44,7 +44,9 @@
  * implemented by Jun-ichiro itojun Itoh <itojun@itojun.org>
  */
 
+
 #include "include/CNIOSHA1.h"
+#include <stdint.h>
 #include <string.h>
 #if !defined(bzero)
 #define bzero(b,l) memset((b), '\0', (l))
@@ -57,15 +59,15 @@
 #elif defined(__linux__) || defined(__APPLE__) || defined(__wasm32__)
 #include <sys/types.h>
 #elif defined(_WIN32) || defined(_WIN64)
-	#ifndef LITTLE_ENDIAN
-	#define LITTLE_ENDIAN 1234
-	#endif
-	#ifndef BIG_ENDIAN
-	#define BIG_ENDIAN 4321
-	#endif
-	#ifndef BYTE_ORDER
-	#define BYTE_ORDER LITTLE_ENDIAN
-	#endif
+#ifndef LITTLE_ENDIAN
+#define LITTLE_ENDIAN 1234
+#endif
+#ifndef BIG_ENDIAN
+#define BIG_ENDIAN 4321
+ #endif
+#ifndef BYTE_ORDER
+#define BYTE_ORDER LITTLE_ENDIAN
+#endif
 #endif
 
 
@@ -102,7 +104,7 @@ static uint32_t _K[] = { 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xca62c1d6 };
 	COUNT %= 64;				\
 	ctxt->c.b64[0] += 8;			\
 	if (COUNT % 64 == 0)			\
-		sha1_step(ctxt);		\
+		c_nio_sha1_step(ctxt);		\
      }
 
 #define	PUTPAD(x)	{ \
@@ -110,13 +112,13 @@ static uint32_t _K[] = { 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xca62c1d6 };
 	COUNT++;				\
 	COUNT %= 64;				\
 	if (COUNT % 64 == 0)			\
-		sha1_step(ctxt);		\
+		c_nio_sha1_step(ctxt);		\
      }
 
-static void sha1_step(struct sha1_ctxt *);
+static void c_nio_sha1_step(struct sha1_ctxt *);
 
 static void
-sha1_step(struct sha1_ctxt *ctxt)
+c_nio_sha1_step(struct sha1_ctxt *ctxt)
 {
 	uint32_t	a, b, c, d, e;
 	size_t t, s;
@@ -224,7 +226,7 @@ c_nio_sha1_pad(struct sha1_ctxt *ctxt)
 		bzero(&ctxt->m.b8[padstart], padlen);
 		COUNT += padlen;
 		COUNT %= 64;
-		sha1_step(ctxt);
+		c_nio_sha1_step(ctxt);
 		padstart = COUNT % 64;	/* should be 0 */
 		padlen = 64 - padstart;	/* should be 64 */
 	}
@@ -264,7 +266,7 @@ c_nio_sha1_loop(struct sha1_ctxt *ctxt, const uint8_t *input, size_t len)
 		COUNT %= 64;
 		ctxt->c.b64[0] += copysiz * 8;
 		if (COUNT % 64 == 0)
-			sha1_step(ctxt);
+			c_nio_sha1_step(ctxt);
 		off += copysiz;
 	}
 }

--- a/Sources/CNIOSHA1/include/CNIOSHA1.h
+++ b/Sources/CNIOSHA1/include/CNIOSHA1.h
@@ -6,7 +6,6 @@
     - use welcoming language (soundness check)
     - ensure BYTE_ORDER is defined
 */
-/*	$FreeBSD$	*/
 /*	$KAME: sha1.h,v 1.5 2000/03/27 04:36:23 sumikawa Exp $	*/
 
 /*-
@@ -50,10 +49,6 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 struct sha1_ctxt {
 	union {
 		uint8_t		b8[20];
@@ -73,12 +68,7 @@ typedef struct sha1_ctxt SHA1_CTX;
 
 #define	SHA1_RESULTLEN	(160/8)
 
-#ifdef __cplusplus
-#define __min_size(x)	(x)
-#else
 #define __min_size(x)	static (x)
-#endif
-
 extern void c_nio_sha1_init(struct sha1_ctxt *);
 extern void c_nio_sha1_pad(struct sha1_ctxt *);
 extern void c_nio_sha1_loop(struct sha1_ctxt *, const uint8_t *, size_t);
@@ -89,8 +79,5 @@ extern void c_nio_sha1_result(struct sha1_ctxt *, char[__min_size(SHA1_RESULTLEN
 #define SHA1Update(x, y, z)	c_nio_sha1_loop((x), (y), (z))
 #define SHA1Final(x, y)		c_nio_sha1_result((y), (x))
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
 
 #endif /*_CRYPTO_SHA1_H_*/

--- a/Sources/CNIOSHA1/update_and_patch_sha1.sh
+++ b/Sources/CNIOSHA1/update_and_patch_sha1.sh
@@ -35,10 +35,10 @@ for f in sha1.c sha1.h; do
       echo "    - use welcoming language (soundness check)"
       echo "    - ensure BYTE_ORDER is defined"
       echo "*/"
-      curl -Ls "https://raw.githubusercontent.com/freebsd/freebsd/master/sys/crypto/$f" # ignore-unacceptable-language
+      curl -Ls "https://raw.githubusercontent.com/freebsd/freebsd-src/refs/heads/main/sys/crypto/$f"
     ) > "$here/c_nio_$f"
 
-    for func in sha1_init sha1_pad sha1_loop sha1_result; do
+    for func in sha1_init sha1_pad sha1_loop sha1_result sha1_step; do
         "$sed" -i \
             -e "s/$func/c_nio_$func/g" \
             "$here/c_nio_$f"
@@ -52,10 +52,10 @@ $sed -e $'/#define _CRYPTO_SHA1_H_/a #include <stdint.h>\\\n#include <stddef.h>'
      -i "$here/c_nio_sha1.h"
 
 $sed -e 's/u_int\([0-9]\+\)_t/uint\1_t/g'                                        \
-     -e '/^#include/d'                                                           \
-     -e $'/__FBSDID/c #include "include/CNIOSHA1.h"\\n#include <string.h>\\n#if !defined(bzero)\\n#define bzero(b,l) memset((b), \'\\\\0\', (l))\\n#endif\\n#if !defined(bcopy)\\n#define bcopy(s,d,l) memmove((d), (s), (l))\\n#endif\\n#ifdef __ANDROID__\\n#include <sys/endian.h>\\n#elif defined(__linux__) || defined(__APPLE__)\\n#include <sys/types.h>\\n#endif' \
+     -e '/#include <sys/d'                                                       \
+     -e $'/^#include <crypto/c #include "include/CNIOSHA1.h"\\n#include <stdint.h>\\n#include <string.h>\\n#if !defined(bzero)\\n#define bzero(b,l) memset((b), \'\\\\0\', (l))\\n#endif\\n#if !defined(bcopy)\\n#define bcopy(s,d,l) memmove((d), (s), (l))\\n#endif\\n#ifdef __ANDROID__\\n#include <sys/endian.h>\\n#elif defined(__linux__) || defined(__APPLE__) || defined(__wasm32__)\\n#include <sys/types.h>\\n#elif defined(_WIN32) || defined(_WIN64)\\n#ifndef LITTLE_ENDIAN\\n#define LITTLE_ENDIAN 1234\\n#endif\\n#ifndef BIG_ENDIAN\\n#define BIG_ENDIAN 4321\\n #endif\\n#ifndef BYTE_ORDER\\n#define BYTE_ORDER LITTLE_ENDIAN\\n#endif\\n#endif\\n' \
      -e 's/sanit[y]/soundness/g'                                                 \
-     -e 's/#if BYTE_ORDER != BIG_ENDIAN/#if !defined(BYTE_ORDER)\\n#error "BYTE_ORDER not defined"\\n#elif BYTE_ORDER != BIG_ENDIAN/' \
+     -e $'s/#if BYTE_ORDER != BIG_ENDIAN/#if !defined(BYTE_ORDER)\\n#error "BYTE_ORDER not defined"\\n#elif BYTE_ORDER != BIG_ENDIAN/' \
      -i "$here/c_nio_sha1.c"
 
 mv "$here/c_nio_sha1.h" "$here/include/CNIOSHA1.h"
@@ -63,7 +63,7 @@ mv "$here/c_nio_sha1.h" "$here/include/CNIOSHA1.h"
 tmp=$(mktemp -d /tmp/.test_compile_XXXXXX)
 
 clang -o "$tmp/test.o" -c "$here/c_nio_sha1.c"
-num_non_nio=$(nm "$tmp/test.o" | grep ' T ' | grep -vc c_nio)
+num_non_nio=$(nm "$tmp/test.o" | grep ' T ' | grep -vc c_nio || true)
 
 test 0 -eq "$num_non_nio" || {
     echo "ERROR: $num_non_nio exported non-prefixed symbols found"


### PR DESCRIPTION
### Motivation:

The sha1 vendoring script used the old place (`master` branch). Also, the supposedly vendored copy had manual edits

### Modifications:

Fix the vendoring script

### Result:

Actually vendored and up to date