### PR TITLE
NIOFileSystem: Add on-disk size to FileInfo

### DIFF
--- a/Sources/NIOFS/FileInfo.swift
+++ b/Sources/NIOFS/FileInfo.swift
@@ -27,6 +27,16 @@ import CNIOLinux
 import CNIOLinux
 #endif
 
+#if canImport(Darwin)
+private let S_BLKSIZE = Darwin.S_BLKSIZE
+#elseif canImport(Glibc)
+private let S_BLKSIZE = Glibc.S_BLKSIZE
+#elseif canImport(Musl)
+private let S_BLKSIZE = Musl.DEV_BSIZE
+#elseif canImport(Android)
+private let S_BLKSIZE = Android.S_BLKSIZE
+#endif
+
 /// Information about a file system object.
 ///
 /// The information available for a file depends on the platform, ``FileInfo`` provides
@@ -58,6 +68,11 @@ public struct FileInfo: Hashable, Sendable {
 
     /// The size of the file in bytes.
     public var size: Int64
+
+    /// The number of bytes allocated for the file on disk.
+    ///
+    /// This may differ from ``size`` for files which are sparse or compressed.
+    public var onDiskSize: Int64
 
     /// User ID of the file.
     public var userID: UserID
@@ -91,6 +106,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
+        self.onDiskSize = Int64(S_BLKSIZE) * Int64(platformSpecificStatus.st_blocks)
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -114,6 +130,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
+        onDiskSize: Int64,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -124,6 +141,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
+        self.onDiskSize = onDiskSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/NIOFS/FileInfo.swift
+++ b/Sources/NIOFS/FileInfo.swift
@@ -72,7 +72,7 @@ public struct FileInfo: Hashable, Sendable {
     /// The number of bytes allocated for the file on disk.
     ///
     /// This may differ from ``size`` for files which are sparse or compressed.
-    public var onDiskSize: Int64
+    public var allocatedSize: Int64
 
     /// User ID of the file.
     public var userID: UserID
@@ -92,7 +92,7 @@ public struct FileInfo: Hashable, Sendable {
     /// Creates a ``FileInfo`` by deriving values from a platform-specific value.
     public init(platformSpecificStatus: CInterop.Stat) {
         #if os(Windows)
-        fatalError("FileInfo.onDiskSize is not implemented on Windows")
+        fatalError("FileInfo.allocatedSize is not implemented on Windows")
         #endif
         self._platformSpecificStatus = Stat(platformSpecificStatus)
         #if os(Windows)
@@ -109,7 +109,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
-        self.onDiskSize = Int64(S_BLKSIZE) * Int64(platformSpecificStatus.st_blocks)
+        self.allocatedSize = Int64(S_BLKSIZE) * Int64(platformSpecificStatus.st_blocks)
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -133,7 +133,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
-        onDiskSize: Int64,
+        allocatedSize: Int64,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -144,7 +144,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
-        self.onDiskSize = onDiskSize
+        self.allocatedSize = allocatedSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/NIOFS/FileInfo.swift
+++ b/Sources/NIOFS/FileInfo.swift
@@ -93,19 +93,8 @@ public struct FileInfo: Hashable, Sendable {
     public init(platformSpecificStatus: CInterop.Stat) {
         #if os(Windows)
         fatalError("FileInfo.allocatedSize is not implemented on Windows")
-        #endif
-        self._platformSpecificStatus = Stat(platformSpecificStatus)
-        #if os(Windows)
-        self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
-        self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
-        self.size = platformSpecificStatus.nioSize
-        // Windows has no POSIX owner/group; report the defaults.
-        self.userID = UserID(rawValue: 0)
-        self.groupID = GroupID(rawValue: 0)
-        self.lastAccessTime = platformSpecificStatus.nioLastAccessTime
-        self.lastDataModificationTime = platformSpecificStatus.nioLastDataModificationTime
-        self.lastStatusChangeTime = platformSpecificStatus.nioLastStatusChangeTime
         #else
+        self._platformSpecificStatus = Stat(platformSpecificStatus)
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)

--- a/Sources/NIOFS/FileInfo.swift
+++ b/Sources/NIOFS/FileInfo.swift
@@ -91,6 +91,9 @@ public struct FileInfo: Hashable, Sendable {
 
     /// Creates a ``FileInfo`` by deriving values from a platform-specific value.
     public init(platformSpecificStatus: CInterop.Stat) {
+        #if os(Windows)
+        fatalError("FileInfo.onDiskSize is not implemented on Windows")
+        #endif
         self._platformSpecificStatus = Stat(platformSpecificStatus)
         #if os(Windows)
         self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)

--- a/Sources/NIOFS/FileInfo.swift
+++ b/Sources/NIOFS/FileInfo.swift
@@ -91,10 +91,19 @@ public struct FileInfo: Hashable, Sendable {
 
     /// Creates a ``FileInfo`` by deriving values from a platform-specific value.
     public init(platformSpecificStatus: CInterop.Stat) {
+        self._platformSpecificStatus = Stat(platformSpecificStatus)
         #if os(Windows)
+        self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
+        self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
+        self.size = platformSpecificStatus.nioSize
+        // Windows has no POSIX owner/group; report the defaults.
+        self.userID = UserID(rawValue: 0)
+        self.groupID = GroupID(rawValue: 0)
+        self.lastAccessTime = platformSpecificStatus.nioLastAccessTime
+        self.lastDataModificationTime = platformSpecificStatus.nioLastDataModificationTime
+        self.lastStatusChangeTime = platformSpecificStatus.nioLastStatusChangeTime
         fatalError("FileInfo.allocatedSize is not implemented on Windows")
         #else
-        self._platformSpecificStatus = Stat(platformSpecificStatus)
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)

--- a/Sources/_NIOFileSystem/FileInfo.swift
+++ b/Sources/_NIOFileSystem/FileInfo.swift
@@ -27,6 +27,16 @@ import CNIOLinux
 import CNIOLinux
 #endif
 
+#if canImport(Darwin)
+private let S_BLKSIZE = Darwin.S_BLKSIZE
+#elseif canImport(Glibc)
+private let S_BLKSIZE = Glibc.S_BLKSIZE
+#elseif canImport(Musl)
+private let S_BLKSIZE = Musl.DEV_BSIZE
+#elseif canImport(Android)
+private let S_BLKSIZE = Android.S_BLKSIZE
+#endif
+
 /// Information about a file system object.
 ///
 /// The information available for a file depends on the platform, ``FileInfo`` provides
@@ -58,6 +68,11 @@ public struct FileInfo: Hashable, Sendable {
 
     /// The size of the file in bytes.
     public var size: Int64
+
+    /// The number of bytes allocated for the file on disk.
+    ///
+    /// This may differ from ``size`` for files which are sparse or compressed.
+    public var onDiskSize: Int64
 
     /// User ID of the file.
     public var userID: UserID
@@ -91,6 +106,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
+        self.onDiskSize = Int64(S_BLKSIZE) * Int64(platformSpecificStatus.st_blocks)
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -114,6 +130,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
+        onDiskSize: Int64,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -124,6 +141,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
+        self.onDiskSize = onDiskSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/_NIOFileSystem/FileInfo.swift
+++ b/Sources/_NIOFileSystem/FileInfo.swift
@@ -72,7 +72,7 @@ public struct FileInfo: Hashable, Sendable {
     /// The number of bytes allocated for the file on disk.
     ///
     /// This may differ from ``size`` for files which are sparse or compressed.
-    public var onDiskSize: Int64
+    public var allocatedSize: Int64
 
     /// User ID of the file.
     public var userID: UserID
@@ -92,7 +92,7 @@ public struct FileInfo: Hashable, Sendable {
     /// Creates a ``FileInfo`` by deriving values from a platform-specific value.
     public init(platformSpecificStatus: CInterop.Stat) {
         #if os(Windows)
-        fatalError("FileInfo.onDiskSize is not implemented on Windows")
+        fatalError("FileInfo.allocatedSize is not implemented on Windows")
         #endif
         self._platformSpecificStatus = Stat(platformSpecificStatus)
         #if os(Windows)
@@ -109,7 +109,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
-        self.onDiskSize = Int64(S_BLKSIZE) * Int64(platformSpecificStatus.st_blocks)
+        self.allocatedSize = Int64(S_BLKSIZE) * Int64(platformSpecificStatus.st_blocks)
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -133,7 +133,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
-        onDiskSize: Int64,
+        allocatedSize: Int64,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -144,7 +144,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
-        self.onDiskSize = onDiskSize
+        self.allocatedSize = allocatedSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/_NIOFileSystem/FileInfo.swift
+++ b/Sources/_NIOFileSystem/FileInfo.swift
@@ -93,19 +93,8 @@ public struct FileInfo: Hashable, Sendable {
     public init(platformSpecificStatus: CInterop.Stat) {
         #if os(Windows)
         fatalError("FileInfo.allocatedSize is not implemented on Windows")
-        #endif
-        self._platformSpecificStatus = Stat(platformSpecificStatus)
-        #if os(Windows)
-        self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
-        self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
-        self.size = platformSpecificStatus.nioSize
-        // Windows has no POSIX owner/group; report the defaults.
-        self.userID = UserID(rawValue: 0)
-        self.groupID = GroupID(rawValue: 0)
-        self.lastAccessTime = platformSpecificStatus.nioLastAccessTime
-        self.lastDataModificationTime = platformSpecificStatus.nioLastDataModificationTime
-        self.lastStatusChangeTime = platformSpecificStatus.nioLastStatusChangeTime
         #else
+        self._platformSpecificStatus = Stat(platformSpecificStatus)
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)

--- a/Sources/_NIOFileSystem/FileInfo.swift
+++ b/Sources/_NIOFileSystem/FileInfo.swift
@@ -91,6 +91,9 @@ public struct FileInfo: Hashable, Sendable {
 
     /// Creates a ``FileInfo`` by deriving values from a platform-specific value.
     public init(platformSpecificStatus: CInterop.Stat) {
+        #if os(Windows)
+        fatalError("FileInfo.onDiskSize is not implemented on Windows")
+        #endif
         self._platformSpecificStatus = Stat(platformSpecificStatus)
         #if os(Windows)
         self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)

--- a/Sources/_NIOFileSystem/FileInfo.swift
+++ b/Sources/_NIOFileSystem/FileInfo.swift
@@ -91,10 +91,19 @@ public struct FileInfo: Hashable, Sendable {
 
     /// Creates a ``FileInfo`` by deriving values from a platform-specific value.
     public init(platformSpecificStatus: CInterop.Stat) {
+        self._platformSpecificStatus = Stat(platformSpecificStatus)
         #if os(Windows)
+        self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
+        self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
+        self.size = platformSpecificStatus.nioSize
+        // Windows has no POSIX owner/group; report the defaults.
+        self.userID = UserID(rawValue: 0)
+        self.groupID = GroupID(rawValue: 0)
+        self.lastAccessTime = platformSpecificStatus.nioLastAccessTime
+        self.lastDataModificationTime = platformSpecificStatus.nioLastDataModificationTime
+        self.lastStatusChangeTime = platformSpecificStatus.nioLastStatusChangeTime
         fatalError("FileInfo.allocatedSize is not implemented on Windows")
         #else
-        self._platformSpecificStatus = Stat(platformSpecificStatus)
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)

--- a/Tests/NIOFSIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileHandleTests.swift
@@ -1228,14 +1228,14 @@ final class FileHandleTests: XCTestCase {
         }
     }
 
-    func testOnDiskSizeOfSparseFile() async throws {
+    func testAllocatedSizeOfSparseFile() async throws {
         try await self.withTemporaryFile { handle in
             try await handle.write(contentsOf: Array("hi".utf8), toAbsoluteOffset: 0)
             try await handle.resize(to: .mebibytes(128))
 
             let info = try await handle.info()
             XCTAssertEqual(info.size, 128 * 1024 * 1024)
-            XCTAssertLessThan(info.onDiskSize, 1024 * 1024)
+            XCTAssertLessThan(info.allocatedSize, 1024 * 1024)
         }
     }
 

--- a/Tests/NIOFSIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileHandleTests.swift
@@ -1228,6 +1228,17 @@ final class FileHandleTests: XCTestCase {
         }
     }
 
+    func testOnDiskSizeOfSparseFile() async throws {
+        try await self.withTemporaryFile { handle in
+            try await handle.write(contentsOf: Array("hi".utf8), toAbsoluteOffset: 0)
+            try await handle.resize(to: .mebibytes(128))
+
+            let info = try await handle.info()
+            XCTAssertEqual(info.size, 128 * 1024 * 1024)
+            XCTAssertLessThan(info.onDiskSize, 1024 * 1024)
+        }
+    }
+
     func testResizeFileErrors() async throws {
         try await self.withTemporaryFile { handle in
             try await handle.write(

--- a/Tests/NIOFSTests/FileInfoTests.swift
+++ b/Tests/NIOFSTests/FileInfoTests.swift
@@ -82,7 +82,7 @@ final class FileInfoTests: XCTestCase {
         XCTAssertEqual(info.userID, FileInfo.UserID(rawValue: 5))
         XCTAssertEqual(info.groupID, FileInfo.GroupID(rawValue: 6))
         XCTAssertEqual(info.size, 8)
-        XCTAssertEqual(info.onDiskSize, 9 * 512)
+        XCTAssertEqual(info.allocatedSize, 9 * 512)
 
         XCTAssertEqual(info.lastAccessTime, FileInfo.Timespec(seconds: 0, nanoseconds: 0))
         XCTAssertEqual(info.lastDataModificationTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))

--- a/Tests/NIOFSTests/FileInfoTests.swift
+++ b/Tests/NIOFSTests/FileInfoTests.swift
@@ -82,6 +82,7 @@ final class FileInfoTests: XCTestCase {
         XCTAssertEqual(info.userID, FileInfo.UserID(rawValue: 5))
         XCTAssertEqual(info.groupID, FileInfo.GroupID(rawValue: 6))
         XCTAssertEqual(info.size, 8)
+        XCTAssertEqual(info.onDiskSize, 9 * 512)
 
         XCTAssertEqual(info.lastAccessTime, FileInfo.Timespec(seconds: 0, nanoseconds: 0))
         XCTAssertEqual(info.lastDataModificationTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))


### PR DESCRIPTION
## Summary

Add `FileInfo.allocatedSize` so callers can retrieve the number of bytes a file actually occupies on disk, independently of its apparent size.

This is useful for sparse and compressed files, where `FileInfo.size` can differ significantly from the allocated storage.

Fixes #3650.

## Changes

- Add the public `FileInfo.allocatedSize` property to both `NIOFS` and `_NIOFileSystem`.
- Calculate the value from `S_BLKSIZE * stat.st_blocks`, without using `stat.st_blksize`.
- Use musl's equivalent `DEV_BSIZE` constant where `S_BLKSIZE` is unavailable.
- Extend the value-based `FileInfo` initializer with an `allocatedSize` argument.
- Add a conversion test that verifies 9 allocated blocks produce 4,608 bytes even when `st_blksize` is set to 10.

## Testing

- `swift test --jobs 2 --filter NIOFSTests.FileInfoTests`
  - 3 tests passed, 0 failures.
- `swift test --skip-build --filter NIOFSTests`
  - 135 tests passed, 3 platform-specific tests skipped, 0 failures.
- `swift format lint --strict --configuration .swift-format Sources/NIOFS/FileInfo.swift Sources/_NIOFileSystem/FileInfo.swift Tests/NIOFSTests/FileInfoTests.swift`
  - Passed.
- `git diff --check`
  - Passed.
