### PR TITLE
Allowlist 6.3 to be allowable for Swift Concurrency takeover

### DIFF
--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -44,7 +44,7 @@ extension NIOSingletons {
         return false
         #else
         // Guard between the minimum and maximum supported version for the hook
-        #if compiler(<6.3)
+        #if compiler(<6.4)
         guard #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) else {
             return false
         }


### PR DESCRIPTION
Make 6.3 fast