### PR TITLE
Remove defunct Xcode version inputs from `macos_tests.yml`

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -6,62 +6,6 @@ permissions:
 on:
   workflow_call:
     inputs:
-      xcode_15_4_enabled:
-        type: boolean
-        description: "⚠️ Jobs with this version of Xcode are deprecated."
-        default: false
-      xcode_15_4_test_arguments_override:
-        type: string
-        description: "⚠️ Deprecated."
-        default: ""
-      xcode_16_0_enabled:
-        type: boolean
-        description: "⚠️ Jobs with this version of Xcode are deprecated."
-        default: false
-      xcode_16_0_build_arguments_override:
-        type: string
-        description: "The arguments passed to swift build in the macOS 5.10 Swift version matrix job."
-        default: ""
-      xcode_16_0_test_arguments_override:
-        type: string
-        description: "The arguments passed to swift test in the macOS 5.10 Swift version matrix job."
-        default: ""
-      xcode_16_0_setup_command:
-        type: string
-        description: "The command(s) to be executed before all other work."
-        default: ""
-      xcode_16_1_enabled:
-        type: boolean
-        description: "⚠️ Jobs with this version of Xcode are deprecated."
-        default: false
-      xcode_16_1_build_arguments_override:
-        type: string
-        description: "The arguments passed to swift build in the Xcode version 16.1 job."
-        default: ""
-      xcode_16_1_test_arguments_override:
-        type: string
-        description: "The arguments passed to swift test in the Xcode version 16.1 job."
-        default: ""
-      xcode_16_1_setup_command:
-        type: string
-        description: "The command(s) to be executed before all other work."
-        default: ""
-      xcode_16_2_enabled:
-        type: boolean
-        description: "⚠️ Jobs with this version of Xcode are deprecated."
-        default: false
-      xcode_16_2_build_arguments_override:
-        type: string
-        description: "The arguments passed to swift build in the Xcode version 16.2 job."
-        default: ""
-      xcode_16_2_test_arguments_override:
-        type: string
-        description: "The arguments passed to swift test in the Xcode version 16.2 job."
-        default: ""
-      xcode_16_2_setup_command:
-        type: string
-        description: "The command(s) to be executed before all other work."
-        default: ""
       xcode_16_3_enabled:
         type: boolean
         description: "⚠️ Jobs with this version of Xcode are deprecated."
@@ -139,22 +83,6 @@ on:
         description: "⚠️ Deprecated."
         default: ""
       xcode_26_2_setup_command:
-        type: string
-        description: "⚠️ Deprecated."
-        default: ""
-      xcode_26_beta_enabled:
-        type: boolean
-        description: "⚠️ Deprecated."
-        default: false
-      xcode_26_beta_1_build_arguments_override:
-        type: string
-        description: "⚠️ Deprecated."
-        default: ""
-      xcode_26_beta_1_test_arguments_override:
-        type: string
-        description: "⚠️ Deprecated."
-        default: ""
-      xcode_26_beta_1_setup_command:
         type: string
         description: "⚠️ Deprecated."
         default: ""
