### PR TITLE
NIOFileSystem: saturate ByteCount unit factories instead of trapping on overflow

### DIFF
--- a/Sources/NIOFS/ByteCount.swift
+++ b/Sources/NIOFS/ByteCount.swift
@@ -27,54 +27,92 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// One kilobyte is 1000 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of kilobytes
     public static func kilobytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1000))
     }
 
     /// Returns a ``ByteCount`` with a given number of megabytes
     ///
     /// One megabyte is 1,000,000 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of megabytes
     public static func megabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1000 * 1000))
     }
 
     /// Returns a ``ByteCount`` with a given number of gigabytes
     ///
     /// One gigabyte is 1,000,000,000 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of gigabytes
     public static func gigabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * 1000 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1000 * 1000 * 1000))
     }
 
     /// Returns a ``ByteCount`` with a given number of kibibytes
     ///
     /// One kibibyte is 1024 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of kibibytes
     public static func kibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1024))
     }
 
     /// Returns a ``ByteCount`` with a given number of mebibytes
     ///
     /// One mebibyte is 10,485,760 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of mebibytes
     public static func mebibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1024 * 1024))
     }
 
     /// Returns a ``ByteCount`` with a given number of gibibytes
     ///
     /// One gibibyte is 10,737,418,240 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of gibibytes
     public static func gibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * 1024 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1024 * 1024 * 1024))
+    }
+}
+
+extension Int64 {
+    /// Multiplies `self` by `other`, saturating to `Int64.max` or `Int64.min`
+    /// on overflow instead of trapping.
+    fileprivate func multipliedSaturating(by other: Int64) -> Int64 {
+        let (result, overflow) = self.multipliedReportingOverflow(by: other)
+        guard overflow else {
+            return result
+        }
+        // The factors are constant positive multipliers, so the sign of the
+        // saturated result follows the sign of `self`.
+        return self < 0 ? .min : .max
     }
 }
 

--- a/Sources/_NIOFileSystem/ByteCount.swift
+++ b/Sources/_NIOFileSystem/ByteCount.swift
@@ -27,54 +27,92 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// One kilobyte is 1000 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of kilobytes
     public static func kilobytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1000))
     }
 
     /// Returns a ``ByteCount`` with a given number of megabytes
     ///
     /// One megabyte is 1,000,000 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of megabytes
     public static func megabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1000 * 1000))
     }
 
     /// Returns a ``ByteCount`` with a given number of gigabytes
     ///
     /// One gigabyte is 1,000,000,000 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of gigabytes
     public static func gigabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * 1000 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1000 * 1000 * 1000))
     }
 
     /// Returns a ``ByteCount`` with a given number of kibibytes
     ///
     /// One kibibyte is 1024 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of kibibytes
     public static func kibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1024))
     }
 
     /// Returns a ``ByteCount`` with a given number of mebibytes
     ///
     /// One mebibyte is 10,485,760 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of mebibytes
     public static func mebibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1024 * 1024))
     }
 
     /// Returns a ``ByteCount`` with a given number of gibibytes
     ///
     /// One gibibyte is 10,737,418,240 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of gibibytes
     public static func gibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * 1024 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1024 * 1024 * 1024))
+    }
+}
+
+extension Int64 {
+    /// Multiplies `self` by `other`, saturating to `Int64.max` or `Int64.min`
+    /// on overflow instead of trapping.
+    fileprivate func multipliedSaturating(by other: Int64) -> Int64 {
+        let (result, overflow) = self.multipliedReportingOverflow(by: other)
+        guard overflow else {
+            return result
+        }
+        // The factors are constant positive multipliers, so the sign of the
+        // saturated result follows the sign of `self`.
+        return self < 0 ? .min : .max
     }
 }
 

--- a/Sources/_NIOFileSystem/ByteCount.swift
+++ b/Sources/_NIOFileSystem/ByteCount.swift
@@ -27,54 +27,93 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// One kilobyte is 1000 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of kilobytes
     public static func kilobytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1000))
     }
 
     /// Returns a ``ByteCount`` with a given number of megabytes
     ///
     /// One megabyte is 1,000,000 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of megabytes
     public static func megabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1000 * 1000))
     }
 
     /// Returns a ``ByteCount`` with a given number of gigabytes
     ///
     /// One gigabyte is 1,000,000,000 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of gigabytes
     public static func gigabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * 1000 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1000 * 1000 * 1000))
     }
 
     /// Returns a ``ByteCount`` with a given number of kibibytes
     ///
     /// One kibibyte is 1024 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of kibibytes
     public static func kibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1024))
     }
 
     /// Returns a ``ByteCount`` with a given number of mebibytes
     ///
     /// One mebibyte is 10,485,760 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of mebibytes
     public static func mebibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1024 * 1024))
     }
 
     /// Returns a ``ByteCount`` with a given number of gibibytes
     ///
     /// One gibibyte is 10,737,418,240 bytes.
     ///
