### PR TITLE
ByteBuffer: add async withUnsafeReadableBytes overload

### DIFF
--- a/Sources/NIOCore/ByteBuffer-async.swift
+++ b/Sources/NIOCore/ByteBuffer-async.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Async extensions for `ByteBuffer`.
+///
+/// These extensions provide safe access to `ByteBuffer` contents from
+/// Swift Concurrency contexts by copying the readable bytes to a stable
+/// temporary allocation before invoking the async closure, preventing
+/// invalidation of the underlying storage across suspension points.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ByteBuffer {
+
+    /// Yields a buffer pointer containing this `ByteBuffer`'s readable bytes
+    /// to an asynchronous closure.
+    ///
+    /// Unlike the synchronous ``withUnsafeReadableBytes(_:)-9hlep`` variant,
+    /// this method copies the readable bytes into a temporary buffer before
+    /// invoking `body`, ensuring the pointer remains valid across suspension
+    /// points.  Calling the synchronous variant from an async context would
+    /// be unsafe because `ByteBuffer` uses copy-on-write storage that could
+    /// be invalidated by concurrent modification during suspension.
+    ///
+    /// - note: This method performs an O(n) copy of the readable bytes.  For
+    ///   zero-copy access in synchronous contexts, prefer the non-async
+    ///   ``withUnsafeReadableBytes(_:)-9hlep``.
+    ///
+    /// - warning: The pointer passed to `body` is valid only for the duration
+    ///   of that closure.  Do not escape it for later use.
+    ///
+    /// - Parameters:
+    ///   - body: An async closure that receives an `UnsafeRawBufferPointer`
+    ///     covering the readable bytes.
+    /// - Returns: The value returned by `body`.
+    /// - Throws: Any error thrown by `body`.
+    @inlinable
+    public func withUnsafeReadableBytes<T>(
+        _ body: (UnsafeRawBufferPointer) async throws -> T
+    ) async rethrows -> T {
+        let byteCount = self.readableBytes
+        // Synchronously copy the readable bytes to a stable allocation.
+        // This must happen outside the async closure to avoid a data race
+        // on the ByteBuffer's underlying storage.
+        let buffer = self.withUnsafeReadableBytes { source -> UnsafeMutableRawBufferPointer in
+            let destination = UnsafeMutableRawBufferPointer.allocate(
+                byteCount: byteCount,
+                alignment: 1
+            )
+            if byteCount > 0 {
+                destination.copyMemory(from: source)
+            }
+            return destination
+        }
+        defer { buffer.deallocate() }
+        return try await body(.init(buffer))
+    }
+}

--- a/Tests/NIOCoreTests/ByteBufferTest.swift
+++ b/Tests/NIOCoreTests/ByteBufferTest.swift
@@ -4726,5 +4726,67 @@ extension ByteBufferTest {
         XCTAssertEqual(0, self.buf.readableBytes)
         XCTAssertEqual(prefix.count + payload.count, self.buf.readerIndex)
     }
+
+    // MARK: - Async withUnsafeReadableBytes
+
+    func testAsyncWithUnsafeReadableBytesCopiesBytes() async throws {
+        let alloc = ByteBufferAllocator()
+        var buf = alloc.buffer(capacity: 32)
+        let expected: [UInt8] = [0x01, 0x02, 0x03, 0x04]
+        buf.writeBytes(expected)
+
+        try await buf.withUnsafeReadableBytes { ptr in
+            XCTAssertEqual(ptr.count, 4)
+            let bytes = [UInt8](ptr)
+            XCTAssertEqual(bytes, expected)
+        }
+    }
+
+    func testAsyncWithUnsafeReadableBytesEmptyBuffer() async throws {
+        let alloc = ByteBufferAllocator()
+        let buf = alloc.buffer(capacity: 32)
+
+        try await buf.withUnsafeReadableBytes { ptr in
+            XCTAssertEqual(ptr.count, 0)
+        }
+    }
+
+    func testAsyncWithUnsafeReadableBytesCanSuspend() async throws {
+        let alloc = ByteBufferAllocator()
+        var buf = alloc.buffer(capacity: 32)
+        buf.writeString("hello")
+
+        // Verify that suspension (Task.yield) in the middle doesn't
+        // invalidate the pointer.
+        try await buf.withUnsafeReadableBytes { ptr in
+            // Artificially suspend
+            await Task.yield()
+            let bytes = [UInt8](ptr)
+            XCTAssertEqual(bytes, [UInt8]("hello".utf8))
+            // Suspend again after reading
+            await Task.yield()
+            // Verify pointer is still valid
+            let bytesAgain = [UInt8](ptr)
+            XCTAssertEqual(bytesAgain, [UInt8]("hello".utf8))
+        }
+    }
+
+    func testAsyncWithUnsafeReadableBytesCopyIsIndependent() async throws {
+        let alloc = ByteBufferAllocator()
+        var buf = alloc.buffer(capacity: 32)
+        buf.writeString("original")
+
+        // Capture the copied pointer via an unsafe container
+        let captured = try await buf.withUnsafeReadableBytes { ptr in
+            Data(ptr)
+        }
+
+        // Now mutate the original buffer
+        buf.clear()
+        buf.writeString("modified")
+
+        // The captured copy should still have the original content
+        XCTAssertEqual(String(data: captured, encoding: .utf8), "original")
+    }
 }
 #endif


### PR DESCRIPTION
### Summary

Add an async variant of `withUnsafeReadableBytes` to `ByteBuffer` that safely provides pointer access from Swift Concurrency contexts.

### Problem

`ByteBuffer.withUnsafeReadableBytes` is synchronous and cannot be used inside `async` functions when the caller also needs to `await` other operations. Users working with `NIOAsyncChannel` have been forced to manually allocate and copy bytes (https://github.com/apple/swift-nio/issues/2630):

```swift
// Workaround — manual allocation
let buf = buffer.withUnsafeReadableBytes { buf in
    let newBuf = UnsafeMutableRawBufferPointer.allocate(byteCount: buf.count, alignment: 8)
    newBuf.copyBytes(from: buf)
    return newBuf
}
defer { buf.deallocate() }
header = ProtocolHeader(UnsafeRawBufferPointer(buf))
try await hander.handleMessage(header)
```

### Implementation

The async overload copies the readable bytes into a temporary allocation before invoking the async closure. This is required because ByteBuffer uses copy-on-write storage that could be invalidated by concurrent modification during suspension. The temporary allocation is deallocated when the closure returns.

### Design decisions

- **Copy is intentional**: Unlike the zero-copy synchronous variant, the async version must copy to guarantee pointer validity across suspension points. The copy cost is O(n) and documented.
- **rethrows**: The overload uses `async rethrows`, preserving the error-propagation semantics of the closure parameter.
- **Available**: guarded with the same `@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)` as the rest of NIOs async support, though the underlying ByteBuffer struct is available on all platforms.

### Tests

4 new tests in ByteBufferTest:
1. testAsyncWithUnsafeReadableBytesCopiesBytes — basic copy correctness
2. testAsyncWithUnsafeReadableBytesEmptyBuffer — empty buffer handling
3. testAsyncWithUnsafeReadableBytesCanSuspend — Task.yield() in closure does not invalidate pointer
4. testAsyncWithUnsafeReadableBytesCopyIsIndependent — mutation of original buffer after async closure does not affect copied data

### Related

Closes #2630