@@ -312,22 +240,6 @@ jobs:
           cat >> "$GITHUB_OUTPUT" << EOM
           darwin-matrix=$(
             runner_pool="${MATRIX_RUNNER_POOL:="nightly"}"
-            xcode_15_4_enabled="${MATRIX_MACOS_15_4_ENABLED:=true}"
-            xcode_15_4_build_arguments_override="${MATRIX_MACOS_15_4_BUILD_ARGUMENTS_OVERRIDE:=""}"
-            xcode_15_4_test_arguments_override="${MATRIX_MACOS_15_4_TEST_ARGUMENTS_OVERRIDE:=""}"
-            xcode_15_4_setup_command="${MATRIX_MACOS_15_4_SETUP_COMMAND:=""}"
-            xcode_16_0_enabled="${MATRIX_MACOS_16_0_ENABLED:=true}"
-            xcode_16_0_build_arguments_override="${MATRIX_MACOS_16_0_BUILD_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_0_test_arguments_override="${MATRIX_MACOS_16_0_TEST_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_0_setup_command="${MATRIX_MACOS_16_0_SETUP_COMMAND:=""}"
-            xcode_16_1_enabled="${MATRIX_MACOS_16_1_ENABLED:=true}"
-            xcode_16_1_build_arguments_override="${MATRIX_MACOS_16_1_BUILD_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_1_test_arguments_override="${MATRIX_MACOS_16_1_TEST_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_1_setup_command="${MATRIX_MACOS_16_1_SETUP_COMMAND:=""}"
-            xcode_16_2_enabled="${MATRIX_MACOS_16_2_ENABLED:=true}"
-            xcode_16_2_build_arguments_override="${MATRIX_MACOS_16_2_BUILD_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_2_test_arguments_override="${MATRIX_MACOS_16_2_TEST_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_2_setup_command="${MATRIX_MACOS_16_2_SETUP_COMMAND:=""}"
             xcode_16_3_enabled="${MATRIX_MACOS_16_3_ENABLED:=true}"
             xcode_16_3_build_arguments_override="${MATRIX_MACOS_16_3_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_16_3_test_arguments_override="${MATRIX_MACOS_16_3_TEST_ARGUMENTS_OVERRIDE:=""}"
@@ -348,10 +260,6 @@ jobs:
             xcode_26_2_build_arguments_override="${MATRIX_MACOS_26_2_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_26_2_test_arguments_override="${MATRIX_MACOS_26_2_TEST_ARGUMENTS_OVERRIDE:=""}"
             xcode_26_2_setup_command="${MATRIX_MACOS_26_2_SETUP_COMMAND:=""}"
-            xcode_latest_beta_enabled="${MATRIX_MACOS_26_BETA_1_ENABLED:=true}" # TODO: remove once no repos use this
-            xcode_latest_beta_build_arguments_override="${MATRIX_MACOS_26_BETA_1_BUILD_ARGUMENTS_OVERRIDE:=""}" # TODO: remove once no repos use this
-            xcode_latest_beta_test_arguments_override="${MATRIX_MACOS_26_BETA_1_TEST_ARGUMENTS_OVERRIDE:=""}" # TODO: remove once no repos use this
-            xcode_latest_beta_setup_command="${MATRIX_MACOS_26_BETA_1_SETUP_COMMAND:=""}" # TODO: remove once no repos use this
             xcode_latest_beta_enabled="${MATRIX_MACOS_LATEST_BETA_ENABLED:=true}"
             xcode_latest_beta_build_arguments_override="${MATRIX_MACOS_LATEST_BETA_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_latest_beta_test_arguments_override="${MATRIX_MACOS_LATEST_BETA_TEST_ARGUMENTS_OVERRIDE:=""}"
@@ -371,46 +279,6 @@ jobs:
 
             # Create matrix from inputs
             matrix='{"config": []}'
-
-            if [[ "$xcode_15_4_enabled" == "true" ]]; then
-                matrix=$(echo "$matrix" | jq -c \
-                --arg setup_command "$xcode_15_4_setup_command"  \
-                --arg build_arguments_override "$xcode_15_4_build_arguments_override"  \
-                --arg test_arguments_override "$xcode_15_4_test_arguments_override"  \
-                --arg runner_pool "$runner_pool"  \
-                --argjson env_vars "$env_vars_json" \
-                '.config[.config| length] |= . + { "name": "Xcode 15.4", "xcode_version": "15.4", "xcode_app": "Xcode_15.4.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
-            fi
-
-            if [[ "$xcode_16_0_enabled" == "true" ]]; then
-                matrix=$(echo "$matrix" | jq -c \
-                --arg setup_command "$xcode_16_0_setup_command"  \
-                --arg build_arguments_override "$xcode_16_0_build_arguments_override"  \
-                --arg test_arguments_override "$xcode_16_0_test_arguments_override"  \
-                --arg runner_pool "$runner_pool"  \
-                --argjson env_vars "$env_vars_json" \
-                '.config[.config| length] |= . + { "name": "Xcode 16.0", "xcode_version": "16.0", "xcode_app": "Xcode_16.0.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
-            fi
-
-            if [[ "$xcode_16_1_enabled" == "true" ]]; then
-                matrix=$(echo "$matrix" | jq -c \
-                --arg setup_command "$xcode_16_1_setup_command"  \
-                --arg build_arguments_override "$xcode_16_1_build_arguments_override"  \
-                --arg test_arguments_override "$xcode_16_1_test_arguments_override"  \
-                --arg runner_pool "$runner_pool"  \
-                --argjson env_vars "$env_vars_json" \
-                '.config[.config| length] |= . + { "name": "Xcode 16.1", "xcode_version": "16.1", "xcode_app": "Xcode_16.1.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
-            fi
-
-            if [[ "$xcode_16_2_enabled" == "true" ]]; then
-                matrix=$(echo "$matrix" | jq -c \
-                --arg setup_command "$xcode_16_2_setup_command"  \
-                --arg build_arguments_override "$xcode_16_2_build_arguments_override"  \
-                --arg test_arguments_override "$xcode_16_2_test_arguments_override"  \
-                --arg runner_pool "$runner_pool"  \
-                --argjson env_vars "$env_vars_json" \
-                '.config[.config| length] |= . + { "name": "Xcode 16.2", "xcode_version": "16.2", "xcode_app": "Xcode_16.2.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
-            fi
 
             if [[ "$xcode_16_3_enabled" == "true" ]]; then
                 matrix=$(echo "$matrix" | jq -c \
@@ -508,22 +376,6 @@ jobs:
         env:
           INPUT_ENV_VARS: ${{ inputs.env_vars }}
           MATRIX_RUNNER_POOL: ${{ inputs.runner_pool }}
-          MATRIX_MACOS_15_4_ENABLED: ${{ inputs.xcode_15_4_enabled }}
-          MATRIX_MACOS_15_4_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_15_4_build_arguments_override }}
-          MATRIX_MACOS_15_4_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_15_4_test_arguments_override }}
-          MATRIX_MACOS_15_4_SETUP_COMMAND: ${{ inputs.xcode_15_4_setup_command }}
-          MATRIX_MACOS_16_0_ENABLED: ${{ inputs.xcode_16_0_enabled }}
-          MATRIX_MACOS_16_0_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_0_build_arguments_override }}
-          MATRIX_MACOS_16_0_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_0_test_arguments_override }}
-          MATRIX_MACOS_16_0_SETUP_COMMAND: ${{ inputs.xcode_16_0_setup_command }}
-          MATRIX_MACOS_16_1_ENABLED: ${{ inputs.xcode_16_1_enabled }}
-          MATRIX_MACOS_16_1_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_1_build_arguments_override }}
-          MATRIX_MACOS_16_1_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_1_test_arguments_override }}
-          MATRIX_MACOS_16_1_SETUP_COMMAND: ${{ inputs.xcode_16_1_setup_command }}
-          MATRIX_MACOS_16_2_ENABLED: ${{ inputs.xcode_16_2_enabled }}
-          MATRIX_MACOS_16_2_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_2_build_arguments_override }}
-          MATRIX_MACOS_16_2_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_2_test_arguments_override }}
-          MATRIX_MACOS_16_2_SETUP_COMMAND: ${{ inputs.xcode_16_2_setup_command }}
           MATRIX_MACOS_16_3_ENABLED: ${{ inputs.xcode_16_3_enabled }}
           MATRIX_MACOS_16_3_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_3_build_arguments_override }}
           MATRIX_MACOS_16_3_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_3_test_arguments_override }}
