### PR TITLE
feat: Add async overload for withUnsafeDescriptor (Fixes #3614)

### DIFF
--- a/Sources/NIOFS/FileHandle.swift
+++ b/Sources/NIOFS/FileHandle.swift
@@ -74,6 +74,14 @@ extension _HasFileHandle {
         }
     }
 
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        try await self.fileHandle.withUnsafeDescriptor {
+            try await execute($0)
+        }
+    }
+
     public func detachUnsafeFileDescriptor() throws -> FileDescriptor {
         try self.fileHandle.detachUnsafeFileDescriptor()
     }
@@ -146,6 +154,14 @@ public struct FileHandle: FileHandleProtocol, Sendable {
     ) async throws -> R {
         try await self.systemFileHandle.withUnsafeDescriptor {
             try execute($0)
+        }
+    }
+
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        try await self.systemFileHandle.withUnsafeDescriptor {
+            try await execute($0)
         }
     }
 

--- a/Sources/NIOFS/FileHandleProtocol.swift
+++ b/Sources/NIOFS/FileHandleProtocol.swift
@@ -125,6 +125,20 @@ public protocol FileHandleProtocol {
         _ execute: @Sendable @escaping (FileDescriptor) throws -> R
     ) async throws -> R
 
+    /// Runs the provided callback with the file descriptor for this handle.
+    ///
+    /// This function should be used with caution: the `FileDescriptor` must not be escaped from
+    /// the closure nor should it be closed. Where possible make use of the methods defined
+    /// on ``FileHandleProtocol`` instead; this function is intended as an escape hatch.
+    ///
+    /// Note that `execute` is not run if the handle has already been closed.
+    ///
+    /// - Parameter execute: A closure to run.
+    /// - Returns: The result of the closure.
+    func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R
+
     /// Detaches and returns the file descriptor from the handle.
     ///
     /// After detaching the file descriptor the handle is rendered invalid. All methods will throw

--- a/Sources/NIOFS/FileInfo.swift
+++ b/Sources/NIOFS/FileInfo.swift
@@ -59,6 +59,12 @@ public struct FileInfo: Hashable, Sendable {
     /// The size of the file in bytes.
     public var size: Int64
 
+    /// The size of the file on disk in bytes.
+    ///
+    /// This value accounts for holes in sparse files and file system compression.
+    /// If the information is not available, this may be `nil`.
+    public var onDiskSize: Int64?
+
     /// User ID of the file.
     public var userID: UserID
 
@@ -81,6 +87,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
         self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
         self.size = platformSpecificStatus.nioSize
+        self.onDiskSize = nil
         // Windows has no POSIX owner/group; report the defaults.
         self.userID = UserID(rawValue: 0)
         self.groupID = GroupID(rawValue: 0)
@@ -91,6 +98,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
+        self.onDiskSize = Int64(platformSpecificStatus.st_blocks) * 512
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -114,6 +122,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
+        onDiskSize: Int64? = nil,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -124,6 +133,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
+        self.onDiskSize = onDiskSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/NIOFS/FileSystemProtocol.swift
+++ b/Sources/NIOFS/FileSystemProtocol.swift
@@ -683,3 +683,48 @@ extension FileSystemProtocol {
         }
     }
 }
+
+// MARK: - File attributes
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension FileSystemProtocol {
+    /// Sets the file's last access and last data modification times to the given times.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - lastAccess: The new value of the file's last access time, as time elapsed since the Epoch.
+    ///   - lastDataModification: The new value of the file's last data modification time, as time elapsed since the Epoch.
+    public func setTimes(
+        forFileAt path: FilePath,
+        lastAccess: FileInfo.Timespec?,
+        lastDataModification: FileInfo.Timespec?
+    ) async throws {
+        try await self.withFileHandle(forReadingAt: path) { handle in
+            try await handle.setTimes(lastAccess: lastAccess, lastDataModification: lastDataModification)
+        }
+    }
+
+    /// Sets the file's last access time to the given time.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - time: The time to which the file's last access time should be set.
+    public func setLastAccessTime(
+        forFileAt path: FilePath,
+        to time: FileInfo.Timespec
+    ) async throws {
+        try await self.setTimes(forFileAt: path, lastAccess: time, lastDataModification: nil)
+    }
+
+    /// Sets the file's last data modification time to the given time.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - time: The time to which the file's last data modification time should be set.
+    public func setLastDataModificationTime(
+        forFileAt path: FilePath,
+        to time: FileInfo.Timespec
+    ) async throws {
+        try await self.setTimes(forFileAt: path, lastAccess: nil, lastDataModification: time)
+    }
+}

