### PR TITLE
Xcode beta

### DIFF
--- a/.github/workflows/android_swift_sdk.yml
+++ b/.github/workflows/android_swift_sdk.yml
@@ -47,8 +47,8 @@ jobs:
                 "platform":"Linux",
                 "runner":"ubuntu-latest",
                 "image":"ubuntu:jammy",
-                "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_sdk.sh | INSTALL_SWIFT_BRANCH=main INSTALL_SWIFT_ARCH=x86_64 INSTALL_SWIFT_SDK=android-sdk bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_android_ndk.sh | bash && hash -r",
-                "command":"curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/swift-build-with-android-sdk.sh | bash -s --",
+                "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/install_swift_sdk.sh | INSTALL_SWIFT_BRANCH=main INSTALL_SWIFT_ARCH=x86_64 INSTALL_SWIFT_SDK=android-sdk bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/install_android_ndk.sh | bash && hash -r",
+                "command":"curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/swift-build-with-android-sdk.sh | bash -s --",
                 "command_arguments":"'"$INPUT_ADDITIONAL_COMMAND_ARGUMENTS"'",
                 "env":'"$env_vars_json"'
               }
@@ -63,7 +63,7 @@ jobs:
     name: Android Swift SDK
     needs: construct-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: "Android Swift SDK"
       matrix_string: '${{ needs.construct-matrix.outputs.android-sdk-matrix }}'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -110,10 +110,10 @@ jobs:
             exit 1
           fi
 
-          echo "benchmarks-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | MATRIX_LINUX_ENV_VARS_JSON="${linux_env_vars_json}" bash)" >> "$GITHUB_OUTPUT"
+          echo "benchmarks-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/generate_matrix.sh | MATRIX_LINUX_ENV_VARS_JSON="${linux_env_vars_json}" bash)" >> "$GITHUB_OUTPUT"
         env:
           INPUT_LINUX_ENV_VARS: ${{ inputs.linux_env_vars }}
-          MATRIX_LINUX_COMMAND: "curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check_benchmark_thresholds.sh | BENCHMARK_PACKAGE_PATH=${{ inputs.benchmark_package_path }} bash"
+          MATRIX_LINUX_COMMAND: "curl -s https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/check_benchmark_thresholds.sh | BENCHMARK_PACKAGE_PATH=${{ inputs.benchmark_package_path }} bash"
           MATRIX_LINUX_SETUP_COMMAND: "swift --version && apt-get update -y -q && apt-get install -y -q curl libjemalloc-dev && git config --global --add safe.directory /$(basename ${{ github.workspace }})"
           MATRIX_MIN_SWIFT_VERSION: ${{ inputs.minimum_swift_version }}
           MATRIX_LINUX_5_9_ENABLED: ${{ inputs.linux_5_9_enabled }}
@@ -129,7 +129,7 @@ jobs:
     name: Benchmarks
     needs: construct-matrix-linux
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: "Benchmarks"
       matrix_string: '${{ needs.construct-matrix-linux.outputs.benchmarks-matrix }}'

--- a/.github/workflows/cmake_tests.yml
+++ b/.github/workflows/cmake_tests.yml
@@ -43,7 +43,7 @@ jobs:
           which curl jq || apt -q update
           which curl || apt -yq install curl
           which jq || apt -yq install jq
-          curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/update-cmake-lists.sh | CONFIG_JSON="$INPUT_UPDATE_CMAKE_LISTS_CONFIG" FAIL_ON_CHANGES=true bash
+          curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/update-cmake-lists.sh | CONFIG_JSON="$INPUT_UPDATE_CMAKE_LISTS_CONFIG" FAIL_ON_CHANGES=true bash
         env:
           INPUT_UPDATE_CMAKE_LISTS_CONFIG: ${{ inputs.update_cmake_lists_config }}
       - name: CMake build
@@ -52,7 +52,7 @@ jobs:
           which curl || apt -yq install curl
           which cmake || apt -yq install cmake
           which ninja || apt -yq install ninja-build
-          curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/cmake-build.sh | TARGET_DIRECTORY="$INPUT_CMAKE_BUILD_TARGET_DIRECTORY" CMAKE_VERSION="$INPUT_CMAKE_VERSION" bash
+          curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/cmake-build.sh | TARGET_DIRECTORY="$INPUT_CMAKE_BUILD_TARGET_DIRECTORY" CMAKE_VERSION="$INPUT_CMAKE_VERSION" bash
         env:
           INPUT_CMAKE_BUILD_TARGET_DIRECTORY: ${{ inputs.cmake_build_target_directory }}
           INPUT_CMAKE_VERSION: ${{ inputs.cmake_version }}

