### PR TITLE
Add support for Xcode 26.2

### DIFF
--- a/.github/workflows/macos_benchmarks.yml
+++ b/.github/workflows/macos_benchmarks.yml
@@ -30,6 +30,10 @@ on:
         type: boolean
         description: "Boolean to enable the macOS Xcode 26.1 benchmark job. Defaults to false."
         default: false
+      macos_xcode_26_2_enabled:
+        type: boolean
+        description: "Boolean to enable the macOS Xcode 26.2 benchmark job. Defaults to false."
+        default: false
       macos_xcode_latest_beta_enabled:
         type: boolean
         description: "Boolean to enable the macOS Xcode latest beta benchmark job. Defaults to false."
@@ -59,6 +63,7 @@ jobs:
       inputs.macos_xcode_16_4_enabled ||
       inputs.macos_xcode_26_0_enabled ||
       inputs.macos_xcode_26_1_enabled ||
+      inputs.macos_xcode_26_2_enabled ||
       inputs.macos_xcode_latest_beta_enabled
     outputs:
       macos-matrix: '${{ steps.generate-matrix.outputs.macos-matrix }}'
@@ -82,6 +87,7 @@ jobs:
           xcode_16_4_enabled="${MACOS_XCODE_16_4_ENABLED}"
           xcode_26_0_enabled="${MACOS_XCODE_26_0_ENABLED}"
           xcode_26_1_enabled="${MACOS_XCODE_26_1_ENABLED}"
+          xcode_26_2_enabled="${MACOS_XCODE_26_2_ENABLED}"
           xcode_latest_beta_enabled="${MACOS_XCODE_LATEST_BETA_ENABLED}"
 
           # Create matrix from inputs
@@ -115,6 +121,13 @@ jobs:
               '.config[.config| length] |= . + { "name": "macOS (Xcode 26.1)", "xcode_version": "26.1", "xcode_app": "Xcode_26.1.app", "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
           fi
 
+          if [[ "$xcode_26_2_enabled" == "true" ]]; then
+              matrix=$(echo "$matrix" | jq -c \
+              --arg runner_pool "$runner_pool" \
+              --argjson env_vars "$macos_env_vars_json" \
+              '.config[.config| length] |= . + { "name": "macOS (Xcode 26.2)", "xcode_version": "26.2", "xcode_app": "Xcode_26.2.app", "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
+          fi
+
           if [[ "$xcode_latest_beta_enabled" == "true" ]]; then
               matrix=$(echo "$matrix" | jq -c \
               --arg runner_pool "$runner_pool" \
@@ -129,6 +142,7 @@ jobs:
           MACOS_XCODE_16_4_ENABLED: ${{ inputs.macos_xcode_16_4_enabled }}
           MACOS_XCODE_26_0_ENABLED: ${{ inputs.macos_xcode_26_0_enabled }}
           MACOS_XCODE_26_1_ENABLED: ${{ inputs.macos_xcode_26_1_enabled }}
+          MACOS_XCODE_26_2_ENABLED: ${{ inputs.macos_xcode_26_2_enabled }}
           MACOS_XCODE_LATEST_BETA_ENABLED: ${{ inputs.macos_xcode_latest_beta_enabled }}
 
   benchmarks-macos:

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -126,6 +126,22 @@ on:
         type: string
         description: "The command(s) to be executed before all other work."
         default: ""
+      xcode_26_2_enabled:
+        type: boolean
+        description: "Boolean to enable the Xcode version 26.2 jobs. Defaults to true."
+        default: true
+      xcode_26_2_build_arguments_override:
+        type: string
+        description: "The arguments passed to swift build in the Xcode version 26.2 job."
+        default: ""
+      xcode_26_2_test_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Xcode version 26.2 job."
+        default: ""
+      xcode_26_2_setup_command:
+        type: string
+        description: "The command(s) to be executed before all other work."
+        default: ""
       xcode_26_beta_enabled:
         type: boolean
         description: "⚠️ Deprecated."
@@ -274,6 +290,10 @@ jobs:
             xcode_26_1_build_arguments_override="${MATRIX_MACOS_26_1_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_26_1_test_arguments_override="${MATRIX_MACOS_26_1_TEST_ARGUMENTS_OVERRIDE:=""}"
             xcode_26_1_setup_command="${MATRIX_MACOS_26_1_SETUP_COMMAND:=""}"
+            xcode_26_2_enabled="${MATRIX_MACOS_26_2_ENABLED:=true}"
+            xcode_26_2_build_arguments_override="${MATRIX_MACOS_26_2_BUILD_ARGUMENTS_OVERRIDE:=""}"
+            xcode_26_2_test_arguments_override="${MATRIX_MACOS_26_2_TEST_ARGUMENTS_OVERRIDE:=""}"
+            xcode_26_2_setup_command="${MATRIX_MACOS_26_2_SETUP_COMMAND:=""}"
             xcode_latest_beta_enabled="${MATRIX_MACOS_26_BETA_1_ENABLED:=true}" # TODO: remove once no repos use this
             xcode_latest_beta_build_arguments_override="${MATRIX_MACOS_26_BETA_1_BUILD_ARGUMENTS_OVERRIDE:=""}" # TODO: remove once no repos use this
             xcode_latest_beta_test_arguments_override="${MATRIX_MACOS_26_BETA_1_TEST_ARGUMENTS_OVERRIDE:=""}" # TODO: remove once no repos use this
@@ -366,6 +386,16 @@ jobs:
                 '.config[.config| length] |= . + { "name": "Xcode 26.1", "xcode_version": "26.1", "xcode_app": "Xcode_26.1.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
             fi
 
+            if [[ "$xcode_26_2_enabled" == "true" ]]; then
+                matrix=$(echo "$matrix" | jq -c \
+                --arg setup_command "$xcode_26_2_setup_command"  \
+                --arg build_arguments_override "$xcode_26_2_build_arguments_override"  \
+                --arg test_arguments_override "$xcode_26_2_test_arguments_override"  \
+                --arg runner_pool "$runner_pool"  \
+                --argjson env_vars "$env_vars_json" \
+                '.config[.config| length] |= . + { "name": "Xcode 26.2", "xcode_version": "26.2", "xcode_app": "Xcode_26.2.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
+            fi
+
             if [[ "$xcode_latest_beta_enabled" == "true" ]]; then
                 matrix=$(echo "$matrix" | jq -c \
                 --arg setup_command "$xcode_latest_beta_setup_command"  \
@@ -413,6 +443,10 @@ jobs:
           MATRIX_MACOS_26_1_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_1_build_arguments_override }}
           MATRIX_MACOS_26_1_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_1_test_arguments_override }}
           MATRIX_MACOS_26_1_SETUP_COMMAND: ${{ inputs.xcode_26_1_setup_command }}
+          MATRIX_MACOS_26_2_ENABLED: ${{ inputs.xcode_26_1_enabled }}
+          MATRIX_MACOS_26_2_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_2_build_arguments_override }}
+          MATRIX_MACOS_26_2_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_2_test_arguments_override }}
+          MATRIX_MACOS_26_2_SETUP_COMMAND: ${{ inputs.xcode_26_2_setup_command }}
           MATRIX_MACOS_26_BETA_1_ENABLED: ${{ inputs.xcode_26_beta_1_enabled }}
           MATRIX_MACOS_26_BETA_1_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_beta_1_build_arguments_override }}
           MATRIX_MACOS_26_BETA_1_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_beta_1_test_arguments_override }}


### PR DESCRIPTION
Adds the required new inputs to the macOS tests and benchmark reusable workflows