### PR TITLE
test: Port EventLoopFutureTest to Swift Testing.

### DIFF
--- a/Tests/NIOPosixTests/EventLoopFutureTest.swift
+++ b/Tests/NIOPosixTests/EventLoopFutureTest.swift
@@ -17,7 +17,7 @@ import Dispatch
 import NIOConcurrencyHelpers
 import NIOEmbedded
 import NIOPosix
-import XCTest
+import Testing
 
 @testable import NIOCore
 
@@ -25,95 +25,106 @@ enum EventLoopFutureTestError: Error {
     case example
 }
 
-class EventLoopFutureTest: XCTestCase {
+@Suite("EventLoopFutureTest", .serialized, .timeLimit(.minutes(1)))
+class EventLoopFutureTest {
+    @Test
     func testFutureFulfilledIfHasResult() throws {
         let eventLoop = EmbeddedEventLoop()
         let f = EventLoopFuture(eventLoop: eventLoop, value: 5)
-        XCTAssertTrue(f.isFulfilled)
+        #expect(f.isFulfilled)
     }
 
+    @Test
     func testFutureFulfilledIfHasError() throws {
         let eventLoop = EmbeddedEventLoop()
         let f = EventLoopFuture<Void>(eventLoop: eventLoop, error: EventLoopFutureTestError.example)
-        XCTAssertTrue(f.isFulfilled)
+        #expect(f.isFulfilled)
     }
 
+    @Test
     func testFoldWithMultipleEventLoops() throws {
         let nThreads = 3
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: nThreads)
         defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+            #expect(throws: Never.self) { try eventLoopGroup.syncShutdownGracefully() }
         }
 
         let eventLoop0 = eventLoopGroup.next()
         let eventLoop1 = eventLoopGroup.next()
         let eventLoop2 = eventLoopGroup.next()
 
-        XCTAssert(eventLoop0 !== eventLoop1)
-        XCTAssert(eventLoop1 !== eventLoop2)
-        XCTAssert(eventLoop0 !== eventLoop2)
+        #expect(eventLoop0 !== eventLoop1)
+        #expect(eventLoop1 !== eventLoop2)
+        #expect(eventLoop0 !== eventLoop2)
 
         let f0: EventLoopFuture<[Int]> = eventLoop0.submit { [0] }
         let f1s: [EventLoopFuture<Int>] = (1...4).map { id in eventLoop1.submit { id } }
         let f2s: [EventLoopFuture<Int>] = (5...8).map { id in eventLoop2.submit { id } }
 
         var fN = f0.fold(f1s) { (f1Value: [Int], f2Value: Int) -> EventLoopFuture<[Int]> in
-            XCTAssert(eventLoop0.inEventLoop)
+            #expect(eventLoop0.inEventLoop)
             return eventLoop1.makeSucceededFuture(f1Value + [f2Value])
         }
 
         fN = fN.fold(f2s) { (f1Value: [Int], f2Value: Int) -> EventLoopFuture<[Int]> in
-            XCTAssert(eventLoop0.inEventLoop)
+            #expect(eventLoop0.inEventLoop)
             return eventLoop2.makeSucceededFuture(f1Value + [f2Value])
         }
 
         let allValues = try fN.wait()
-        XCTAssert(fN.eventLoop === f0.eventLoop)
-        XCTAssert(fN.isFulfilled)
-        XCTAssertEqual(allValues, [0, 1, 2, 3, 4, 5, 6, 7, 8])
+        #expect(fN.eventLoop === f0.eventLoop)
+        #expect(fN.isFulfilled)
+        #expect(allValues == [0, 1, 2, 3, 4, 5, 6, 7, 8])
     }
 
+    @Test
     func testFoldWithSuccessAndAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
         let f0 = eventLoop.makeSucceededFuture([0])
 
-        let futures: [EventLoopFuture<Int>] = (1...5).map { (id: Int) in secondEventLoop.makeSucceededFuture(id) }
+        let futures: [EventLoopFuture<Int>] = (1...5).map { (id: Int) in
+            secondEventLoop.makeSucceededFuture(id)
+        }
 
         let fN = f0.fold(futures) { (f1Value: [Int], f2Value: Int) -> EventLoopFuture<[Int]> in
-            XCTAssert(eventLoop.inEventLoop)
+            #expect(eventLoop.inEventLoop)
             return secondEventLoop.makeSucceededFuture(f1Value + [f2Value])
         }
 
         let allValues = try fN.wait()
-        XCTAssert(fN.eventLoop === f0.eventLoop)
-        XCTAssert(fN.isFulfilled)
-        XCTAssertEqual(allValues, [0, 1, 2, 3, 4, 5])
+        #expect(fN.eventLoop === f0.eventLoop)
+        #expect(fN.isFulfilled)
+        #expect(allValues == [0, 1, 2, 3, 4, 5])
     }
 
+    @Test
     func testFoldWithSuccessAndOneFailure() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
         let f0: EventLoopFuture<Int> = eventLoop.makeSucceededFuture(0)
 
-        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makePromise() }
+        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in
+            secondEventLoop.makePromise()
+        }
         var futures = promises.map { $0.futureResult }
         let failedFuture: EventLoopFuture<Int> = secondEventLoop.makeFailedFuture(E())
         futures.insert(failedFuture, at: futures.startIndex)
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
-            XCTAssert(eventLoop.inEventLoop)
+            #expect(eventLoop.inEventLoop)
             return secondEventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
         _ = promises.map { $0.succeed(0) }
-        XCTAssert(fN.isFulfilled)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(fN.isFulfilled)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testFoldWithSuccessAndEmptyFutureList() throws {
         let eventLoop = EmbeddedEventLoop()
         let f0 = eventLoop.makeSucceededFuture(0)
@@ -121,15 +132,16 @@ class EventLoopFutureTest: XCTestCase {
         let futures: [EventLoopFuture<Int>] = []
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
-            XCTAssert(eventLoop.inEventLoop)
+            #expect(eventLoop.inEventLoop)
             return eventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
         let summationResult = try fN.wait()
-        XCTAssert(fN.isFulfilled)
-        XCTAssertEqual(summationResult, 0)
+        #expect(fN.isFulfilled)
+        #expect(summationResult == 0)
     }
 
+    @Test
     func testFoldWithFailureAndEmptyFutureList() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
@@ -138,85 +150,96 @@ class EventLoopFutureTest: XCTestCase {
         let futures: [EventLoopFuture<Int>] = []
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
-            XCTAssert(eventLoop.inEventLoop)
+            #expect(eventLoop.inEventLoop)
             return eventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
-        XCTAssert(fN.isFulfilled)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(fN.isFulfilled)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testFoldWithFailureAndAllSuccesses() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
         let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(E())
 
-        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makePromise() }
+        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in
+            secondEventLoop.makePromise()
+        }
         let futures = promises.map { $0.futureResult }
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
-            XCTAssert(eventLoop.inEventLoop)
+            #expect(eventLoop.inEventLoop)
             return secondEventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
         _ = promises.map { $0.succeed(1) }
-        XCTAssert(fN.isFulfilled)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(fN.isFulfilled)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testFoldWithFailureAndAllUnfulfilled() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
         let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(E())
 
-        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makePromise() }
+        let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in
+            secondEventLoop.makePromise()
+        }
         let futures = promises.map { $0.futureResult }
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
-            XCTAssert(eventLoop.inEventLoop)
+            #expect(eventLoop.inEventLoop)
             return secondEventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
-        XCTAssert(fN.isFulfilled)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(fN.isFulfilled)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testFoldWithFailureAndAllFailures() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let secondEventLoop = EmbeddedEventLoop()
         let f0: EventLoopFuture<Int> = eventLoop.makeFailedFuture(E())
 
-        let futures: [EventLoopFuture<Int>] = (0..<100).map { (_: Int) in secondEventLoop.makeFailedFuture(E()) }
+        let futures: [EventLoopFuture<Int>] = (0..<100).map { (_: Int) in
+            secondEventLoop.makeFailedFuture(E())
+        }
 
         let fN = f0.fold(futures) { (f1Value: Int, f2Value: Int) -> EventLoopFuture<Int> in
-            XCTAssert(eventLoop.inEventLoop)
+            #expect(eventLoop.inEventLoop)
             return secondEventLoop.makeSucceededFuture(f1Value + f2Value)
         }
 
