### PR TITLE
Tests: inline TestUtils.swift in NIOHTTP1Tests to avoid broken symlink on non-symlink filesystems

### DIFF
--- a/Tests/NIOHTTP1Tests/TestUtils.swift
+++ b/Tests/NIOHTTP1Tests/TestUtils.swift
@@ -12,10 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// NOTE: This file intentionally duplicates the contents of
-// Tests/NIOPosixTests/TestUtils.swift. The repository sometimes uses symlinks
-// for cross-target test utilities; on filesystems where symlinks are not
-// preserved, we inline the contents to ensure compilation.
+// NOTE: This file intentionally duplicates Tests/NIOPosixTests/TestUtils.swift
+// to avoid relying on symlinks, which do not work on all Windows setups.
 
 // swift-format-ignore: AmbiguousTrailingClosureOverload
 
@@ -402,4 +400,469 @@ func resolverDebugInformation(
         IPv4: \(ipv4Results)
         IPv6: \(ipv6Results)
         """
+}
+
+func assert(
+    _ condition: @autoclosure () -> Bool,
+    within time: TimeAmount,
+    testInterval: TimeAmount? = nil,
+    _ message: String = "condition not satisfied in time",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    let testInterval = testInterval ?? TimeAmount.nanoseconds(time.nanoseconds / 5)
+    let endTime = NIODeadline.now() + time
+
+    repeat {
+        if condition() { return }
+        usleep(UInt32(testInterval.nanoseconds / 1000))
+    } while NIODeadline.now() < endTime
+
+    if !condition() {
+        XCTFail(message, file: (file), line: line)
+    }
+}
+
+func getBoolSocketOption(
+    channel: Channel,
+    level: NIOBSDSocket.OptionLevel,
+    name: NIOBSDSocket.Option,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws -> Bool {
+    try assertNoThrowWithValue(
+        channel.getOption(ChannelOptions.Types.SocketOption(level: level, name: name)),
+        file: (file),
+        line: line
+    ).wait() != 0
+}
+
+func assertSuccess<Value>(_ result: Result<Value, Error>, file: StaticString = #filePath, line: UInt = #line) {
+    guard case .success = result else { return XCTFail("Expected result to be successful", file: (file), line: line) }
+}
+
+func assertFailure<Value>(_ result: Result<Value, Error>, file: StaticString = #filePath, line: UInt = #line) {
+    guard case .failure = result else { return XCTFail("Expected result to be a failure", file: (file), line: line) }
+}
+
+/// Fulfills the promise when the respective event is first received.
+///
+/// - Note: Once this is used more widely and shows value, we might want to put it into `NIOTestUtils`.
+final class FulfillOnFirstEventHandler: ChannelDuplexHandler, Sendable {
+    typealias InboundIn = Any
+    typealias OutboundIn = Any
+
+    struct ExpectedEventMissing: Error {}
+
+    private let channelRegisteredPromise: EventLoopPromise<Void>?
+    private let channelUnregisteredPromise: EventLoopPromise<Void>?
+    private let channelActivePromise: EventLoopPromise<Void>?
+    private let channelInactivePromise: EventLoopPromise<Void>?
+    private let channelReadPromise: EventLoopPromise<Void>?
+    private let channelReadCompletePromise: EventLoopPromise<Void>?
+    private let channelWritabilityChangedPromise: EventLoopPromise<Void>?
+    private let userInboundEventTriggeredPromise: EventLoopPromise<Void>?
+    private let errorCaughtPromise: EventLoopPromise<Void>?
+    private let registerPromise: EventLoopPromise<Void>?
+    private let bindPromise: EventLoopPromise<Void>?
+    private let connectPromise: EventLoopPromise<Void>?
+    private let writePromise: EventLoopPromise<Void>?
+    private let flushPromise: EventLoopPromise<Void>?
+    private let readPromise: EventLoopPromise<Void>?
+    private let closePromise: EventLoopPromise<Void>?
+    private let triggerUserOutboundEventPromise: EventLoopPromise<Void>?
+
+    init(
+        channelRegisteredPromise: EventLoopPromise<Void>? = nil,
+        channelUnregisteredPromise: EventLoopPromise<Void>? = nil,
+        channelActivePromise: EventLoopPromise<Void>? = nil,
+        channelInactivePromise: EventLoopPromise<Void>? = nil,
+        channelReadPromise: EventLoopPromise<Void>? = nil,
+        channelReadCompletePromise: EventLoopPromise<Void>? = nil,
+        channelWritabilityChangedPromise: EventLoopPromise<Void>? = nil,
+        userInboundEventTriggeredPromise: EventLoopPromise<Void>? = nil,
+        errorCaughtPromise: EventLoopPromise<Void>? = nil,
+        registerPromise: EventLoopPromise<Void>? = nil,
+        bindPromise: EventLoopPromise<Void>? = nil,
+        connectPromise: EventLoopPromise<Void>? = nil,
+        writePromise: EventLoopPromise<Void>? = nil,
+        flushPromise: EventLoopPromise<Void>? = nil,
+        readPromise: EventLoopPromise<Void>? = nil,
+        closePromise: EventLoopPromise<Void>? = nil,
+        triggerUserOutboundEventPromise: EventLoopPromise<Void>? = nil
+    ) {
+        self.channelRegisteredPromise = channelRegisteredPromise
+        self.channelUnregisteredPromise = channelUnregisteredPromise
+        self.channelActivePromise = channelActivePromise
+        self.channelInactivePromise = channelInactivePromise
+        self.channelReadPromise = channelReadPromise
+        self.channelReadCompletePromise = channelReadCompletePromise
+        self.channelWritabilityChangedPromise = channelWritabilityChangedPromise
+        self.userInboundEventTriggeredPromise = userInboundEventTriggeredPromise
+        self.errorCaughtPromise = errorCaughtPromise
+        self.registerPromise = registerPromise
+        self.bindPromise = bindPromise
+        self.connectPromise = connectPromise
+        self.writePromise = writePromise
+        self.flushPromise = flushPromise
+        self.readPromise = readPromise
+        self.closePromise = closePromise
+        self.triggerUserOutboundEventPromise = triggerUserOutboundEventPromise
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        self.channelRegisteredPromise?.fail(ExpectedEventMissing())
+        self.channelUnregisteredPromise?.fail(ExpectedEventMissing())
+        self.channelActivePromise?.fail(ExpectedEventMissing())
+        self.channelInactivePromise?.fail(ExpectedEventMissing())
+        self.channelReadPromise?.fail(ExpectedEventMissing())
+        self.channelReadCompletePromise?.fail(ExpectedEventMissing())
+        self.channelWritabilityChangedPromise?.fail(ExpectedEventMissing())
+        self.userInboundEventTriggeredPromise?.fail(ExpectedEventMissing())
+        self.errorCaughtPromise?.fail(ExpectedEventMissing())
+        self.registerPromise?.fail(ExpectedEventMissing())
+        self.bindPromise?.fail(ExpectedEventMissing())
+        self.connectPromise?.fail(ExpectedEventMissing())
+        self.writePromise?.fail(ExpectedEventMissing())
+        self.flushPromise?.fail(ExpectedEventMissing())
+        self.readPromise?.fail(ExpectedEventMissing())
+        self.closePromise?.fail(ExpectedEventMissing())
+        self.triggerUserOutboundEventPromise?.fail(ExpectedEventMissing())
+    }
+
+    func channelRegistered(context: ChannelHandlerContext) {
+        self.channelRegisteredPromise?.succeed(())
+        context.fireChannelRegistered()
+    }
+
+    func channelUnregistered(context: ChannelHandlerContext) {
+        self.channelUnregisteredPromise?.succeed(())
+        context.fireChannelUnregistered()
+    }
+
+    func channelActive(context: ChannelHandlerContext) {
+        self.channelActivePromise?.succeed(())
+        context.fireChannelActive()
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        self.channelInactivePromise?.succeed(())
+        context.fireChannelInactive()
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.channelReadPromise?.succeed(())
+        context.fireChannelRead(data)
+    }
+
+    func channelReadComplete(context: ChannelHandlerContext) {
+        self.channelReadCompletePromise?.succeed(())
+        context.fireChannelReadComplete()
+    }
+
+    func channelWritabilityChanged(context: ChannelHandlerContext) {
+        self.channelWritabilityChangedPromise?.succeed(())
+        context.fireChannelWritabilityChanged()
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        self.userInboundEventTriggeredPromise?.succeed(())
+        context.fireUserInboundEventTriggered(event)
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        self.errorCaughtPromise?.succeed(())
+        context.fireErrorCaught(error)
+    }
+
+    func register(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
+        self.registerPromise?.succeed(())
+        context.register(promise: promise)
+    }
+
+    func bind(context: ChannelHandlerContext, to: SocketAddress, promise: EventLoopPromise<Void>?) {
+        self.bindPromise?.succeed(())
+        context.bind(to: to, promise: promise)
+    }
+
+    func connect(context: ChannelHandlerContext, to: SocketAddress, promise: EventLoopPromise<Void>?) {
+        self.connectPromise?.succeed(())
+        context.connect(to: to, promise: promise)
+    }
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        self.writePromise?.succeed(())
+        context.write(data, promise: promise)
+    }
+
+    func flush(context: ChannelHandlerContext) {
+        self.flushPromise?.succeed(())
+        context.flush()
+    }
+
+    func read(context: ChannelHandlerContext) {
+        self.readPromise?.succeed(())
+        context.read()
+    }
+
+    func close(context: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
+        self.closePromise?.succeed(())
+        context.close(mode: mode, promise: promise)
+    }
+
+    func triggerUserOutboundEvent(context: ChannelHandlerContext, event: Any, promise: EventLoopPromise<Void>?) {
+        self.triggerUserOutboundEventPromise?.succeed(())
+        context.triggerUserOutboundEvent(event, promise: promise)
+    }
+}
+
+func forEachActiveChannelType<T>(
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ body: @escaping (Channel) throws -> T
+) throws -> [T] {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer {
+        XCTAssertNoThrow(try group.syncShutdownGracefully())
+    }
+    let channelEL = group.next()
+
+    let lock = NIOLock()
+    var ret: [T] = []
+    _ = try forEachCrossConnectedStreamChannelPair(file: (file), line: line) {
+        (chan1: Channel, chan2: Channel) throws -> Void in
+        var innerRet: [T] = [try body(chan1)]
+        if let parent = chan1.parent {
+            innerRet.append(try body(parent))
+        }
+        lock.withLock {
+            ret.append(contentsOf: innerRet)
+        }
+    }
+
+    // UDP
+    let udpChannel = DatagramBootstrap(group: channelEL)
+        .channelInitializer { channel in
+            XCTAssert(channel.eventLoop.inEventLoop)
+            return channelEL.makeSucceededFuture(())
+        }
+        .bind(host: "127.0.0.1", port: 0)
+    defer {
+        XCTAssertNoThrow(try udpChannel.wait().syncCloseAcceptingAlreadyClosed())
+    }
+
+    return try lock.withLock {
+        ret.append(try body(udpChannel.wait()))
+        return ret
+    }
+}
+
+func withTCPServerChannel<R>(
+    bindTarget: SocketAddress? = nil,
+    group: EventLoopGroup,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ body: (Channel) throws -> R
+) throws -> R {
+    let server = try ServerBootstrap(group: group)
+        .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+        .bind(to: bindTarget ?? .init(ipAddress: "127.0.0.1", port: 0))
+        .wait()
+    do {
+        let result = try body(server)
+        try server.close().wait()
+        return result
+    } catch {
+        try? server.close().wait()
+        throw error
+    }
+}
+
+func withCrossConnectedSockAddrChannels<R>(
+    bindTarget: SocketAddress,
+    forceSeparateEventLoops: Bool = false,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ body: (Channel, Channel) throws -> R
+) throws -> R {
+    let serverGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer {
+        XCTAssertNoThrow(try serverGroup.syncShutdownGracefully())
+    }
+    let clientGroup: MultiThreadedEventLoopGroup
+    if forceSeparateEventLoops {
+        clientGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    } else {
+        clientGroup = serverGroup
+    }
+    defer {
+        // this may fail if clientGroup === serverGroup
+        try? clientGroup.syncShutdownGracefully()
+    }
+    let serverChannelEL = serverGroup.next()
+    let clientChannelEL = clientGroup.next()
+
+    let tcpAcceptedChannel = serverChannelEL.makePromise(of: Channel.self)
+    let tcpServerChannel = try assertNoThrowWithValue(
+        ServerBootstrap(group: serverChannelEL)
+            .childChannelInitializer { channel in
+                let accepted = channel.eventLoop.makePromise(of: Void.self)
+                accepted.futureResult.map {
+                    channel
+                }.cascade(to: tcpAcceptedChannel)
+                return channel.pipeline.addHandler(FulfillOnFirstEventHandler(channelActivePromise: accepted))
+            }
+            .bind(to: bindTarget)
+            .wait(),
+        file: (file),
+        line: line
+    )
+    defer {
+        XCTAssertNoThrow(try tcpServerChannel.syncCloseAcceptingAlreadyClosed())
+    }
+
+    let tcpClientChannel = try assertNoThrowWithValue(
+        ClientBootstrap(group: clientChannelEL)
+            .channelInitializer { channel in
+                XCTAssert(channel.eventLoop.inEventLoop)
+                return channel.eventLoop.makeSucceededFuture(())
+            }
+            .connect(to: tcpServerChannel.localAddress!)
+            .wait()
+    )
+    defer {
+        XCTAssertNoThrow(try tcpClientChannel.syncCloseAcceptingAlreadyClosed())
+    }
+
+    return try body(try tcpAcceptedChannel.futureResult.wait(), tcpClientChannel)
+}
+
+func withCrossConnectedTCPChannels<R>(
+    forceSeparateEventLoops: Bool = false,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ body: (Channel, Channel) throws -> R
+) throws -> R {
+    try withCrossConnectedSockAddrChannels(
+        bindTarget: .init(ipAddress: "127.0.0.1", port: 0),
+        forceSeparateEventLoops: forceSeparateEventLoops,
+        body
+    )
+}
+
+func withCrossConnectedUnixDomainSocketChannels<R>(
+    forceSeparateEventLoops: Bool = false,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ body: (Channel, Channel) throws -> R
+) throws -> R {
+    try withTemporaryDirectory { tempDir in
+        let bindTarget = try SocketAddress(unixDomainSocketPath: tempDir + "/s")
+        return try withCrossConnectedSockAddrChannels(
+            bindTarget: bindTarget,
+            forceSeparateEventLoops: forceSeparateEventLoops,
+            body
+        )
+    }
+}
+
+func withCrossConnectedPipeChannels<R>(
+    forceSeparateEventLoops: Bool = false,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ body: (Channel, Channel) throws -> R
+) throws -> R {
+    let channel1Group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer {
+        XCTAssertNoThrow(try channel1Group.syncShutdownGracefully(), file: (file), line: line)
+    }
+    let channel2Group: MultiThreadedEventLoopGroup
+    if forceSeparateEventLoops {
+        channel2Group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    } else {
+        channel2Group = channel1Group
+    }
+    defer {
+        // may fail if pipe1Group == pipe2Group
+        try? channel2Group.syncShutdownGracefully()
+    }
+
+    var result: R? = nil
+
+    XCTAssertNoThrow(
+        try withPipe { pipe1Read, pipe1Write -> [NIOFileHandle] in
+            try withPipe { pipe2Read, pipe2Write -> [NIOFileHandle] in
+                try pipe1Read.withUnsafeFileDescriptor { pipe1Read in
+                    try pipe1Write.withUnsafeFileDescriptor { pipe1Write in
+                        try pipe2Read.withUnsafeFileDescriptor { pipe2Read in
+                            try pipe2Write.withUnsafeFileDescriptor { pipe2Write in
+                                let channel1 = try NIOPipeBootstrap(group: channel1Group)
+                                    .takingOwnershipOfDescriptors(input: pipe1Read, output: pipe2Write)
+                                    .wait()
+                                defer {
+                                    XCTAssertNoThrow(try channel1.syncCloseAcceptingAlreadyClosed())
+                                }
+                                let channel2 = try NIOPipeBootstrap(group: channel2Group)
+                                    .takingOwnershipOfDescriptors(input: pipe2Read, output: pipe1Write)
+                                    .wait()
+                                defer {
+                                    XCTAssertNoThrow(try channel2.syncCloseAcceptingAlreadyClosed())
+                                }
+                                result = try body(channel1, channel2)
+                            }
+                        }
+                    }
+                }
+                XCTAssertNoThrow(try pipe1Read.takeDescriptorOwnership(), file: (file), line: line)
+                XCTAssertNoThrow(try pipe1Write.takeDescriptorOwnership(), file: (file), line: line)
+                XCTAssertNoThrow(try pipe2Read.takeDescriptorOwnership(), file: (file), line: line)
+                XCTAssertNoThrow(try pipe2Write.takeDescriptorOwnership(), file: (file), line: line)
+                return []
+            }
+            return []  // the channels are closing the pipes
+        },
+        file: (file),
+        line: line
+    )
+    return result!
+}
+
+func forEachCrossConnectedStreamChannelPair<R>(
+    forceSeparateEventLoops: Bool = false,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ body: (Channel, Channel) throws -> R
+) throws -> [R] {
+    let r1 = try withCrossConnectedTCPChannels(forceSeparateEventLoops: forceSeparateEventLoops, body)
+    let r2 = try withCrossConnectedPipeChannels(forceSeparateEventLoops: forceSeparateEventLoops, body)
+    let r3 = try withCrossConnectedUnixDomainSocketChannels(forceSeparateEventLoops: forceSeparateEventLoops, body)
+    return [r1, r2, r3]
+}
+
+extension EventLoopFuture {
+    var isFulfilled: Bool {
+        if self.eventLoop.inEventLoop {
+            // Easy, we're on the EventLoop. Let's just use our knowledge that we run completed future callbacks
+            // immediately.
+            var fulfilled = false
+            self.assumeIsolated().whenComplete { _ in
+                fulfilled = true
+            }
+            return fulfilled
+        } else {
+            let fulfilledBox = NIOLockedValueBox(false)
+            let group = DispatchGroup()
+
+            group.enter()
+            self.eventLoop.execute {
+                let isFulfilled = self.isFulfilled  // This will now enter the above branch.
+                fulfilledBox.withLockedValue {
+                    $0 = isFulfilled
+                }
+                group.leave()
+            }
+            group.wait()  // this is very nasty but this is for tests only, so...
+            return fulfilledBox.withLockedValue { $0 }
+        }
+    }
 }


### PR DESCRIPTION
On filesystems without symlink support for Windows, the symlinked test helper at is materialized as a plain text file containing the relative path, which breaks compilation with errors like:
```
expressions are not allowed at the top level
cannot find 'assertNoThrowWithValue' in scope
```
This change inlines the contents, restoring the intended shared test utilities for the NIOHTTP1 test target. This helps Windows compile the Test target