### PR TITLE
[perf] Manually implement `firstIndex(where:)` in `ByteBufferView`

### DIFF
--- a/Sources/NIOCore/ByteBuffer-views.swift
+++ b/Sources/NIOCore/ByteBuffer-views.swift
@@ -242,6 +242,23 @@ extension ByteBufferView: RangeReplaceableCollection {
             self._range = self._range.startIndex..<self._range.endIndex.advanced(by: additionalByteCount)
         }
     }
+
+    /// Returns the first index in which a byte satisfies the given predicate.
+    ///
+    /// - Parameter predicate: A closure that takes a byte as its argument
+    ///   and returns a Boolean value that indicates whether the passed byte
+    ///   represents a match.
+    /// - Returns: The index of the first byte for which `predicate` returns
+    ///   `true`. If no bytes in the collection satisfy the given predicate,
+    ///   returns `nil`.
+    ///
+    /// - Complexity: O(*n*), where *n* is the length of the collection.
+    @inlinable
+    public func firstIndex(where predicate: (UInt8) throws -> Bool) rethrows -> Index? {
+        try self.withUnsafeBytes { ptr in
+            try ptr.firstIndex(where: predicate).map { $0 + self._range.lowerBound }
+        }
+    }
 }
 
 extension ByteBuffer {

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -2406,6 +2406,20 @@ class ByteBufferTest: XCTestCase {
         XCTAssertNil(view?.firstIndex(of: UInt8(0x3F)))
     }
 
+    func testBufferViewFirstIndexWithWhereClosure() {
+        self.buf.clear()
+        self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
+        self.buf.setBytes([UInt8(0x59)], at: 1000)
+        self.buf.setBytes([UInt8(0x59)], at: 1001)
+        self.buf.setBytes([UInt8(0x59)], at: 1022)
+        self.buf.setBytes([UInt8(0x59)], at: 3)
+        self.buf.setBytes([UInt8(0x3F)], at: 1023)
+        self.buf.setBytes([UInt8(0x3F)], at: 2)
+        let view = self.buf.viewBytes(at: 5, length: 1010)
+        XCTAssertEqual(1000, view?.firstIndex(where: { $0 == UInt8(0x59) }))
+        XCTAssertNil(view?.firstIndex(where: { $0 == UInt8(0x3F) }))
+    }
+
     func testBufferViewLastIndex() {
         self.buf.clear()
         self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))


### PR DESCRIPTION
### Motivation:

`ByteBuffer.firsIndex` is of suboptimal performance.
The default Collection implementations don't go through any "magic underscored" functions like `_customIndexOfEquatableElement`.

### Modifications:

Manually implement `firstIndex(where:)`.

### Result:

Basically free performance boost. 2x+ boost even for not big buffers of a few hundred bytes.

There are some usage of this function in `BufferedReader`. Those will become much faster.
Also this function is used in `ByteBufferView.trim(limitingElements:)`.

Also makes #3411 stuff faster. See: https://github.com/apple/swift-nio/pull/3411#discussion_r2436260691 
