### PR TITLE
[Windows] Compile the low-hanging test targets

### DIFF
--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -100,6 +100,7 @@ extension ChannelOptions {
             // Use `init(level:name:)` taking `NIOBSDSocket.OptionLevel`/`Option`
             // instead (their `.ip`/`.tcp`/etc. accessors read the enum's raw
             // value).
+
             /// Create a new `SocketOption`.
             ///
             /// - Parameters:

--- a/Sources/NIOCore/ChannelOption.swift
+++ b/Sources/NIOCore/ChannelOption.swift
@@ -93,6 +93,13 @@ extension ChannelOptions {
             }
 
             #if !os(Windows)
+            // Unavailable on Windows: there, WinSDK imports the socket option
+            // level/name constants (`IPPROTO_IP`, `IP_TTL`, `SO_REUSEADDR`, …)
+            // as enumeration cases rather than plain integers, so they don't fit
+            // the integer `SocketOptionLevel`/`SocketOptionName` typealiases.
+            // Use `init(level:name:)` taking `NIOBSDSocket.OptionLevel`/`Option`
+            // instead (their `.ip`/`.tcp`/etc. accessors read the enum's raw
+            // value).
             /// Create a new `SocketOption`.
             ///
             /// - Parameters:
@@ -312,6 +319,8 @@ extension ChannelOptions {
 
 /// Provides `ChannelOption`s to be used with a `Channel`, `Bootstrap` or `ServerBootstrap`.
 public struct ChannelOptions: Sendable {
+    // Unavailable on Windows; see `SocketOption.init(level:name:)`. Use the
+    // typed `socketOption(_:)`/`ipOption(_:)`/`tcpOption(_:)` accessors instead.
     #if !os(Windows)
     public static let socket: @Sendable (SocketOptionLevel, SocketOptionName) -> ChannelOptions.Types.SocketOption = {
         (level: SocketOptionLevel, name: SocketOptionName) -> Types.SocketOption in
@@ -388,6 +397,8 @@ public struct ChannelOptions: Sendable {
 
 /// - seealso: `SocketOption`.
 extension ChannelOption where Self == ChannelOptions.Types.SocketOption {
+    // Unavailable on Windows; see `SocketOption.init(level:name:)`. Use the
+    // typed `socketOption(_:)`/`ipOption(_:)`/`tcpOption(_:)` accessors instead.
     #if !(os(Windows))
     public static func socket(_ level: SocketOptionLevel, _ name: SocketOptionName) -> Self {
         .init(level: NIOBSDSocket.OptionLevel(rawValue: CInt(level)), name: NIOBSDSocket.Option(rawValue: CInt(name)))

--- a/Sources/NIOFS/Internal/System Calls/SystemPackage+Windows.swift
+++ b/Sources/NIOFS/Internal/System Calls/SystemPackage+Windows.swift
@@ -103,25 +103,28 @@ extension CInterop {
 
 extension FileDescriptor.OpenOptions {
     // Distinct high bits we own. These are placeholders for a real Win32
-    // mapping in the future implementation.
-    static var noFollow: FileDescriptor.OpenOptions {
+    // mapping in the future implementation. They are `@_spi(Testing) public` to
+    // match the accessibility of the swift-system equivalents on other
+    // platforms (which NIOFS's tests reach via an SPI import).
+    @_spi(Testing) public static var noFollow: FileDescriptor.OpenOptions {
         FileDescriptor.OpenOptions(rawValue: 0x4000_0000)
     }
-    static var closeOnExec: FileDescriptor.OpenOptions {
+    @_spi(Testing) public static var closeOnExec: FileDescriptor.OpenOptions {
         FileDescriptor.OpenOptions(rawValue: 0x2000_0000)
     }
-    static var nonBlocking: FileDescriptor.OpenOptions {
+    @_spi(Testing) public static var nonBlocking: FileDescriptor.OpenOptions {
         FileDescriptor.OpenOptions(rawValue: 0x1000_0000)
     }
-    static var directory: FileDescriptor.OpenOptions {
+    @_spi(Testing) public static var directory: FileDescriptor.OpenOptions {
         FileDescriptor.OpenOptions(rawValue: 0x0800_0000)
     }
 }
 
 extension Errno {
     /// No direct equivalent on Windows; alias to `EINVAL` so switches stay
-    /// exhaustive.
-    static var noData: Errno { Errno.invalidArgument }
+    /// exhaustive. `@_spi(Testing) public` to match the swift-system equivalent
+    /// on other platforms (which NIOFS's tests reach via an SPI import).
+    @_spi(Testing) public static var noData: Errno { Errno.invalidArgument }
 }
 
 // MARK: - `stat` mode constants (typed to `CInterop.Mode`)

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -101,6 +101,7 @@ private let sysWrite = _write
 private let sysRead = _read
 private let sysLseek = _lseek
 private let sysFtruncate = _chsize_s
+private let sysClose = _close
 #endif
 
 #if os(Android)
@@ -580,6 +581,7 @@ internal enum Posix: Sendable {
             sysShutdown(descriptor, how.cValue)
         }
     }
+    #endif
 
     @inline(never)
     public static func close(descriptor: CInt) throws {
@@ -605,6 +607,7 @@ internal enum Posix: Sendable {
         }
     }
 
+    #if !os(Windows)
     @inline(never)
     public static func bind(descriptor: CInt, ptr: UnsafePointer<sockaddr>, bytes: Int) throws {
         _ = try syscall(blocking: false) {

--- a/Sources/_NIOFileSystem/Internal/System Calls/SystemPackage+Windows.swift
+++ b/Sources/_NIOFileSystem/Internal/System Calls/SystemPackage+Windows.swift
@@ -103,25 +103,28 @@ extension CInterop {
 
 extension FileDescriptor.OpenOptions {
     // Distinct high bits we own. These are placeholders for a real Win32
-    // mapping in the future implementation.
-    static var noFollow: FileDescriptor.OpenOptions {
+    // mapping in the future implementation. They are `@_spi(Testing) public` to
+    // match the accessibility of the swift-system equivalents on other
+    // platforms (which NIOFS's tests reach via an SPI import).
+    @_spi(Testing) public static var noFollow: FileDescriptor.OpenOptions {
         FileDescriptor.OpenOptions(rawValue: 0x4000_0000)
     }
-    static var closeOnExec: FileDescriptor.OpenOptions {
+    @_spi(Testing) public static var closeOnExec: FileDescriptor.OpenOptions {
         FileDescriptor.OpenOptions(rawValue: 0x2000_0000)
     }
-    static var nonBlocking: FileDescriptor.OpenOptions {
+    @_spi(Testing) public static var nonBlocking: FileDescriptor.OpenOptions {
         FileDescriptor.OpenOptions(rawValue: 0x1000_0000)
     }
-    static var directory: FileDescriptor.OpenOptions {
+    @_spi(Testing) public static var directory: FileDescriptor.OpenOptions {
         FileDescriptor.OpenOptions(rawValue: 0x0800_0000)
     }
 }
 
 extension Errno {
     /// No direct equivalent on Windows; alias to `EINVAL` so switches stay
-    /// exhaustive.
-    static var noData: Errno { Errno.invalidArgument }
+    /// exhaustive. `@_spi(Testing) public` to match the swift-system equivalent
+    /// on other platforms (which NIOFS's tests reach via an SPI import).
+    @_spi(Testing) public static var noData: Errno { Errno.invalidArgument }
 }
 
 // MARK: - `stat` mode constants (typed to `CInterop.Mode`)

--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
@@ -24,6 +24,16 @@ import Darwin
 import Glibc
 #elseif canImport(Android)
 import Android
+#elseif os(Windows)
+import WinSDK
+
+// Windows has no `usleep`; approximate it with `Sleep`, which takes whole
+// milliseconds. The coarse precision is fine for these test poll loops.
+@discardableResult
+func usleep(_ microseconds: UInt32) -> CInt {
+    Sleep(microseconds / 1000)
+    return 0
+}
 #else
 #error("The Concurrency helpers test module was unable to identify your C library.")
 #endif

--- a/Tests/NIOCoreTests/UtilitiesTest.swift
+++ b/Tests/NIOCoreTests/UtilitiesTest.swift
@@ -22,6 +22,9 @@ class UtilitiesTest: XCTestCase {
 
     @available(*, deprecated)
     func testEnumeratingInterfaces() throws {
+        // `System.enumerateInterfaces` is not available on Windows; the
+        // equivalent coverage is provided by `testEnumeratingDevices`.
+        #if !os(Windows)
         // This is a tricky test, because we can't really assert much and expect this
         // to pass on all systems. The best we can do is assume there is a loopback:
         // maybe an IPv4 one, maybe an IPv6 one, but there will be one. We look for
@@ -50,6 +53,7 @@ class UtilitiesTest: XCTestCase {
         }
 
         XCTAssertTrue(ipv4LoopbackPresent || ipv6LoopbackPresent)
+        #endif
     }
 
     func testEnumeratingDevices() throws {

--- a/Tests/NIOCoreTests/XCTest+Extensions.swift
+++ b/Tests/NIOCoreTests/XCTest+Extensions.swift
@@ -17,6 +17,16 @@ import XCTest
 
 #if canImport(Android)
 import Android
+#elseif os(Windows)
+import WinSDK
+
+// Windows has no `usleep`; approximate it with `Sleep`, which takes whole
+// milliseconds. The coarse precision is fine for these test poll loops.
+@discardableResult
+func usleep(_ microseconds: UInt32) -> CInt {
+    Sleep(microseconds / 1000)
+    return 0
+}
 #endif
 
 func assert(

--- a/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
+++ b/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift
@@ -751,6 +751,9 @@ class AsyncTestingChannelTests: XCTestCase {
     }
 
     func testGetSetOption() async throws {
+        // `ChannelOptions.socket(_:_:)` and the `IPPROTO_IP`/`IP_TTL` constants
+        // are not available on Windows.
+        #if !os(Windows)
         let channel = NIOAsyncTestingChannel()
         let option = ChannelOptions.socket(IPPROTO_IP, IP_TTL)
         let _ = try await channel.setOption(option, value: 1).get()
@@ -761,6 +764,7 @@ class AsyncTestingChannelTests: XCTestCase {
         let _ = try await channel.setOption(option, value: 2).get()
         let optionValue2 = try await channel.getOption(option).get()
         XCTAssertEqual(2, optionValue2)
+        #endif
     }
 
     func testSocketAddressesOnContext() async throws {

--- a/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
+++ b/Tests/NIOEmbeddedTests/EmbeddedChannelTest.swift
@@ -825,6 +825,9 @@ class EmbeddedChannelTest: XCTestCase {
     }
 
     func testGetSetOption() throws {
+        // `ChannelOptions.socket(_:_:)` and the `IPPROTO_IP`/`IP_TTL` constants
+        // are not available on Windows.
+        #if !os(Windows)
         let channel = EmbeddedChannel()
         let option = ChannelOptions.socket(IPPROTO_IP, IP_TTL)
         let _ = channel.setOption(option, value: 1)
@@ -835,6 +838,7 @@ class EmbeddedChannelTest: XCTestCase {
         let _ = channel.setOption(option, value: 2)
         let optionValue2 = try channel.getOption(option).wait()
         XCTAssertEqual(2, optionValue2)
+        #endif
     }
 
     func testGetSetOptionOptInThrowing() {

--- a/Tests/NIOEmbeddedTests/TestUtils.swift
+++ b/Tests/NIOEmbeddedTests/TestUtils.swift
@@ -19,6 +19,16 @@ import XCTest
 
 #if canImport(Android)
 import Android
+#elseif os(Windows)
+import WinSDK
+
+// Windows has no `usleep`; approximate it with `Sleep`, which takes whole
+// milliseconds. The coarse precision is fine for these test poll loops.
+@discardableResult
+func usleep(_ microseconds: UInt32) -> CInt {
+    Sleep(microseconds / 1000)
+    return 0
+}
 #endif
 
 // FIXME: Duplicated with NIO

--- a/Tests/NIOFSFoundationCompatTests/FileSystemFoundationCompatTests.swift
+++ b/Tests/NIOFSFoundationCompatTests/FileSystemFoundationCompatTests.swift
@@ -64,6 +64,9 @@ final class FileSystemBytesConformanceTests: XCTestCase {
         )
     }
 
+    // `Data(contentsOf:maximumSizeAllowed:)` is only provided on these
+    // platforms (see `NIOFSFoundationCompat/Data+FileSystem.swift`).
+    #if canImport(Darwin) || os(Linux) || os(Android)
     func testReadFileIntoData() async throws {
         let fs = FileSystem.shared
         let path = try await fs.temporaryFilePath()
@@ -76,4 +79,5 @@ final class FileSystemBytesConformanceTests: XCTestCase {
 
         XCTAssertEqual(contents, Data([0, 1, 2]))
     }
+    #endif
 }

--- a/Tests/NIOFSIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileHandleTests.swift
@@ -302,6 +302,8 @@ final class FileHandleTests: XCTestCase {
         }
     }
 
+    // These tests create FIFOs via `mkfifo`, which is unavailable on Windows.
+    #if !os(Windows)
     func testWriteAndReadUnseekableFile() async throws {
         let privateTempDirPath = try await FileSystem.shared.createTemporaryDirectory(template: "test-XXX")
         self.addTeardownBlock {
@@ -384,6 +386,7 @@ final class FileHandleTests: XCTestCase {
             }
         }
     }
+    #endif  // !os(Windows)
 
     func testReadWholeFileWithOffsets() async throws {
         try await self.withHandle(forFileAtPath: Self.thisFile) { handle in

--- a/Tests/NIOFSTests/FileInfoTests.swift
+++ b/Tests/NIOFSTests/FileInfoTests.swift
@@ -32,6 +32,10 @@ private let S_IFREG = Glibc.S_IFREG
 private let S_IFREG = Musl.S_IFREG
 #endif
 
+// `CInterop.Stat` is `BY_HANDLE_FILE_INFORMATION` on Windows, so these tests
+// (which build a POSIX `struct stat`) don't apply as written. Windows coverage
+// that constructs a `BY_HANDLE_FILE_INFORMATION` is a follow-up.
+#if !os(Windows)
 final class FileInfoTests: XCTestCase {
     private var status: CInterop.Stat {
         var status = CInterop.Stat()
@@ -167,3 +171,4 @@ final class FileInfoTests: XCTestCase {
         #endif
     }
 }
+#endif  // !os(Windows)

--- a/Tests/NIOFSTests/FileTypeTests.swift
+++ b/Tests/NIOFSTests/FileTypeTests.swift
@@ -56,6 +56,8 @@ final class FileTypeTests: XCTestCase {
     }
 
     func testConversionFromModeT() {
+        // `S_IFSOCK`/`S_IFLNK`/`S_IFBLK` don't exist on Windows.
+        #if !os(Windows)
         XCTAssertEqual(FileType(platformSpecificMode: S_IFIFO), .fifo)
         XCTAssertEqual(FileType(platformSpecificMode: S_IFCHR), .character)
         XCTAssertEqual(FileType(platformSpecificMode: S_IFDIR), .directory)
@@ -66,9 +68,12 @@ final class FileTypeTests: XCTestCase {
         #if canImport(Darwin)
         XCTAssertEqual(FileType(platformSpecificMode: S_IFWHT), .whiteout)
         #endif
+        #endif
     }
 
     func testConversionFromDirentType() {
+        // The `DT_*` constants aren't available on Windows.
+        #if !os(Windows)
         XCTAssertEqual(FileType(direntType: numericCast(DT_FIFO)), .fifo)
         XCTAssertEqual(FileType(direntType: numericCast(DT_CHR)), .character)
         XCTAssertEqual(FileType(direntType: numericCast(DT_DIR)), .directory)
@@ -78,6 +83,7 @@ final class FileTypeTests: XCTestCase {
         XCTAssertEqual(FileType(direntType: numericCast(DT_SOCK)), .socket)
         #if canImport(Darwin)
         XCTAssertEqual(FileType(direntType: numericCast(DT_WHT)), .whiteout)
+        #endif
         #endif
     }
 }

--- a/Tests/NIOFSTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFSTests/Internal/SyscallTests.swift
@@ -20,6 +20,9 @@ import XCTest
 #if ENABLE_MOCKING
 final class SyscallTests: XCTestCase {
     func test_openat() throws {
+        // Asserts POSIX `oflag` bit values; the Windows `OpenOptions` bits are
+        // placeholders, so this doesn't apply as written.
+        #if !os(Windows)
         let fd = FileDescriptor(rawValue: 42)
         let testCases = [
             MockTestCase(
@@ -60,6 +63,7 @@ final class SyscallTests: XCTestCase {
         ]
 
         testCases.run()
+        #endif
     }
 
     func test_stat() throws {
@@ -239,7 +243,9 @@ final class SyscallTests: XCTestCase {
 
     func test_flistxattr() throws {
         let fd = FileDescriptor(rawValue: 42)
-        let buffer = UnsafeMutableBufferPointer<CInterop.PlatformChar>.allocate(capacity: 1024)
+        // `flistxattr` takes a `CChar` buffer (equivalent to `PlatformChar` off
+        // Windows, where `PlatformChar` is `UInt16`).
+        let buffer = UnsafeMutableBufferPointer<CChar>.allocate(capacity: 1024)
         defer { buffer.deallocate() }
 
         let testCases: [MockTestCase] = [

--- a/Tests/NIOHTTP1Tests/TestUtils.swift
+++ b/Tests/NIOHTTP1Tests/TestUtils.swift
@@ -23,6 +23,19 @@ import XCTest
 @testable import NIOCore
 @testable import NIOPosix
 
+#if os(Windows)
+import WinSDK
+import ucrt
+
+// Windows has no `usleep`; approximate it with `Sleep`, which takes whole
+// milliseconds. The coarse precision is fine for these test poll loops.
+@discardableResult
+func usleep(_ microseconds: UInt32) -> CInt {
+    Sleep(microseconds / 1000)
+    return 0
+}
+#endif
+
 extension System {
     static var supportsIPv6: Bool {
         do {
@@ -48,7 +61,12 @@ extension System {
 func withPipe(_ body: (NIOCore.NIOFileHandle, NIOCore.NIOFileHandle) throws -> [NIOCore.NIOFileHandle]) throws {
     var fds: [Int32] = [-1, -1]
     fds.withUnsafeMutableBufferPointer { ptr in
+        #if os(Windows)
+        // Windows has no `pipe`; `_pipe` is the CRT equivalent.
+        XCTAssertEqual(0, _pipe(ptr.baseAddress!, 4096, _O_BINARY))
+        #else
         XCTAssertEqual(0, pipe(ptr.baseAddress!))
+        #endif
     }
     let readFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[0])
     let writeFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[1])
@@ -73,7 +91,12 @@ func withPipe(
 ) async throws {
     var fds: [Int32] = [-1, -1]
     fds.withUnsafeMutableBufferPointer { ptr in
+        #if os(Windows)
+        // Windows has no `pipe`; `_pipe` is the CRT equivalent.
+        XCTAssertEqual(0, _pipe(ptr.baseAddress!, 4096, _O_BINARY))
+        #else
         XCTAssertEqual(0, pipe(ptr.baseAddress!))
+        #endif
     }
     let readFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[0])
     let writeFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[1])
@@ -235,6 +258,16 @@ var temporaryDirectory: String {
 }
 
 func createTemporaryDirectory() -> String {
+    #if os(Windows)
+    // Windows has no `mkdtemp`. Build a uniquely-named directory (using a GUID)
+    // under the temporary directory and create it with `CreateDirectoryW`.
+    let path = "\(temporaryDirectory)/.NIOTests-temp-dir_\(UUID().uuidString)"
+    let created = path.withCString(encodedAs: UTF16.self) {
+        CreateDirectoryW($0, nil)
+    }
+    XCTAssertTrue(created)
+    return path
+    #else
     let template = "\(temporaryDirectory)/.NIOTests-temp-dir_XXXXXX"
 
     var templateBytes = template.utf8 + [0]
@@ -248,9 +281,34 @@ func createTemporaryDirectory() -> String {
     }
     templateBytes.removeLast()
     return String(decoding: templateBytes, as: Unicode.UTF8.self)
+    #endif
 }
 
 func openTemporaryFile() -> (CInt, String) {
+    #if os(Windows)
+    // Windows has no `mkstemp`. Generate a unique name with `_mktemp_s`, then
+    // create and open it with `_sopen_s`.
+    var templateBytes = "\(temporaryDirectory)/nio_XXXXXX".utf8 + [0]
+    let templateBytesCount = templateBytes.count
+    let fd = templateBytes.withUnsafeMutableBufferPointer { ptr in
+        ptr.baseAddress!.withMemoryRebound(to: CChar.self, capacity: templateBytesCount) {
+            (ptr: UnsafeMutablePointer<CChar>) -> CInt in
+            XCTAssertEqual(_mktemp_s(ptr, templateBytesCount), 0)
+            var fd: CInt = -1
+            let err = _sopen_s(
+                &fd,
+                ptr,
+                _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY,
+                _SH_DENYNO,
+                _S_IREAD | _S_IWRITE
+            )
+            XCTAssertEqual(err, 0)
+            return fd
+        }
+    }
+    templateBytes.removeLast()
+    return (fd, String(decoding: templateBytes, as: Unicode.UTF8.self))
+    #else
     let template = "\(temporaryDirectory)/nio_XXXXXX"
     var templateBytes = template.utf8 + [0]
     let templateBytesCount = templateBytes.count
@@ -262,6 +320,7 @@ func openTemporaryFile() -> (CInt, String) {
     }
     templateBytes.removeLast()
     return (fd, String(decoding: templateBytes, as: Unicode.UTF8.self))
+    #endif
 }
 
 extension Channel {

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -20,6 +20,19 @@ import XCTest
 @testable import NIOCore
 @testable import NIOPosix
 
+#if os(Windows)
+import WinSDK
+import ucrt
+
+// Windows has no `usleep`; approximate it with `Sleep`, which takes whole
+// milliseconds. The coarse precision is fine for these test poll loops.
+@discardableResult
+func usleep(_ microseconds: UInt32) -> CInt {
+    Sleep(microseconds / 1000)
+    return 0
+}
+#endif
+
 extension System {
     static var supportsIPv6: Bool {
         do {
@@ -45,7 +58,12 @@ extension System {
 func withPipe(_ body: (NIOCore.NIOFileHandle, NIOCore.NIOFileHandle) throws -> [NIOCore.NIOFileHandle]) throws {
     var fds: [Int32] = [-1, -1]
     fds.withUnsafeMutableBufferPointer { ptr in
+        #if os(Windows)
+        // Windows has no `pipe`; `_pipe` is the CRT equivalent.
+        XCTAssertEqual(0, _pipe(ptr.baseAddress!, 4096, _O_BINARY))
+        #else
         XCTAssertEqual(0, pipe(ptr.baseAddress!))
+        #endif
     }
     let readFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[0])
     let writeFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[1])
@@ -70,7 +88,12 @@ func withPipe(
 ) async throws {
     var fds: [Int32] = [-1, -1]
     fds.withUnsafeMutableBufferPointer { ptr in
+        #if os(Windows)
+        // Windows has no `pipe`; `_pipe` is the CRT equivalent.
+        XCTAssertEqual(0, _pipe(ptr.baseAddress!, 4096, _O_BINARY))
+        #else
         XCTAssertEqual(0, pipe(ptr.baseAddress!))
+        #endif
     }
     let readFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[0])
     let writeFH = NIOFileHandle(_deprecatedTakingOwnershipOfDescriptor: fds[1])
@@ -232,6 +255,16 @@ var temporaryDirectory: String {
 }
 
 func createTemporaryDirectory() -> String {
+    #if os(Windows)
+    // Windows has no `mkdtemp`. Build a uniquely-named directory (using a GUID)
+    // under the temporary directory and create it with `CreateDirectoryW`.
+    let path = "\(temporaryDirectory)/.NIOTests-temp-dir_\(UUID().uuidString)"
+    let created = path.withCString(encodedAs: UTF16.self) {
+        CreateDirectoryW($0, nil)
+    }
+    XCTAssertTrue(created)
+    return path
+    #else
     let template = "\(temporaryDirectory)/.NIOTests-temp-dir_XXXXXX"
 
     var templateBytes = template.utf8 + [0]
@@ -245,9 +278,34 @@ func createTemporaryDirectory() -> String {
     }
     templateBytes.removeLast()
     return String(decoding: templateBytes, as: Unicode.UTF8.self)
+    #endif
 }
 
 func openTemporaryFile() -> (CInt, String) {
+    #if os(Windows)
+    // Windows has no `mkstemp`. Generate a unique name with `_mktemp_s`, then
+    // create and open it with `_sopen_s`.
+    var templateBytes = "\(temporaryDirectory)/nio_XXXXXX".utf8 + [0]
+    let templateBytesCount = templateBytes.count
+    let fd = templateBytes.withUnsafeMutableBufferPointer { ptr in
+        ptr.baseAddress!.withMemoryRebound(to: CChar.self, capacity: templateBytesCount) {
+            (ptr: UnsafeMutablePointer<CChar>) -> CInt in
+            XCTAssertEqual(_mktemp_s(ptr, templateBytesCount), 0)
+            var fd: CInt = -1
+            let err = _sopen_s(
+                &fd,
+                ptr,
+                _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY,
+                _SH_DENYNO,
+                _S_IREAD | _S_IWRITE
+            )
+            XCTAssertEqual(err, 0)
+            return fd
+        }
+    }
+    templateBytes.removeLast()
+    return (fd, String(decoding: templateBytes, as: Unicode.UTF8.self))
+    #else
     let template = "\(temporaryDirectory)/nio_XXXXXX"
     var templateBytes = template.utf8 + [0]
     let templateBytesCount = templateBytes.count
@@ -259,6 +317,7 @@ func openTemporaryFile() -> (CInt, String) {
     }
     templateBytes.removeLast()
     return (fd, String(decoding: templateBytes, as: Unicode.UTF8.self))
+    #endif
 }
 
 extension Channel {

--- a/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
+++ b/Tests/NIOTestUtilsTests/NIOHTTP1TestServerTest.swift
@@ -18,6 +18,18 @@ import NIOPosix
 import NIOTestUtils
 import XCTest
 
+#if os(Windows)
+import WinSDK
+
+// Windows has no `usleep`; approximate it with `Sleep`, which takes whole
+// milliseconds. The coarse precision is fine for these test poll loops.
+@discardableResult
+func usleep(_ microseconds: UInt32) -> CInt {
+    Sleep(microseconds / 1000)
+    return 0
+}
+#endif
+
 typealias SendableRequestPart = HTTPPart<HTTPRequestHead, ByteBuffer>
 
 extension HTTPClientRequestPart {


### PR DESCRIPTION
## Motivation

Follow-up to #3649 (all non-test targets now build on Windows). This gets the bulk of the **test** targets compiling on Windows so we can start moving toward running them in CI.

Of the 16 test targets, 6 already compiled unchanged. This brings **8 more** to a clean compile, leaving only two as dedicated follow-ups:
- `NIOPosixTests` — large, many distinct Winsock/POSIX issues; deserves its own PR.
- `NIOFoundationCompatTests` — a `missing required module 'CNIOPosix'` issue to investigate separately.

The changes are **compile-only** — they don't aim to make the tests *pass* on Windows yet. Verified by building each target on a Windows ARM64 VM; not yet wired into CI (CI still builds products only, since the two deferred targets would fail `--build-tests`).

## What's here

Three commits:

1. **Make `Posix.close` available on Windows** — it was gated out only because it sat inside the socket-syscalls `#if !os(Windows)` block (next to `shutdown`), even though its body already handled Windows. Define `sysClose = _close` and lift `close(descriptor:)` out of that block. No behavior change off Windows.
2. **Compile the low-hanging test targets** — a gate-out-plus-minimal-shim approach:
   - A tiny `#if os(Windows)` `usleep` shim (backed by `Sleep`), once per affected target, plus a Windows branch for the `#error` C-library check.
   - Real Windows implementations for the temp-file/pipe test helpers rather than stubs: `withPipe` → `_pipe`, `openTemporaryFile` → `_mktemp_s` + `_sopen_s`, `createTemporaryDirectory` → a GUID + `CreateDirectoryW`.
   - Gate out genuinely-unavailable test logic behind `#if !os(Windows)`: `System.enumerateInterfaces`, `ChannelOptions.socket(IPPROTO_IP, IP_TTL)`, `mkfifo`-based tests, the POSIX-`stat`-shaped `FileInfoTests`, the `S_IFSOCK`/`DT_*` conversion tests, and the `openat` oflag-bit test.
   - Two Windows-only shim tweaks make the NIOFS `OpenOptions` gap values and `Errno.noData` `@_spi(Testing) public`, matching how swift-system exposes the equivalents elsewhere (the tests reach them via an SPI import).
   - The `NIOHTTP1Tests` and `NIOPosixTests` copies of `TestUtils.swift` are intentional duplicates and get identical Windows helper implementations to stay in sync.
3. **Document why `SocketOption`'s integer API is unavailable on Windows** — comment-only: WinSDK imports the socket option level/name constants as enumeration cases, not plain integers, so they don't fit the integer `SocketOptionLevel`/`SocketOptionName` typealiases.

## Notes for reviewers

- No behavior change off Windows: every change is behind `#if os(Windows)` / `#if !os(Windows)`; the one shared edit (a test buffer typed `CChar` instead of `CInterop.PlatformChar`) is identical on POSIX.
- The `usleep` shim is duplicated per target rather than shared: there's no test-only support target these all depend on (the shared deps, `NIOCore`/`NIOTestUtils`, are shipping libraries). It can be centralised later if desired.
