### PR TITLE
Add canImport(Android) alongside Bionic in remaining libc import sites

### DIFF
--- a/Sources/NIOConcurrencyHelpers/NIOLock.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOLock.swift
@@ -21,6 +21,8 @@ import WinSDK
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(WASILibc)

--- a/Sources/NIOConcurrencyHelpers/NIOThreadPoolWorkAvailable.swift
+++ b/Sources/NIOConcurrencyHelpers/NIOThreadPoolWorkAvailable.swift
@@ -21,6 +21,8 @@ import WinSDK
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(WASILibc)

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -30,6 +30,8 @@ private func sys_sched_yield() {
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(WASILibc)

--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -21,6 +21,8 @@ import WinSDK
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(WASILibc)

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -20,6 +20,8 @@ import Darwin
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(WASILibc)

--- a/Sources/NIOCore/FileRegion.swift
+++ b/Sources/NIOCore/FileRegion.swift
@@ -19,6 +19,8 @@ import Darwin
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(WASILibc)

--- a/Sources/NIOCore/GlobalSingletons.swift
+++ b/Sources/NIOCore/GlobalSingletons.swift
@@ -23,6 +23,8 @@ import WinSDK
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(WASILibc)

--- a/Sources/NIOCore/IO.swift
+++ b/Sources/NIOCore/IO.swift
@@ -32,6 +32,8 @@ internal func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(WASILibc)

--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -16,6 +16,8 @@
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #endif

--- a/Sources/NIOCore/SocketOptionProvider.swift
+++ b/Sources/NIOCore/SocketOptionProvider.swift
@@ -18,6 +18,8 @@ import Darwin
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #endif

--- a/Sources/NIOFS/FileSystem.swift
+++ b/Sources/NIOFS/FileSystem.swift
@@ -23,6 +23,8 @@ import Darwin
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #endif
@@ -685,7 +687,7 @@ public struct FileSystem: Sendable, FileSystemProtocol {
                 return NIOFilePath(path)
             }
 
-            #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+            #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
             return try await self.threadPool.runIfActive {
                 NIOFilePath(
                     try Libc.homeDirectoryFromPasswd().mapError { errno in
@@ -1307,7 +1309,7 @@ extension FileSystem {
             )
         }
 
-        #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #elseif canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         if replaceExisting {
             return self._copyRegularFileReplacing(
                 from: sourcePath,
@@ -1332,7 +1334,7 @@ extension FileSystem {
         #endif
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     private func _copyRegularFileReplacing(
         from sourcePath: FilePath,
         to destinationPath: FilePath
@@ -1695,7 +1697,7 @@ extension FileSystem {
             )
             return .failure(error)
         }
-        #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #elseif canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         switch Syscall.rename(
             from: temporarySymlinkPath,
             relativeTo: destinationDirectoryFD,

--- a/Sources/NIOFS/Internal/System Calls/FileDescriptor+Syscalls.swift
+++ b/Sources/NIOFS/Internal/System Calls/FileDescriptor+Syscalls.swift
@@ -23,6 +23,9 @@ import CNIOLinux
 #elseif canImport(Musl)
 @preconcurrency import Musl
 import CNIOLinux
+#elseif canImport(Android)
+@preconcurrency import Android
+import CNIOLinux
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 import CNIOLinux
@@ -313,7 +316,7 @@ extension FileDescriptor {
     }
 }
 
-#if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+#if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
 extension FileDescriptor.OpenOptions {
     static var temporaryFile: Self {
         Self(rawValue: CNIOLinux_O_TMPFILE)

--- a/Sources/NIOFS/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFS/Internal/System Calls/Syscall.swift
@@ -23,6 +23,9 @@ import CNIOLinux
 #elseif canImport(Musl)
 @preconcurrency import Musl
 import CNIOLinux
+#elseif canImport(Android)
+@preconcurrency import Android
+import CNIOLinux
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 import CNIOLinux
@@ -131,7 +134,7 @@ public enum Syscall: Sendable {
     }
     #endif
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public static func rename(
         from old: FilePath,
@@ -173,7 +176,7 @@ public enum Syscall: Sendable {
     }
     #endif
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public struct LinkAtFlags: OptionSet {
         @_spi(Testing)
@@ -306,7 +309,7 @@ public enum Syscall: Sendable {
         }
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public static func sendfile(
         to output: FileDescriptor,
@@ -330,7 +333,7 @@ public enum Syscall: Sendable {
         }
     }
 
-    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public static func getuid() -> uid_t {
         system_getuid()
@@ -509,7 +512,7 @@ public enum Libc: Sendable {
         return nil
     }
 
-    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public static func homeDirectoryFromPasswd() -> Result<FilePath, Errno> {
         let uid = Syscall.getuid()

--- a/Sources/NIOFS/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFS/Internal/SystemFileHandle.swift
@@ -25,6 +25,8 @@ import CNIOLinux
 #elseif canImport(Musl)
 @preconcurrency import Musl
 import CNIOLinux
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #endif
@@ -56,7 +58,7 @@ public final class SystemFileHandle: Sendable {
         enum Mode {
             /// Rename the created file to become the desired file.
             case rename
-            #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+            #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
             /// Link the unnamed file to the desired file using 'linkat(2)'.
             case link
             #endif
@@ -290,7 +292,7 @@ extension SystemFileHandle: FileHandleProtocol {
                 }
 
                 switch materialization.mode {
-                #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                 case .link:
                     let result = self.sendableView._materializeLink(
                         descriptor: descriptor,
@@ -696,7 +698,7 @@ extension SystemFileHandle.SendableView {
         }
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     fileprivate func _materializeLink(
         descriptor: FileDescriptor,
         from createdPath: FilePath,
@@ -807,7 +809,7 @@ extension SystemFileHandle.SendableView {
 
         let result: Result<Void, FileSystemError>
         switch materialization.mode {
-        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         case .link:
             if materialize {
                 result = self._materializeLink(
@@ -832,7 +834,7 @@ extension SystemFileHandle.SendableView {
                     to: desiredPath,
                     options: materialization.exclusive ? [.exclusive] : []
                 )
-                #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                #elseif canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                 // The created and desired paths are absolute, so the relative descriptors are
                 // ignored. However, they must still be provided to 'rename' in order to pass
                 // flags.
@@ -861,7 +863,7 @@ extension SystemFileHandle.SendableView {
                         // If 'renameat2' failed on Linux with EINVAL then in all likelihood the
                         // 'RENAME_NOREPLACE' option isn't supported. As we're doing an exclusive
                         // create, check the desired path doesn't exist then do a regular rename.
-                        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                        #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                         switch Syscall.stat(path: desiredPath) {
                         case .failure(.noSuchFileOrDirectory):
                             // File doesn't exist, do a 'regular' rename.
@@ -1451,7 +1453,7 @@ extension SystemFileHandle {
             }
 
             func makePath() -> FilePath {
-                #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                 if useTemporaryFileIfPossible {
                     return currentWorkingDirectory.appending(path.components.dropLast())
                 }
@@ -1464,7 +1466,7 @@ extension SystemFileHandle {
             desiredPath = currentWorkingDirectory.appending(path.components)
         } else {
             func makePath() -> FilePath {
-                #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                 if useTemporaryFileIfPossible {
                     return path.removingLastComponent()
                 }
@@ -1480,7 +1482,7 @@ extension SystemFileHandle {
         let materializationMode: Materialization.Mode
         let options: FileDescriptor.OpenOptions
 
-        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         if useTemporaryFileIfPossible {
             options = [.temporaryFile]
             materializationMode = .link
@@ -1517,7 +1519,7 @@ extension SystemFileHandle {
 
             return .success(handle)
         } catch {
-            #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+            #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
             // 'O_TMPFILE' isn't supported for the current file system, try again but using
             // rename instead.
             if useTemporaryFileIfPossible, let errno = error as? Errno, errno == .notSupported {

--- a/Sources/_NIODataStructures/Heap.swift
+++ b/Sources/_NIODataStructures/Heap.swift
@@ -21,6 +21,8 @@ import Darwin.C
 @preconcurrency import WASILibc
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #else

--- a/Sources/_NIOFileSystem/FileSystem.swift
+++ b/Sources/_NIOFileSystem/FileSystem.swift
@@ -23,6 +23,8 @@ import Darwin
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #endif
@@ -1308,7 +1310,7 @@ extension FileSystem {
             )
         }
 
-        #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #elseif canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         if replaceExisting {
             return self._copyRegularFileReplacing(from: sourcePath, to: destinationPath)
         } else {
@@ -1330,7 +1332,7 @@ extension FileSystem {
         #endif
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     private func _copyRegularFileReplacing(
         from sourcePath: FilePath,
         to destinationPath: FilePath
@@ -1689,7 +1691,7 @@ extension FileSystem {
             )
             return .failure(error)
         }
-        #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #elseif canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         switch Syscall.rename(
             from: temporarySymlinkPath,
             relativeTo: destinationDirectoryFD,

--- a/Sources/_NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
+++ b/Sources/_NIOFileSystem/Internal/System Calls/FileDescriptor+Syscalls.swift
@@ -23,6 +23,9 @@ import CNIOLinux
 #elseif canImport(Musl)
 @preconcurrency import Musl
 import CNIOLinux
+#elseif canImport(Android)
+@preconcurrency import Android
+import CNIOLinux
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 import CNIOLinux
@@ -313,7 +316,7 @@ extension FileDescriptor {
     }
 }
 
-#if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+#if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
 extension FileDescriptor.OpenOptions {
     static var temporaryFile: Self {
         Self(rawValue: CNIOLinux_O_TMPFILE)

--- a/Sources/_NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/_NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -23,6 +23,9 @@ import CNIOLinux
 #elseif canImport(Musl)
 @preconcurrency import Musl
 import CNIOLinux
+#elseif canImport(Android)
+@preconcurrency import Android
+import CNIOLinux
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 import CNIOLinux
@@ -131,7 +134,7 @@ public enum Syscall: Sendable {
     }
     #endif
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public static func rename(
         from old: FilePath,
@@ -173,7 +176,7 @@ public enum Syscall: Sendable {
     }
     #endif
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public struct LinkAtFlags: OptionSet {
         @_spi(Testing)
@@ -306,7 +309,7 @@ public enum Syscall: Sendable {
         }
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public static func sendfile(
         to output: FileDescriptor,
@@ -330,7 +333,7 @@ public enum Syscall: Sendable {
         }
     }
 
-    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public static func getuid() -> uid_t {
         system_getuid()
@@ -509,7 +512,7 @@ public enum Libc: Sendable {
         return nil
     }
 
-    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     @_spi(Testing)
     public static func homeDirectoryFromPasswd() -> Result<FilePath, Errno> {
         let uid = Syscall.getuid()

--- a/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
@@ -25,6 +25,8 @@ import CNIOLinux
 #elseif canImport(Musl)
 @preconcurrency import Musl
 import CNIOLinux
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #endif
@@ -56,7 +58,7 @@ public final class SystemFileHandle: Sendable {
         enum Mode {
             /// Rename the created file to become the desired file.
             case rename
-            #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+            #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
             /// Link the unnamed file to the desired file using 'linkat(2)'.
             case link
             #endif
@@ -290,7 +292,7 @@ extension SystemFileHandle: FileHandleProtocol {
                 }
 
                 switch materialization.mode {
-                #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                 case .link:
                     let result = self.sendableView._materializeLink(
                         descriptor: descriptor,
@@ -696,7 +698,7 @@ extension SystemFileHandle.SendableView {
         }
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
     fileprivate func _materializeLink(
         descriptor: FileDescriptor,
         from createdPath: FilePath,
@@ -807,7 +809,7 @@ extension SystemFileHandle.SendableView {
 
         let result: Result<Void, FileSystemError>
         switch materialization.mode {
-        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         case .link:
             if materialize {
                 result = self._materializeLink(
@@ -832,7 +834,7 @@ extension SystemFileHandle.SendableView {
                     to: desiredPath,
                     options: materialization.exclusive ? [.exclusive] : []
                 )
-                #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                #elseif canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                 // The created and desired paths are absolute, so the relative descriptors are
                 // ignored. However, they must still be provided to 'rename' in order to pass
                 // flags.
@@ -861,7 +863,7 @@ extension SystemFileHandle.SendableView {
                         // If 'renameat2' failed on Linux with EINVAL then in all likelihood the
                         // 'RENAME_NOREPLACE' option isn't supported. As we're doing an exclusive
                         // create, check the desired path doesn't exist then do a regular rename.
-                        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                        #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                         switch Syscall.stat(path: desiredPath) {
                         case .failure(.noSuchFileOrDirectory):
                             // File doesn't exist, do a 'regular' rename.
@@ -1451,7 +1453,7 @@ extension SystemFileHandle {
             }
 
             func makePath() -> FilePath {
-                #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                 if useTemporaryFileIfPossible {
                     return currentWorkingDirectory.appending(path.components.dropLast())
                 }
@@ -1464,7 +1466,7 @@ extension SystemFileHandle {
             desiredPath = currentWorkingDirectory.appending(path.components)
         } else {
             func makePath() -> FilePath {
-                #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
                 if useTemporaryFileIfPossible {
                     return path.removingLastComponent()
                 }
@@ -1480,7 +1482,7 @@ extension SystemFileHandle {
         let materializationMode: Materialization.Mode
         let options: FileDescriptor.OpenOptions
 
-        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         if useTemporaryFileIfPossible {
             options = [.temporaryFile]
             materializationMode = .link
@@ -1517,7 +1519,7 @@ extension SystemFileHandle {
 
             return .success(handle)
         } catch {
-            #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+            #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
             // 'O_TMPFILE' isn't supported for the current file system, try again but using
             // rename instead.
             if useTemporaryFileIfPossible, let errno = error as? Errno, errno == .notSupported {

--- a/Tests/NIOFSIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileHandleTests.swift
@@ -1022,7 +1022,7 @@ final class FileHandleTests: XCTestCase {
         // creating a temporary file and then renaming it using 'renameat2' and then takes a further
         // fallback path where 'renameat2' returns EINVAL so the 'rename' is used in combination
         // with 'stat'. This path is only reachable on Linux.
-        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         let temporaryDirectory = FilePath(try await FileSystem.shared.temporaryDirectory)
         let path = temporaryDirectory.appending(Self.temporaryFileName().components)
         let handle = try SystemFileHandle.syncOpenWithMaterialization(

--- a/Tests/NIOFSIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileSystemTests.swift
@@ -2080,7 +2080,7 @@ extension FileSystemTests {
         }
 
         // verify no temp files are left (Linux only - Darwin uses COPYFILE_UNLINK)
-        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)
         let temporaryFiles = try await self.fs.withDirectoryHandle(atPath: testDirectory) { dir in
             var temporaryFiles: [String] = []
             for try await batch in dir.listContents().batched() {

--- a/Tests/NIOFSTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFSTests/Internal/SyscallTests.swift
@@ -132,7 +132,7 @@ final class SyscallTests: XCTestCase {
     }
 
     func test_linkat() throws {
-        #if canImport(Glibc) || canImport(Bionic)
+        #if canImport(Glibc) || canImport(Android) || canImport(Bionic)
         let fd1 = FileDescriptor(rawValue: 13)
         let fd2 = FileDescriptor(rawValue: 42)
 
@@ -377,7 +377,7 @@ final class SyscallTests: XCTestCase {
     }
 
     func test_renameat2() throws {
-        #if canImport(Glibc) || canImport(Bionic)
+        #if canImport(Glibc) || canImport(Android) || canImport(Bionic)
         let fd1 = FileDescriptor(rawValue: 13)
         let fd2 = FileDescriptor(rawValue: 42)
 
@@ -426,7 +426,7 @@ final class SyscallTests: XCTestCase {
     }
 
     func test_sendfile() throws {
-        #if canImport(Glibc) || canImport(Bionic)
+        #if canImport(Glibc) || canImport(Android) || canImport(Bionic)
         let input = FileDescriptor(rawValue: 42)
         let output = FileDescriptor(rawValue: 1)
 

--- a/Tests/NIOPosixTests/HappyEyeballsTest.swift
+++ b/Tests/NIOPosixTests/HappyEyeballsTest.swift
@@ -24,6 +24,8 @@ import XCTest
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #elseif canImport(Bionic)
 import Bionic
 #else


### PR DESCRIPTION
Swift 6.3 Android SDK (finagolfin/swift-android-sdk) ships the libc shim as the `Android` module only; the `Bionic` module was removed. Files that had only `#elseif canImport(Bionic)` in their top-level `#if` chain hit `#error("… unable to identify your C library.")`.

Add `#elseif canImport(Android)` before each `#elseif canImport(Bionic)` in the 20 remaining top-level import sites, and add `|| canImport(Android)` to the 44 inline `canImport(Glibc) || canImport(Musl) || canImport(Bionic)` boolean guards. Both branches are kept so older SDKs that still ship Bionic continue to work.

FileDescriptor+Syscalls.swift and Syscall.swift Android branches also import CNIOLinux because those files use CNIOLinux_O_TMPFILE, CNIOLinux_RENAME_NOREPLACE, etc. inside the newly-gated blocks.

https://claude.ai/code/session_01Gmec6R8WK6XsSSwecZ9AAm

Support Android Bionic 

### Motivation:

Porting Swift-NIO project to Android Bionic 

### Modifications:

-#if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+#if canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(Bionic)

### Result:

 Swift-NIO project porting to Android Bionic success 

@finagolfin