### PR TITLE
Add helpers for reading length-prefixed things

### DIFF
--- a/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
+++ b/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
@@ -13,8 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 /// Describes a way to encode and decode an integer as bytes.
-/// For more information, see <doc:ByteBuffer-lengthPrefix>
 ///
+/// For more information, see <doc:ByteBuffer-lengthPrefix>
 public protocol NIOBinaryIntegerEncodingStrategy {
     /// Read an integer from a buffer.
     /// If there are not enough bytes to read an integer of this encoding, return nil, and do not move the reader index.
@@ -288,6 +288,7 @@ extension ByteBuffer {
 
 extension ByteBuffer {
     /// Reads a buffer which is prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create a buffer.
+    /// - Parameter strategy: The encoding strategy to use.
     /// - Returns: The buffer, if there are enough bytes to read it fully. In this case, the readerIndex will move to after the buffer.
     /// If there are not enough bytes to read the full buffer, the readerIndex will stay unchanged.
     @inlinable
@@ -304,6 +305,7 @@ extension ByteBuffer {
     }
 
     /// Reads a string which is prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create a string.
+    /// - Parameter strategy: The encoding strategy to use.
     /// - Returns: The string, if there are enough bytes to read it fully. In this case, the readerIndex will move to after the string.
     /// If there are not enough bytes to read the full string, the readerIndex will stay unchanged.
     @inlinable
@@ -320,6 +322,7 @@ extension ByteBuffer {
     }
 
     /// Reads bytes which are prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create an array of bytes.
+    /// - Parameter strategy: The encoding strategy to use.
     /// - Returns: The array of bytes, if there are enough bytes to read it fully. In this case, the readerIndex will move to after the bytes.
     /// If there are not enough bytes to read the full array of bytes, the readerIndex will stay unchanged.
     @inlinable

--- a/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
+++ b/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
@@ -284,6 +284,58 @@ extension ByteBuffer {
     }
 }
 
+// MARK: - Helpers for reading length-prefixed things
+
+extension ByteBuffer {
+    /// Reads a buffer which is prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create a buffer.
+    /// - Returns: The buffer, if there are enough bytes to read it fully. In this case, the readerIndex will move to after the buffer.
+    /// If there are not enough bytes to read the full buffer, the readerIndex will stay unchanged.
+    @inlinable
+    public mutating func readLengthPrefixedBuffer<Strategy: NIOBinaryIntegerEncodingStrategy>(
+        strategy: Strategy
+    ) -> ByteBuffer? {
+        let originalReaderIndex = self.readerIndex
+        guard let length = strategy.readInteger(as: Int.self, from: &self), let slice = self.readSlice(length: length)
+        else {
+            self.moveReaderIndex(to: originalReaderIndex)
+            return nil
+        }
+        return slice
+    }
+
+    /// Reads a string which is prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create a string.
+    /// - Returns: The string, if there are enough bytes to read it fully. In this case, the readerIndex will move to after the string.
+    /// If there are not enough bytes to read the full string, the readerIndex will stay unchanged.
+    @inlinable
+    public mutating func readLengthPrefixedString<Strategy: NIOBinaryIntegerEncodingStrategy>(
+        strategy: Strategy
+    ) -> String? {
+        let originalReaderIndex = self.readerIndex
+        guard let length = strategy.readInteger(as: Int.self, from: &self), let string = self.readString(length: length)
+        else {
+            self.moveReaderIndex(to: originalReaderIndex)
+            return nil
+        }
+        return string
+    }
+
+    /// Reads bytes which are prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create an array of bytes.
+    /// - Returns: The array of bytes, if there are enough bytes to read it fully. In this case, the readerIndex will move to after the bytes.
+    /// If there are not enough bytes to read the full array of bytes, the readerIndex will stay unchanged.
+    @inlinable
+    public mutating func readLengthPrefixedBytes<Strategy: NIOBinaryIntegerEncodingStrategy>(
+        strategy: Strategy
+    ) -> [UInt8]? {
+        let originalReaderIndex = self.readerIndex
+        guard let length = strategy.readInteger(as: Int.self, from: &self), let bytes = self.readBytes(length: length)
+        else {
+            self.moveReaderIndex(to: originalReaderIndex)
+            return nil
+        }
+        return bytes
+    }
+}
+
 extension ByteBuffer {
     /// Creates `requiredSpace` bytes of free space immediately before `index`.
     /// e.g. given [a, b, c, d, e, f, g, h, i, j] and calling this function with (before: 4, requiredSpace: 2) would result in

--- a/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
+++ b/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
@@ -288,23 +288,6 @@ extension ByteBuffer {
 // MARK: - Helpers for reading length-prefixed things
 
 extension ByteBuffer {
-    /// Reads a buffer which is prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create a buffer.
-    /// - Parameter strategy: The encoding strategy to use.
-    /// - Returns: The buffer, if there are enough bytes to read it fully. In this case, the readerIndex will move to after the buffer.
-    /// If there are not enough bytes to read the full buffer, the readerIndex will stay unchanged.
-    @inlinable
-    public mutating func readLengthPrefixedBuffer<Strategy: NIOBinaryIntegerEncodingStrategy>(
-        strategy: Strategy
-    ) -> ByteBuffer? {
-        let originalReaderIndex = self.readerIndex
-        guard let length = strategy.readInteger(as: Int.self, from: &self), let slice = self.readSlice(length: length)
-        else {
-            self.moveReaderIndex(to: originalReaderIndex)
-            return nil
-        }
-        return slice
-    }
-
     /// Reads a string which is prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create a string.
     /// - Parameter strategy: The encoding strategy to use.
     /// - Returns: The string, if there are enough bytes to read it fully. In this case, the readerIndex will move to after the string.

--- a/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
+++ b/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
@@ -191,6 +191,7 @@ extension ByteBuffer {
     }
 
     /// Reads a slice which is prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create a slice.
+    /// - Parameter strategy: The encoding strategy to use.
     /// - Returns: The slice, if there are enough bytes to read it fully. In this case, the readerIndex will move to after the slice.
     /// If there are not enough bytes to read the full slice, the readerIndex will stay unchanged.
     @inlinable

--- a/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
+++ b/Sources/NIOCore/ByteBuffer-binaryEncodedLengthPrefix.swift
@@ -296,13 +296,7 @@ extension ByteBuffer {
     public mutating func readLengthPrefixedString<Strategy: NIOBinaryIntegerEncodingStrategy>(
         strategy: Strategy
     ) -> String? {
-        let originalReaderIndex = self.readerIndex
-        guard let length = strategy.readInteger(as: Int.self, from: &self), let string = self.readString(length: length)
-        else {
-            self.moveReaderIndex(to: originalReaderIndex)
-            return nil
-        }
-        return string
+        self.readLengthPrefixedSlice(strategy: strategy).map { String(buffer: $0) }
     }
 
     /// Reads bytes which are prefixed with a length. The length will be read using `strategy`, and then that many bytes will be read to create an array of bytes.
@@ -313,13 +307,7 @@ extension ByteBuffer {
     public mutating func readLengthPrefixedBytes<Strategy: NIOBinaryIntegerEncodingStrategy>(
         strategy: Strategy
     ) -> [UInt8]? {
-        let originalReaderIndex = self.readerIndex
-        guard let length = strategy.readInteger(as: Int.self, from: &self), let bytes = self.readBytes(length: length)
-        else {
-            self.moveReaderIndex(to: originalReaderIndex)
-            return nil
-        }
-        return bytes
+        self.readLengthPrefixedSlice(strategy: strategy).map { Array(buffer: $0) }
     }
 }
 

--- a/Sources/NIOCore/Docs.docc/ByteBuffer-lengthPrefix.md
+++ b/Sources/NIOCore/Docs.docc/ByteBuffer-lengthPrefix.md
@@ -45,7 +45,7 @@ starting from after the integer.
 ```swift
 let bytes = myBuffer.readLengthPrefixedBytes(strategy: .quic)
 let string = myBuffer.readLengthPrefixedString(strategy: .quic)
-let buffer = myBuffer.readLengthPrefixedBuffer(strategy: .quic)
+let buffer = myBuffer.readLengthPrefixedSlice(strategy: .quic)
 ```
 
 Similarly, there are APIs which take data, write its length using the provided strategy, and then write the data itself.

--- a/Sources/NIOCore/Docs.docc/ByteBuffer-lengthPrefix.md
+++ b/Sources/NIOCore/Docs.docc/ByteBuffer-lengthPrefix.md
@@ -11,9 +11,9 @@ integer encodings, in which smaller numbers can be encoded in fewer bytes.
 We have added functions to help with reading and writing data which is prefixed with lengths encoded by various
 strategies.
 
-## ``NIOBinaryIntegerEncodingStrategy`` protocol
+## NIOBinaryIntegerEncodingStrategy protocol
 
-The first building block is a protocol which describes how to encode and decode an integer.
+The first building block is the ``NIOBinaryIntegerEncodingStrategy`` protocol which describes how to encode and decode an integer.
 
 An implementation of this protocol is needed for any encoding strategy. One example is the ``ByteBuffer/QUICBinaryEncodingStrategy``.
 
@@ -30,7 +30,7 @@ Note that implementations of this protocol need to either:
   reading. This is what QUIC does.
 - Always use the same length, e.g. a simple strategy which always writes the integer as a `UInt64`.
 
-## Extensions on ``ByteBuffer``
+## Extensions on ByteBuffer
 
 To provide a more user-friendly API, we have added extensions on `ByteBuffer` for writing integers with a
 chosen ``NIOBinaryIntegerEncodingStrategy``. These are ``ByteBuffer/writeEncodedInteger(_:strategy:)``
@@ -42,7 +42,19 @@ We added further APIs on ByteBuffer for reading data, strings and buffers which 
 APIs first read an integer using a chosen encoding strategy. The integer then dictates how many bytes of data are read
 starting from after the integer.
 
+```swift
+let bytes = myBuffer.readLengthPrefixedBytes(strategy: .quic)
+let string = myBuffer.readLengthPrefixedString(strategy: .quic)
+let buffer = myBuffer.readLengthPrefixedBuffer(strategy: .quic)
+```
+
 Similarly, there are APIs which take data, write its length using the provided strategy, and then write the data itself.
+
+```swift
+myBuffer.writeLengthPrefixedBytes([0x48, 0x65, 0x6c, 0x6c, 0x6f], strategy: .quic)
+myBuffer.writeLengthPrefixedString("Hello World", strategy: .quic)
+myBuffer.writeLengthPrefixedBuffer(ByteBuffer(...), strategy: .quic)
+```
 
 ## Writing complex data with a length-prefix
 

--- a/Tests/NIOCoreTests/ByteBufferBinaryEncodedLengthPrefixTests.swift
+++ b/Tests/NIOCoreTests/ByteBufferBinaryEncodedLengthPrefixTests.swift
@@ -329,4 +329,39 @@ final class ByteBufferBinaryEncodedLengthPrefixTests: XCTestCase {
         XCTAssertEqual(buffer.readBytes(length: 5), [4] + "test".utf8)
         XCTAssertTrue(buffer.readableBytesView.isEmpty)
     }
+
+    // MARK: - readLengthPrefixed* tests
+
+    func testReadLengthPrefixedString() {
+        let string = "Hello World"
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt8(string.utf8.count))  // length prefix
+        buffer.writeString(string)
+        let result = buffer.readLengthPrefixedString(
+            strategy: UInt8ReadingTestStrategy(expectedRead: UInt8(string.utf8.count))
+        )
+        XCTAssertEqual(result, string)
+    }
+
+    func testReadLengthPrefixedBytes() {
+        let bytes = [UInt8](repeating: 1, count: 10)
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt8(bytes.count))  // length prefix
+        buffer.writeBytes(bytes)
+        let result = buffer.readLengthPrefixedBytes(
+            strategy: UInt8ReadingTestStrategy(expectedRead: UInt8(bytes.count))
+        )
+        XCTAssertEqual(result, bytes)
+    }
+
+    func testReadLengthPrefixedBuffer() {
+        let string = "test"
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt8(string.utf8.count))  // length prefix
+        buffer.writeString(string)
+        let result = buffer.readLengthPrefixedBuffer(
+            strategy: UInt8ReadingTestStrategy(expectedRead: UInt8(string.utf8.count))
+        )
+        XCTAssertEqual(result, ByteBuffer(string: string))
+    }
 }

--- a/Tests/NIOCoreTests/ByteBufferBinaryEncodedLengthPrefixTests.swift
+++ b/Tests/NIOCoreTests/ByteBufferBinaryEncodedLengthPrefixTests.swift
@@ -353,15 +353,4 @@ final class ByteBufferBinaryEncodedLengthPrefixTests: XCTestCase {
         )
         XCTAssertEqual(result, bytes)
     }
-
-    func testReadLengthPrefixedBuffer() {
-        let string = "test"
-        var buffer = ByteBuffer()
-        buffer.writeInteger(UInt8(string.utf8.count))  // length prefix
-        buffer.writeString(string)
-        let result = buffer.readLengthPrefixedBuffer(
-            strategy: UInt8ReadingTestStrategy(expectedRead: UInt8(string.utf8.count))
-        )
-        XCTAssertEqual(result, ByteBuffer(string: string))
-    }
 }


### PR DESCRIPTION
Add missing helpers for reading length-prefixed strings and bytes with customizable encodings for the length.

### Motivation:

There are already some APIs for writing length-prefixed strings and bytes with a custom strategy for encoding the length, but there weren't helpers to read them.

### Modifications:

- Add missing helpers for reading length-prefixed strings and bytes with customizable encodings for the length
- Add tests for the new APIs 
- Fix DocC comments and improve the related article 

### Result:

New APIs are added for reading length-prefixed strings and bytes with a custom strategy for encoding the length.
