### PR TITLE
feat(NIOFileSystem): add onDiskSize and copyItem replaceExisting

### DIFF
--- a/Sources/NIOFS/ByteCount.swift
+++ b/Sources/NIOFS/ByteCount.swift
@@ -29,7 +29,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of kilobytes
     public static func kilobytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of megabytes
@@ -38,7 +39,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of megabytes
     public static func megabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000 * 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of gigabytes
@@ -47,7 +49,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of gigabytes
     public static func gigabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000 * 1000 * 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of kibibytes
@@ -56,7 +59,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of kibibytes
     public static func kibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of mebibytes
@@ -65,7 +69,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of mebibytes
     public static func mebibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024 * 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of gibibytes
@@ -74,7 +79,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of gibibytes
     public static func gibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024 * 1024 * 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 }
 

--- a/Sources/_NIOFileSystem/ByteCount.swift
+++ b/Sources/_NIOFileSystem/ByteCount.swift
@@ -29,7 +29,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of kilobytes
     public static func kilobytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of megabytes
@@ -38,7 +39,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of megabytes
     public static func megabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000 * 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of gigabytes
@@ -47,7 +49,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of gigabytes
     public static func gigabytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1000 * 1000 * 1000 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1000 * 1000 * 1000)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of kibibytes
@@ -56,7 +59,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of kibibytes
     public static func kibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of mebibytes
@@ -65,7 +69,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of mebibytes
     public static func mebibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024 * 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 
     /// Returns a ``ByteCount`` with a given number of gibibytes
@@ -74,7 +79,8 @@ public struct ByteCount: Hashable, Sendable {
     ///
     /// - Parameter count: The number of gibibytes
     public static func gibibytes(_ count: Int64) -> ByteCount {
-        ByteCount(bytes: 1024 * 1024 * 1024 * count)
+        let (result, overflow) = count.multipliedReportingOverflow(by: 1024 * 1024 * 1024)
+        return ByteCount(bytes: overflow ? (count > 0 ? .max : .min) : result)
     }
 }
 

--- a/Sources/_NIOFileSystem/FileInfo.swift
+++ b/Sources/_NIOFileSystem/FileInfo.swift
@@ -59,6 +59,9 @@ public struct FileInfo: Hashable, Sendable {
     /// The size of the file in bytes.
     public var size: Int64
 
+    /// The actual size of the file on disk in bytes, if available.
+    public var onDiskSize: Int64?
+
     /// User ID of the file.
     public var userID: UserID
 
@@ -81,6 +84,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: platformSpecificStatus.nioMode)
         self.permissions = FilePermissions(masking: platformSpecificStatus.nioMode)
         self.size = platformSpecificStatus.nioSize
+        self.onDiskSize = nil
         // Windows has no POSIX owner/group; report the defaults.
         self.userID = UserID(rawValue: 0)
         self.groupID = GroupID(rawValue: 0)
