### PR TITLE
Add get/setMultipleIntegers on ByteBuffer

### DIFF
--- a/Sources/NIOCore/ByteBuffer-multi-int.swift
+++ b/Sources/NIOCore/ByteBuffer-multi-int.swift
@@ -17,59 +17,25 @@
 extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
-        endianness: Endianness = .big,
-        as: (T1, T2).Type = (T1, T2).self
-    ) -> (T1, T2)? {
-        var bytesRequired: Int = MemoryLayout<T1>.size
-        bytesRequired &+= MemoryLayout<T2>.size
-
-        guard self.readableBytes >= bytesRequired else {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> (T1, T2)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2))
-        case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2))
-        }
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
-        endianness: Endianness = .big,
-        as: (T1, T2).Type = (T1, T2).self
-    ) -> (T1, T2)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> (T1, T2)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2).Type = (T1, T2).self
-    ) -> (T1, T2)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> (T1, T2)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
 
@@ -82,7 +48,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -104,49 +70,16 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
-        _ value1: T1,
-        _ value2: T2,
-        endianness: Endianness = .big,
-        as: (T1, T2).Type = (T1, T2).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(_ value1: T1, _ value2: T2, endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
-        _ value1: T1,
-        _ value2: T2,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2).Type = (T1, T2).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(_ value1: T1, _ value2: T2, at index: Int, endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> Int {
         var v1: T1
         var v2: T2
         switch endianness {
@@ -169,65 +102,26 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3).Type = (T1, T2, T3).self
-    ) -> (T1, T2, T3)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> (T1, T2, T3)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3))
-        case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3))
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3).Type = (T1, T2, T3).self
-    ) -> (T1, T2, T3)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> (T1, T2, T3)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3).Type = (T1, T2, T3).self
-    ) -> (T1, T2, T3)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> (T1, T2, T3)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -242,7 +136,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -268,57 +162,16 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3).Type = (T1, T2, T3).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3).Type = (T1, T2, T3).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -346,80 +199,27 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger
-    >(endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
         bytesRequired &+= MemoryLayout<T4>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4))
-        case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4))
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger
-    >(endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self
-    ) -> (T1, T2, T3, T4)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -436,7 +236,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -466,75 +266,16 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -567,94 +308,28 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger
-    >(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)?
-    {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
         bytesRequired &+= MemoryLayout<T4>.size
         bytesRequired &+= MemoryLayout<T5>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5))
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger
-    >(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)?
-    {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self
-    ) -> (T1, T2, T3, T4, T5)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -673,7 +348,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -700,95 +375,23 @@ extension ByteBuffer {
         case .big:
             return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -826,110 +429,29 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
-    ) -> (T1, T2, T3, T4, T5, T6)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> (T1, T2, T3, T4, T5, T6)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
         bytesRequired &+= MemoryLayout<T4>.size
         bytesRequired &+= MemoryLayout<T5>.size
         bytesRequired &+= MemoryLayout<T6>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
