### PR TITLE
fix off-by-one boundaries in QUIC bytesNeededForInteger

### DIFF
--- a/Sources/NIOCore/ByteBuffer-quicBinaryEncodingStrategy.swift
+++ b/Sources/NIOCore/ByteBuffer-quicBinaryEncodingStrategy.swift
@@ -72,13 +72,13 @@ extension ByteBuffer {
             // The second case cannot be represented at all in UInt8, because 16383 is too big
             // Swift will end up creating the 16383 literal as 0, and thus we will fall all the way through to the default
             switch UInt64(integer) {
-            case 0..<63:
+            case 0...63:
                 return 1
-            case 0..<16383:
+            case 0...16383:
                 return 2
-            case 0..<1_073_741_823:
+            case 0...1_073_741_823:
                 return 4
-            case 0..<4_611_686_018_427_387_903:
+            case 0...4_611_686_018_427_387_903:
                 return 8
             default:
                 fatalError("QUIC variable-length integer outside of valid range")

--- a/Tests/NIOCoreTests/ByteBufferQUICBinaryEncodingStrategyTests.swift
+++ b/Tests/NIOCoreTests/ByteBufferQUICBinaryEncodingStrategyTests.swift
@@ -20,8 +20,8 @@ final class ByteBufferQUICBinaryEncodingStrategyTests: XCTestCase {
     // MARK: - writeEncodedInteger tests
 
     func testWriteOneByteQUICVariableLengthInteger() {
-        // One byte, ie less than 63, just write out as-is
-        for number in 0..<63 {
+        // One byte covers 0...63 (6 bits), written out as-is
+        for number in 0...63 {
             var buffer = ByteBuffer()
             let strategy = ByteBuffer.QUICBinaryEncodingStrategy.quic
             let bytesWritten = strategy.writeInteger(number, to: &buffer)
@@ -30,6 +30,35 @@ final class ByteBufferQUICBinaryEncodingStrategyTests: XCTestCase {
             XCTAssertEqual(buffer.readInteger(as: UInt8.self), UInt8(number))
             XCTAssertEqual(buffer.readableBytes, 0)
         }
+    }
+
+    func testBytesNeededForIntegerAtBoundaries() {
+        // The 1/2/4/8 byte encodings cover the values representable in 6/14/30/62 bits,
+        // ie up to and including 2^6-1, 2^14-1, 2^30-1 and 2^62-1 (RFC 9000 § 16).
+        let cases: [(Int64, Int)] = [
+            (62, 1), (63, 1), (64, 2),
+            (16383, 2), (16384, 4),
+            (1_073_741_823, 4), (1_073_741_824, 8),
+            (4_611_686_018_427_387_903, 8),
+        ]
+        for (value, expected) in cases {
+            XCTAssertEqual(
+                ByteBuffer.QUICBinaryEncodingStrategy.bytesNeededForInteger(value),
+                expected,
+                "wrong byte count for \(value)"
+            )
+        }
+    }
+
+    func testWriteReadMaximumQUICVariableLengthInteger() {
+        // 2^62-1 is the largest value the encoding can represent and must round-trip.
+        let maximum: Int64 = 4_611_686_018_427_387_903
+        var buffer = ByteBuffer()
+        let strategy = ByteBuffer.QUICBinaryEncodingStrategy.quic
+        let bytesWritten = strategy.writeInteger(maximum, to: &buffer)
+        XCTAssertEqual(bytesWritten, 8)
+        XCTAssertEqual(strategy.readInteger(as: Int64.self, from: &buffer), maximum)
+        XCTAssertEqual(buffer.readableBytes, 0)
     }
 
     func testWriteBigUInt8() {


### PR DESCRIPTION
Off-by-one in the QUIC variable-length integer length boundaries.

### Motivation:

`bytesNeededForInteger` classifies an integer into the 1/2/4/8 byte QUIC encoding using half-open ranges (`0..<63`, `0..<16383`, `0..<1_073_741_823`, `0..<4_611_686_018_427_387_903`). Those upper bounds are the *largest* value each size can hold (2^6-1, 2^14-1, 2^30-1 and 2^62-1 per RFC 9000 § 16), so each maximum is wrongly excluded:

- 63, 16383 and 2^30-1 report one byte too many, so the encoder writes them with a larger encoding than needed.
- 2^62-1, the largest value the encoding can represent, falls through to the `fatalError` and crashes the encoder.

The existing one-byte write test only iterates `0..<63`, so the 63 case was never exercised.

### Modifications:

- Switch the four ranges in `bytesNeededForInteger` to inclusive bounds.
- Extend the one-byte write test to include 63, and add boundary checks plus a 2^62-1 round-trip test.

### Result:

Boundary values encode in the minimal number of bytes and 2^62-1 round-trips instead of crashing.
