### PR TITLE
Normalize Android NDK download host tag

### DIFF
--- a/scripts/install_android_ndk.sh
+++ b/scripts/install_android_ndk.sh
@@ -29,8 +29,24 @@ CURL_BIN="${CURL_BIN:-$(which curl 2> /dev/null)}"; test -n "$CURL_BIN" || fatal
 UNZIP_BIN="${UNZIP_BIN:-$(which unzip 2> /dev/null)}"; test -n "$UNZIP_BIN" || fatal "UNZIP_BIN unset and no unzip on PATH"
 SHASUM_BIN="${SHASUM_BIN:-$(which shasum 2> /dev/null)}"; test -n "$SHASUM_BIN" || fatal "SHASUM_BIN unset and no shasum on PATH"
 
+host_os="$(uname -s)"
+case "$host_os" in
+  "Linux")
+    android_ndk_host="linux"
+    ;;
+  "Darwin")
+    android_ndk_host="darwin"
+    ;;
+  MINGW*|MSYS*|CYGWIN*|"Windows_NT")
+    android_ndk_host="windows"
+    ;;
+  *)
+    fatal "Unexpected host OS: $host_os"
+    ;;
+esac
+
 # download and link the NDK
-android_ndk_url="https://dl.google.com/android/repository/android-ndk-${android_ndk_version}-$(uname -s).zip"
+android_ndk_url="https://dl.google.com/android/repository/android-ndk-${android_ndk_version}-${android_ndk_host}.zip"
 
 log "Android Native Development Kit URL: $android_ndk_url"
 "$CURL_BIN" -fsSL -o android_ndk.zip --retry 3 "$android_ndk_url"


### PR DESCRIPTION
### Motivation
The Android NDK download script builds the archive URL with the raw output of uname -s. The Android NDK downloads page documents lowercase host tags in archive names, for example android-ndk-r27d-linux.zip.

Google's download endpoint currently accepts the old Linux casing too, but using the documented host tag keeps the URL construction predictable and avoids relying on that behavior.

### Modification
Map known host OS values to the Android NDK archive host tags before constructing the download URL:

- Linux -> linux
- Darwin -> darwin
- MINGW/MSYS/CYGWIN/Windows_NT -> windows

Unknown host values now fail with a clear error instead of constructing a likely-bad URL.

### Result
The installer uses documented Android NDK archive names across recognized hosts.

### Validation
- bash -n scripts/install_android_ndk.sh
- git diff --check
- Verified the current r27d download names from the Android NDK downloads page and checked the r27d linux/darwin/windows ZIP URLs with curl HEAD.