### PR TITLE
Translate `HTTPHeaderValidationTests` to Swift testing

### DIFF
--- a/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
@@ -12,14 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Dispatch
 import NIOCore
 import NIOEmbedded
 import NIOHTTP1
-import XCTest
+import Testing
 
-final class HTTPHeaderValidationTests: XCTestCase {
-    func testEncodingInvalidHeaderFieldNamesInRequests() throws {
+@Suite struct HTTPHeaderValidationTests {
+    @Test func encodingInvalidHeaderFieldNamesInRequests() throws {
         // The spec in [RFC 9110](https://httpwg.org/specs/rfc9110.html#fields.values) defines the valid
         // characters as the following:
         //
@@ -32,7 +31,8 @@ final class HTTPHeaderValidationTests: XCTestCase {
         //                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
         //                / DIGIT / ALPHA
         //                ; any VCHAR, except delimiters
-        let weirdAllowedFieldName = "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        let weirdAllowedFieldName =
+            "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
         let channel = EmbeddedChannel()
         try channel.pipeline.syncOperations.addHTTPClientHandlers()
@@ -43,13 +43,9 @@ final class HTTPHeaderValidationTests: XCTestCase {
             string: "GET / HTTP/1.1\r\nHost: example.com\r\n\(weirdAllowedFieldName): present\r\n\r\n"
         )
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)))
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.end(nil)))
-
-        var maybeReceivedBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeReceivedBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeReceivedBytes, goodRequestBytes)
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)) }
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.end(nil)) }
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodRequestBytes)
 
         // Now confirm all other bytes are rejected.
         for byte in UInt8(0)...UInt8(255) {
@@ -65,17 +61,15 @@ final class HTTPHeaderValidationTests: XCTestCase {
             let headers = HTTPHeaders([("Host", "example.com"), (forbiddenFieldName, "present")])
             let badRequest = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/", headers: headers)
 
-            XCTAssertThrowsError(
-                try channel.writeOutbound(HTTPClientRequestPart.head(badRequest)),
-                "Incorrectly tolerated character in header field name: \(String(decoding: [byte], as: UTF8.self))"
-            ) { error in
-                XCTAssertEqual(error as? HTTPParserError, .invalidHeaderToken)
+            let error = #expect(throws: HTTPParserError.self) {
+                try channel.writeOutbound(HTTPClientRequestPart.head(badRequest))
             }
+            #expect(error == .invalidHeaderToken)
             _ = try? channel.finish()
         }
     }
 
-    func testEncodingInvalidTrailerFieldNamesInRequests() throws {
+    @Test func encodingInvalidTrailerFieldNamesInRequests() throws {
         // The spec in [RFC 9110](https://httpwg.org/specs/rfc9110.html#fields.values) defines the valid
         // characters as the following:
         //
@@ -88,7 +82,8 @@ final class HTTPHeaderValidationTests: XCTestCase {
         //                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
         //                / DIGIT / ALPHA
         //                ; any VCHAR, except delimiters
-        let weirdAllowedFieldName = "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        let weirdAllowedFieldName =
+            "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
         let channel = EmbeddedChannel()
         try channel.pipeline.syncOperations.addHTTPClientHandlers()
@@ -100,16 +95,11 @@ final class HTTPHeaderValidationTests: XCTestCase {
         )
         let goodTrailers = ByteBuffer(string: "0\r\n\(weirdAllowedFieldName): present\r\n\r\n")
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)))
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.end([weirdAllowedFieldName: "present"])))
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)) }
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.end([weirdAllowedFieldName: "present"])) }
 
-        var maybeRequestHeadBytes: ByteBuffer?
-        var maybeRequestEndBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeRequestHeadBytes = try channel.readOutbound())
-        XCTAssertNoThrow(maybeRequestEndBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeRequestHeadBytes, goodRequestBytes)
-        XCTAssertEqual(maybeRequestEndBytes, goodTrailers)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodRequestBytes)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodTrailers)
 
         // Now confirm all other bytes are rejected.
         for byte in UInt8(0)...UInt8(255) {
@@ -122,19 +112,17 @@ final class HTTPHeaderValidationTests: XCTestCase {
             let channel = EmbeddedChannel()
             try channel.pipeline.syncOperations.addHTTPClientHandlers()
 
-            XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)))
+            #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)) }
 
