### PR TITLE
Move nightly-next CI to 6.3

### DIFF
--- a/scripts/check-matrix-job.sh
+++ b/scripts/check-matrix-job.sh
@@ -46,7 +46,7 @@ elif [[ "$swift_version" == "6.2" ]] && [[ -n "$command_6_2" ]]; then
   log "Running 6.2 command override"
   eval "$command_6_2"
 elif [[ "$swift_version" == "nightly-next" ]] && [[ -n "$command_nightly_next" ]]; then
-  log "Running nightly 6.1 command override"
+  log "Running nightly next command override"
   eval "$command_nightly_next"
 elif [[ "$swift_version" == "nightly-main" ]] && [[ -n "$command_nightly_main" ]]; then
   log "Running nightly main command override"

--- a/scripts/generate_matrix.sh
+++ b/scripts/generate_matrix.sh
@@ -69,7 +69,7 @@ linux_5_10_container_image="swift:5.10-jammy"
 linux_6_0_container_image="swift:6.0-jammy"
 linux_6_1_container_image="swift:6.1-jammy"
 linux_6_2_container_image="swift:6.2-noble"
-linux_nightly_next_container_image="swiftlang/swift:nightly-6.2-jammy"
+linux_nightly_next_container_image="swiftlang/swift:nightly-6.3-jammy"
 linux_nightly_main_container_image="swiftlang/swift:nightly-main-jammy"
 
 windows_6_0_runner="windows-2022"


### PR DESCRIPTION
This PR moves the nightly-next CI to use the 6.3 images. Since those checks should be non required on any user of this package and the name of the check doesn't change with moving images this should be a non-breaking change.