### PR TITLE
[Windows] Build currently-supported targets in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,37 @@ jobs:
       tvos_xcode_test_enabled: true
       visionos_xcode_test_enabled: true
 
+  construct-windows-build-matrix:
+    name: Construct Windows build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      windows-build-matrix: '${{ steps.generate-matrix.outputs.windows-build-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "windows-build-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_6_0_ENABLED: false
+          MATRIX_LINUX_6_1_ENABLED: false
+          MATRIX_LINUX_6_2_ENABLED: false
+          MATRIX_LINUX_6_3_ENABLED: false
+          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: false
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+          MATRIX_WINDOWS_6_3_ENABLED: true
+          MATRIX_WINDOWS_COMMAND: "swift build --target _NIOBase64 && swift build --target _NIOConcurrency && swift build --target _NIODataStructures && swift build --target NIOConcurrencyHelpers && swift build --target NIOCore && swift build --target NIOEmbedded && swift build --target NIOFoundationCompat && swift build --target NIOFoundationEssentialsCompat && swift build --target NIOHTTP1 && swift build --target NIOTLS && swift build --target NIOWebSocket"
+
+  windows-build:
+    name: Windows build (currently-supported targets)
+    needs: construct-windows-build-matrix
+    # Workaround https://github.com/nektos/act/issues/1875
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: "Windows build (currently-supported targets)"
+      matrix_string: '${{ needs.construct-windows-build-matrix.outputs.windows-build-matrix }}'
+
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -65,6 +65,37 @@ jobs:
       name: "Integration tests"
       matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
 
+  construct-windows-build-matrix:
+    name: Construct Windows build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      windows-build-matrix: '${{ steps.generate-matrix.outputs.windows-build-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "windows-build-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_6_0_ENABLED: false
+          MATRIX_LINUX_6_1_ENABLED: false
+          MATRIX_LINUX_6_2_ENABLED: false
+          MATRIX_LINUX_6_3_ENABLED: false
+          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: false
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+          MATRIX_WINDOWS_6_3_ENABLED: true
+          MATRIX_WINDOWS_COMMAND: "swift build --target _NIOBase64 && swift build --target _NIOConcurrency && swift build --target _NIODataStructures && swift build --target NIOConcurrencyHelpers && swift build --target NIOCore && swift build --target NIOEmbedded && swift build --target NIOFoundationCompat && swift build --target NIOFoundationEssentialsCompat && swift build --target NIOHTTP1 && swift build --target NIOTLS && swift build --target NIOWebSocket"
+
+  windows-build:
+    name: Windows build (currently-supported targets)
+    needs: construct-windows-build-matrix
+    # Workaround https://github.com/nektos/act/issues/1875
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: "Windows build (currently-supported targets)"
+      matrix_string: '${{ needs.construct-windows-build-matrix.outputs.windows-build-matrix }}'
+
   vsock-tests:
     name: Vsock tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a Windows PR/main CI job that builds the targets which compile cleanly today: _NIOBase64, _NIOConcurrency, _NIODataStructures, NIOConcurrencyHelpers, NIOCore, NIOEmbedded, NIOFoundationCompat, NIOFoundationEssentialsCompat, NIOHTTP1, NIOTLS, NIOWebSocket. The remaining targets (NIOPosix, NIO, NIOTestUtils, downstream tests, examples) still fail on Windows and are not yet covered.

The existing unit-tests workflow path runs swift test, which does not accept --target, so flipping windows_6_3_enabled there would attempt to test the whole package and fail. Instead this is an inline job that runs swift build with explicit --target flags. As more targets come up on Windows we'll extend the list, then eventually retire this job in favor of windows_6_3_enabled when swift test of the whole package is green.