### PR TITLE
FileSystem docs: redirect users from underscore-prefixed modules to NIOFS

### DIFF
--- a/Sources/NIOFileSystem/Docs.docc/index.md
+++ b/Sources/NIOFileSystem/Docs.docc/index.md
@@ -1,13 +1,8 @@
 # ``NIOFileSystem``
 
-> Warning: Do not use this module. Instead use [`_NIOFileSystem`][_fs-docs].
+> Warning: Do not use this module.
 >
-> `NIOFileSystem` currently exposes the same API as `_NIOFileSystem`, which is not API stable. `NIOFileSystem`
-> was created in error, and its lack of underscore incorrectly implies API stability. Users who are currently importing
-> `NIOFileSystem` should move to `_NIOFileSystem`.
->
-> Refer to [`_NIOFilesystem`][_fs-docs] for documentation on the API of this module.
->
-> There is ongoing work in NIO to provide a filesystem library with a stable API.
-
-[_fs-docs]: ./_NIOFileSystem
+> `NIOFileSystem` was created in error; its lack of underscore incorrectly implies API stability.
+> Users who are currently importing `NIOFileSystem` should migrate to
+> [`NIOFS`](https://github.com/apple/swift-nio/tree/main/Sources/NIOFS), which provides the same
+> API as a stable module.

--- a/Sources/_NIOFileSystem/Docs.docc/index.md
+++ b/Sources/_NIOFileSystem/Docs.docc/index.md
@@ -1,5 +1,9 @@
 # ``_NIOFileSystem``
 
+> Warning: This is the legacy implementation module. Users should migrate to
+> [`NIOFS`](https://github.com/apple/swift-nio/tree/main/Sources/NIOFS) which
+> provides the same API under a stable module name.
+
 A file system library for Swift.
 
 ## Overview


### PR DESCRIPTION
### Summary

Update documentation for `_NIOFileSystem` and `NIOFileSystem` to direct users to the stable `NIOFS` module instead of pointing at each other.

### Changes

- **Sources/_NIOFileSystem/Docs.docc/index.md**: Add warning directing users to `NIOFS` as the stable replacement module.
- **Sources/NIOFileSystem/Docs.docc/index.md**: Update warning to point to `NIOFS` instead of `_NIOFileSystem`. Remove outdated references to "ongoing work" since `NIOFS` already provides the stable API.

### Background

The `_NIOFileSystem` module was prefixed with an underscore to indicate it was not yet API stable, while `NIOFileSystem` was created in error (the lack of underscore incorrectly implied stability). Both have been superseded by the `NIOFS` module, which provides the same API under a stable name.

This addresses issue #3052 — "Remove underbar prefix from _NIOFileSystem" — by documenting that the rename has effectively been achieved through the creation of the `NIOFS` module and providing migration guidance.

### Related

Closes #3052