### PR TITLE
feat: Enable NIOFoundationCompat to compile using Swift for WebAssembly. Fix NIOCore WASI compilation issue.

### DIFF
--- a/Sources/NIOFoundationCompat/WaitSpinningRunLoop.swift
+++ b/Sources/NIOFoundationCompat/WaitSpinningRunLoop.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import Atomics
 import Foundation
 import NIOConcurrencyHelpers
@@ -70,3 +72,5 @@ extension EventLoopFuture {
         }
     }
 }
+
+#endif  // !os(WASI)


### PR DESCRIPTION
Fix Swift for WebAssembly compilation in NIOFoundationCompat.

### Motivation:

NIO is a common dependency, and it is important to enable compiling NIO using Swift for WebAssembly. This PR fixes compilation for NIOFoundationCompat.

### Modifications:

- Fix NIOFoundationCompat compilation

### Result:

With these changes, the following build commands succeed: ✅ 

```
swift build --swift-sdk wasm32-unknown-wasip1-threads --target NIOCore
swift build --swift-sdk wasm32-unknown-wasip1-threads --target NIOFoundationCompat
```

### Context:

This PR is [part of a larger effort by PassiveLogic](https://github.com/PassiveLogic/swift-web-examples/issues/1) to improve Swift for WebAssembly support

