### PR TITLE
make BaseSocketChannel less generic

### DIFF
--- a/Sources/NIOCore/Channel.swift
+++ b/Sources/NIOCore/Channel.swift
@@ -304,6 +304,26 @@ extension ChannelCore {
         data.forceAs()
     }
 
+    /// Unwraps the given `NIOAny` as a specific concrete type.
+    ///
+    /// This method is intended for use when writing custom `ChannelCore` implementations.
+    /// This can safely be called in methods like `write0` to extract data from the `NIOAny`
+    /// provided in those cases.
+    ///
+    /// Note that if the unwrap fails, this will cause a runtime trap. `ChannelCore`
+    /// implementations should be concrete about what types they support writing. If multiple
+    /// types are supported, consider using a tagged union to store the type information like
+    /// NIO's own `IOData`, which will minimise the amount of runtime type checking.
+    ///
+    /// - Parameters:
+    ///   - data: The `NIOAny` to unwrap.
+    ///   - as: The type to extract from the `NIOAny`.
+    /// - Returns: The content of the `NIOAny`.
+    @inlinable
+    public static func unwrapData<T>(_ data: NIOAny, as: T.Type = T.self) -> T {
+        data.forceAs()
+    }
+
     /// Attempts to unwrap the given `NIOAny` as a specific concrete type.
     ///
     /// This method is intended for use when writing custom `ChannelCore` implementations.