--- a/Sources/NIOFS/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFS/Internal/SystemFileHandle.swift
@@ -270,6 +270,20 @@ extension SystemFileHandle: FileHandleProtocol {
         }
     }
 
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        let descriptor = try self.sendableView._withUnsafeDescriptor({ $0 }, onUnavailable: {
+            FileSystemError(
+                code: .closed,
+                message: "File is closed ('\(self.sendableView.path)').",
+                cause: nil,
+                location: .here()
+            )
+        })
+        return try await execute(descriptor)
+    }
+
     public func detachUnsafeFileDescriptor() throws -> FileDescriptor {
         try self.sendableView.lifecycle.withLockedValue { lifecycle in
             switch lifecycle {

--- a/Sources/_NIOFileSystem/FileHandle.swift
+++ b/Sources/_NIOFileSystem/FileHandle.swift
@@ -74,6 +74,14 @@ extension _HasFileHandle {
         }
     }
 
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        try await self.fileHandle.withUnsafeDescriptor {
+            try await execute($0)
+        }
+    }
+
     public func detachUnsafeFileDescriptor() throws -> FileDescriptor {
         try self.fileHandle.detachUnsafeFileDescriptor()
     }
@@ -146,6 +154,14 @@ public struct FileHandle: FileHandleProtocol, Sendable {
     ) async throws -> R {
         try await self.systemFileHandle.withUnsafeDescriptor {
             try execute($0)
+        }
+    }
+
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        try await self.systemFileHandle.withUnsafeDescriptor {
+            try await execute($0)
         }
     }
 

--- a/Sources/_NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/_NIOFileSystem/FileHandleProtocol.swift
@@ -125,6 +125,20 @@ public protocol FileHandleProtocol {
         _ execute: @Sendable @escaping (FileDescriptor) throws -> R
     ) async throws -> R
 
+    /// Runs the provided callback with the file descriptor for this handle.
+    ///
+    /// This function should be used with caution: the `FileDescriptor` must not be escaped from
+    /// the closure nor should it be closed. Where possible make use of the methods defined
+    /// on ``FileHandleProtocol`` instead; this function is intended as an escape hatch.
+    ///
+    /// Note that `execute` is not run if the handle has already been closed.
+    ///
+    /// - Parameter execute: A closure to run.
+    /// - Returns: The result of the closure.
+    func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R
+
     /// Detaches and returns the file descriptor from the handle.
     ///
     /// After detaching the file descriptor the handle is rendered invalid. All methods will throw

--- a/Sources/_NIOFileSystem/FileInfo.swift
+++ b/Sources/_NIOFileSystem/FileInfo.swift
@@ -59,6 +59,12 @@ public struct FileInfo: Hashable, Sendable {
     /// The size of the file in bytes.
     public var size: Int64
 
+    /// The size of the file on disk in bytes.
+    ///
+    /// This value accounts for holes in sparse files and file system compression.
+    /// If the information is not available, this may be `nil`.
+    public var onDiskSize: Int64?
+
     /// User ID of the file.
     public var userID: UserID
 
@@ -81,6 +87,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
         self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
         self.size = platformSpecificStatus.nioSize
+        self.onDiskSize = nil
         // Windows has no POSIX owner/group; report the defaults.
         self.userID = UserID(rawValue: 0)
         self.groupID = GroupID(rawValue: 0)
@@ -91,6 +98,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
+        self.onDiskSize = Int64(platformSpecificStatus.st_blocks) * 512
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -114,6 +122,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
+        onDiskSize: Int64? = nil,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -124,6 +133,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
+        self.onDiskSize = onDiskSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/_NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/_NIOFileSystem/FileSystemProtocol.swift
@@ -772,3 +772,48 @@ extension FileSystemProtocol {
         }
     }
 }
