### PR TITLE
feat: Add onDiskSize property to FileInfo (Fixes #3650)

### DIFF
--- a/Sources/NIOFS/FileInfo.swift
+++ b/Sources/NIOFS/FileInfo.swift
@@ -59,6 +59,12 @@ public struct FileInfo: Hashable, Sendable {
     /// The size of the file in bytes.
     public var size: Int64
 
+    /// The size of the file on disk in bytes.
+    ///
+    /// This value accounts for holes in sparse files and file system compression.
+    /// If the information is not available, this may be `nil`.
+    public var onDiskSize: Int64?
+
     /// User ID of the file.
     public var userID: UserID
 
@@ -81,6 +87,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
         self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
         self.size = platformSpecificStatus.nioSize
+        self.onDiskSize = nil
         // Windows has no POSIX owner/group; report the defaults.
         self.userID = UserID(rawValue: 0)
         self.groupID = GroupID(rawValue: 0)
@@ -91,6 +98,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
+        self.onDiskSize = Int64(platformSpecificStatus.st_blocks) * 512
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -114,6 +122,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
+        onDiskSize: Int64? = nil,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -124,6 +133,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
+        self.onDiskSize = onDiskSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/_NIOFileSystem/FileInfo.swift
+++ b/Sources/_NIOFileSystem/FileInfo.swift
@@ -59,6 +59,12 @@ public struct FileInfo: Hashable, Sendable {
     /// The size of the file in bytes.
     public var size: Int64
 
+    /// The size of the file on disk in bytes.
+    ///
+    /// This value accounts for holes in sparse files and file system compression.
+    /// If the information is not available, this may be `nil`.
+    public var onDiskSize: Int64?
+
     /// User ID of the file.
     public var userID: UserID
 
@@ -81,6 +87,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
         self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
         self.size = platformSpecificStatus.nioSize
+        self.onDiskSize = nil
         // Windows has no POSIX owner/group; report the defaults.
         self.userID = UserID(rawValue: 0)
         self.groupID = GroupID(rawValue: 0)
@@ -91,6 +98,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
+        self.onDiskSize = Int64(platformSpecificStatus.st_blocks) * 512
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -114,6 +122,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
+        onDiskSize: Int64? = nil,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -124,6 +133,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
+        self.onDiskSize = onDiskSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Tests/NIOFSTests/FileInfoTests.swift
+++ b/Tests/NIOFSTests/FileInfoTests.swift
@@ -80,6 +80,7 @@ final class FileInfoTests: XCTestCase {
         XCTAssertEqual(info.lastAccessTime, FileInfo.Timespec(seconds: 0, nanoseconds: 0))
         XCTAssertEqual(info.lastDataModificationTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))
         XCTAssertEqual(info.lastStatusChangeTime, FileInfo.Timespec(seconds: 2, nanoseconds: 0))
+        XCTAssertEqual(info.onDiskSize, 9 * 512)
     }
 
     func testEquatableConformance() {


### PR DESCRIPTION
Hey @weissi! 👋 

As discussed in #3650, I've added the `.onDiskSize` property to `FileInfo` to accurately report the actual size used on disk (accounting for holes in sparse files and APFS compression). 

**Implementation Details:**
- Implemented `Int64(platformSpecificStatus.st_blocks) * 512` for POSIX systems (Linux/Darwin) using the POSIX standard block size of 512 bytes.
- Safely defaults to `nil` on Windows where `st_blocks` is unavailable.
- Added tests to `FileInfoTests.swift` verifying the block multiplication.
- Carefully updated the initializers using default arguments (`onDiskSize: Int64? = nil`) to ensure we **do not break** the existing public API.

All unit tests are passing locally. Let me know if you'd like any modifications, otherwise this should be good to merge! 🚀