-            XCTAssertThrowsError(
-                try channel.writeOutbound(HTTPClientRequestPart.end([forbiddenFieldName: "present"])),
-                "Incorrectly tolerated character in trailer field name: \(String(decoding: [byte], as: UTF8.self))"
-            ) { error in
-                XCTAssertEqual(error as? HTTPParserError, .invalidHeaderToken)
+            let error = #expect(throws: HTTPParserError.self) {
+                try channel.writeOutbound(HTTPClientRequestPart.end([forbiddenFieldName: "present"]))
             }
+            #expect(error == .invalidHeaderToken)
             _ = try? channel.finish()
         }
     }
 
-    func testEncodingInvalidHeaderFieldValuesInRequests() throws {
+    @Test func encodingInvalidHeaderFieldValuesInRequests() throws {
         // We reject all ASCII control characters except HTAB and tolerate everything else.
         let weirdAllowedFieldValue =
             "!\" \t#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
@@ -148,12 +136,8 @@ final class HTTPHeaderValidationTests: XCTestCase {
             string: "GET / HTTP/1.1\r\nHost: example.com\r\nWeird-Value: \(weirdAllowedFieldValue)\r\n\r\n"
         )
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)))
-
-        var maybeBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeBytes, goodRequestBytes)
+        try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest))
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodRequestBytes)
 
         // Now confirm all other bytes in the ASCII range are rejected.
         for byte in UInt8(0)..<UInt8(128) {
@@ -169,12 +153,10 @@ final class HTTPHeaderValidationTests: XCTestCase {
             let headers = HTTPHeaders([("Host", "example.com"), ("Weird-Value", forbiddenFieldValue)])
             let badRequest = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/", headers: headers)
 
-            XCTAssertThrowsError(
-                try channel.writeOutbound(HTTPClientRequestPart.head(badRequest)),
-                "Incorrectly tolerated character in header field value: \(String(decoding: [byte], as: UTF8.self))"
-            ) { error in
-                XCTAssertEqual(error as? HTTPParserError, .invalidHeaderToken)
+            let error = #expect(throws: HTTPParserError.self) {
+                try channel.writeOutbound(HTTPClientRequestPart.head(badRequest))
             }
+            #expect(error == .invalidHeaderToken)
             _ = try? channel.finish()
         }
 
@@ -191,18 +173,13 @@ final class HTTPHeaderValidationTests: XCTestCase {
                 string: "GET / HTTP/1.1\r\nHost: example.com\r\nWeird-Value: \(evenWeirderAllowedValue)\r\n\r\n"
             )
 
-            XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)))
-
-            var maybeBytes: ByteBuffer?
-
-            XCTAssertNoThrow(maybeBytes = try channel.readOutbound())
-            XCTAssertEqual(maybeBytes, goodRequestBytes)
-
+            #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)) }
+            #expect(try channel.readOutbound(as: ByteBuffer.self) == goodRequestBytes)
             _ = try? channel.finish()
         }
     }
 
-    func testEncodingInvalidTrailerFieldValuesInRequests() throws {
+    @Test func encodingInvalidTrailerFieldValuesInRequests() throws {
         // We reject all ASCII control characters except HTAB and tolerate everything else.
         let weirdAllowedFieldValue =
             "!\" \t#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
@@ -217,16 +194,11 @@ final class HTTPHeaderValidationTests: XCTestCase {
         )
         let goodTrailers = ByteBuffer(string: "0\r\nWeird-Value: \(weirdAllowedFieldValue)\r\n\r\n")
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)))
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.end(["Weird-Value": weirdAllowedFieldValue])))
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)) }
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.end(["Weird-Value": weirdAllowedFieldValue])) }
 
-        var maybeRequestHeadBytes: ByteBuffer?
-        var maybeRequestEndBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeRequestHeadBytes = try channel.readOutbound())
-        XCTAssertNoThrow(maybeRequestEndBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeRequestHeadBytes, goodRequestBytes)
-        XCTAssertEqual(maybeRequestEndBytes, goodTrailers)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodRequestBytes)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodTrailers)
 
         // Now confirm all other bytes in the ASCII range are rejected.
         for byte in UInt8(0)..<UInt8(128) {
@@ -239,14 +211,12 @@ final class HTTPHeaderValidationTests: XCTestCase {
             let channel = EmbeddedChannel()
             try channel.pipeline.syncOperations.addHTTPClientHandlers()
 
-            XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)))
+            try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest))
 