-    ) -> (T1, T2, T3, T4, T5, T6)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> (T1, T2, T3, T4, T5, T6)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
-    ) -> (T1, T2, T3, T4, T5, T6)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> (T1, T2, T3, T4, T5, T6)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -950,7 +472,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -979,110 +501,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -1125,18 +562,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> (T1, T2, T3, T4, T5, T6, T7)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1144,100 +573,19 @@ extension ByteBuffer {
         bytesRequired &+= MemoryLayout<T5>.size
         bytesRequired &+= MemoryLayout<T6>.size
         bytesRequired &+= MemoryLayout<T7>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var v7: T7 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            withUnsafeMutableBytes(of: &v7) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
-            }
-            offset = offset &+ MemoryLayout<T7>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> (T1, T2, T3, T4, T5, T6, T7)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> (T1, T2, T3, T4, T5, T6, T7)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1260,7 +608,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -1293,120 +641,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        var v7: T7
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-            v7 = value7.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-            v7 = value7.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-        spaceNeeded &+= MemoryLayout<T7>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            (basePtr + offset).copyMemory(from: &v7, byteCount: MemoryLayout<T7>.size)
-            offset = offset &+ MemoryLayout<T7>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -1454,19 +707,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1475,107 +719,19 @@ extension ByteBuffer {
         bytesRequired &+= MemoryLayout<T6>.size
         bytesRequired &+= MemoryLayout<T7>.size
         bytesRequired &+= MemoryLayout<T8>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var v7: T7 = 0
-        var v8: T8 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            withUnsafeMutableBytes(of: &v7) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
-            }
-            offset = offset &+ MemoryLayout<T7>.size
-            withUnsafeMutableBytes(of: &v8) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
-            }
-            offset = offset &+ MemoryLayout<T8>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1600,7 +756,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -1637,130 +793,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        var v7: T7
-        var v8: T8
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-            v7 = value7.bigEndian
-            v8 = value8.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-            v7 = value7.littleEndian
-            v8 = value8.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-        spaceNeeded &+= MemoryLayout<T7>.size
-        spaceNeeded &+= MemoryLayout<T8>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            (basePtr + offset).copyMemory(from: &v7, byteCount: MemoryLayout<T7>.size)
-            offset = offset &+ MemoryLayout<T7>.size
-            (basePtr + offset).copyMemory(from: &v8, byteCount: MemoryLayout<T8>.size)
-            offset = offset &+ MemoryLayout<T8>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -1813,20 +864,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1836,115 +877,19 @@ extension ByteBuffer {
         bytesRequired &+= MemoryLayout<T7>.size
         bytesRequired &+= MemoryLayout<T8>.size
         bytesRequired &+= MemoryLayout<T9>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var v7: T7 = 0
-        var v8: T8 = 0
-        var v9: T9 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            withUnsafeMutableBytes(of: &v7) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
-            }
-            offset = offset &+ MemoryLayout<T7>.size
-            withUnsafeMutableBytes(of: &v8) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
-            }
-            offset = offset &+ MemoryLayout<T8>.size
-            withUnsafeMutableBytes(of: &v9) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
-            }
-            offset = offset &+ MemoryLayout<T9>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1971,7 +916,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -2012,141 +957,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        var v7: T7
-        var v8: T8
-        var v9: T9
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-            v7 = value7.bigEndian
-            v8 = value8.bigEndian
-            v9 = value9.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-            v7 = value7.littleEndian
-            v8 = value8.littleEndian
-            v9 = value9.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-        spaceNeeded &+= MemoryLayout<T7>.size
-        spaceNeeded &+= MemoryLayout<T8>.size
-        spaceNeeded &+= MemoryLayout<T9>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            (basePtr + offset).copyMemory(from: &v7, byteCount: MemoryLayout<T7>.size)
-            offset = offset &+ MemoryLayout<T7>.size
-            (basePtr + offset).copyMemory(from: &v8, byteCount: MemoryLayout<T8>.size)
-            offset = offset &+ MemoryLayout<T8>.size
-            (basePtr + offset).copyMemory(from: &v9, byteCount: MemoryLayout<T9>.size)
-            offset = offset &+ MemoryLayout<T9>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -2204,21 +1033,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -2229,122 +1047,19 @@ extension ByteBuffer {
         bytesRequired &+= MemoryLayout<T8>.size
         bytesRequired &+= MemoryLayout<T9>.size
         bytesRequired &+= MemoryLayout<T10>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var v7: T7 = 0
-        var v8: T8 = 0
-        var v9: T9 = 0
-        var v10: T10 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            withUnsafeMutableBytes(of: &v7) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
-            }
-            offset = offset &+ MemoryLayout<T7>.size
-            withUnsafeMutableBytes(of: &v8) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
-            }
-            offset = offset &+ MemoryLayout<T8>.size
-            withUnsafeMutableBytes(of: &v9) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
-            }
-            offset = offset &+ MemoryLayout<T9>.size
-            withUnsafeMutableBytes(of: &v10) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
-            }
-            offset = offset &+ MemoryLayout<T10>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -2373,7 +1088,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -2418,151 +1133,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        var v7: T7
-        var v8: T8
-        var v9: T9
-        var v10: T10
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-            v7 = value7.bigEndian
-            v8 = value8.bigEndian
-            v9 = value9.bigEndian
-            v10 = value10.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-            v7 = value7.littleEndian
-            v8 = value8.littleEndian
-            v9 = value9.littleEndian
-            v10 = value10.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-        spaceNeeded &+= MemoryLayout<T7>.size
-        spaceNeeded &+= MemoryLayout<T8>.size
-        spaceNeeded &+= MemoryLayout<T9>.size
-        spaceNeeded &+= MemoryLayout<T10>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            (basePtr + offset).copyMemory(from: &v7, byteCount: MemoryLayout<T7>.size)
-            offset = offset &+ MemoryLayout<T7>.size
-            (basePtr + offset).copyMemory(from: &v8, byteCount: MemoryLayout<T8>.size)
-            offset = offset &+ MemoryLayout<T8>.size
-            (basePtr + offset).copyMemory(from: &v9, byteCount: MemoryLayout<T9>.size)
-            offset = offset &+ MemoryLayout<T9>.size
-            (basePtr + offset).copyMemory(from: &v10, byteCount: MemoryLayout<T10>.size)
-            offset = offset &+ MemoryLayout<T10>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -2625,22 +1214,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -2652,130 +1229,19 @@ extension ByteBuffer {
         bytesRequired &+= MemoryLayout<T9>.size
         bytesRequired &+= MemoryLayout<T10>.size
         bytesRequired &+= MemoryLayout<T11>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var v7: T7 = 0
-        var v8: T8 = 0
-        var v9: T9 = 0
-        var v10: T10 = 0
-        var v11: T11 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            withUnsafeMutableBytes(of: &v7) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
-            }
-            offset = offset &+ MemoryLayout<T7>.size
-            withUnsafeMutableBytes(of: &v8) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
-            }
-            offset = offset &+ MemoryLayout<T8>.size
-            withUnsafeMutableBytes(of: &v9) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
-            }
-            offset = offset &+ MemoryLayout<T9>.size
-            withUnsafeMutableBytes(of: &v10) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
-            }
-            offset = offset &+ MemoryLayout<T10>.size
-            withUnsafeMutableBytes(of: &v11) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
-            }
-            offset = offset &+ MemoryLayout<T11>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -2806,7 +1272,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -2855,162 +1321,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        var v7: T7
-        var v8: T8
-        var v9: T9
-        var v10: T10
-        var v11: T11
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-            v7 = value7.bigEndian
-            v8 = value8.bigEndian
-            v9 = value9.bigEndian
-            v10 = value10.bigEndian
-            v11 = value11.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-            v7 = value7.littleEndian
-            v8 = value8.littleEndian
-            v9 = value9.littleEndian
-            v10 = value10.littleEndian
-            v11 = value11.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-        spaceNeeded &+= MemoryLayout<T7>.size
-        spaceNeeded &+= MemoryLayout<T8>.size
-        spaceNeeded &+= MemoryLayout<T9>.size
-        spaceNeeded &+= MemoryLayout<T10>.size
-        spaceNeeded &+= MemoryLayout<T11>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            (basePtr + offset).copyMemory(from: &v7, byteCount: MemoryLayout<T7>.size)
-            offset = offset &+ MemoryLayout<T7>.size
-            (basePtr + offset).copyMemory(from: &v8, byteCount: MemoryLayout<T8>.size)
-            offset = offset &+ MemoryLayout<T8>.size
-            (basePtr + offset).copyMemory(from: &v9, byteCount: MemoryLayout<T9>.size)
-            offset = offset &+ MemoryLayout<T9>.size
-            (basePtr + offset).copyMemory(from: &v10, byteCount: MemoryLayout<T10>.size)
-            offset = offset &+ MemoryLayout<T10>.size
-            (basePtr + offset).copyMemory(from: &v11, byteCount: MemoryLayout<T11>.size)
-            offset = offset &+ MemoryLayout<T11>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -3078,25 +1407,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -3109,141 +1423,19 @@ extension ByteBuffer {
         bytesRequired &+= MemoryLayout<T10>.size
         bytesRequired &+= MemoryLayout<T11>.size
         bytesRequired &+= MemoryLayout<T12>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var v7: T7 = 0
-        var v8: T8 = 0
-        var v9: T9 = 0
-        var v10: T10 = 0
-        var v11: T11 = 0
-        var v12: T12 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            withUnsafeMutableBytes(of: &v7) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
-            }
-            offset = offset &+ MemoryLayout<T7>.size
-            withUnsafeMutableBytes(of: &v8) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
-            }
-            offset = offset &+ MemoryLayout<T8>.size
-            withUnsafeMutableBytes(of: &v9) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
-            }
-            offset = offset &+ MemoryLayout<T9>.size
-            withUnsafeMutableBytes(of: &v10) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
-            }
-            offset = offset &+ MemoryLayout<T10>.size
-            withUnsafeMutableBytes(of: &v11) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
-            }
-            offset = offset &+ MemoryLayout<T11>.size
-            withUnsafeMutableBytes(of: &v12) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T12>.size)
-            }
-            offset = offset &+ MemoryLayout<T12>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11), T12(bigEndian: v12)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -3276,7 +1468,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -3329,176 +1521,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11), T12(bigEndian: v12)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11), T12(bigEndian: v12))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        _ value12: T12,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
-        ).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        var v7: T7
-        var v8: T8
-        var v9: T9
-        var v10: T10
-        var v11: T11
-        var v12: T12
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-            v7 = value7.bigEndian
-            v8 = value8.bigEndian
-            v9 = value9.bigEndian
-            v10 = value10.bigEndian
-            v11 = value11.bigEndian
-            v12 = value12.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-            v7 = value7.littleEndian
-            v8 = value8.littleEndian
-            v9 = value9.littleEndian
-            v10 = value10.littleEndian
-            v11 = value11.littleEndian
-            v12 = value12.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-        spaceNeeded &+= MemoryLayout<T7>.size
-        spaceNeeded &+= MemoryLayout<T8>.size
-        spaceNeeded &+= MemoryLayout<T9>.size
-        spaceNeeded &+= MemoryLayout<T10>.size
-        spaceNeeded &+= MemoryLayout<T11>.size
-        spaceNeeded &+= MemoryLayout<T12>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            (basePtr + offset).copyMemory(from: &v7, byteCount: MemoryLayout<T7>.size)
-            offset = offset &+ MemoryLayout<T7>.size
-            (basePtr + offset).copyMemory(from: &v8, byteCount: MemoryLayout<T8>.size)
-            offset = offset &+ MemoryLayout<T8>.size
-            (basePtr + offset).copyMemory(from: &v9, byteCount: MemoryLayout<T9>.size)
-            offset = offset &+ MemoryLayout<T9>.size
-            (basePtr + offset).copyMemory(from: &v10, byteCount: MemoryLayout<T10>.size)
-            offset = offset &+ MemoryLayout<T10>.size
-            (basePtr + offset).copyMemory(from: &v11, byteCount: MemoryLayout<T11>.size)
-            offset = offset &+ MemoryLayout<T11>.size
-            (basePtr + offset).copyMemory(from: &v12, byteCount: MemoryLayout<T12>.size)
-            offset = offset &+ MemoryLayout<T12>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        _ value12: T12,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
-        ).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -3571,26 +1612,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -3604,149 +1629,19 @@ extension ByteBuffer {
         bytesRequired &+= MemoryLayout<T11>.size
         bytesRequired &+= MemoryLayout<T12>.size
         bytesRequired &+= MemoryLayout<T13>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var v7: T7 = 0
-        var v8: T8 = 0
-        var v9: T9 = 0
-        var v10: T10 = 0
-        var v11: T11 = 0
-        var v12: T12 = 0
-        var v13: T13 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            withUnsafeMutableBytes(of: &v7) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
-            }
-            offset = offset &+ MemoryLayout<T7>.size
-            withUnsafeMutableBytes(of: &v8) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
-            }
-            offset = offset &+ MemoryLayout<T8>.size
-            withUnsafeMutableBytes(of: &v9) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
-            }
-            offset = offset &+ MemoryLayout<T9>.size
-            withUnsafeMutableBytes(of: &v10) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
-            }
-            offset = offset &+ MemoryLayout<T10>.size
-            withUnsafeMutableBytes(of: &v11) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
-            }
-            offset = offset &+ MemoryLayout<T11>.size
-            withUnsafeMutableBytes(of: &v12) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T12>.size)
-            }
-            offset = offset &+ MemoryLayout<T12>.size
-            withUnsafeMutableBytes(of: &v13) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T13>.size)
-            }
-            offset = offset &+ MemoryLayout<T13>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
-                T13(littleEndian: v13)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -3781,7 +1676,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -3838,187 +1733,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
-                T13(littleEndian: v13)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12), T13(littleEndian: v13))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        _ value12: T12,
-        _ value13: T13,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
-        ).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        var v7: T7
-        var v8: T8
-        var v9: T9
-        var v10: T10
-        var v11: T11
-        var v12: T12
-        var v13: T13
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-            v7 = value7.bigEndian
-            v8 = value8.bigEndian
-            v9 = value9.bigEndian
-            v10 = value10.bigEndian
-            v11 = value11.bigEndian
-            v12 = value12.bigEndian
-            v13 = value13.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-            v7 = value7.littleEndian
-            v8 = value8.littleEndian
-            v9 = value9.littleEndian
-            v10 = value10.littleEndian
-            v11 = value11.littleEndian
-            v12 = value12.littleEndian
-            v13 = value13.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-        spaceNeeded &+= MemoryLayout<T7>.size
-        spaceNeeded &+= MemoryLayout<T8>.size
-        spaceNeeded &+= MemoryLayout<T9>.size
-        spaceNeeded &+= MemoryLayout<T10>.size
-        spaceNeeded &+= MemoryLayout<T11>.size
-        spaceNeeded &+= MemoryLayout<T12>.size
-        spaceNeeded &+= MemoryLayout<T13>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            (basePtr + offset).copyMemory(from: &v7, byteCount: MemoryLayout<T7>.size)
-            offset = offset &+ MemoryLayout<T7>.size
-            (basePtr + offset).copyMemory(from: &v8, byteCount: MemoryLayout<T8>.size)
-            offset = offset &+ MemoryLayout<T8>.size
-            (basePtr + offset).copyMemory(from: &v9, byteCount: MemoryLayout<T9>.size)
-            offset = offset &+ MemoryLayout<T9>.size
-            (basePtr + offset).copyMemory(from: &v10, byteCount: MemoryLayout<T10>.size)
-            offset = offset &+ MemoryLayout<T10>.size
-            (basePtr + offset).copyMemory(from: &v11, byteCount: MemoryLayout<T11>.size)
-            offset = offset &+ MemoryLayout<T11>.size
-            (basePtr + offset).copyMemory(from: &v12, byteCount: MemoryLayout<T12>.size)
-            offset = offset &+ MemoryLayout<T12>.size
-            (basePtr + offset).copyMemory(from: &v13, byteCount: MemoryLayout<T13>.size)
-            offset = offset &+ MemoryLayout<T13>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        _ value12: T12,
-        _ value13: T13,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
-        ).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -4096,27 +1829,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -4131,156 +1847,19 @@ extension ByteBuffer {
         bytesRequired &+= MemoryLayout<T12>.size
         bytesRequired &+= MemoryLayout<T13>.size
         bytesRequired &+= MemoryLayout<T14>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var v7: T7 = 0
-        var v8: T8 = 0
-        var v9: T9 = 0
-        var v10: T10 = 0
-        var v11: T11 = 0
-        var v12: T12 = 0
-        var v13: T13 = 0
-        var v14: T14 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            withUnsafeMutableBytes(of: &v7) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
-            }
-            offset = offset &+ MemoryLayout<T7>.size
-            withUnsafeMutableBytes(of: &v8) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
-            }
-            offset = offset &+ MemoryLayout<T8>.size
-            withUnsafeMutableBytes(of: &v9) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
-            }
-            offset = offset &+ MemoryLayout<T9>.size
-            withUnsafeMutableBytes(of: &v10) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
-            }
-            offset = offset &+ MemoryLayout<T10>.size
-            withUnsafeMutableBytes(of: &v11) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
-            }
-            offset = offset &+ MemoryLayout<T11>.size
-            withUnsafeMutableBytes(of: &v12) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T12>.size)
-            }
-            offset = offset &+ MemoryLayout<T12>.size
-            withUnsafeMutableBytes(of: &v13) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T13>.size)
-            }
-            offset = offset &+ MemoryLayout<T13>.size
-            withUnsafeMutableBytes(of: &v14) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T14>.size)
-            }
-            offset = offset &+ MemoryLayout<T14>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
-                T13(littleEndian: v13), T14(littleEndian: v14)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -4317,7 +1896,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -4378,197 +1957,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
-                T13(littleEndian: v13), T14(littleEndian: v14)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12), T13(littleEndian: v13), T14(littleEndian: v14))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        _ value12: T12,
-        _ value13: T13,
-        _ value14: T14,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
-        ).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        var v7: T7
-        var v8: T8
-        var v9: T9
-        var v10: T10
-        var v11: T11
-        var v12: T12
-        var v13: T13
-        var v14: T14
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-            v7 = value7.bigEndian
-            v8 = value8.bigEndian
-            v9 = value9.bigEndian
-            v10 = value10.bigEndian
-            v11 = value11.bigEndian
-            v12 = value12.bigEndian
-            v13 = value13.bigEndian
-            v14 = value14.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-            v7 = value7.littleEndian
-            v8 = value8.littleEndian
-            v9 = value9.littleEndian
-            v10 = value10.littleEndian
-            v11 = value11.littleEndian
-            v12 = value12.littleEndian
-            v13 = value13.littleEndian
-            v14 = value14.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-        spaceNeeded &+= MemoryLayout<T7>.size
-        spaceNeeded &+= MemoryLayout<T8>.size
-        spaceNeeded &+= MemoryLayout<T9>.size
-        spaceNeeded &+= MemoryLayout<T10>.size
-        spaceNeeded &+= MemoryLayout<T11>.size
-        spaceNeeded &+= MemoryLayout<T12>.size
-        spaceNeeded &+= MemoryLayout<T13>.size
-        spaceNeeded &+= MemoryLayout<T14>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            (basePtr + offset).copyMemory(from: &v7, byteCount: MemoryLayout<T7>.size)
-            offset = offset &+ MemoryLayout<T7>.size
-            (basePtr + offset).copyMemory(from: &v8, byteCount: MemoryLayout<T8>.size)
-            offset = offset &+ MemoryLayout<T8>.size
-            (basePtr + offset).copyMemory(from: &v9, byteCount: MemoryLayout<T9>.size)
-            offset = offset &+ MemoryLayout<T9>.size
-            (basePtr + offset).copyMemory(from: &v10, byteCount: MemoryLayout<T10>.size)
-            offset = offset &+ MemoryLayout<T10>.size
-            (basePtr + offset).copyMemory(from: &v11, byteCount: MemoryLayout<T11>.size)
-            offset = offset &+ MemoryLayout<T11>.size
-            (basePtr + offset).copyMemory(from: &v12, byteCount: MemoryLayout<T12>.size)
-            offset = offset &+ MemoryLayout<T12>.size
-            (basePtr + offset).copyMemory(from: &v13, byteCount: MemoryLayout<T13>.size)
-            offset = offset &+ MemoryLayout<T13>.size
-            (basePtr + offset).copyMemory(from: &v14, byteCount: MemoryLayout<T14>.size)
-            offset = offset &+ MemoryLayout<T14>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, _ value14: T14, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        _ value12: T12,
-        _ value13: T13,
-        _ value14: T14,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
-        ).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, _ value14: T14, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -4651,28 +2058,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger,
-        T15: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
+        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
+            return nil
+        }
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -4688,163 +2077,19 @@ extension ByteBuffer {
         bytesRequired &+= MemoryLayout<T13>.size
         bytesRequired &+= MemoryLayout<T14>.size
         bytesRequired &+= MemoryLayout<T15>.size
-
-        guard self.readableBytes >= bytesRequired else {
-            return nil
-        }
-
-        var v1: T1 = 0
-        var v2: T2 = 0
-        var v3: T3 = 0
-        var v4: T4 = 0
-        var v5: T5 = 0
-        var v6: T6 = 0
-        var v7: T7 = 0
-        var v8: T8 = 0
-        var v9: T9 = 0
-        var v10: T10 = 0
-        var v11: T11 = 0
-        var v12: T12 = 0
-        var v13: T13 = 0
-        var v14: T14 = 0
-        var v15: T15 = 0
-        var offset = 0
-        self.readWithUnsafeReadableBytes { ptr -> Int in
-            assert(ptr.count >= bytesRequired)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
-            withUnsafeMutableBytes(of: &v1) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
-            }
-            offset = offset &+ MemoryLayout<T1>.size
-            withUnsafeMutableBytes(of: &v2) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
-            }
-            offset = offset &+ MemoryLayout<T2>.size
-            withUnsafeMutableBytes(of: &v3) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
-            }
-            offset = offset &+ MemoryLayout<T3>.size
-            withUnsafeMutableBytes(of: &v4) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
-            }
-            offset = offset &+ MemoryLayout<T4>.size
-            withUnsafeMutableBytes(of: &v5) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
-            }
-            offset = offset &+ MemoryLayout<T5>.size
-            withUnsafeMutableBytes(of: &v6) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
-            }
-            offset = offset &+ MemoryLayout<T6>.size
-            withUnsafeMutableBytes(of: &v7) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
-            }
-            offset = offset &+ MemoryLayout<T7>.size
-            withUnsafeMutableBytes(of: &v8) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
-            }
-            offset = offset &+ MemoryLayout<T8>.size
-            withUnsafeMutableBytes(of: &v9) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
-            }
-            offset = offset &+ MemoryLayout<T9>.size
-            withUnsafeMutableBytes(of: &v10) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
-            }
-            offset = offset &+ MemoryLayout<T10>.size
-            withUnsafeMutableBytes(of: &v11) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
-            }
-            offset = offset &+ MemoryLayout<T11>.size
-            withUnsafeMutableBytes(of: &v12) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T12>.size)
-            }
-            offset = offset &+ MemoryLayout<T12>.size
-            withUnsafeMutableBytes(of: &v13) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T13>.size)
-            }
-            offset = offset &+ MemoryLayout<T13>.size
-            withUnsafeMutableBytes(of: &v14) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T14>.size)
-            }
-            offset = offset &+ MemoryLayout<T14>.size
-            withUnsafeMutableBytes(of: &v15) { destPtr in
-                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T15>.size)
-            }
-            offset = offset &+ MemoryLayout<T15>.size
-            assert(offset == bytesRequired)
-            return offset
-        }
-        switch endianness {
-        case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14), T15(bigEndian: v15)
-            )
-        case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
-                T13(littleEndian: v13), T14(littleEndian: v14), T15(littleEndian: v15)
-            )
-        }
+        self._moveReaderIndex(forwardBy: bytesRequired)
+        return result
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger,
-        T15: FixedWidthInteger
-    >(
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
-        var copy = self
-        return copy.readMultipleIntegers(endianness: endianness, as: `as`)
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
+        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger,
-        T15: FixedWidthInteger
-    >(
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
-        ).self
-    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -4883,7 +2128,7 @@ extension ByteBuffer {
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
             assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -4948,207 +2193,25 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (
-                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
-                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
-                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14), T15(bigEndian: v15)
-            )
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14), T15(bigEndian: v15))
         case .little:
-            return (
-                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
-                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
-                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
-                T13(littleEndian: v13), T14(littleEndian: v14), T15(littleEndian: v15)
-            )
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12), T13(littleEndian: v13), T14(littleEndian: v14), T15(littleEndian: v15))
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger,
-        T15: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        _ value12: T12,
-        _ value13: T13,
-        _ value14: T14,
-        _ value15: T15,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
-        ).self
-    ) -> Int {
-        var v1: T1
-        var v2: T2
-        var v3: T3
-        var v4: T4
-        var v5: T5
-        var v6: T6
-        var v7: T7
-        var v8: T8
-        var v9: T9
-        var v10: T10
-        var v11: T11
-        var v12: T12
-        var v13: T13
-        var v14: T14
-        var v15: T15
-        switch endianness {
-        case .big:
-            v1 = value1.bigEndian
-            v2 = value2.bigEndian
-            v3 = value3.bigEndian
-            v4 = value4.bigEndian
-            v5 = value5.bigEndian
-            v6 = value6.bigEndian
-            v7 = value7.bigEndian
-            v8 = value8.bigEndian
-            v9 = value9.bigEndian
-            v10 = value10.bigEndian
-            v11 = value11.bigEndian
-            v12 = value12.bigEndian
-            v13 = value13.bigEndian
-            v14 = value14.bigEndian
-            v15 = value15.bigEndian
-        case .little:
-            v1 = value1.littleEndian
-            v2 = value2.littleEndian
-            v3 = value3.littleEndian
-            v4 = value4.littleEndian
-            v5 = value5.littleEndian
-            v6 = value6.littleEndian
-            v7 = value7.littleEndian
-            v8 = value8.littleEndian
-            v9 = value9.littleEndian
-            v10 = value10.littleEndian
-            v11 = value11.littleEndian
-            v12 = value12.littleEndian
-            v13 = value13.littleEndian
-            v14 = value14.littleEndian
-            v15 = value15.littleEndian
-        }
-
-        var spaceNeeded: Int = MemoryLayout<T1>.size
-        spaceNeeded &+= MemoryLayout<T2>.size
-        spaceNeeded &+= MemoryLayout<T3>.size
-        spaceNeeded &+= MemoryLayout<T4>.size
-        spaceNeeded &+= MemoryLayout<T5>.size
-        spaceNeeded &+= MemoryLayout<T6>.size
-        spaceNeeded &+= MemoryLayout<T7>.size
-        spaceNeeded &+= MemoryLayout<T8>.size
-        spaceNeeded &+= MemoryLayout<T9>.size
-        spaceNeeded &+= MemoryLayout<T10>.size
-        spaceNeeded &+= MemoryLayout<T11>.size
-        spaceNeeded &+= MemoryLayout<T12>.size
-        spaceNeeded &+= MemoryLayout<T13>.size
-        spaceNeeded &+= MemoryLayout<T14>.size
-        spaceNeeded &+= MemoryLayout<T15>.size
-
-        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in
-            assert(ptr.count >= spaceNeeded)
-            var offset = 0
-            let basePtr = ptr.baseAddress!  // safe: pointer is non zero length
-            (basePtr + offset).copyMemory(from: &v1, byteCount: MemoryLayout<T1>.size)
-            offset = offset &+ MemoryLayout<T1>.size
-            (basePtr + offset).copyMemory(from: &v2, byteCount: MemoryLayout<T2>.size)
-            offset = offset &+ MemoryLayout<T2>.size
-            (basePtr + offset).copyMemory(from: &v3, byteCount: MemoryLayout<T3>.size)
-            offset = offset &+ MemoryLayout<T3>.size
-            (basePtr + offset).copyMemory(from: &v4, byteCount: MemoryLayout<T4>.size)
-            offset = offset &+ MemoryLayout<T4>.size
-            (basePtr + offset).copyMemory(from: &v5, byteCount: MemoryLayout<T5>.size)
-            offset = offset &+ MemoryLayout<T5>.size
-            (basePtr + offset).copyMemory(from: &v6, byteCount: MemoryLayout<T6>.size)
-            offset = offset &+ MemoryLayout<T6>.size
-            (basePtr + offset).copyMemory(from: &v7, byteCount: MemoryLayout<T7>.size)
-            offset = offset &+ MemoryLayout<T7>.size
-            (basePtr + offset).copyMemory(from: &v8, byteCount: MemoryLayout<T8>.size)
-            offset = offset &+ MemoryLayout<T8>.size
-            (basePtr + offset).copyMemory(from: &v9, byteCount: MemoryLayout<T9>.size)
-            offset = offset &+ MemoryLayout<T9>.size
-            (basePtr + offset).copyMemory(from: &v10, byteCount: MemoryLayout<T10>.size)
-            offset = offset &+ MemoryLayout<T10>.size
-            (basePtr + offset).copyMemory(from: &v11, byteCount: MemoryLayout<T11>.size)
-            offset = offset &+ MemoryLayout<T11>.size
-            (basePtr + offset).copyMemory(from: &v12, byteCount: MemoryLayout<T12>.size)
-            offset = offset &+ MemoryLayout<T12>.size
-            (basePtr + offset).copyMemory(from: &v13, byteCount: MemoryLayout<T13>.size)
-            offset = offset &+ MemoryLayout<T13>.size
-            (basePtr + offset).copyMemory(from: &v14, byteCount: MemoryLayout<T14>.size)
-            offset = offset &+ MemoryLayout<T14>.size
-            (basePtr + offset).copyMemory(from: &v15, byteCount: MemoryLayout<T15>.size)
-            offset = offset &+ MemoryLayout<T15>.size
-            assert(offset == spaceNeeded)
-            return offset
-        }
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, _ value14: T14, _ value15: T15, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> Int {
+        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, at: self.writerIndex, endianness: endianness, as: `as`)
+        self._moveWriterIndex(forwardBy: bytesWritten)
+        return bytesWritten
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<
-        T1: FixedWidthInteger,
-        T2: FixedWidthInteger,
-        T3: FixedWidthInteger,
-        T4: FixedWidthInteger,
-        T5: FixedWidthInteger,
-        T6: FixedWidthInteger,
-        T7: FixedWidthInteger,
-        T8: FixedWidthInteger,
-        T9: FixedWidthInteger,
-        T10: FixedWidthInteger,
-        T11: FixedWidthInteger,
-        T12: FixedWidthInteger,
-        T13: FixedWidthInteger,
-        T14: FixedWidthInteger,
-        T15: FixedWidthInteger
-    >(
-        _ value1: T1,
-        _ value2: T2,
-        _ value3: T3,
-        _ value4: T4,
-        _ value5: T5,
-        _ value6: T6,
-        _ value7: T7,
-        _ value8: T8,
-        _ value9: T9,
-        _ value10: T10,
-        _ value11: T11,
-        _ value12: T12,
-        _ value13: T13,
-        _ value14: T14,
-        _ value15: T15,
-        at index: Int,
-        endianness: Endianness = .big,
-        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
-            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
-        ).self
-    ) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, _ value14: T14, _ value15: T15, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3

