### PR TITLE
Add SO_TIMESTAMP support for datagram channels

### DIFF
--- a/Sources/NIOCore/AddressedEnvelope.swift
+++ b/Sources/NIOCore/AddressedEnvelope.swift
@@ -50,6 +50,13 @@ public struct AddressedEnvelope<DataType> {
         /// (if attached).
         public var segmentSize: Int?
 
+        /// The timestamp this datagram was received by the kernel.
+        ///
+        /// When `SO_TIMESTAMP` is enabled on a `DatagramChannel`, the kernel records the time each packet arrives.
+        /// This value is expressed as the number of seconds since the Unix epoch (January 1, 1970), with
+        /// sub-second precision.
+        public var timestamp: Double?
+
         public init(ecnState: NIOExplicitCongestionNotificationState) {
             self.ecnState = ecnState
             self.packetInfo = nil
@@ -70,6 +77,18 @@ public struct AddressedEnvelope<DataType> {
             self.ecnState = ecnState
             self.packetInfo = packetInfo
             self.segmentSize = segmentSize
+        }
+
+        public init(
+            ecnState: NIOExplicitCongestionNotificationState,
+            packetInfo: NIOPacketInfo?,
+            segmentSize: Int?,
+            timestamp: Double?
+        ) {
+            self.ecnState = ecnState
+            self.packetInfo = packetInfo
+            self.segmentSize = segmentSize
+            self.timestamp = timestamp
         }
     }
 }

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -236,6 +236,12 @@ extension ChannelOptions {
             public init() {}
         }
 
+        /// When set to true timestamp information will be reported through `AddressedEnvelope.Metadata`
+        public struct TimestampOption: ChannelOption, Sendable {
+            public typealias Value = Bool
+            public init() {}
+        }
+
         /// The watermark used to detect when `Channel.isWritable` returns `true` or `false`.
         public struct WriteBufferWaterMark: Sendable {
             /// The low mark setting for a `Channel`.
@@ -379,6 +385,9 @@ public struct ChannelOptions: Sendable {
     /// - seealso: `ExplicitCongestionNotificationsOption`
     public static let explicitCongestionNotification = Types.ExplicitCongestionNotificationsOption()
 
+    /// - seealso: `TimestampOption`
+    public static let timestamp = Types.TimestampOption()
+
     /// - seealso: `ReceivePacketInfo`
     public static let receivePacketInfo = Types.ReceivePacketInfo()
 
@@ -475,6 +484,11 @@ extension ChannelOption where Self == ChannelOptions.Types.DatagramReceiveSegmen
 /// - seealso: `ExplicitCongestionNotificationsOption`.
 extension ChannelOption where Self == ChannelOptions.Types.ExplicitCongestionNotificationsOption {
     public static var explicitCongestionNotification: Self { .init() }
+}
+
+/// - seealso: `TimestampOption`.
+extension ChannelOption where Self == ChannelOptions.Types.TimestampOption {
+    public static var timestamp: Self { .init() }
 }
 
 /// - seealso: `ReceivePacketInfo`.


### PR DESCRIPTION
### Motivation:

NIO supports ECN, packet info, and segmentation metadata but not timestamps. Userspace timestamps are imprecise due to scheduler latency between packet arrival and recvmsg. SO_TIMESTAMP captures the exact kernel receive time with microsecond precision via control messages, which is critical for accurate RTT measurements and latency monitoring.

### Modifications:

- Add timestamp field to AddressedEnvelope.Metadata
- Add TimestampOption channel option
- Parse SCM_TIMESTAMP control messages in ControlMessageParser
- Add init(ecnState:packetInfo:segmentSize:timestamp:) to Metadata
- Add test coverage

### Result:

Datagram channels can enable .receiveTimestamp to receive kernel timestamps in AddressedEnvelope.Metadata.timestamp as a Double (seconds since epoch with microsecond precision).
