### PR TITLE
docs: String(buffer:) needs to mention that it will always succeed

### DIFF
--- a/Sources/NIOCore/ByteBuffer-conversions.swift
+++ b/Sources/NIOCore/ByteBuffer-conversions.swift
@@ -31,6 +31,13 @@ extension Array where Element == UInt8 {
 extension String {
 
     /// Creates a `String` from a given `ByteBuffer`. The entire readable portion of the buffer will be read.
+    ///
+    /// This initializer always succeeds. If the buffer contains bytes that are not valid UTF-8, they will be
+    /// replaced with the Unicode replacement character (U+FFFD).
+    ///
+    /// If you need to validate that the buffer contains valid UTF-8, use ``ByteBuffer/readUTF8ValidatedString(length:)``
+    /// instead, which throws an error for invalid UTF-8.
+    ///
     /// - Parameter buffer: The buffer to read.
     @inlinable
     public init(buffer: ByteBuffer) {


### PR DESCRIPTION
### Motivation:
The documentation for String(buffer:) initializer does not clearly indicate
that this operation will always succeed, which may leave developers uncertain
about error handling requirements.
fixes: https://github.com/apple/swift-nio/issues/3449

### Modifications:
Updated the documentation for String(buffer:) to explicitly mention that
the initialization will always succeed.

### Result:
Developers will have clearer understanding that String(buffer:) is a safe
operation that does not require error handling.