@@ -323,6 +343,28 @@ extension ChannelCore {
     ///     are doing something _extremely_ unusual.
     @inlinable
     public func tryUnwrapData<T>(_ data: NIOAny, as: T.Type = T.self) -> T? {
+        data.tryAs()
+    }
+
+    /// Attempts to unwrap the given `NIOAny` as a specific concrete type.
+    ///
+    /// This method is intended for use when writing custom `ChannelCore` implementations.
+    /// This can safely be called in methods like `write0` to extract data from the `NIOAny`
+    /// provided in those cases.
+    ///
+    /// If the unwrap fails, this will return `nil`. `ChannelCore` implementations should almost
+    /// always support only one runtime type, so in general they should avoid using this and prefer
+    /// using `unwrapData` instead. This method exists for rare use-cases where tolerating type
+    /// mismatches is acceptable.
+    ///
+    /// - Parameters:
+    ///   - data: The `NIOAny` to unwrap.
+    ///   - as: The type to extract from the `NIOAny`.
+    /// - Returns: The content of the `NIOAny`, or `nil` if the type is incorrect.
+    /// - warning: If you are implementing a `ChannelCore`, you should use `unwrapData` unless you
+    ///     are doing something _extremely_ unusual.
+    @inlinable
+    public static func tryUnwrapData<T>(_ data: NIOAny, as: T.Type = T.self) -> T? {
         data.tryAs()
     }
 

--- a/Sources/NIOPosix/BaseStreamSocketChannel.swift
+++ b/Sources/NIOPosix/BaseStreamSocketChannel.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIOCore
 
-class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>, @unchecked Sendable {
+class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket, IOData>, @unchecked Sendable {
     internal var connectTimeoutScheduled: Optional<Scheduled<Void>>
     private var allowRemoteHalfClosure: Bool = false
     private var inputShutdown: Bool = false
@@ -288,13 +288,11 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         super.read0()
     }
 
-    final override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
+    final override func bufferPendingWrite(data: IOData, promise: EventLoopPromise<Void>?) {
         if self.outputShutdown {
             promise?.fail(ChannelError._outputClosed)
             return
         }
-
-        let data = self.unwrapData(data, as: IOData.self)
 
         if !self.pendingWrites.add(data: data, promise: promise) {
             self.pipeline.syncOperations.fireChannelWritabilityChanged()

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -196,7 +196,7 @@ final class SocketChannel: BaseStreamSocketChannel<Socket>, @unchecked Sendable 
 /// A `Channel` for a server socket.
 ///
 /// - Note: All operations on `ServerSocketChannel` are thread-safe.
-final class ServerSocketChannel: BaseSocketChannel<ServerSocket>, @unchecked Sendable {
+final class ServerSocketChannel: BaseSocketChannel<ServerSocket, Void>, @unchecked Sendable {
 
     private var backlog: Int32 = 128
     private let group: EventLoopGroup
@@ -422,8 +422,8 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket>, @unchecked Sen
         false
     }
 
-    override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
-        promise?.fail(ChannelError._operationUnsupported)
+    override func bufferPendingWrite(data: Void, promise: EventLoopPromise<Void>?) {
+        promise?.fail(ChannelError.operationUnsupported)
     }
 
     override func markFlushPoint() {
@@ -459,12 +459,19 @@ final class ServerSocketChannel: BaseSocketChannel<ServerSocket>, @unchecked Sen
             promise?.fail(ChannelError._operationUnsupported)
         }
     }
+
+    override func unwrapAsWriteType(_ data: NIOAny) -> () {}
+}
+
+enum DatagramWriteType {
+    case addressed(AddressedEnvelope<ByteBuffer>)
+    case unaddressed(ByteBuffer)
 }
 
 /// A channel used with datagram sockets.
 ///
 /// Currently, it does not support connected mode which is well worth adding.
-final class DatagramChannel: BaseSocketChannel<Socket>, @unchecked Sendable {
+final class DatagramChannel: BaseSocketChannel<Socket, DatagramWriteType>, @unchecked Sendable {
     private var reportExplicitCongestionNotifications = false
     private var receivePacketInfo = false
 
@@ -894,6 +901,14 @@ final class DatagramChannel: BaseSocketChannel<Socket>, @unchecked Sendable {
         }
     }
 
+    override func unwrapAsWriteType(_ data: NIOAny) -> DatagramWriteType {
+        if let envelope = self.tryUnwrapData(data, as: AddressedEnvelope<ByteBuffer>.self) {
+            return .addressed(envelope)
+        } else {
+            return .unaddressed(Self.unwrapData(data, as: ByteBuffer.self))
+        }
+    }
+
     /// Buffer a write in preparation for a flush.
     ///
     /// When the channel is unconnected, `data` _must_ be of type `AddressedEnvelope<ByteBuffer>`.
@@ -902,14 +917,13 @@ final class DatagramChannel: BaseSocketChannel<Socket>, @unchecked Sendable {
     /// `AddressedEnvelope<ByteBuffer>` to allow users to provide protocol control messages via
     /// `AddressedEnvelope.metadata`. In this case, `AddressedEnvelope.remoteAddress` _must_ match
     /// the address of the connected peer.
-    override func bufferPendingWrite(data: NIOAny, promise: EventLoopPromise<Void>?) {
-        if let envelope = self.tryUnwrapData(data, as: AddressedEnvelope<ByteBuffer>.self) {
-            return bufferPendingAddressedWrite(envelope: envelope, promise: promise)
+    override func bufferPendingWrite(data: DatagramWriteType, promise: EventLoopPromise<Void>?) {
+        switch data {
+        case .addressed(let addressedBytes):
+            return self.bufferPendingAddressedWrite(envelope: addressedBytes, promise: promise)
+        case .unaddressed(let bytes):
+            return self.bufferPendingUnaddressedWrite(data: bytes, promise: promise)
         }
-        // If it's not an `AddressedEnvelope` then it must be a `ByteBuffer` so we let the common
-        // `unwrapData(_:as:)` throw the fatal error if it's some other type.
-        let data = self.unwrapData(data, as: ByteBuffer.self)
-        return bufferPendingUnaddressedWrite(data: data, promise: promise)
     }
 
     /// Buffer a write in preparation for a flush.


### PR DESCRIPTION
### Motivation:

I have seen a bunch of generic metadata instantiation in `BaseStreamSocketChannel.bufferPendingWrite(data:promise:)` and I think that's unnecessary.

### Modifications:

- Introduce a generic `WriteType` to `BaseSocketChannel`

### Result:

- Should do less with generic metadata as it's travelling less across the Channel class hierarchy.