### PR TITLE
fix: Prevent arithmetic overflow in ByteCount factory methods

### DIFF
--- a/Sources/NIOFS/ByteCount.swift
+++ b/Sources/NIOFS/ByteCount.swift
@@ -29,7 +29,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of kilobytes
     public static func kilobytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of megabytes
@@ -38,7 +39,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of megabytes
     public static func megabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000 * 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of gigabytes
@@ -47,7 +49,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of gigabytes
     public static func gigabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000 * 1000 * 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of kibibytes
@@ -56,7 +59,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of kibibytes
     public static func kibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of mebibytes
@@ -65,7 +69,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of mebibytes
     public static func mebibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024 * 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of gibibytes
@@ -74,7 +79,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of gibibytes
     public static func gibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024 * 1024 * 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 }
 

--- a/Sources/_NIOFileSystem/ByteCount.swift
+++ b/Sources/_NIOFileSystem/ByteCount.swift
@@ -29,7 +29,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of kilobytes
     public static func kilobytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of megabytes
@@ -38,7 +39,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of megabytes
     public static func megabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000 * 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of gigabytes
@@ -47,7 +49,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of gigabytes
     public static func gigabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000 * 1000 * 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of kibibytes
@@ -56,7 +59,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of kibibytes
     public static func kibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of mebibytes
@@ -65,7 +69,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of mebibytes
     public static func mebibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024 * 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of gibibytes
@@ -74,7 +79,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of gibibytes
     public static func gibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024 * 1024 * 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 }
 

--- a/Tests/NIOFSTests/ByteCountTests.swift
+++ b/Tests/NIOFSTests/ByteCountTests.swift
@@ -88,4 +88,29 @@ class ByteCountTests: XCTestCase {
         XCTAssertLessThan(byteCount1, byteCount2)
         XCTAssertGreaterThan(byteCount2, byteCount1)
     }
+
+    func testByteCountNegative() {
+        XCTAssertEqual(ByteCount.kilobytes(-10).bytes, -10_000)
+        XCTAssertEqual(ByteCount.megabytes(-10).bytes, -10_000_000)
+        XCTAssertEqual(ByteCount.gigabytes(-10).bytes, -10_000_000_000)
+        XCTAssertEqual(ByteCount.kibibytes(-10).bytes, -10_240)
+        XCTAssertEqual(ByteCount.mebibytes(-10).bytes, -10_485_760)
+        XCTAssertEqual(ByteCount.gibibytes(-10).bytes, -10_737_418_240)
+    }
+
+    func testByteCountOverflow() {
+        XCTAssertEqual(ByteCount.kilobytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.megabytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.gigabytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.kibibytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.mebibytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.gibibytes(.max).bytes, .max)
+
+        XCTAssertEqual(ByteCount.kilobytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.megabytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.gigabytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.kibibytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.mebibytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.gibibytes(.min).bytes, .min)
+    }
 }


### PR DESCRIPTION
Fixes #2877