--- a/Sources/NIOCore/ByteBuffer-multi-int.swift
+++ b/Sources/NIOCore/ByteBuffer-multi-int.swift
@@ -65,6 +65,44 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2).Type = (T1, T2).self
+    ) -> (T1, T2)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (T1(bigEndian: v1), T2(bigEndian: v2))
+        case .little:
+            return (T1(littleEndian: v1), T2(littleEndian: v2))
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
         _ value1: T1,
@@ -97,6 +135,36 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
+        _ value1: T1,
+        _ value2: T2,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2).Type = (T1, T2).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -155,6 +223,50 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3).Type = (T1, T2, T3).self
+    ) -> (T1, T2, T3)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3))
+        case .little:
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3))
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
         _ value1: T1,
@@ -194,6 +306,42 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3).Type = (T1, T2, T3).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -262,6 +410,61 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self
+    ) -> (T1, T2, T3, T4)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4))
+        case .little:
+            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4))
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -313,6 +516,53 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -394,6 +644,71 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self
+    ) -> (T1, T2, T3, T4, T5)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5))
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -453,6 +768,60 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -549,6 +918,81 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
+    ) -> (T1, T2, T3, T4, T5, T6)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -616,6 +1060,67 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -720,6 +1225,88 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+        bytesRequired &+= MemoryLayout<T7>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var v7: T7 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            withUnsafeMutableBytes(of: &v7) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
+            }
+            offset = offset &+ MemoryLayout<T7>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -795,6 +1382,74 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        var v7: T7
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+            v7 = value7.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+            v7 = value7.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v7) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T7>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -907,6 +1562,95 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+        bytesRequired &+= MemoryLayout<T7>.size
+        bytesRequired &+= MemoryLayout<T8>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var v7: T7 = 0
+        var v8: T8 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            withUnsafeMutableBytes(of: &v7) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
+            }
+            offset = offset &+ MemoryLayout<T7>.size
+            withUnsafeMutableBytes(of: &v8) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
+            }
+            offset = offset &+ MemoryLayout<T8>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -990,6 +1734,81 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        var v7: T7
+        var v8: T8
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+            v7 = value7.bigEndian
+            v8 = value8.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+            v7 = value7.littleEndian
+            v8 = value8.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v7) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T7>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v8) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T8>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -1111,6 +1930,103 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+        bytesRequired &+= MemoryLayout<T7>.size
+        bytesRequired &+= MemoryLayout<T8>.size
+        bytesRequired &+= MemoryLayout<T9>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var v7: T7 = 0
+        var v8: T8 = 0
+        var v9: T9 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            withUnsafeMutableBytes(of: &v7) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
+            }
+            offset = offset &+ MemoryLayout<T7>.size
+            withUnsafeMutableBytes(of: &v8) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
+            }
+            offset = offset &+ MemoryLayout<T8>.size
+            withUnsafeMutableBytes(of: &v9) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
+            }
+            offset = offset &+ MemoryLayout<T9>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -1202,6 +2118,88 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        var v7: T7
+        var v8: T8
+        var v9: T9
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+            v7 = value7.bigEndian
+            v8 = value8.bigEndian
+            v9 = value9.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+            v7 = value7.littleEndian
+            v8 = value8.littleEndian
+            v9 = value9.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v7) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T7>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v8) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T8>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v9) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T9>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -1331,6 +2329,110 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+        bytesRequired &+= MemoryLayout<T7>.size
+        bytesRequired &+= MemoryLayout<T8>.size
+        bytesRequired &+= MemoryLayout<T9>.size
+        bytesRequired &+= MemoryLayout<T10>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var v7: T7 = 0
+        var v8: T8 = 0
+        var v9: T9 = 0
+        var v10: T10 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            withUnsafeMutableBytes(of: &v7) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
+            }
+            offset = offset &+ MemoryLayout<T7>.size
+            withUnsafeMutableBytes(of: &v8) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
+            }
+            offset = offset &+ MemoryLayout<T8>.size
+            withUnsafeMutableBytes(of: &v9) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
+            }
+            offset = offset &+ MemoryLayout<T9>.size
+            withUnsafeMutableBytes(of: &v10) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
+            }
+            offset = offset &+ MemoryLayout<T10>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -1430,6 +2532,95 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        var v7: T7
+        var v8: T8
+        var v9: T9
+        var v10: T10
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+            v7 = value7.bigEndian
+            v8 = value8.bigEndian
+            v9 = value9.bigEndian
+            v10 = value10.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+            v7 = value7.littleEndian
+            v8 = value8.littleEndian
+            v9 = value9.littleEndian
+            v10 = value10.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v7) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T7>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v8) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T8>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v9) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T9>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v10) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T10>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -1568,6 +2759,118 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+        bytesRequired &+= MemoryLayout<T7>.size
+        bytesRequired &+= MemoryLayout<T8>.size
+        bytesRequired &+= MemoryLayout<T9>.size
+        bytesRequired &+= MemoryLayout<T10>.size
+        bytesRequired &+= MemoryLayout<T11>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var v7: T7 = 0
+        var v8: T8 = 0
+        var v9: T9 = 0
+        var v10: T10 = 0
+        var v11: T11 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            withUnsafeMutableBytes(of: &v7) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
+            }
+            offset = offset &+ MemoryLayout<T7>.size
+            withUnsafeMutableBytes(of: &v8) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
+            }
+            offset = offset &+ MemoryLayout<T8>.size
+            withUnsafeMutableBytes(of: &v9) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
+            }
+            offset = offset &+ MemoryLayout<T9>.size
+            withUnsafeMutableBytes(of: &v10) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
+            }
+            offset = offset &+ MemoryLayout<T10>.size
+            withUnsafeMutableBytes(of: &v11) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
+            }
+            offset = offset &+ MemoryLayout<T11>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -1675,6 +2978,102 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        var v7: T7
+        var v8: T8
+        var v9: T9
+        var v10: T10
+        var v11: T11
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+            v7 = value7.bigEndian
+            v8 = value8.bigEndian
+            v9 = value9.bigEndian
+            v10 = value10.bigEndian
+            v11 = value11.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+            v7 = value7.littleEndian
+            v8 = value8.littleEndian
+            v9 = value9.littleEndian
+            v10 = value10.littleEndian
+            v11 = value11.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v7) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T7>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v8) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T8>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v9) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T9>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v10) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T10>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v11) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T11>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -1825,6 +3224,127 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+        bytesRequired &+= MemoryLayout<T7>.size
+        bytesRequired &+= MemoryLayout<T8>.size
+        bytesRequired &+= MemoryLayout<T9>.size
+        bytesRequired &+= MemoryLayout<T10>.size
+        bytesRequired &+= MemoryLayout<T11>.size
+        bytesRequired &+= MemoryLayout<T12>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var v7: T7 = 0
+        var v8: T8 = 0
+        var v9: T9 = 0
+        var v10: T10 = 0
+        var v11: T11 = 0
+        var v12: T12 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            withUnsafeMutableBytes(of: &v7) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
+            }
+            offset = offset &+ MemoryLayout<T7>.size
+            withUnsafeMutableBytes(of: &v8) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
+            }
+            offset = offset &+ MemoryLayout<T8>.size
+            withUnsafeMutableBytes(of: &v9) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
+            }
+            offset = offset &+ MemoryLayout<T9>.size
+            withUnsafeMutableBytes(of: &v10) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
+            }
+            offset = offset &+ MemoryLayout<T10>.size
+            withUnsafeMutableBytes(of: &v11) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
+            }
+            offset = offset &+ MemoryLayout<T11>.size
+            withUnsafeMutableBytes(of: &v12) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T12>.size)
+            }
+            offset = offset &+ MemoryLayout<T12>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11), T12(bigEndian: v12)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -1942,6 +3462,111 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
+        ).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        var v7: T7
+        var v8: T8
+        var v9: T9
+        var v10: T10
+        var v11: T11
+        var v12: T12
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+            v7 = value7.bigEndian
+            v8 = value8.bigEndian
+            v9 = value9.bigEndian
+            v10 = value10.bigEndian
+            v11 = value11.bigEndian
+            v12 = value12.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+            v7 = value7.littleEndian
+            v8 = value8.littleEndian
+            v9 = value9.littleEndian
+            v10 = value10.littleEndian
+            v11 = value11.littleEndian
+            v12 = value12.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v7) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T7>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v8) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T8>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v9) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T9>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v10) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T10>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v11) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T11>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v12) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T12>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -2101,6 +3726,135 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+        bytesRequired &+= MemoryLayout<T7>.size
+        bytesRequired &+= MemoryLayout<T8>.size
+        bytesRequired &+= MemoryLayout<T9>.size
+        bytesRequired &+= MemoryLayout<T10>.size
+        bytesRequired &+= MemoryLayout<T11>.size
+        bytesRequired &+= MemoryLayout<T12>.size
+        bytesRequired &+= MemoryLayout<T13>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var v7: T7 = 0
+        var v8: T8 = 0
+        var v9: T9 = 0
+        var v10: T10 = 0
+        var v11: T11 = 0
+        var v12: T12 = 0
+        var v13: T13 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            withUnsafeMutableBytes(of: &v7) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
+            }
+            offset = offset &+ MemoryLayout<T7>.size
+            withUnsafeMutableBytes(of: &v8) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
+            }
+            offset = offset &+ MemoryLayout<T8>.size
+            withUnsafeMutableBytes(of: &v9) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
+            }
+            offset = offset &+ MemoryLayout<T9>.size
+            withUnsafeMutableBytes(of: &v10) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
+            }
+            offset = offset &+ MemoryLayout<T10>.size
+            withUnsafeMutableBytes(of: &v11) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
+            }
+            offset = offset &+ MemoryLayout<T11>.size
+            withUnsafeMutableBytes(of: &v12) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T12>.size)
+            }
+            offset = offset &+ MemoryLayout<T12>.size
+            withUnsafeMutableBytes(of: &v13) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T13>.size)
+            }
+            offset = offset &+ MemoryLayout<T13>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
+                T13(littleEndian: v13)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -2226,6 +3980,118 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        _ value13: T13,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
+        ).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        var v7: T7
+        var v8: T8
+        var v9: T9
+        var v10: T10
+        var v11: T11
+        var v12: T12
+        var v13: T13
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+            v7 = value7.bigEndian
+            v8 = value8.bigEndian
+            v9 = value9.bigEndian
+            v10 = value10.bigEndian
+            v11 = value11.bigEndian
+            v12 = value12.bigEndian
+            v13 = value13.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+            v7 = value7.littleEndian
+            v8 = value8.littleEndian
+            v9 = value9.littleEndian
+            v10 = value10.littleEndian
+            v11 = value11.littleEndian
+            v12 = value12.littleEndian
+            v13 = value13.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v7) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T7>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v8) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T8>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v9) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T9>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v10) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T10>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v11) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T11>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v12) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T12>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v13) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T13>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -2393,6 +4259,142 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+        bytesRequired &+= MemoryLayout<T7>.size
+        bytesRequired &+= MemoryLayout<T8>.size
+        bytesRequired &+= MemoryLayout<T9>.size
+        bytesRequired &+= MemoryLayout<T10>.size
+        bytesRequired &+= MemoryLayout<T11>.size
+        bytesRequired &+= MemoryLayout<T12>.size
+        bytesRequired &+= MemoryLayout<T13>.size
+        bytesRequired &+= MemoryLayout<T14>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var v7: T7 = 0
+        var v8: T8 = 0
+        var v9: T9 = 0
+        var v10: T10 = 0
+        var v11: T11 = 0
+        var v12: T12 = 0
+        var v13: T13 = 0
+        var v14: T14 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            withUnsafeMutableBytes(of: &v7) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
+            }
+            offset = offset &+ MemoryLayout<T7>.size
+            withUnsafeMutableBytes(of: &v8) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
+            }
+            offset = offset &+ MemoryLayout<T8>.size
+            withUnsafeMutableBytes(of: &v9) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
+            }
+            offset = offset &+ MemoryLayout<T9>.size
+            withUnsafeMutableBytes(of: &v10) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
+            }
+            offset = offset &+ MemoryLayout<T10>.size
+            withUnsafeMutableBytes(of: &v11) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
+            }
+            offset = offset &+ MemoryLayout<T11>.size
+            withUnsafeMutableBytes(of: &v12) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T12>.size)
+            }
+            offset = offset &+ MemoryLayout<T12>.size
+            withUnsafeMutableBytes(of: &v13) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T13>.size)
+            }
+            offset = offset &+ MemoryLayout<T13>.size
+            withUnsafeMutableBytes(of: &v14) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T14>.size)
+            }
+            offset = offset &+ MemoryLayout<T14>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
+                T13(littleEndian: v13), T14(littleEndian: v14)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -2526,6 +4528,125 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        _ value13: T13,
+        _ value14: T14,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
+        ).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        var v7: T7
+        var v8: T8
+        var v9: T9
+        var v10: T10
+        var v11: T11
+        var v12: T12
+        var v13: T13
+        var v14: T14
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+            v7 = value7.bigEndian
+            v8 = value8.bigEndian
+            v9 = value9.bigEndian
+            v10 = value10.bigEndian
+            v11 = value11.bigEndian
+            v12 = value12.bigEndian
+            v13 = value13.bigEndian
+            v14 = value14.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+            v7 = value7.littleEndian
+            v8 = value8.littleEndian
+            v9 = value9.littleEndian
+            v10 = value10.littleEndian
+            v11 = value11.littleEndian
+            v12 = value12.littleEndian
+            v13 = value13.littleEndian
+            v14 = value14.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v7) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T7>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v8) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T8>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v9) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T9>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v10) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T10>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v11) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T11>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v12) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T12>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v13) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T13>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v14) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T14>.size
+        return bytesWritten
     }
 
     @inlinable
