### PR TITLE
Wait for the docker daemon on Windows

### DIFF
--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -182,6 +182,22 @@ jobs:
             swift_version: "6.0"
             enabled: ${{ inputs.matrix_windows_6_0_enabled }}
     steps:
+      - name: Wait for Docker daemon
+        if: ${{ matrix.swift.enabled }}
+        run: |
+          $maxAttempts = 30
+          $attempt = 0
+          do {
+            $attempt++
+            docker info 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($attempt -ge $maxAttempts) {
+              Write-Error "Docker daemon did not become ready after $maxAttempts attempts"
+              exit 1
+            }
+            Start-Sleep -Seconds 2
+          } while ($true)
+        shell: pwsh
       - name: Pull Docker image
         if: ${{ matrix.swift.enabled }}
         run: docker pull ${{ matrix.swift.image }}
@@ -213,6 +229,22 @@ jobs:
             swift_version: "nightly-main"
             enabled: ${{ inputs.matrix_windows_nightly_main_enabled }}
     steps:
+      - name: Wait for Docker daemon
+        if: ${{ matrix.swift.enabled }}
+        run: |
+          $maxAttempts = 30
+          $attempt = 0
+          do {
+            $attempt++
+            docker info 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($attempt -ge $maxAttempts) {
+              Write-Error "Docker daemon did not become ready after $maxAttempts attempts"
+              exit 1
+            }
+            Start-Sleep -Seconds 2
+          } while ($true)
+        shell: pwsh
       - name: Pull Docker image
         if: ${{ matrix.swift.enabled }}
         run: docker pull ${{ matrix.swift.image }}

--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -33,6 +33,22 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+      - name: Wait for Docker daemon (Windows)
+        if: ${{ matrix.config.platform == 'Windows' }}
+        run: |
+          $maxAttempts = 30
+          $attempt = 0
+          do {
+            $attempt++
+            docker info 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($attempt -ge $maxAttempts) {
+              Write-Error "Docker daemon did not become ready after $maxAttempts attempts"
+              exit 1
+            }
+            Start-Sleep -Seconds 2
+          } while ($true)
+        shell: pwsh
       - name: Pull Docker image
         run: docker pull ${{ matrix.config.image }}
       - name: Run matrix job


### PR DESCRIPTION
Sometimes the docker daemon on Windows runners isn't ready immediately. This adds a step to wait for it to become ready.