-            XCTAssertThrowsError(
-                try channel.writeOutbound(HTTPClientRequestPart.end(["Weird-Value": forbiddenFieldValue])),
-                "Incorrectly tolerated character in trailer field value: \(String(decoding: [byte], as: UTF8.self))"
-            ) { error in
-                XCTAssertEqual(error as? HTTPParserError, .invalidHeaderToken)
+            let error = #expect(throws: HTTPParserError.self) {
+                try channel.writeOutbound(HTTPClientRequestPart.end(["Weird-Value": forbiddenFieldValue]))
             }
+            #expect(error == .invalidHeaderToken)
             _ = try? channel.finish()
         }
 
@@ -259,20 +229,19 @@ final class HTTPHeaderValidationTests: XCTestCase {
 
             let weirdGoodTrailers = ByteBuffer(string: "0\r\nWeird-Value: \(evenWeirderAllowedValue)\r\n\r\n")
 
-            XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)))
-            XCTAssertNoThrow(
-                try channel.writeOutbound(HTTPClientRequestPart.end(["Weird-Value": evenWeirderAllowedValue]))
-            )
-            XCTAssertNoThrow(maybeRequestHeadBytes = try channel.readOutbound())
-            XCTAssertNoThrow(maybeRequestEndBytes = try channel.readOutbound())
-            XCTAssertEqual(maybeRequestHeadBytes, goodRequestBytes)
-            XCTAssertEqual(maybeRequestEndBytes, weirdGoodTrailers)
-
+            #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)) }
+            #expect(throws: Never.self) {
+                try channel.writeOutbound(
+                    HTTPClientRequestPart.end(["Weird-Value": evenWeirderAllowedValue])
+                )
+            }
+            #expect(try channel.readOutbound(as: ByteBuffer.self) == goodRequestBytes)
+            #expect(try channel.readOutbound(as: ByteBuffer.self) == weirdGoodTrailers)
             _ = try? channel.finish()
         }
     }
 
-    func testEncodingInvalidHeaderFieldNamesInResponses() throws {
+    @Test func encodingInvalidHeaderFieldNamesInResponses() throws {
         // The spec in [RFC 9110](https://httpwg.org/specs/rfc9110.html#fields.values) defines the valid
         // characters as the following:
         //
@@ -285,7 +254,8 @@ final class HTTPHeaderValidationTests: XCTestCase {
         //                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
         //                / DIGIT / ALPHA
         //                ; any VCHAR, except delimiters
-        let weirdAllowedFieldName = "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        let weirdAllowedFieldName =
+            "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
         let channel = EmbeddedChannel()
         try channel.pipeline.syncOperations.configureHTTPServerPipeline(withErrorHandling: false)
@@ -297,20 +267,14 @@ final class HTTPHeaderValidationTests: XCTestCase {
             string: "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\(weirdAllowedFieldName): present\r\n\r\n"
         )
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)))
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
-
-        var maybeReceivedBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeReceivedBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeReceivedBytes, goodResponseBytes)
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)) }
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.end(nil)) }
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodResponseBytes)
 
         // Now confirm all other bytes are rejected.
         for byte in UInt8(0)...UInt8(255) {
             // Skip bytes that we already believe are allowed.
-            if weirdAllowedFieldName.utf8.contains(byte) {
-                continue
-            }
+            if weirdAllowedFieldName.utf8.contains(byte) { continue }
             let forbiddenFieldName = weirdAllowedFieldName + String(decoding: [byte], as: UTF8.self)
 
             let channel = EmbeddedChannel()
@@ -320,17 +284,15 @@ final class HTTPHeaderValidationTests: XCTestCase {
             let headers = HTTPHeaders([("Content-Length", "0"), (forbiddenFieldName, "present")])
             let badResponse = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
 
-            XCTAssertThrowsError(
-                try channel.writeOutbound(HTTPServerResponsePart.head(badResponse)),
-                "Incorrectly tolerated character in header field name: \(String(decoding: [byte], as: UTF8.self))"
-            ) { error in
-                XCTAssertEqual(error as? HTTPParserError, .invalidHeaderToken)
+            let error = #expect(throws: HTTPParserError.self) {
+                try channel.writeOutbound(HTTPServerResponsePart.head(badResponse))
             }
+            #expect(error == .invalidHeaderToken)
             _ = try? channel.finish()
         }
     }
 
