### PR TITLE
Enable Xcode beta by default in macos_tests.yml

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -129,7 +129,7 @@ on:
       xcode_latest_beta_enabled:
         type: boolean
         description: "Boolean to enable the Xcode beta jobs (uses latest beta if one currently exists). Defaults to true."
-        default: false
+        default: true
       xcode_latest_beta_build_arguments_override:
         type: string
         description: "The arguments passed to swift build in the Xcode beta job."


### PR DESCRIPTION
26.1 Beta 2 has been released so we have an Xcode beta to be testing, we should enable it by default again. It was previously disabled under the impression that there was no current beta.
