### PR TITLE
Implement customisation point for scheduled callback on isolated EL

### DIFF
--- a/Benchmarks/Benchmarks/NIOPosixBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOPosixBenchmarks/Benchmarks.swift
@@ -132,6 +132,51 @@ let benchmarks: @Sendable () -> Void = {
     }
 
     Benchmark(
+        "MTELG.assumeIsolated().scheduleTask(in:_:)",
+        configuration: Benchmark.Configuration(
+            metrics: defaultMetrics,
+            scalingFactor: .mega,
+            maxDuration: .seconds(10_000_000),
+            maxIterations: 5
+        )
+    ) { benchmark in
+        let iterations = benchmark.scaledIterations.count
+        try! eventLoop.submit {
+            benchmark.startMeasurement()
+            let isolatedEventLoop = eventLoop.assumeIsolated()
+            for _ in 0..<iterations {
+                isolatedEventLoop.scheduleTask(in: .hours(1), {})
+            }
+            benchmark.stopMeasurement()
+        }.wait()
+    }
+
+    Benchmark(
+        "MTELG.assumeIsolated().scheduleCallback(in:_:)",
+        configuration: Benchmark.Configuration(
+            metrics: defaultMetrics,
+            scalingFactor: .mega,
+            maxDuration: .seconds(10_000_000),
+            maxIterations: 5
+        )
+    ) { benchmark in
+        final class Timer: NIOScheduledCallbackHandler, Sendable {
+            func handleScheduledCallback(eventLoop: some EventLoop) {}
+        }
+        let timer = Timer()
+        let iterations = benchmark.scaledIterations.count
+
+        try! eventLoop.submit {
+            benchmark.startMeasurement()
+            let isolatedEventLoop = eventLoop.assumeIsolated()
+            for _ in 0..<iterations {
+                let handle = try! isolatedEventLoop.scheduleCallback(in: .hours(1), handler: timer)
+            }
+            benchmark.stopMeasurement()
+        }.wait()
+    }
+
+    Benchmark(
         "Jump to EL and back using execute and unsafecontinuation",
         configuration: .init(
             metrics: defaultMetrics,

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -456,6 +456,27 @@ internal final class SelectableEventLoop: EventLoop, @unchecked Sendable {
         self._scheduleTaskIsolatedUnsafeUnchecked(deadline: .now() + delay, task)
     }
 
+    @inlinable
+    @discardableResult
+    func _scheduleCallbackIsolatedUnsafeUnchecked(
+        at deadline: NIODeadline,
+        handler: some NIOScheduledCallbackHandler
+    ) throws -> NIOScheduledCallback {
+        let taskID = self.scheduledTaskCounter.loadThenWrappingIncrement(ordering: .relaxed)
+        let task = ScheduledTask(id: taskID, handler, deadline)
+        try self._scheduleIsolated0(.scheduled(task))
+        return NIOScheduledCallback(self, id: taskID)
+    }
+
+    @inlinable
+    @discardableResult
+    func _scheduleCallbackIsolatedUnsafeUnchecked(
+        in amount: TimeAmount,
+        handler: some NIOScheduledCallbackHandler
+    ) throws -> NIOScheduledCallback {
+        try self._scheduleCallbackIsolatedUnsafeUnchecked(at: .now() + amount, handler: handler)
+    }
+
     // - see: `EventLoop.execute`
     @inlinable
     internal func execute(_ task: @escaping () -> Void) {

--- a/Tests/NIOPosixTests/NIOScheduledCallbackTests.swift
+++ b/Tests/NIOPosixTests/NIOScheduledCallbackTests.swift
@@ -211,6 +211,38 @@ final class IsolatedEventLoopScheduledCallbackTests: XCTestCase {
     }
 }
 
+// `SelectableEventLoop` overrides `_scheduleCallbackIsolatedUnsafeUnchecked` override; test that
+// path specifically rather than relying on the default `IsolatedEventLoopScheduledCallbackTests`.
+final class SelectableEventLoopIsolatedScheduledCallbackTests: XCTestCase {
+    func testScheduledCallbackExecutedAtDeadlineOnIsolatedEventLoop() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try! group.syncShutdownGracefully() }
+        let loop = group.next()
+        let handler = MockScheduledCallbackHandler()
+
+        try loop.submit {
+            _ = try loop.assumeIsolated().scheduleCallback(in: .milliseconds(1), handler: handler)
+        }.wait()
+
+        try loop.scheduleTask(in: .milliseconds(10)) {}.futureResult.wait()
+        handler.assert(callbackCount: 1, cancelCount: 0)
+    }
+
+    func testCancelOnIsolatedEventLoopExecutesCancellationCallback() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try! group.syncShutdownGracefully() }
+        let loop = group.next()
+        let handler = MockScheduledCallbackHandler()
+
+        try loop.submit {
+            let scheduledCallback = try loop.assumeIsolated().scheduleCallback(in: .hours(1), handler: handler)
+            scheduledCallback.cancel()
+        }.wait()
+
+        handler.assert(callbackCount: 0, cancelCount: 1)
+    }
+}
+
 class _BaseScheduledCallbackTests: XCTestCase {
     // EL-specific test requirements.
     var requirements: (any ScheduledCallbackTestRequirements)! = nil


### PR DESCRIPTION
Motivation:

The schedule callback mechanism on `EventLoop` has an equivalent on an isolated `EventLoop`. The default isolated implementation puts the hander in a loop bound box and calls the non-isolated version.

This is okay but introduces a number of additional "in event loop" checks which are required for correctness in the general case (i.e. not called from an isolated event loop).

Modifications:

- Implement the customisation point directly to avoid the additional checks (the are unecessary by definition of being on the isolated event loop).
- Add benchmarks

Result:

On the isolated event loop, in micro benchmarks:
- scheduleTask is ~1.6x faster
- scheduleCallback is ~2x faster