### PR TITLE
Enable NonIsolatedNonSendableByDefault

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let swiftSettings: [SwiftSetting] = [
     // this "experimental" feature flag without two subsequent releases. We assume they will respect that
     // promise, so we enable this here. For more, see:
     // https://forums.swift.org/t/experimental-support-for-lifetime-dependencies-in-swift-6-2-and-beyond/78638
-    .enableExperimentalFeature("Lifetimes")
+    .enableExperimentalFeature("Lifetimes"),
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
 ]
 
 // This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and

--- a/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
+++ b/Sources/NIOCore/AsyncChannel/AsyncChannelOutboundWriter.swift
@@ -57,8 +57,14 @@ public struct NIOAsyncChannelOutboundWriter<OutboundOut: Sendable>: Sendable {
                 self.iterator = iterator
             }
 
+            @concurrent
             public mutating func next() async -> Element? {
                 await self.iterator.next()
+            }
+
+            @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+            public mutating func next(isolation actor: isolated (any Actor)?) async -> Element? {
+                await self.iterator.next(isolation: actor)
             }
         }
     }

--- a/Sources/NIOCore/NIODecodedAsyncSequence.swift
+++ b/Sources/NIOCore/NIODecodedAsyncSequence.swift
@@ -122,6 +122,7 @@ extension NIODecodedAsyncSequence: AsyncSequence {
         /// The same as `next(isolation:)` but not isolated to an actor, which allows
         /// for less availability restrictions.
         @inlinable
+        @concurrent
         public mutating func next() async throws -> Element? {
             while true {
                 switch self.state {

--- a/Sources/NIOFS/FileChunks.swift
+++ b/Sources/NIOFS/FileChunks.swift
@@ -74,8 +74,14 @@ public struct FileChunks: AsyncSequence, Sendable {
             self.iterator = iterator
         }
 
+        @concurrent
         public mutating func next() async throws -> ByteBuffer? {
             try await self.iterator.next()
+        }
+
+        @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)
+        public mutating func next(isolation actor: isolated (any Actor)?) async throws(any Error) -> ByteBuffer? {
+            try await self.iterator.next(isolation: actor)
         }
     }
 }

--- a/Sources/NIOPerformanceTester/main.swift
+++ b/Sources/NIOPerformanceTester/main.swift
@@ -88,7 +88,7 @@ public func measureAndPrint(desc: String, fn: () throws -> Int) rethrows {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public func measure(_ fn: () async throws -> Int) async rethrows -> [Double] {
-    func measureOne(_ fn: () async throws -> Int) async rethrows -> Double {
+    nonisolated(nonsending) func measureOne(_ fn: () async throws -> Int) async rethrows -> Double {
         let start = DispatchTime.now().uptimeNanoseconds
         _ = try await fn()
         let end = DispatchTime.now().uptimeNanoseconds

--- a/Sources/_NIOFileSystem/Internal/BufferedOrAnyStream.swift
+++ b/Sources/_NIOFileSystem/Internal/BufferedOrAnyStream.swift
@@ -92,7 +92,13 @@ internal struct AnyAsyncSequence<Element>: AsyncSequence, Sendable {
         }
 
         internal mutating func next() async throws -> Element? {
-            try await self.iterator.next() as? Element
+            var box = UnsafeTransfer(self.iterator)
+            return try await box.wrappedValue.next() as? Element
+        }
+
+        @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)
+        internal mutating func next(isolation actor: isolated (any Actor)?) async throws(any Error) -> Element? {
+            try await self.iterator.next(isolation: actor) as? Element
         }
     }
 }

--- a/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift
@@ -762,6 +762,7 @@ private func XCTAssertEqualWithoutAutoclosure<T>(
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncSequence {
     /// Collect all elements in the sequence into an array.
+    @concurrent
     fileprivate func collect() async rethrows -> [Element] {
         try await self.reduce(into: []) { accumulated, next in
             accumulated.append(next)

--- a/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
+++ b/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift
@@ -386,13 +386,12 @@ final class NIOThrowingAsyncSequenceProducerTests: XCTestCase {
 
         var elements = [Int]()
 
-        await XCTAssertThrowsError(
-            try await {
-                for try await element in self.sequence {
-                    elements.append(element)
-                }
-            }()
-        ) { error in
+        do {
+            for try await element in self.sequence {
+                elements.append(element)
+            }
+            XCTFail("Expected that an error is thrown in the loop above")
+        } catch {
             XCTAssertEqual(error as? ChannelError, .alreadyClosed)
         }
 
@@ -923,6 +922,7 @@ private func XCTAssertEqualWithoutAutoclosure<T>(
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncSequence {
     /// Collect all elements in the sequence into an array.
+    @concurrent
     fileprivate func collect() async rethrows -> [Element] {
         try await self.reduce(into: []) { accumulated, next in
             accumulated.append(next)

--- a/Tests/NIOCoreTests/XCTest+AsyncAwait.swift
+++ b/Tests/NIOCoreTests/XCTest+AsyncAwait.swift
@@ -42,7 +42,7 @@
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-internal func XCTAssertThrowsError<T>(
+nonisolated(nonsending) internal func XCTAssertThrowsError<T>(
     _ expression: @autoclosure () async throws -> T,
     file: StaticString = #filePath,
     line: UInt = #line,
@@ -57,7 +57,7 @@ internal func XCTAssertThrowsError<T>(
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-internal func XCTAssertNoThrow<T>(
+nonisolated(nonsending) internal func XCTAssertNoThrow<T>(
     _ expression: @autoclosure () async throws -> T,
     file: StaticString = #filePath,
     line: UInt = #line
@@ -70,7 +70,7 @@ internal func XCTAssertNoThrow<T>(
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-internal func XCTAssertNoThrowWithResult<Result>(
+nonisolated(nonsending) internal func XCTAssertNoThrowWithResult<Result>(
     _ expression: @autoclosure () async throws -> Result,
     file: StaticString = #filePath,
     line: UInt = #line
@@ -84,7 +84,7 @@ internal func XCTAssertNoThrowWithResult<Result>(
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-internal func XCTAsyncAssertNotNil(
+nonisolated(nonsending) internal func XCTAsyncAssertNotNil(
     _ expression: @autoclosure () async throws -> Any?,
     file: StaticString = #filePath,
     line: UInt = #line
@@ -94,7 +94,7 @@ internal func XCTAsyncAssertNotNil(
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-internal func XCTAsyncAssertNil(
+nonisolated(nonsending) internal func XCTAsyncAssertNil(
     _ expression: @autoclosure () async throws -> Any?,
     file: StaticString = #filePath,
     line: UInt = #line

--- a/Tests/NIOEmbeddedTests/XCTest+AsyncAwait.swift
+++ b/Tests/NIOEmbeddedTests/XCTest+AsyncAwait.swift
@@ -42,6 +42,7 @@
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+nonisolated(nonsending)
 internal func XCTAssertThrowsError<T>(
     _ expression: @autoclosure () async throws -> T,
     file: StaticString = #filePath,
@@ -57,6 +58,7 @@ internal func XCTAssertThrowsError<T>(
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+nonisolated(nonsending)
 internal func XCTAssertNoThrowWithResult<Result>(
     _ expression: @autoclosure () async throws -> Result,
     file: StaticString = #filePath,

--- a/Tests/NIOFSIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileHandleTests.swift
@@ -699,10 +699,12 @@ final class FileHandleTests: XCTestCase {
         try await self.testCloseOrDetachMidRead(close: false)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)
     func testCloseBeforeReadingFromFile() async throws {
         try await self.testCloseOrDetachBeforeRead(close: true)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)
     func testDetachBeforeReadingFromFile() async throws {
         try await self.testCloseOrDetachBeforeRead(close: false)
     }
@@ -748,6 +750,7 @@ final class FileHandleTests: XCTestCase {
         }
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)
     private func testCloseOrDetachBeforeRead(close: Bool) async throws {
         try await self.withHandle(forFileAtPath: Self.thisFile, autoClose: false) { handle in
             if close {
@@ -759,7 +762,7 @@ final class FileHandleTests: XCTestCase {
 
             var iterator = handle.readChunks().makeAsyncIterator()
             await XCTAssertThrowsFileSystemErrorAsync {
-                try await iterator.next()
+                try await iterator.next(isolation: #isolation)
             } onError: { error in
                 XCTAssertEqual(error.code, .closed)
             }

--- a/Tests/NIOFSIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileSystemTests.swift
@@ -1230,22 +1230,22 @@ final class FileSystemTests: XCTestCase {
     }
 
     func testReplaceFile(_ existingType: FileType?, with replacementType: FileType) async throws {
-        func makeRegularFile(at path: NIOFilePath) async throws {
+        nonisolated(nonsending) func makeRegularFile(at path: NIOFilePath) async throws {
             try await self.fs.withFileHandle(
                 forWritingAt: path,
                 options: .newFile(replaceExisting: false)
             ) { _ in }
         }
 
-        func makeSymbolicLink(at path: NIOFilePath) async throws {
+        nonisolated(nonsending) func makeSymbolicLink(at path: NIOFilePath) async throws {
             try await self.fs.createSymbolicLink(at: path, withDestination: "/whatever")
         }
 
-        func makeDirectory(at path: NIOFilePath) async throws {
+        nonisolated(nonsending) func makeDirectory(at path: NIOFilePath) async throws {
             try await self.fs.createDirectory(at: path, withIntermediateDirectories: true)
         }
 
-        func makeFile(ofType type: FileType, at path: NIOFilePath) async throws {
+        nonisolated(nonsending) func makeFile(ofType type: FileType, at path: NIOFilePath) async throws {
             switch type {
             case .regular:
                 try await makeRegularFile(at: path)
@@ -1424,7 +1424,7 @@ final class FileSystemTests: XCTestCase {
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension FileSystemTests {
     private func checkDirectoriesMatch(_ root1: NIOFilePath, _ root2: NIOFilePath) async throws {
-        func namesAndTypes(_ root: NIOFilePath) async throws -> [(String, FileType)] {
+        nonisolated(nonsending) func namesAndTypes(_ root: NIOFilePath) async throws -> [(String, FileType)] {
             try await self.fs.withDirectoryHandle(atPath: root) { dir in
                 try await dir.listContents()
                     .reduce(into: []) { $0.append($1) }

--- a/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
+++ b/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
@@ -1081,7 +1081,7 @@ final class BufferedStreamTests: XCTestCase {
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
     /// Collect all elements in the sequence into an array.
-    fileprivate func collect() async rethrows -> [Element] {
+    @concurrent fileprivate func collect() async rethrows -> [Element] {
         try await self.reduce(into: []) { accumulated, next in
             accumulated.append(next)
         }

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -198,7 +198,7 @@ private final class AddressedEnvelopingHandler: ChannelDuplexHandler {
     }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)
 final class AsyncChannelBootstrapTests: XCTestCase {
     var group: MultiThreadedEventLoopGroup!
 
@@ -266,7 +266,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 try await outbound.write("hello")
             }
 
-            await XCTAsyncAssertEqual(await iterator.next(), .string("hello"))
+            await XCTAsyncAssertEqual(await iterator.next(isolation: #isolation), .string("hello"))
 
             group.cancelAll()
         }
@@ -330,7 +330,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     // This is the actual content
                     try await outbound.write("hello")
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
+                await XCTAsyncAssertEqual(await serverIterator.next(isolation: #isolation), .string("hello"))
             case .byte:
                 preconditionFailure()
             }
@@ -349,7 +349,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     // This is the actual content
                     try await outbound.write(UInt8(8))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .byte(8))
+                await XCTAsyncAssertEqual(await serverIterator.next(isolation: #isolation), .byte(8))
             }
 
             group.cancelAll()
@@ -412,7 +412,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     // This is the actual content
                     try await outbound.write("hello")
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
+                await XCTAsyncAssertEqual(await serverIterator.next(isolation: #isolation), .string("hello"))
             case .byte:
                 preconditionFailure()
             }
@@ -429,7 +429,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     // This is the actual content
                     try await outbound.write("hello")
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
+                await XCTAsyncAssertEqual(await serverIterator.next(isolation: #isolation), .string("hello"))
             case .byte:
                 preconditionFailure()
             }
@@ -448,7 +448,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     // This is the actual content
                     try await outbound.write(UInt8(8))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .byte(8))
+                await XCTAsyncAssertEqual(await serverIterator.next(isolation: #isolation), .byte(8))
             }
 
             let stringByteNegotiationResult = try await self.makeClientChannelWithNestedProtocolNegotiation(
@@ -465,7 +465,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     // This is the actual content
                     try await outbound.write(UInt8(8))
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .byte(8))
+                await XCTAsyncAssertEqual(await serverIterator.next(isolation: #isolation), .byte(8))
             }
 
             group.cancelAll()
@@ -563,7 +563,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     // This is the actual content
                     try await outbound.write("hello")
                 }
-                await XCTAsyncAssertEqual(await serverIterator.next(), .string("hello"))
+                await XCTAsyncAssertEqual(await serverIterator.next(isolation: #isolation), .string("hello"))
             case .byte:
                 preconditionFailure()
             }
@@ -654,7 +654,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 try await outbound.write("hello")
             }
 
-            await XCTAsyncAssertEqual(await iterator.next(), .string("hello"))
+            await XCTAsyncAssertEqual(await iterator.next(isolation: #isolation), .string("hello"))
 
             group.cancelAll()
         }
@@ -676,10 +676,10 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 var clientInboundIterator = clientChannelInbound.makeAsyncIterator()
 
                 try await clientChannelOutbound.write("request")
-                try await XCTAsyncAssertEqual(try await serverInboundIterator.next(), "request")
+                try await XCTAsyncAssertEqual(try await serverInboundIterator.next(isolation: #isolation), "request")
 
                 try await serverChannelOutbound.write("response")
-                try await XCTAsyncAssertEqual(try await clientInboundIterator.next(), "response")
+                try await XCTAsyncAssertEqual(try await clientInboundIterator.next(isolation: #isolation), "response")
             }
         }
     }
@@ -731,10 +731,10 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                         var secondInboundIterator = secondChannelInbound.makeAsyncIterator()
 
                         try await firstChannelOutbound.write("request")
-                        try await XCTAsyncAssertEqual(try await secondInboundIterator.next(), "request")
+                        try await XCTAsyncAssertEqual(try await secondInboundIterator.next(isolation: #isolation), "request")
 
                         try await secondChannelOutbound.write("response")
-                        try await XCTAsyncAssertEqual(try await firstInboundIterator.next(), "response")
+                        try await XCTAsyncAssertEqual(try await firstInboundIterator.next(isolation: #isolation), "response")
                     }
                 }
 
@@ -829,11 +829,11 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     var fromChannelInboundIterator = fromChannelInbound.makeAsyncIterator()
 
                     try await toChannelOutbound.write(.init(string: "Request"))
-                    try await XCTAsyncAssertEqual(try await inboundIterator.next(), ByteBuffer(string: "Request"))
+                    try await XCTAsyncAssertEqual(try await inboundIterator.next(isolation: #isolation), ByteBuffer(string: "Request"))
 
                     let response = ByteBuffer(string: "Response")
                     try await channelOutbound.write(response)
-                    try await XCTAsyncAssertEqual(try await fromChannelInboundIterator.next(), response)
+                    try await XCTAsyncAssertEqual(try await fromChannelInboundIterator.next(isolation: #isolation), response)
                 }
             }
         }
@@ -882,11 +882,11 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 var inboundIterator = channelInbound.makeAsyncIterator()
                 var fromChannelInboundIterator = fromChannelInbound.makeAsyncIterator()
 
-                try await XCTAsyncAssertEqual(try await inboundIterator.next(), nil)
+                try await XCTAsyncAssertEqual(try await inboundIterator.next(isolation: #isolation), nil)
 
                 let response = ByteBuffer(string: "Response")
                 try await channelOutbound.write(response)
-                try await XCTAsyncAssertEqual(try await fromChannelInboundIterator.next(), response)
+                try await XCTAsyncAssertEqual(try await fromChannelInboundIterator.next(isolation: #isolation), response)
             }
         }
     }
@@ -935,7 +935,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 var inboundIterator = channelInbound.makeAsyncIterator()
 
                 try await toChannelOutbound.write(.init(string: "Request"))
-                try await XCTAsyncAssertEqual(try await inboundIterator.next(), ByteBuffer(string: "Request"))
+                try await XCTAsyncAssertEqual(try await inboundIterator.next(isolation: #isolation), ByteBuffer(string: "Request"))
 
                 let response = ByteBuffer(string: "Response")
                 await XCTAsyncAssertThrowsError(try await channelOutbound.write(response)) { error in
@@ -1011,11 +1011,11 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     try await channel.executeThenClose { channelInbound, channelOutbound in
                         var inboundIterator = channelInbound.makeAsyncIterator()
                         do {
-                            try await XCTAsyncAssertEqual(try await inboundIterator.next(), "Hello")
+                            try await XCTAsyncAssertEqual(try await inboundIterator.next(isolation: #isolation), "Hello")
 
                             let expectedResponse = ByteBuffer(string: "Response\n")
                             try await channelOutbound.write("Response")
-                            let response = try await fromChannelInboundIterator.next()
+                            let response = try await fromChannelInboundIterator.next(isolation: #isolation)
                             XCTAssertEqual(response, expectedResponse)
                         } catch {
                             // We only got to close the FDs that are not owned by the PipeChannel
@@ -1109,11 +1109,11 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                     var fromChannelInboundIterator = fromChannelInbound.makeAsyncIterator()
 
                     try await toChannelOutbound.write(.init(string: "Request"))
-                    try await XCTAsyncAssertEqual(try await inboundIterator.next(), ByteBuffer(string: "Request"))
+                    try await XCTAsyncAssertEqual(try await inboundIterator.next(isolation: #isolation), ByteBuffer(string: "Request"))
 
                     let response = ByteBuffer(string: "Response")
                     try await channelOutbound.write(response)
-                    try await XCTAsyncAssertEqual(try await fromChannelInboundIterator.next(), response)
+                    try await XCTAsyncAssertEqual(try await fromChannelInboundIterator.next(isolation: #isolation), response)
                 }
             }
         }
@@ -1173,11 +1173,11 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 var inboundIterator = channelInbound.makeAsyncIterator()
                 var fromChannelInboundIterator = fromChannelInbound.makeAsyncIterator()
 
-                try await XCTAsyncAssertEqual(try await inboundIterator.next(), nil)
+                try await XCTAsyncAssertEqual(try await inboundIterator.next(isolation: #isolation), nil)
 
                 let response = ByteBuffer(string: "Response")
                 try await channelOutbound.write(response)
-                try await XCTAsyncAssertEqual(try await fromChannelInboundIterator.next(), response)
+                try await XCTAsyncAssertEqual(try await fromChannelInboundIterator.next(isolation: #isolation), response)
             }
         }
 
@@ -1237,7 +1237,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 var inboundIterator = channelInbound.makeAsyncIterator()
 
                 try await toChannelOutbound.write(.init(string: "Request"))
-                try await XCTAsyncAssertEqual(try await inboundIterator.next(), ByteBuffer(string: "Request"))
+                try await XCTAsyncAssertEqual(try await inboundIterator.next(isolation: #isolation), ByteBuffer(string: "Request"))
 
                 let response = ByteBuffer(string: "Response")
                 await XCTAsyncAssertThrowsError(try await channelOutbound.write(response)) { error in
@@ -1264,10 +1264,10 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 var clientInboundIterator = clientChannelInbound.makeAsyncIterator()
 
                 try await clientChannelOutbound.write("request")
-                try await XCTAsyncAssertEqual(try await serverInboundIterator.next(), "request")
+                try await XCTAsyncAssertEqual(try await serverInboundIterator.next(isolation: #isolation), "request")
 
                 try await serverChannelOutbound.write("response")
-                try await XCTAsyncAssertEqual(try await clientInboundIterator.next(), "response")
+                try await XCTAsyncAssertEqual(try await clientInboundIterator.next(isolation: #isolation), "response")
             }
         }
     }
@@ -1305,10 +1305,10 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                         var secondInboundIterator = secondChannelInbound.makeAsyncIterator()
 
                         try await firstChannelOutbound.write("request")
-                        try await XCTAsyncAssertEqual(try await secondInboundIterator.next(), "request")
+                        try await XCTAsyncAssertEqual(try await secondInboundIterator.next(isolation: #isolation), "request")
 
                         try await secondChannelOutbound.write("response")
-                        try await XCTAsyncAssertEqual(try await firstInboundIterator.next(), "response")
+                        try await XCTAsyncAssertEqual(try await firstInboundIterator.next(isolation: #isolation), "response")
                     }
                 }
 
@@ -1375,7 +1375,7 @@ final class AsyncChannelBootstrapTests: XCTestCase {
                 try await outbound.write("hello")
             }
 
-            await XCTAsyncAssertEqual(await iterator.next(), .string("hello"))
+            await XCTAsyncAssertEqual(await iterator.next(isolation: #isolation), .string("hello"))
 
             group.cancelAll()
         }

--- a/Tests/NIOPosixTests/NIOScheduledCallbackTests.swift
+++ b/Tests/NIOPosixTests/NIOScheduledCallbackTests.swift
@@ -459,7 +459,7 @@ func XCTWithTimeout<Result>(
     _ timeout: TimeAmount,
     file: StaticString = #filePath,
     line: UInt = #line,
-    operation: @escaping @Sendable () async throws -> Result
+    operation: @isolated(any) @escaping @Sendable () async throws -> Result
 ) async throws -> Result where Result: Sendable {
     do {
         return try await withTimeout(timeout, operation: operation)
@@ -471,7 +471,7 @@ func XCTWithTimeout<Result>(
 
 func withTimeout<Result>(
     _ timeout: TimeAmount,
-    operation: @escaping @Sendable () async throws -> Result
+    operation: @isolated(any) @escaping @Sendable () async throws -> Result
 ) async throws -> Result where Result: Sendable {
     try await withThrowingTaskGroup(of: Result.self) { group in
         group.addTask {

--- a/Tests/NIOPosixTests/XCTest+AsyncAwait.swift
+++ b/Tests/NIOPosixTests/XCTest+AsyncAwait.swift
@@ -42,7 +42,7 @@ import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal func XCTAssertThrowsError<T>(
-    _ expression: () async throws -> T,
+    _ expression: nonisolated(nonsending) () async throws -> T,
     file: StaticString = #filePath,
     line: UInt = #line,
     verify: (Error) -> Void = { _ in }


### PR DESCRIPTION
In order to enable uses of `nonisolated(nonsending)` in #3378 without adding this sequence of characters everywhere, this pr enables the upcoming feature `NonIsolatedNonSendableByDefault `

Most of the changes are about adding `next(isolation:)` calls, where non existed before and wiring through the isolation level to the underlying next call. To please the compiler, I've also made explicit that `next()` runs on the concurrent executor, by slapping `@concurrent` on it.

Interestingly `nonisolated(nonsending)` is not applied to nested function definitions. I applied those manually.