### PR TITLE
Add multi-version matrix support to Wasm Swift SDK workflow

### DIFF
--- a/.github/workflows/wasm_swift_sdk.yml
+++ b/.github/workflows/wasm_swift_sdk.yml
@@ -10,9 +10,9 @@ on:
         type: boolean
         description: "Boolean to enable the nightly-main WASM Swift SDK matrix job. Defaults to true."
         default: true
-      nightly_6_3_enabled:
+      nightly_next_enabled:
         type: boolean
-        description: "Boolean to enable the nightly-6.3 WASM Swift SDK matrix job. Defaults to true."
+        description: "Boolean to enable the nightly-next WASM Swift SDK matrix job. Defaults to true."
         default: true
       release_6_3_enabled:
         type: boolean
@@ -76,7 +76,7 @@ jobs:
             entries="${entries:+${entries},}${entry}"
           fi
 
-          if [[ "$INPUT_NIGHTLY_6_3_ENABLED" == "true" ]]; then
+          if [[ "$INPUT_NIGHTLY_NEXT_ENABLED" == "true" ]]; then
             entry=$(make_entry "nightly-6.3" "INSTALL_SWIFT_BRANCH=swift-6.3-branch")
             entries="${entries:+${entries},}${entry}"
           fi
@@ -94,7 +94,7 @@ jobs:
           echo "wasm-swift-sdk-matrix=$(echo "{\"config\":[${entries}]}" | jq -c)" >> "$GITHUB_OUTPUT"
         env:
           INPUT_NIGHTLY_MAIN_ENABLED: ${{ inputs.nightly_main_enabled }}
-          INPUT_NIGHTLY_6_3_ENABLED: ${{ inputs.nightly_6_3_enabled }}
+          INPUT_NIGHTLY_NEXT_ENABLED: ${{ inputs.nightly_next_enabled }}
           INPUT_RELEASE_6_3_ENABLED: ${{ inputs.release_6_3_enabled }}
           INPUT_ENV_VARS: ${{ inputs.env_vars }}
           INPUT_ADDITIONAL_COMMAND_ARGUMENTS: ${{ inputs.additional_command_arguments }}

--- a/.github/workflows/wasm_swift_sdk.yml
+++ b/.github/workflows/wasm_swift_sdk.yml
@@ -77,7 +77,7 @@ jobs:
           fi
 
           if [[ "$INPUT_NIGHTLY_NEXT_ENABLED" == "true" ]]; then
-            entry=$(make_entry "nightly-6.3" "INSTALL_SWIFT_BRANCH=swift-6.3-branch")
+            entry=$(make_entry "$NIGHTLY_NEXT_VERSION" "INSTALL_SWIFT_BRANCH=$NIGHTLY_NEXT_BRANCH")
             entries="${entries:+${entries},}${entry}"
           fi
 
@@ -98,6 +98,8 @@ jobs:
           INPUT_RELEASE_6_3_ENABLED: ${{ inputs.release_6_3_enabled }}
           INPUT_ENV_VARS: ${{ inputs.env_vars }}
           INPUT_ADDITIONAL_COMMAND_ARGUMENTS: ${{ inputs.additional_command_arguments }}
+          NIGHTLY_NEXT_VERSION: nightly-6.3
+          NIGHTLY_NEXT_BRANCH: swift-6.3-branch
 
   wasm-swift-sdk:
     name: WebAssembly Swift SDK

--- a/.github/workflows/wasm_swift_sdk.yml
+++ b/.github/workflows/wasm_swift_sdk.yml
@@ -6,10 +6,18 @@ permissions:
 on:
   workflow_call:
     inputs:
-      swift_versions:
-        type: string
-        description: "Swift version list (JSON). Use 'nightly-main', 'nightly-X.Y' for branch snapshots, or 'X.Y' for releases."
-        default: '["nightly-main", "nightly-6.3", "6.3"]'
+      nightly_main_enabled:
+        type: boolean
+        description: "Boolean to enable the nightly-main WASM Swift SDK matrix job. Defaults to true."
+        default: true
+      nightly_6_3_enabled:
+        type: boolean
+        description: "Boolean to enable the nightly-6.3 WASM Swift SDK matrix job. Defaults to true."
+        default: true
+      release_6_3_enabled:
+        type: boolean
+        description: "Boolean to enable the 6.3 release WASM Swift SDK matrix job. Defaults to true."
+        default: true
       env_vars:
         type: string
         description: "Environment variables for jobs as JSON (e.g., '{\"DEBUG\":\"1\",\"LOG_LEVEL\":\"info\"}')."
