### PR TITLE
Document trapping behavior of ByteBuffer set*(at:) write APIs

### DIFF
--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -218,10 +218,10 @@ public struct ByteBufferAllocator: Sendable {
 /// If you need to loop over all the bytes in the buffer, you can use the `Collection` conformance with ``readableBytesView``:
 ///
 ///
-    /// - Precondition: `index` must be a valid, non-negative index within the buffer's storage.
-    ///   Unlike the `get*` family (which returns `nil` for an out-of-range index), this method
-    ///   traps on an invalid `index` — it is the caller's responsibility to validate any
-    ///   `index` derived from untrusted or external input before calling this method.
+/// - Precondition: `index` must be a valid, non-negative index within the buffer's storage.
+///   Unlike the `get*` family (which returns `nil` for an out-of-range index), this method
+///   traps on an invalid `index` — it is the caller's responsibility to validate any
+///   `index` derived from untrusted or external input before calling this method.
 ///     for byte in buffer.readableBytesView {
 ///         print(byte)
 ///     }

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -104,6 +104,11 @@ public struct ByteBufferAllocator: Sendable {
     ///
     /// ## Example: Integrating with External Buffer System
     ///
+    /// - Precondition: `index` must be a valid, non-negative index within the buffer's storage.
+    ///   Unlike the `get*` family (which returns `nil` for an out-of-range index), this method
+    ///   traps on an invalid `index` — it is the caller's responsibility to validate any
+    ///   `index` derived from untrusted or external input before calling this method.
+    ///
     /// ```swift
     /// let allocator = ByteBufferAllocator { size in
     ///     externalSystem.allocate(Int(size))
@@ -212,6 +217,11 @@ public struct ByteBufferAllocator: Sendable {
 ///
 /// If you need to loop over all the bytes in the buffer, you can use the `Collection` conformance with ``readableBytesView``:
 ///
+///
+    /// - Precondition: `index` must be a valid, non-negative index within the buffer's storage.
+    ///   Unlike the `get*` family (which returns `nil` for an out-of-range index), this method
+    ///   traps on an invalid `index` — it is the caller's responsibility to validate any
+    ///   `index` derived from untrusted or external input before calling this method.
 ///     for byte in buffer.readableBytesView {
 ///         print(byte)
 ///     }
@@ -1269,11 +1279,22 @@ extension ByteBuffer: CustomStringConvertible, CustomDebugStringConvertible {
 // change types to the user visible `Int`
 extension ByteBuffer {
     /// Copy the collection of `bytes` into the `ByteBuffer` at `index`. Does not move the writer index.
+    ///
+    /// - Precondition: `index` must be a valid, non-negative index within the buffer's storage.
+    ///   Unlike the `get*` family (which returns `nil` for an out-of-range index), this method
+    ///   traps on an invalid `index` — it is the caller's responsibility to validate any
+    ///   `index` derived from untrusted or external input before calling this method.
     @discardableResult
     @inlinable
     public mutating func setBytes<Bytes: Sequence>(_ bytes: Bytes, at index: Int) -> Int where Bytes.Element == UInt8 {
         Int(self._setBytes(bytes, at: _toIndex(index)))
     }
+
+    ///
+    /// - Precondition: `index` must be a valid, non-negative index within the buffer's storage.
+    ///   Unlike the `get*` family (which returns `nil` for an out-of-range index), this method
+    ///   traps on an invalid `index` — it is the caller's responsibility to validate any
+    ///   `index` derived from untrusted or external input before calling this method.
 
     /// Copy `bytes` into the `ByteBuffer` at `index`. Does not move the writer index.
     @discardableResult


### PR DESCRIPTION
Motivation:

GHSA-ffw9-jrfx-pfvc raised a question about whether `setBytes(_:at:)`, `setInteger(_:at:...)`, and `setString(_:at:)` correctly validate an out-of-range `index`. On review, this turned out to be working-as-intended: these APIs trap on an invalid index by design, unlike the `get*` family, which validates via `rangeWithinReadableBytes` and returns `nil` instead. That asymmetry wasn't previously called out in the doc comments, which made it easy to mistake for an unmitigated validation gap rather than documented behavior.

Modifications:

Added a `- Precondition:` note to the doc comments of `setBytes(_:at:)` (all overloads), `setInteger(_:at:...)`, and `setString(_:at:)` in NIOCore, making the trapping behavior explicit and noting that callers must validate any externally-derived `index` before use.

Result:

No behavior changes. The trapping contract on these `set*` write APIs is now documented, matching the existing convention used by `get*`'s optional-return documentation.One line description of your change

