### PR TITLE
Add support for --security-opt docker flags in custom CI jobs

### DIFF
--- a/.github/workflows/swift_test_matrix.yml
+++ b/.github/workflows/swift_test_matrix.yml
@@ -97,6 +97,13 @@ jobs:
             done < <(echo "$MATRIX_DOCKER_CAPABILITIES" | jq -r '.[]')
           fi
 
+          # Add Docker security options if specified
+          if [[ "$MATRIX_DOCKER_SECURITY_OPTS" != '[]' ]]; then
+            while IFS= read -r opt; do
+              docker_args+=("--security-opt" "$opt")
+            done < <(echo "$MATRIX_DOCKER_SECURITY_OPTS" | jq -r '.[]')
+          fi
+
           if [[ "$MATRIX_ENV_JSON" != '{}' ]]; then
             while IFS="=" read -r key value; do
               if [[ -n "$key" && -n "$value" ]]; then
@@ -118,6 +125,7 @@ jobs:
           MATRIX_COMMAND_ARGUMENTS: ${{ matrix.config.command_arguments }}
           MATRIX_ENV_JSON: ${{ toJson(matrix.config.env) }}
           MATRIX_DOCKER_CAPABILITIES: ${{ toJson(matrix.config.docker_capabilities) }}
+          MATRIX_DOCKER_SECURITY_OPTS: ${{ toJson(matrix.config.docker_security_opts) }}
           GITHUB_WORKSPACE: ${{ github.workspace }}
       - name: Run matrix job (Windows)
         if: ${{ matrix.config.platform == 'Windows' }}

--- a/scripts/generate_matrix.sh
+++ b/scripts/generate_matrix.sh
@@ -32,6 +32,7 @@ linux_command="${MATRIX_LINUX_COMMAND:-}"  # required if any Linux pipeline is e
 linux_setup_command="${MATRIX_LINUX_SETUP_COMMAND:-}"
 linux_dockerfile="${MATRIX_LINUX_DOCKERFILE:-}"
 linux_docker_capabilities_json="${MATRIX_LINUX_DOCKER_CAPABILITIES_JSON:-"[]"}"
+linux_docker_security_opts_json="${MATRIX_LINUX_DOCKER_SECURITY_OPTS_JSON:-"[]"}"
 linux_5_9_enabled="${MATRIX_LINUX_5_9_ENABLED:=false}"
 linux_5_9_command_arguments="${MATRIX_LINUX_5_9_COMMAND_ARGUMENTS:-}"
 linux_5_10_enabled="${MATRIX_LINUX_5_10_ENABLED:=false}"
