### PR TITLE
[Windows] Skip unsupported/flaky tests and run the Windows unit tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ jobs:
       linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_3_enabled: true
+      windows_nightly_next_enabled: true
+      windows_nightly_main_enabled: true
 
   cxx-interop:
     name: Cxx interop
@@ -89,37 +92,6 @@ jobs:
       watchos_xcode_test_enabled: true
       tvos_xcode_test_enabled: true
       visionos_xcode_test_enabled: true
-
-  construct-windows-build-matrix:
-    name: Construct Windows build matrix
-    runs-on: ubuntu-latest
-    outputs:
-      windows-build-matrix: '${{ steps.generate-matrix.outputs.windows-build-matrix }}'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-      - id: generate-matrix
-        run: echo "windows-build-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
-        env:
-          MATRIX_LINUX_6_0_ENABLED: false
-          MATRIX_LINUX_6_1_ENABLED: false
-          MATRIX_LINUX_6_2_ENABLED: false
-          MATRIX_LINUX_6_3_ENABLED: false
-          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: false
-          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
-          MATRIX_WINDOWS_6_3_ENABLED: true
-          MATRIX_WINDOWS_COMMAND: "swift build --build-tests"
-
-  windows-build:
-    name: Windows build (currently-supported targets)
-    needs: construct-windows-build-matrix
-    # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
-    with:
-      name: "Windows build (currently-supported targets)"
-      matrix_string: '${{ needs.construct-windows-build-matrix.outputs.windows-build-matrix }}'
 
   release-builds:
     name: Release builds

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,9 @@ jobs:
       linux_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
       linux_env_vars: '{"SWIFTNIO_RUN_SLOW_TESTS": "1", "SWIFTNIO_CI": "1"}'
+      windows_6_3_enabled: true
+      windows_nightly_next_enabled: true
+      windows_nightly_main_enabled: true
 
   benchmarks:
     name: Benchmarks
@@ -65,37 +68,6 @@ jobs:
     with:
       name: "Integration tests"
       matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
-
-  construct-windows-build-matrix:
-    name: Construct Windows build matrix
-    runs-on: ubuntu-latest
-    outputs:
-      windows-build-matrix: '${{ steps.generate-matrix.outputs.windows-build-matrix }}'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-      - id: generate-matrix
-        run: echo "windows-build-matrix=$(curl -s --retry 3 https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
-        env:
-          MATRIX_LINUX_6_0_ENABLED: false
-          MATRIX_LINUX_6_1_ENABLED: false
-          MATRIX_LINUX_6_2_ENABLED: false
-          MATRIX_LINUX_6_3_ENABLED: false
-          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: false
-          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
-          MATRIX_WINDOWS_6_3_ENABLED: true
-          MATRIX_WINDOWS_COMMAND: "swift build --build-tests"
-
-  windows-build:
-    name: Windows build (currently-supported targets)
-    needs: construct-windows-build-matrix
-    # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
-    with:
-      name: "Windows build (currently-supported targets)"
-      matrix_string: '${{ needs.construct-windows-build-matrix.outputs.windows-build-matrix }}'
 
   vsock-tests:
     name: Vsock tests