-    func testEncodingInvalidTrailerFieldNamesInResponses() throws {
+    @Test func encodingInvalidTrailerFieldNamesInResponses() throws {
         // The spec in [RFC 9110](https://httpwg.org/specs/rfc9110.html#fields.values) defines the valid
         // characters as the following:
         //
@@ -343,7 +305,8 @@ final class HTTPHeaderValidationTests: XCTestCase {
         //                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
         //                / DIGIT / ALPHA
         //                ; any VCHAR, except delimiters
-        let weirdAllowedFieldName = "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        let weirdAllowedFieldName =
+            "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
         let channel = EmbeddedChannel()
         try channel.pipeline.syncOperations.configureHTTPServerPipeline(withErrorHandling: false)
@@ -354,16 +317,11 @@ final class HTTPHeaderValidationTests: XCTestCase {
         let goodResponseBytes = ByteBuffer(string: "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n")
         let goodTrailers = ByteBuffer(string: "0\r\n\(weirdAllowedFieldName): present\r\n\r\n")
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)))
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end([weirdAllowedFieldName: "present"])))
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)) }
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.end([weirdAllowedFieldName: "present"])) }
 
-        var maybeRequestHeadBytes: ByteBuffer?
-        var maybeRequestEndBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeRequestHeadBytes = try channel.readOutbound())
-        XCTAssertNoThrow(maybeRequestEndBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeRequestHeadBytes, goodResponseBytes)
-        XCTAssertEqual(maybeRequestEndBytes, goodTrailers)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodResponseBytes)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodTrailers)
 
         // Now confirm all other bytes are rejected.
         for byte in UInt8(0)...UInt8(255) {
@@ -377,19 +335,17 @@ final class HTTPHeaderValidationTests: XCTestCase {
             try channel.pipeline.syncOperations.configureHTTPServerPipeline(withErrorHandling: false)
             try channel.primeForResponse()
 
-            XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)))
+            try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse))
 
-            XCTAssertThrowsError(
-                try channel.writeOutbound(HTTPServerResponsePart.end([forbiddenFieldName: "present"])),
-                "Incorrectly tolerated character in trailer field name: \(String(decoding: [byte], as: UTF8.self))"
-            ) { error in
-                XCTAssertEqual(error as? HTTPParserError, .invalidHeaderToken)
+            let error = #expect(throws: HTTPParserError.self) {
+                try channel.writeOutbound(HTTPServerResponsePart.end([forbiddenFieldName: "present"]))
             }
+            #expect(error == .invalidHeaderToken)
             _ = try? channel.finish()
         }
     }
 
-    func testEncodingInvalidHeaderFieldValuesInResponses() throws {
+    @Test func encodingInvalidHeaderFieldValuesInResponses() throws {
         // We reject all ASCII control characters except HTAB and tolerate everything else.
         let weirdAllowedFieldValue =
             "!\" \t#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
@@ -404,12 +360,8 @@ final class HTTPHeaderValidationTests: XCTestCase {
             string: "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nWeird-Value: \(weirdAllowedFieldValue)\r\n\r\n"
         )
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)))
-
-        var maybeBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeBytes, goodResponseBytes)
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)) }
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodResponseBytes)
 
         // Now confirm all other bytes in the ASCII range are rejected.
         for byte in UInt8(0)..<UInt8(128) {
@@ -426,12 +378,10 @@ final class HTTPHeaderValidationTests: XCTestCase {
             let headers = HTTPHeaders([("Content-Length", "0"), ("Weird-Value", forbiddenFieldValue)])
             let badResponse = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
 
-            XCTAssertThrowsError(
-                try channel.writeOutbound(HTTPServerResponsePart.head(badResponse)),
-                "Incorrectly tolerated character in header field value: \(String(decoding: [byte], as: UTF8.self))"
-            ) { error in
-                XCTAssertEqual(error as? HTTPParserError, .invalidHeaderToken)
+            let error = #expect(throws: HTTPParserError.self) {
+                try channel.writeOutbound(HTTPServerResponsePart.head(badResponse))
             }
+            #expect(error == .invalidHeaderToken)
             _ = try? channel.finish()
         }
 
@@ -446,21 +396,17 @@ final class HTTPHeaderValidationTests: XCTestCase {
             let headers = HTTPHeaders([("Content-Length", "0"), ("Weird-Value", evenWeirderAllowedValue)])
             let goodResponse = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
             let goodResponseBytes = ByteBuffer(
-                string: "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nWeird-Value: \(evenWeirderAllowedValue)\r\n\r\n"
+                string:
+                    "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nWeird-Value: \(evenWeirderAllowedValue)\r\n\r\n"
             )
 
-            XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)))
-
-            var maybeBytes: ByteBuffer?
-
-            XCTAssertNoThrow(maybeBytes = try channel.readOutbound())
-            XCTAssertEqual(maybeBytes, goodResponseBytes)
-
+            #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)) }
+            #expect(try channel.readOutbound(as: ByteBuffer.self) == goodResponseBytes)
             _ = try? channel.finish()
         }
     }
 
