### PR TITLE
build: Elide NIOPosix for WASI platforms only

### DIFF
--- a/Sources/NIOPosix/BSDSocketAPICommon.swift
+++ b/Sources/NIOPosix/BSDSocketAPICommon.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import NIOCore
 
 #if os(Windows)
@@ -391,3 +394,4 @@ enum NIOBSDSocketControlMessage: _BSDSocketControlMessageProtocol {}
 
 /// The requested UDS path exists and has wrong type (not a socket).
 public struct UnixDomainSocketPathWrongType: Error {}
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/BSDSocketAPIPosix.swift
+++ b/Sources/NIOPosix/BSDSocketAPIPosix.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import NIOCore
 
 #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin) || os(OpenBSD)
@@ -426,3 +429,4 @@ extension msghdr {
     }
 }
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 #if os(Windows)
@@ -803,3 +805,4 @@ extension WSAMSG {
     }
 }
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import CNIOLinux
 import CNIOOpenBSD
 import NIOConcurrencyHelpers
@@ -420,3 +422,4 @@ func __testOnly_withMutableSockAddr<ReturnType>(
 ) rethrows -> ReturnType {
     try addr.withMutableSockAddr(body)
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/BaseSocketChannel+SocketOptionProvider.swift
+++ b/Sources/NIOPosix/BaseSocketChannel+SocketOptionProvider.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import NIOCore
 
 extension BaseSocketChannel: SocketOptionProvider {
@@ -83,3 +86,4 @@ extension BaseSocketChannel: SocketOptionProvider {
         try self.socket.getOption(level: level, name: name)
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import Atomics
 import NIOConcurrencyHelpers
 import NIOCore
@@ -1435,3 +1437,4 @@ func executeAndComplete<Value: Sendable>(_ promise: EventLoopPromise<Value>?, _ 
         promise?.fail(e)
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/BaseStreamSocketChannel.swift
+++ b/Sources/NIOPosix/BaseStreamSocketChannel.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import NIOCore
 
 class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>, @unchecked Sendable {
@@ -301,3 +304,4 @@ class BaseStreamSocketChannel<Socket: SocketProtocol>: BaseSocketChannel<Socket>
         }
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import CNIOLinux
 import CNIOOpenBSD
 import NIOCore
@@ -2701,3 +2704,4 @@ private struct DefaultNIOPipeBootstrapHooks: NIOPipeBootstrapHooks {
         try PipeChannel(eventLoop: eventLoop, input: input, output: output)
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/ControlMessage.swift
+++ b/Sources/NIOPosix/ControlMessage.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import NIOCore
 
 #if canImport(Darwin)
@@ -438,3 +441,4 @@ extension AddressedEnvelope.Metadata {
         )
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/DatagramVectorReadManager.swift
+++ b/Sources/NIOPosix/DatagramVectorReadManager.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import CNIODarwin
 import CNIOLinux
 import CNIOOpenBSD
@@ -296,3 +299,4 @@ extension UnsafeMutableBufferPointer {
         rawPointer.deallocate()
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Errors+Any.swift
+++ b/Sources/NIOPosix/Errors+Any.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 // 'any Error' is unconditionally boxed, avoid allocating per use by statically boxing them.
@@ -35,3 +37,4 @@ extension EventLoopError {
     static let _shutdown: any Error = EventLoopError.shutdown
     static let _unsupportedOperation: any Error = EventLoopError.unsupportedOperation
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/FileDescriptor.swift
+++ b/Sources/NIOPosix/FileDescriptor.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 #if !os(Windows)
 import NIOCore
 
@@ -31,3 +33,4 @@ extension FileDescriptor {
     }
 }
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/GetaddrinfoResolver.swift
+++ b/Sources/NIOPosix/GetaddrinfoResolver.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 #if canImport(Dispatch)
@@ -236,3 +238,4 @@ internal final class GetaddrinfoResolver: Resolver, Sendable {
         }
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/HappyEyeballs.swift
+++ b/Sources/NIOPosix/HappyEyeballs.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 // This module implements Happy Eyeballs 2 (RFC 8305). A few notes should be made about the design.
@@ -758,3 +760,4 @@ private final class HappyEyeballsConnectorRunner<ChannelBuilderResult: Sendable>
         processInput(.resolutionDelayElapsed)
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/IO.swift
+++ b/Sources/NIOPosix/IO.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 extension IOResult where T: FixedWidthInteger {
     var result: T {
         switch self {
@@ -46,3 +48,4 @@ extension IOResult {
         }
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/IntegerBitPacking.swift
+++ b/Sources/NIOPosix/IntegerBitPacking.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 @usableFromInline
 enum _IntegerBitPacking: Sendable {}
 
@@ -129,3 +131,4 @@ extension IntegerBitPacking {
         return (unpacked.0, unpacked.1)
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/IntegerTypes.swift
+++ b/Sources/NIOPosix/IntegerTypes.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 // MARK: _UInt24
 
 /// A 24-bit unsigned integer value type.
@@ -132,3 +134,4 @@ extension _UInt56: CustomStringConvertible {
         UInt64(self).description
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Linux.swift
+++ b/Sources/NIOPosix/Linux.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 // This is a companion to System.swift that provides only Linux specials: either things that exist
 // only on Linux, or things that have Linux-specific extensions.
 
@@ -208,3 +210,4 @@ internal enum Linux {
     }
 }
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/LinuxCPUSet.swift
+++ b/Sources/NIOPosix/LinuxCPUSet.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 #if os(Linux) || os(Android)
 import CNIOLinux
 
@@ -97,3 +99,4 @@ extension MultiThreadedEventLoopGroup {
     }
 }
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/LinuxUring.swift
+++ b/Sources/NIOPosix/LinuxUring.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 #if SWIFTNIO_USE_IO_URING
 #if os(Linux)
 
@@ -631,3 +633,4 @@ extension Optional where Wrapped == UnsafeMutableRawPointer {
 #endif
 
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
+++ b/Sources/NIOPosix/MultiThreadedEventLoopGroup.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import Atomics
 import NIOConcurrencyHelpers
 import NIOCore
@@ -660,3 +662,4 @@ extension MultiThreadedEventLoopGroup {
         }
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/NIOPosixSendableMetatype.swift
+++ b/Sources/NIOPosix/NIOPosixSendableMetatype.swift
@@ -12,8 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 #if compiler(>=6.2)
 public typealias _NIOPosixSendableMetatype = SendableMetatype
 #else
 public typealias _NIOPosixSendableMetatype = Any
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/NIOThreadPool.swift
+++ b/Sources/NIOPosix/NIOThreadPool.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import Atomics
 import DequeModule
 import NIOConcurrencyHelpers
@@ -552,3 +554,4 @@ extension ConditionLock {
         return result
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import CNIOLinux
 import CNIOOpenBSD
 import CNIOWindows
@@ -1326,3 +1328,4 @@ extension NonBlockingFileIO {
     }
     #endif
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import Atomics
 import CNIODarwin
 import CNIOLinux
@@ -718,3 +720,4 @@ final class PendingDatagramWritesManager: PendingWritesManager {
         assert(self.state.isEmpty)
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/PendingWritesManager.swift
+++ b/Sources/NIOPosix/PendingWritesManager.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import Atomics
 import CNIOLinux
 import CNIOOpenBSD
@@ -693,3 +695,4 @@ extension PendingStreamWritesManager: CustomStringConvertible {
             + "writabilityFlag: \(self.channelWritabilityFlag.load(ordering: .relaxed))), state: \(self.state) }"
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/PipeChannel.swift
+++ b/Sources/NIOPosix/PipeChannel.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import NIOCore
 
 final class PipeChannel: BaseStreamSocketChannel<PipePair>, @unchecked Sendable {
@@ -152,3 +155,4 @@ extension PipeChannel: CustomStringConvertible {
         "PipeChannel { \(self.socketDescription), active = \(self.isActive), localAddress = \(self.localAddress.debugDescription), remoteAddress = \(self.remoteAddress.debugDescription) }"
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/PipePair.swift
+++ b/Sources/NIOPosix/PipePair.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 #if canImport(WinSDK)
@@ -240,3 +242,4 @@ final class PipePair: SocketProtocol {
         throw ChannelError._operationUnsupported
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Pool.swift
+++ b/Sources/NIOPosix/Pool.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 protocol PoolElement {
     init()
     func evictedFromPool()
@@ -384,3 +386,4 @@ struct PooledMsgBuffer: PoolElement {
         }
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import Atomics
 import NIOCore
 
@@ -139,3 +141,4 @@ where
 {
     typealias AtomicRep = Wrapped.AtomicOptionalRepresentation
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/PosixSingletons.swift
+++ b/Sources/NIOPosix/PosixSingletons.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 extension NIOSingletons {
@@ -120,3 +122,4 @@ private let globalPosixBlockingPool: NIOThreadPool = {
     _ = Unmanaged.passRetained(pool)  // never gonna let you down.
     return pool
 }()
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/RawSocketBootstrap.swift
+++ b/Sources/NIOPosix/RawSocketBootstrap.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import NIOCore
 
 /// A `RawSocketBootstrap` is an easy way to interact with IP based protocols other then TCP and UDP.
@@ -380,3 +383,4 @@ extension NIORawSocketBootstrap {
 
 @available(*, unavailable)
 extension NIORawSocketBootstrap: Sendable {}
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Resolver.swift
+++ b/Sources/NIOPosix/Resolver.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 /// A protocol that covers an object that does DNS lookups.
@@ -48,3 +50,4 @@ public protocol Resolver {
     /// This method is not guaranteed to terminate the outstanding queries.
     func cancelQueries()
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Selectable.swift
+++ b/Sources/NIOPosix/Selectable.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 /// Represents a selectable resource which can be registered to a `Selector` to
@@ -23,3 +25,4 @@ import NIOCore
 protocol Selectable {
     func withUnsafeHandle<T>(_: (NIOBSDSocket.Handle) throws -> T) throws -> T
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/SelectableChannel.swift
+++ b/Sources/NIOPosix/SelectableChannel.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOConcurrencyHelpers
 import NIOCore
 
@@ -58,3 +60,4 @@ internal enum ErrorResult {
     case fatal
     case nonFatal
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import Atomics
 import CNIOPosix
 import DequeModule
@@ -1247,3 +1249,4 @@ struct SelectableEventLoopUniqueID: Sendable {
         c_nio_posix_set_el_id(0)
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/SelectorEpoll.swift
+++ b/Sources/NIOPosix/SelectorEpoll.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOConcurrencyHelpers
 import NIOCore
 
@@ -342,3 +344,4 @@ extension Selector: _SelectorBackendProtocol {
 #endif
 
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOConcurrencyHelpers
 import NIOCore
 
@@ -533,3 +535,4 @@ enum SelectorStrategy: Sendable {
         hasher.combine(self._rawValue)
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/SelectorKqueue.swift
+++ b/Sources/NIOPosix/SelectorKqueue.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOConcurrencyHelpers
 import NIOCore
 
@@ -478,3 +480,4 @@ private struct KeventTriple {
 }
 
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/SelectorUring.swift
+++ b/Sources/NIOPosix/SelectorUring.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 #if SWIFTNIO_USE_IO_URING
@@ -424,3 +426,4 @@ extension Selector: _SelectorBackendProtocol {
 #endif
 
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/SelectorWSAPoll.swift
+++ b/Sources/NIOPosix/SelectorWSAPoll.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 #if os(Windows)
 import CNIOWindows
 import NIOCore
@@ -193,3 +195,4 @@ private func wakeupTarget(_ ptr: UInt64) {
     // We don't really need to do anything here. We just need any target
 }
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/ServerSocket.swift
+++ b/Sources/NIOPosix/ServerSocket.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 /// A server socket that can accept new connections.
@@ -150,3 +152,4 @@ class ServerSocket: BaseSocket, ServerSocketProtocol {
         }
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import CNIOLinux
 import CNIOOpenBSD
 import NIOCore
@@ -375,3 +377,4 @@ class Socket: BaseSocket, SocketProtocol {
         }
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import CNIOLinux
 import NIOCore
 
@@ -1283,3 +1286,4 @@ extension DatagramChannel: MulticastChannel {
         }
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/SocketProtocols.swift
+++ b/Sources/NIOPosix/SocketProtocols.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import NIOCore
 
 #if canImport(WinSDK)
@@ -127,3 +130,4 @@ extension BaseSocketProtocol {
         #endif
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/StructuredConcurrencyHelpers.swift
+++ b/Sources/NIOPosix/StructuredConcurrencyHelpers.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the AsyncHTTPClient open source project
@@ -58,3 +60,4 @@ internal func asyncDo<R>(
     }.value
     return result
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -15,6 +15,8 @@
 //  value before we were able to read it.
 //  It's important that all static methods are declared with `@inline(never)` so it's not possible any ARC traffic happens while we need to read errno.
 
+#if !os(WASI)
+
 import NIOCore
 
 #if canImport(Darwin)
@@ -1133,3 +1135,4 @@ internal enum KQueue: Sendable {
     }
 }
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Thread.swift
+++ b/Sources/NIOPosix/Thread.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOConcurrencyHelpers
 
 #if os(Linux) || os(FreeBSD) || os(Android)
@@ -285,3 +287,4 @@ public final class ThreadSpecificVariable<Value: AnyObject> {
 }
 
 extension ThreadSpecificVariable: @unchecked Sendable where Value: Sendable {}
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/ThreadPosix.swift
+++ b/Sources/NIOPosix/ThreadPosix.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin) || os(OpenBSD)
 
 #if os(Linux) || os(Android)
@@ -235,3 +237,4 @@ enum ThreadOpsPosix: ThreadOps {
 }
 
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/ThreadWindows.swift
+++ b/Sources/NIOPosix/ThreadWindows.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 #if os(Windows)
 
 import WinSDK
@@ -93,3 +95,4 @@ enum ThreadOpsWindows: ThreadOps {
 }
 
 #endif
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/UnsafeTransfer.swift
+++ b/Sources/NIOPosix/UnsafeTransfer.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 /// ``UnsafeTransfer`` can be used to make non-`Sendable` values `Sendable`.
 /// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler.
 /// It can be used similar to `@unsafe Sendable` but for values instead of types.
@@ -30,3 +32,4 @@ extension UnsafeTransfer: @unchecked Sendable {}
 
 extension UnsafeTransfer: Equatable where Wrapped: Equatable {}
 extension UnsafeTransfer: Hashable where Wrapped: Hashable {}
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Utilities.swift
+++ b/Sources/NIOPosix/Utilities.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 /// A utility function that runs the body code only in debug builds, without
 /// emitting compiler warnings.
 ///
@@ -32,3 +34,4 @@ final class Box<T> {
     let value: T
     init(_ value: T) { self.value = value }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/VsockAddress.swift
+++ b/Sources/NIOPosix/VsockAddress.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import NIOCore
 
 #if canImport(Darwin)
@@ -292,3 +294,4 @@ extension BaseSocket {
 }
 
 #endif  // canImport(Darwin) || os(Linux) || os(Android)
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/VsockChannelEvents.swift
+++ b/Sources/NIOPosix/VsockChannelEvents.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
 import NIOCore
 
 public enum VsockChannelEvents: Sendable {
@@ -38,3 +41,4 @@ public enum VsockChannelEvents: Sendable {
         }
     }
 }
+#endif  // !os(WASI)

--- a/Sources/NIOPosix/Windows.swift
+++ b/Sources/NIOPosix/Windows.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 #if os(Windows)
 import NIOCore
 import WinSDK
@@ -133,3 +135,4 @@ extension NIOCore.Windows {
 }
 
 #endif
+#endif  // !os(WASI)


### PR DESCRIPTION
### Motivation:

Packages that consume NIOPosix should be able to compile to WASI platforms without special configurations. This change elides the NIOPosix source from WASI platforms to simplify configuration.

Without this change:

```swift
dependencies: [
    // Without this PR, downstream packages must maintain exhaustive platform list to exclude `.wasi`:
    .product(
        name: "NIOPosix",
        package: "swift-nio",
        condition: .when(platforms: [
            .macOS,
            .macCatalyst,
            .iOS,
            .tvOS,
            .watchOS,
            .visionOS,
            .driverKit,
            .linux,
            .windows,
            .android,
            .openbsd,
            // .wasi // <-- Need to exclude this, because there is no exclusion list api for SPM conditionals
        ])
    ),
]
```

With this change:

```swift
dependencies: [
    // Without this PR, downstream packages can consume NIOPosix simply:
    .product(name: "NIOPosix", package: "swift-nio"),
]
```

### Modifications:

- Add compiler directives (`#if !os(WASI)`) to all source files in NIOPosix

### Result:

Downstream packages can compile to wasm without manually excluding the NIOPosix dependency.

### Testing performed

- Verified `swift build --swift-sdk wasm32-unknown-wasip1 --target NIOPosix` compiles, which demonstrates proper elision of source files in NIOPosix that aren't wasm-ready.
- Confirmed GitHub [checks pass](https://github.com/PassiveLogic/swift-nio/actions/runs/21151341738).