@@ -544,10 +396,6 @@ jobs:
           MATRIX_MACOS_26_2_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_2_build_arguments_override }}
           MATRIX_MACOS_26_2_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_2_test_arguments_override }}
           MATRIX_MACOS_26_2_SETUP_COMMAND: ${{ inputs.xcode_26_2_setup_command }}
-          MATRIX_MACOS_26_BETA_1_ENABLED: ${{ inputs.xcode_26_beta_1_enabled }}
-          MATRIX_MACOS_26_BETA_1_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_beta_1_build_arguments_override }}
-          MATRIX_MACOS_26_BETA_1_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_beta_1_test_arguments_override }}
-          MATRIX_MACOS_26_BETA_1_SETUP_COMMAND: ${{ inputs.xcode_26_beta_1_setup_command }}
           MATRIX_MACOS_LATEST_BETA_ENABLED: ${{ inputs.xcode_latest_beta_enabled }}
           MATRIX_MACOS_LATEST_BETA_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_latest_beta_build_arguments_override }}
           MATRIX_MACOS_LATEST_BETA_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_latest_beta_test_arguments_override }}

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -8,67 +8,67 @@ on:
     inputs:
       xcode_16_3_enabled:
         type: boolean
-        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        description: "⚠️ Deprecated, has no effect. This Xcode version is no longer installed on the runners."
         default: false
       xcode_16_3_build_arguments_override:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_16_3_test_arguments_override:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_16_3_setup_command:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_16_4_enabled:
         type: boolean
-        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        description: "⚠️ Deprecated, has no effect. This Xcode version is no longer installed on the runners."
         default: false
       xcode_16_4_build_arguments_override:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_16_4_test_arguments_override:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_16_4_setup_command:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_26_0_enabled:
         type: boolean
-        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        description: "⚠️ Deprecated, has no effect. This Xcode version is no longer installed on the runners."
         default: false
       xcode_26_0_build_arguments_override:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_26_0_test_arguments_override:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_26_0_setup_command:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_26_1_enabled:
         type: boolean