--- a/.github/workflows/cxx_interop.yml
+++ b/.github/workflows/cxx_interop.yml
@@ -113,11 +113,11 @@ jobs:
             exit 1
           fi
 
-          echo "cxx-interop-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | MATRIX_LINUX_ENV_VARS_JSON="${linux_env_vars_json}" MATRIX_WINDOWS_ENV_VARS_JSON="${windows_env_vars_json}" bash)" >> "$GITHUB_OUTPUT"
+          echo "cxx-interop-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/generate_matrix.sh | MATRIX_LINUX_ENV_VARS_JSON="${linux_env_vars_json}" MATRIX_WINDOWS_ENV_VARS_JSON="${windows_env_vars_json}" bash)" >> "$GITHUB_OUTPUT"
         env:
           INPUT_LINUX_ENV_VARS: ${{ inputs.linux_env_vars }}
           INPUT_WINDOWS_ENV_VARS: ${{ inputs.windows_env_vars }}
-          MATRIX_LINUX_COMMAND: "curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-cxx-interop-compatibility.sh | bash"
+          MATRIX_LINUX_COMMAND: "curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/check-cxx-interop-compatibility.sh | bash"
           MATRIX_LINUX_SETUP_COMMAND: "swift --version && apt-get update -y -q && apt-get install -y -q curl jq"
           MATRIX_MIN_SWIFT_VERSION: ${{ inputs.minimum_swift_version }}
           MATRIX_LINUX_5_9_ENABLED: ${{ inputs.linux_5_9_enabled }}
@@ -133,7 +133,7 @@ jobs:
     name: Cxx interop
     needs: construct-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: "Cxx interop"
       matrix_string: '${{ needs.construct-matrix.outputs.cxx-interop-matrix }}'

--- a/.github/workflows/macos_benchmarks.yml
+++ b/.github/workflows/macos_benchmarks.yml
@@ -220,7 +220,7 @@ jobs:
           MATRIX_ENV_JSON: ${{ toJSON(matrix.config.env) }}
       - name: Run benchmarks script
         run: |
-          curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check_benchmark_thresholds.sh | bash -s -- --disable-sandbox --allow-writing-to-package-directory
+          curl -s https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/check_benchmark_thresholds.sh | bash -s -- --disable-sandbox --allow-writing-to-package-directory
         env:
           BENCHMARK_PACKAGE_PATH: ${{ inputs.benchmark_package_path }}
           BENCHMARK_PACKAGE_PATHS: ${{ inputs.benchmark_package_paths }}

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -89,7 +89,7 @@ on:
       xcode_latest_beta_enabled:
         type: boolean
         description: "Boolean to enable the Xcode beta jobs (uses latest beta if one currently exists). Defaults to true."
-        default: false
+        default: true
       xcode_latest_beta_build_arguments_override:
         type: string
         description: "The arguments passed to swift build in the Xcode beta job."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   unit-tests:
     name: Unit tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+    uses: apple/swift-nio/.github/workflows/unit_tests.yml@xcode_beta
     with:
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -24,12 +24,12 @@ jobs:
   cxx-interop:
     name: Cxx interop
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@xcode_beta
 
   benchmarks:
     name: Benchmarks
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/benchmarks.yml@main
+    uses: apple/swift-nio/.github/workflows/benchmarks.yml@xcode_beta
     with:
       benchmark_package_path: "Benchmarks"
 
@@ -44,7 +44,7 @@ jobs:
         with:
           persist-credentials: false
       - id: generate-matrix
-        run: echo "integration-test-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        run: echo "integration-test-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq"
           MATRIX_LINUX_COMMAND: "./scripts/integration_tests.sh"
@@ -54,7 +54,7 @@ jobs:
     name: Integration tests
     needs: construct-integration-test-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: "Integration tests"
       matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
@@ -62,24 +62,24 @@ jobs:
   static-sdk:
     name: Static Linux Swift SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+    uses: apple/swift-nio/.github/workflows/static_sdk.yml@xcode_beta
 
   wasm-sdk:
     name: WebAssembly Swift SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@main
+    uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@xcode_beta
     with:
       additional_command_arguments: "--target NIOCore"
 
   android-sdk:
     name: Android Swift SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/android_swift_sdk.yml@main
+    uses: apple/swift-nio/.github/workflows/android_swift_sdk.yml@xcode_beta
 
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@xcode_beta
     with:
       runner_pool: nightly
       build_scheme: swift-nio-Package
