### PR TITLE
Do not run the matrix if there is no macOS versions picked for benchmarks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,6 @@ jobs:
     with:
       benchmark_package_path: "Benchmarks"
 
-
   cxx-interop:
     name: Cxx interop
     # Workaround https://github.com/nektos/act/issues/1875


### PR DESCRIPTION
After the recent addition of macOS-based benchmarks, the `main` workflow has been failing with: 

```
Error when evaluating 'strategy' for job 'benchmarks-macos'. apple/swift-nio/.github/workflows/benchmarks.yml@main (Line: 239, Col: 15): Matrix vector 'config' does not contain any values
```

This happens because `swift-nio` does not set any `_enabled` flag for any version of Xcode to run the benchmarks.

An example of a failed run: https://github.com/apple/swift-nio/actions/runs/19479529118

### Motivation:

Scheduled jobs should not fail.

### Modifications:

Added a condition for running macOS benchmarks matrix generation job.

### Result:

Jobs should not fail without any Xcode versions picked for running benchmarks.

An example of a run with macos-matrix job skipped: https://github.com/apple/swift-nio/actions/runs/19482328681/job/55758816398
An example of a run with a opt-in macOS Benchmarks: https://github.com/apple/swift-nio/actions/runs/19484086327/job/55762298924