### PR TITLE
Support custom Dockerfiles and Docker capabilities in matrix CI

### DIFF
--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -53,7 +53,21 @@ jobs:
           } while ($true)
         shell: pwsh
       - name: Pull Docker image
+        if: ${{ matrix.config.dockerfile == '' }}
         run: docker pull ${{ matrix.config.image }}
+      - name: Build Docker image from Dockerfile
+        if: ${{ matrix.config.platform != 'Windows' && matrix.config.dockerfile != '' }}
+        run: |
+          local_tag="local-ci-image:$(echo "$MATRIX_SWIFT_VERSION" | tr ':/' '-')"
+          docker build \
+            --build-arg SWIFT_IMAGE="$MATRIX_IMAGE" \
+            -f "$MATRIX_DOCKERFILE" \
+            -t "$local_tag" \
+            .
+        env:
+          MATRIX_SWIFT_VERSION: ${{ matrix.config.swift_version }}
+          MATRIX_IMAGE: ${{ matrix.config.image }}
+          MATRIX_DOCKERFILE: ${{ matrix.config.dockerfile }}
       - name: Run matrix job
         if: ${{ matrix.config.platform != 'Windows' }}
         run: |
@@ -63,6 +77,12 @@ jobs:
             setup_command_expression=""
           fi
           workspace="/$(basename "$GITHUB_WORKSPACE")"
+
+          # Use the locally built image if a Dockerfile was provided
+          image="$MATRIX_IMAGE"
+          if [[ -n "$MATRIX_DOCKERFILE" ]]; then
+            image="local-ci-image:$(echo "$MATRIX_SWIFT_VERSION" | tr ':/' '-')"
+          fi
 
           docker_args=(
             "run"
@@ -74,6 +94,13 @@ jobs:
             "-e" "workspace=$workspace"
           )
 
+          # Add Docker capabilities if specified
+          if [[ "$MATRIX_DOCKER_CAPABILITIES" != '[]' ]]; then
+            while IFS= read -r cap; do
+              docker_args+=("--cap-add=$cap")
+            done < <(echo "$MATRIX_DOCKER_CAPABILITIES" | jq -r '.[]')
+          fi
+
           if [[ "$MATRIX_ENV_JSON" != '{}' ]]; then
             while IFS="=" read -r key value; do
               if [[ -n "$key" && -n "$value" ]]; then