-    func testEncodingInvalidTrailerFieldValuesInResponses() throws {
+    @Test func encodingInvalidTrailerFieldValuesInResponses() throws {
         // We reject all ASCII control characters except HTAB and tolerate everything else.
         let weirdAllowedFieldValue =
             "!\" \t#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
@@ -474,16 +420,11 @@ final class HTTPHeaderValidationTests: XCTestCase {
         let goodResponseBytes = ByteBuffer(string: "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n")
         let goodTrailers = ByteBuffer(string: "0\r\nWeird-Value: \(weirdAllowedFieldValue)\r\n\r\n")
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)))
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(["Weird-Value": weirdAllowedFieldValue])))
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)) }
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.end(["Weird-Value": weirdAllowedFieldValue])) }
 
-        var maybeResponseHeadBytes: ByteBuffer?
-        var maybeResponseEndBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeResponseHeadBytes = try channel.readOutbound())
-        XCTAssertNoThrow(maybeResponseEndBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeResponseHeadBytes, goodResponseBytes)
-        XCTAssertEqual(maybeResponseEndBytes, goodTrailers)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodResponseBytes)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == goodTrailers)
 
         // Now confirm all other bytes in the ASCII range are rejected.
         for byte in UInt8(0)..<UInt8(128) {
@@ -497,14 +438,12 @@ final class HTTPHeaderValidationTests: XCTestCase {
             try channel.pipeline.syncOperations.configureHTTPServerPipeline(withErrorHandling: false)
             try channel.primeForResponse()
 
-            XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)))
+            try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse))
 
-            XCTAssertThrowsError(
-                try channel.writeOutbound(HTTPServerResponsePart.end(["Weird-Value": forbiddenFieldValue])),
-                "Incorrectly tolerated character in trailer field value: \(String(decoding: [byte], as: UTF8.self))"
-            ) { error in
-                XCTAssertEqual(error as? HTTPParserError, .invalidHeaderToken)
+            let error = #expect(throws: HTTPParserError.self) {
+                try channel.writeOutbound(HTTPServerResponsePart.end(["Weird-Value": forbiddenFieldValue]))
             }
+            #expect(error == .invalidHeaderToken)
             _ = try? channel.finish()
         }
 
@@ -518,57 +457,58 @@ final class HTTPHeaderValidationTests: XCTestCase {
 
             let weirdGoodTrailers = ByteBuffer(string: "0\r\nWeird-Value: \(evenWeirderAllowedValue)\r\n\r\n")
 
-            XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)))
-            XCTAssertNoThrow(
-                try channel.writeOutbound(HTTPServerResponsePart.end(["Weird-Value": evenWeirderAllowedValue]))
-            )
-            XCTAssertNoThrow(maybeResponseHeadBytes = try channel.readOutbound())
-            XCTAssertNoThrow(maybeResponseEndBytes = try channel.readOutbound())
-            XCTAssertEqual(maybeResponseHeadBytes, goodResponseBytes)
-            XCTAssertEqual(maybeResponseEndBytes, weirdGoodTrailers)
-
+            #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)) }
+            #expect(throws: Never.self) {
+                try channel.writeOutbound(
+                    HTTPServerResponsePart.end(["Weird-Value": evenWeirderAllowedValue])
+                )
+            }
+            #expect(try channel.readOutbound(as: ByteBuffer.self) == goodResponseBytes)
+            #expect(try channel.readOutbound(as: ByteBuffer.self) == weirdGoodTrailers)
             _ = try? channel.finish()
         }
     }
 