-        XCTAssert(fN.isFulfilled)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(fN.isFulfilled)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testAndAllWithEmptyFutureList() throws {
         let eventLoop = EmbeddedEventLoop()
         let futures: [EventLoopFuture<Void>] = []
 
         let fN = EventLoopFuture.andAllSucceed(futures, on: eventLoop)
 
-        XCTAssert(fN.isFulfilled)
+        #expect(fN.isFulfilled)
     }
 
+    @Test
     func testAndAllWithAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
         let promises: [EventLoopPromise<Void>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
@@ -227,6 +250,7 @@ class EventLoopFutureTest: XCTestCase {
         () = try fN.wait()
     }
 
+    @Test
     func testAndAllWithAllFailures() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
@@ -235,11 +259,12 @@ class EventLoopFutureTest: XCTestCase {
 
         let fN = EventLoopFuture.andAllSucceed(futures, on: eventLoop)
         _ = promises.map { $0.fail(E()) }
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testAndAllWithOneFailure() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
@@ -252,11 +277,12 @@ class EventLoopFutureTest: XCTestCase {
         let futures = promises.map { $0.futureResult }
 
         let fN = EventLoopFuture.andAllSucceed(futures, on: eventLoop)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testReduceWithAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
         let promises: [EventLoopPromise<Int>] = (0..<5).map { (_: Int) in eventLoop.makePromise() }
@@ -269,10 +295,11 @@ class EventLoopFutureTest: XCTestCase {
             promises[i - 1].succeed((i))
         }
         let results = try fN.wait()
-        XCTAssertEqual(results, [1, 2, 3, 4, 5])
-        XCTAssert(fN.eventLoop === eventLoop)
+        #expect(results == [1, 2, 3, 4, 5])
+        #expect(fN.eventLoop === eventLoop)
     }
 
+    @Test
     func testReduceWithOnlyInitialValue() throws {
         let eventLoop = EmbeddedEventLoop()
         let futures: [EventLoopFuture<Int>] = []
@@ -282,24 +309,28 @@ class EventLoopFutureTest: XCTestCase {
         }
 
         let results = try fN.wait()
-        XCTAssertEqual(results, [])
-        XCTAssert(fN.eventLoop === eventLoop)
+        #expect(results == [])
+        #expect(fN.eventLoop === eventLoop)
     }
 
+    @Test
     func testReduceWithAllFailures() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
         let promises: [EventLoopPromise<Int>] = (0..<100).map { (_: Int) in eventLoop.makePromise() }
         let futures = promises.map { $0.futureResult }
 
-        let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, on: eventLoop) { $0 + $1 }
+        let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, on: eventLoop) {
+            $0 + $1
+        }
         _ = promises.map { $0.fail(E()) }
-        XCTAssert(fN.eventLoop === eventLoop)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(fN.eventLoop === eventLoop)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testReduceWithOneFailure() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
@@ -311,13 +342,16 @@ class EventLoopFutureTest: XCTestCase {
 
         let futures = promises.map { $0.futureResult }
 
-        let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, on: eventLoop) { $0 + $1 }
-        XCTAssert(fN.eventLoop === eventLoop)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, on: eventLoop) {
+            $0 + $1
+        }
+        #expect(fN.eventLoop === eventLoop)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testReduceWhichDoesFailFast() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
@@ -327,22 +361,31 @@ class EventLoopFutureTest: XCTestCase {
         promises.insert(failedPromise, at: promises.startIndex)
 
         let futures = promises.map { $0.futureResult }
-        let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, on: eventLoop) { $0 + $1 }
+        let fN: EventLoopFuture<Int> = EventLoopFuture<Int>.reduce(0, futures, on: eventLoop) {
+            $0 + $1
+        }
 
         failedPromise.fail(E())
 
-        XCTAssertTrue(fN.isFulfilled)
-        XCTAssert(fN.eventLoop === eventLoop)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(fN.isFulfilled)
+        #expect(fN.eventLoop === eventLoop)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testReduceIntoWithAllSuccesses() throws {
         let eventLoop = EmbeddedEventLoop()
-        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.makeSucceededFuture(id) }
+        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in
+            eventLoop.makeSucceededFuture(id)
+        }
 