-        description: "⚠️ Jobs with this version of Xcode are deprecated."
+        description: "⚠️ Deprecated, has no effect. This Xcode version is no longer installed on the runners."
         default: false
       xcode_26_1_build_arguments_override:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_26_1_test_arguments_override:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_26_1_setup_command:
         type: string
-        description: "⚠️ Deprecated."
+        description: "⚠️ Deprecated, has no effect."
         default: ""
       xcode_26_2_enabled:
         type: boolean
@@ -240,22 +240,6 @@ jobs:
           cat >> "$GITHUB_OUTPUT" << EOM
           darwin-matrix=$(
             runner_pool="${MATRIX_RUNNER_POOL:="nightly"}"
-            xcode_16_3_enabled="${MATRIX_MACOS_16_3_ENABLED:=true}"
-            xcode_16_3_build_arguments_override="${MATRIX_MACOS_16_3_BUILD_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_3_test_arguments_override="${MATRIX_MACOS_16_3_TEST_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_3_setup_command="${MATRIX_MACOS_16_3_SETUP_COMMAND:=""}"
-            xcode_16_4_enabled="${MATRIX_MACOS_16_4_ENABLED:=true}"
-            xcode_16_4_build_arguments_override="${MATRIX_MACOS_16_4_BUILD_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_4_test_arguments_override="${MATRIX_MACOS_16_4_TEST_ARGUMENTS_OVERRIDE:=""}"
-            xcode_16_4_setup_command="${MATRIX_MACOS_16_4_SETUP_COMMAND:=""}"
-            xcode_26_0_enabled="${MATRIX_MACOS_26_0_ENABLED:=true}"
-            xcode_26_0_build_arguments_override="${MATRIX_MACOS_26_0_BUILD_ARGUMENTS_OVERRIDE:=""}"
-            xcode_26_0_test_arguments_override="${MATRIX_MACOS_26_0_TEST_ARGUMENTS_OVERRIDE:=""}"
-            xcode_26_0_setup_command="${MATRIX_MACOS_26_0_SETUP_COMMAND:=""}"
-            xcode_26_1_enabled="${MATRIX_MACOS_26_1_ENABLED:=true}"
-            xcode_26_1_build_arguments_override="${MATRIX_MACOS_26_1_BUILD_ARGUMENTS_OVERRIDE:=""}"
-            xcode_26_1_test_arguments_override="${MATRIX_MACOS_26_1_TEST_ARGUMENTS_OVERRIDE:=""}"
-            xcode_26_1_setup_command="${MATRIX_MACOS_26_1_SETUP_COMMAND:=""}"
             xcode_26_2_enabled="${MATRIX_MACOS_26_2_ENABLED:=true}"
             xcode_26_2_build_arguments_override="${MATRIX_MACOS_26_2_BUILD_ARGUMENTS_OVERRIDE:=""}"
             xcode_26_2_test_arguments_override="${MATRIX_MACOS_26_2_TEST_ARGUMENTS_OVERRIDE:=""}"
@@ -279,46 +263,6 @@ jobs:
 
             # Create matrix from inputs
             matrix='{"config": []}'
-
-            if [[ "$xcode_16_3_enabled" == "true" ]]; then
-                matrix=$(echo "$matrix" | jq -c \
-                --arg setup_command "$xcode_16_3_setup_command"  \
-                --arg build_arguments_override "$xcode_16_3_build_arguments_override"  \
-                --arg test_arguments_override "$xcode_16_3_test_arguments_override"  \
-                --arg runner_pool "$runner_pool"  \
-                --argjson env_vars "$env_vars_json" \
-                '.config[.config| length] |= . + { "name": "Xcode 16.3", "xcode_version": "16.3", "xcode_app": "Xcode_16.3.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
-            fi
-
-            if [[ "$xcode_16_4_enabled" == "true" ]]; then
-                matrix=$(echo "$matrix" | jq -c \
-                --arg setup_command "$xcode_16_4_setup_command"  \
-                --arg build_arguments_override "$xcode_16_4_build_arguments_override"  \
-                --arg test_arguments_override "$xcode_16_4_test_arguments_override"  \
-                --arg runner_pool "$runner_pool"  \
-                --argjson env_vars "$env_vars_json" \
-                '.config[.config| length] |= . + { "name": "Xcode 16.4", "xcode_version": "16.4", "xcode_app": "Xcode_16.4.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
-            fi
-
-            if [[ "$xcode_26_0_enabled" == "true" ]]; then
-                matrix=$(echo "$matrix" | jq -c \
-                --arg setup_command "$xcode_26_0_setup_command"  \
-                --arg build_arguments_override "$xcode_26_0_build_arguments_override"  \
-                --arg test_arguments_override "$xcode_26_0_test_arguments_override"  \
-                --arg runner_pool "$runner_pool"  \
-                --argjson env_vars "$env_vars_json" \
-                '.config[.config| length] |= . + { "name": "Xcode 26.0", "xcode_version": "26.0", "xcode_app": "Xcode_26.0.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
-            fi
-
-            if [[ "$xcode_26_1_enabled" == "true" ]]; then
-                matrix=$(echo "$matrix" | jq -c \
-                --arg setup_command "$xcode_26_1_setup_command"  \
-                --arg build_arguments_override "$xcode_26_1_build_arguments_override"  \
-                --arg test_arguments_override "$xcode_26_1_test_arguments_override"  \
-                --arg runner_pool "$runner_pool"  \
-                --argjson env_vars "$env_vars_json" \
-                '.config[.config| length] |= . + { "name": "Xcode 26.1", "xcode_version": "26.1", "xcode_app": "Xcode_26.1.app", "setup_command": $setup_command, "build_arguments_override": $build_arguments_override, "test_arguments_override": $test_arguments_override, "os": "tahoe", "arch": "ARM64", "pool": $runner_pool, "env": $env_vars }')
-            fi
 
             if [[ "$xcode_26_2_enabled" == "true" ]]; then
                 matrix=$(echo "$matrix" | jq -c \
@@ -376,22 +320,6 @@ jobs:
         env:
           INPUT_ENV_VARS: ${{ inputs.env_vars }}
           MATRIX_RUNNER_POOL: ${{ inputs.runner_pool }}
-          MATRIX_MACOS_16_3_ENABLED: ${{ inputs.xcode_16_3_enabled }}
-          MATRIX_MACOS_16_3_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_3_build_arguments_override }}
-          MATRIX_MACOS_16_3_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_3_test_arguments_override }}
-          MATRIX_MACOS_16_3_SETUP_COMMAND: ${{ inputs.xcode_16_3_setup_command }}
-          MATRIX_MACOS_16_4_ENABLED: ${{ inputs.xcode_16_4_enabled }}
-          MATRIX_MACOS_16_4_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_4_build_arguments_override }}
-          MATRIX_MACOS_16_4_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_16_4_test_arguments_override }}
-          MATRIX_MACOS_16_4_SETUP_COMMAND: ${{ inputs.xcode_16_4_setup_command }}
-          MATRIX_MACOS_26_0_ENABLED: ${{ inputs.xcode_26_0_enabled }}
-          MATRIX_MACOS_26_0_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_0_build_arguments_override }}
-          MATRIX_MACOS_26_0_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_0_test_arguments_override }}
-          MATRIX_MACOS_26_0_SETUP_COMMAND: ${{ inputs.xcode_26_0_setup_command }}
-          MATRIX_MACOS_26_1_ENABLED: ${{ inputs.xcode_26_1_enabled }}
-          MATRIX_MACOS_26_1_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_1_build_arguments_override }}
-          MATRIX_MACOS_26_1_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_1_test_arguments_override }}
-          MATRIX_MACOS_26_1_SETUP_COMMAND: ${{ inputs.xcode_26_1_setup_command }}
           MATRIX_MACOS_26_2_ENABLED: ${{ inputs.xcode_26_2_enabled }}
           MATRIX_MACOS_26_2_BUILD_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_2_build_arguments_override }}
           MATRIX_MACOS_26_2_TEST_ARGUMENTS_OVERRIDE: ${{ inputs.xcode_26_2_test_arguments_override }}


### PR DESCRIPTION
  ### Motivation

  * Xcode 15.4, 16.0, 16.1, 16.2, and 26 beta were already deprecated
    and defaulted to `false` with no callers enabling them — redundant code.
  * Xcode 16.3, 16.4, 26.0, and 26.1 will soon be uninstalled from the
    runners. Their inputs are kept so downstream callers don't break, but
    they should no longer produce any matrix entries.

  ### Modifications

  * Remove input declarations, shell variables, matrix construction
    blocks, and environment variable mappings for 15.4/16.0/16.1/16.2/26
    beta entirely.
  * Remove the matrix logic for 16.3/16.4/26.0/26.1 but retain the input
    declarations as no-ops, with descriptions communicating they have no
    effect.

  ### Result

  * Less dead code in the shared workflow.
  * Callers still passing `xcode_16_3` through `xcode_26_1` inputs get no
    error but also no job — a graceful no-op while they migrate to
    `swift_*` inputs.