-    func testResponseIsDroppedIfHeadersInvalid() throws {
+    @Test func responseIsDroppedIfHeadersInvalid() throws {
         let channel = EmbeddedChannel()
         try channel.pipeline.syncOperations.configureHTTPServerPipeline(withErrorHandling: false)
         try channel.primeForResponse()
 
-        func assertReadHead(from channel: EmbeddedChannel) throws {
-            if case .head = try channel.readInbound(as: HTTPServerRequestPart.self) {
-                ()
-            } else {
-                XCTFail("Expected 'head'")
-            }
-        }
-
-        func assertReadEnd(from channel: EmbeddedChannel) throws {
-            if case .end = try channel.readInbound(as: HTTPServerRequestPart.self) {
-                ()
-            } else {
-                XCTFail("Expected 'end'")
-            }
-        }
-
         // Read the first request.
-        try assertReadHead(from: channel)
-        try assertReadEnd(from: channel)
-        XCTAssertNil(try channel.readInbound(as: HTTPServerRequestPart.self))
+        let requestHead = try #require(try channel.readInbound(as: HTTPServerRequestPart.self))
+        guard case .head = requestHead else {
+            Issue.record("Expected 'head'")
+            return
+        }
+
+        let requestEnd = try #require(try channel.readInbound(as: HTTPServerRequestPart.self))
+        guard case .end = requestEnd else {
+            Issue.record("Expected 'end'")
+            return
+        }
+
+        #expect(try channel.readInbound(as: HTTPServerRequestPart.self) == nil)
 
         // Respond with bad headers; they should cause an error and result in the rest of the
         // response being dropped.
         let head = HTTPResponseHead(version: .http1_1, status: .ok, headers: [":pseudo-header": "not-here"])
-        XCTAssertThrowsError(try channel.writeOutbound(HTTPServerResponsePart.head(head)))
-        XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self))
-        XCTAssertThrowsError(try channel.writeOutbound(HTTPServerResponsePart.body(.byteBuffer(ByteBuffer()))))
-        XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self))
-        XCTAssertThrowsError(try channel.writeOutbound(HTTPServerResponsePart.end(nil)))
-        XCTAssertNil(try channel.readOutbound(as: ByteBuffer.self))
+        #expect(throws: (any Error).self) {
+            try channel.writeOutbound(HTTPServerResponsePart.head(head))
+        }
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == nil)
+
+        #expect(throws: (any Error).self) {
+            try channel.writeOutbound(HTTPServerResponsePart.body(.byteBuffer(ByteBuffer())))
+        }
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == nil)
+
+        #expect(throws: (any Error).self) {
+            try channel.writeOutbound(HTTPServerResponsePart.end(nil))
+        }
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == nil)
     }
 
-    func testDisablingValidationClientSide() throws {
+    @Test func disablingValidationClientSide() throws {
         let invalidHeaderName = "HeaderNameWith\"Quote"
         let invalidHeaderValue = "HeaderValueWith\rCR"
 
@@ -588,19 +528,14 @@ final class HTTPHeaderValidationTests: XCTestCase {
                 "0\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\(invalidHeaderName): \(invalidHeaderValue)\r\n\r\n"
         )
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.head(toleratedRequest)))
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPClientRequestPart.end(headers)))
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(toleratedRequest)) }
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.end(headers)) }
 
-        var maybeReceivedHeadBytes: ByteBuffer?
-        var maybeReceivedTrailerBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeReceivedHeadBytes = try channel.readOutbound())
-        XCTAssertNoThrow(maybeReceivedTrailerBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeReceivedHeadBytes, toleratedRequestBytes)
-        XCTAssertEqual(maybeReceivedTrailerBytes, toleratedTrailerBytes)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == toleratedRequestBytes)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == toleratedTrailerBytes)
     }
 
-    func testDisablingValidationServerSide() throws {
+    @Test func disablingValidationServerSide() throws {
         let invalidHeaderName = "HeaderNameWith\"Quote"
         let invalidHeaderValue = "HeaderValueWith\rCR"
 
@@ -614,8 +549,8 @@ final class HTTPHeaderValidationTests: XCTestCase {
         let headers = HTTPHeaders([
             ("Host", "example.com"), ("Transfer-Encoding", "chunked"), (invalidHeaderName, invalidHeaderValue),
         ])
-        let toleratedRequest = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
-        let toleratedRequestBytes = ByteBuffer(
+        let toleratedResponse = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
+        let toleratedResponseBytes = ByteBuffer(
             string:
                 "HTTP/1.1 200 OK\r\nHost: example.com\r\n\(invalidHeaderName): \(invalidHeaderValue)\r\ntransfer-encoding: chunked\r\n\r\n"
         )
@@ -624,16 +559,11 @@ final class HTTPHeaderValidationTests: XCTestCase {
                 "0\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\(invalidHeaderName): \(invalidHeaderValue)\r\n\r\n"
         )
 
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(toleratedRequest)))
-        XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.end(headers)))
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.head(toleratedResponse)) }
+        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.end(headers)) }
 
