### PR TITLE
Drop unused SystemPackage import from FileSystemTests

### DIFF
--- a/Tests/NIOFSIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileSystemTests.swift
@@ -15,7 +15,6 @@
 import NIOConcurrencyHelpers
 import NIOCore
 @_spi(Testing) @testable import NIOFS
-import SystemPackage
 import XCTest
 
 extension NIOFilePath {


### PR DESCRIPTION
Drop unused SystemPackage import from FileSystemTests

### Motivation:

swift-system 1.7.0 exposes a new type named `FileType`, which is ambiguous with `NIOFS.FileType` when both modules are imported in the same file. This causes a compile-time error when building `FileSystemTests.swift` in the `NIOFSIntegrationTests` target.

Fixes #3622.

### Modifications:

Drop the unused `SystemPackage` import in `FileSystemTests.swift`.

### Result:

`NIOFSIntegrationTests` builds against swift-system 1.7.0 and later.
