### PR TITLE
Avoid exit tests on iOS/tvOS/watchOS/visionOS

### DIFF
--- a/Tests/NIOCoreTests/ByteBufferCrashTests.swift
+++ b/Tests/NIOCoreTests/ByteBufferCrashTests.swift
@@ -16,7 +16,7 @@ import Foundation
 @_spi(CustomByteBufferAllocator) import NIOCore
 import Testing
 
-#if compiler(>=6.2)
+#if compiler(>=6.2) && !(canImport(Darwin) && !os(macOS))
 @Suite struct ByteBufferCrashTests {
 
     @Test func copyBytesToIndexExceedingUInt32Max() async {


### PR DESCRIPTION
Motivation:

The exit tests fail to compile on these platforms.

Modifications:

Commented out the exit tests on those platforms.

Result:

Better testing