@@ -2701,6 +4822,149 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger,
+        T15: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
+        var bytesRequired: Int = MemoryLayout<T1>.size
+        bytesRequired &+= MemoryLayout<T2>.size
+        bytesRequired &+= MemoryLayout<T3>.size
+        bytesRequired &+= MemoryLayout<T4>.size
+        bytesRequired &+= MemoryLayout<T5>.size
+        bytesRequired &+= MemoryLayout<T6>.size
+        bytesRequired &+= MemoryLayout<T7>.size
+        bytesRequired &+= MemoryLayout<T8>.size
+        bytesRequired &+= MemoryLayout<T9>.size
+        bytesRequired &+= MemoryLayout<T10>.size
+        bytesRequired &+= MemoryLayout<T11>.size
+        bytesRequired &+= MemoryLayout<T12>.size
+        bytesRequired &+= MemoryLayout<T13>.size
+        bytesRequired &+= MemoryLayout<T14>.size
+        bytesRequired &+= MemoryLayout<T15>.size
+
+        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {
+            return nil
+        }
+
+        var v1: T1 = 0
+        var v2: T2 = 0
+        var v3: T3 = 0
+        var v4: T4 = 0
+        var v5: T5 = 0
+        var v6: T6 = 0
+        var v7: T7 = 0
+        var v8: T8 = 0
+        var v9: T9 = 0
+        var v10: T10 = 0
+        var v11: T11 = 0
+        var v12: T12 = 0
+        var v13: T13 = 0
+        var v14: T14 = 0
+        var v15: T15 = 0
+        var offset = range.lowerBound
+        self.withUnsafeReadableBytes { ptr in
+            assert(ptr.count >= range.upperBound)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
+            withUnsafeMutableBytes(of: &v1) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
+            }
+            offset = offset &+ MemoryLayout<T1>.size
+            withUnsafeMutableBytes(of: &v2) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T2>.size)
+            }
+            offset = offset &+ MemoryLayout<T2>.size
+            withUnsafeMutableBytes(of: &v3) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T3>.size)
+            }
+            offset = offset &+ MemoryLayout<T3>.size
+            withUnsafeMutableBytes(of: &v4) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T4>.size)
+            }
+            offset = offset &+ MemoryLayout<T4>.size
+            withUnsafeMutableBytes(of: &v5) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T5>.size)
+            }
+            offset = offset &+ MemoryLayout<T5>.size
+            withUnsafeMutableBytes(of: &v6) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T6>.size)
+            }
+            offset = offset &+ MemoryLayout<T6>.size
+            withUnsafeMutableBytes(of: &v7) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T7>.size)
+            }
+            offset = offset &+ MemoryLayout<T7>.size
+            withUnsafeMutableBytes(of: &v8) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T8>.size)
+            }
+            offset = offset &+ MemoryLayout<T8>.size
+            withUnsafeMutableBytes(of: &v9) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T9>.size)
+            }
+            offset = offset &+ MemoryLayout<T9>.size
+            withUnsafeMutableBytes(of: &v10) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T10>.size)
+            }
+            offset = offset &+ MemoryLayout<T10>.size
+            withUnsafeMutableBytes(of: &v11) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T11>.size)
+            }
+            offset = offset &+ MemoryLayout<T11>.size
+            withUnsafeMutableBytes(of: &v12) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T12>.size)
+            }
+            offset = offset &+ MemoryLayout<T12>.size
+            withUnsafeMutableBytes(of: &v13) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T13>.size)
+            }
+            offset = offset &+ MemoryLayout<T13>.size
+            withUnsafeMutableBytes(of: &v14) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T14>.size)
+            }
+            offset = offset &+ MemoryLayout<T14>.size
+            withUnsafeMutableBytes(of: &v15) { destPtr in
+                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T15>.size)
+            }
+            offset = offset &+ MemoryLayout<T15>.size
+            assert(offset == range.upperBound)
+        }
+        switch endianness {
+        case .big:
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14), T15(bigEndian: v15)
+            )
+        case .little:
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
+                T13(littleEndian: v13), T14(littleEndian: v14), T15(littleEndian: v15)
+            )
+        }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
     @discardableResult
     public mutating func writeMultipleIntegers<
         T1: FixedWidthInteger,
