### PR TITLE
Allow sending values into EventLoopFuture

### DIFF
--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -131,7 +131,7 @@ extension EventLoopPromise {
     @preconcurrency
     @inlinable
     public func completeWithTask(
-        _ body: sending @escaping () async throws -> Value
+        _ body: @escaping @Sendable () async throws -> Value
     ) -> Task<Void, Never> where Value: Sendable {
         Task {
             do {
@@ -549,7 +549,7 @@ extension EventLoop {
     @preconcurrency
     @inlinable
     public func makeFutureWithTask<Return: Sendable>(
-        _ body: sending @escaping () async throws -> Return
+        _ body: @Sendable @escaping () async throws -> Return
     ) -> EventLoopFuture<Return> {
         let promise = self.makePromise(of: Return.self)
         promise.completeWithTask(body)

--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -131,8 +131,31 @@ extension EventLoopPromise {
     @preconcurrency
     @inlinable
     public func completeWithTask(
-        _ body: @escaping @Sendable () async throws -> Value
+        _ body: sending @escaping () async throws -> Value
     ) -> Task<Void, Never> where Value: Sendable {
+        Task {
+            do {
+                let value = try await body()
+                self.succeed(value)
+            } catch {
+                self.fail(error)
+            }
+        }
+    }
+
+    /// Complete a future with the result (or error) of the `async` function `body`.
+    ///
+    /// This function can be used to bridge the `async` world into an `EventLoopPromise`.
+    ///
+    /// - Parameters:
+    ///   - body: The `async` function to run.
+    /// - Returns: A `Task` which was created to `await` the `body`.
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @discardableResult
+    @inlinable
+    public func completeWithTaskSending(
+        _ body: sending @escaping () async throws -> sending Value
+    ) -> Task<Void, Never> {
         Task {
             do {
                 let value = try await body()
@@ -526,10 +549,20 @@ extension EventLoop {
     @preconcurrency
     @inlinable
     public func makeFutureWithTask<Return: Sendable>(
-        _ body: @Sendable @escaping () async throws -> Return
+        _ body: sending @escaping () async throws -> Return
     ) -> EventLoopFuture<Return> {
         let promise = self.makePromise(of: Return.self)
         promise.completeWithTask(body)
+        return promise.futureResult
+    }
+
+    @preconcurrency
+    @inlinable
+    public func makeFutureWithTaskSending<Return>(
+        _ body: sending @escaping () async throws -> sending Return
+    ) -> EventLoopFuture<Return> {
+        let promise = self.makePromise(of: Return.self)
+        promise.completeWithTaskSending(body)
         return promise.futureResult
     }
 }

--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -546,6 +546,11 @@ extension AsyncSequenceFromIterator: Sendable where AsyncIterator: Sendable {}
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension EventLoop {
+    /// Create a future that will be completed with the result of a Task.
+    /// This overload requires the task body result to be `Sendable`. If your return type is not sendable, consider using ``makeFutureWithTaskSending(_:)``.
+    /// - Parameter body: Async work to be run in a Task. The result of this function will be used to complete the future.
+    /// - Note: This Task is unstructured. It cannot be cancelled.
+    /// - Returns: A future which will be completed with the result of `body`
     @preconcurrency
     @inlinable
     public func makeFutureWithTask<Return: Sendable>(
@@ -555,8 +560,12 @@ extension EventLoop {
         promise.completeWithTask(body)
         return promise.futureResult
     }
-
-    @preconcurrency
+    
+    /// Create a future that will be completed with the result of a Task.
+    /// This overload requires the task body to return the result as `sending`, so the result does not need to be `Sendable`. If your return type is not disconnected, and is Sendable, consider using ``makeFutureWithTask(_:)``.
+    /// - Parameter body: Async work to be run in a Task. The result of this function will be used to complete the future.
+    /// - Note: This Task is unstructured. It cannot be cancelled.
+    /// - Returns: A future which will be completed with the result of `body`
     @inlinable
     public func makeFutureWithTaskSending<Return>(
         _ body: sending @escaping () async throws -> sending Return

--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -560,7 +560,7 @@ extension EventLoop {
         promise.completeWithTask(body)
         return promise.futureResult
     }
-    
+
     /// Create a future that will be completed with the result of a Task.
     /// This overload requires the task body to return the result as `sending`, so the result does not need to be `Sendable`. If your return type is not disconnected, and is Sendable, consider using ``makeFutureWithTask(_:)``.
     /// - Parameter body: Async work to be run in a Task. The result of this function will be used to complete the future.

--- a/Sources/NIOCore/EventLoop+Deprecated.swift
+++ b/Sources/NIOCore/EventLoop+Deprecated.swift
@@ -26,8 +26,8 @@ extension EventLoop {
     @preconcurrency
     @inlinable
     @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
-    public func makeSucceededFuture<Success: Sendable>(
-        _ value: Success,
+    public func makeSucceededFuture<Success>(
+        _ value: sending Success,
         file: StaticString = #fileID,
         line: UInt = #line
     ) -> EventLoopFuture<Success> {

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -1165,7 +1165,7 @@ extension EventLoop {
     /// - Returns: a succeeded `EventLoopFuture`.
     @preconcurrency
     @inlinable
-    public func makeSucceededFuture<Success: Sendable>(_ value: Success) -> EventLoopFuture<Success> {
+    public func makeSucceededFuture<Success>(_ value: sending Success) -> EventLoopFuture<Success> {
         if Success.self == Void.self {
             // The as! will always succeed because we previously checked that Success.self == Void.self.
             return self.makeSucceededVoidFuture() as! EventLoopFuture<Success>
@@ -1197,7 +1197,7 @@ extension EventLoop {
     /// - Returns: A completed `EventLoopFuture`.
     @preconcurrency
     @inlinable
-    public func makeCompletedFuture<Success: Sendable>(_ result: Result<Success, Error>) -> EventLoopFuture<Success> {
+    public func makeCompletedFuture<Success>(_ result: sending Result<Success, Error>) -> EventLoopFuture<Success> {
         switch result {
         case .success(let value):
             return self.makeSucceededFuture(value)
@@ -1218,6 +1218,23 @@ extension EventLoop {
     ) -> EventLoopFuture<Success> {
         let trans = Result(catching: body)
         return self.makeCompletedFuture(trans)
+    }
+
+    /// Creates and returns a new `EventLoopFuture` that is marked as succeeded or failed with the value returned by `body`.
+    ///
+    /// - Parameters:
+    ///   - body: The function that is used to complete the `EventLoopFuture`
+    /// - Returns: A completed `EventLoopFuture`.
+    @inlinable
+    public func makeCompletedFutureSending<Success>(
+        withResultOf body: () throws -> sending Success
+    ) -> EventLoopFuture<Success> {
+        do {
+            let success = try body()
+            return self.makeCompletedFuture(.success(success))
+        } catch {
+            return self.makeCompletedFuture(.failure(error))
+        }
     }
 
     /// An `EventLoop` forms a singular `EventLoopGroup`, returning itself as the 'next' `EventLoop`.

--- a/Sources/NIOCore/EventLoopFuture.swift
+++ b/Sources/NIOCore/EventLoopFuture.swift
@@ -210,7 +210,7 @@ public struct EventLoopPromise<Value> {
     ///   - value: The successful result of the operation.
     @preconcurrency
     @inlinable
-    public func succeed(_ value: Value) where Value: Sendable {
+    public func succeed(_ value: sending Value) {
         self._resolve(value: .success(value))
     }
 
@@ -262,7 +262,7 @@ public struct EventLoopPromise<Value> {
     ///   - result: The result which will be used to succeed or fail this promise.
     @preconcurrency
     @inlinable
-    public func completeWith(_ result: Result<Value, Error>) where Value: Sendable {
+    public func completeWith(_ result: sending Result<Value, Error>) {
         self._resolve(value: result)
     }
 
@@ -275,12 +275,13 @@ public struct EventLoopPromise<Value> {
     /// - Parameters:
     ///   - value: The value to fire the future with.
     @inlinable
-    internal func _resolve(value: Result<Value, Error>) where Value: Sendable {
+    internal func _resolve(value: sending Result<Value, Error>) {
         if self.futureResult.eventLoop.inEventLoop {
             self._setValue(value: value)._run()
         } else {
+            let box = NIOLoopBound(sending: value, eventLoop: self.futureResult.eventLoop)
             self.futureResult.eventLoop.execute {
-                self._setValue(value: value)._run()
+                self._setValue(value: box.value)._run()
             }
         }
     }
@@ -448,7 +449,7 @@ public final class EventLoopFuture<Value> {
 
     /// A EventLoopFuture<Value> that has already succeeded
     @inlinable
-    internal init(eventLoop: EventLoop, value: Value) where Value: Sendable {
+    internal init(eventLoop: EventLoop, value: sending Value) {
         self.eventLoop = eventLoop
         self._value = .success(value)
         self._callbacks = .init()

--- a/Sources/NIOCore/NIOLoopBound.swift
+++ b/Sources/NIOCore/NIOLoopBound.swift
@@ -44,7 +44,7 @@ public struct NIOLoopBound<Value>: @unchecked Sendable {
         self._value = value
     }
 
-    /// Initialise a ``NIOLoopBound`` to `value` with the precondition that the code is running on `eventLoop`.
+    /// Initialise a ``NIOLoopBound`` to `value` by sending value into `eventLoop`. Caller does not need to be on the EventLoop.
     @inlinable
     public init(sending value: sending Value, eventLoop: EventLoop) {
         self.eventLoop = eventLoop

--- a/Sources/NIOCore/NIOLoopBound.swift
+++ b/Sources/NIOCore/NIOLoopBound.swift
@@ -44,6 +44,13 @@ public struct NIOLoopBound<Value>: @unchecked Sendable {
         self._value = value
     }
 
+    /// Initialise a ``NIOLoopBound`` to `value` with the precondition that the code is running on `eventLoop`.
+    @inlinable
+    public init(sending value: sending Value, eventLoop: EventLoop) {
+        self.eventLoop = eventLoop
+        self._value = value
+    }
+
     /// Access the `value` with the precondition that the code is running on `eventLoop`.
     ///
     /// - Note: ``NIOLoopBound`` itself is value-typed, so any writes will only affect the current value.

--- a/Tests/NIOPosixTests/EventLoopFutureTest.swift
+++ b/Tests/NIOPosixTests/EventLoopFutureTest.swift
@@ -1901,6 +1901,132 @@ class EventLoopFutureTest {
         #expect(promise1 != promise2)
         #expect(promise3 != promise2)
     }
+
+    // MARK: - Sending non-Sendable values into promises and futures
+
+    @Test
+    func testSucceedPromiseBySendingNonSendableValue() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
+        }
+        let eventLoop = group.next()
+
+        let promise = eventLoop.makePromise(of: NonSendableObject.self)
+        let value = promise.futureResult.map { $0.value }
+        // `succeed` takes a `sending` value, so a non-`Sendable` value can be sent in
+        // from off the `EventLoop` without needing `assumeIsolated`.
+        promise.succeed(NonSendableObject(value: 42))
+        #expect(try value.wait() == 42)
+    }
+
+    @Test
+    func testCompleteWithBySendingNonSendableResult() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
+        }
+        let eventLoop = group.next()
+
+        let successPromise = eventLoop.makePromise(of: NonSendableObject.self)
+        let value = successPromise.futureResult.map { $0.value }
+        successPromise.completeWith(.success(NonSendableObject(value: 42)))
+        #expect(try value.wait() == 42)
+
+        let failurePromise = eventLoop.makePromise(of: NonSendableObject.self)
+        failurePromise.completeWith(.failure(EventLoopFutureTestError.example))
+        #expect(throws: EventLoopFutureTestError.example) {
+            try failurePromise.futureResult.map { $0.value }.wait()
+        }
+    }
+
+    @Test
+    func testMakeSucceededFutureBySendingNonSendableValue() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
+        }
+        let eventLoop = group.next()
+
+        let future = eventLoop.makeSucceededFuture(NonSendableObject(value: 42))
+        #expect(try future.map { $0.value }.wait() == 42)
+    }
+
+    @Test
+    func testMakeCompletedFutureBySendingNonSendableResult() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
+        }
+        let eventLoop = group.next()
+
+        let successFuture = eventLoop.makeCompletedFuture(.success(NonSendableObject(value: 42)))
+        #expect(try successFuture.map { $0.value }.wait() == 42)
+
+        let failureFuture = eventLoop.makeCompletedFuture(
+            Result<NonSendableObject, Error>.failure(EventLoopFutureTestError.example)
+        )
+        #expect(throws: EventLoopFutureTestError.example) {
+            try failureFuture.map { $0.value }.wait()
+        }
+    }
+
+    @Test
+    func testMakeCompletedFutureSendingWithResultOf() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
+        }
+        let eventLoop = group.next()
+
+        let successFuture = eventLoop.makeCompletedFutureSending {
+            NonSendableObject(value: 42)
+        }
+        #expect(try successFuture.map { $0.value }.wait() == 42)
+
+        let failureFuture = eventLoop.makeCompletedFutureSending { () throws -> NonSendableObject in
+            throw EventLoopFutureTestError.example
+        }
+        #expect(throws: EventLoopFutureTestError.example) {
+            try failureFuture.map { $0.value }.wait()
+        }
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @Test
+    func testCompleteWithTaskSendingSuccess() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
+        }
+        let eventLoop = group.next()
+
+        let promise = eventLoop.makePromise(of: NonSendableObject.self)
+        promise.completeWithTaskSending {
+            try await Task.sleep(nanoseconds: 37)
+            return NonSendableObject(value: 42)
+        }
+        #expect(try promise.futureResult.map { $0.value }.wait() == 42)
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @Test
+    func testCompleteWithTaskSendingFailure() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            #expect(throws: Never.self) { try group.syncShutdownGracefully() }
+        }
+        let eventLoop = group.next()
+
+        let promise = eventLoop.makePromise(of: NonSendableObject.self)
+        promise.completeWithTaskSending {
+            try await Task.sleep(nanoseconds: 37)
+            throw EventLoopFutureTestError.example
+        }
+        #expect(throws: EventLoopFutureTestError.example) {
+            try promise.futureResult.map { $0.value }.wait()
+        }
+    }
 }
 
 class NonSendableObject: Equatable {

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -2013,6 +2013,46 @@ final class MultiThreadedEventLoopGroupTests {
         }
     }
 
+    @Test
+    func testAsyncToFutureConversionSendingSuccess() throws {
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            #expect(throws: Never.self) {
+                try group.syncShutdownGracefully()
+            }
+        }
+
+        // `makeFutureWithTaskSending` returns the result as `sending`, so the body may
+        // return a non-`Sendable` value.
+        let future = group.next().makeFutureWithTaskSending {
+            try await Task.sleep(nanoseconds: 37)
+            return NonSendableObject(value: 42)
+        }
+        #expect(try future.map { $0.value }.wait() == 42)
+    }
+
+    @Test
+    func testAsyncToFutureConversionSendingFailure() throws {
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            #expect(throws: Never.self) {
+                try group.syncShutdownGracefully()
+            }
+        }
+
+        struct DummyError: Error {}
+
+        let future = group.next().makeFutureWithTaskSending { () async throws -> NonSendableObject in
+            try await Task.sleep(nanoseconds: 37)
+            throw DummyError()
+        }
+        #expect(throws: DummyError.self) {
+            try future.map { $0.value }.wait()
+        }
+    }
+
     // Test for possible starvation discussed here: https://github.com/apple/swift-nio/pull/2645#discussion_r1486747118
     @Test
     func testNonStarvation() throws {

--- a/Tests/NIOPosixTests/NIOLoopBoundTests.swift
+++ b/Tests/NIOPosixTests/NIOLoopBoundTests.swift
@@ -106,6 +106,34 @@ final class NIOLoopBoundTests: XCTestCase {
         )
     }
 
+    func testLoopBoundCanBeInitialisedBySendingValueOffLoop() {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        let loop = group.any()
+
+        final class NonSendableIntBox {
+            var value: Int
+
+            init(value: Int) {
+                self.value = value
+            }
+        }
+
+        // `NIOLoopBound(sending:eventLoop:)` does not require the caller to be on the
+        // `EventLoop`, unlike `NIOLoopBound(_:eventLoop:)`, so a non-`Sendable` value
+        // can be sent in from off the loop.
+        let loopBound = NIOLoopBound(sending: NonSendableIntBox(value: 100), eventLoop: loop)
+        XCTAssertEqual(
+            100,
+            try loop.submit {
+                loopBound.value.value
+            }.wait()
+        )
+    }
+
     func testInPlaceMutation() {
         var loopBound = NIOLoopBound(CoWValue(), eventLoop: loop)
         XCTAssertTrue(loopBound.value.mutateInPlace())


### PR DESCRIPTION
### Motivation:

Users may want to move a non-Sendable value into an EventLoopFuture. This is safe if we take the value as `sending`

### Modifications:

Change functions whcih currently require Sendable parameters to instead take the parameter as `sending` where possible. This seems to not break API

Some functions take closures whcih return Sendable values, those ones now take closures which return sending values. This has been done as an overload, because a straight replacement seems to break API