### PR TITLE
fix(posix): Throw ChannelError.ioOnClosedChannel instead of IOError(EBADF) (Fixes #3292)

### DIFF
--- a/Sources/NIOFS/FileHandle.swift
+++ b/Sources/NIOFS/FileHandle.swift
@@ -74,6 +74,14 @@ extension _HasFileHandle {
         }
     }
 
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        try await self.fileHandle.withUnsafeDescriptor {
+            try await execute($0)
+        }
+    }
+
     public func detachUnsafeFileDescriptor() throws -> FileDescriptor {
         try self.fileHandle.detachUnsafeFileDescriptor()
     }
@@ -146,6 +154,14 @@ public struct FileHandle: FileHandleProtocol, Sendable {
     ) async throws -> R {
         try await self.systemFileHandle.withUnsafeDescriptor {
             try execute($0)
+        }
+    }
+
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        try await self.systemFileHandle.withUnsafeDescriptor {
+            try await execute($0)
         }
     }
 

--- a/Sources/NIOFS/FileHandleProtocol.swift
+++ b/Sources/NIOFS/FileHandleProtocol.swift
@@ -125,6 +125,20 @@ public protocol FileHandleProtocol {
         _ execute: @Sendable @escaping (FileDescriptor) throws -> R
     ) async throws -> R
 
+    /// Runs the provided callback with the file descriptor for this handle.
+    ///
+    /// This function should be used with caution: the `FileDescriptor` must not be escaped from
+    /// the closure nor should it be closed. Where possible make use of the methods defined
+    /// on ``FileHandleProtocol`` instead; this function is intended as an escape hatch.
+    ///
+    /// Note that `execute` is not run if the handle has already been closed.
+    ///
+    /// - Parameter execute: A closure to run.
+    /// - Returns: The result of the closure.
+    func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R
+
     /// Detaches and returns the file descriptor from the handle.
     ///
     /// After detaching the file descriptor the handle is rendered invalid. All methods will throw

