### PR TITLE
Deprecate Xcode version inputs in macos_tests.yml

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -64,83 +64,83 @@ on:
         default: ""
       xcode_16_3_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode version 16.3 jobs. Defaults to true."
-        default: true
+        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        default: false
       xcode_16_3_build_arguments_override:
         type: string
-        description: "The arguments passed to swift build in the Xcode version 16.3 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_16_3_test_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Xcode version 16.3 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_16_3_setup_command:
         type: string
-        description: "The command(s) to be executed before all other work."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_16_4_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode version 16.4 jobs. Defaults to true."
-        default: true
+        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        default: false
       xcode_16_4_build_arguments_override:
         type: string
-        description: "The arguments passed to swift build in the Xcode version 16.4 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_16_4_test_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Xcode version 16.4 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_16_4_setup_command:
         type: string
-        description: "The command(s) to be executed before all other work."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_0_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode version 26.0 jobs. Defaults to true."
-        default: true
+        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        default: false
       xcode_26_0_build_arguments_override:
         type: string
-        description: "The arguments passed to swift build in the Xcode version 26.0 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_0_test_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Xcode version 26.0 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_0_setup_command:
         type: string
-        description: "The command(s) to be executed before all other work."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_1_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode version 26.1 jobs. Defaults to true."
-        default: true
+        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        default: false
       xcode_26_1_build_arguments_override:
         type: string
-        description: "The arguments passed to swift build in the Xcode version 26.1 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_1_test_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Xcode version 26.1 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_1_setup_command:
         type: string
-        description: "The command(s) to be executed before all other work."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_2_enabled:
         type: boolean
-        description: "Boolean to enable the Xcode version 26.2 jobs. Defaults to true."
-        default: true
+        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        default: false
       xcode_26_2_build_arguments_override:
         type: string
-        description: "The arguments passed to swift build in the Xcode version 26.2 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_2_test_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Xcode version 26.2 job."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_2_setup_command:
         type: string
-        description: "The command(s) to be executed before all other work."
+        description: "⚠️ Deprecated."
         default: ""
       xcode_26_beta_enabled:
         type: boolean
@@ -177,8 +177,8 @@ on:
 
       swift_6_1_enabled:
         type: boolean
-        description: "Boolean to enable the Swift 6.1 jobs. Defaults to false."
-        default: false
+        description: "Boolean to enable the Swift 6.1 jobs. Defaults to true."
+        default: true
       swift_6_1_build_arguments_override:
         type: string
         description: "The arguments passed to swift build in the Swift 6.1 job."
@@ -193,8 +193,8 @@ on:
         default: ""
       swift_6_2_enabled:
         type: boolean
-        description: "Boolean to enable the Swift 6.2 jobs. Defaults to false."
-        default: false
+        description: "Boolean to enable the Swift 6.2 jobs. Defaults to true."
+        default: true
       swift_6_2_build_arguments_override:
         type: string
         description: "The arguments passed to swift build in the Swift 6.2 job."
@@ -209,8 +209,8 @@ on:
         default: ""
       swift_6_3_enabled:
         type: boolean
-        description: "Boolean to enable the Swift 6.3 jobs. Defaults to false."
-        default: false
+        description: "Boolean to enable the Swift 6.3 jobs. Defaults to true."
+        default: true
       swift_6_3_build_arguments_override:
         type: string
         description: "The arguments passed to swift build in the Swift 6.3 job."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,14 +84,6 @@ jobs:
       runner_pool: nightly
       build_scheme: swift-nio-Package
       debug_output_enabled: true
-      xcode_16_3_enabled: false
-      xcode_16_4_enabled: false
-      xcode_26_0_enabled: false
-      xcode_26_1_enabled: false
-      xcode_26_2_enabled: false
-      swift_6_1_enabled: true
-      swift_6_2_enabled: true
-      swift_6_3_enabled: true
       macos_xcode_test_enabled: false  # Disabled because of an issue
       ios_xcode_test_enabled: true
       watchos_xcode_test_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -90,14 +90,6 @@ jobs:
     with:
       runner_pool: general
       build_scheme: swift-nio-Package
-      xcode_16_3_enabled: false
-      xcode_16_4_enabled: false
-      xcode_26_0_enabled: false
-      xcode_26_1_enabled: false
-      xcode_26_2_enabled: false
-      swift_6_1_enabled: true
-      swift_6_2_enabled: true
-      swift_6_3_enabled: true
 
   static-sdk:
     name: Static Linux Swift SDK


### PR DESCRIPTION
### Motivation

* The `swift_*` inputs request Xcodes by Swift version with symlinks on
  the runners owning the mapping. This more directly expresses the
  library support window.
* All callers should migrate to `swift_6_1/6_2/6_3_enabled` instead of
  specifying Xcode versions directly.

### Modifications

* Default `xcode_16_3/16_4/26_0/26_1/26_2_enabled` to `false` and mark
  their descriptions as deprecated.
* Default `swift_6_1/6_2/6_3_enabled` to `true`.

### Result

* Repos still passing `xcode_*_enabled: true` explicitly continue to
  work until they migrate.