### PR TITLE
[NFC] Remove trailing whitespaces from CNIOFreeBSD

### DIFF
--- a/Sources/CNIOFreeBSD/include/CNIOFreeBSD.h
+++ b/Sources/CNIOFreeBSD/include/CNIOFreeBSD.h
@@ -11,18 +11,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#ifndef C_NIO_FREEBSD_H                                                                                                                                                                                            
-#define C_NIO_FREEBSD_H                                                                                                                                                                                            
-                                                                                                                                                                                                                     
-#if defined(__FreeBSD__)                                                                                                                                                                                           
-#include <arpa/inet.h>                                                                                                                                                                                             
-#include <netinet/in.h>                                                                                                                                                                                            
-#include <netinet/ip.h>                                                                                                                                                                                            
-#include <sys/socket.h>                                                                                                                                                                                            
+#ifndef C_NIO_FREEBSD_H
+#define C_NIO_FREEBSD_H
 
-const char *CNIOFreeBSD_inet_ntop(int af, const void *src, char *dst, socklen_t size);                                                                                                                             
+#if defined(__FreeBSD__)
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <sys/socket.h>
+
+const char *CNIOFreeBSD_inet_ntop(int af, const void *src, char *dst, socklen_t size);
 int CNIOFreeBSD_inet_pton(int af, const char *src, void *dst);
 
-#endif                                                                                                                                                                                                             
-                                                                                                                                                                                                                     
+#endif
+
 #endif

--- a/Sources/CNIOFreeBSD/shim.c
+++ b/Sources/CNIOFreeBSD/shim.c
@@ -14,14 +14,14 @@
 
 void CNIOFreeBSD_i_do_nothing_just_working_around_a_darwin_toolchain_bug(void) {}
 
-#if defined(__FreeBSD__)                                                                                                                                                                                           
-#include <arpa/inet.h>                                                                                                                                                                                             
-                                                                                                                                                                                                                     
-const char *CNIOFreeBSD_inet_ntop(int af, const void *src, char *dst, socklen_t size) {                                                                                                                            
-    return inet_ntop(af, src, dst, size);                                                                                                                                                                          
-}                                                                                                                                                                                                                  
-                  
-int CNIOFreeBSD_inet_pton(int af, const char *src, void *dst) {                                                                                                                                                    
+#if defined(__FreeBSD__)
+#include <arpa/inet.h>
+
+const char *CNIOFreeBSD_inet_ntop(int af, const void *src, char *dst, socklen_t size) {
+    return inet_ntop(af, src, dst, size);
+}
+
+int CNIOFreeBSD_inet_pton(int af, const char *src, void *dst) {
     return inet_pton(af, src, dst);
-}                                                                                                                                                                                                                  
+}
 #endif


### PR DESCRIPTION
This PR is just a cleanup of the source code.

### Motivation:

The `CNIOFreeBSD` source code contains inconsistent trailing whitespaces, which hinders future modifications.

### Modifications:

Removed all trailing whitespaces from `CNIOFreeBSD`.

### Result:

The source code remains exactly the same; only the trailing whitespaces have been removed.