@@ -257,6 +258,7 @@ should_include_version() {
 #   $9: env_vars_json
 #   ${10}: dockerfile (optional, path relative to repo root)
 #   ${11}: docker_capabilities_json (optional, JSON array e.g. '["CAP_BPF"]')
+#   ${12}: docker_security_opts_json (optional, JSON array e.g. '["seccomp=unconfined"]')
 add_matrix_entry() {
     local platform="$1"
     local version="$2"
@@ -269,6 +271,7 @@ add_matrix_entry() {
     local env_vars_json="$9"
     local dockerfile="${10:-}"
     local docker_capabilities_json="${11:-"[]"}"
+    local docker_security_opts_json="${12:-"[]"}"
 
     if [[ "$enabled" == "true" ]] && should_include_version "$version"; then
         # shellcheck disable=SC2016  # Our use of JQ_BIN means that shellcheck can't tell this is a `jq` invocation
@@ -283,7 +286,8 @@ add_matrix_entry() {
             --argjson env_vars "$env_vars_json" \
             --arg dockerfile "$dockerfile" \
             --argjson docker_capabilities "$docker_capabilities_json" \
-            '.config[.config| length] |= . + { "name": $version, "image": $container_image, "swift_version": $version, "platform": $platform, "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner, "env": $env_vars, "dockerfile": $dockerfile, "docker_capabilities": $docker_capabilities}')
+            --argjson docker_security_opts "$docker_security_opts_json" \
+            '.config[.config| length] |= . + { "name": $version, "image": $container_image, "swift_version": $version, "platform": $platform, "command": $command, "command_arguments": $command_arguments, "setup_command": $setup_command, "runner": $runner, "env": $env_vars, "dockerfile": $dockerfile, "docker_capabilities": $docker_capabilities, "docker_security_opts": $docker_security_opts}')
     fi
 }
 
@@ -314,15 +318,15 @@ if [[ \
   fi
 fi
 
-#                 Platform   Version         Enabled                        Setup                   Command          Arguments                               Image                                 Runner           Env                     Dockerfile            Capabilities
-add_matrix_entry "Linux"    "5.9"           "$linux_5_9_enabled"           "$linux_setup_command"  "$linux_command" "$linux_5_9_command_arguments"          "$linux_5_9_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
-add_matrix_entry "Linux"    "5.10"          "$linux_5_10_enabled"          "$linux_setup_command"  "$linux_command" "$linux_5_10_command_arguments"         "$linux_5_10_container_image"         "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
-add_matrix_entry "Linux"    "6.0"           "$linux_6_0_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_0_command_arguments"          "$linux_6_0_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
-add_matrix_entry "Linux"    "6.1"           "$linux_6_1_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_1_command_arguments"          "$linux_6_1_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
-add_matrix_entry "Linux"    "6.2"           "$linux_6_2_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_2_command_arguments"          "$linux_6_2_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
-add_matrix_entry "Linux"    "6.3"           "$linux_6_3_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_3_command_arguments"          "$linux_6_3_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
-add_matrix_entry "Linux"    "nightly-next"  "$linux_nightly_next_enabled"  "$linux_setup_command"  "$linux_command" "$linux_nightly_next_command_arguments" "$linux_nightly_next_container_image" "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
-add_matrix_entry "Linux"    "nightly-main"  "$linux_nightly_main_enabled"  "$linux_setup_command"  "$linux_command" "$linux_nightly_main_command_arguments" "$linux_nightly_main_container_image" "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"
+#                 Platform   Version         Enabled                        Setup                   Command          Arguments                               Image                                 Runner           Env                     Dockerfile            Capabilities                         Security opts
+add_matrix_entry "Linux"    "5.9"           "$linux_5_9_enabled"           "$linux_setup_command"  "$linux_command" "$linux_5_9_command_arguments"          "$linux_5_9_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"     "$linux_docker_security_opts_json"
+add_matrix_entry "Linux"    "5.10"          "$linux_5_10_enabled"          "$linux_setup_command"  "$linux_command" "$linux_5_10_command_arguments"         "$linux_5_10_container_image"         "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"     "$linux_docker_security_opts_json"
+add_matrix_entry "Linux"    "6.0"           "$linux_6_0_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_0_command_arguments"          "$linux_6_0_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"     "$linux_docker_security_opts_json"
+add_matrix_entry "Linux"    "6.1"           "$linux_6_1_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_1_command_arguments"          "$linux_6_1_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"     "$linux_docker_security_opts_json"
+add_matrix_entry "Linux"    "6.2"           "$linux_6_2_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_2_command_arguments"          "$linux_6_2_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"     "$linux_docker_security_opts_json"
+add_matrix_entry "Linux"    "6.3"           "$linux_6_3_enabled"           "$linux_setup_command"  "$linux_command" "$linux_6_3_command_arguments"          "$linux_6_3_container_image"          "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"     "$linux_docker_security_opts_json"
+add_matrix_entry "Linux"    "nightly-next"  "$linux_nightly_next_enabled"  "$linux_setup_command"  "$linux_command" "$linux_nightly_next_command_arguments" "$linux_nightly_next_container_image" "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"     "$linux_docker_security_opts_json"
+add_matrix_entry "Linux"    "nightly-main"  "$linux_nightly_main_enabled"  "$linux_setup_command"  "$linux_command" "$linux_nightly_main_command_arguments" "$linux_nightly_main_container_image" "$linux_runner"  "$linux_env_vars_json"  "$linux_dockerfile"   "$linux_docker_capabilities_json"     "$linux_docker_security_opts_json"
 
 ## Windows
 if [[ \


### PR DESCRIPTION
### Motivation:

A recent PR (#3574) added support for customising the container environment used for the matrix job for users of the reusable workflow. It supported a custom Dockerfile and controlling `--cap-add` options to the `docker run` command. Users who require this fine-grained control with `--cap-add` also will benefit from being able to control the `--security-opt` of the `docker run` command.

### Modifications:

- Add support for `--security-opt` docker flags in custom CI jobs

### Result:

Users of the reusable matrix CI workflow can control the `--security-opt` for the container.