@@ -82,7 +109,7 @@ jobs:
             done < <(echo "$MATRIX_ENV_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"')
           fi
 
-          docker_args+=("$MATRIX_IMAGE")
+          docker_args+=("$image")
           docker_args+=("bash" "-c" "$setup_command_expression $MATRIX_COMMAND $MATRIX_COMMAND_ARGUMENTS")
 
           echo "Executing Docker command: docker ${docker_args[*]}"
@@ -94,6 +121,8 @@ jobs:
           MATRIX_COMMAND: ${{ matrix.config.command }}
           MATRIX_COMMAND_ARGUMENTS: ${{ matrix.config.command_arguments }}
           MATRIX_ENV_JSON: ${{ toJson(matrix.config.env) }}
+          MATRIX_DOCKERFILE: ${{ matrix.config.dockerfile }}
+          MATRIX_DOCKER_CAPABILITIES: ${{ toJson(matrix.config.docker_capabilities) }}
           GITHUB_WORKSPACE: ${{ github.workspace }}
       - name: Run matrix job (Windows)
         if: ${{ matrix.config.platform == 'Windows' }}

--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -56,14 +56,16 @@ jobs:
         if: ${{ matrix.config.dockerfile == '' }}
         run: docker pull ${{ matrix.config.image }}
       - name: Build Docker image from Dockerfile
+        id: docker-build
         if: ${{ matrix.config.platform != 'Windows' && matrix.config.dockerfile != '' }}
         run: |
           local_tag="local-ci-image:$(echo "$MATRIX_SWIFT_VERSION" | tr ':/' '-')"
-          docker build \
+          docker buildx build \
             --build-arg SWIFT_IMAGE="$MATRIX_IMAGE" \
             -f "$MATRIX_DOCKERFILE" \
             -t "$local_tag" \
             .
+          echo "image=$local_tag" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_SWIFT_VERSION: ${{ matrix.config.swift_version }}
           MATRIX_IMAGE: ${{ matrix.config.image }}
@@ -77,12 +79,6 @@ jobs:
             setup_command_expression=""
           fi
           workspace="/$(basename "$GITHUB_WORKSPACE")"
-
-          # Use the locally built image if a Dockerfile was provided
-          image="$MATRIX_IMAGE"
-          if [[ -n "$MATRIX_DOCKERFILE" ]]; then
-            image="local-ci-image:$(echo "$MATRIX_SWIFT_VERSION" | tr ':/' '-')"
-          fi
 
           docker_args=(
             "run"
@@ -109,7 +105,7 @@ jobs:
             done < <(echo "$MATRIX_ENV_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"')
           fi
 
-          docker_args+=("$image")
+          docker_args+=("$MATRIX_IMAGE")
           docker_args+=("bash" "-c" "$setup_command_expression $MATRIX_COMMAND $MATRIX_COMMAND_ARGUMENTS")
 
           echo "Executing Docker command: docker ${docker_args[*]}"
@@ -117,11 +113,10 @@ jobs:
         env:
           MATRIX_SETUP_COMMAND: ${{ matrix.config.setup_command }}
           MATRIX_SWIFT_VERSION: ${{ matrix.config.swift_version }}
-          MATRIX_IMAGE: ${{ matrix.config.image }}
+          MATRIX_IMAGE: ${{ steps.docker-build.outputs.image || matrix.config.image }}
           MATRIX_COMMAND: ${{ matrix.config.command }}
           MATRIX_COMMAND_ARGUMENTS: ${{ matrix.config.command_arguments }}
           MATRIX_ENV_JSON: ${{ toJson(matrix.config.env) }}
-          MATRIX_DOCKERFILE: ${{ matrix.config.dockerfile }}
           MATRIX_DOCKER_CAPABILITIES: ${{ toJson(matrix.config.docker_capabilities) }}
           GITHUB_WORKSPACE: ${{ github.workspace }}
       - name: Run matrix job (Windows)

--- a/scripts/generate_matrix.sh
+++ b/scripts/generate_matrix.sh
@@ -30,6 +30,8 @@ find_subdirectory_manifests_enabled="${FIND_SUBDIRECTORY_MANIFESTS_ENABLED:=fals
 
 linux_command="${MATRIX_LINUX_COMMAND:-}"  # required if any Linux pipeline is enabled
 linux_setup_command="${MATRIX_LINUX_SETUP_COMMAND:-}"
+linux_dockerfile="${MATRIX_LINUX_DOCKERFILE:-}"
+linux_docker_capabilities_json="${MATRIX_LINUX_DOCKER_CAPABILITIES_JSON:-"[]"}"
 linux_5_9_enabled="${MATRIX_LINUX_5_9_ENABLED:=false}"
 linux_5_9_command_arguments="${MATRIX_LINUX_5_9_COMMAND_ARGUMENTS:-}"
 linux_5_10_enabled="${MATRIX_LINUX_5_10_ENABLED:=false}"
@@ -253,6 +255,8 @@ should_include_version() {
 #   $7: container_image
 #   $8: runner
 #   $9: env_vars_json
+#   ${10}: dockerfile (optional, path relative to repo root)
+#   ${11}: docker_capabilities_json (optional, JSON array e.g. '["CAP_BPF"]')
 add_matrix_entry() {
     local platform="$1"
     local version="$2"
@@ -263,6 +267,8 @@ add_matrix_entry() {
     local container_image="$7"
     local runner="$8"
     local env_vars_json="$9"
+    local dockerfile="${10:-}"
+    local docker_capabilities_json="${11:-"[]"}"
 
     if [[ "$enabled" == "true" ]] && should_include_version "$version"; then
         # shellcheck disable=SC2016  # Our use of JQ_BIN means that shellcheck can't tell this is a `jq` invocation
@@ -275,7 +281,9 @@ add_matrix_entry() {
             --arg platform "$platform" \
             --arg version "$version" \
             --argjson env_vars "$env_vars_json" \
-            '.config[.config| length] |= . + { "name": $version, "image": $container_image, "swift_version": $version, "platform": $platform, "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner, "env": $env_vars}')
+            --arg dockerfile "$dockerfile" \
+            --argjson docker_capabilities "$docker_capabilities_json" \
+            '.config[.config| length] |= . + { "name": $version, "image": $container_image, "swift_version": $version, "platform": $platform, "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner, "env": $env_vars, "dockerfile": $dockerfile, "docker_capabilities": $docker_capabilities}')
     fi
 }
 
@@ -306,15 +314,15 @@ if [[ \
   fi
 fi
 
-#                 Platform   Version         Enabled                        Setup                   Command          Arguments                               Image                                 Runner           Env
-add_matrix_entry "Linux"    "5.9"           "$linux_5_9_enabled"           "$linux_setup_command"  "$linux_command" "$linux_5_9_command_arguments"          "$linux_5_9_container_image"          "$linux_runner"  "$linux_env_vars_json"
-add_matrix_entry "Linux"    "5.10"          "$linux_5_10_enabled"          "$linux_setup_command"  "$linux_command" "$linux_5_10_command_arguments"         "$linux_5_10_container_image"         "$linux_runner"  "$linux_env_vars_json"
-add_matrix_entry "Linux"    "6.0"           "$linux_6_0_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_0_command_arguments"          "$linux_6_0_container_image"          "$linux_runner"  "$linux_env_vars_json"
-add_matrix_entry "Linux"    "6.1"           "$linux_6_1_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_1_command_arguments"          "$linux_6_1_container_image"          "$linux_runner"  "$linux_env_vars_json"
-add_matrix_entry "Linux"    "6.2"           "$linux_6_2_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_2_command_arguments"          "$linux_6_2_container_image"          "$linux_runner"  "$linux_env_vars_json"
-add_matrix_entry "Linux"    "6.3"           "$linux_6_3_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_3_command_arguments"          "$linux_6_3_container_image"          "$linux_runner"  "$linux_env_vars_json"
-add_matrix_entry "Linux"    "nightly-next"  "$linux_nightly_next_enabled"  "$linux_setup_command"  "$linux_command" "$linux_nightly_next_command_arguments" "$linux_nightly_next_container_image" "$linux_runner"  "$linux_env_vars_json"
-add_matrix_entry "Linux"    "nightly-main"  "$linux_nightly_main_enabled"  "$linux_setup_command"  "$linux_command" "$linux_nightly_main_command_arguments" "$linux_nightly_main_container_image" "$linux_runner"  "$linux_env_vars_json"
+#                 Platform   Version         Enabled                        Setup                   Command          Arguments                               Image                                 Runner           Env                     Dockerfile            Capabilities
+add_matrix_entry "Linux"    "5.9"           "$linux_5_9_enabled"           "$linux_setup_command"  "$linux_command" "$linux_5_9_command_arguments"          "$linux_5_9_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
+add_matrix_entry "Linux"    "5.10"          "$linux_5_10_enabled"          "$linux_setup_command"  "$linux_command" "$linux_5_10_command_arguments"         "$linux_5_10_container_image"         "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
+add_matrix_entry "Linux"    "6.0"           "$linux_6_0_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_0_command_arguments"          "$linux_6_0_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
+add_matrix_entry "Linux"    "6.1"           "$linux_6_1_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_1_command_arguments"          "$linux_6_1_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
+add_matrix_entry "Linux"    "6.2"           "$linux_6_2_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_2_command_arguments"          "$linux_6_2_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
+add_matrix_entry "Linux"    "6.3"           "$linux_6_3_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_3_command_arguments"          "$linux_6_3_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
+add_matrix_entry "Linux"    "nightly-next"  "$linux_nightly_next_enabled"  "$linux_setup_command"  "$linux_command" "$linux_nightly_next_command_arguments" "$linux_nightly_next_container_image" "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
+add_matrix_entry "Linux"    "nightly-main"  "$linux_nightly_main_enabled"  "$linux_setup_command"  "$linux_command" "$linux_nightly_main_command_arguments" "$linux_nightly_main_container_image" "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
 
 ## Windows
 if [[ \


### PR DESCRIPTION
### Motivation

* Some consumers need to run CI inside custom Docker images with additional Linux capabilities. The shared matrix workflows had no way to express this — consumers had to maintain entirely bespoke CI workflows instead.

### Modifications

* Added `MATRIX_LINUX_DOCKERFILE` and `MATRIX_LINUX_DOCKER_CAPABILITIES_JSON` environment variables to `generate_matrix.sh`. These propagate as `dockerfile` (string) and `docker_capabilities` (JSON array) fields in the matrix JSON. Defaults are empty/`[]` so existing callers are unaffected.
* Extended `add_matrix_entry()` with two optional trailing parameters for the new fields.
* In `swift_test_matrix.yml`:
  - Made the "Pull Docker image" step conditional — skipped when a `dockerfile` is provided.
  - Added a "Build Docker image from Dockerfile" step that builds the image with `--build-arg SWIFT_IMAGE=<matrix image>` so consumers can parameterise the Swift base image.
  - Added `--cap-add` flags to `docker run` when `docker_capabilities` is non-empty.

### Result

* Consumers can set `MATRIX_LINUX_DOCKERFILE` to a repo-relative path and `MATRIX_LINUX_DOCKER_CAPABILITIES_JSON` to a JSON array of capabilities. The matrix will build their Dockerfile per Swift version and run containers with the requested capabilities.
* Existing consumers that don't set these variables see no change.
