### PR TITLE
[NIOFileSystem] Fallback to rename when `renameat2` is not available

### DIFF
--- a/Sources/NIOFS/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFS/Internal/SystemFileHandle.swift
@@ -665,7 +665,7 @@ extension SystemFileHandle.SendableView {
     }
 
     @_spi(Testing)
-    public func _close(materialize: Bool, failRenameat2WithEINVAL: Bool = false) -> Result<Void, FileSystemError> {
+    public func _close(materialize: Bool, simulatedRenameat2Errno: Errno? = nil) -> Result<Void, FileSystemError> {
         let descriptor: FileDescriptor? = self.lifecycle.withLockedValue { lifecycle in
             switch lifecycle {
             case let .open(descriptor):
@@ -684,7 +684,7 @@ extension SystemFileHandle.SendableView {
         let materializeResult = self._materialize(
             materialize,
             descriptor: descriptor,
-            failRenameat2WithEINVAL: failRenameat2WithEINVAL
+            simulatedRenameat2Errno: simulatedRenameat2Errno
         )
 
         return Result {
@@ -798,7 +798,7 @@ extension SystemFileHandle.SendableView {
     func _materialize(
         _ materialize: Bool,
         descriptor: FileDescriptor,
-        failRenameat2WithEINVAL: Bool
+        simulatedRenameat2Errno: Errno?
     ) -> Result<Void, FileSystemError> {
         guard let materialization = self.materialization else { return .success(()) }
 
@@ -837,8 +837,8 @@ extension SystemFileHandle.SendableView {
                 // ignored. However, they must still be provided to 'rename' in order to pass
                 // flags.
                 renameFunction = "renameat2"
-                if materialization.exclusive, failRenameat2WithEINVAL {
-                    renameResult = .failure(.invalidArgument)
+                if let simulatedRenameat2Errno {
+                    renameResult = .failure(simulatedRenameat2Errno)
                 } else {
                     renameResult = Syscall.rename(
                         from: createdPath,
@@ -857,10 +857,14 @@ extension SystemFileHandle.SendableView {
                         // creation, clear up by removing the file that we did create.
                         _ = Libc.remove(createdPath)
 
-                    case .failure(.invalidArgument):
-                        // If 'renameat2' failed on Linux with EINVAL then in all likelihood the
-                        // 'RENAME_NOREPLACE' option isn't supported. As we're doing an exclusive
-                        // create, check the desired path doesn't exist then do a regular rename.
+                    case let .failure(renameErrno)
+                    where renameErrno == .invalidArgument || renameErrno == .noFunction:
+                        // 'renameat2' isn't usable here. Either it failed on Linux with EINVAL, in
+                        // which case the 'RENAME_NOREPLACE' option in all likelihood isn't
+                        // supported, or it failed with ENOSYS, in which case the syscall isn't
+                        // implemented by the filesystem at all (seen on the FUSE-backed emulated
+                        // storage of some Android devices). As we're doing an exclusive create,
+                        // check the desired path doesn't exist then do a regular rename.
                         #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
                         switch Syscall.stat(path: desiredPath) {
                         case .failure(.noSuchFileOrDirectory):
@@ -891,7 +895,7 @@ extension SystemFileHandle.SendableView {
                                 message: "Couldn't open '\(desiredPath)'.",
                                 cause: FileSystemError.rename(
                                     "renameat2",
-                                    errno: .invalidArgument,
+                                    errno: renameErrno,
                                     oldName: createdPath,
                                     newName: desiredPath,
                                     location: .here()
@@ -907,6 +911,17 @@ extension SystemFileHandle.SendableView {
                     case .success, .failure:
                         ()
                     }
+                } else {
+                    // Non-exclusive materialization. On Linux 'renameat2' is called only to use the
+                    // '*at' form; with no flags it behaves exactly like 'rename'. If the syscall
+                    // isn't implemented by the filesystem it fails with ENOSYS (seen on the
+                    // FUSE-backed emulated storage of some Android devices); fall back to a plain
+                    // 'rename', which also atomically replaces any file at the destination.
+                    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                    if case .failure(.noFunction) = renameResult {
+                        renameResult = Syscall.rename(from: createdPath, to: desiredPath)
+                    }
+                    #endif
                 }
 
                 result = renameResult.mapError { errno in

--- a/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
@@ -665,7 +665,7 @@ extension SystemFileHandle.SendableView {
     }
 
     @_spi(Testing)
-    public func _close(materialize: Bool, failRenameat2WithEINVAL: Bool = false) -> Result<Void, FileSystemError> {
+    public func _close(materialize: Bool, simulatedRenameat2Errno: Errno? = nil) -> Result<Void, FileSystemError> {
         let descriptor: FileDescriptor? = self.lifecycle.withLockedValue { lifecycle in
             switch lifecycle {
             case let .open(descriptor):
@@ -684,7 +684,7 @@ extension SystemFileHandle.SendableView {
         let materializeResult = self._materialize(
             materialize,
             descriptor: descriptor,
-            failRenameat2WithEINVAL: failRenameat2WithEINVAL
+            simulatedRenameat2Errno: simulatedRenameat2Errno
         )
 
         return Result {
@@ -798,7 +798,7 @@ extension SystemFileHandle.SendableView {
     func _materialize(
         _ materialize: Bool,
         descriptor: FileDescriptor,
-        failRenameat2WithEINVAL: Bool
+        simulatedRenameat2Errno: Errno?
     ) -> Result<Void, FileSystemError> {
         guard let materialization = self.materialization else { return .success(()) }
 
@@ -837,8 +837,8 @@ extension SystemFileHandle.SendableView {
                 // ignored. However, they must still be provided to 'rename' in order to pass
                 // flags.
                 renameFunction = "renameat2"
-                if materialization.exclusive, failRenameat2WithEINVAL {
-                    renameResult = .failure(.invalidArgument)
+                if let simulatedRenameat2Errno {
+                    renameResult = .failure(simulatedRenameat2Errno)
                 } else {
                     renameResult = Syscall.rename(
                         from: createdPath,
@@ -857,10 +857,14 @@ extension SystemFileHandle.SendableView {
                         // creation, clear up by removing the file that we did create.
                         _ = Libc.remove(createdPath)
 
-                    case .failure(.invalidArgument):
-                        // If 'renameat2' failed on Linux with EINVAL then in all likelihood the
-                        // 'RENAME_NOREPLACE' option isn't supported. As we're doing an exclusive
-                        // create, check the desired path doesn't exist then do a regular rename.
+                    case let .failure(renameErrno)
+                    where renameErrno == .invalidArgument || renameErrno == .noFunction:
+                        // 'renameat2' isn't usable here. Either it failed on Linux with EINVAL, in
+                        // which case the 'RENAME_NOREPLACE' option in all likelihood isn't
+                        // supported, or it failed with ENOSYS, in which case the syscall isn't
+                        // implemented by the filesystem at all (seen on the FUSE-backed emulated
+                        // storage of some Android devices). As we're doing an exclusive create,
+                        // check the desired path doesn't exist then do a regular rename.
                         #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
                         switch Syscall.stat(path: desiredPath) {
                         case .failure(.noSuchFileOrDirectory):
@@ -891,7 +895,7 @@ extension SystemFileHandle.SendableView {
                                 message: "Couldn't open '\(desiredPath)'.",
                                 cause: FileSystemError.rename(
                                     "renameat2",
-                                    errno: .invalidArgument,
+                                    errno: renameErrno,
                                     oldName: createdPath,
                                     newName: desiredPath,
                                     location: .here()
@@ -907,6 +911,17 @@ extension SystemFileHandle.SendableView {
                     case .success, .failure:
                         ()
                     }
+                } else {
+                    // Non-exclusive materialization. On Linux 'renameat2' is called only to use the
+                    // '*at' form; with no flags it behaves exactly like 'rename'. If the syscall
+                    // isn't implemented by the filesystem it fails with ENOSYS (seen on the
+                    // FUSE-backed emulated storage of some Android devices); fall back to a plain
+                    // 'rename', which also atomically replaces any file at the destination.
+                    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+                    if case .failure(.noFunction) = renameResult {
+                        renameResult = Syscall.rename(from: createdPath, to: desiredPath)
+                    }
+                    #endif
                 }
 
                 result = renameResult.mapError { errno in

--- a/Tests/NIOFSIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileHandleTests.swift
@@ -1036,7 +1036,60 @@ final class FileHandleTests: XCTestCase {
 
         // Close, but take the path where 'renameat2' fails with EINVAL. This shouldn't throw and
         // the file should be available.
-        let result = handle.sendableView._close(materialize: true, failRenameat2WithEINVAL: true)
+        let result = handle.sendableView._close(materialize: true, simulatedRenameat2Errno: .invalidArgument)
+        try result.get()
+
+        let info = try await FileSystem.shared.info(forFileAt: NIOFilePath(path))
+        XCTAssertNotNil(info)
+        #else
+        throw XCTSkip("This test requires 'renameat2' which isn't supported on this platform")
+        #endif
+    }
+
+    func testOpenExclusiveCreateWithoutOTMPFILEOrRenameat2ENOSYS() async throws {
+        // As above, but takes the fallback path where 'renameat2' fails with ENOSYS (the syscall
+        // isn't implemented by the filesystem, as on some FUSE-backed Android storage). The
+        // exclusive create should still succeed via 'stat' + 'rename'. Only reachable on Linux.
+        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        let temporaryDirectory = FilePath(try await FileSystem.shared.temporaryDirectory)
+        let path = temporaryDirectory.appending(Self.temporaryFileName().components)
+        let handle = try SystemFileHandle.syncOpenWithMaterialization(
+            atPath: path,
+            mode: .writeOnly,
+            options: [.exclusiveCreate, .create],
+            permissions: .ownerReadWrite,
+            threadPool: .singleton,
+            useTemporaryFileIfPossible: false
+        ).get()
+
+        let result = handle.sendableView._close(materialize: true, simulatedRenameat2Errno: .noFunction)
+        try result.get()
+
+        let info = try await FileSystem.shared.info(forFileAt: NIOFilePath(path))
+        XCTAssertNotNil(info)
+        #else
+        throw XCTSkip("This test requires 'renameat2' which isn't supported on this platform")
+        #endif
+    }
+
+    func testOpenNonExclusiveWithoutOTMPFILEOrRenameat2ENOSYS() async throws {
+        // Takes the path where 'O_TMPFILE' doesn't exist so a temporary file is created and renamed
+        // into place, then the fallback path where the 'renameat2' syscall fails with ENOSYS (not
+        // implemented by the filesystem, as on some FUSE-backed Android storage). A non-exclusive
+        // materialization should fall back to a plain 'rename'. Only reachable on Linux.
+        #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        let temporaryDirectory = FilePath(try await FileSystem.shared.temporaryDirectory)
+        let path = temporaryDirectory.appending(Self.temporaryFileName().components)
+        let handle = try SystemFileHandle.syncOpenWithMaterialization(
+            atPath: path,
+            mode: .writeOnly,
+            options: [.truncate, .create],
+            permissions: .ownerReadWrite,
+            threadPool: .singleton,
+            useTemporaryFileIfPossible: false
+        ).get()
+
+        let result = handle.sendableView._close(materialize: true, simulatedRenameat2Errno: .noFunction)
         try result.get()
 
         let info = try await FileSystem.shared.info(forFileAt: NIOFilePath(path))


### PR DESCRIPTION
We are running into some issues when doing:

```swift
        let writeOptions: OpenOptions.Write =
            byteOffset > 0 ? .modifyFile(createIfNecessary: true) : .newFile(replaceExisting: true)

        try await FileSystem.shared.withFileHandle(
            forWritingAt: FilePath(outputFilePath),
            options: writeOptions
        ) { fileHandle in
```

which results in crashes on some Android devices where `renameat2` is not available:

```
('renameat2' system call failed with '(38) Function not implemented'.)
```

This PR adds functionality similar to what is already done for `EINVAL` on Linux, such that both lead to the same recovery: stat the destination, then plain rename() if absent.

And for non-exclusive renames where it also fails to function not implemented, it falls back to plain `rename`.