### PR TITLE
benchmark diff missing new threshold files

### DIFF
--- a/scripts/check_benchmark_thresholds.sh
+++ b/scripts/check_benchmark_thresholds.sh
@@ -53,6 +53,7 @@ if [[ "$update_rc" != 0 ]]; then
 fi
 
 echo "=== BEGIN DIFF ==="  # use echo, not log for clean output to be scraped
+git add --intent-to-add .
 git diff HEAD
 exit 1
 


### PR DESCRIPTION
### Motivation

* When threshold files don't exist yet, `thresholds update` creates new untracked files. `git diff HEAD` only shows changes to tracked files, so newly created threshold files were silently omitted from the diff.

### Modifications

* Run `git add --intent-to-add .` before `git diff HEAD` so that untracked files are registered in the index and appear in the diff output without staging their contents.

### Result

* The diff output now includes newly created threshold files.