@@ -92,4 +92,4 @@ jobs:
 
   release-builds:
     name: Release builds
-    uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@xcode_beta

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
   unit-tests:
     name: Unit tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+    uses: apple/swift-nio/.github/workflows/unit_tests.yml@xcode_beta
     with:
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -30,14 +30,14 @@ jobs:
   benchmarks:
     name: Benchmarks
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/benchmarks.yml@main
+    uses: apple/swift-nio/.github/workflows/benchmarks.yml@xcode_beta
     with:
       benchmark_package_path: "Benchmarks"
 
   cxx-interop:
     name: Cxx interop
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@xcode_beta
 
   construct-integration-test-matrix:
     name: Construct integration test matrix
@@ -50,7 +50,7 @@ jobs:
         with:
           persist-credentials: false
       - id: generate-matrix
-        run: echo "integration-test-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        run: echo "integration-test-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q lsof dnsutils netcat-openbsd net-tools curl jq"
           MATRIX_LINUX_COMMAND: "./scripts/integration_tests.sh"
@@ -60,7 +60,7 @@ jobs:
     name: Integration tests
     needs: construct-integration-test-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: "Integration tests"
       matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
@@ -86,7 +86,7 @@ jobs:
   macos-tests:
     name: macOS tests
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@xcode_beta
     with:
       runner_pool: general
       build_scheme: swift-nio-Package
@@ -94,20 +94,20 @@ jobs:
   static-sdk:
     name: Static Linux Swift SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+    uses: apple/swift-nio/.github/workflows/static_sdk.yml@xcode_beta
 
   wasm-sdk:
     name: WebAssembly Swift SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@main
+    uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@xcode_beta
     with:
       additional_command_arguments: "--target NIOCore"
 
   android-sdk:
     name: Android Swift SDK
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/android_swift_sdk.yml@main
+    uses: apple/swift-nio/.github/workflows/android_swift_sdk.yml@xcode_beta
 
   release-builds:
     name: Release builds
-    uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@xcode_beta

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -153,7 +153,7 @@ jobs:
             exit 1
           fi
 
-          echo "release-build-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | MATRIX_LINUX_ENV_VARS_JSON="${linux_env_vars_json}" MATRIX_WINDOWS_ENV_VARS_JSON="${windows_env_vars_json}" bash)" >> "$GITHUB_OUTPUT"
+          echo "release-build-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/generate_matrix.sh | MATRIX_LINUX_ENV_VARS_JSON="${linux_env_vars_json}" MATRIX_WINDOWS_ENV_VARS_JSON="${windows_env_vars_json}" bash)" >> "$GITHUB_OUTPUT"
         env:
           INPUT_LINUX_ENV_VARS: ${{ inputs.linux_env_vars }}
           INPUT_WINDOWS_ENV_VARS: ${{ inputs.windows_env_vars }}
@@ -192,7 +192,7 @@ jobs:
     name: Release builds
     needs: construct-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: "Release builds"
       matrix_string: '${{ needs.construct-matrix.outputs.release-build-matrix }}'

--- a/.github/workflows/static_sdk.yml
+++ b/.github/workflows/static_sdk.yml
@@ -47,7 +47,7 @@ jobs:
                 "platform":"Linux",
                 "runner":"ubuntu-latest",
                 "image":"ubuntu:jammy",
-                "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_sdk.sh | INSTALL_SWIFT_VERSION=latest INSTALL_SWIFT_ARCH=x86_64 bash && hash -r",
+                "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/install_swift_sdk.sh | INSTALL_SWIFT_VERSION=latest INSTALL_SWIFT_ARCH=x86_64 bash && hash -r",
                 "command":"swift build",
                 "command_arguments":"--swift-sdks-path /tmp/swiftsdks '"$INPUT_COMMAND_ARGUMENTS"'",
                 "env":'"$env_vars_json"'
@@ -58,7 +58,7 @@ jobs:
                 "platform":"Linux",
                 "runner":"ubuntu-latest",
                 "image":"ubuntu:jammy",
-                "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_sdk.sh | INSTALL_SWIFT_BRANCH=main INSTALL_SWIFT_ARCH=x86_64 bash && hash -r",
+                "setup_command":"apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/install_swift_sdk.sh | INSTALL_SWIFT_BRANCH=main INSTALL_SWIFT_ARCH=x86_64 bash && hash -r",
                 "command":"swift build",
                 "command_arguments":"--swift-sdks-path /tmp/swiftsdks '"$INPUT_COMMAND_ARGUMENTS"'",
                 "env":'"$env_vars_json"'
