### PR TITLE
make internal FTSInfo take CInt

### DIFF
--- a/Sources/_NIOFileSystem/DirectoryEntries.swift
+++ b/Sources/_NIOFileSystem/DirectoryEntries.swift
@@ -382,8 +382,19 @@ private struct DirectoryEnumerator: Sendable {
         case symbolicLink
         case symbolicLinkToNonExistentTarget
 
+        // Compatibility function.
+        @_disfavoredOverload
         init?(rawValue: UInt16) {
-            switch Int32(rawValue) {
+            // This cast is safe on all platforms that matter, CInt it at least 32bits, so we can safely assign
+            // an unsigned 16bit integer
+            guard let value = FTSInfo(rawValue: CInt(rawValue)) else {
+                return nil
+            }
+            self = value
+        }
+
+        init?(rawValue: CInt) {
+            switch rawValue {
             case FTS_D:
                 self = .directoryPreOrder
             case FTS_DC:


### PR DESCRIPTION
### Motivation:

Internally, `FTSInfo` always casted up to `CInt` from `UInt16` but for some reason it only accepted `UInt16`. Let's add a `CInt` constructor too.

### Modifications:

- Make internal `FTSInfo` constructible from `CInt` and `UInt16`.

### Result:

- Slightly better platform compatibility
- Possibly fewer casts