### PR TITLE
fix(nio-filesystem): Fallback to non-positional read/write on ENXIO (Fixes #3613)

### DIFF
--- a/Sources/NIOFS/FileSystemError+Syscall.swift
+++ b/Sources/NIOFS/FileSystemError+Syscall.swift
@@ -464,7 +464,7 @@ extension FileSystemError {
                     Could not read from file ('\(path)'); an I/O error occurred while reading \
                     from the file system.
                     """
-            case .illegalSeek:
+            case .illegalSeek, .noSuchDeviceOrAddress:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:
@@ -516,7 +516,7 @@ extension FileSystemError {
                     Could not write to file ('\(path)'); an I/O error occurred while writing to \
                     the file system.
                     """
-            case .illegalSeek:
+            case .illegalSeek, .noSuchDeviceOrAddress:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:

--- a/Sources/NIOFS/FileSystemError+Syscall.swift
+++ b/Sources/NIOFS/FileSystemError+Syscall.swift
@@ -464,7 +464,7 @@ extension FileSystemError {
                     Could not read from file ('\(path)'); an I/O error occurred while reading \
                     from the file system.
                     """
-            case .illegalSeek, .noSuchDeviceOrAddress:
+            case .illegalSeek, .noSuchAddressOrDevice:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:
@@ -516,7 +516,7 @@ extension FileSystemError {
                     Could not write to file ('\(path)'); an I/O error occurred while writing to \
                     the file system.
                     """
-            case .illegalSeek, .noSuchDeviceOrAddress:
+            case .illegalSeek, .noSuchAddressOrDevice:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:

--- a/Sources/NIOFS/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFS/Internal/SystemFileHandle.swift
@@ -1047,7 +1047,7 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
                     fromAbsoluteOffset: offset,
                     length: length.bytes
                 ).flatMapError { error in
-                    if let errno = error as? Errno, errno == .illegalSeek {
+                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
                         guard offset == 0 else {
                             return .failure(
                                 FileSystemError(
@@ -1111,7 +1111,7 @@ extension SystemFileHandle: WritableFileHandleProtocol {
             try sendableView._withUnsafeDescriptor { descriptor in
                 try descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
                     .flatMapError { error in
-                        if let errno = error as? Errno, errno == .illegalSeek {
+                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
                             guard offset == 0 else {
                                 return .failure(
                                     FileSystemError(

--- a/Sources/NIOFS/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFS/Internal/SystemFileHandle.swift
@@ -1047,7 +1047,7 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
                     fromAbsoluteOffset: offset,
                     length: length.bytes
                 ).flatMapError { error in
-                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
+                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
                         guard offset == 0 else {
                             return .failure(
                                 FileSystemError(
@@ -1111,7 +1111,7 @@ extension SystemFileHandle: WritableFileHandleProtocol {
             try sendableView._withUnsafeDescriptor { descriptor in
                 try descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
                     .flatMapError { error in
-                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
+                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
                             guard offset == 0 else {
                                 return .failure(
                                     FileSystemError(

--- a/Sources/_NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/_NIOFileSystem/FileSystemError+Syscall.swift
@@ -464,7 +464,7 @@ extension FileSystemError {
                     Could not read from file ('\(path)'); an I/O error occurred while reading \
                     from the file system.
                     """
-            case .illegalSeek:
+            case .illegalSeek, .noSuchDeviceOrAddress:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:
@@ -516,7 +516,7 @@ extension FileSystemError {
                     Could not write to file ('\(path)'); an I/O error occurred while writing to \
                     the file system.
                     """
-            case .illegalSeek:
+            case .illegalSeek, .noSuchDeviceOrAddress:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:

--- a/Sources/_NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/_NIOFileSystem/FileSystemError+Syscall.swift
@@ -464,7 +464,7 @@ extension FileSystemError {
                     Could not read from file ('\(path)'); an I/O error occurred while reading \
                     from the file system.
                     """
-            case .illegalSeek, .noSuchDeviceOrAddress:
+            case .illegalSeek, .noSuchAddressOrDevice:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:
@@ -516,7 +516,7 @@ extension FileSystemError {
                     Could not write to file ('\(path)'); an I/O error occurred while writing to \
                     the file system.
                     """
-            case .illegalSeek, .noSuchDeviceOrAddress:
+            case .illegalSeek, .noSuchAddressOrDevice:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:

--- a/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
@@ -1047,7 +1047,7 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
                     fromAbsoluteOffset: offset,
                     length: length.bytes
                 ).flatMapError { error in
-                    if let errno = error as? Errno, errno == .illegalSeek {
+                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
                         guard offset == 0 else {
                             return .failure(
                                 FileSystemError(
@@ -1111,7 +1111,7 @@ extension SystemFileHandle: WritableFileHandleProtocol {
             try sendableView._withUnsafeDescriptor { descriptor in
                 try descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
                     .flatMapError { error in
-                        if let errno = error as? Errno, errno == .illegalSeek {
+                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
                             guard offset == 0 else {
                                 return .failure(
                                     FileSystemError(

--- a/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
@@ -1047,7 +1047,7 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
                     fromAbsoluteOffset: offset,
                     length: length.bytes
                 ).flatMapError { error in
-                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
+                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
                         guard offset == 0 else {
                             return .failure(
                                 FileSystemError(
@@ -1111,7 +1111,7 @@ extension SystemFileHandle: WritableFileHandleProtocol {
             try sendableView._withUnsafeDescriptor { descriptor in
                 try descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
                     .flatMapError { error in
-                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
+                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
                             guard offset == 0 else {
                                 return .failure(
                                     FileSystemError(

--- a/Tests/NIOFSTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFSTests/FileSystemErrorTests.swift
@@ -399,7 +399,7 @@ final class FileSystemErrorTests: XCTestCase {
                 .badFileDescriptor: .closed,
                 .ioError: .io,
                 .illegalSeek: .unsupported,
-                .noSuchDeviceOrAddress: .unsupported,
+                .noSuchAddressOrDevice: .unsupported,
             ]
         ) { errno in
             .read(usingSyscall: .pread, error: errno, path: "", location: .fixed)
@@ -423,7 +423,7 @@ final class FileSystemErrorTests: XCTestCase {
                 .badFileDescriptor: .closed,
                 .ioError: .io,
                 .illegalSeek: .unsupported,
-                .noSuchDeviceOrAddress: .unsupported,
+                .noSuchAddressOrDevice: .unsupported,
             ]
         ) { errno in
             .write(usingSyscall: .pwrite, error: errno, path: "", location: .fixed)

--- a/Tests/NIOFSTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFSTests/FileSystemErrorTests.swift
@@ -399,6 +399,7 @@ final class FileSystemErrorTests: XCTestCase {
                 .badFileDescriptor: .closed,
                 .ioError: .io,
                 .illegalSeek: .unsupported,
+                .noSuchDeviceOrAddress: .unsupported,
             ]
         ) { errno in
             .read(usingSyscall: .pread, error: errno, path: "", location: .fixed)
@@ -422,6 +423,7 @@ final class FileSystemErrorTests: XCTestCase {
                 .badFileDescriptor: .closed,
                 .ioError: .io,
                 .illegalSeek: .unsupported,
+                .noSuchDeviceOrAddress: .unsupported,
             ]
         ) { errno in
             .write(usingSyscall: .pwrite, error: errno, path: "", location: .fixed)


### PR DESCRIPTION
Hey @weissi! 👋

This PR addresses **#3613** where writing to `/dev/stdout` fails with `ENXIO (6) Device not configured` when running in a terminal environment instead of a pipe.

Currently, `SystemFileHandle` checks for `errno == .illegalSeek` (ESPIPE) when deciding whether to fall back from positional `pwrite`/`pread` to non-positional `write`/`read` for unseekable files like pipes. However, macOS/Darwin returns `ENXIO` (`Errno.noSuchDeviceOrAddress`) instead of `ESPIPE` when attempting a positional write/read on a terminal device.

**Changes:**
- Added `.noSuchDeviceOrAddress` to the fallback conditions in `SystemFileHandle.swift` for both `readChunk` and `write`.
- Updated `FileSystemError+Syscall.swift` to map `.noSuchDeviceOrAddress` to `.unsupported` alongside `.illegalSeek`.
- Replicated these changes across both the `_NIOFileSystem` and `NIOFS` modules.

This allows `FileSystem.shared.withFileHandle` and other APIs to work transparently with terminal devices like `/dev/stdout`!