### PR TITLE
NFC: Move `fileIO` binding before use in `childChannelInitializer`

### DIFF
--- a/Sources/NIOHTTP1Server/main.swift
+++ b/Sources/NIOHTTP1Server/main.swift
@@ -630,13 +630,14 @@ default:
     bindTarget = BindTo.ip(host: defaultHost, port: defaultPort)
 }
 
+let fileIO = NonBlockingFileIO(threadPool: .singleton)
+
 func childChannelInitializer(channel: Channel) -> EventLoopFuture<Void> {
     channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMapThrowing {
         try channel.pipeline.syncOperations.addHandler(HTTPHandler(fileIO: fileIO, htdocsPath: htdocs))
     }
 }
 
-let fileIO = NonBlockingFileIO(threadPool: .singleton)
 let socketBootstrap = ServerBootstrap(group: MultiThreadedEventLoopGroup.singleton)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(.backlog, value: 256)


### PR DESCRIPTION
I'm hoping to ban use-before-declarations at the top level of a `main.swift` (swiftlang/swift#88082), fix-up this case.