@@ -2842,6 +5106,132 @@ extension ByteBuffer {
             assert(offset == spaceNeeded)
             return offset
         }
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @discardableResult
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger,
+        T15: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        _ value13: T13,
+        _ value14: T14,
+        _ value15: T15,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
+        ).self
+    ) -> Int {
+        var v1: T1
+        var v2: T2
+        var v3: T3
+        var v4: T4
+        var v5: T5
+        var v6: T6
+        var v7: T7
+        var v8: T8
+        var v9: T9
+        var v10: T10
+        var v11: T11
+        var v12: T12
+        var v13: T13
+        var v14: T14
+        var v15: T15
+        switch endianness {
+        case .big:
+            v1 = value1.bigEndian
+            v2 = value2.bigEndian
+            v3 = value3.bigEndian
+            v4 = value4.bigEndian
+            v5 = value5.bigEndian
+            v6 = value6.bigEndian
+            v7 = value7.bigEndian
+            v8 = value8.bigEndian
+            v9 = value9.bigEndian
+            v10 = value10.bigEndian
+            v11 = value11.bigEndian
+            v12 = value12.bigEndian
+            v13 = value13.bigEndian
+            v14 = value14.bigEndian
+            v15 = value15.bigEndian
+        case .little:
+            v1 = value1.littleEndian
+            v2 = value2.littleEndian
+            v3 = value3.littleEndian
+            v4 = value4.littleEndian
+            v5 = value5.littleEndian
+            v6 = value6.littleEndian
+            v7 = value7.littleEndian
+            v8 = value8.littleEndian
+            v9 = value9.littleEndian
+            v10 = value10.littleEndian
+            v11 = value11.littleEndian
+            v12 = value12.littleEndian
+            v13 = value13.littleEndian
+            v14 = value14.littleEndian
+            v15 = value15.littleEndian
+        }
+
+        var offset = index
+        var bytesWritten = 0
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v1) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T1>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v2) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T2>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v3) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T3>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v4) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T4>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v5) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T5>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v6) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T6>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v7) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T7>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v8) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T8>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v9) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T9>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v10) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T10>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v11) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T11>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v12) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T12>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v13) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T13>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v14) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T14>.size
+        bytesWritten &+= Swift.withUnsafeBytes(of: &v15) { self.setBytes($0, at: offset) }
+        offset = offset &+ MemoryLayout<T15>.size
+        return bytesWritten
     }
 
 }

--- a/Sources/NIOCore/ByteBuffer-multi-int.swift
+++ b/Sources/NIOCore/ByteBuffer-multi-int.swift
@@ -17,7 +17,10 @@
 extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> (T1, T2)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
+        endianness: Endianness = .big,
+        as: (T1, T2).Type = (T1, T2).self
+    ) -> (T1, T2)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -29,13 +32,20 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> (T1, T2)? {
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
+        endianness: Endianness = .big,
+        as: (T1, T2).Type = (T1, T2).self
+    ) -> (T1, T2)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> (T1, T2)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2).Type = (T1, T2).self
+    ) -> (T1, T2)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
 
@@ -47,8 +57,8 @@ extension ByteBuffer {
         var v2: T2 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -70,8 +80,19 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(_ value1: T1, _ value2: T2, endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
+        _ value1: T1,
+        _ value2: T2,
+        endianness: Endianness = .big,
+        as: (T1, T2).Type = (T1, T2).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -79,7 +100,13 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(_ value1: T1, _ value2: T2, at index: Int, endianness: Endianness = .big, as: (T1, T2).Type = (T1, T2).self) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger>(
+        _ value1: T1,
+        _ value2: T2,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2).Type = (T1, T2).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         switch endianness {
@@ -102,7 +129,10 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> (T1, T2, T3)? {
+    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3).Type = (T1, T2, T3).self
+    ) -> (T1, T2, T3)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -115,13 +145,20 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> (T1, T2, T3)? {
+    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3).Type = (T1, T2, T3).self
+    ) -> (T1, T2, T3)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> (T1, T2, T3)? {
+    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3).Type = (T1, T2, T3).self
+    ) -> (T1, T2, T3)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -135,8 +172,8 @@ extension ByteBuffer {
         var v3: T3 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -162,8 +199,21 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3).Type = (T1, T2, T3).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -171,7 +221,14 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3).Type = (T1, T2, T3).self) -> Int {
+    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger>(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3).Type = (T1, T2, T3).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -199,7 +256,12 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger
+    >(endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -213,13 +275,27 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger
+    >(endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> (T1, T2, T3, T4)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self
+    ) -> (T1, T2, T3, T4)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -235,8 +311,8 @@ extension ByteBuffer {
         var v4: T4 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -266,8 +342,28 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -275,7 +371,20 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4).Type = (T1, T2, T3, T4).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -308,7 +417,14 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger
+    >(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)?
+    {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -323,13 +439,30 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger
+    >(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)?
+    {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> (T1, T2, T3, T4, T5)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self
+    ) -> (T1, T2, T3, T4, T5)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -347,8 +480,8 @@ extension ByteBuffer {
         var v5: T5 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -375,15 +508,41 @@ extension ByteBuffer {
         case .big:
             return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5))
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -391,7 +550,22 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5).Type = (T1, T2, T3, T4, T5).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -429,7 +603,17 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> (T1, T2, T3, T4, T5, T6)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
+    ) -> (T1, T2, T3, T4, T5, T6)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -445,13 +629,34 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> (T1, T2, T3, T4, T5, T6)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
+    ) -> (T1, T2, T3, T4, T5, T6)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> (T1, T2, T3, T4, T5, T6)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
+    ) -> (T1, T2, T3, T4, T5, T6)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -471,8 +676,8 @@ extension ByteBuffer {
         var v6: T6 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -501,17 +706,49 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -519,7 +756,24 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6).Type = (T1, T2, T3, T4, T5, T6).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -562,7 +816,18 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> (T1, T2, T3, T4, T5, T6, T7)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -579,13 +844,36 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> (T1, T2, T3, T4, T5, T6, T7)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> (T1, T2, T3, T4, T5, T6, T7)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -607,8 +895,8 @@ extension ByteBuffer {
         var v7: T7 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -641,17 +929,52 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            value7,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -659,7 +982,26 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7).Type = (T1, T2, T3, T4, T5, T6, T7).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -707,7 +1049,19 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -725,13 +1079,38 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -755,8 +1134,8 @@ extension ByteBuffer {
         var v8: T8 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -793,17 +1172,55 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            value7,
+            value8,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -811,7 +1228,28 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8).Type = (T1, T2, T3, T4, T5, T6, T7, T8).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -864,7 +1302,20 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -883,13 +1334,40 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -915,8 +1393,8 @@ extension ByteBuffer {
         var v9: T9 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -957,17 +1435,59 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            value7,
+            value8,
+            value9,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -975,7 +1495,30 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -1033,7 +1576,21 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -1053,13 +1610,42 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1087,8 +1673,8 @@ extension ByteBuffer {
         var v10: T10 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -1133,17 +1719,62 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            value7,
+            value8,
+            value9,
+            value10,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -1151,7 +1782,32 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -1214,7 +1870,22 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -1235,13 +1906,44 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1271,8 +1973,8 @@ extension ByteBuffer {
         var v11: T11 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -1321,17 +2023,66 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            value7,
+            value8,
+            value9,
+            value10,
+            value11,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -1339,7 +2090,34 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -1407,7 +2185,25 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -1429,13 +2225,50 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1467,8 +2300,8 @@ extension ByteBuffer {
         var v12: T12 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -1521,17 +2354,71 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11), T12(bigEndian: v12))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11), T12(bigEndian: v12)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
+        ).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            value7,
+            value8,
+            value9,
+            value10,
+            value11,
+            value12,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -1539,7 +2426,38 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
+        ).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -1612,7 +2530,26 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -1635,13 +2572,52 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1675,8 +2651,8 @@ extension ByteBuffer {
         var v13: T13 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -1733,17 +2709,75 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12), T13(littleEndian: v13))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
+                T13(littleEndian: v13)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        _ value13: T13,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
+        ).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            value7,
+            value8,
+            value9,
+            value10,
+            value11,
+            value12,
+            value13,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -1751,7 +2785,40 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        _ value13: T13,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
+        ).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -1829,7 +2896,27 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -1853,13 +2940,54 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -1895,8 +3023,8 @@ extension ByteBuffer {
         var v14: T14 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -1957,17 +3085,78 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12), T13(littleEndian: v13), T14(littleEndian: v14))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
