### PR TITLE
fix: Address memory leak that can occur if an instance loses all strong references before a scheduled repeating task begins.

### DIFF
--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -90,8 +90,8 @@ public final class RepeatedTask {
         if self.eventLoop.inEventLoop {
             self.begin0(in: delay)
         } else {
-            self.eventLoop.execute {
-                self.begin0(in: delay)
+            self.eventLoop.execute { [weak self] in
+                self?.begin0(in: delay)
             }
         }
     }


### PR DESCRIPTION
### Motivation:

The primary motivation is to reduce bugs that may occur due to a memory leak in NIOCore. A new unit test demonstrates one known case where the memory leak could occur.

### Modifications:

Added `[weak self]` to a closure that begins repeating tasks.

### Result:

Before: ❌ Unit test fails. Memory leak occurs if the last remaining strong reference to a class or actor goes away before the repeating task begins.

After: ✅ Unit test succeeds. Memory does not leak and owning class successfully deinitializes.
