### PR TITLE
Tolerate upgrader search completing after handler removal

### DIFF
--- a/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
+++ b/Sources/NIOHTTP1/NIOTypedHTTPServerUpgraderStateMachine.swift
@@ -360,7 +360,14 @@ struct NIOTypedHTTPServerUpgraderStateMachine<UpgradeResult> {
                 }
             }
 
-        case .upgrading, .unbuffering, .finished:
+        case .finished:
+            // The channel was closed (e.g. the peer disconnected mid-upgrade) and the handler was
+            // removed from the pipeline while the future searching for an upgrader was still in flight.
+            // `handlerRemoved` already advanced us to `.finished` and failed the upgrade promise, so
+            // there is nothing left to do other than tolerate the late completion.
+            return nil
+
+        case .upgrading, .unbuffering:
             fatalError("Internal inconsistency in HTTPServerUpgradeStateMachine")
 
         case .modifying:

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -2417,4 +2417,64 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
         try connectedServer.pipeline.waitForUpgraderToBeRemoved()
         XCTAssertEqual(errorCaught.wrappedValue, true)
     }
+
+    // Regression test for https://github.com/apple/swift-nio/issues/3596
+    //
+    // The handler can be removed from the pipeline (e.g. because the channel was closed by a peer
+    // disconnecting mid-upgrade) while the future searching for a suitable upgrader is still in
+    // flight. `handlerRemoved` advances the state machine to `.finished`, so when the search future
+    // later completes, `findingUpgraderCompleted` used to hit a `fatalError`. It must instead
+    // tolerate the late completion.
+    func testUpgraderSearchCompletingAfterHandlerRemovalDoesNotCrash() throws {
+        let channel = EmbeddedChannel()
+        defer {
+            // The channel was force-closed below; tolerate whatever state it is in.
+            _ = try? channel.finish()
+        }
+
+        // An upgrader whose `buildUpgradeResponse` never completes until we say so. This keeps the
+        // state machine parked in `.awaitingUpgrader` with the search future outstanding.
+        let responsePromise = channel.eventLoop.makePromise(of: HTTPHeaders.self)
+        let upgrader = SuccessfulUpgrader(
+            forProtocol: "myproto",
+            requiringHeaders: [],
+            buildUpgradeResponseFuture: { _, _ in responsePromise.futureResult },
+            onUpgradeComplete: { _ in XCTFail("Upgrade must not complete after the channel was closed") }
+        )
+
+        let encoder = HTTPResponseEncoder()
+        let handler = NIOTypedHTTPServerUpgradeHandler<Bool>(
+            httpEncoder: encoder,
+            extraHTTPHandlers: [],
+            upgradeConfiguration: .init(
+                upgraders: [upgrader],
+                notUpgradingCompletionHandler: { $0.eventLoop.makeSucceededFuture(false) }
+            )
+        )
+
+        try channel.pipeline.syncOperations.addHandler(encoder)
+        try channel.pipeline.syncOperations.addHandler(handler)
+
+        // Drive the upgrade request in. This transitions the state machine into `.awaitingUpgrader`
+        // and kicks off the (now-stalled) search future.
+        var headers = HTTPHeaders()
+        headers.add(name: "Host", value: "localhost")
+        headers.add(name: "Upgrade", value: "myproto")
+        headers.add(name: "Connection", value: "upgrade")
+        let head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/", headers: headers)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        // Simulate the peer disconnecting mid-upgrade: closing the channel removes the handler from
+        // the pipeline, which advances the state machine to `.finished` and fails the upgrade promise.
+        channel.pipeline.fireChannelInactive()
+        try channel.close().wait()
+
+        // Now the in-flight upgrader search finally completes. Before the fix this hit a `fatalError`
+        // because the state machine was already `.finished`; it must now be tolerated silently.
+        responsePromise.succeed(headers)
+        channel.embeddedEventLoop.run()
+
+        XCTAssertFalse(channel.isActive)
+    }
 }


### PR DESCRIPTION
## Motivation

`NIOTypedHTTPServerUpgraderStateMachine.findingUpgraderCompleted` traps with `fatalError("Internal inconsistency...")` when the channel closes mid-upgrade and the handler is removed before the upgrader-search future resolves (#3596).

Sequence:
1. On the request head the handler enters `.awaitingUpgrader` and starts the `handleUpgradeForProtocol` future chain (awaiting the user's `buildUpgradeResponse` future).
2. The peer disconnects mid-upgrade; the pipeline tears down and `handlerRemoved` runs `stateMachine.handlerRemoved()`, advancing `.awaitingUpgrader → .finished` and failing the upgrade promise.
3. The in-flight search future then completes, `findingUpgraderCompleted` runs in state `.finished`, and hits `fatalError`.

`.finished` is the only state reachable from `.awaitingUpgrader` while a search future is outstanding (`channelRead`/`inputClosed` all keep `.awaitingUpgrader`). The sibling `upgradingHandlerCompleted` already tolerates `.finished` for exactly this close-vs-future race; that tolerance was simply never applied to `findingUpgraderCompleted`.

## Modifications

In `findingUpgraderCompleted`, handle `.finished` by returning `nil` (nothing left to do — `handlerRemoved` already failed the promise). `.upgrading` / `.unbuffering` remain `fatalError`, since they are genuinely unreachable from `.awaitingUpgrader` with a pending search future.

## Result

The upgrade-vs-close race no longer crashes the process.

## Test plan

- Added `testUpgraderSearchCompletingAfterHandlerRemovalDoesNotCrash` (deterministic, `EmbeddedChannel` + a `SuccessfulUpgrader` whose `buildUpgradeResponse` returns a manually-controlled promise): park in `.awaitingUpgrader`, close the channel (→ `.finished`), then complete the promise. Crashes before the fix; returns cleanly after.

> Verification note: I was unable to run `swift build`/`swift test` locally — the installed toolchain's stdlib is missing `OutputRawSpan`, so even an unmodified `main` fails to build in this environment. The change is small and type-correct against the surrounding code and the test uses long-stable APIs, but I'm flagging that CI should be the source of truth for the build/test run. Developed with AI assistance.

Fixes #3596