### PR TITLE
Add latest release to Android CI matrix

### DIFF
--- a/.github/workflows/android_swift_sdk.yml
+++ b/.github/workflows/android_swift_sdk.yml
@@ -42,6 +42,17 @@ jobs:
           android-sdk-matrix=$(echo '{
             "config":[
               {
+                "name":"latest-release Jammy",
+                "swift_version":"latest-release",
+                "platform":"Linux",
+                "runner":"ubuntu-latest",
+                "image":"ubuntu:jammy",
+                "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_sdk.sh | INSTALL_SWIFT_BRANCH=latest INSTALL_SWIFT_ARCH=x86_64 INSTALL_SWIFT_SDK=android-sdk bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_android_ndk.sh | bash && hash -r",
+                "command":"curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/swift-build-with-android-sdk.sh | bash -s --",
+                "command_arguments":"'"$INPUT_ADDITIONAL_COMMAND_ARGUMENTS"'",
+                "env":'"$env_vars_json"'
+              },
+              {
                 "name":"main Jammy",
                 "swift_version":"main",
                 "platform":"Linux",


### PR DESCRIPTION
Build swift-nio against latest Android release

### Motivation:

With the release of official Android support, we can now tests against the latest release (6.3) as well as main.

### Modifications:

Updates the `generate-matrix` step of the Android CI matrix to add the latest release tag. This mirrors how it is done with the static Linux SDK: https://github.com/apple/swift-nio/blob/98f8824da0bbf8cbca88b8fefb8a03b83651587c/.github/workflows/static_sdk.yml#L42-L67

### Result:

Android CI will run against both the latest release as well as `main`.