+                T13(littleEndian: v13), T14(littleEndian: v14)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, _ value14: T14, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        _ value13: T13,
+        _ value14: T14,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
+        ).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            value7,
+            value8,
+            value9,
+            value10,
+            value11,
+            value12,
+            value13,
+            value14,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -1975,7 +3164,42 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, _ value14: T14, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        _ value13: T13,
+        _ value14: T14,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
+        ).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3
@@ -2058,7 +3282,28 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public mutating func readMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
+    public mutating func readMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger,
+        T15: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
         guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`) else {
             return nil
         }
@@ -2083,13 +3328,56 @@ extension ByteBuffer {
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func peekMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
+    public func peekMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger,
+        T15: FixedWidthInteger
+    >(
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
         self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: `as`)
     }
 
     @inlinable
     @_alwaysEmitIntoClient
-    public func getMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
+    public func getMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger,
+        T15: FixedWidthInteger
+    >(
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
+        ).self
+    ) -> (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)? {
         var bytesRequired: Int = MemoryLayout<T1>.size
         bytesRequired &+= MemoryLayout<T2>.size
         bytesRequired &+= MemoryLayout<T3>.size
@@ -2127,8 +3415,8 @@ extension ByteBuffer {
         var v15: T15 = 0
         var offset = range.lowerBound
         self.withUnsafeReadableBytes { ptr in
-            assert(ptr.count >= range.upperBound)
-            let basePtr = ptr.baseAddress! // safe, ptr is non-empty
+            assert(ptr.count >= range.lowerBound + bytesRequired)
+            let basePtr = ptr.baseAddress!  // safe, ptr is non-empty
             withUnsafeMutableBytes(of: &v1) { destPtr in
                 destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T1>.size)
             }
@@ -2193,17 +3481,81 @@ extension ByteBuffer {
         }
         switch endianness {
         case .big:
-            return (T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5), T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10), T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14), T15(bigEndian: v15))
+            return (
+                T1(bigEndian: v1), T2(bigEndian: v2), T3(bigEndian: v3), T4(bigEndian: v4), T5(bigEndian: v5),
+                T6(bigEndian: v6), T7(bigEndian: v7), T8(bigEndian: v8), T9(bigEndian: v9), T10(bigEndian: v10),
+                T11(bigEndian: v11), T12(bigEndian: v12), T13(bigEndian: v13), T14(bigEndian: v14), T15(bigEndian: v15)
+            )
         case .little:
-            return (T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4), T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8), T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12), T13(littleEndian: v13), T14(littleEndian: v14), T15(littleEndian: v15))
+            return (
+                T1(littleEndian: v1), T2(littleEndian: v2), T3(littleEndian: v3), T4(littleEndian: v4),
+                T5(littleEndian: v5), T6(littleEndian: v6), T7(littleEndian: v7), T8(littleEndian: v8),
+                T9(littleEndian: v9), T10(littleEndian: v10), T11(littleEndian: v11), T12(littleEndian: v12),
+                T13(littleEndian: v13), T14(littleEndian: v14), T15(littleEndian: v15)
+            )
         }
     }
 
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func writeMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, _ value14: T14, _ value15: T15, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> Int {
-        let bytesWritten = self.setMultipleIntegers(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, at: self.writerIndex, endianness: endianness, as: `as`)
+    public mutating func writeMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger,
+        T15: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        _ value13: T13,
+        _ value14: T14,
+        _ value15: T15,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
+        ).self
+    ) -> Int {
+        let bytesWritten = self.setMultipleIntegers(
+            value1,
+            value2,
+            value3,
+            value4,
+            value5,
+            value6,
+            value7,
+            value8,
+            value9,
+            value10,
+            value11,
+            value12,
+            value13,
+            value14,
+            value15,
+            at: self.writerIndex,
+            endianness: endianness,
+            as: `as`
+        )
         self._moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
     }
@@ -2211,7 +3563,44 @@ extension ByteBuffer {
     @inlinable
     @_alwaysEmitIntoClient
     @discardableResult
-    public mutating func setMultipleIntegers<T1: FixedWidthInteger, T2: FixedWidthInteger, T3: FixedWidthInteger, T4: FixedWidthInteger, T5: FixedWidthInteger, T6: FixedWidthInteger, T7: FixedWidthInteger, T8: FixedWidthInteger, T9: FixedWidthInteger, T10: FixedWidthInteger, T11: FixedWidthInteger, T12: FixedWidthInteger, T13: FixedWidthInteger, T14: FixedWidthInteger, T15: FixedWidthInteger>(_ value1: T1, _ value2: T2, _ value3: T3, _ value4: T4, _ value5: T5, _ value6: T6, _ value7: T7, _ value8: T8, _ value9: T9, _ value10: T10, _ value11: T11, _ value12: T12, _ value13: T13, _ value14: T14, _ value15: T15, at index: Int, endianness: Endianness = .big, as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).self) -> Int {
+    public mutating func setMultipleIntegers<
+        T1: FixedWidthInteger,
+        T2: FixedWidthInteger,
+        T3: FixedWidthInteger,
+        T4: FixedWidthInteger,
+        T5: FixedWidthInteger,
+        T6: FixedWidthInteger,
+        T7: FixedWidthInteger,
+        T8: FixedWidthInteger,
+        T9: FixedWidthInteger,
+        T10: FixedWidthInteger,
+        T11: FixedWidthInteger,
+        T12: FixedWidthInteger,
+        T13: FixedWidthInteger,
+        T14: FixedWidthInteger,
+        T15: FixedWidthInteger
+    >(
+        _ value1: T1,
+        _ value2: T2,
+        _ value3: T3,
+        _ value4: T4,
+        _ value5: T5,
+        _ value6: T6,
+        _ value7: T7,
+        _ value8: T8,
+        _ value9: T9,
+        _ value10: T10,
+        _ value11: T11,
+        _ value12: T12,
+        _ value13: T13,
+        _ value14: T14,
+        _ value15: T15,
+        at index: Int,
+        endianness: Endianness = .big,
+        as: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15).Type = (
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
+        ).self
+    ) -> Int {
         var v1: T1
         var v2: T2
         var v3: T3

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -3955,6 +3955,153 @@ extension ByteBufferTest {
         XCTAssertEqual(0, self.buf.readableBytes, "Buffer should be fully consumed after all reads.")
     }
 
+    func testGetAndSetMultipleIntegers() {
+        // This test mirrors 'testReadAndWriteMultipleIntegers' but uses set/getMultipleIntegers.
+        for endianness in [Endianness.little, .big] {
+            let v1: UInt8 = .random(in: .min ... .max)
+            let v2: UInt16 = .random(in: .min ... .max)
+            let v3: UInt32 = .random(in: .min ... .max)
+            let v4: UInt64 = .random(in: .min ... .max)
+            let v5: UInt64 = .random(in: .min ... .max)
+            let v6: UInt32 = .random(in: .min ... .max)
+            let v7: UInt16 = .random(in: .min ... .max)
+            let v8: UInt8 = .random(in: .min ... .max)
+            let v9: UInt16 = .random(in: .min ... .max)
+            let v10: UInt32 = .random(in: .min ... .max)
+
+            // Reserve some readable bytes in front so the integers don't start at the reader index.
+            self.buf.clear()
+            self.buf.writeRepeatingByte(0, count: 7)
+            let index = self.buf.writerIndex
+            self.buf.writeRepeatingByte(0, count: 256)
+
+            let startReaderIndex = self.buf.readerIndex
+            let startWriterIndex = self.buf.writerIndex
+            let written = self.buf.setMultipleIntegers(
+                v1,
+                v2,
+                v3,
+                v4,
+                v5,
+                v6,
+                v7,
+                v8,
+                v9,
+                v10,
+                at: index,
+                endianness: endianness,
+                as: (UInt8, UInt16, UInt32, UInt64, UInt64, UInt32, UInt16, UInt8, UInt16, UInt32).self
+            )
+            // set does not move either index.
+            XCTAssertEqual(startReaderIndex, self.buf.readerIndex, "endianness: \(endianness)")
+            XCTAssertEqual(startWriterIndex, self.buf.writerIndex, "endianness: \(endianness)")
+
+            let result = self.buf.getMultipleIntegers(
+                at: index,
+                endianness: endianness,
+                as: (UInt8, UInt16, UInt32, UInt64, UInt64, UInt32, UInt16, UInt8, UInt16, UInt32).self
+            )
+            // get does not move either index.
+            XCTAssertEqual(startReaderIndex, self.buf.readerIndex, "endianness: \(endianness)")
+            XCTAssertEqual(startWriterIndex, self.buf.writerIndex, "endianness: \(endianness)")
+            XCTAssertNotNil(result, "endianness: \(endianness)")
+
+            XCTAssertEqual(v1, result?.0, "endianness: \(endianness)")
+            XCTAssertEqual(v2, result?.1, "endianness: \(endianness)")
+            XCTAssertEqual(v3, result?.2, "endianness: \(endianness)")
+            XCTAssertEqual(v4, result?.3, "endianness: \(endianness)")
+            XCTAssertEqual(v5, result?.4, "endianness: \(endianness)")
+            XCTAssertEqual(v6, result?.5, "endianness: \(endianness)")
+            XCTAssertEqual(v7, result?.6, "endianness: \(endianness)")
+            XCTAssertEqual(v8, result?.7, "endianness: \(endianness)")
+            XCTAssertEqual(v9, result?.8, "endianness: \(endianness)")
+            XCTAssertEqual(v10, result?.9, "endianness: \(endianness)")
+
+            // The bytes we set must be byte-for-byte identical to those produced by writeMultipleIntegers.
+            var expected = ByteBufferAllocator().buffer(capacity: written)
+            expected.writeMultipleIntegers(
+                v1,
+                v2,
+                v3,
+                v4,
+                v5,
+                v6,
+                v7,
+                v8,
+                v9,
+                v10,
+                endianness: endianness,
+                as: (UInt8, UInt16, UInt32, UInt64, UInt64, UInt32, UInt16, UInt8, UInt16, UInt32).self
+            )
+            XCTAssertEqual(
+                self.buf.getSlice(at: index, length: written).map { Array($0.readableBytesView) },
+                Array(expected.readableBytesView),
+                "endianness: \(endianness)"
+            )
+        }
+    }
+
+    func testGetMultipleIntegersReturnsNilWhenOutOfBounds() {
+        self.buf.clear()
+        self.buf.writeRepeatingByte(0, count: 8)
+        // Move the reader index forward so we can also test indices that precede it.
+        self.buf.moveReaderIndex(forwardBy: 4)
+        let index = self.buf.readerIndex
+
+        // Asking for 4 bytes when only 4 are readable from `index` must return nil if we ask for more.
+        XCTAssertNil(self.buf.getMultipleIntegers(at: index, as: (UInt32, UInt8).self))
+        // Asking for an index before the reader index must return nil, even though those bytes exist.
+        XCTAssertNil(self.buf.getMultipleIntegers(at: index - 1, as: (UInt8, UInt8).self))
+        // A request that just fits must succeed.
+        XCTAssertNotNil(self.buf.getMultipleIntegers(at: index, as: (UInt16, UInt16).self))
+    }
+
+    func testAllByteBufferMultiByteVersionsGetSet() {
+        // This test mirrors 'testAllByteBufferMultiByteVersions' but using set/getMultipleIntegers.
+        let i = UInt8(86)
+        var index = self.buf.writerIndex
+
+        index += self.buf.setMultipleIntegers(i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, i, i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, i, i, i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, i, i, i, i, i, i, i, i, at: index)
+        index += self.buf.setMultipleIntegers(i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, at: index)
+
+        // setMultipleIntegers does not move the writer index (just like setInteger), so expose the
+        // bytes we just wrote before reading them back.
+        XCTAssertEqual(0, self.buf.writerIndex)
+        self.buf.moveWriterIndex(to: index)
+        XCTAssertEqual(Array(repeating: UInt8(86), count: 119), Array(self.buf.readableBytesView))
+
+        var readIndex = self.buf.readerIndex
+        var values2 = self.buf.getMultipleIntegers(at: readIndex, as: (UInt8, UInt8).self)!
+        readIndex += MemoryLayout<UInt8>.size * 2
+        var values3 = self.buf.getMultipleIntegers(at: readIndex, as: (UInt8, UInt8, UInt8).self)!
+        readIndex += MemoryLayout<UInt8>.size * 3
+        var values4 = self.buf.getMultipleIntegers(at: readIndex, as: (UInt8, UInt8, UInt8, UInt8).self)!
+        readIndex += MemoryLayout<UInt8>.size * 4
+        var values5 = self.buf.getMultipleIntegers(at: readIndex, as: (UInt8, UInt8, UInt8, UInt8, UInt8).self)!
+        readIndex += MemoryLayout<UInt8>.size * 5
+
+        XCTAssertEqual([i, i], withUnsafeBytes(of: &values2, { Array($0) }))
+        XCTAssertEqual([i, i, i], withUnsafeBytes(of: &values3, { Array($0) }))
+        XCTAssertEqual([i, i, i, i], withUnsafeBytes(of: &values4, { Array($0) }))
+        XCTAssertEqual([i, i, i, i, i], withUnsafeBytes(of: &values5, { Array($0) }))
+
+        // get must not have consumed anything.
+        XCTAssertEqual(self.buf.readerIndex, 0)
+        XCTAssertEqual(Array(repeating: UInt8(86), count: 119), Array(self.buf.readableBytesView))
+    }
+
     func testByteBufferEncode() throws {
         let encoder = JSONEncoder()
         let hello = "Hello, world!"

--- a/dev/generate-bytebuffer-multi-int.sh
+++ b/dev/generate-bytebuffer-multi-int.sh
@@ -105,6 +105,64 @@ function gen() {
     echo "    }"
     echo
 
+    # GET
+    echo "    @inlinable"
+    echo "    @_alwaysEmitIntoClient"
+    echo -n "    public func getMultipleIntegers<T1: FixedWidthInteger"
+    for n in $(seq 2 "$how_many"); do
+        echo -n ", T$n: FixedWidthInteger"
+    done
+    echo -n ">("
+    echo -n "at index: Int, endianness: Endianness = .big, as: (T1"
+    for n in $(seq 2 "$how_many"); do
+        echo -n ", T$n"
+    done
+    echo -n ").Type = (T1"
+    for n in $(seq 2 "$how_many"); do
+        echo -n ", T$n"
+    done
+    echo -n ").self) -> (T1"
+    for n in $(seq 2 "$how_many"); do
+        echo -n ", T$n"
+    done
+    echo ")? {"
+    echo "        var bytesRequired: Int = MemoryLayout<T1>.size"
+    for n in $(seq 2 "$how_many"); do
+        echo "        bytesRequired &+= MemoryLayout<T$n>.size"
+    done
+    echo
+    echo "        guard let range = self.rangeWithinReadableBytes(index: index, length: bytesRequired) else {"
+    echo "            return nil"
+    echo "        }"
+    echo
+    for n in $(seq 1 "$how_many"); do
+        echo "        var v$n: T$n = 0"
+    done
+    echo "        var offset = range.lowerBound"
+    echo "        self.withUnsafeReadableBytes { ptr in"
+    echo "            assert(ptr.count >= range.upperBound)"
+    echo "            let basePtr = ptr.baseAddress! // safe, ptr is non-empty"
+    for n in $(seq 1 "$how_many"); do
+        echo "            withUnsafeMutableBytes(of: &v$n) { destPtr in"
+        echo "                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T$n>.size)"
+        echo "            }"
+        echo "            offset = offset &+ MemoryLayout<T$n>.size"
+    done
+    echo "            assert(offset == range.upperBound)"
+    echo "        }"
+    echo "        switch endianness {"
+    for endianness in big little; do
+        echo "        case .$endianness:"
+        echo -n "            return (T1(${endianness}Endian: v1)"
+        for n in $(seq 2 "$how_many"); do
+            echo -n ", T$n(${endianness}Endian: v$n)"
+        done
+        echo ")"
+    done
+    echo "        }"
+    echo "    }"
+    echo
+
     # WRITE
     echo "    @inlinable"
     echo "    @_alwaysEmitIntoClient"
@@ -154,6 +212,49 @@ function gen() {
     echo "            assert(offset == spaceNeeded)"
     echo "            return offset"
     echo "        }"
+    echo "    }"
+    echo
+
+    # SET
+    echo "    @inlinable"
+    echo "    @_alwaysEmitIntoClient"
+    echo "    @discardableResult"
+    echo -n "    public mutating func setMultipleIntegers<T1: FixedWidthInteger"
+    for n in $(seq 2 "$how_many"); do
+        echo -n ", T$n: FixedWidthInteger"
+    done
+    echo -n ">(_ value1: T1"
+    for n in $(seq 2 "$how_many"); do
+        echo -n ", _ value$n: T$n"
+    done
+    echo -n ", at index: Int, endianness: Endianness = .big, as: (T1"
+    for n in $(seq 2 "$how_many"); do
+        echo -n ", T$n"
+    done
+    echo -n ").Type = (T1"
+    for n in $(seq 2 "$how_many"); do
+        echo -n ", T$n"
+    done
+    echo ").self) -> Int {"
+    for n in $(seq 1 "$how_many"); do
+        echo "        var v$n: T$n"
+    done
+    echo "        switch endianness {"
+    for endianness in .big .little; do
+        echo "        case $endianness:"
+        for n in $(seq 1 "$how_many"); do
+            echo "            v$n = value$n${endianness}Endian"
+        done
+    done
+    echo "        }"
+    echo
+    echo "        var offset = index"
+    echo "        var bytesWritten = 0"
+    for n in $(seq 1 "$how_many"); do
+        echo "        bytesWritten &+= Swift.withUnsafeBytes(of: &v$n) { self.setBytes(\$0, at: offset) }"
+        echo "        offset = offset &+ MemoryLayout<T$n>.size"
+    done
+    echo "        return bytesWritten"
     echo "    }"
     echo
 }

--- a/dev/generate-bytebuffer-multi-int.sh
+++ b/dev/generate-bytebuffer-multi-int.sh
@@ -113,7 +113,7 @@ function gen() {
     done
     echo "        var offset = range.lowerBound"
     echo "        self.withUnsafeReadableBytes { ptr in"
-    echo "            assert(ptr.count >= range.upperBound)"
+    echo "            assert(ptr.count >= range.lowerBound + bytesRequired)"
     echo "            let basePtr = ptr.baseAddress! // safe, ptr is non-empty"
     for n in $(seq 1 "$how_many"); do
         echo "            withUnsafeMutableBytes(of: &v$n) { destPtr in"

--- a/dev/generate-bytebuffer-multi-int.sh
+++ b/dev/generate-bytebuffer-multi-int.sh
@@ -41,41 +41,15 @@ function gen() {
         echo -n ", T$n"
     done
     echo ")? {"
+    echo "        guard let result = self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: \`as\`) else {"
+    echo "            return nil"
+    echo "        }"
     echo "        var bytesRequired: Int = MemoryLayout<T1>.size"
     for n in $(seq 2 "$how_many"); do
         echo "        bytesRequired &+= MemoryLayout<T$n>.size"
     done
-    echo
-    echo "        guard self.readableBytes >= bytesRequired else {"
-    echo "            return nil"
-    echo "        }"
-    echo
-    for n in $(seq 1 "$how_many"); do
-        echo "        var v$n: T$n = 0"
-    done
-    echo "        var offset = 0"
-    echo "        self.readWithUnsafeReadableBytes { ptr -> Int in"
-    echo "            assert(ptr.count >= bytesRequired)"
-    echo "            let basePtr = ptr.baseAddress! // safe, ptr is non-empty"
-    for n in $(seq 1 "$how_many"); do
-        echo "            withUnsafeMutableBytes(of: &v$n) { destPtr in"
-        echo "                destPtr.baseAddress!.copyMemory(from: basePtr + offset, byteCount: MemoryLayout<T$n>.size)"
-        echo "            }"
-        echo "            offset = offset &+ MemoryLayout<T$n>.size"
-    done
-    echo "            assert(offset == bytesRequired)"
-    echo "            return offset"
-    echo "        }"
-    echo "        switch endianness {"
-    for endianness in big little; do
-        echo "        case .$endianness:"
-        echo -n "            return (T1(${endianness}Endian: v1)"
-        for n in $(seq 2 "$how_many"); do
-            echo -n ", T$n(${endianness}Endian: v$n)"
-        done
-        echo ")"
-    done
-    echo "        }"
+    echo "        self._moveReaderIndex(forwardBy: bytesRequired)"
+    echo "        return result"
     echo "    }"
     echo
 
@@ -100,8 +74,7 @@ function gen() {
         echo -n ", T$n"
     done
     echo ")? {"
-    echo "        var copy = self"
-    echo "        return copy.readMultipleIntegers(endianness: endianness, as: \`as\`)"
+    echo "        self.getMultipleIntegers(at: self.readerIndex, endianness: endianness, as: \`as\`)"
     echo "    }"
     echo
 
@@ -184,34 +157,13 @@ function gen() {
         echo -n ", T$n"
     done
     echo ").self) -> Int {"
-    for n in $(seq 1 "$how_many"); do
-        echo "        var v$n: T$n"
-    done
-    echo "        switch endianness {"
-    for endianness in .big .little; do
-        echo "        case $endianness:"
-        for n in $(seq 1 "$how_many"); do
-            echo "            v$n = value$n${endianness}Endian"
-        done
-    done
-    echo "        }"
-    echo
-    echo "        var spaceNeeded: Int = MemoryLayout<T1>.size"
+    echo -n "        let bytesWritten = self.setMultipleIntegers(value1"
     for n in $(seq 2 "$how_many"); do
-        echo "        spaceNeeded &+= MemoryLayout<T$n>.size"
+        echo -n ", value$n"
     done
-    echo
-    echo "        return self.writeWithUnsafeMutableBytes(minimumWritableBytes: spaceNeeded) { ptr -> Int in"
-    echo "            assert(ptr.count >= spaceNeeded)"
-    echo "            var offset = 0"
-    echo "            let basePtr = ptr.baseAddress! // safe: pointer is non zero length"
-    for n in $(seq 1 "$how_many"); do
-        echo "            (basePtr + offset).copyMemory(from: &v$n, byteCount: MemoryLayout<T$n>.size)"
-        echo "            offset = offset &+ MemoryLayout<T$n>.size"
-    done
-    echo "            assert(offset == spaceNeeded)"
-    echo "            return offset"
-    echo "        }"
+    echo ", at: self.writerIndex, endianness: endianness, as: \`as\`)"
+    echo "        self._moveWriterIndex(forwardBy: bytesWritten)"
+    echo "        return bytesWritten"
     echo "    }"
     echo
 


### PR DESCRIPTION
`ByteBuffer` exposes `read`, `write`, and (since the peek work landed) `peek`
variants of `MultipleIntegers`, but not the absolute-index `get`/`set` pair that
every other integer accessor on `ByteBuffer` has. This fills that gap, which is
what #2736 originally asked for.

The thread on #2736 settled on adding `peek*` first so that the common
"look without consuming" use case has a non-mutating, index-free spelling, and
that is now in place. `get`/`set` remain useful for the niche cases that
genuinely need to address an arbitrary index, so this completes the set of four
for `MultipleIntegers` to match `getInteger`/`setInteger`.

Both methods are generated from `dev/generate-bytebuffer-multi-int.sh`, the same
script that produces the read/write/peek variants, so they stay in lockstep with
the rest of the file across all arities (2 through 15):

- `getMultipleIntegers(at:endianness:as:)` reads at an explicit index without
  moving the reader index and returns `nil` when the requested bytes are not
  readable, exactly like `getInteger(at:)`.
- `setMultipleIntegers(_:at:endianness:as:)` writes at an explicit index without
  moving the writer index and returns the number of bytes written, exactly like
  `setInteger(_:at:)`.

The new tests mirror the existing read/write and peek tests: a round-trip across
both endiannesses, a check that the bytes written by `set` are byte-for-byte
identical to `writeMultipleIntegers`, coverage of every arity, a check that
neither method moves the reader or writer index, and the out-of-bounds /
before-reader-index cases that must return `nil`.

Resolves #2736
