### PR TITLE
Fix doubled 'the' in NIOAsyncChannel upgrade docs

### DIFF
--- a/Sources/NIOCore/Docs.docc/swift-concurrency.md
+++ b/Sources/NIOCore/Docs.docc/swift-concurrency.md
@@ -282,7 +282,7 @@ let upgradeResult: EventLoopFuture<UpgradeResult> = try await ClientBootstrap(gr
 ```
 
 After having configured the pipeline to negotiate a websocket upgrade. We can
-switch over the the `upgradeResult`. Importantly, we have to `await` the
+switch over the `upgradeResult`. Importantly, we have to `await` the
 `upgradeResult` first since it has to be negotiated on the connection.
 
 ```


### PR DESCRIPTION
## Summary

Trivial typo fix in the Swift Concurrency user-facing documentation.

In [`Sources/NIOCore/Docs.docc/swift-concurrency.md`](https://github.com/apple/swift-nio/blob/main/Sources/NIOCore/Docs.docc/swift-concurrency.md), the NIOAsyncChannel websocket-upgrade walkthrough reads:

> switch over the the `upgradeResult`. Importantly, we have to `await` the

Drops the duplicate "the".

## Test plan

- [x] `grep -rEn '\b(the the|of of|in in|and and|that that|is is|to to)\b' --include='*.swift' --include='*.md' Sources` — exit 1 after the fix (was the only hit before).

## Scope

One-character change in one Markdown file. No code, no behavior, no API.