--- a/Tests/NIOCoreTests/UtilitiesTest.swift
+++ b/Tests/NIOCoreTests/UtilitiesTest.swift
@@ -57,6 +57,13 @@ class UtilitiesTest: XCTestCase {
     }
 
     func testEnumeratingDevices() throws {
+        #if os(Windows)
+        // `System.enumerateDevices()` currently crashes on Windows: its
+        // `GetAdaptersAddresses`-based implementation mis-sizes its buffer (see
+        // `Sources/NIOCore/Utilities.swift`), so this test is skipped there
+        // pending a fix to the underlying enumeration.
+        throw XCTSkip("System.enumerateDevices() currently crashes on Windows")
+        #endif
         // This is a tricky test, because we can't really assert much and expect this
         // to pass on all systems. The best we can do is assume there is a loopback:
         // maybe an IPv4 one, maybe an IPv6 one, but there will be one. We look for

--- a/Tests/NIOFSFoundationCompatTests/FileSystemFoundationCompatTests.swift
+++ b/Tests/NIOFSFoundationCompatTests/FileSystemFoundationCompatTests.swift
@@ -49,6 +49,12 @@ extension FileSystem {
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class FileSystemBytesConformanceTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func testTimepecToDate() async throws {
         XCTAssertEqual(
             FileInfo.Timespec(seconds: 0, nanoseconds: 0).date,

--- a/Tests/NIOFSIntegrationTests/BufferedReaderTests.swift
+++ b/Tests/NIOFSIntegrationTests/BufferedReaderTests.swift
@@ -18,6 +18,12 @@ import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class BufferedReaderTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func testBufferedReaderSizeAndCapacity() async throws {
         let fs = FileSystem.shared
         try await fs.withFileHandle(forReadingAt: #filePath) { handle in

--- a/Tests/NIOFSIntegrationTests/BufferedWriterTests.swift
+++ b/Tests/NIOFSIntegrationTests/BufferedWriterTests.swift
@@ -18,6 +18,12 @@ import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class BufferedWriterTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func testBufferedWriter() async throws {
         let fs = FileSystem.shared
         let path = try await fs.temporaryFilePath()

--- a/Tests/NIOFSIntegrationTests/ConvenienceTests.swift
+++ b/Tests/NIOFSIntegrationTests/ConvenienceTests.swift
@@ -18,6 +18,12 @@ import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class ConvenienceTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     static let fs = FileSystem.shared
 
     func testWriteStringToFile() async throws {

--- a/Tests/NIOFSIntegrationTests/FileHandleTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileHandleTests.swift
@@ -20,6 +20,12 @@ import XCTest
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 final class FileHandleTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     static let thisFile = FilePath(#filePath)
     static let testData = FilePath(#filePath)
         .removingLastComponent()  // FileHandleTests.swift

--- a/Tests/NIOFSIntegrationTests/FileSystemTests.swift
+++ b/Tests/NIOFSIntegrationTests/FileSystemTests.swift
@@ -62,6 +62,12 @@ extension FileSystem {
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class FileSystemTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     var fs: FileSystem { .shared }
 
     func testOpenFileForReading() async throws {

--- a/Tests/NIOFSTests/ByteCountTests.swift
+++ b/Tests/NIOFSTests/ByteCountTests.swift
@@ -16,6 +16,12 @@ import NIOFS
 import XCTest
 
 class ByteCountTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func testByteCountBytes() {
         let byteCount = ByteCount.bytes(10)
         XCTAssertEqual(byteCount.bytes, 10)

--- a/Tests/NIOFSTests/DirectoryEntriesTests.swift
+++ b/Tests/NIOFSTests/DirectoryEntriesTests.swift
@@ -17,6 +17,12 @@ import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class DirectoryEntriesTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func testDirectoryEntriesWrapsAsyncStream() async throws {
         let stream = AsyncThrowingStream<[DirectoryEntry], Error> {
             $0.yield([DirectoryEntry(path: "foo", type: .regular)!])

--- a/Tests/NIOFSTests/FileChunksTests.swift
+++ b/Tests/NIOFSTests/FileChunksTests.swift
@@ -18,6 +18,12 @@ import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class FileChunksTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func testFileChunksWrapsAsyncStream() async throws {
         let stream = AsyncThrowingStream<ByteBuffer, Error> {
             $0.yield(ByteBuffer(bytes: [0, 1, 2]))

--- a/Tests/NIOFSTests/FileHandleTests.swift
+++ b/Tests/NIOFSTests/FileHandleTests.swift
@@ -19,6 +19,12 @@ import XCTest
 #if ENABLE_MOCKING
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal final class FileHandleTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     private func withHandleForMocking(
         path: FilePath = "/probably/does/not/exist",
         _ execute: (SystemFileHandle, MockingDriver) throws -> Void

--- a/Tests/NIOFSTests/FileInfoTests.swift
+++ b/Tests/NIOFSTests/FileInfoTests.swift
@@ -37,6 +37,12 @@ private let S_IFREG = Musl.S_IFREG
 // that constructs a `BY_HANDLE_FILE_INFORMATION` is a follow-up.
 #if !os(Windows)
 final class FileInfoTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     private var status: CInterop.Stat {
         var status = CInterop.Stat()
         status.st_dev = 1

--- a/Tests/NIOFSTests/FileOpenOptionsTests.swift
+++ b/Tests/NIOFSTests/FileOpenOptionsTests.swift
@@ -16,6 +16,12 @@
 import XCTest
 
 final class FileOpenOptionsTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     private let expectedDefaults: FilePermissions = [
         .ownerReadWrite,
         .groupRead,

--- a/Tests/NIOFSTests/FilePathTests.swift
+++ b/Tests/NIOFSTests/FilePathTests.swift
@@ -21,6 +21,12 @@ import System
 #endif
 
 final class FilePathTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     /// Tests that the conversion of a SystemPackage.FilePath instance to a NIOFilePath instance (and vice-versa) results in the same underlying object.
     func testConversion() {
         // Create a NIOFilePath and SystemPackage.FilePath instance, both pointing to "/foo/bar/../baz"

--- a/Tests/NIOFSTests/FileSystemErrorTests.swift
+++ b/Tests/NIOFSTests/FileSystemErrorTests.swift
@@ -16,6 +16,12 @@
 import XCTest
 
 final class FileSystemErrorTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func testFileSystemErrorCustomStringConvertible() throws {
         var error = FileSystemError(
             code: .unsupported,

--- a/Tests/NIOFSTests/FileTypeTests.swift
+++ b/Tests/NIOFSTests/FileTypeTests.swift
@@ -24,6 +24,12 @@ import Android
 #endif
 
 final class FileTypeTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func testFileTypeEquatable() {
         let types = FileType.allCases
         // Use indices to avoid using the `Equatable` conformance to write the tests.

--- a/Tests/NIOFSTests/Internal/CancellationTests.swift
+++ b/Tests/NIOFSTests/Internal/CancellationTests.swift
@@ -18,6 +18,12 @@ import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class CancellationTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func testWithoutCancellation() async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.cancelAll()

--- a/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
+++ b/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift
@@ -18,6 +18,12 @@ import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class BufferedStreamTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     // MARK: - sequenceDeinitialized
 
     func testSequenceDeinitialized_whenNoIterator() async throws {

--- a/Tests/NIOFSTests/Internal/SyscallTests.swift
+++ b/Tests/NIOFSTests/Internal/SyscallTests.swift
@@ -19,6 +19,12 @@ import XCTest
 
 #if ENABLE_MOCKING
 final class SyscallTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("The NIOFileSystem family is not yet functional on Windows")
+        #endif
+    }
+
     func test_openat() throws {
         // Asserts POSIX `oflag` bit values; the Windows `OpenOptions` bits are
         // placeholders, so this doesn't apply as written.

--- a/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift
@@ -320,6 +320,9 @@ class HTTPServerClientTest: XCTestCase {
     }
 
     func testSimpleGetFileRegion() throws {
+        #if os(Windows)
+        throw XCTSkip("Sending a FileRegion over a socket is not yet supported on Windows")
+        #endif
         try testSimpleGet(.fileRegion)
     }
 
@@ -441,6 +444,9 @@ class HTTPServerClientTest: XCTestCase {
     }
 
     func testSimpleGetChunkedEncodingFileRegion() throws {
+        #if os(Windows)
+        throw XCTSkip("Sending a FileRegion over a socket is not yet supported on Windows")
+        #endif
         try testSimpleGetChunkedEncoding(.fileRegion)
     }
 
@@ -514,6 +520,9 @@ class HTTPServerClientTest: XCTestCase {
     }
 
     func testSimpleGetTrailersFileRegion() throws {
+        #if os(Windows)
+        throw XCTSkip("Sending a FileRegion over a socket is not yet supported on Windows")
+        #endif
         try testSimpleGetTrailers(.fileRegion)
     }
 
@@ -653,6 +662,9 @@ class HTTPServerClientTest: XCTestCase {
     }
 
     func testMassiveResponseFileRegion() throws {
+        #if os(Windows)
+        throw XCTSkip("Sending a FileRegion over a socket is not yet supported on Windows")
+        #endif
         try testMassiveResponse(.fileRegion)
     }
 

--- a/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
+++ b/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift
@@ -2367,6 +2367,9 @@ final class TypedHTTPServerUpgradeTestCase: HTTPServerUpgradeTestCase {
 
     /// Test that send a request and closing immediately performs a successful upgrade
     func testSendRequestCloseImmediately() throws {
+        #if os(Windows)
+        throw XCTSkip("Half-closing the connection immediately races the upgrade and is unreliable on Windows")
+        #endif
         let upgradePerformed = UnsafeMutableTransferBox<Bool>(false)
 
         let upgrader = SuccessfulUpgrader(forProtocol: "myproto", requiringHeaders: ["kafkaesque"]) { _ in

--- a/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
+++ b/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift
@@ -671,6 +671,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     // MARK: Datagram Bootstrap
 
     func testDatagramBootstrap_withAsyncChannel_andHostPort() async throws {
+        #if os(Windows)
+        throw XCTSkip("Datagram channels are not yet functional on Windows")
+        #endif
         let eventLoopGroup = self.group!
 
         let serverChannel = try await self.makeUDPServerChannel(eventLoopGroup: eventLoopGroup)
@@ -693,6 +696,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     }
 
     func testDatagramBootstrap_withProtocolNegotiation_andHostPort() async throws {
+        #if os(Windows)
+        throw XCTSkip("Datagram channels are not yet functional on Windows")
+        #endif
         let eventLoopGroup = self.group!
 
         // We are creating a channel here to get a random port from the system
@@ -775,6 +781,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     // MARK: - Pipe Bootstrap
 
     func testPipeBootstrap() async throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         let eventLoopGroup = self.group!
         let (pipe1ReadFD, pipe1WriteFD, pipe2ReadFD, pipe2WriteFD) = self.makePipeFileDescriptors()
         let channel: NIOAsyncChannel<ByteBuffer, ByteBuffer>
@@ -848,6 +857,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     }
 
     func testPipeBootstrap_whenInputNil() async throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         let eventLoopGroup = self.group!
         let (pipe1ReadFD, pipe1WriteFD) = self.makePipeFileDescriptors()
         let channel: NIOAsyncChannel<ByteBuffer, ByteBuffer>
@@ -900,6 +912,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     }
 
     func testPipeBootstrap_whenOutputNil() async throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         let eventLoopGroup = self.group!
         let (pipe1ReadFD, pipe1WriteFD) = self.makePipeFileDescriptors()
         let channel: NIOAsyncChannel<ByteBuffer, ByteBuffer>
@@ -954,6 +969,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     }
 
     func testPipeBootstrap_withProtocolNegotiation() async throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         let eventLoopGroup = self.group!
         let (pipe1ReadFD, pipe1WriteFD, pipe2ReadFD, pipe2WriteFD) = self.makePipeFileDescriptors()
         let negotiationResult: EventLoopFuture<NegotiationResult>
@@ -1042,6 +1060,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     }
 
     func testPipeBootstrap_callsChannelInitializer() async throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         let eventLoopGroup = self.group!
         let (pipe1ReadFD, pipe1WriteFD, pipe2ReadFD, pipe2WriteFD) = self.makePipeFileDescriptors()
         let channel: NIOAsyncChannel<ByteBuffer, ByteBuffer>
@@ -1130,6 +1151,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     }
 
     func testPipeBootstrap_whenInputNil_callsChannelInitializer() async throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         let eventLoopGroup = self.group!
         let (pipe1ReadFD, pipe1WriteFD) = self.makePipeFileDescriptors()
         let channel: NIOAsyncChannel<ByteBuffer, ByteBuffer>
@@ -1193,6 +1217,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     }
 
     func testPipeBootstrap_whenOutputNil_callsChannelInitializer() async throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         let eventLoopGroup = self.group!
         let (pipe1ReadFD, pipe1WriteFD) = self.makePipeFileDescriptors()
         let channel: NIOAsyncChannel<ByteBuffer, ByteBuffer>
@@ -1260,6 +1287,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     // MARK: RawSocket bootstrap
 
     func testRawSocketBootstrap() async throws {
+        #if os(Windows)
+        throw XCTSkip("Raw sockets are not yet supported on Windows")
+        #endif
         try XCTSkipIfUserHasNotEnoughRightsForRawSocketAPI()
         let eventLoopGroup = self.group!
 
@@ -1281,6 +1311,9 @@ final class AsyncChannelBootstrapTests: XCTestCase {
     }
 
     func testRawSocketBootstrap_withProtocolNegotiation() async throws {
+        #if os(Windows)
+        throw XCTSkip("Raw sockets are not yet supported on Windows")
+        #endif
         try XCTSkipIfUserHasNotEnoughRightsForRawSocketAPI()
         let eventLoopGroup = self.group!
 

--- a/Tests/NIOPosixTests/BootstrapTest.swift
+++ b/Tests/NIOPosixTests/BootstrapTest.swift
@@ -178,6 +178,9 @@ class BootstrapTest: XCTestCase {
     }
 
     func testUDPBootstrapToleratesFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
+        #if os(Windows)
+        throw XCTSkip("Datagram channels are not yet functional on Windows")
+        #endif
         XCTAssertNoThrow(
             try DatagramBootstrap(group: Self.freshEventLoop(self.state))
                 .channelInitializer { [state] channel in
@@ -194,6 +197,9 @@ class BootstrapTest: XCTestCase {
     #if !os(Windows)
     // Uses Posix.socketpair / socklen_t / CInt socket handles, unavailable on Windows.
     func testPreConnectedClientSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
+        #if os(Windows)
+        throw XCTSkip("Bootstrapping from a pre-connected socket is not yet supported on Windows")
+        #endif
         var socketFDs: [CInt] = [-1, -1]
         XCTAssertNoThrow(
             try Posix.socketpair(
@@ -222,6 +228,9 @@ class BootstrapTest: XCTestCase {
     }
 
     func testPreConnectedServerSocketToleratesFuturesFromDifferentEventLoopsReturnedInInitializers() throws {
+        #if os(Windows)
+        throw XCTSkip("Bootstrapping from a pre-connected socket is not yet supported on Windows")
+        #endif
         let socket =
             try NIOBSDSocket.socket(domain: .inet, type: .stream, protocolSubtype: .default)
 
@@ -422,7 +431,10 @@ class BootstrapTest: XCTestCase {
         #endif
     }
 
-    func testDatagramBootstrapSetsChannelOptionsBeforeChannelInitializer() {
+    func testDatagramBootstrapSetsChannelOptionsBeforeChannelInitializer() throws {
+        #if os(Windows)
+        throw XCTSkip("Datagram channels are not yet functional on Windows")
+        #endif
         var channel: Channel? = nil
         XCTAssertNoThrow(
             channel = try DatagramBootstrap(group: self.group)
@@ -443,7 +455,10 @@ class BootstrapTest: XCTestCase {
         XCTAssertNoThrow(try channel?.close().wait())
     }
 
-    func testPipeBootstrapSetsChannelOptionsBeforeChannelInitializer() {
+    func testPipeBootstrapSetsChannelOptionsBeforeChannelInitializer() throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         XCTAssertNoThrow(
             try withPipe { inPipe, outPipe in
                 var maybeInFD: CInt? = nil
@@ -722,7 +737,10 @@ class BootstrapTest: XCTestCase {
         )
     }
 
-    func testClientBindWorksOnSocketsBoundToEitherIPv4OrIPv6Only() {
+    func testClientBindWorksOnSocketsBoundToEitherIPv4OrIPv6Only() throws {
+        #if os(Windows)
+        throw XCTSkip("Binding a client socket to an IPv4/IPv6 address crashes on Windows")
+        #endif
         for isIPv4 in [true, false] {
             guard System.supportsIPv6 || isIPv4 else {
                 continue  // need to skip IPv6 tests if we don't support it.
@@ -810,7 +828,10 @@ class BootstrapTest: XCTestCase {
     // There was a bug where file handle ownership was not released when creating pipe channels failed.
     #if !os(Windows)
     // Uses raw socket()/Posix.socketpair with CInt handles, unavailable on Windows.
-    func testReleaseFileHandleOnOwningFailure() {
+    func testReleaseFileHandleOnOwningFailure() throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         struct NIOPipeBootstrapHooksChannelFail: NIOPipeBootstrapHooks {
             func makePipeChannel(
                 eventLoop: NIOPosix.SelectableEventLoop,
@@ -879,24 +900,36 @@ class BootstrapTest: XCTestCase {
     }
 
     func testNoDoubleAddOnPipeBootstrapTakingOwnership_inputOutput() throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
             $0.takingOwnershipOfDescriptor(inputOutput: $1)
         }
     }
 
     func testNoDoubleAddOnPipeBootstrapTakingOwnership_input() throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
             $0.takingOwnershipOfDescriptor(input: $1)
         }
     }
 
     func testNoDoubleAddOnPipeBootstrapTakingOwnership_output() throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
             $0.takingOwnershipOfDescriptor(output: $1)
         }
     }
 
     func testNoDoubleAddOnPipeBootstrapTakingOwnership_inputOutputSeparate() throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
         try self.doTestNoDoubleAddOnPipeBootstrapTakingOwnership {
             $0.takingOwnershipOfDescriptors(input: $1, output: dup($1))
         }

--- a/Tests/NIOPosixTests/ChannelTests.swift
+++ b/Tests/NIOPosixTests/ChannelTests.swift
@@ -78,6 +78,12 @@ class ChannelLifecycleHandler: ChannelInboundHandler {
 }
 
 final class ChannelTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("ChannelTests exercise socket channel behaviour that is not yet functional on Windows")
+        #endif
+    }
+
     func testBasicLifecycle() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let loop = group.next()

--- a/Tests/NIOPosixTests/DatagramChannelTests.swift
+++ b/Tests/NIOPosixTests/DatagramChannelTests.swift
@@ -143,6 +143,12 @@ final class DatagramReadRecorder<DataType: Sendable>: ChannelInboundHandler {
 }
 
 class DatagramChannelTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("Datagram channels are not yet functional on Windows")
+        #endif
+    }
+
     private var group: MultiThreadedEventLoopGroup! = nil
     private var firstChannel: Channel! = nil
     private var secondChannel: Channel! = nil

--- a/Tests/NIOPosixTests/EchoServerClientTest.swift
+++ b/Tests/NIOPosixTests/EchoServerClientTest.swift
@@ -22,7 +22,7 @@ import XCTest
 class EchoServerClientTest: XCTestCase {
     override func setUpWithError() throws {
         #if os(Windows)
-        // Several of these socket echo integration tests hang or crash on
+        // Several of these socket echo integration tests stall or crash on
         // Windows (Unix domain sockets, dual-stack IPv4/IPv6 binds, and others),
         // so the whole suite is skipped there pending functional networking.
         throw XCTSkip("EchoServerClientTest exercises socket behaviour that is not yet functional on Windows")

--- a/Tests/NIOPosixTests/EchoServerClientTest.swift
+++ b/Tests/NIOPosixTests/EchoServerClientTest.swift
@@ -20,6 +20,15 @@ import XCTest
 @testable import NIOPosix
 
 class EchoServerClientTest: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        // Several of these socket echo integration tests hang or crash on
+        // Windows (Unix domain sockets, dual-stack IPv4/IPv6 binds, and others),
+        // so the whole suite is skipped there pending functional networking.
+        throw XCTSkip("EchoServerClientTest exercises socket behaviour that is not yet functional on Windows")
+        #endif
+    }
+
     func testEcho() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {

--- a/Tests/NIOPosixTests/EventLoopMetricsDelegateTests.swift
+++ b/Tests/NIOPosixTests/EventLoopMetricsDelegateTests.swift
@@ -34,6 +34,15 @@ final class RecorderDelegate: NIOEventLoopMetricsDelegate, Sendable {
 }
 
 final class EventLoopMetricsDelegateTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        // These tests assert on event-loop tick counts, but the WSAPoll selector
+        // wakes far more often than epoll/kqueue, so the counts are unreliable
+        // (and flaky) on Windows.
+        throw XCTSkip("Event-loop tick-count metrics are unreliable on the WSAPoll selector")
+        #endif
+    }
+
     func testMetricsDelegateNotCalledWhenNoEvents() throws {
         let delegate = RecorderDelegate()
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1, metricsDelegate: delegate)
@@ -41,7 +50,7 @@ final class EventLoopMetricsDelegateTests: XCTestCase {
         try group.syncShutdownGracefully()
     }
 
-    func testMetricsDelegateTickInfo() {
+    func testMetricsDelegateTickInfo() throws {
         let delegate = RecorderDelegate()
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1, metricsDelegate: delegate)
         defer {

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -559,7 +559,15 @@ final class MultiThreadedEventLoopGroupTests {
         try group.syncShutdownGracefully()
     }
 
-    @Test
+    @Test(
+        .disabled("Registering an invalid fd traps in the WSAPoll selector on Windows") {
+            #if os(Windows)
+            return true
+            #else
+            return false
+            #endif
+        }
+    )
     func testShuttingDownFailsRegistration() throws {
         // This test catches a regression where the selectable event loop would allow a socket registration while
         // it was nominally "shutting down". To do this, we take advantage of the fact that the event loop attempts
@@ -2272,7 +2280,15 @@ final class MultiThreadedEventLoopGroupTests {
         }
     }
 
-    @Test
+    @Test(
+        .disabled("The WSAPoll selector has no epoll-style descriptor, so its debugDescription differs on Windows") {
+            #if os(Windows)
+            return true
+            #else
+            return false
+            #endif
+        }
+    )
     func testStructuredConcurrencyMTELGStartStop() async throws {
         let loops = try await MultiThreadedEventLoopGroup.withEventLoopGroup(
             numberOfThreads: 3

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -559,15 +559,7 @@ final class MultiThreadedEventLoopGroupTests {
         try group.syncShutdownGracefully()
     }
 
-    @Test(
-        .disabled("Registering an invalid fd traps in the WSAPoll selector on Windows") {
-            #if os(Windows)
-            return true
-            #else
-            return false
-            #endif
-        }
-    )
+    @Test(.disabled(if: System.isWindows, "Registering an invalid fd traps in the WSAPoll selector on Windows"))
     func testShuttingDownFailsRegistration() throws {
         // This test catches a regression where the selectable event loop would allow a socket registration while
         // it was nominally "shutting down". To do this, we take advantage of the fact that the event loop attempts
@@ -1626,13 +1618,10 @@ final class MultiThreadedEventLoopGroupTests {
     // Takes over the current thread as an event loop, which relies on the
     // concurrency-takeover machinery that is unsupported on Windows.
     @Test(
-        .disabled("Taking over the current thread as an event loop is not supported on Windows") {
-            #if os(Windows)
-            return true
-            #else
-            return false
-            #endif
-        }
+        .disabled(
+            if: System.isWindows,
+            "Taking over the current thread as an event loop is not supported on Windows"
+        )
     )
     func testWeCanDoTrulySingleThreadedNetworking() {
         final class SaveReceivedByte: ChannelInboundHandler {
@@ -2281,13 +2270,10 @@ final class MultiThreadedEventLoopGroupTests {
     }
 
     @Test(
-        .disabled("The WSAPoll selector has no epoll-style descriptor, so its debugDescription differs on Windows") {
-            #if os(Windows)
-            return true
-            #else
-            return false
-            #endif
-        }
+        .disabled(
+            if: System.isWindows,
+            "The WSAPoll selector has no epoll-style descriptor, so its debugDescription differs on Windows"
+        )
     )
     func testStructuredConcurrencyMTELGStartStop() async throws {
         let loops = try await MultiThreadedEventLoopGroup.withEventLoopGroup(

--- a/Tests/NIOPosixTests/FileRegionTest.swift
+++ b/Tests/NIOPosixTests/FileRegionTest.swift
@@ -18,6 +18,11 @@ import XCTest
 @testable import NIOPosix
 
 class FileRegionTest: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("Sending FileRegions over a socket is not yet supported on Windows")
+        #endif
+    }
 
     func testWriteFileRegion() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Tests/NIOPosixTests/NIOTransportAccessibleChannelCoreTests.swift
+++ b/Tests/NIOPosixTests/NIOTransportAccessibleChannelCoreTests.swift
@@ -90,7 +90,16 @@ private let STDOUT_FILENO: CInt = 1
     }
 
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    @Test func testUnderlyingTransportConformanceForExpectedChannels() throws {
+    @Test(
+        .disabled("NIOPipeBootstrap is not supported on Windows") {
+            #if os(Windows)
+            return true
+            #else
+            return false
+            #endif
+        }
+    )
+    func testUnderlyingTransportConformanceForExpectedChannels() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { #expect(throws: Never.self) { try group.syncShutdownGracefully() } }
 

--- a/Tests/NIOPosixTests/NIOTransportAccessibleChannelCoreTests.swift
+++ b/Tests/NIOPosixTests/NIOTransportAccessibleChannelCoreTests.swift
@@ -90,15 +90,7 @@ private let STDOUT_FILENO: CInt = 1
     }
 
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    @Test(
-        .disabled("NIOPipeBootstrap is not supported on Windows") {
-            #if os(Windows)
-            return true
-            #else
-            return false
-            #endif
-        }
-    )
+    @Test(.disabled(if: System.isWindows, "NIOPipeBootstrap is not supported on Windows"))
     func testUnderlyingTransportConformanceForExpectedChannels() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { #expect(throws: Never.self) { try group.syncShutdownGracefully() } }

--- a/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
+++ b/Tests/NIOPosixTests/NonBlockingFileIOTest.swift
@@ -472,6 +472,9 @@ class NonBlockingFileIOTest: XCTestCase {
     }
 
     func testFileRegionReadFromPipeFails() throws {
+        #if os(Windows)
+        throw XCTSkip("Pipes are not supported on Windows")
+        #endif
         try withPipe { readFH, writeFH in
             try! writeFH.withUnsafeFileDescriptor { writeFD in
                 _ = try! Posix.write(descriptor: writeFD, pointer: "ABC", size: 3)
@@ -744,6 +747,9 @@ class NonBlockingFileIOTest: XCTestCase {
     }
 
     func testFileOpenFails() throws {
+        #if os(Windows)
+        throw XCTSkip("Opening a nonexistent file reports a different errno on Windows")
+        #endif
         do {
             try self.fileIO.openFile(
                 _deprecatedPath: "/dev/null/this/does/not/exist",
@@ -1685,6 +1691,9 @@ extension NonBlockingFileIOTest {
     }
 
     func testAsyncFileOpenFails() async throws {
+        #if os(Windows)
+        throw XCTSkip("Opening a nonexistent file reports a different errno on Windows")
+        #endif
         do {
             _ = try await self.fileIO.withFileRegion(_deprecatedPath: "/dev/null/this/does/not/exist") { _ in }
             XCTFail("should've thrown")

--- a/Tests/NIOPosixTests/PipeChannelTest.swift
+++ b/Tests/NIOPosixTests/PipeChannelTest.swift
@@ -20,6 +20,12 @@ import XCTest
 @testable import NIOPosix
 
 final class PipeChannelTest: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("Pipe channels are not supported on Windows")
+        #endif
+    }
+
     var group: MultiThreadedEventLoopGroup! = nil
     var channel: Channel! = nil
     var toChannel: FileHandle! = nil
@@ -31,6 +37,11 @@ final class PipeChannelTest: XCTestCase {
     }
 
     override func setUp() {
+        #if os(Windows)
+        // Pipe channels are unsupported on Windows (see `setUpWithError`); avoid
+        // running the pipe setup, which would trap, before the tests are skipped.
+        return
+        #else
         self.group = .init(numberOfThreads: 1)
 
         XCTAssertNoThrow(
@@ -61,9 +72,13 @@ final class PipeChannelTest: XCTestCase {
             }
         )
         self.buffer = self.channel.allocator.buffer(capacity: 128)
+        #endif
     }
 
     override func tearDown() {
+        #if os(Windows)
+        return
+        #else
         self.buffer = nil
         self.toChannel.closeFile()
         self.fromChannel.closeFile()
@@ -71,6 +86,7 @@ final class PipeChannelTest: XCTestCase {
         self.fromChannel = nil
         XCTAssertNoThrow(try self.channel.syncCloseAcceptingAlreadyClosed())
         XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+        #endif
     }
 
     func testBasicIO() throws {

--- a/Tests/NIOPosixTests/RawSocketBootstrapTests.swift
+++ b/Tests/NIOPosixTests/RawSocketBootstrapTests.swift
@@ -41,6 +41,12 @@ func XCTSkipIfUserHasNotEnoughRightsForRawSocketAPI(file: StaticString = #filePa
 }
 
 final class RawSocketBootstrapTests: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("Raw sockets are not yet supported on Windows")
+        #endif
+    }
+
     func testBindWithRecevMmsg() throws {
         try XCTSkipIfUserHasNotEnoughRightsForRawSocketAPI()
 

--- a/Tests/NIOPosixTests/SelectorTest.swift
+++ b/Tests/NIOPosixTests/SelectorTest.swift
@@ -126,6 +126,9 @@ class SelectorTest: XCTestCase {
 
     private static let testWeDoNotDeliverEventsForPreviouslyClosedChannels_numberOfChannelsToUse = 10
     func testWeDoNotDeliverEventsForPreviouslyClosedChannels() throws {
+        #if os(Windows)
+        throw XCTSkip("Reconnecting channels are not reliably re-registered with the selector on Windows")
+        #endif
         enum DidNotReadError: Error {
             case didNotReadGotInactive
             case didNotReadGotReadComplete

--- a/Tests/NIOPosixTests/SocketChannelTest.swift
+++ b/Tests/NIOPosixTests/SocketChannelTest.swift
@@ -1033,6 +1033,9 @@ final class SocketChannelTest: XCTestCase {
     }
 
     func testServerClosesTheConnectionImmediately() throws {
+        #if os(Windows)
+        throw XCTSkip("Connection-reset handling is unreliable on Windows and can leak a promise")
+        #endif
         // This is a regression test for a problem that the grpc-swift compatibility tests hit where everything would
         // get stuck on a server that just insta-closes every accepted connection.
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Tests/NIOPosixTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOPosixTests/SocketOptionProviderTest.swift
@@ -22,6 +22,12 @@ import WinSDK
 #endif
 
 final class SocketOptionProviderTest: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("setUp relies on System.enumerateDevices(), which crashes on Windows")
+        #endif
+    }
+
     var group: MultiThreadedEventLoopGroup!
     var serverChannel: Channel!
     var clientChannel: Channel!
@@ -74,6 +80,11 @@ final class SocketOptionProviderTest: XCTestCase {
     }
 
     override func setUp() {
+        #if os(Windows)
+        // This suite is skipped on Windows (see `setUpWithError`); avoid running
+        // the `enumerateDevices`-based setup, which would trap, beforehand.
+        return
+        #else
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.serverChannel = try? assertNoThrowWithValue(
             ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
@@ -121,14 +132,19 @@ final class SocketOptionProviderTest: XCTestCase {
                 ).map { channel }
             }.wait()
         }
+        #endif
     }
 
     override func tearDown() {
+        #if os(Windows)
+        return
+        #else
         XCTAssertNoThrow(try ipv6DatagramChannel?.close().wait())
         XCTAssertNoThrow(try ipv4DatagramChannel?.close().wait())
         XCTAssertNoThrow(try clientChannel.close().wait())
         XCTAssertNoThrow(try serverChannel.close().wait())
         XCTAssertNoThrow(try group.syncShutdownGracefully())
+        #endif
     }
 
     func testSettingAndGettingComplexSocketOption() throws {

--- a/Tests/NIOPosixTests/StreamChannelsTest.swift
+++ b/Tests/NIOPosixTests/StreamChannelsTest.swift
@@ -22,6 +22,12 @@ import XCTest
 @testable import NIOPosix
 
 class StreamChannelTest: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("These stream-channel tests crash on Windows")
+        #endif
+    }
+
     var buffer: ByteBuffer! = nil
 
     override func setUp() {

--- a/Tests/NIOPosixTests/StrictCrashTests.swift
+++ b/Tests/NIOPosixTests/StrictCrashTests.swift
@@ -26,7 +26,15 @@ import ucrt
 
 @Suite
 struct StrictCrashTests {
-    @Test
+    @Test(
+        .disabled("Scheduling after shutdown does not trap as expected on Windows") {
+            #if os(Windows)
+            return true
+            #else
+            return false
+            #endif
+        }
+    )
     func eventLoopScheduleAfterShutdown() async {
         let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
             func blockingFunctionsAllowedInCrashTest() {

--- a/Tests/NIOPosixTests/StrictCrashTests.swift
+++ b/Tests/NIOPosixTests/StrictCrashTests.swift
@@ -26,15 +26,7 @@ import ucrt
 
 @Suite
 struct StrictCrashTests {
-    @Test(
-        .disabled("Scheduling after shutdown does not trap as expected on Windows") {
-            #if os(Windows)
-            return true
-            #else
-            return false
-            #endif
-        }
-    )
+    @Test(.disabled(if: System.isWindows, "Scheduling after shutdown does not trap as expected on Windows"))
     func eventLoopScheduleAfterShutdown() async {
         let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
             func blockingFunctionsAllowedInCrashTest() {

--- a/Tests/NIOPosixTests/SystemCrashTests.swift
+++ b/Tests/NIOPosixTests/SystemCrashTests.swift
@@ -29,15 +29,7 @@ struct SystemCrashTests {
     // `NIOPipeBootstrap` deliberately `fatalError`s on Windows, so this test can
     // only exercise its `EBADF` handling on the POSIX platforms. It's compiled
     // everywhere exit tests are available but skipped at runtime on Windows.
-    @Test(
-        .disabled("NIOPipeBootstrap is not supported on Windows") {
-            #if os(Windows)
-            return true
-            #else
-            return false
-            #endif
-        }
-    )
+    @Test(.disabled(if: System.isWindows, "NIOPipeBootstrap is not supported on Windows"))
     func ebadfIsUnacceptable() async {
         let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
             func blockingFunctionsAllowedInCrashTest() {

--- a/Tests/NIOPosixTests/TestUtils.swift
+++ b/Tests/NIOPosixTests/TestUtils.swift
@@ -34,6 +34,14 @@ func usleep(_ microseconds: UInt32) -> CInt {
 #endif
 
 extension System {
+    static var isWindows: Bool {
+        #if os(Windows)
+        return true
+        #else
+        return false
+        #endif
+    }
+
     static var supportsIPv6: Bool {
         do {
             let ipv6Loopback = try SocketAddress.makeAddressResolvingHost("::1", port: 0)

--- a/Tests/NIOPosixTests/ThreadTest.swift
+++ b/Tests/NIOPosixTests/ThreadTest.swift
@@ -22,7 +22,7 @@ import XCTest
 class ThreadTest: XCTestCase {
     override func setUpWithError() throws {
         #if os(Windows)
-        throw XCTSkip("ThreadTest crashes or hangs on Windows")
+        throw XCTSkip("ThreadTest crashes or stalls on Windows")
         #endif
     }
 

--- a/Tests/NIOPosixTests/ThreadTest.swift
+++ b/Tests/NIOPosixTests/ThreadTest.swift
@@ -20,6 +20,12 @@ import XCTest
 @testable import NIOPosix
 
 class ThreadTest: XCTestCase {
+    override func setUpWithError() throws {
+        #if os(Windows)
+        throw XCTSkip("ThreadTest crashes or hangs on Windows")
+        #endif
+    }
+
     func testCurrentThreadWorks() {
         let s = DispatchSemaphore(value: 0)
         let thread = NIOLockedValueBox<NIOThread?>(nil)


### PR DESCRIPTION
### Motivation:

All of the test targets now compile on Windows (#3663, #3665), but `swift test` doesn't yet pass: a number of tests exercise functionality that isn't supported or isn't yet functional on Windows, some crash or hang, and a few are flaky on the WSAPoll-based selector. Before the Windows unit tests can run in CI, those tests need to be skipped (with reasons) so a full `swift test` exits cleanly.

### Modifications:

Skip the tests that don't pass on Windows, using `XCTSkip` / Swift Testing's `.disabled` / a gated `setUp` where a fixture itself traps, each with a reason. Broadly:

- **Unsupported transports/APIs:** Unix domain sockets, datagram/UDP channels, pipe channels, raw sockets, vsock, pre-connected sockets, and `FileRegion` sends.
- **Whole suites** for subsystems that aren't functional on Windows yet, including the **NIOFileSystem family** (`NIOFSTests`, `NIOFSIntegrationTests`, `NIOFSFoundationCompatTests`) whose Windows syscall shims are still stubbed, plus `EchoServerClientTest`, `ChannelTests`, `DatagramChannelTests`, `StreamChannelTest`, `FileRegionTest`, `PipeChannelTest`, `RawSocketBootstrapTests`, `ThreadTest`, and `SocketOptionProviderTest`.
- **Real crashes surfaced by a full run:** `System.enumerateDevices()` (mis-sized `GetAdaptersAddresses` buffer), the WSAPoll selector trapping on an invalid fd and on schedule-after-shutdown, and a connection-reset promise leak.
- **Flaky, timing-sensitive tests:** the event-loop tick-count metrics tests (the WSAPoll selector wakes far more often than epoll/kqueue).

Then enable the Windows 6.3 + nightly jobs in the reusable unit-tests workflow (which runs `swift test`) in both the PR and push workflows, and drop the separate build-only Windows job (which only ran `swift build --build-tests`).

Windows uses the default `swift test` arguments rather than the Linux `-Xswiftc -warnings-as-errors` override, because a `#warning` in the (skipped) stream-channel tests would otherwise fail the build.

All skips are Windows-only; there is no behaviour change on other platforms.

### Result:

`swift test` passes on Windows, and the Windows unit tests run in CI.
