### PR TITLE
update actions/checkout and introduce dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-

--- a/.github/workflows/android_swift_sdk.yml
+++ b/.github/workflows/android_swift_sdk.yml
@@ -23,7 +23,7 @@ jobs:
       android-sdk-matrix: '${{ steps.generate-matrix.outputs.android-sdk-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -120,7 +120,7 @@ jobs:
       benchmarks-matrix: '${{ steps.generate-matrix.outputs.benchmarks-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix
@@ -159,7 +159,7 @@ jobs:
       macos-matrix: '${{ steps.generate-matrix.outputs.macos-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix
@@ -245,7 +245,7 @@ jobs:
       matrix: ${{ fromJson(needs.construct-matrix-macos.outputs.macos-matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
           submodules: true

--- a/.github/workflows/cmake_tests.yml
+++ b/.github/workflows/cmake_tests.yml
@@ -31,7 +31,7 @@ jobs:
       image: ${{ inputs.image }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
           submodules: true

--- a/.github/workflows/cxx_interop.yml
+++ b/.github/workflows/cxx_interop.yml
@@ -86,7 +86,7 @@ jobs:
       cxx-interop-matrix: '${{ steps.generate-matrix.outputs.cxx-interop-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -225,7 +225,7 @@ jobs:
       darwin-matrix: '${{ steps.generate-matrix.outputs.darwin-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix
@@ -432,7 +432,7 @@ jobs:
       matrix: ${{ fromJson(needs.construct-matrix.outputs.darwin-matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
           submodules: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       integration-test-matrix: '${{ steps.generate-matrix.outputs.integration-test-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,7 +47,7 @@ jobs:
       integration-test-matrix: '${{ steps.generate-matrix.outputs.integration-test-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - name: Load vsock_loopback kernel module

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -14,7 +14,7 @@ jobs:
         timeout-minutes: 1
         steps:
             - name: Checkout repository
-              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
               with:
                   persist-credentials: false
             - name: Check for Semantic Version label

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -118,7 +118,7 @@ jobs:
       release-build-matrix: '${{ steps.generate-matrix.outputs.release-build-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix

--- a/.github/workflows/static_sdk.yml
+++ b/.github/workflows/static_sdk.yml
@@ -23,7 +23,7 @@ jobs:
       static-sdk-matrix: '${{ steps.generate-matrix.outputs.static-sdk-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix

--- a/.github/workflows/swift_6_language_mode.yml
+++ b/.github/workflows/swift_6_language_mode.yml
@@ -19,7 +19,7 @@ jobs:
       image: swift:6.0-jammy
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
           submodules: true

--- a/.github/workflows/swift_load_test_matrix.yml
+++ b/.github/workflows/swift_load_test_matrix.yml
@@ -23,7 +23,7 @@ jobs:
       swift-matrix: ${{ steps.load-matrix.outputs.swift-matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - name: Mark the workspace as safe

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -148,7 +148,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: ${{ matrix.swift.enabled }}
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
           submodules: true
@@ -187,7 +187,7 @@ jobs:
         run: docker pull ${{ matrix.swift.image }}
       - name: Checkout repository
         if: ${{ matrix.swift.enabled }}
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - name: Donwload matrix script
@@ -218,7 +218,7 @@ jobs:
         run: docker pull ${{ matrix.swift.image }}
       - name: Checkout repository
         if: ${{ matrix.swift.enabled }}
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
           submodules: true

--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -29,7 +29,7 @@ jobs:
       matrix: ${{ fromJson(inputs.matrix_string) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
           submodules: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -158,7 +158,7 @@ jobs:
       unit-test-matrix: '${{ steps.generate-matrix.outputs.unit-test-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix

--- a/.github/workflows/wasm_swift_sdk.yml
+++ b/.github/workflows/wasm_swift_sdk.yml
@@ -23,7 +23,7 @@ jobs:
       wasm-swift-sdk-matrix: '${{ steps.generate-matrix.outputs.wasm-swift-sdk-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - id: generate-matrix


### PR DESCRIPTION
Update the actions/checkout action to the latest release (v6.0.1)

### Motivation:

https://github.com/actions/checkout?tab=readme-ov-file#whats-new

> * Improved credential security: persist-credentials now stores credentials in a separate file under $RUNNER_TEMP instead of directly in .git/config
> * No workflow changes required — git fetch, git push, etc. continue to work automatically
> * Running authenticated git commands from a [Docker container action](https://docs.github.com/actions/sharing-automations/creating-actions/creating-a-docker-container-action) requires Actions Runner [v2.329.0](https://github.com/actions/runner/releases/tag/v2.329.0) or later
> * Updated to the node24 runtime
This requires a minimum Actions Runner version of [v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) to run.

### Modifications:

Updated the dependency version and added dependabot to take care of future upgrades.

### Result:

Our workflows will be more secure!