### PR TITLE
Fix incorrect status lines in HTTPResponseEncoder fast paths

### DIFF
--- a/Sources/NIOHTTP1/HTTPEncoder.swift
+++ b/Sources/NIOHTTP1/HTTPEncoder.swift
@@ -387,7 +387,7 @@ extension ByteBuffer {
         case (1, 0, .useProxy):
             self.writeStaticString("HTTP/1.0 305 Use Proxy\r\n")
         case (1, 0, .temporaryRedirect):
-            self.writeStaticString("HTTP/1.0 307 Tempory Redirect\r\n")
+            self.writeStaticString("HTTP/1.0 307 Temporary Redirect\r\n")
         case (1, 0, .permanentRedirect):
             self.writeStaticString("HTTP/1.0 308 Permanent Redirect\r\n")
         case (1, 0, .badRequest):
@@ -465,7 +465,7 @@ extension ByteBuffer {
         case (1, 0, .notExtended):
             self.writeStaticString("HTTP/1.0 510 Not Extended\r\n")
         case (1, 0, .networkAuthenticationRequired):
-            self.writeStaticString("HTTP/1.1 511 Network Authentication Required\r\n")
+            self.writeStaticString("HTTP/1.0 511 Network Authentication Required\r\n")
 
         // Optimization for HTTP/1.1
         case (1, 1, .custom(_, _)):
@@ -511,7 +511,7 @@ extension ByteBuffer {
         case (1, 1, .useProxy):
             self.writeStaticString("HTTP/1.1 305 Use Proxy\r\n")
         case (1, 1, .temporaryRedirect):
-            self.writeStaticString("HTTP/1.1 307 Tempory Redirect\r\n")
+            self.writeStaticString("HTTP/1.1 307 Temporary Redirect\r\n")
         case (1, 1, .permanentRedirect):
             self.writeStaticString("HTTP/1.1 308 Permanent Redirect\r\n")
         case (1, 1, .badRequest):
@@ -547,7 +547,7 @@ extension ByteBuffer {
         case (1, 1, .unsupportedMediaType):
             self.writeStaticString("HTTP/1.1 415 Unsupported Media Type\r\n")
         case (1, 1, .rangeNotSatisfiable):
-            self.writeStaticString("HTTP/1.1 416 Request Range Not Satisified\r\n")
+            self.writeStaticString("HTTP/1.1 416 Range Not Satisfiable\r\n")
         case (1, 1, .expectationFailed):
             self.writeStaticString("HTTP/1.1 417 Expectation Failed\r\n")
         case (1, 1, .misdirectedRequest):
@@ -565,7 +565,7 @@ extension ByteBuffer {
         case (1, 1, .tooManyRequests):
             self.writeStaticString("HTTP/1.1 429 Too Many Requests\r\n")
         case (1, 1, .requestHeaderFieldsTooLarge):
-            self.writeStaticString("HTTP/1.1 431 Range Not Satisfiable\r\n")
+            self.writeStaticString("HTTP/1.1 431 Request Header Fields Too Large\r\n")
         case (1, 1, .unavailableForLegalReasons):
             self.writeStaticString("HTTP/1.1 451 Unavailable For Legal Reasons\r\n")
         case (1, 1, .internalServerError):

--- a/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
@@ -37,6 +37,7 @@ class HTTPResponseEncoderTests: XCTestCase {
     private func sendResponse(
         withStatus status: HTTPResponseStatus,
         andHeaders headers: HTTPHeaders,
+        version: HTTPVersion = .http1_1,
         configuration: HTTPResponseEncoder.Configuration = .init()
     ) -> ByteBuffer {
         let channel = EmbeddedChannel()
@@ -47,7 +48,7 @@ class HTTPResponseEncoderTests: XCTestCase {
         XCTAssertNoThrow(
             try channel.pipeline.syncOperations.addHandler(HTTPResponseEncoder(configuration: configuration))
         )
-        var switchingResponse = HTTPResponseHead(version: .http1_1, status: status)
+        var switchingResponse = HTTPResponseHead(version: version, status: status)
         switchingResponse.headers = headers
         XCTAssertNoThrow(try channel.writeOutbound(HTTPServerResponsePart.head(switchingResponse)))
         do {
@@ -61,6 +62,47 @@ class HTTPResponseEncoderTests: XCTestCase {
             var buf = channel.allocator.buffer(capacity: 16)
             buf.writeString("unexpected error: \(error)")
             return buf
+        }
+    }
+
+    /// The encoder writes hand-optimised status lines for the well-known statuses (rather than
+    /// going through the general `default` path that uses `HTTPResponseStatus.reasonPhrase`). Those
+    /// fast paths must stay in lockstep with `reasonPhrase` and must carry the correct HTTP version,
+    /// otherwise the bytes on the wire depend on whether a status happens to have a fast path.
+    func testStatusLineFastPathsMatchCanonicalReasonPhraseAndVersion() throws {
+        let statuses: [HTTPResponseStatus] = [
+            .continue, .switchingProtocols, .processing,
+            .ok, .created, .accepted, .nonAuthoritativeInformation, .noContent, .resetContent,
+            .partialContent, .multiStatus, .alreadyReported, .imUsed,
+            .multipleChoices, .movedPermanently, .found, .seeOther, .notModified, .useProxy,
+            .temporaryRedirect, .permanentRedirect,
+            .badRequest, .unauthorized, .paymentRequired, .forbidden, .notFound, .methodNotAllowed,
+            .notAcceptable, .proxyAuthenticationRequired, .requestTimeout, .conflict, .gone,
+            .lengthRequired, .preconditionFailed, .payloadTooLarge, .uriTooLong, .unsupportedMediaType,
+            .rangeNotSatisfiable, .expectationFailed, .imATeapot, .misdirectedRequest,
+            .unprocessableEntity, .locked, .failedDependency, .upgradeRequired, .preconditionRequired,
+            .tooManyRequests, .requestHeaderFieldsTooLarge, .unavailableForLegalReasons,
+            .internalServerError, .notImplemented, .badGateway, .serviceUnavailable, .gatewayTimeout,
+            .httpVersionNotSupported, .variantAlsoNegotiates, .insufficientStorage, .loopDetected,
+            .notExtended, .networkAuthenticationRequired,
+        ]
+
+        for version in [HTTPVersion.http1_0, .http1_1] {
+            for status in statuses {
+                let written = sendResponse(
+                    withStatus: status,
+                    andHeaders: HTTPHeaders(),
+                    version: version
+                )
+                let bytes = written.getString(at: written.readerIndex, length: written.readableBytes)!
+                let statusLine = bytes.components(separatedBy: "\r\n").first ?? ""
+                let expected = "HTTP/\(version.major).\(version.minor) \(status.code) \(status.reasonPhrase)"
+                XCTAssertEqual(
+                    statusLine,
+                    expected,
+                    "status line for \(status) on HTTP/\(version.major).\(version.minor) did not match canonical form"
+                )
+            }
         }
     }
 

--- a/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPResponseEncoderTest.swift
@@ -94,7 +94,7 @@ class HTTPResponseEncoderTests: XCTestCase {
                     andHeaders: HTTPHeaders(),
                     version: version
                 )
-                let bytes = written.getString(at: written.readerIndex, length: written.readableBytes)!
+                let bytes = String(buffer: written)
                 let statusLine = bytes.components(separatedBy: "\r\n").first ?? ""
                 let expected = "HTTP/\(version.major).\(version.minor) \(status.code) \(status.reasonPhrase)"
                 XCTAssertEqual(


### PR DESCRIPTION
### Motivation

`HTTPResponseEncoder` writes hand-optimised status lines for the well-known `HTTPResponseStatus` values instead of going through the general `default` path that formats `HTTP/<version> <code> <reasonPhrase>`. Several of those fast paths had drifted out of sync with `HTTPResponseStatus.reasonPhrase`, so the exact bytes on the wire depended on whether a status happened to have a fast path:

* **HTTP/1.0 + 511** emitted the wrong HTTP version (`HTTP/1.1 511 ...`) — a wire-format correctness bug, not just cosmetic.
* **HTTP/1.1 + 431** emitted the reason phrase `Range Not Satisfiable` instead of `Request Header Fields Too Large`.
* **HTTP/1.1 + 416** emitted `Request Range Not Satisified` (also misspelled) instead of `Range Not Satisfiable`.
* **HTTP/1.0 and HTTP/1.1 + 307** emitted `Tempory Redirect` (misspelled) instead of `Temporary Redirect`.

Resolves #3630.

### Modifications

* Correct the five diverging status lines in `HTTPResponseEncoder` so they match `HTTPResponseStatus.reasonPhrase` and carry the correct HTTP version.
* Add a regression test that, for every well-known status at both HTTP/1.0 and HTTP/1.1, asserts the encoded status line equals the canonical `HTTP/<version> <code> <reasonPhrase>` form, keeping the fast paths in lockstep with `reasonPhrase`.

### Result

The encoder now produces correct, consistent status lines for all well-known statuses regardless of whether they use a fast path. The new test fails on the pre-fix code (the 511 case fails on the version, the 431/416/307 cases on the reason phrase) and passes after the fix.