### PR TITLE
HTTPDecoder: restore old limit of 80 kB headers

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -549,13 +549,16 @@ public struct NIOHTTPDecoderLimitConfiguration: Sendable, Hashable {
     /// Maximum total size (in bytes) of all header field names and values combined in a single message. Default: 81,920 (80 KB).
     public var maxHeaderListSize: Int
 
-    /// Maximum number of header fields allowed in a single message (including trailers). Default: 65,535.
+    /// Maximum number of header fields allowed in a single message (including trailers). Default: 65,534.
+    ///
+    /// The default is `UInt16.max - 1` for compatibility with `swift-http-types`, whose
+    /// `HTTPFields` representation supports up to that many fields.
     public var maxHeaderFieldCount: Int
 
     public init() {
         self.maxHeaderFieldSize = 80 * 1024
         self.maxHeaderListSize = 80 * 1024
-        self.maxHeaderFieldCount = Int(UInt16.max)
+        self.maxHeaderFieldCount = Int(UInt16.max) - 1
     }
 }
 

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -546,16 +546,16 @@ public struct NIOHTTPDecoderLimitConfiguration: Sendable, Hashable {
     /// Maximum size (in bytes) of a single header field (name + value). Default: 81,920 (80 KB).
     public var maxHeaderFieldSize: Int
 
-    /// Maximum total size (in bytes) of all header field names and values combined in a single message. Default: 2,097,152 (2 MB).
+    /// Maximum total size (in bytes) of all header field names and values combined in a single message. Default: 81,920 (80 KB).
     public var maxHeaderListSize: Int
 
-    /// Maximum number of header fields allowed in a single message (including trailers). Default: 256.
+    /// Maximum number of header fields allowed in a single message (including trailers). Default: 65,535.
     public var maxHeaderFieldCount: Int
 
     public init() {
         self.maxHeaderFieldSize = 80 * 1024
-        self.maxHeaderListSize = 16384 * 128
-        self.maxHeaderFieldCount = 256
+        self.maxHeaderListSize = 80 * 1024
+        self.maxHeaderFieldCount = Int(UInt16.max)
     }
 }
 

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTesting.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTesting.swift
@@ -152,16 +152,19 @@ import Testing
     }
 
     @Test func defaultFieldCountLimitRejectsExcessiveHeaders() throws {
+        var config = NIOHTTPDecoderLimitConfiguration()
+        config.maxHeaderListSize = .max
+        let decoder = HTTPRequestDecoder(limitConfiguration: config)
         let channel = EmbeddedChannel()
-        try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(HTTPRequestDecoder()))
+        try channel.pipeline.syncOperations.addHandler(ByteToMessageHandler(decoder))
 
         var buffer = channel.allocator.buffer(capacity: 64)
         buffer.writeString("GET / HTTP/1.1\r\nHost: example.com\r\n")
         try channel.writeInbound(buffer)
 
-        // Default limit is 256 fields. Sending 257 should fail.
+        // Default limit is UInt16.max fields. Sending UInt16.max+1 should fail.
         var threwError = false
-        for i in 0..<257 {
+        for i in 0..<(Int(UInt16.max) + 1) {
             let headerBuffer = ByteBuffer(string: "X-H-\(i): v\r\n")
             do {
                 try channel.writeInbound(headerBuffer)
@@ -171,7 +174,7 @@ import Testing
             }
         }
 
-        #expect(threwError, "Expected default field count limit to reject request with 257+ headers")
+        #expect(threwError, "Expected default field count limit to reject request with UInt16.max+1 headers")
         _ = try? channel.finish()
     }
 
@@ -220,7 +223,7 @@ import Testing
         _ = try? channel.finish()
     }
 
-    @Test func defaultMaxHeaderListSizeIs2MB() throws {
+    @Test func defaultMaxHeaderListSizeIs80KB() throws {
         var config = NIOHTTPDecoderLimitConfiguration()
         config.maxHeaderFieldCount = 10_000
         let decoder = HTTPRequestDecoder(limitConfiguration: config)
@@ -231,13 +234,13 @@ import Testing
         buffer.writeString("GET / HTTP/1.1\r\n")
         try channel.writeInbound(buffer)
 
-        // Default maxHeaderListSize is 16384 * 128 = 2 MB. Send headers totaling > 2 MB.
-        // Use values just under the default 16 KB field-size limit so the field-size
-        // limit doesn't trigger first.
-        let valueSize = 16000
+        // Default maxHeaderListSize is 80 KB. Send headers totaling > 80 KB.
+        // Use values well under the default 80 KB field-size limit so the
+        // field-size limit doesn't trigger first.
+        let valueSize = 8000
         var totalBytes = 0
         var threwError = false
-        for i in 0..<200 {
+        for i in 0..<32 {
             let name = "X-H-\(i)"
             let value = String(repeating: "a", count: valueSize)
             let headerBuffer = ByteBuffer(string: "\(name): \(value)\r\n")
@@ -250,8 +253,8 @@ import Testing
             }
         }
 
-        #expect(threwError, "Expected default 2 MB header list size limit to reject request")
-        #expect(totalBytes > 16384 * 128, "Test should have exceeded 2 MB before error")
+        #expect(threwError, "Expected default 80 KB header list size limit to reject request")
+        #expect(totalBytes > 80 * 1024, "Test should have exceeded 80 KB before error")
         _ = try? channel.finish()
     }
 

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTesting.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTesting.swift
@@ -162,9 +162,9 @@ import Testing
         buffer.writeString("GET / HTTP/1.1\r\nHost: example.com\r\n")
         try channel.writeInbound(buffer)
 
-        // Default limit is UInt16.max fields. Sending UInt16.max+1 should fail.
+        // Default limit is UInt16.max - 1 fields. Sending UInt16.max should fail.
         var threwError = false
-        for i in 0..<(Int(UInt16.max) + 1) {
+        for i in 0..<Int(UInt16.max) {
             let headerBuffer = ByteBuffer(string: "X-H-\(i): v\r\n")
             do {
                 try channel.writeInbound(headerBuffer)
@@ -174,7 +174,7 @@ import Testing
             }
         }
 
-        #expect(threwError, "Expected default field count limit to reject request with UInt16.max+1 headers")
+        #expect(threwError, "Expected default field count limit to reject request with UInt16.max headers")
         _ = try? channel.finish()
     }
 


### PR DESCRIPTION
### Motivation:

NIO's historic limit was that the maximum header block was limited to 80 kB which is a sensible limit and originates from Nginx's http_parser.c.

The history of the changes:
- commit e67fc995: Introduces the 80 kB limit
- commit 69180342: Accidentally removes the limit entirely
- commit b24872d3: Introduced the 2 MB / 256 headers limit

I would argue that 2MB & 256 headers is a bad limit:
- 2MB is way too big, that allows pretty powerful slowloris-style attacks forcing NIO to hold on to 2 MB per connection
- 256 headers is too little for software that may be a proxy
  - in HTTP, the number of headers is _non-semantic_
    - A: `a: 1\r\n a: 2\r\n a: 3\r\n a: 4\r\n a: 5\r\n a: 6\r\n[...]\r\na: 257\r\n`
    - B: `a: 1, 2, 3, 4, 5, ..., 257\r\n`
    - A & B are _equivalent_. Yet, A would be rejected and B accepted. That's not right.
 
### Modifications:

Restore the old limits.

### Result:

- More compatible (because we allow more than 256 headers)
- More secure (because the default goes back to 80kB)