+    /// If the resulting number of bytes does not fit in an `Int64` the value
+    /// saturates to `Int64.max` (or `Int64.min` for negative counts) rather
+    /// than overflowing.
+    ///
     /// - Parameter count: The number of gibibytes
     public static func gibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * 1024 * count)
+        ByteCount(bytes: count.multipliedSaturating(by: 1024 * 1024 * 1024))
+    }
+}
+
+extension Int64 {
+    /// Multiplies `self` by `other`, saturating to `Int64.max` or `Int64.min`
+    /// on overflow instead of trapping.
+    fileprivate func multipliedSaturating(by other: Int64) -> Int64 {
+        let (result, overflow) = self.multipliedReportingOverflow(by: other)
+        guard overflow else {
+            return result
+        }
+        // On overflow the sign of the true product is the product of the operand
+        // signs, which holds for any multiplier rather than only the positive
+        // constants used above.
+        return (self < 0) == (other < 0) ? .max : .min
     }
 }
 

--- a/Tests/NIOFSTests/ByteCountTests.swift
+++ b/Tests/NIOFSTests/ByteCountTests.swift
@@ -51,6 +51,28 @@ class ByteCountTests: XCTestCase {
         XCTAssertEqual(byteCount.bytes, 10_737_418_240)
     }
 
+    func testByteCountSaturatesOnPositiveOverflow() {
+        // Passing very large counts to a unit factory used to trap on
+        // arithmetic overflow. Instead the value should saturate to Int64.max.
+        XCTAssertEqual(ByteCount.kilobytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.megabytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.gigabytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.kibibytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.mebibytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.gibibytes(.max).bytes, .max)
+    }
+
+    func testByteCountSaturatesOnNegativeOverflow() {
+        // Likewise, very large negative counts should saturate to Int64.min
+        // rather than trapping.
+        XCTAssertEqual(ByteCount.kilobytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.megabytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.gigabytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.kibibytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.mebibytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.gibibytes(.min).bytes, .min)
+    }
+
     func testByteCountUnlimited() {
         let byteCount = ByteCount.unlimited
         XCTAssertEqual(byteCount.bytes, .max)

--- a/Tests/NIOFSTests/ByteCountTests.swift
+++ b/Tests/NIOFSTests/ByteCountTests.swift
@@ -57,6 +57,28 @@ class ByteCountTests: XCTestCase {
         XCTAssertEqual(byteCount.bytes, 10_737_418_240)
     }
 
+    func testByteCountSaturatesOnPositiveOverflow() {
+        // Passing very large counts to a unit factory used to trap on
+        // arithmetic overflow. Instead the value should saturate to Int64.max.
+        XCTAssertEqual(ByteCount.kilobytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.megabytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.gigabytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.kibibytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.mebibytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.gibibytes(.max).bytes, .max)
+    }
+
+    func testByteCountSaturatesOnNegativeOverflow() {
+        // Likewise, very large negative counts should saturate to Int64.min
+        // rather than trapping.
+        XCTAssertEqual(ByteCount.kilobytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.megabytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.gigabytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.kibibytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.mebibytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.gibibytes(.min).bytes, .min)
+    }
+
     func testByteCountUnlimited() {
         let byteCount = ByteCount.unlimited
         XCTAssertEqual(byteCount.bytes, .max)


### PR DESCRIPTION
Saturate the `ByteCount` unit factories so large counts no longer trap on overflow.

### Motivation:

`ByteCount` exposes unit factories such as `kilobytes`, `megabytes`, `gigabytes`, `kibibytes`, `mebibytes`, and `gibibytes`. Each one computed the byte total with a plain multiplication, for example `1024 * 1024 * 1024 * count` in `gibibytes`. When a caller passes a very large count, that multiplication overflows `Int64` and traps, crashing the process. This is exactly what issue #2877 reports: `ByteCount(contentsOf:maximumSizeAllowed: .gibibytes(.max))` crashes with an arithmetic overflow inside `gibibytes`, even though passing a huge value is a natural way to express "effectively no limit".

### Modifications:

I added a small `fileprivate` saturating multiplication helper on `Int64` and routed every unit factory through it. The helper uses `multipliedReportingOverflow(by:)` and, on overflow, clamps to `Int64.max` for positive counts or `Int64.min` for negative counts. Counts that fit continue to produce the exact same value as before, so there is no behavior change for normal inputs. I extended `ByteCountTests` with positive and negative overflow cases, and applied the identical change to both copies of `ByteCount.swift` (`NIOFS` and `_NIOFileSystem`) to keep them in sync, matching the convention used by recent changes to those targets.

### Result:

Passing extreme values such as `.gibibytes(.max)` saturates to `Int64.max` instead of trapping, so disabling a size limit via a large value no longer crashes. I verified this by running `swift test --filter ByteCountTests`, which passes after the change. To confirm the tests are load bearing I reverted the source fix and re-ran the new tests, which crashed with signal 5 (the overflow trap) exactly as the issue describes, and they pass again with the fix in place. `swift format lint --strict` reports no issues on the changed files.

Fixes #2877
