### PR TITLE
EL takeover works on 6.4 & main

### DIFF
--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -46,7 +46,7 @@ extension NIOSingletons {
         return false
         #else
         // Guard between the minimum and maximum supported version for the hook
-        #if compiler(<6.4)
+        #if compiler(<6.6)
         guard #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) else {
             return false
         }


### PR DESCRIPTION
### Motivation:

EventLoop takeover of the Concurrency pool works fine on 6.4 & main.

### Modifications:

Raise limit.

### Result:

More speed.