-        let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(into: [:], futures, on: eventLoop) {
+        let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(
+            into: [:],
+            futures,
+            on: eventLoop
+        ) {
             (freqs, elem) in
             if let value = freqs[elem] {
                 freqs[elem] = value + 1
@@ -352,15 +395,20 @@ class EventLoopFutureTest: XCTestCase {
         }
 
         let results = try fN.wait()
-        XCTAssertEqual(results, [1: 1, 2: 2, 3: 3])
-        XCTAssert(fN.eventLoop === eventLoop)
+        #expect(results == [1: 1, 2: 2, 3: 3])
+        #expect(fN.eventLoop === eventLoop)
     }
 
+    @Test
     func testReduceIntoWithEmptyFutureList() throws {
         let eventLoop = EmbeddedEventLoop()
         let futures: [EventLoopFuture<Int>] = []
 
-        let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(into: [:], futures, on: eventLoop) {
+        let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(
+            into: [:],
+            futures,
+            on: eventLoop
+        ) {
             (freqs, elem) in
             if let value = freqs[elem] {
                 freqs[elem] = value + 1
@@ -370,16 +418,23 @@ class EventLoopFutureTest: XCTestCase {
         }
 
         let results = try fN.wait()
-        XCTAssert(results.isEmpty)
-        XCTAssert(fN.eventLoop === eventLoop)
+        #expect(results.isEmpty)
+        #expect(fN.eventLoop === eventLoop)
     }
 
+    @Test
     func testReduceIntoWithAllFailure() throws {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
-        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in eventLoop.makeFailedFuture(E()) }
+        let futures: [EventLoopFuture<Int>] = [1, 2, 2, 3, 3, 3].map { (id: Int) in
+            eventLoop.makeFailedFuture(E())
+        }
 
-        let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(into: [:], futures, on: eventLoop) {
+        let fN: EventLoopFuture<[Int: Int]> = EventLoopFuture<[Int: Int]>.reduce(
+            into: [:],
+            futures,
+            on: eventLoop
+        ) {
             (freqs, elem) in
             if let value = freqs[elem] {
                 freqs[elem] = value + 1
@@ -388,34 +443,36 @@ class EventLoopFutureTest: XCTestCase {
             }
         }
 
-        XCTAssert(fN.isFulfilled)
-        XCTAssert(fN.eventLoop === eventLoop)
-        XCTAssertThrowsError(try fN.wait()) { error in
-            XCTAssertNotNil(error as? E)
+        #expect(fN.isFulfilled)
+        #expect(fN.eventLoop === eventLoop)
+        #expect(throws: E.self) {
+            try fN.wait()
         }
     }
 
+    @Test
     func testReduceIntoWithMultipleEventLoops() throws {
         let nThreads = 3
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: nThreads)
         defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+            #expect(throws: Never.self) { try eventLoopGroup.syncShutdownGracefully() }
         }
 
         let eventLoop0 = eventLoopGroup.next()
         let eventLoop1 = eventLoopGroup.next()
         let eventLoop2 = eventLoopGroup.next()
 
-        XCTAssert(eventLoop0 !== eventLoop1)
-        XCTAssert(eventLoop1 !== eventLoop2)
-        XCTAssert(eventLoop0 !== eventLoop2)
+        #expect(eventLoop0 !== eventLoop1)
+        #expect(eventLoop1 !== eventLoop2)
+        #expect(eventLoop0 !== eventLoop2)
 
         let f0: EventLoopFuture<[Int: Int]> = eventLoop0.submit { [:] }
         let f1s: [EventLoopFuture<Int>] = (1...4).map { id in eventLoop1.submit { id / 2 } }
         let f2s: [EventLoopFuture<Int>] = (5...8).map { id in eventLoop2.submit { id / 2 } }
 
-        let fN = EventLoopFuture<[Int: Int]>.reduce(into: [:], f1s + f2s, on: eventLoop0) { (freqs, elem) in
-            XCTAssert(eventLoop0.inEventLoop)
+        let fN = EventLoopFuture<[Int: Int]>.reduce(into: [:], f1s + f2s, on: eventLoop0) {
+            (freqs, elem) in
+            #expect(eventLoop0.inEventLoop)
             if let value = freqs[elem] {
                 freqs[elem] = value + 1
             } else {
@@ -424,12 +481,13 @@ class EventLoopFutureTest: XCTestCase {
         }
 
         let allValues = try fN.wait()
-        XCTAssert(fN.eventLoop === f0.eventLoop)
-        XCTAssert(fN.isFulfilled)
-        XCTAssertEqual(allValues, [0: 1, 1: 2, 2: 2, 3: 2, 4: 1])
+        #expect(fN.eventLoop === f0.eventLoop)
+        #expect(fN.isFulfilled)
+        #expect(allValues == [0: 1, 1: 2, 2: 2, 3: 2, 4: 1])
     }
 
-    func testThenThrowingWhichDoesNotThrow() {
+    @Test
+    func testThenThrowingWhichDoesNotThrow() throws {
         let eventLoop = EmbeddedEventLoop()
         var ran = false
         let p = eventLoop.makePromise(of: String.self)
@@ -439,13 +497,14 @@ class EventLoopFutureTest: XCTestCase {
             1 + $0
         }.assumeIsolated().whenSuccess {
             ran = true
-            XCTAssertEqual($0, 6)
+            #expect($0 == 6)
         }
         p.succeed("hello")
-        XCTAssertTrue(ran)
+        #expect(ran)
     }
 
-    func testThenThrowingWhichDoesThrow() {
+    @Test
+    func testThenThrowingWhichDoesThrow() throws {
         enum DummyError: Error, Equatable {
             case dummyError
         }
@@ -455,20 +514,21 @@ class EventLoopFutureTest: XCTestCase {
         p.futureResult.map {
             $0.count
         }.flatMapThrowing { (x: Int) throws -> Int in
-            XCTAssertEqual(5, x)
+            #expect(5 == x)
             throw DummyError.dummyError
         }.map { (x: Int) -> Int in
-            XCTFail("shouldn't have been called")
+            Issue.record("shouldn't have been called")
             return x
         }.assumeIsolated().whenFailure {
             ran = true
-            XCTAssertEqual(.some(DummyError.dummyError), $0 as? DummyError)
+            #expect(.some(DummyError.dummyError) == $0 as? DummyError)
         }
         p.succeed("hello")
-        XCTAssertTrue(ran)
+        #expect(ran)
     }
 
-    func testflatMapErrorThrowingWhichDoesNotThrow() {
+    @Test
+    func testflatMapErrorThrowingWhichDoesNotThrow() throws {
         enum DummyError: Error, Equatable {
             case dummyError
         }
@@ -478,20 +538,21 @@ class EventLoopFutureTest: XCTestCase {
         p.futureResult.map {
             $0.count
         }.flatMapErrorThrowing {
-            XCTAssertEqual(.some(DummyError.dummyError), $0 as? DummyError)
+            #expect(.some(DummyError.dummyError) == $0 as? DummyError)
             return 5
         }.flatMapErrorThrowing { (_: Error) in
-            XCTFail("shouldn't have been called")
+            Issue.record("shouldn't have been called")
             return 5
         }.assumeIsolated().whenSuccess {
             ran = true
-            XCTAssertEqual($0, 5)
+            #expect($0 == 5)
         }
         p.fail(DummyError.dummyError)
-        XCTAssertTrue(ran)
+        #expect(ran)
     }
 
-    func testflatMapErrorThrowingWhichDoesThrow() {
+    @Test
+    func testflatMapErrorThrowingWhichDoesThrow() throws {
         enum DummyError: Error, Equatable {
             case dummyError1
             case dummyError2
@@ -502,38 +563,44 @@ class EventLoopFutureTest: XCTestCase {
         p.futureResult.map {
             $0.count
         }.flatMapErrorThrowing { (x: Error) throws -> Int in
-            XCTAssertEqual(.some(DummyError.dummyError1), x as? DummyError)
+            #expect(.some(DummyError.dummyError1) == x as? DummyError)
             throw DummyError.dummyError2
         }.map { (x: Int) -> Int in
-            XCTFail("shouldn't have been called")
+            Issue.record("shouldn't have been called")
             return x
         }.assumeIsolated().whenFailure {
             ran = true
-            XCTAssertEqual(.some(DummyError.dummyError2), $0 as? DummyError)
+            #expect(.some(DummyError.dummyError2) == $0 as? DummyError)
         }
         p.fail(DummyError.dummyError1)
-        XCTAssertTrue(ran)
+        #expect(ran)
     }
 
+    @Test
     func testOrderOfFutureCompletion() throws {
         let eventLoop = EmbeddedEventLoop()
         var state = 0
-        let p: EventLoopPromise<Void> = EventLoopPromise(eventLoop: eventLoop, file: #filePath, line: #line)
+        let p: EventLoopPromise<Void> = EventLoopPromise(
+            eventLoop: eventLoop,
+            file: #filePath,
+            line: #line
+        )
         p.futureResult.assumeIsolated().map {
-            XCTAssertEqual(state, 0)
+            #expect(state == 0)
             state += 1
         }.map {
-            XCTAssertEqual(state, 1)
+            #expect(state == 1)
             state += 1
         }.whenSuccess {
-            XCTAssertEqual(state, 2)
+            #expect(state == 2)
             state += 1
         }
         p.succeed(())
-        XCTAssertTrue(p.futureResult.isFulfilled)
-        XCTAssertEqual(state, 3)
+        #expect(p.futureResult.isFulfilled)
+        #expect(state == 3)
     }
 
+    @Test
     func testEventLoopHoppingInThen() throws {
         let n = 20
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
@@ -541,18 +608,20 @@ class EventLoopFutureTest: XCTestCase {
         for i in (1..<20) {
             let p = elg.next().makePromise(of: Int.self)
             prev.flatMap { (i2: Int) -> EventLoopFuture<Int> in
-                XCTAssertEqual(i - 1, i2)
+                #expect(i - 1 == i2)
                 p.succeed(i)
                 return p.futureResult
             }.whenSuccess { i2 in
-                XCTAssertEqual(i, i2)
+                #expect(i == i2)
             }
             prev = p.futureResult
         }
-        XCTAssertEqual(n - 1, try prev.wait())
-        XCTAssertNoThrow(try elg.syncShutdownGracefully())
+        let result = try prev.wait()
+        #expect(n - 1 == result)
+        #expect(throws: Never.self) { try elg.syncShutdownGracefully() }
     }
 
+    @Test
     func testEventLoopHoppingInThenWithFailures() throws {
         enum DummyError: Error {
             case dummy
@@ -563,7 +632,7 @@ class EventLoopFutureTest: XCTestCase {
         for i in (1..<n) {
             let p = elg.next().makePromise(of: Int.self)
             prev.flatMap { (i2: Int) -> EventLoopFuture<Int> in
-                XCTAssertEqual(i - 1, i2)
+                #expect(i - 1 == i2)
                 if i == n / 2 {
                     p.fail(DummyError.dummy)
                 } else {
@@ -574,16 +643,17 @@ class EventLoopFutureTest: XCTestCase {
                 p.fail(error)
                 return p.futureResult
             }.whenSuccess { i2 in
-                XCTAssertEqual(i, i2)
+                #expect(i == i2)
             }
             prev = p.futureResult
         }
-        XCTAssertThrowsError(try prev.wait()) { error in
-            XCTAssertNotNil(error as? DummyError)
+        #expect(throws: DummyError.self) {
+            try prev.wait()
         }
-        XCTAssertNoThrow(try elg.syncShutdownGracefully())
+        #expect(throws: Never.self) { try elg.syncShutdownGracefully() }
     }
 
+    @Test
     func testEventLoopHoppingAndAll() throws {
         let n = 20
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: n)
@@ -597,9 +667,10 @@ class EventLoopFutureTest: XCTestCase {
             }
         }
         try allOfEm.wait()
-        XCTAssertNoThrow(try elg.syncShutdownGracefully())
+        #expect(throws: Never.self) { try elg.syncShutdownGracefully() }
     }
 
+    @Test
     func testEventLoopHoppingAndAllWithFailures() throws {
         enum DummyError: Error { case dummy }
         let n = 20
@@ -618,13 +689,14 @@ class EventLoopFutureTest: XCTestCase {
                 }
             }
         }
-        XCTAssertThrowsError(try allOfEm.wait()) { error in
-            XCTAssertNotNil(error as? DummyError)
+        #expect(throws: DummyError.self) {
+            try allOfEm.wait()
         }
-        XCTAssertNoThrow(try elg.syncShutdownGracefully())
-        XCTAssertNoThrow(try fireBackEl.syncShutdownGracefully())
+        #expect(throws: Never.self) { try elg.syncShutdownGracefully() }
+        #expect(throws: Never.self) { try fireBackEl.syncShutdownGracefully() }
     }
 
+    @Test
     func testFutureInVariousScenarios() throws {
         enum DummyError: Error {
             case dummy0
@@ -700,89 +772,93 @@ class EventLoopFutureTest: XCTestCase {
                     do {
                         let result = try fAll.wait()
                         if !whoSucceeds.0 || !whoSucceeds.1 {
-                            XCTFail("unexpected success")
+                            Issue.record("unexpected success")
                         } else {
-                            XCTAssert((7, "hello") == result)
+                            #expect((7, "hello") == result)
                         }
                     } catch let e as DummyError {
                         switch e {
                         case .dummy0:
-                            XCTAssertFalse(whoSucceeds.0)
+                            #expect(!whoSucceeds.0)
                         case .dummy1:
-                            XCTAssertFalse(whoSucceeds.1)
+                            #expect(!whoSucceeds.1)
                         }
                     } catch {
-                        XCTFail("unexpected error: \(error)")
+                        Issue.record("unexpected error: \(error)")
                     }
                 }
             }
         }
 
-        XCTAssertNoThrow(try elg.syncShutdownGracefully())
+        #expect(throws: Never.self) { try elg.syncShutdownGracefully() }
     }
 
+    @Test
     func testLoopHoppingHelperSuccess() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
         let loop1 = group.next()
         let loop2 = group.next()
-        XCTAssertFalse(loop1 === loop2)
+        #expect(!(loop1 === loop2))
 
         let succeedingPromise = loop1.makePromise(of: Void.self)
         let succeedingFuture = succeedingPromise.futureResult.map {
-            XCTAssertTrue(loop1.inEventLoop)
+            #expect(loop1.inEventLoop)
         }.hop(to: loop2).map {
-            XCTAssertTrue(loop2.inEventLoop)
+            #expect(loop2.inEventLoop)
         }
         succeedingPromise.succeed(())
-        XCTAssertNoThrow(try succeedingFuture.wait())
+        #expect(throws: Never.self) { try succeedingFuture.wait() }
     }
 
+    @Test
     func testLoopHoppingHelperFailure() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
 
         let loop1 = group.next()
         let loop2 = group.next()
-        XCTAssertFalse(loop1 === loop2)
+        #expect(!(loop1 === loop2))
 
         let failingPromise = loop2.makePromise(of: Void.self)
         let failingFuture = failingPromise.futureResult.flatMapErrorThrowing { error in
-            XCTAssertEqual(error as? EventLoopFutureTestError, EventLoopFutureTestError.example)
-            XCTAssertTrue(loop2.inEventLoop)
+            #expect(error as? EventLoopFutureTestError == EventLoopFutureTestError.example)
+            #expect(loop2.inEventLoop)
             throw error
         }.hop(to: loop1).recover { error in
-            XCTAssertEqual(error as? EventLoopFutureTestError, EventLoopFutureTestError.example)
-            XCTAssertTrue(loop1.inEventLoop)
+            #expect(error as? EventLoopFutureTestError == EventLoopFutureTestError.example)
+            #expect(loop1.inEventLoop)
         }
 
         failingPromise.fail(EventLoopFutureTestError.example)
-        XCTAssertNoThrow(try failingFuture.wait())
+        #expect(throws: Never.self) { try failingFuture.wait() }
     }
 
+    @Test
     func testLoopHoppingHelperNoHopping() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
         let loop1 = group.next()
         let loop2 = group.next()
-        XCTAssertFalse(loop1 === loop2)
+        #expect(!(loop1 === loop2))
 
         let noHoppingPromise = loop1.makePromise(of: Void.self)
         let noHoppingFuture = noHoppingPromise.futureResult.hop(to: loop1)
-        XCTAssertTrue(noHoppingFuture === noHoppingPromise.futureResult)
+        #expect(noHoppingFuture === noHoppingPromise.futureResult)
         noHoppingPromise.succeed(())
     }
 
+    @Test
     func testFlatMapResultHappyPath() {
         let el = EmbeddedEventLoop()
         defer {
-            XCTAssertNoThrow(try el.syncShutdownGracefully())
+            #expect(throws: Never.self) { try el.syncShutdownGracefully() }
         }
 
         let p = el.makePromise(of: Int.self)
@@ -790,14 +866,18 @@ class EventLoopFutureTest: XCTestCase {
             Result<String, Never>.success("hello world")
         }
         p.succeed(1)
-        XCTAssertNoThrow(XCTAssertEqual("hello world", try f.wait()))
+        #expect(throws: Never.self) {
+            let result = try f.wait()
+            #expect("hello world" == result)
+        }
     }
 
+    @Test
     func testFlatMapResultFailurePath() {
         struct DummyError: Error {}
         let el = EmbeddedEventLoop()
         defer {
-            XCTAssertNoThrow(try el.syncShutdownGracefully())
+            #expect(throws: Never.self) { try el.syncShutdownGracefully() }
         }
 
         let p = el.makePromise(of: Int.self)
@@ -805,15 +885,14 @@ class EventLoopFutureTest: XCTestCase {
             Result<Int, Error>.failure(DummyError())
         }
         p.succeed(1)
-        XCTAssertThrowsError(try f.wait()) { error in
-            XCTAssert(type(of: error) == DummyError.self)
-        }
+        #expect(throws: DummyError.self) { try f.wait() }
     }
 
+    @Test
     func testWhenAllSucceedFailsImmediately() {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
 
         func doTest(promise: EventLoopPromise<[Int]>?) {
@@ -832,8 +911,8 @@ class EventLoopFutureTest: XCTestCase {
             }
 
             promises[0].fail(EventLoopFutureTestError.example)
-            XCTAssertThrowsError(try futureResult.wait()) { error in
-                XCTAssert(type(of: error) == EventLoopFutureTestError.self)
+            #expect(throws: EventLoopFutureTestError.self) {
+                try futureResult.wait()
             }
         }
 
@@ -841,10 +920,11 @@ class EventLoopFutureTest: XCTestCase {
         doTest(promise: group.next().makePromise())
     }
 
+    @Test
     func testWhenAllSucceedResolvesAfterFutures() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 6)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
 
         func doTest(promise: EventLoopPromise<[Int]>?) throws {
@@ -864,13 +944,13 @@ class EventLoopFutureTest: XCTestCase {
             }
 
             mainFuture.whenSuccess { _ in
-                XCTAssertTrue(completedPromises.withLockedValue { $0 })
-                XCTAssertFalse(succeeded.withLockedValue { $0 })
+                #expect(completedPromises.withLockedValue { $0 })
+                #expect(!succeeded.withLockedValue { $0 })
                 succeeded.withLockedValue { $0 = true }
             }
 
             // Should be false, as none of the promises have completed yet
-            XCTAssertFalse(succeeded.withLockedValue { $0 })
+            #expect(!succeeded.withLockedValue { $0 })
 
             // complete the first four promises
             for (index, promise) in promises.dropLast().enumerated() {
@@ -878,24 +958,25 @@ class EventLoopFutureTest: XCTestCase {
             }
 
             // Should still be false, as one promise hasn't completed yet
-            XCTAssertFalse(succeeded.withLockedValue { $0 })
+            #expect(!succeeded.withLockedValue { $0 })
 
             // Complete the last promise
             completedPromises.withLockedValue { $0 = true }
             promises.last!.succeed(4)
 
             let results = try assertNoThrowWithValue(mainFuture.wait())
-            XCTAssertEqual(results, [0, 1, 2, 3, 4])
+            #expect(results == [0, 1, 2, 3, 4])
         }
 
-        XCTAssertNoThrow(try doTest(promise: nil))
-        XCTAssertNoThrow(try doTest(promise: group.next().makePromise()))
+        #expect(throws: Never.self) { try doTest(promise: nil) }
+        #expect(throws: Never.self) { try doTest(promise: group.next().makePromise()) }
     }
 
+    @Test
     func testWhenAllSucceedIsIndependentOfFulfillmentOrder() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 6)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
 
         func doTest(promise: EventLoopPromise<[Int]>?) throws {
@@ -916,8 +997,8 @@ class EventLoopFutureTest: XCTestCase {
             }
 
             mainFuture.whenSuccess { _ in
-                XCTAssertTrue(completedPromises.withLockedValue { $0 })
-                XCTAssertFalse(succeeded.withLockedValue { $0 })
+                #expect(completedPromises.withLockedValue { $0 })
+                #expect(!succeeded.withLockedValue { $0 })
                 succeeded.withLockedValue { $0 = true }
             }
 
@@ -929,17 +1010,18 @@ class EventLoopFutureTest: XCTestCase {
             }
 
             let results = try assertNoThrowWithValue(mainFuture.wait())
-            XCTAssertEqual(results, expected)
+            #expect(results == expected)
         }
 
-        XCTAssertNoThrow(try doTest(promise: nil))
-        XCTAssertNoThrow(try doTest(promise: group.next().makePromise()))
+        #expect(throws: Never.self) { try doTest(promise: nil) }
+        #expect(throws: Never.self) { try doTest(promise: group.next().makePromise()) }
     }
 
+    @Test
     func testWhenAllCompleteResultsWithFailuresStillSucceed() {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
 
         func doTest(promise: EventLoopPromise<[Result<Bool, Error>]>?) {
@@ -956,17 +1038,18 @@ class EventLoopFutureTest: XCTestCase {
                 future = EventLoopFuture.whenAllComplete(futures, on: group.next())
             }
 
-            XCTAssertNoThrow(try future.wait())
+            #expect(throws: Never.self) { try future.wait() }
         }
 
         doTest(promise: nil)
         doTest(promise: group.next().makePromise())
     }
 
+    @Test
     func testWhenAllCompleteResults() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
 
         func doTest(promise: EventLoopPromise<[Result<Int, Error>]>?) throws {
@@ -988,21 +1071,22 @@ class EventLoopFutureTest: XCTestCase {
 
             let results = try assertNoThrowWithValue(future.wait())
 
-            XCTAssertEqual(try results[0].get(), 3)
-            XCTAssertThrowsError(try results[1].get())
-            XCTAssertEqual(try results[2].get(), 10)
-            XCTAssertThrowsError(try results[3].get())
-            XCTAssertEqual(try results[4].get(), 5)
+            #expect(try results[0].get() == 3)
+            #expect(throws: Error.self) { try results[1].get() }
+            #expect(try results[2].get() == 10)
+            #expect(throws: Error.self) { try results[3].get() }
+            #expect(try results[4].get() == 5)
         }
 
-        XCTAssertNoThrow(try doTest(promise: nil))
-        XCTAssertNoThrow(try doTest(promise: group.next().makePromise()))
+        #expect(throws: Never.self) { try doTest(promise: nil) }
+        #expect(throws: Never.self) { try doTest(promise: group.next().makePromise()) }
     }
 
+    @Test
     func testWhenAllCompleteResolvesAfterFutures() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 6)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
 
         func doTest(promise: EventLoopPromise<[Result<Int, Error>]>?) throws {
@@ -1022,13 +1106,13 @@ class EventLoopFutureTest: XCTestCase {
             }
 
             mainFuture.whenSuccess { _ in
-                XCTAssertTrue(completedPromises.withLockedValue { $0 })
-                XCTAssertFalse(succeeded.withLockedValue { $0 })
+                #expect(completedPromises.withLockedValue { $0 })
+                #expect(!succeeded.withLockedValue { $0 })
                 succeeded.withLockedValue { $0 = true }
             }
 
             // Should be false, as none of the promises have completed yet
-            XCTAssertFalse(succeeded.withLockedValue { $0 })
+            #expect(!succeeded.withLockedValue { $0 })
 
             // complete the first four promises
             for (index, promise) in promises.dropLast().enumerated() {
@@ -1036,18 +1120,18 @@ class EventLoopFutureTest: XCTestCase {
             }
 
             // Should still be false, as one promise hasn't completed yet
-            XCTAssertFalse(succeeded.withLockedValue { $0 })
+            #expect(!succeeded.withLockedValue { $0 })
 
             // Complete the last promise
             completedPromises.withLockedValue { $0 = true }
             promises.last!.succeed(4)
 
             let results = try assertNoThrowWithValue(mainFuture.wait().map { try $0.get() })
-            XCTAssertEqual(results, [0, 1, 2, 3, 4])
+            #expect(results == [0, 1, 2, 3, 4])
         }
 
-        XCTAssertNoThrow(try doTest(promise: nil))
-        XCTAssertNoThrow(try doTest(promise: group.next().makePromise()))
+        #expect(throws: Never.self) { try doTest(promise: nil) }
+        #expect(throws: Never.self) { try doTest(promise: group.next().makePromise()) }
     }
 
     struct DatabaseError: Error {}
@@ -1072,36 +1156,40 @@ class EventLoopFutureTest: XCTestCase {
         }
     }
 
+    @Test
     func testAlways() throws {
         let group = EmbeddedEventLoop()
         let loop = group.next()
         let db = Database { loop.makeSucceededFuture(["Item 1", "Item 2", "Item 3"]) }
 
-        XCTAssertFalse(db.closed)
+        #expect(!db.closed)
         let _ = try assertNoThrowWithValue(
             db.runQuery().always { result in
                 assertSuccess(result)
                 db.close()
             }.map { $0.map { $0.uppercased() } }.wait()
         )
-        XCTAssertTrue(db.closed)
+        #expect(db.closed)
     }
 
+    @Test
     func testAlwaysWithFailingPromise() throws {
         let group = EmbeddedEventLoop()
         let loop = group.next()
         let db = Database { loop.makeFailedFuture(DatabaseError()) }
 
-        XCTAssertFalse(db.closed)
-        let _ = try XCTAssertThrowsError(
-            db.runQuery().always { result in
+        #expect(!db.closed)
+
+        #expect(throws: DatabaseError.self) {
+            try db.runQuery().always { result in
                 assertFailure(result)
                 db.close()
             }.map { $0.map { $0.uppercased() } }.wait()
-        ) { XCTAssertTrue($0 is DatabaseError) }
-        XCTAssertTrue(db.closed)
+        }
+        #expect(db.closed)
     }
 
+    @Test
     func testPromiseCompletedWithSuccessfulFuture() throws {
         let group = EmbeddedEventLoop()
         let loop = group.next()
@@ -1110,15 +1198,17 @@ class EventLoopFutureTest: XCTestCase {
         let promise = loop.makePromise(of: String.self)
 
         promise.completeWith(future)
-        XCTAssertEqual(try promise.futureResult.wait(), "yay")
+        #expect(try promise.futureResult.wait() == "yay")
     }
 
+    @Test
     func testFutureFulfilledIfHasNonSendableResult() throws {
         let eventLoop = EmbeddedEventLoop()
         let f = EventLoopFuture(eventLoop: eventLoop, isolatedValue: NonSendableObject(value: 5))
-        XCTAssertTrue(f.isFulfilled)
+        #expect(f.isFulfilled)
     }
 
+    @Test
     func testSucceededIsolatedFutureIsCompleted() throws {
         let group = EmbeddedEventLoop()
         let loop = group.next()
@@ -1130,26 +1220,30 @@ class EventLoopFutureTest: XCTestCase {
         future.whenComplete { result in
             switch result {
             case .success(let nonSendableStruct):
-                XCTAssertEqual(nonSendableStruct, value)
+                #expect(nonSendableStruct == value)
             case .failure(let error):
-                XCTFail("\(error)")
+                Issue.record("\(error)")
             }
         }
     }
 
+    @Test
     func testPromiseCompletedWithFailedFuture() throws {
         let group = EmbeddedEventLoop()
         let loop = group.next()
 
-        let future: EventLoopFuture<EventLoopFutureTestError> = loop.makeFailedFuture(EventLoopFutureTestError.example)
+        let future: EventLoopFuture<EventLoopFutureTestError> = loop.makeFailedFuture(
+            EventLoopFutureTestError.example
+        )
         let promise = loop.makePromise(of: EventLoopFutureTestError.self)
 
         promise.completeWith(future)
-        XCTAssertThrowsError(try promise.futureResult.wait()) { error in
-            XCTAssert(type(of: error) == EventLoopFutureTestError.self)
+        #expect(throws: EventLoopFutureTestError.self) {
+            try promise.futureResult.wait()
         }
     }
 
+    @Test
     func testPromiseCompletedWithSuccessfulResult() throws {
         let group = EmbeddedEventLoop()
         let loop = group.next()
@@ -1158,9 +1252,10 @@ class EventLoopFutureTest: XCTestCase {
 
         let result: Result<Void, Error> = .success(())
         promise.completeWith(result)
-        XCTAssertNoThrow(try promise.futureResult.wait())
+        #expect(throws: Never.self) { try promise.futureResult.wait() }
     }
 
+    @Test
     func testPromiseCompletedWithFailedResult() throws {
         let group = EmbeddedEventLoop()
         let loop = group.next()
@@ -1169,17 +1264,19 @@ class EventLoopFutureTest: XCTestCase {
 
         let result: Result<Void, Error> = .failure(EventLoopFutureTestError.example)
         promise.completeWith(result)
-        XCTAssertThrowsError(try promise.futureResult.wait()) { error in
-            XCTAssert(type(of: error) == EventLoopFutureTestError.self)
+        #expect(throws: EventLoopFutureTestError.self) {
+            try promise.futureResult.wait()
         }
     }
 
+    @Test
     func testAndAllCompleteWithZeroFutures() {
         let eventLoop = EmbeddedEventLoop()
         let done = DispatchSemaphore(value: 0)
-        EventLoopFuture<Void>.andAllComplete([], on: eventLoop).whenComplete { (result: Result<Void, Error>) in
+        EventLoopFuture<Void>.andAllComplete([], on: eventLoop).whenComplete {
+            (result: Result<Void, Error>) in
             _ = result.mapError { error -> Error in
-                XCTFail("unexpected error \(error)")
+                Issue.record("unexpected error \(error)")
                 return error
             }
             done.signal()
@@ -1187,12 +1284,13 @@ class EventLoopFutureTest: XCTestCase {
         done.wait()
     }
 
+    @Test
     func testAndAllSucceedWithZeroFutures() {
         let eventLoop = EmbeddedEventLoop()
         let done = DispatchSemaphore(value: 0)
         EventLoopFuture<Void>.andAllSucceed([], on: eventLoop).whenComplete { result in
             _ = result.mapError { error -> Error in
-                XCTFail("unexpected error \(error)")
+                Issue.record("unexpected error \(error)")
                 return error
             }
             done.signal()
@@ -1200,35 +1298,38 @@ class EventLoopFutureTest: XCTestCase {
         done.wait()
     }
 
+    @Test
     func testAndAllCompleteWithPreSucceededFutures() {
         let eventLoop = EmbeddedEventLoop()
         let succeeded = eventLoop.makeSucceededFuture(())
 
         for i in 0..<10 {
-            XCTAssertNoThrow(
+            #expect(throws: Never.self) {
                 try EventLoopFuture<Void>.andAllComplete(
                     Array(repeating: succeeded, count: i),
                     on: eventLoop
                 ).wait()
-            )
+            }
         }
     }
 
+    @Test
     func testAndAllCompleteWithPreFailedFutures() {
         struct Dummy: Error {}
         let eventLoop = EmbeddedEventLoop()
         let failed: EventLoopFuture<Void> = eventLoop.makeFailedFuture(Dummy())
 
         for i in 0..<10 {
-            XCTAssertNoThrow(
+            #expect(throws: Never.self) {
                 try EventLoopFuture<Void>.andAllComplete(
                     Array(repeating: failed, count: i),
                     on: eventLoop
                 ).wait()
-            )
+            }
         }
     }
 
+    @Test
     func testAndAllCompleteWithMixOfPreSuccededAndNotYetCompletedFutures() {
         struct Dummy: Error {}
         let eventLoop = EmbeddedEventLoop()
@@ -1249,18 +1350,19 @@ class EventLoopFutureTest: XCTestCase {
         }
 
         let overall = EventLoopFuture<Void>.andAllComplete(futures, on: eventLoop)
-        XCTAssertFalse(overall.isFulfilled)
+        #expect(!overall.isFulfilled)
         for (idx, incomplete) in incompletes.enumerated() {
-            XCTAssertFalse(overall.isFulfilled)
+            #expect(!overall.isFulfilled)
             if idx % 2 == 0 {
                 incomplete.succeed(())
             } else {
                 incomplete.fail(Dummy())
             }
         }
-        XCTAssertNoThrow(try overall.wait())
+        #expect(throws: Never.self) { try overall.wait() }
     }
 
+    @Test
     func testWhenAllCompleteWithMixOfPreSuccededAndNotYetCompletedFutures() {
         struct Dummy: Error {}
         let eventLoop = EmbeddedEventLoop()
@@ -1281,9 +1383,9 @@ class EventLoopFutureTest: XCTestCase {
         }
 
         let overall = EventLoopFuture<Void>.whenAllComplete(futures, on: eventLoop)
-        XCTAssertFalse(overall.isFulfilled)
+        #expect(!overall.isFulfilled)
         for (idx, incomplete) in incompletes.enumerated() {
-            XCTAssertFalse(overall.isFulfilled)
+            #expect(!overall.isFulfilled)
             if idx % 2 == 0 {
                 incomplete.succeed(())
             } else {
@@ -1298,7 +1400,7 @@ class EventLoopFutureTest: XCTestCase {
             .success(()), .success(()),
         ]
         func assertIsEqual(_ expecteds: [Result<Void, Error>], _ actuals: [Result<Void, Error>]) {
-            XCTAssertEqual(expecteds.count, actuals.count, "counts not equal")
+            #expect(expecteds.count == actuals.count, "counts not equal")
             for i in expecteds.indices {
                 let expected = expecteds[i]
                 let actual = actuals[i]
@@ -1306,25 +1408,26 @@ class EventLoopFutureTest: XCTestCase {
                 case (.success(()), .success(())):
                     ()
                 case (.failure(let le), .failure(let re)):
-                    XCTAssert(le is Dummy)
-                    XCTAssert(re is Dummy)
+                    #expect(le is Dummy)
+                    #expect(re is Dummy)
                 default:
-                    XCTFail("\(expecteds) and \(actuals) not equal")
+                    Issue.record("\(expecteds) and \(actuals) not equal")
                 }
             }
         }
-        XCTAssertNoThrow(assertIsEqual(expected, try overall.wait()))
+        #expect(throws: Never.self) { assertIsEqual(expected, try overall.wait()) }
     }
 
+    @Test
     func testRepeatedTaskOffEventLoopGroupFuture() throws {
         let elg1: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
-            XCTAssertNoThrow(try elg1.syncShutdownGracefully())
+            #expect(throws: Never.self) { try elg1.syncShutdownGracefully() }
         }
 
         let elg2: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
-            XCTAssertNoThrow(try elg2.syncShutdownGracefully())
+            #expect(throws: Never.self) { try elg2.syncShutdownGracefully() }
         }
 
         let exitPromise: EventLoopPromise<Void> = elg1.next().makePromise()
@@ -1340,7 +1443,7 @@ class EventLoopFutureTest: XCTestCase {
                 task.cancel(promise: exitPromise)
                 return elg2.next().makeFailedFuture(Dummy())
             default:
-                XCTFail("shouldn't be called \(callNumber)")
+                Issue.record("shouldn't be called \(callNumber)")
                 return elg2.next().makeFailedFuture(Dummy())
             }
         }
@@ -1348,54 +1451,59 @@ class EventLoopFutureTest: XCTestCase {
         try exitPromise.futureResult.wait()
     }
 
-    func testEventLoopFutureOrErrorNoThrow() {
+    @Test
+    func testEventLoopFutureOrErrorNoThrow() throws {
         let eventLoop = EmbeddedEventLoop()
         let promise = eventLoop.makePromise(of: Int?.self)
         let result: Result<Int?, Error> = .success(42)
         promise.completeWith(result)
 
-        XCTAssertEqual(try promise.futureResult.unwrap(orError: EventLoopFutureTestError.example).wait(), 42)
+        #expect(try promise.futureResult.unwrap(orError: EventLoopFutureTestError.example).wait() == 42)
     }
 
+    @Test
     func testEventLoopFutureOrThrows() {
         let eventLoop = EmbeddedEventLoop()
         let promise = eventLoop.makePromise(of: Int?.self)
         let result: Result<Int?, Error> = .success(nil)
         promise.completeWith(result)
 
-        XCTAssertThrowsError(try promise.futureResult.unwrap(orError: EventLoopFutureTestError.example).wait()) {
-            (error) -> Void in
-            XCTAssertEqual(error as! EventLoopFutureTestError, EventLoopFutureTestError.example)
+        #expect(throws: EventLoopFutureTestError.example) {
+            try promise.futureResult.unwrap(orError: EventLoopFutureTestError.example).wait()
         }
     }
 
+    @Test
     func testEventLoopFutureOrNoReplacement() {
         let eventLoop = EmbeddedEventLoop()
         let promise = eventLoop.makePromise(of: Int?.self)
         let result: Result<Int?, Error> = .success(42)
         promise.completeWith(result)
 
-        XCTAssertEqual(try! promise.futureResult.unwrap(orReplace: 41).wait(), 42)
+        #expect(try! promise.futureResult.unwrap(orReplace: 41).wait() == 42)
     }
 
+    @Test
     func testEventLoopFutureOrReplacement() {
         let eventLoop = EmbeddedEventLoop()
         let promise = eventLoop.makePromise(of: Int?.self)
         let result: Result<Int?, Error> = .success(nil)
         promise.completeWith(result)
 
-        XCTAssertEqual(try! promise.futureResult.unwrap(orReplace: 42).wait(), 42)
+        #expect(try! promise.futureResult.unwrap(orReplace: 42).wait() == 42)
     }
 
+    @Test
     func testEventLoopFutureOrNoElse() {
         let eventLoop = EmbeddedEventLoop()
         let promise = eventLoop.makePromise(of: Int?.self)
         let result: Result<Int?, Error> = .success(42)
         promise.completeWith(result)
 
-        XCTAssertEqual(try! promise.futureResult.unwrap(orElse: { 41 }).wait(), 42)
+        #expect(try! promise.futureResult.unwrap(orElse: { 41 }).wait() == 42)
     }
 
+    @Test
     func testEventLoopFutureOrElse() {
         let eventLoop = EmbeddedEventLoop()
         let promise = eventLoop.makePromise(of: Int?.self)
@@ -1403,14 +1511,16 @@ class EventLoopFutureTest: XCTestCase {
         promise.completeWith(result)
 
         let x = 2
-        XCTAssertEqual(try! promise.futureResult.unwrap(orElse: { x * 2 }).wait(), 4)
+        #expect(try! promise.futureResult.unwrap(orElse: { x * 2 }).wait() == 4)
     }
 
+    @Test
     func testFlatBlockingMapOnto() {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
         }
+
         let eventLoop = group.next()
         let p = eventLoop.makePromise(of: String.self)
         let sem = DispatchSemaphore(value: 0)
@@ -1423,9 +1533,11 @@ class EventLoopFutureTest: XCTestCase {
             blockingRan.store(true, ordering: .sequentiallyConsistent)
             return 1 + value
         }.whenSuccess {
-            XCTAssertEqual($0, 6)
-            XCTAssertTrue(blockingRan.load(ordering: .sequentiallyConsistent))
-            XCTAssertTrue(nonBlockingRan.load(ordering: .sequentiallyConsistent))
+            #expect($0 == 6)
+            let blockingRanResult = blockingRan.load(ordering: .sequentiallyConsistent)
+            #expect(blockingRanResult)
+            let nonBlockingRanResult = nonBlockingRan.load(ordering: .sequentiallyConsistent)
+            #expect(nonBlockingRanResult)
         }
         p.succeed("hello")
 
@@ -1438,6 +1550,7 @@ class EventLoopFutureTest: XCTestCase {
         sem.signal()
     }
 
+    @Test
     func testWhenSuccessBlocking() {
         let eventLoop = EmbeddedEventLoop()
         let sem = DispatchSemaphore(value: 0)
@@ -1445,8 +1558,8 @@ class EventLoopFutureTest: XCTestCase {
         let p = eventLoop.makePromise(of: String.self)
         p.futureResult.whenSuccessBlocking(onto: DispatchQueue.global()) {
             sem.wait()  // Block in callback
-            XCTAssertEqual($0, "hello")
-            nonBlockingRan.withLockedValue { XCTAssertTrue($0) }
+            #expect($0 == "hello")
+            nonBlockingRan.withLockedValue { #expect($0) }
 
         }
         p.succeed("hello")
@@ -1457,9 +1570,12 @@ class EventLoopFutureTest: XCTestCase {
         }
         p2.succeed(true)
 
+        let didRun = try! p2.futureResult.wait()
+        #expect(didRun)
         sem.signal()
     }
 
+    @Test
     func testWhenFailureBlocking() {
         let eventLoop = EmbeddedEventLoop()
         let sem = DispatchSemaphore(value: 0)
@@ -1467,8 +1583,8 @@ class EventLoopFutureTest: XCTestCase {
         let p = eventLoop.makePromise(of: String.self)
         p.futureResult.whenFailureBlocking(onto: DispatchQueue.global()) { err in
             sem.wait()  // Block in callback
-            XCTAssertEqual(err as! EventLoopFutureTestError, EventLoopFutureTestError.example)
-            XCTAssertTrue(nonBlockingRan.withLockedValue { $0 })
+            #expect(err as! EventLoopFutureTestError == EventLoopFutureTestError.example)
+            #expect(nonBlockingRan.withLockedValue { $0 })
         }
         p.fail(EventLoopFutureTestError.example)
 
@@ -1478,9 +1594,12 @@ class EventLoopFutureTest: XCTestCase {
         }
         p2.succeed(true)
 
+        let didRun = try! p2.futureResult.wait()
+        #expect(didRun)
         sem.signal()
     }
 
+    @Test
     func testWhenCompleteBlockingSuccess() {
         let eventLoop = EmbeddedEventLoop()
         let sem = DispatchSemaphore(value: 0)
@@ -1488,7 +1607,7 @@ class EventLoopFutureTest: XCTestCase {
         let p = eventLoop.makePromise(of: String.self)
         p.futureResult.whenCompleteBlocking(onto: DispatchQueue.global()) { _ in
             sem.wait()  // Block in callback
-            XCTAssertTrue(nonBlockingRan.withLockedValue { $0 })
+            #expect(nonBlockingRan.withLockedValue { $0 })
         }
         p.succeed("hello")
 
@@ -1498,9 +1617,12 @@ class EventLoopFutureTest: XCTestCase {
         }
         p2.succeed(true)
 
+        let didRun = try! p2.futureResult.wait()
+        #expect(didRun)
         sem.signal()
     }
 
+    @Test
     func testWhenCompleteBlockingFailure() {
         let eventLoop = EmbeddedEventLoop()
         let sem = DispatchSemaphore(value: 0)
@@ -1508,7 +1630,7 @@ class EventLoopFutureTest: XCTestCase {
         let p = eventLoop.makePromise(of: String.self)
         p.futureResult.whenCompleteBlocking(onto: DispatchQueue.global()) { _ in
             sem.wait()  // Block in callback
-            XCTAssertTrue(nonBlockingRan.withLockedValue { $0 })
+            #expect(nonBlockingRan.withLockedValue { $0 })
         }
         p.fail(EventLoopFutureTestError.example)
 
@@ -1518,35 +1640,36 @@ class EventLoopFutureTest: XCTestCase {
         }
         p2.succeed(true)
 
+        let didRun = try! p2.futureResult.wait()
+        #expect(didRun)
         sem.signal()
     }
 
-    func testFlatMapWithEL() {
+    @Test
+    func testFlatMapWithEL() throws {
         let el = EmbeddedEventLoop()
 
-        XCTAssertEqual(
-            2,
-            try el.makeSucceededFuture(1).flatMapWithEventLoop { one, el2 in
-                XCTAssert(el === el2)
-                return el2.makeSucceededFuture(one + 1)
-            }.wait()
-        )
+        let result = try el.makeSucceededFuture(1).flatMapWithEventLoop { one, el2 in
+            #expect(el === el2)
+            return el2.makeSucceededFuture(one + 1)
+        }.wait()
+        #expect(2 == result)
     }
 
-    func testFlatMapErrorWithEL() {
+    @Test
+    func testFlatMapErrorWithEL() throws {
         let el = EmbeddedEventLoop()
         struct E: Error {}
 
-        XCTAssertEqual(
-            1,
-            try el.makeFailedFuture(E()).flatMapErrorWithEventLoop { error, el2 in
-                XCTAssert(error is E)
-                return el2.makeSucceededFuture(1)
-            }.wait()
-        )
+        let result = try el.makeFailedFuture(E()).flatMapErrorWithEventLoop { error, el2 in
+            #expect(error is E)
+            return el2.makeSucceededFuture(1)
+        }.wait()
+        #expect(1 == result)
     }
 
-    func testFoldWithEL() {
+    @Test
+    func testFoldWithEL() throws {
         let el = EmbeddedEventLoop()
 
         let futures = (1...10).map { el.makeSucceededFuture($0) }
@@ -1554,14 +1677,17 @@ class EventLoopFutureTest: XCTestCase {
         let calls = NIOLockedValueBox(0)
         let all = el.makeSucceededFuture(0).foldWithEventLoop(futures) { l, r, el2 in
             calls.withLockedValue { $0 += 1 }
-            XCTAssert(el === el2)
-            XCTAssertEqual(calls.withLockedValue { $0 }, r)
+            #expect(el === el2)
+            #expect(calls.withLockedValue { $0 } == r)
             return el2.makeSucceededFuture(l + r)
         }
 
-        XCTAssertEqual((1...10).reduce(0, +), try all.wait())
+        let expectedResult = (1...10).reduce(0, +)
+        let result = try all.wait()
+        #expect(expectedResult == result)
     }
 
+    @Test
     func testAssertSuccess() {
         let eventLoop = EmbeddedEventLoop()
 
@@ -1569,9 +1695,10 @@ class EventLoopFutureTest: XCTestCase {
         let assertedFuture = promise.futureResult.assertSuccess()
         promise.succeed("hello")
 
-        XCTAssertNoThrow(try assertedFuture.wait())
+        #expect(throws: Never.self) { try assertedFuture.wait() }
     }
 
+    @Test
     func testAssertFailure() {
         let eventLoop = EmbeddedEventLoop()
 
@@ -1579,11 +1706,12 @@ class EventLoopFutureTest: XCTestCase {
         let assertedFuture = promise.futureResult.assertFailure()
         promise.fail(EventLoopFutureTestError.example)
 
-        XCTAssertThrowsError(try assertedFuture.wait()) { error in
-            XCTAssertEqual(error as? EventLoopFutureTestError, EventLoopFutureTestError.example)
+        #expect(throws: EventLoopFutureTestError.example) {
+            try assertedFuture.wait()
         }
     }
 
+    @Test
     func testPreconditionSuccess() {
         let eventLoop = EmbeddedEventLoop()
 
@@ -1591,9 +1719,10 @@ class EventLoopFutureTest: XCTestCase {
         let preconditionedFuture = promise.futureResult.preconditionSuccess()
         promise.succeed("hello")
 
-        XCTAssertNoThrow(try preconditionedFuture.wait())
+        #expect(throws: Never.self) { try preconditionedFuture.wait() }
     }
 
+    @Test
     func testPreconditionFailure() {
         let eventLoop = EmbeddedEventLoop()
 
@@ -1601,22 +1730,24 @@ class EventLoopFutureTest: XCTestCase {
         let preconditionedFuture = promise.futureResult.preconditionFailure()
         promise.fail(EventLoopFutureTestError.example)
 
-        XCTAssertThrowsError(try preconditionedFuture.wait()) { error in
-            XCTAssertEqual(error as? EventLoopFutureTestError, EventLoopFutureTestError.example)
+        #expect(throws: EventLoopFutureTestError.example) {
+            try preconditionedFuture.wait()
         }
     }
 
+    @Test
     func testSetOrCascadeReplacesNil() throws {
         let eventLoop = EmbeddedEventLoop()
 
         var promise: EventLoopPromise<Void>? = nil
         let other = eventLoop.makePromise(of: Void.self)
         promise.setOrCascade(to: other)
-        XCTAssertNotNil(promise)
+        #expect(promise != nil)
         promise?.succeed()
         try other.futureResult.wait()
     }
 
+    @Test
     func testSetOrCascadeCascadesToExisting() throws {
         let eventLoop = EmbeddedEventLoop()
 
@@ -1627,29 +1758,32 @@ class EventLoopFutureTest: XCTestCase {
         try other.futureResult.wait()
     }
 
+    @Test
     func testSetOrCascadeNoOpOnNil() throws {
         let eventLoop = EmbeddedEventLoop()
 
         var promise: EventLoopPromise<Void>? = eventLoop.makePromise(of: Void.self)
         promise.setOrCascade(to: nil)
-        XCTAssertNotNil(promise)
+        #expect(promise != nil)
         promise?.succeed()
     }
 
+    @Test
     func testPromiseEquatable() {
         let eventLoop = EmbeddedEventLoop()
 
         let promise1 = eventLoop.makePromise(of: Void.self)
         let promise2 = eventLoop.makePromise(of: Void.self)
         let promise3 = promise1
-        XCTAssertEqual(promise1, promise3)
-        XCTAssertNotEqual(promise1, promise2)
-        XCTAssertNotEqual(promise3, promise2)
+        #expect(promise1 == promise3)
+        #expect(promise1 != promise2)
+        #expect(promise3 != promise2)
 
         promise1.succeed()
         promise2.succeed()
     }
 
+    @Test
     func testPromiseEquatable_WhenSucceeded() {
         let eventLoop = EmbeddedEventLoop()
 
@@ -1659,11 +1793,12 @@ class EventLoopFutureTest: XCTestCase {
 
         promise1.succeed()
         promise2.succeed()
-        XCTAssertEqual(promise1, promise3)
-        XCTAssertNotEqual(promise1, promise2)
-        XCTAssertNotEqual(promise3, promise2)
+        #expect(promise1 == promise3)
+        #expect(promise1 != promise2)
+        #expect(promise3 != promise2)
     }
 
+    @Test
     func testPromiseEquatable_WhenFailed() {
         struct E: Error {}
         let eventLoop = EmbeddedEventLoop()
@@ -1674,9 +1809,9 @@ class EventLoopFutureTest: XCTestCase {
 
         promise1.fail(E())
         promise2.fail(E())
-        XCTAssertEqual(promise1, promise3)
-        XCTAssertNotEqual(promise1, promise2)
-        XCTAssertNotEqual(promise3, promise2)
+        #expect(promise1 == promise3)
+        #expect(promise1 != promise2)
+        #expect(promise3 != promise2)
     }
 }
 


### PR DESCRIPTION
Port `EventLoopFutureTest` to Swift Testing. Includes some adjustments to ensure tests are ran from the event loop, among other minor changes

### Motivation:

Tests should use the latest Swift Testing framework when possible.

### Modifications:

- Ported `EventLoopFutureTest ` from XCTest to Swift Testing

### Result:

All tests continue to pass, EventLoopFutureTest now has more modern Swift Testing syntax.
