### PR TITLE
Fix readInlineArray reading from the wrong index when readerIndex is non-zero

### DIFF
--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -76,13 +76,16 @@ extension ByteBuffer {
             return nil
         }
 
+        let readerIndex = self.readerIndex
         let inlineArray = InlineArray<count, IntegerType> { (outputSpan: inout OutputSpan<IntegerType>) in
             for index in 0..<count {
-                // already made sure of 'self.readableBytes >= bytesRequired' above,
-                // so this is safe to force-unwrap as it's guaranteed to exist
+                // 'getInteger(at:)' takes an absolute index into the buffer, so we offset from
+                // the reader index. We already made sure of 'self.readableBytes >= bytesRequired'
+                // above, so this is safe to force-unwrap as it's guaranteed to exist.
                 let integer = self.getInteger(
-                    // this is less than 'bytesRequired' so is safe to multiply
-                    at: stride &* index,
+                    // 'stride &* index' is less than 'bytesRequired' so is safe to multiply, and
+                    // adding the reader index can't overflow because it stays within the writer index.
+                    at: readerIndex &+ (stride &* index),
                     endianness: endianness,
                     as: IntegerType.self
                 )!

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -4553,5 +4553,31 @@ extension ByteBufferTest {
         XCTAssertEqual(written, self.buf.readableBytes)
         XCTAssertEqual(0, self.buf.readerIndex)
     }
+
+    func testReadInlineArrayWithNonZeroReaderIndex() throws {
+        guard #available(macOS 26, iOS 26, tvOS 26, watchOS 26, visionOS 26, *) else {
+            throw XCTSkip("Span methods only available on 26 OSes")
+        }
+        // Write a prefix that we read off first so that the reader index is no
+        // longer zero before reading the `InlineArray`.
+        let prefix: [UInt8] = [0xaa, 0xbb, 0xcc]
+        let payload = (0..<10).map { _ in UInt8.random(in: .min ... .max) }
+        self.buf.writeBytes(prefix)
+        self.buf.writeBytes(payload)
+
+        XCTAssertEqual(prefix, self.buf.readBytes(length: prefix.count))
+        XCTAssertEqual(prefix.count, self.buf.readerIndex)
+        XCTAssertEqual(payload.count, self.buf.readableBytes)
+
+        let result = try XCTUnwrap(
+            self.buf.readInlineArray(as: InlineArray<10, UInt8>.self)
+        )
+        XCTAssertEqual(10, result.count)
+        for idx in result.indices {
+            XCTAssertEqual(payload[idx], result[idx])
+        }
+        XCTAssertEqual(0, self.buf.readableBytes)
+        XCTAssertEqual(prefix.count + payload.count, self.buf.readerIndex)
+    }
 }
 #endif


### PR DESCRIPTION
ByteBuffer.readInlineArray reads each element through getInteger(at:). The index parameter of getInteger(at:) is an absolute index into the buffer, the same one readInteger passes self.readerIndex into. The loop in readInlineArray instead passed stride * index, which starts at zero and never accounts for the reader index.

As long as the buffer has a reader index of zero this absolute index lines up with the bytes the caller expects, which is why the current tests pass: they all read from a freshly written buffer. On any buffer whose reader index has already moved (the normal case once some bytes have been consumed, for example reading a length prefix before the array), getInteger(at:) is given an index below the reader index. rangeWithinReadableBytes rejects it, getInteger returns nil, and the force-unwrap on the result traps. So a public read API crashes the process on entirely valid input.

The fix snapshots the reader index before building the array and offsets each element index by it, so getInteger(at:) gets the correct absolute index. The multiplication stays bounded by bytesRequired as before, and adding the reader index cannot overflow because the result stays within the writer index.

I added a regression test that writes a short prefix, reads it off so the reader index is non-zero, then reads an InlineArray and checks both the element values and the resulting reader index. It traps before this change and passes after it. The three existing InlineArray tests, the full ByteBufferTest suite (275 tests), and ByteBufferSpanTests all still pass.

Reopening the change from #3604, which I closed inadvertently. The original branch and fork were deleted, so this is a fresh PR with the identical commit.
