### PR TITLE
docs: update broken SSWG badge target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![sswg:graduated|104x20](https://img.shields.io/badge/sswg-graduated-green.svg)](https://github.com/swift-server/sswg/blob/main/process/incubation.md#graduated-level)
+[![sswg:graduated|104x20](https://img.shields.io/badge/sswg-graduated-green.svg)](https://swift.org/sswg/incubated-packages.html)
 
 # SwiftNIO
 


### PR DESCRIPTION
This updates the SSWG graduated badge link in the README to the current swift.org page now that the old GitHub target returns 404.

Fixes #3660.