### PR TITLE
Avoid zombie pipe channels when receiving writeEOF

### DIFF
--- a/Sources/NIOPosix/PipeChannel.swift
+++ b/Sources/NIOPosix/PipeChannel.swift
@@ -121,6 +121,17 @@ final class PipeChannel: BaseStreamSocketChannel<PipePair>, @unchecked Sendable 
         }
         try! self.selectableEventLoop.deregister(channel: self, mode: .output)
         try! outputSPH.close()
+
+        // Only close the entire channel if the input is already closed.
+        // If input is still open, we can continue half-duplex operation.
+        var inputIsClosed = true
+        if let inputSPH = self.pipePair.input {
+            inputIsClosed = !inputSPH.isOpen
+        }
+        if inputIsClosed {
+            let error = IOError(errnoCode: EPIPE, reason: "Broken pipe")
+            self.close0(error: error, mode: .all, promise: nil)
+        }
     }
 
     override func shutdownSocket(mode: CloseMode) throws {


### PR DESCRIPTION
Motivation

In rare cases where the inbound side of a pipe channel is already closed (either because it was never open or because it was closed during use), we can get into trouble if the reader drops the read side of our write pipe. In that context, the Linux kernel will deliver an EPOLLHUP, but while we'll close the FD we'll let the channel hang out as a zombie. This is, obviously, suboptimal.

Modifications

In writeEOF, we check whether the read side is already closed. If it is, we trigger a close internally to shut the channel down. Added a test for this as needed, and modified an existing test that would now trip over this behaviour. Also added a new test for the reverse case to ensure we don't end up with zombies there (we don't).

Results

No zombie channels.