@@ -74,7 +74,7 @@ jobs:
     name: Static SDK
     needs: construct-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: "Static SDK"
       matrix_string: '${{ needs.construct-matrix.outputs.static-sdk-matrix }}'

--- a/.github/workflows/swift_load_test_matrix.yml
+++ b/.github/workflows/swift_load_test_matrix.yml
@@ -40,7 +40,7 @@ jobs:
     name: Execute matrix
     needs: load-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: ${{ inputs.name }}
       matrix_string: '${{ needs.load-matrix.outputs.swift-matrix }}'

--- a/.github/workflows/swift_matrix.yml
+++ b/.github/workflows/swift_matrix.yml
@@ -168,7 +168,7 @@ jobs:
           COMMAND_OVERRIDE_NIGHTLY_MAIN: ${{ inputs.matrix_linux_nightly_main_command_override }}
         run: |
           apt-get -qq update && apt-get -qq -y install curl
-          curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.sh | bash
+          curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/check-matrix-job.sh | bash
 
   windows:
     name: Windows (${{ matrix.swift.swift_version }})
@@ -208,7 +208,7 @@ jobs:
           persist-credentials: false
       - name: Donwload matrix script
         if: ${{ matrix.swift.enabled }}
-        run: curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.ps1 -o __check-matrix-job.ps1
+        run: curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/check-matrix-job.ps1 -o __check-matrix-job.ps1
       - name: Run matrix job
         if: ${{ matrix.swift.enabled }}
         run: |
@@ -259,7 +259,7 @@ jobs:
           submodules: true
       - name: Donwload matrix script
         if: ${{ matrix.swift.enabled }}
-        run: curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.ps1 -o __check-matrix-job.ps1
+        run: curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/check-matrix-job.ps1 -o __check-matrix-job.ps1
       - name: Run matrix job
         if: ${{ matrix.swift.enabled }}
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -195,7 +195,7 @@ jobs:
           fi
 
           # Generate matrix
-          echo "unit-test-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | MATRIX_LINUX_ENV_VARS_JSON="${linux_env_vars_json}" MATRIX_WINDOWS_ENV_VARS_JSON="${windows_env_vars_json}" bash)" >> "$GITHUB_OUTPUT"
+          echo "unit-test-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/generate_matrix.sh | MATRIX_LINUX_ENV_VARS_JSON="${linux_env_vars_json}" MATRIX_WINDOWS_ENV_VARS_JSON="${windows_env_vars_json}" bash)" >> "$GITHUB_OUTPUT"
         env:
           INPUT_LINUX_ENV_VARS: ${{ inputs.linux_env_vars }}
           INPUT_WINDOWS_ENV_VARS: ${{ inputs.windows_env_vars }}
@@ -236,7 +236,7 @@ jobs:
     name: Unit tests
     needs: construct-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: "Unit tests"
       matrix_string: '${{ needs.construct-matrix.outputs.unit-test-matrix }}'

--- a/.github/workflows/wasm_swift_sdk.yml
+++ b/.github/workflows/wasm_swift_sdk.yml
@@ -64,8 +64,8 @@ jobs:
                 "platform": "Linux",
                 "runner": "ubuntu-latest",
                 "image": "ubuntu:jammy",
-                "setup_command": ("apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/install_swift_sdk.sh | " + $install_env + " INSTALL_SWIFT_ARCH=x86_64 INSTALL_SWIFT_SDK=wasm-sdk bash && hash -r"),
-                "command": "curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/swift-build-with-wasm-sdk.sh | bash -s --",
+                "setup_command": ("apt update -q && apt install -y -q curl jq tar && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/install_swift_prerequisites.sh | bash && curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/install_swift_sdk.sh | " + $install_env + " INSTALL_SWIFT_ARCH=x86_64 INSTALL_SWIFT_SDK=wasm-sdk bash && hash -r"),
+                "command": "curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/xcode_beta/scripts/swift-build-with-wasm-sdk.sh | bash -s --",
                 "command_arguments": $command_arguments,
                 "env": $env
               }'
@@ -105,7 +105,7 @@ jobs:
     name: WebAssembly Swift SDK
     needs: construct-matrix
     # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@xcode_beta
     with:
       name: "WebAssembly Swift SDK"
       matrix_string: '${{ needs.construct-matrix.outputs.wasm-swift-sdk-matrix }}'


### PR DESCRIPTION
Enable Xcode betas by default now that they are available on runners again

### Motivation:

Xcode betas are available on runners again

### Modifications:

Enable Xcode betas by default now that they are available on runners again

### Result

Downstream packages will run Xcode beta builds 