### PR TITLE
build: Elide NIOEmbedded for WASI platforms only

### DIFF
--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -725,8 +725,9 @@ extension NIOAsyncTestingChannel.LeftOverState: @unchecked Sendable {}
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension NIOAsyncTestingChannel.BufferState: @unchecked Sendable {}
-#endif
 
 // Synchronous options are never Sendable.
 @available(*, unavailable)
 extension NIOAsyncTestingChannel.SynchronousOptions: Sendable {}
+
+#endif  // canImport(Dispatch)


### PR DESCRIPTION
### Motivation:

Packages that consume NIOEmbedded should be able to compile to WASI platforms without special configurations. This change elides the NIOEmbedded source from WASI platforms to simplify configuration.

Without this change:

```swift
dependencies: [
    // Without this PR, downstream packages must maintain exhaustive platform list to exclude `.wasi`:
    .product(
        name: "NIOEmbedded",
        package: "swift-nio",
        condition: .when(platforms: [
            .macOS,
            .macCatalyst,
            .iOS,
            .tvOS,
            .watchOS,
            .visionOS,
            .driverKit,
            .linux,
            .windows,
            .android,
            .openbsd,
            // .wasi // <-- Need to exclude this, because there is no exclusion list api for SPM conditionals
        ])
    ),
]
```

With this change:

```swift
dependencies: [
    // Without this PR, downstream packages can consume NIOEmbedded simply:
    .product(name: "NIOEmbedded", package: "swift-nio"),
]
```

### Modifications:

- Fix compiler directive using in AsyncTestingChannel.swift to include an extension

### Result:

Packages can compile to wasm without manually excluding the NIOEmbedded dependency.

### Testing performed

- Verified `swift build --swift-sdk wasm32-unknown-wasip1 --target NIOEmbedded` compiles, which demonstrates proper elision of source files in NIOEmbedded that aren't wasm-ready.
- Confirmed GitHub [checks pass](https://github.com/PassiveLogic/swift-nio/actions/runs/21151287289).
