### PR TITLE
[perf] Manually implement `lastIndex(where:)` in `ByteBufferView`

### DIFF
--- a/Sources/NIOCore/ByteBuffer-views.swift
+++ b/Sources/NIOCore/ByteBuffer-views.swift
@@ -259,6 +259,22 @@ extension ByteBufferView: RangeReplaceableCollection {
             try ptr.firstIndex(where: predicate).map { $0 + self._range.lowerBound }
         }
     }
+
+    /// Returns the index of the last byte that matches the given predicate.
+    ///
+    /// - Parameter predicate: A closure that takes a byte as its argument
+    ///   and returns a Boolean value that indicates whether the passed byte
+    ///   represents a match.
+    /// - Returns: The index of the last byte in the collection that matches
+    ///   `predicate`, or `nil` if no bytes match.
+    ///
+    /// - Complexity: O(*n*), where *n* is the length of the collection.
+    @inlinable
+    public func lastIndex(where predicate: (UInt8) throws -> Bool) rethrows -> Index? {
+        try self.withUnsafeBytes { ptr in
+            try ptr.lastIndex(where: predicate).map { $0 + self._range.lowerBound }
+        }
+    }
 }
 
 extension ByteBuffer {

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -2423,15 +2423,35 @@ class ByteBufferTest: XCTestCase {
     func testBufferViewLastIndex() {
         self.buf.clear()
         self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
-        self.buf.setBytes([UInt8(0x59)], at: 1000)
-        self.buf.setBytes([UInt8(0x59)], at: 1001)
-        self.buf.setBytes([UInt8(0x59)], at: 1022)
-        self.buf.setBytes([UInt8(0x59)], at: 3)
-        self.buf.setBytes([UInt8(0x3F)], at: 1023)
         self.buf.setBytes([UInt8(0x3F)], at: 2)
+        self.buf.setBytes([UInt8(0x59)], at: 3)
+        self.buf.setBytes([UInt8(0x61)], at: 1000)
+        self.buf.setBytes([UInt8(0x59)], at: 1001)
+        self.buf.setBytes([UInt8(0x61)], at: 1002)
+        self.buf.setBytes([UInt8(0x59)], at: 1003)
+        self.buf.setBytes([UInt8(0x61)], at: 1004)
+        self.buf.setBytes([UInt8(0x59)], at: 1023)
+        self.buf.setBytes([UInt8(0x3F)], at: 1024)
         let view = self.buf.viewBytes(at: 5, length: 1010)
-        XCTAssertEqual(1001, view?.lastIndex(of: UInt8(0x59)))
+        XCTAssertEqual(1003, view?.lastIndex(of: UInt8(0x59)))
         XCTAssertNil(view?.lastIndex(of: UInt8(0x3F)))
+    }
+
+    func testBufferViewLastIndexWithWhereClosure() {
+        self.buf.clear()
+        self.buf.writeBytes(Array(repeating: UInt8(0x4E), count: 1024))
+        self.buf.setBytes([UInt8(0x3F)], at: 2)
+        self.buf.setBytes([UInt8(0x59)], at: 3)
+        self.buf.setBytes([UInt8(0x61)], at: 1000)
+        self.buf.setBytes([UInt8(0x59)], at: 1001)
+        self.buf.setBytes([UInt8(0x61)], at: 1002)
+        self.buf.setBytes([UInt8(0x59)], at: 1003)
+        self.buf.setBytes([UInt8(0x61)], at: 1004)
+        self.buf.setBytes([UInt8(0x59)], at: 1023)
+        self.buf.setBytes([UInt8(0x3F)], at: 1024)
+        let view = self.buf.viewBytes(at: 5, length: 1010)
+        XCTAssertEqual(1003, view?.lastIndex(where: { $0 == UInt8(0x59) }))
+        XCTAssertNil(view?.lastIndex(where: { $0 == UInt8(0x3F) }))
     }
 
     func testBufferViewContains() {


### PR DESCRIPTION
### Motivation:

`ByteBuffer.lastIndex(where:)` is of suboptimal performance.
The default Collection implementations don't go through any "magic underscored" functions like `_customIndexOfEquatableElement`.

### Modifications:

Manually implement `lastIndex(where:)`.

### Result:

Basically free performance boost. 2x+ boost even for not big buffers of a few hundred bytes.

This function is currently used in `ByteBufferView.trim(limitingElements:)`.

I have no immediate use case for this function, but it's still an issue worth addressing.
