### PR TITLE
 Allow concurrent createDirectory calls with shared ancestor paths

### DIFF
--- a/Sources/NIOFS/FileSystem.swift
+++ b/Sources/NIOFS/FileSystem.swift
@@ -929,6 +929,23 @@ extension FileSystem {
             case .success:
                 continue
             case let .failure(errno):
+                // Gracefully handle concurrent _createDirectory() calls on file paths with shared
+                // ancestors like /foo/bar/dir1 and /foo/bar/dir2.
+                if errno == .fileExists {
+                    switch self._info(forFileAt: path, infoAboutSymbolicLink: false) {
+                    case .success(let maybeInfo):
+                        if let info = maybeInfo, info.type == .directory {
+                            // Another task beat us to creating this ancestor; that's fine.
+                            continue
+                        } else {
+                            // A non-directory exists at this path.
+                            return .failure(.mkdir(errno: errno, path: path, location: .here()))
+                        }
+                    case .failure:
+                        // Unable to determine what exists at this path.
+                        return .failure(.mkdir(errno: errno, path: path, location: .here()))
+                    }
+                }
                 return .failure(.mkdir(errno: errno, path: path, location: .here()))
             }
         }

--- a/Sources/_NIOFileSystem/FileSystem.swift
+++ b/Sources/_NIOFileSystem/FileSystem.swift
@@ -933,6 +933,23 @@ extension FileSystem {
             case .success:
                 continue
             case let .failure(errno):
+                // Gracefully handle concurrent _createDirectory() calls on file paths with shared
+                // ancestors like /foo/bar/dir1 and /foo/bar/dir2.
+                if errno == .fileExists {
+                    switch self._info(forFileAt: path, infoAboutSymbolicLink: false) {
+                    case let .success(maybeInfo):
+                        if let info = maybeInfo, info.type == .directory {
+                            // Another task beat us to creating this ancestor; that's fine.
+                            continue
+                        } else {
+                            // A non-directory exists at this path.
+                            return .failure(.mkdir(errno: errno, path: path, location: .here()))
+                        }
+                    case .failure:
+                        // Unable to determine what exists at this path.
+                        return .failure(.mkdir(errno: errno, path: path, location: .here()))
+                    }
+                }
                 return .failure(.mkdir(errno: errno, path: path, location: .here()))
             }
         }

--- a/Tests/NIOFSIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileSystemTests.swift
@@ -480,6 +480,28 @@ final class FileSystemTests: XCTestCase {
         }
     }
 
+    func testCreateDirectoryWithIntermediatePathsConcurrently() async throws {
+        // Two paths sharing a common ancestor created concurrently; both should succeed
+        // even if one task races to create the shared ancestor first.
+        let base = try await self.fs.temporaryFilePath()
+        let path1 = NIOFilePath(base.underlying.appending("shared-ancestor").appending("child1"))
+        let path2 = NIOFilePath(base.underlying.appending("shared-ancestor").appending("child2"))
+
+        let fs = self.fs
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await fs.createDirectory(at: path1, withIntermediateDirectories: true) }
+            group.addTask { try await fs.createDirectory(at: path2, withIntermediateDirectories: true) }
+            try await group.waitForAll()
+        }
+
+        for path in [path1, path2] {
+            try await self.fs.withDirectoryHandle(atPath: path) { dir in
+                let info = try await dir.info()
+                XCTAssertEqual(info.type, .directory)
+            }
+        }
+    }
+
     func testCreateDirectoryAtPathWhichExists() async throws {
         let path = try await self.fs.temporaryFilePath()
         try await self.fs.withFileHandle(


### PR DESCRIPTION
Allow concurrent calls of `_createDirectory()` for file paths with shared ancestors.

### Motivation:

The current implementation of `_createDirectory(withIntermediateDirectories: true)`  does not catch and continue during execution when the intermediate directory path it is trying to create already exists. 

The current loop looks like this: 

```swift
 // Successfully made a directory, construct its children.
        while let subdirectory = droppedComponents.popLast() {
            path.append(subdirectory)
            switch Syscall.mkdir(at: path, permissions: permissions) {
            case .success:
                continue
            case let .failure(errno):
                return .failure(.mkdir(errno: errno, path: path, location: .here()))
            }
        }
```
If we are concurrently trying to create directories `/foo/bar/dir1` and `foo/bar/dir2`, we can fail with an error like `directory /foo already exists` because one of the two task's `mkdir` syscall on line 928 errored with a `fileExists` error. 
 
### Modifications:

The code adds the same logic already present on lines 894-907 of `FileSystem.swift` to the failure case while iterating over the subdirectory paths: 

If the syscall errors because the directory already exists, (but didn't exist during the loop on lines 886-923), we can safely continue. Another task must have beaten our task to creating the directory, but that is ok. 

### Result:

Without this change, it would be difficult to actually call the `FileSystem.createDirectory(withIntermediateDirectories: true)` function in concurrent tasks, because if you were creating directories with common ancestors, at least one of the 2 tasks would error due to the race condition on directory creation. With this change, the `createDirectory()` function can now be called concurrently without this race issue potentially causing an error. I added the change to both the `NIOFS` and `_NIOFileSystem` directories since they seem to be copies of each other. 