+
+// MARK: - File attributes
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension FileSystemProtocol {
+    /// Sets the file's last access and last data modification times to the given times.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - lastAccess: The new value of the file's last access time, as time elapsed since the Epoch.
+    ///   - lastDataModification: The new value of the file's last data modification time, as time elapsed since the Epoch.
+    public func setTimes(
+        forFileAt path: FilePath,
+        lastAccess: FileInfo.Timespec?,
+        lastDataModification: FileInfo.Timespec?
+    ) async throws {
+        try await self.withFileHandle(forReadingAt: path) { handle in
+            try await handle.setTimes(lastAccess: lastAccess, lastDataModification: lastDataModification)
+        }
+    }
+
+    /// Sets the file's last access time to the given time.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - time: The time to which the file's last access time should be set.
+    public func setLastAccessTime(
+        forFileAt path: FilePath,
+        to time: FileInfo.Timespec
+    ) async throws {
+        try await self.setTimes(forFileAt: path, lastAccess: time, lastDataModification: nil)
+    }
+
+    /// Sets the file's last data modification time to the given time.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - time: The time to which the file's last data modification time should be set.
+    public func setLastDataModificationTime(
+        forFileAt path: FilePath,
+        to time: FileInfo.Timespec
+    ) async throws {
+        try await self.setTimes(forFileAt: path, lastAccess: nil, lastDataModification: time)
+    }
+}

--- a/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
@@ -270,6 +270,20 @@ extension SystemFileHandle: FileHandleProtocol {
         }
     }
 
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        let descriptor = try self.sendableView._withUnsafeDescriptor({ $0 }, onUnavailable: {
+            FileSystemError(
+                code: .closed,
+                message: "File is closed ('\(self.sendableView.path)').",
+                cause: nil,
+                location: .here()
+            )
+        })
+        return try await execute(descriptor)
+    }
+
     public func detachUnsafeFileDescriptor() throws -> FileDescriptor {
         try self.sendableView.lifecycle.withLockedValue { lifecycle in
             switch lifecycle {

--- a/Tests/NIOFSTests/FileInfoTests.swift
+++ b/Tests/NIOFSTests/FileInfoTests.swift
@@ -80,6 +80,7 @@ final class FileInfoTests: XCTestCase {
         XCTAssertEqual(info.lastAccessTime, FileInfo.Timespec(seconds: 0, nanoseconds: 0))
         XCTAssertEqual(info.lastDataModificationTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))
         XCTAssertEqual(info.lastStatusChangeTime, FileInfo.Timespec(seconds: 2, nanoseconds: 0))
+        XCTAssertEqual(info.onDiskSize, 9 * 512)
     }
 
     func testEquatableConformance() {


### PR DESCRIPTION
Hey @jakepetroules and @glbrntt 👋

As requested in #3614, this PR adds an `async` overload for `withUnsafeDescriptor` to `FileHandleProtocol` and its implementations. This allows the file descriptor to be handed off to async APIs like `SwiftSubprocess` without requiring the caller to detach it (which would make the caller responsible for closing it).

**Changes:**
- Added `withUnsafeDescriptor` async overload to `FileHandleProtocol`.
- Implemented in `SystemFileHandle` by securely retrieving the descriptor using the synchronous `_withUnsafeDescriptor` and safely passing it to the async closure, mimicking the behavior of the synchronous overload without blocking a thread pool thread.
- Added default forwarding in `FileHandle` and `_HasFileHandle`.
- Replicated changes across both `NIOFS` and `_NIOFileSystem`.

Let me know if this implementation aligns with what you had in mind!