### PR TITLE
Fix Linux allocation hook calloc overflow handling

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Sources/HookedFunctions/src/hooked-functions-unix.c
+++ b/IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Sources/HookedFunctions/src/hooked-functions-unix.c
@@ -19,6 +19,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdatomic.h>
+#include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -199,8 +200,15 @@ void *replacement_realloc(void *ptr, size_t size) {
 }
 
 void *replacement_calloc(size_t count, size_t size) {
-    void *ptr = replacement_malloc(count * size);
-    memset(ptr, 0, count * size);
+    if (size != 0 && count > SIZE_MAX / size) {
+        return NULL;
+    }
+
+    size_t total_size = count * size;
+    void *ptr = replacement_malloc(total_size);
+    if (ptr) {
+        memset(ptr, 0, total_size);
+    }
     return ptr;
 }
 


### PR DESCRIPTION
### Motivation
The Linux allocation-counting hook implements calloc by multiplying count and size before allocating, then zeroing the result unconditionally. If the multiplication overflows, the hook can allocate a smaller buffer than requested. If allocation fails, it can pass NULL to memset.

### Modification
This checks for count/size overflow before multiplying, reuses the computed total size, and only zeroes memory after allocation succeeds.

### Result
The Linux hook now follows calloc-style failure behavior for overflow and avoids zeroing a NULL pointer on allocation failure.

### Validation
- swift build --package-path IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook
- clang -std=gnu11 -fsyntax-only -U__APPLE__ -IIntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Sources/HookedFunctions/include -IIntegrationTests/allocation-counter-tests-framework/template/AtomicCounter/Sources/AtomicCounter/include IntegrationTests/allocation-counter-tests-framework/template/HookedFunctionsDoHook/Sources/HookedFunctions/src/hooked-functions-unix.c