@@ -37,36 +45,14 @@ jobs:
             echo "Error: env_vars is not valid JSON"
             exit 1
           fi
-          if ! echo "$INPUT_SWIFT_VERSIONS" | jq empty 2>/dev/null; then
-            echo "Error: swift_versions is not valid JSON"
-            exit 1
-          fi
-          if ! echo "$INPUT_SWIFT_VERSIONS" | jq -e 'type == "array" and (length > 0) and all(type == "string")' > /dev/null 2>&1; then
-            echo "Error: swift_versions must be a non-empty JSON array of strings"
-            exit 1
-          fi
-          invalid=$(echo "$INPUT_SWIFT_VERSIONS" | jq -r '.[] | select(test("^(nightly-[a-zA-Z0-9._-]+|[0-9]+\\.[0-9]+(\\.[0-9]+)?)$") | not)')
-          if [[ -n "$invalid" ]]; then
-            echo "Error: invalid swift_versions entries (expected 'nightly-X', 'nightly-X.Y', or 'X.Y'): $invalid"
-            exit 1
-          fi
 
           env_vars_json="$INPUT_ENV_VARS"
           entries=""
 
-          while IFS= read -r swift_version; do
-            if [[ "$swift_version" == nightly-* ]]; then
-              branch_suffix="${swift_version#nightly-}"
-              if [[ "$branch_suffix" == "main" ]]; then
-                install_env="INSTALL_SWIFT_BRANCH=main"
-              else
-                install_env="INSTALL_SWIFT_BRANCH=swift-${branch_suffix}-branch"
-              fi
-            else
-              install_env="INSTALL_SWIFT_VERSION=${swift_version}"
-            fi
-
-            entry=$(jq -n \
+          make_entry() {
+            local swift_version="$1"
+            local install_env="$2"
+            jq -n \
               --arg name "${swift_version} Jammy" \
               --arg swift_version "$swift_version" \
               --arg install_env "$install_env" \
@@ -82,18 +68,34 @@ jobs:
                 "command": "curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/swift-build-with-wasm-sdk.sh | bash -s --",
                 "command_arguments": $command_arguments,
                 "env": $env
-              }')
+              }'
+          }
 
-            if [[ -n "$entries" ]]; then
-              entries="${entries},${entry}"
-            else
-              entries="$entry"
-            fi
-          done < <(echo "$INPUT_SWIFT_VERSIONS" | jq -r '.[]')
+          if [[ "$INPUT_NIGHTLY_MAIN_ENABLED" == "true" ]]; then
+            entry=$(make_entry "nightly-main" "INSTALL_SWIFT_BRANCH=main")
+            entries="${entries:+${entries},}${entry}"
+          fi
+
+          if [[ "$INPUT_NIGHTLY_6_3_ENABLED" == "true" ]]; then
+            entry=$(make_entry "nightly-6.3" "INSTALL_SWIFT_BRANCH=swift-6.3-branch")
+            entries="${entries:+${entries},}${entry}"
+          fi
+
+          if [[ "$INPUT_RELEASE_6_3_ENABLED" == "true" ]]; then
+            entry=$(make_entry "6.3" "INSTALL_SWIFT_VERSION=6.3")
+            entries="${entries:+${entries},}${entry}"
+          fi
+
+          if [[ -z "$entries" ]]; then
+            echo "Error: No WASM Swift SDK matrix jobs enabled"
+            exit 1
+          fi
 
           echo "wasm-swift-sdk-matrix=$(echo "{\"config\":[${entries}]}" | jq -c)" >> "$GITHUB_OUTPUT"
         env:
-          INPUT_SWIFT_VERSIONS: ${{ inputs.swift_versions }}
+          INPUT_NIGHTLY_MAIN_ENABLED: ${{ inputs.nightly_main_enabled }}
+          INPUT_NIGHTLY_6_3_ENABLED: ${{ inputs.nightly_6_3_enabled }}
+          INPUT_RELEASE_6_3_ENABLED: ${{ inputs.release_6_3_enabled }}
           INPUT_ENV_VARS: ${{ inputs.env_vars }}
           INPUT_ADDITIONAL_COMMAND_ARGUMENTS: ${{ inputs.additional_command_arguments }}
 