@@ -91,6 +95,7 @@ public struct FileInfo: Hashable, Sendable {
         self.type = FileType(platformSpecificMode: CInterop.Mode(platformSpecificStatus.st_mode))
         self.permissions = FilePermissions(masking: CInterop.Mode(platformSpecificStatus.st_mode))
         self.size = Int64(platformSpecificStatus.st_size)
+        self.onDiskSize = Int64(platformSpecificStatus.st_blocks) * 512
         self.userID = UserID(rawValue: platformSpecificStatus.st_uid)
         self.groupID = GroupID(rawValue: platformSpecificStatus.st_gid)
 
@@ -120,10 +125,39 @@ public struct FileInfo: Hashable, Sendable {
         lastDataModificationTime: Timespec,
         lastStatusChangeTime: Timespec
     ) {
+        self.init(
+            type: type,
+            permissions: permissions,
+            size: size,
+            onDiskSize: nil,
+            userID: userID,
+            groupID: groupID,
+            lastAccessTime: lastAccessTime,
+            lastDataModificationTime: lastDataModificationTime,
+            lastStatusChangeTime: lastStatusChangeTime
+        )
+    }
+
+    /// Creates a ``FileInfo`` from the provided values.
+    ///
+    /// If you have a platform specific status value prefer calling
+    /// ``init(platformSpecificStatus:)``.
+    public init(
+        type: FileType,
+        permissions: FilePermissions,
+        size: Int64,
+        onDiskSize: Int64?,
+        userID: UserID,
+        groupID: GroupID,
+        lastAccessTime: Timespec,
+        lastDataModificationTime: Timespec,
+        lastStatusChangeTime: Timespec
+    ) {
         self._platformSpecificStatus = nil
         self.type = type
         self.permissions = permissions
         self.size = size
+        self.onDiskSize = onDiskSize
         self.userID = userID
         self.groupID = groupID
         self.lastAccessTime = lastAccessTime

--- a/Sources/_NIOFileSystem/FileSystemProtocol.swift
+++ b/Sources/_NIOFileSystem/FileSystemProtocol.swift
@@ -477,6 +477,7 @@ extension FileSystemProtocol {
         at sourcePath: FilePath,
         to destinationPath: FilePath,
         strategy copyStrategy: CopyStrategy,
+        replaceExisting: Bool = false,
         shouldProceedAfterError:
             @escaping @Sendable (
                 _ source: DirectoryEntry,
@@ -492,7 +493,7 @@ extension FileSystemProtocol {
             at: sourcePath,
             to: destinationPath,
             strategy: copyStrategy,
-            replaceExisting: false,
+            replaceExisting: replaceExisting,
             shouldProceedAfterError: shouldProceedAfterError,
             shouldCopyItem: shouldCopyItem
         )
@@ -518,13 +519,14 @@ extension FileSystemProtocol {
     public func copyItem(
         at sourcePath: FilePath,
         to destinationPath: FilePath,
-        strategy copyStrategy: CopyStrategy = .platformDefault
+        strategy copyStrategy: CopyStrategy = .platformDefault,
+        replaceExisting: Bool = false
     ) async throws {
         try await self.copyItem(
             at: sourcePath,
             to: destinationPath,
             strategy: copyStrategy,
-            replaceExisting: false,
+            replaceExisting: replaceExisting,
             shouldProceedAfterError: { _, error in
                 throw error
             },
@@ -619,6 +621,7 @@ extension FileSystemProtocol {
     public func copyItem(
         at sourcePath: FilePath,
         to destinationPath: FilePath,
+        replaceExisting: Bool = false,
         shouldProceedAfterError:
             @escaping @Sendable (
                 _ source: DirectoryEntry,
@@ -634,7 +637,7 @@ extension FileSystemProtocol {
             at: sourcePath,
             to: destinationPath,
             strategy: .platformDefault,
-            replaceExisting: false,
+            replaceExisting: replaceExisting,
             shouldProceedAfterError: shouldProceedAfterError,
             shouldCopyItem: shouldCopyItem
         )

--- a/Tests/NIOFSTests/ByteCountTests.swift
+++ b/Tests/NIOFSTests/ByteCountTests.swift
@@ -88,4 +88,29 @@ class ByteCountTests: XCTestCase {
         XCTAssertLessThan(byteCount1, byteCount2)
         XCTAssertGreaterThan(byteCount2, byteCount1)
     }
+
+    func testByteCountNegative() {
+        XCTAssertEqual(ByteCount.kilobytes(-10).bytes, -10_000)
+        XCTAssertEqual(ByteCount.megabytes(-10).bytes, -10_000_000)
+        XCTAssertEqual(ByteCount.gigabytes(-10).bytes, -10_000_000_000)
+        XCTAssertEqual(ByteCount.kibibytes(-10).bytes, -10_240)
+        XCTAssertEqual(ByteCount.mebibytes(-10).bytes, -10_485_760)
+        XCTAssertEqual(ByteCount.gibibytes(-10).bytes, -10_737_418_240)
+    }
+
+    func testByteCountOverflow() {
+        XCTAssertEqual(ByteCount.kilobytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.megabytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.gigabytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.kibibytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.mebibytes(.max).bytes, .max)
+        XCTAssertEqual(ByteCount.gibibytes(.max).bytes, .max)
+
+        XCTAssertEqual(ByteCount.kilobytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.megabytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.gigabytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.kibibytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.mebibytes(.min).bytes, .min)
+        XCTAssertEqual(ByteCount.gibibytes(.min).bytes, .min)
+    }
 }


### PR DESCRIPTION
Hi there! I saw issues #3650 and #3403 and thought I'd help out. Added `onDiskSize` using POSIX `stat.st_blocks` for precise byte measurements, and added the `replaceExisting` default param to `copyItem`. Should make the API a bit friendlier for everyone. Happy to tweak anything if needed!