### PR TITLE
Add some slack to the TCPEcho benchmark

### DIFF
--- a/Benchmarks/Benchmarks/NIOPosixBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOPosixBenchmarks/Benchmarks.swift
@@ -31,7 +31,8 @@ let benchmarks = {
             metrics: defaultMetrics,
             scalingFactor: .mega,
             maxDuration: .seconds(10_000_000),
-            maxIterations: 5
+            maxIterations: 5,
+            thresholds: [.mallocCountTotal: .init(absolute: [.p90: 50])]
         )
     ) { benchmark in
         try runTCPEcho(


### PR DESCRIPTION
Motivation:

TCPEcho has some run-to-run variation which makes CI flaky.

Modifications:

- Add a little slack to TCPEcho; it has a low total alloc count so some slack is fine as it's less than a per iteration allocation

Result:

CI less flaky