--- a/.github/workflows/wasm_swift_sdk.yml
+++ b/.github/workflows/wasm_swift_sdk.yml
@@ -6,6 +6,10 @@ permissions:
 on:
   workflow_call:
     inputs:
+      swift_versions:
+        type: string
+        description: "Swift version list (JSON). Use 'nightly-main', 'nightly-X.Y' for branch snapshots, or 'X.Y' for releases."
+        default: '["nightly-main", "nightly-6.3", "6.3"]'
       env_vars:
         type: string
         description: "Environment variables for jobs as JSON (e.g., '{\"DEBUG\":\"1\",\"LOG_LEVEL\":\"info\"}')."
@@ -28,34 +32,68 @@ jobs:
           persist-credentials: false
       - id: generate-matrix
         run: |
-          # Validate and use JSON environment variables directly
-          env_vars_json="$INPUT_ENV_VARS"
-
-          # Validate JSON format
-          if ! echo "$env_vars_json" | jq empty 2>/dev/null; then
+          # Validate JSON inputs
+          if ! echo "$INPUT_ENV_VARS" | jq empty 2>/dev/null; then
             echo "Error: env_vars is not valid JSON"
             exit 1
           fi
+          if ! echo "$INPUT_SWIFT_VERSIONS" | jq empty 2>/dev/null; then
+            echo "Error: swift_versions is not valid JSON"
+            exit 1
+          fi
+          if ! echo "$INPUT_SWIFT_VERSIONS" | jq -e 'type == "array" and (length > 0) and all(type == "string")' > /dev/null 2>&1; then
+            echo "Error: swift_versions must be a non-empty JSON array of strings"
+            exit 1
+          fi
+          invalid=$(echo "$INPUT_SWIFT_VERSIONS" | jq -r '.[] | select(test("^(nightly-[a-zA-Z0-9._-]+|[0-9]+\\.[0-9]+(\\.[0-9]+)?)$") | not)')
+          if [[ -n "$invalid" ]]; then
+            echo "Error: invalid swift_versions entries (expected 'nightly-X', 'nightly-X.Y', or 'X.Y'): $invalid"
+            exit 1
+          fi
 
-          # Generate matrix with parsed environment variables
-          cat >> "$GITHUB_OUTPUT" << EOM
-          wasm-swift-sdk-matrix=$(echo '{
-            "config":[
-              {
-                "name":"main Jammy",
-                "swift_version":"main",
-                "platform":"Linux",
-                "runner":"ubuntu-latest",
-                "image":"ubuntu:jammy",
-                "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_sdk.sh | INSTALL_SWIFT_BRANCH=main INSTALL_SWIFT_ARCH=x86_64 INSTALL_SWIFT_SDK=wasm-sdk bash && hash -r",
-                "command":"curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/swift-build-with-wasm-sdk.sh | bash -s --",
-                "command_arguments":"'"$INPUT_ADDITIONAL_COMMAND_ARGUMENTS"'",
-                "env":'"$env_vars_json"'
-              }
-            ]
-          }' | jq -c)
-          EOM
+          env_vars_json="$INPUT_ENV_VARS"
+          entries=""
+
+          while IFS= read -r swift_version; do
+            if [[ "$swift_version" == nightly-* ]]; then
+              branch_suffix="${swift_version#nightly-}"
+              if [[ "$branch_suffix" == "main" ]]; then
+                install_env="INSTALL_SWIFT_BRANCH=main"
+              else
+                install_env="INSTALL_SWIFT_BRANCH=swift-${branch_suffix}-branch"
+              fi
+            else
+              install_env="INSTALL_SWIFT_VERSION=${swift_version}"
+            fi
+
+            entry=$(jq -n \
+              --arg name "${swift_version} Jammy" \
+              --arg swift_version "$swift_version" \
+              --arg install_env "$install_env" \
+              --arg command_arguments "$INPUT_ADDITIONAL_COMMAND_ARGUMENTS" \
+              --argjson env "$env_vars_json" \
+              '{
+                "name": $name,
+                "swift_version": $swift_version,
+                "platform": "Linux",
+                "runner": "ubuntu-latest",
+                "image": "ubuntu:jammy",
+                "setup_command": ("apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_sdk.sh | " + $install_env + " INSTALL_SWIFT_ARCH=x86_64 INSTALL_SWIFT_SDK=wasm-sdk bash && hash -r"),
+                "command": "curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/swift-build-with-wasm-sdk.sh | bash -s --",
+                "command_arguments": $command_arguments,
+                "env": $env
+              }')
+
+            if [[ -n "$entries" ]]; then
+              entries="${entries},${entry}"
+            else
+              entries="$entry"
+            fi
+          done < <(echo "$INPUT_SWIFT_VERSIONS" | jq -r '.[]')
+
+          echo "wasm-swift-sdk-matrix=$(echo "{\"config\":[${entries}]}" | jq -c)" >> "$GITHUB_OUTPUT"
         env:
+          INPUT_SWIFT_VERSIONS: ${{ inputs.swift_versions }}
           INPUT_ENV_VARS: ${{ inputs.env_vars }}
           INPUT_ADDITIONAL_COMMAND_ARGUMENTS: ${{ inputs.additional_command_arguments }}
 

--- a/scripts/install_swift_sdk.sh
+++ b/scripts/install_swift_sdk.sh
@@ -111,12 +111,24 @@ if [[ -n "$branch" ]]; then
   # Some snapshots may not have all the artefacts we require
   log "Discovering branch snapshot for branch $branch"
 
-  # shellcheck disable=SC2016  # Our use of JQ_BIN means that shellcheck can't tell this is a `jq` invocation
-  snapshots="$("$CURL_BIN" -s "https://www.swift.org/api/v1/install/dev/main/${os_image_sanitized}.json" | "$JQ_BIN" -r --arg arch "$arch" '.[$arch] | unique | reverse | .[].dir')"
+  # Map branch name to download path: "main" uses "development", release branches use their branch name
+  if [[ "$branch" == "main" ]]; then
+    download_path="development"
+  else
+    download_path="$branch"
+  fi
 
+  # shellcheck disable=SC2016  # Our use of JQ_BIN means that shellcheck can't tell this is a `jq` invocation
+  snapshots="$("$CURL_BIN" -s "https://www.swift.org/api/v1/install/dev/${branch}/${os_image_sanitized}.json" | "$JQ_BIN" -r --arg arch "$arch" '.[$arch] | unique | reverse | .[].dir')"
+
+  if [[ -z "$snapshots" ]]; then
+    fatal "No snapshots found for branch '$branch' on ${os_image_sanitized}/${arch}. Check the branch name and that swift.org is reachable."
+  fi
+
+  snapshot=""
   for snapshot in $snapshots; do
-    snapshot_url="https://download.swift.org/development/${os_image_sanitized}${arch_suffix}/${snapshot}/${snapshot}-${os_image}${arch_suffix}.tar.gz"
-    sdk_url="https://download.swift.org/development/${sdk_dir}/${snapshot}/${snapshot}${sdk_suffix}.artifactbundle.tar.gz"
+    snapshot_url="https://download.swift.org/${download_path}/${os_image_sanitized}${arch_suffix}/${snapshot}/${snapshot}-${os_image}${arch_suffix}.tar.gz"
+    sdk_url="https://download.swift.org/${download_path}/${sdk_dir}/${snapshot}/${snapshot}${sdk_suffix}.artifactbundle.tar.gz"
 
     # check that the files exist
     "$CURL_BIN" -sILXGET --fail "$snapshot_url" > /dev/null; snapshot_return_code=$?


### PR DESCRIPTION
Add multi-version matrix support to Wasm Swift SDK workflow

### Motivation:

The WASM CI only ran against nightly-main, making it impossible to distinguish toolchain regressions from code issues. Other repos in the ecosystem using `swiftlang/github-workflows` already test against `nightly-main`, `nightly-6.3`, and `6.3` by default.

### Modifications:

- Add `nightly_main_enabled`, `nightly_6_3_enabled`, and `release_6_3_enabled` boolean inputs to `wasm_swift_sdk.yml` (all defaulting to `true`, matching the coverage of `swiftlang/github-workflows/swift_package_test.yml`) and update the matrix generation to emit the appropriate entry per enabled version.
- Update `install_swift_sdk.sh` to support non-main branch snapshots by deriving the API and download paths from `INSTALL_SWIFT_BRANCH` rather than hardcoding `main`/`development`.
- Fail early with a clear message if the branch snapshot API returns no results, rather than hitting an unbound variable error.

### Result:

WASM builds are now tested against multiple Swift versions, providing a stable baseline to identify nightly-only regressions. Callers using the workflow without arguments get the new default coverage automatically; those who want to narrow the matrix can set specific version inputs to `false`.