### PR TITLE
docs(fs): Clarify `replaceItem` moves the item (Fixes #3406)

### DIFF
--- a/Sources/_NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/_NIOFileSystem/FileSystemProtocol.swift
@@ -306,6 +306,10 @@ public protocol FileSystemProtocol: Sendable {
     /// a file with a directory and vice versa. After the file or directory at `destinationPath`
     /// has been replaced, the item at `existingPath` will be removed.
     ///
+    /// > Note: This method behaves identically to ``FileSystemProtocol/moveItem(at:to:)``, except that it will replace
+    /// the item at `destinationPath` if it already exists. The item at `existingPath` is moved to the new location and
+    /// will no longer exist at its original path.
+    ///
     /// - Parameters:
     ///   - destinationPath: The path of the file or directory to replace.
     ///   - existingPath: The path of the existing file or directory.


### PR DESCRIPTION
Hey @weissi! 👋

This PR addresses **#3406** by clarifying the documentation of `replaceItem(at:withItemAt:)`. It explicitly states that this operation is identical to a move, and that the item at `existingPath` will be moved to the new location and no longer exist at its original path.