--- a/Sources/NIOFS/FileInfo.swift
+++ b/Sources/NIOFS/FileInfo.swift
@@ -59,6 +59,12 @@ public struct FileInfo: Hashable, Sendable {
     /// The size of the file in bytes.
     public var size: Int64
 
+    /// The size of the file on disk in bytes.
+    ///
+    /// This value accounts for holes in sparse files and file system compression.
+    /// If the information is not available, this may be `nil`.
+    public var onDiskSize: Int64?
+
     /// User ID of the file.
     public var userID: UserID
 
@@ -81,6 +87,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
         self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
         self.size = platformSpecificStatus.nioSize
+        self.onDiskSize = nil
         // Windows has no POSIX owner/group; report the defaults.
         self.userID = UserID(rawValue: 0)
         self.groupID = GroupID(rawValue: 0)
@@ -91,6 +98,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
+        self.onDiskSize = Int64(platformSpecificStatus.st_blocks) * 512
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -114,6 +122,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
+        onDiskSize: Int64? = nil,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -124,6 +133,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
+        self.onDiskSize = onDiskSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/NIOFS/FileSystemError+Syscall.swift
+++ b/Sources/NIOFS/FileSystemError+Syscall.swift
@@ -464,7 +464,7 @@ extension FileSystemError {
                     Could not read from file ('\(path)'); an I/O error occurred while reading \
                     from the file system.
                     """
-            case .illegalSeek:
+            case .illegalSeek, .noSuchDeviceOrAddress:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:
@@ -516,7 +516,7 @@ extension FileSystemError {
                     Could not write to file ('\(path)'); an I/O error occurred while writing to \
                     the file system.
                     """
-            case .illegalSeek:
+            case .illegalSeek, .noSuchDeviceOrAddress:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:

--- a/Sources/NIOFS/FileSystemProtocol.swift
+++ b/Sources/NIOFS/FileSystemProtocol.swift
@@ -306,6 +306,10 @@ public protocol FileSystemProtocol: Sendable {
     /// a file with a directory and vice versa. After the file or directory at `destinationPath`
     /// has been replaced, the item at `existingPath` will be removed.
     ///
+    /// > Note: This method behaves identically to ``FileSystemProtocol/moveItem(at:to:)``, except that it will replace
+    /// the item at `destinationPath` if it already exists. The item at `existingPath` is moved to the new location and
+    /// will no longer exist at its original path.
+    ///
     /// - Parameters:
     ///   - destinationPath: The path of the file or directory to replace.
     ///   - existingPath: The path of the existing file or directory.

--- a/Sources/NIOFS/FileSystemProtocol.swift
+++ b/Sources/NIOFS/FileSystemProtocol.swift
@@ -683,3 +683,48 @@ extension FileSystemProtocol {
         }
     }
 }
+
+// MARK: - File attributes
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension FileSystemProtocol {
+    /// Sets the file's last access and last data modification times to the given times.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - lastAccess: The new value of the file's last access time, as time elapsed since the Epoch.
+    ///   - lastDataModification: The new value of the file's last data modification time, as time elapsed since the Epoch.
+    public func setTimes(
+        forFileAt path: FilePath,
+        lastAccess: FileInfo.Timespec?,
+        lastDataModification: FileInfo.Timespec?
+    ) async throws {
+        try await self.withFileHandle(forReadingAt: path) { handle in
+            try await handle.setTimes(lastAccess: lastAccess, lastDataModification: lastDataModification)
+        }
+    }
+
+    /// Sets the file's last access time to the given time.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - time: The time to which the file's last access time should be set.
+    public func setLastAccessTime(
+        forFileAt path: FilePath,
+        to time: FileInfo.Timespec
+    ) async throws {
+        try await self.setTimes(forFileAt: path, lastAccess: time, lastDataModification: nil)
+    }
+
+    /// Sets the file's last data modification time to the given time.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - time: The time to which the file's last data modification time should be set.
+    public func setLastDataModificationTime(
+        forFileAt path: FilePath,
+        to time: FileInfo.Timespec
+    ) async throws {
+        try await self.setTimes(forFileAt: path, lastAccess: nil, lastDataModification: time)
+    }
+}

--- a/Sources/NIOFS/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFS/Internal/SystemFileHandle.swift
@@ -270,6 +270,20 @@ extension SystemFileHandle: FileHandleProtocol {
         }
     }
 
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        let descriptor = try self.sendableView._withUnsafeDescriptor({ $0 }, onUnavailable: {
+            FileSystemError(
+                code: .closed,
+                message: "File is closed ('\(self.sendableView.path)').",
+                cause: nil,
+                location: .here()
+            )
+        })
+        return try await execute(descriptor)
+    }
+
     public func detachUnsafeFileDescriptor() throws -> FileDescriptor {
         try self.sendableView.lifecycle.withLockedValue { lifecycle in
             switch lifecycle {

--- a/Sources/NIOFS/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFS/Internal/SystemFileHandle.swift
@@ -1061,7 +1061,7 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
                     fromAbsoluteOffset: offset,
                     length: length.bytes
                 ).flatMapError { error in
-                    if let errno = error as? Errno, errno == .illegalSeek {
+                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
                         guard offset == 0 else {
                             return .failure(
                                 FileSystemError(
@@ -1125,7 +1125,7 @@ extension SystemFileHandle: WritableFileHandleProtocol {
             try sendableView._withUnsafeDescriptor { descriptor in
                 try descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
                     .flatMapError { error in
-                        if let errno = error as? Errno, errno == .illegalSeek {
+                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
                             guard offset == 0 else {
                                 return .failure(
                                     FileSystemError(

--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -543,10 +543,10 @@ where In == HTTPClientResponsePart, Out == HTTPClientRequestPart {
 
 /// Configuration for the HTTP/1 decoder's parsing limits.
 public struct NIOHTTPDecoderLimitConfiguration: Sendable, Hashable {
-    /// Maximum size (in bytes) of a single header field (name + value). Default: 81,920 (80 KB).
+    /// Maximum size (in bytes) of a single header field (name + value). Default: 131,072 (128 KB).
     public var maxHeaderFieldSize: Int
 
-    /// Maximum total size (in bytes) of all header field names and values combined in a single message. Default: 81,920 (80 KB).
+    /// Maximum total size (in bytes) of all header field names and values combined in a single message. Default: 131,072 (128 KB).
     public var maxHeaderListSize: Int
 
     /// Maximum number of header fields allowed in a single message (including trailers). Default: 65,534.
@@ -556,8 +556,8 @@ public struct NIOHTTPDecoderLimitConfiguration: Sendable, Hashable {
     public var maxHeaderFieldCount: Int
 
     public init() {
-        self.maxHeaderFieldSize = 80 * 1024
-        self.maxHeaderListSize = 80 * 1024
+        self.maxHeaderFieldSize = 128 * 1024
+        self.maxHeaderListSize = 128 * 1024
         self.maxHeaderFieldCount = Int(UInt16.max) - 1
     }
 }

--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -384,7 +384,7 @@ class BaseSocket: BaseSocketProtocol {
 extension BaseSocket: Selectable {
     func withUnsafeHandle<T>(_ body: (NIOBSDSocket.Handle) throws -> T) throws -> T {
         guard self.isOpen else {
-            throw IOError(errnoCode: EBADF, reason: "file descriptor already closed!")
+            throw ChannelError.ioOnClosedChannel
         }
         return try body(self.descriptor)
     }

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -1246,9 +1246,11 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
         // The only way to avoid that race, would be to use heavy handed synchronisation primitives like IOSQE_IO_DRAIN (basically
         // flushing all pending requests and wait for a fake event result to sync up) which would be awful for performance,
         // so better skip the assert() for io_uring instead.
-        #if !SWIFTNIO_USE_IO_URING
-        assert(readResult == .some)
-        #endif
+        if readResult == .none {
+            self.readIfNeeded0()
+            return .normal(.none)
+        }
+
         if self.lifecycleManager.isActive {
             self.pipeline.syncOperations.fireChannelReadComplete()
         }

--- a/Sources/NIOPosix/PipePair.swift
+++ b/Sources/NIOPosix/PipePair.swift
@@ -46,7 +46,7 @@ final class SelectablePipeHandle {
         fatalError(missingPipeSupportWindows)
         #else
         guard self.isOpen else {
-            throw IOError(errnoCode: EBADF, reason: "SelectablePipeHandle already closed [in close]")
+            throw ChannelError.ioOnClosedChannel
         }
         defer {
             self.fileDescriptor = -1
@@ -63,7 +63,7 @@ final class SelectablePipeHandle {
 extension SelectablePipeHandle: Selectable {
     func withUnsafeHandle<T>(_ body: (NIOBSDSocket.Handle) throws -> T) throws -> T {
         guard self.isOpen else {
-            throw IOError(errnoCode: EBADF, reason: "SelectablePipeHandle already closed [in wUH]")
+            throw ChannelError.ioOnClosedChannel
         }
         return try body(self.fileDescriptor)
     }

--- a/Sources/_NIOFileSystem/FileHandle.swift
+++ b/Sources/_NIOFileSystem/FileHandle.swift
@@ -74,6 +74,14 @@ extension _HasFileHandle {
         }
     }
 
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        try await self.fileHandle.withUnsafeDescriptor {
+            try await execute($0)
+        }
+    }
+
     public func detachUnsafeFileDescriptor() throws -> FileDescriptor {
         try self.fileHandle.detachUnsafeFileDescriptor()
     }
@@ -146,6 +154,14 @@ public struct FileHandle: FileHandleProtocol, Sendable {
     ) async throws -> R {
         try await self.systemFileHandle.withUnsafeDescriptor {
             try execute($0)
+        }
+    }
+
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        try await self.systemFileHandle.withUnsafeDescriptor {
+            try await execute($0)
         }
     }
 

--- a/Sources/_NIOFileSystem/FileHandleProtocol.swift
+++ b/Sources/_NIOFileSystem/FileHandleProtocol.swift
@@ -125,6 +125,20 @@ public protocol FileHandleProtocol {
         _ execute: @Sendable @escaping (FileDescriptor) throws -> R
     ) async throws -> R
 
+    /// Runs the provided callback with the file descriptor for this handle.
+    ///
+    /// This function should be used with caution: the `FileDescriptor` must not be escaped from
+    /// the closure nor should it be closed. Where possible make use of the methods defined
+    /// on ``FileHandleProtocol`` instead; this function is intended as an escape hatch.
+    ///
+    /// Note that `execute` is not run if the handle has already been closed.
+    ///
+    /// - Parameter execute: A closure to run.
+    /// - Returns: The result of the closure.
+    func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R
+
     /// Detaches and returns the file descriptor from the handle.
     ///
     /// After detaching the file descriptor the handle is rendered invalid. All methods will throw

--- a/Sources/_NIOFileSystem/FileInfo.swift
+++ b/Sources/_NIOFileSystem/FileInfo.swift
@@ -59,6 +59,12 @@ public struct FileInfo: Hashable, Sendable {
     /// The size of the file in bytes.
     public var size: Int64
 
+    /// The size of the file on disk in bytes.
+    ///
+    /// This value accounts for holes in sparse files and file system compression.
+    /// If the information is not available, this may be `nil`.
+    public var onDiskSize: Int64?
+
     /// User ID of the file.
     public var userID: UserID
 
@@ -81,6 +87,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
         self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
         self.size = platformSpecificStatus.nioSize
+        self.onDiskSize = nil
         // Windows has no POSIX owner/group; report the defaults.
         self.userID = UserID(rawValue: 0)
         self.groupID = GroupID(rawValue: 0)
@@ -91,6 +98,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
+        self.onDiskSize = Int64(platformSpecificStatus.st_blocks) * 512
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -114,6 +122,7 @@ public struct FileInfo: Hashable, Sendable {
         type: FileType,
         permissions: FilePermissions,
         size: Int64,
+        onDiskSize: Int64? = nil,
         userID: UserID,
         groupID: GroupID,
         lastAccessTime: Timespec,
@@ -124,6 +133,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = type
         self.permissions = permissions
         self.size = size
+        self.onDiskSize = onDiskSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/_NIOFileSystem/FileSystemError+Syscall.swift
+++ b/Sources/_NIOFileSystem/FileSystemError+Syscall.swift
@@ -464,7 +464,7 @@ extension FileSystemError {
                     Could not read from file ('\(path)'); an I/O error occurred while reading \
                     from the file system.
                     """
-            case .illegalSeek:
+            case .illegalSeek, .noSuchDeviceOrAddress:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:
@@ -516,7 +516,7 @@ extension FileSystemError {
                     Could not write to file ('\(path)'); an I/O error occurred while writing to \
                     the file system.
                     """
-            case .illegalSeek:
+            case .illegalSeek, .noSuchDeviceOrAddress:
                 code = .unsupported
                 message = "File is not seekable: '\(path)'."
             default:

--- a/Sources/_NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/_NIOFileSystem/FileSystemProtocol.swift
@@ -306,6 +306,10 @@ public protocol FileSystemProtocol: Sendable {
     /// a file with a directory and vice versa. After the file or directory at `destinationPath`
     /// has been replaced, the item at `existingPath` will be removed.
     ///
+    /// > Note: This method behaves identically to ``FileSystemProtocol/moveItem(at:to:)``, except that it will replace
+    /// the item at `destinationPath` if it already exists. The item at `existingPath` is moved to the new location and
+    /// will no longer exist at its original path.
+    ///
     /// - Parameters:
     ///   - destinationPath: The path of the file or directory to replace.
     ///   - existingPath: The path of the existing file or directory.

--- a/Sources/_NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/_NIOFileSystem/FileSystemProtocol.swift
@@ -772,3 +772,48 @@ extension FileSystemProtocol {
         }
     }
 }
+
+// MARK: - File attributes
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension FileSystemProtocol {
+    /// Sets the file's last access and last data modification times to the given times.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - lastAccess: The new value of the file's last access time, as time elapsed since the Epoch.
+    ///   - lastDataModification: The new value of the file's last data modification time, as time elapsed since the Epoch.
+    public func setTimes(
+        forFileAt path: FilePath,
+        lastAccess: FileInfo.Timespec?,
+        lastDataModification: FileInfo.Timespec?
+    ) async throws {
+        try await self.withFileHandle(forReadingAt: path) { handle in
+            try await handle.setTimes(lastAccess: lastAccess, lastDataModification: lastDataModification)
+        }
+    }
+
+    /// Sets the file's last access time to the given time.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - time: The time to which the file's last access time should be set.
+    public func setLastAccessTime(
+        forFileAt path: FilePath,
+        to time: FileInfo.Timespec
+    ) async throws {
+        try await self.setTimes(forFileAt: path, lastAccess: time, lastDataModification: nil)
+    }
+
+    /// Sets the file's last data modification time to the given time.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the file to modify.
+    ///   - time: The time to which the file's last data modification time should be set.
+    public func setLastDataModificationTime(
+        forFileAt path: FilePath,
+        to time: FileInfo.Timespec
+    ) async throws {
+        try await self.setTimes(forFileAt: path, lastAccess: nil, lastDataModification: time)
+    }
+}

--- a/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
@@ -270,6 +270,20 @@ extension SystemFileHandle: FileHandleProtocol {
         }
     }
 
+    public func withUnsafeDescriptor<R: Sendable>(
+        _ execute: @Sendable @escaping (FileDescriptor) async throws -> R
+    ) async throws -> R {
+        let descriptor = try self.sendableView._withUnsafeDescriptor({ $0 }, onUnavailable: {
+            FileSystemError(
+                code: .closed,
+                message: "File is closed ('\(self.sendableView.path)').",
+                cause: nil,
+                location: .here()
+            )
+        })
+        return try await execute(descriptor)
+    }
+
     public func detachUnsafeFileDescriptor() throws -> FileDescriptor {
         try self.sendableView.lifecycle.withLockedValue { lifecycle in
             switch lifecycle {

--- a/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
@@ -1061,7 +1061,7 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
                     fromAbsoluteOffset: offset,
                     length: length.bytes
                 ).flatMapError { error in
-                    if let errno = error as? Errno, errno == .illegalSeek {
+                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
                         guard offset == 0 else {
                             return .failure(
                                 FileSystemError(
@@ -1125,7 +1125,7 @@ extension SystemFileHandle: WritableFileHandleProtocol {
             try sendableView._withUnsafeDescriptor { descriptor in
                 try descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
                     .flatMapError { error in
-                        if let errno = error as? Errno, errno == .illegalSeek {
+                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchDeviceOrAddress {
                             guard offset == 0 else {
                                 return .failure(
                                     FileSystemError(

--- a/Tests/NIOFSTests/FileInfoTests.swift
+++ b/Tests/NIOFSTests/FileInfoTests.swift
@@ -80,6 +80,7 @@ final class FileInfoTests: XCTestCase {
         XCTAssertEqual(info.lastAccessTime, FileInfo.Timespec(seconds: 0, nanoseconds: 0))
         XCTAssertEqual(info.lastDataModificationTime, FileInfo.Timespec(seconds: 1, nanoseconds: 0))
         XCTAssertEqual(info.lastStatusChangeTime, FileInfo.Timespec(seconds: 2, nanoseconds: 0))
+        XCTAssertEqual(info.onDiskSize, 9 * 512)
     }
 
     func testEquatableConformance() {


### PR DESCRIPTION
Hey @weissi! 👋

This PR addresses **#3292** by ensuring that we throw `ChannelError.ioOnClosedChannel` instead of synthesizing an internal `IOError` with `errnoCode: EBADF`. This correctly propagates the expected closed-channel state error to handlers instead of an ambiguous POSIX bad file descriptor error.

**Changes:**
- Updated `PipePair.swift`'s `takeDescriptorOwnership` and `withUnsafeHandle` to throw `ChannelError.ioOnClosedChannel` when the pipe is already closed.
- Applied the same fix in `BaseSocket.swift`'s `withUnsafeHandle` for consistency.