### PR TITLE
NonBlockingFileIO: error instead of silently truncating oversized reads

### DIFF
--- a/Sources/NIOPosix/NonBlockingFileIO.swift
+++ b/Sources/NIOPosix/NonBlockingFileIO.swift
@@ -360,14 +360,24 @@ public struct NonBlockingFileIO: Sendable {
     private func read0(
         fileHandle: NIOFileHandle,
         fromOffset: Int64?,  // > 2 GB offset is reasonable on 32-bit systems
-        byteCount rawByteCount: Int,
+        byteCount: Int,
         allocator: ByteBufferAllocator,
         eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
-        guard rawByteCount > 0 else {
+        guard byteCount > 0 else {
             return eventLoop.makeSucceededFuture(allocator.buffer(capacity: 0))
         }
-        let byteCount = rawByteCount < Int32.max ? rawByteCount : size_t(Int32.max)
+        // A `ByteBuffer` can hold at most `UInt32.max` bytes, so anything larger can never be returned. Rather than
+        // silently reading fewer bytes than requested we fail the read. On 32-bit platforms `Int.max` is smaller than
+        // `UInt32.max` so this guard is never true there.
+        guard byteCount <= UInt32.max else {
+            return eventLoop.makeFailedFuture(
+                IOError(
+                    errnoCode: EINVAL,
+                    reason: "byteCount (\(byteCount)) is larger than the maximum size a ByteBuffer can hold"
+                )
+            )
+        }
 
         return self.threadPool.runIfActive(eventLoop: eventLoop) { () -> ByteBuffer in
             try self.readSync(
@@ -389,21 +399,26 @@ public struct NonBlockingFileIO: Sendable {
         var buf = allocator.buffer(capacity: byteCount)
 
         while bytesRead < byteCount {
-            let n = try buf.writeWithUnsafeMutableBytes(minimumWritableBytes: byteCount - bytesRead) { ptr -> Int in
+            // The OS returns EINVAL if a single read/pread requests more than `Int32.max` bytes, so we cap the size of
+            // each individual syscall. The surrounding loop keeps reading until the whole `byteCount` is satisfied (or
+            // we hit end-of-file), so capping the per-syscall size does not limit the total number of bytes read.
+            let remaining = byteCount - bytesRead
+            let readSize = min(remaining, Int(Int32.max))
+            let n = try buf.writeWithUnsafeMutableBytes(minimumWritableBytes: readSize) { ptr -> Int in
                 let res = try fileHandle.withUnsafeFileDescriptor { descriptor -> IOResult<ssize_t> in
                     if let offset = fromOffset {
                         #if !os(Windows)
                         return try Posix.pread(
                             descriptor: descriptor,
                             pointer: ptr.baseAddress!,
-                            size: byteCount - bytesRead,
+                            size: readSize,
                             offset: off_t(offset) + off_t(bytesRead)
                         )
                         #else
                         return try Windows.pread(
                             descriptor: descriptor,
                             pointer: ptr.baseAddress!,
-                            size: byteCount - bytesRead,
+                            size: readSize,
                             offset: off_t(offset) + off_t(bytesRead)
                         )
                         #endif
@@ -412,7 +427,7 @@ public struct NonBlockingFileIO: Sendable {
                     return try Posix.read(
                         descriptor: descriptor,
                         pointer: ptr.baseAddress!,
-                        size: byteCount - bytesRead
+                        size: readSize
                     )
                 }
                 switch res {
@@ -990,13 +1005,21 @@ extension NonBlockingFileIO {
     private func read0(
         fileHandle: NIOFileHandle,
         fromOffset: Int64?,  // > 2 GB offset is reasonable on 32-bit systems
-        byteCount rawByteCount: Int,
+        byteCount: Int,
         allocator: ByteBufferAllocator
     ) async throws -> ByteBuffer {
-        guard rawByteCount > 0 else {
+        guard byteCount > 0 else {
             return allocator.buffer(capacity: 0)
         }
-        let byteCount = rawByteCount < Int32.max ? rawByteCount : size_t(Int32.max)
+        // A `ByteBuffer` can hold at most `UInt32.max` bytes, so anything larger can never be returned. Rather than
+        // silently reading fewer bytes than requested we fail the read. On 32-bit platforms `Int.max` is smaller than
+        // `UInt32.max` so this guard is never true there.
+        guard byteCount <= UInt32.max else {
+            throw IOError(
+                errnoCode: EINVAL,
+                reason: "byteCount (\(byteCount)) is larger than the maximum size a ByteBuffer can hold"
+            )
+        }
 
         return try await self.threadPool.runIfActive { () -> ByteBuffer in
             try self.readSync(

--- a/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
@@ -359,6 +359,51 @@ class NonBlockingFileIOTest: XCTestCase {
         )
     }
 
+    func testReadMoreBytesThanAByteBufferCanHoldThrows() throws {
+        // A `ByteBuffer` can hold at most `UInt32.max` bytes. On 32-bit platforms `Int.max` is smaller than that so
+        // the request can never be expressed and there is nothing to test.
+        try XCTSkipIf(MemoryLayout<size_t>.size == MemoryLayout<UInt32>.size)
+        // The byte count is larger than a `ByteBuffer` can ever hold so the read must fail rather than silently
+        // returning fewer bytes than requested. The guard fires before any allocation, so this is cheap regardless of
+        // the requested size.
+        try withTemporaryFile(
+            content: "some-dummy-content",
+            { (filehandle, path) -> Void in
+                XCTAssertThrowsError(
+                    try self.fileIO.read(
+                        fileHandle: filehandle,
+                        // Use overflow addition so this compiles on 32-bit platforms where the test is skipped anyway.
+                        byteCount: Int(UInt32.max) &+ 1,
+                        allocator: .init(),
+                        eventLoop: self.eventLoop
+                    ).wait()
+                ) { error in
+                    guard let error = error as? IOError, error.errnoCode == EINVAL else {
+                        XCTFail("unexpected error: \(error)")
+                        return
+                    }
+                }
+            }
+        )
+    }
+
+    func testReadMoreBytesThanAByteBufferCanHoldThrowsAsync() async throws {
+        try XCTSkipIf(MemoryLayout<size_t>.size == MemoryLayout<UInt32>.size)
+        let fileIO = self.fileIO!
+        try await withTemporaryFile(content: "some-dummy-content") { filehandle, _ in
+            do {
+                _ = try await fileIO.read(
+                    fileHandle: filehandle,
+                    byteCount: Int(UInt32.max) &+ 1,
+                    allocator: .init()
+                )
+                XCTFail("expected read to throw")
+            } catch let error as IOError {
+                XCTAssertEqual(error.errnoCode, EINVAL)
+            }
+        }
+    }
+
     func testChunkedReadDoesNotReadShort() throws {
         var innerError: Error? = nil
         try withPipe { readFH, writeFH in


### PR DESCRIPTION
Error instead of silently truncating oversized `NonBlockingFileIO` reads.

### Motivation:

A `ByteBuffer` can hold at most `UInt32.max` bytes, so a read for more than that can never be satisfied. Today the read functions clamp the requested `byteCount` to `Int32.max` and then read at most that many bytes, returning a short buffer with no error and no end-of-file. That silently breaks the documented contract that the returned `ByteBuffer` is only shorter than `byteCount` when end-of-file is reached. It also means a request between 2 GiB and 4 GiB returns fewer bytes than the caller asked for.

Resolves #2591.

### Modifications:

- `read0` (both the `EventLoopFuture` and the `async` overload) now fails with an `IOError` (`EINVAL`) when `byteCount` is larger than `UInt32.max` instead of clamping. The guard runs before any allocation. On 32-bit platforms `Int.max` is smaller than `UInt32.max` so the guard is never hit there, and behaviour is unchanged.
- `readSync` now caps the size of each individual `read`/`pread` syscall at `Int32.max` rather than capping the total `byteCount`. The OS returns `EINVAL` for a single read larger than `Int32.max`, and the surrounding loop already reads repeatedly until the whole request is satisfied or end-of-file is reached, so a request up to `UInt32.max` is now read in full.
- Added tests covering the future and async read variants for a `byteCount` larger than a `ByteBuffer` can hold.

I went with `IOError(errnoCode: EINVAL, ...)` rather than a new `NonBlockingFileIO.Error` case to keep this non API-breaking, matching the existing `IOError(errnoCode: ENOTDIR, ...)` use in the same file. Happy to switch to a typed error case if you would prefer that.

### Result:

A read that cannot fit in a `ByteBuffer` fails clearly, and reads between 2 GiB and 4 GiB are no longer truncated. No public API changes.