-        var maybeReceivedHeadBytes: ByteBuffer?
-        var maybeReceivedTrailerBytes: ByteBuffer?
-
-        XCTAssertNoThrow(maybeReceivedHeadBytes = try channel.readOutbound())
-        XCTAssertNoThrow(maybeReceivedTrailerBytes = try channel.readOutbound())
-        XCTAssertEqual(maybeReceivedHeadBytes, toleratedRequestBytes)
-        XCTAssertEqual(maybeReceivedTrailerBytes, toleratedTrailerBytes)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == toleratedResponseBytes)
+        #expect(try channel.readOutbound(as: ByteBuffer.self) == toleratedTrailerBytes)
     }
 }
 

--- a/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
@@ -96,7 +96,9 @@ import Testing
         let goodTrailers = ByteBuffer(string: "0\r\n\(weirdAllowedFieldName): present\r\n\r\n")
 
         #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)) }
-        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.end([weirdAllowedFieldName: "present"])) }
+        #expect(throws: Never.self) {
+            try channel.writeOutbound(HTTPClientRequestPart.end([weirdAllowedFieldName: "present"]))
+        }
 
         #expect(try channel.readOutbound(as: ByteBuffer.self) == goodRequestBytes)
         #expect(try channel.readOutbound(as: ByteBuffer.self) == goodTrailers)
@@ -195,7 +197,9 @@ import Testing
         let goodTrailers = ByteBuffer(string: "0\r\nWeird-Value: \(weirdAllowedFieldValue)\r\n\r\n")
 
         #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)) }
-        #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.end(["Weird-Value": weirdAllowedFieldValue])) }
+        #expect(throws: Never.self) {
+            try channel.writeOutbound(HTTPClientRequestPart.end(["Weird-Value": weirdAllowedFieldValue]))
+        }
 
         #expect(try channel.readOutbound(as: ByteBuffer.self) == goodRequestBytes)
         #expect(try channel.readOutbound(as: ByteBuffer.self) == goodTrailers)
@@ -318,7 +322,9 @@ import Testing
         let goodTrailers = ByteBuffer(string: "0\r\n\(weirdAllowedFieldName): present\r\n\r\n")
 
         #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)) }
-        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.end([weirdAllowedFieldName: "present"])) }
+        #expect(throws: Never.self) {
+            try channel.writeOutbound(HTTPServerResponsePart.end([weirdAllowedFieldName: "present"]))
+        }
 
         #expect(try channel.readOutbound(as: ByteBuffer.self) == goodResponseBytes)
         #expect(try channel.readOutbound(as: ByteBuffer.self) == goodTrailers)
@@ -421,7 +427,9 @@ import Testing
         let goodTrailers = ByteBuffer(string: "0\r\nWeird-Value: \(weirdAllowedFieldValue)\r\n\r\n")
 
         #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse)) }
-        #expect(throws: Never.self) { try channel.writeOutbound(HTTPServerResponsePart.end(["Weird-Value": weirdAllowedFieldValue])) }
+        #expect(throws: Never.self) {
+            try channel.writeOutbound(HTTPServerResponsePart.end(["Weird-Value": weirdAllowedFieldValue]))
+        }
 
         #expect(try channel.readOutbound(as: ByteBuffer.self) == goodResponseBytes)
         #expect(try channel.readOutbound(as: ByteBuffer.self) == goodTrailers)

--- a/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPHeaderValidationTests.swift
@@ -61,7 +61,10 @@ import Testing
             let headers = HTTPHeaders([("Host", "example.com"), (forbiddenFieldName, "present")])
             let badRequest = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/", headers: headers)
 
-            let error = #expect(throws: HTTPParserError.self) {
+            let error = #expect(
+                throws: HTTPParserError.self,
+                "Incorrectly tolerated character in header field name: \(String(decoding: [byte], as: UTF8.self))"
+            ) {
                 try channel.writeOutbound(HTTPClientRequestPart.head(badRequest))
             }
             #expect(error == .invalidHeaderToken)
@@ -116,7 +119,10 @@ import Testing
 
             #expect(throws: Never.self) { try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest)) }
 
-            let error = #expect(throws: HTTPParserError.self) {
+            let error = #expect(
+                throws: HTTPParserError.self,
+                "Incorrectly tolerated character in trailer field name: \(String(decoding: [byte], as: UTF8.self))"
+            ) {
                 try channel.writeOutbound(HTTPClientRequestPart.end([forbiddenFieldName: "present"]))
             }
             #expect(error == .invalidHeaderToken)
@@ -155,7 +161,10 @@ import Testing
             let headers = HTTPHeaders([("Host", "example.com"), ("Weird-Value", forbiddenFieldValue)])
             let badRequest = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/", headers: headers)
 
-            let error = #expect(throws: HTTPParserError.self) {
+            let error = #expect(
+                throws: HTTPParserError.self,
+                "Incorrectly tolerated character in header field value: \(String(decoding: [byte], as: UTF8.self))"
+            ) {
                 try channel.writeOutbound(HTTPClientRequestPart.head(badRequest))
             }
             #expect(error == .invalidHeaderToken)
@@ -217,7 +226,10 @@ import Testing
 
             try channel.writeOutbound(HTTPClientRequestPart.head(goodRequest))
 
-            let error = #expect(throws: HTTPParserError.self) {
+            let error = #expect(
+                throws: HTTPParserError.self,
+                "Incorrectly tolerated character in trailer field value: \(String(decoding: [byte], as: UTF8.self))"
+            ) {
                 try channel.writeOutbound(HTTPClientRequestPart.end(["Weird-Value": forbiddenFieldValue]))
             }
             #expect(error == .invalidHeaderToken)
@@ -288,7 +300,10 @@ import Testing
             let headers = HTTPHeaders([("Content-Length", "0"), (forbiddenFieldName, "present")])
             let badResponse = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
 
-            let error = #expect(throws: HTTPParserError.self) {
+            let error = #expect(
+                throws: HTTPParserError.self,
+                "Incorrectly tolerated character in header field name: \(String(decoding: [byte], as: UTF8.self))"
+            ) {
                 try channel.writeOutbound(HTTPServerResponsePart.head(badResponse))
             }
             #expect(error == .invalidHeaderToken)
@@ -343,7 +358,10 @@ import Testing
 
             try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse))
 
-            let error = #expect(throws: HTTPParserError.self) {
+            let error = #expect(
+                throws: HTTPParserError.self,
+                "Incorrectly tolerated character in trailer field name: \(String(decoding: [byte], as: UTF8.self))"
+            ) {
                 try channel.writeOutbound(HTTPServerResponsePart.end([forbiddenFieldName: "present"]))
             }
             #expect(error == .invalidHeaderToken)
@@ -384,7 +402,10 @@ import Testing
             let headers = HTTPHeaders([("Content-Length", "0"), ("Weird-Value", forbiddenFieldValue)])
             let badResponse = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
 
-            let error = #expect(throws: HTTPParserError.self) {
+            let error = #expect(
+                throws: HTTPParserError.self,
+                "Incorrectly tolerated character in header field value: \(String(decoding: [byte], as: UTF8.self))"
+            ) {
                 try channel.writeOutbound(HTTPServerResponsePart.head(badResponse))
             }
             #expect(error == .invalidHeaderToken)
@@ -448,7 +469,10 @@ import Testing
 
             try channel.writeOutbound(HTTPServerResponsePart.head(goodResponse))
 
-            let error = #expect(throws: HTTPParserError.self) {
+            let error = #expect(
+                throws: HTTPParserError.self,
+                "Incorrectly tolerated character in trailer field value: \(String(decoding: [byte], as: UTF8.self))"
+            ) {
                 try channel.writeOutbound(HTTPServerResponsePart.end(["Weird-Value": forbiddenFieldValue]))
             }
             #expect(error == .invalidHeaderToken)


### PR DESCRIPTION
Translate `HTTPHeaderValidationTests` to Swift testing

### Motivation:

We want to add tests that use parameterized testing to `HTTPHeaderValidationTests`. In order to allow this we first need to translate this file to use Swift Testing instead of XCTest.

### Modifications:

- Mechanical translation of `HTTPHeaderValidationTests` from XCTest to Swift testing.

### Result:

We can add parameterized tests to HTTPHeaderValidationTests. 
