### PR TITLE
[Windows] Fix buffer sizing in System.enumerateDevices()

### DIFF
--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -28,6 +28,7 @@ import ucrt
 import let WinSDK.RelationProcessorCore
 
 import let WinSDK.AF_UNSPEC
+import let WinSDK.ERROR_BUFFER_OVERFLOW
 import let WinSDK.ERROR_SUCCESS
 
 import func WinSDK.GetAdaptersAddresses
@@ -201,42 +202,53 @@ public enum System: Sendable {
         devices.reserveCapacity(12)  // Arbitrary choice.
 
         #if os(Windows)
-        var ulSize: ULONG = 0
-        _ = GetAdaptersAddresses(ULONG(AF_UNSPEC), 0, nil, nil, &ulSize)
+        // `GetAdaptersAddresses` writes a linked list of variably sized records into the
+        // caller's buffer, so the buffer must be sized in *bytes*, not in whole
+        // `IP_ADAPTER_ADDRESSES` records. 15KB is the initial allocation recommended by the
+        // documentation; if that is not enough (or if the adapter information grows between
+        // two calls) the call reports `ERROR_BUFFER_OVERFLOW` and updates `ulSize` with the
+        // size now required, so the enumeration is retried a small number of times.
+        var ulSize: ULONG = 15 * 1024
+        let ulBufferOverflow: ULONG = ULONG(ERROR_BUFFER_OVERFLOW)
+        var ulResult: ULONG = ulBufferOverflow
+        var attemptsRemaining: Int = 3
 
-        let stride: Int = MemoryLayout<IP_ADAPTER_ADDRESSES>.stride
-        let pBuffer: UnsafeMutableBufferPointer<IP_ADAPTER_ADDRESSES> =
-            UnsafeMutableBufferPointer.allocate(capacity: Int(ulSize) / stride)
-        defer {
-            pBuffer.deallocate()
+        while ulResult == ulBufferOverflow && attemptsRemaining > 0 {
+            attemptsRemaining -= 1
+
+            let pBuffer: UnsafeMutableRawPointer =
+                UnsafeMutableRawPointer.allocate(
+                    byteCount: Int(ulSize),
+                    alignment: MemoryLayout<IP_ADAPTER_ADDRESSES>.alignment
+                )
+            defer {
+                pBuffer.deallocate()
+            }
+
+            let pAdapters: UnsafeMutablePointer<IP_ADAPTER_ADDRESSES> =
+                pBuffer.bindMemory(to: IP_ADAPTER_ADDRESSES.self, capacity: 1)
+
+            ulResult = GetAdaptersAddresses(ULONG(AF_UNSPEC), 0, nil, pAdapters, &ulSize)
+            guard ulResult == ERROR_SUCCESS else {
+                continue
+            }
+
+            var pAdapter: UnsafeMutablePointer<IP_ADAPTER_ADDRESSES>? = pAdapters
+            while let adapter = pAdapter {
+                var pUnicastAddress: UnsafeMutablePointer<IP_ADAPTER_UNICAST_ADDRESS>? =
+                    adapter.pointee.FirstUnicastAddress
+                while let unicastAddress = pUnicastAddress {
+                    if let device = NIONetworkDevice(adapter, unicastAddress) {
+                        devices.append(device)
+                    }
+                    pUnicastAddress = unicastAddress.pointee.Next
+                }
+                pAdapter = adapter.pointee.Next
+            }
         }
 
-        let ulResult: ULONG =
-            GetAdaptersAddresses(
-                ULONG(AF_UNSPEC),
-                0,
-                nil,
-                pBuffer.baseAddress,
-                &ulSize
-            )
         guard ulResult == ERROR_SUCCESS else {
             throw IOError(windows: ulResult, reason: "GetAdaptersAddresses")
-        }
-
-        var pAdapter: UnsafeMutablePointer<IP_ADAPTER_ADDRESSES>? =
-            UnsafeMutablePointer(pBuffer.baseAddress)
-        while pAdapter != nil {
-            let pUnicastAddresses: UnsafeMutablePointer<IP_ADAPTER_UNICAST_ADDRESS>? =
-                pAdapter!.pointee.FirstUnicastAddress
-            var pUnicastAddress: UnsafeMutablePointer<IP_ADAPTER_UNICAST_ADDRESS>? =
-                pUnicastAddresses
-            while pUnicastAddress != nil {
-                if let device = NIONetworkDevice(pAdapter!, pUnicastAddress!) {
-                    devices.append(device)
-                }
-                pUnicastAddress = pUnicastAddress!.pointee.Next
-            }
-            pAdapter = pAdapter!.pointee.Next
         }
         #elseif !os(WASI)
         var interface: UnsafeMutablePointer<ifaddrs>? = nil

--- a/Tests/NIOCoreTests/UtilitiesTest.swift
+++ b/Tests/NIOCoreTests/UtilitiesTest.swift
@@ -57,13 +57,6 @@ class UtilitiesTest: XCTestCase {
     }
 
     func testEnumeratingDevices() throws {
-        #if os(Windows)
-        // `System.enumerateDevices()` currently crashes on Windows: its
-        // `GetAdaptersAddresses`-based implementation mis-sizes its buffer (see
-        // `Sources/NIOCore/Utilities.swift`), so this test is skipped there
-        // pending a fix to the underlying enumeration.
-        throw XCTSkip("System.enumerateDevices() currently crashes on Windows")
-        #endif
         // This is a tricky test, because we can't really assert much and expect this
         // to pass on all systems. The best we can do is assume there is a loopback:
         // maybe an IPv4 one, maybe an IPv6 one, but there will be one. We look for

--- a/Tests/NIOPosixTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOPosixTests/SocketOptionProviderTest.swift
@@ -22,12 +22,6 @@ import WinSDK
 #endif
 
 final class SocketOptionProviderTest: XCTestCase {
-    override func setUpWithError() throws {
-        #if os(Windows)
-        throw XCTSkip("setUp relies on System.enumerateDevices(), which crashes on Windows")
-        #endif
-    }
-
     var group: MultiThreadedEventLoopGroup!
     var serverChannel: Channel!
     var clientChannel: Channel!
@@ -80,11 +74,6 @@ final class SocketOptionProviderTest: XCTestCase {
     }
 
     override func setUp() {
-        #if os(Windows)
-        // This suite is skipped on Windows (see `setUpWithError`); avoid running
-        // the `enumerateDevices`-based setup, which would trap, beforehand.
-        return
-        #else
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.serverChannel = try? assertNoThrowWithValue(
             ServerBootstrap(group: group).bind(host: "127.0.0.1", port: 0).wait()
@@ -132,19 +121,14 @@ final class SocketOptionProviderTest: XCTestCase {
                 ).map { channel }
             }.wait()
         }
-        #endif
     }
 
     override func tearDown() {
-        #if os(Windows)
-        return
-        #else
         XCTAssertNoThrow(try ipv6DatagramChannel?.close().wait())
         XCTAssertNoThrow(try ipv4DatagramChannel?.close().wait())
         XCTAssertNoThrow(try clientChannel.close().wait())
         XCTAssertNoThrow(try serverChannel.close().wait())
         XCTAssertNoThrow(try group.syncShutdownGracefully())
-        #endif
     }
 
     func testSettingAndGettingComplexSocketOption() throws {
@@ -201,10 +185,25 @@ final class SocketOptionProviderTest: XCTestCase {
         // we just abandon the other tests: this is sufficient to prove that the error path works.
         let provider = try assertNoThrowWithValue(self.convertedChannel())
 
+        #if os(Windows)
+        // Winsock's `SO_RCVTIMEO` takes a `DWORD` rather than a `timeval`, so the `Int` used
+        // below is (more than) large enough and would be accepted. A single byte is too small
+        // for any option, and Winsock reports that as `WSAEFAULT`.
+        XCTAssertThrowsError(
+            try provider.unsafeSetSocketOption(level: .socket, name: .so_rcvtimeo, value: UInt8(1)).wait()
+        ) { error in
+            guard case .winsock(let code)? = (error as? IOError)?.error else {
+                XCTFail("Expected a winsock-domain IOError, got \(error)")
+                return
+            }
+            XCTAssertEqual(WSAEFAULT, code)
+        }
+        #else
         XCTAssertThrowsError(try provider.unsafeSetSocketOption(level: .socket, name: .so_rcvtimeo, value: 1).wait()) {
             error in
             XCTAssertEqual(EINVAL, (error as? IOError)?.errnoCode)
         }
+        #endif
     }
 
     // MARK: Tests for the safe helper functions.


### PR DESCRIPTION
### Motivation:

`System.enumerateDevices()` crashes on Windows, which in turn makes `UtilitiesTest.testEnumeratingDevices` and the whole of `SocketOptionProviderTest` (whose `setUp` enumerates devices) unrunnable there; both are currently skipped.

`GetAdaptersAddresses` reports the size its output requires in *bytes*, but the buffer was allocated as `Int(ulSize) / MemoryLayout<IP_ADAPTER_ADDRESSES>.stride` *elements*. That integer division truncates, so the buffer was always smaller than what the OS asked for, and the OS then wrote its linked list of variably sized records (adapter names, sockaddrs, unicast address entries) past the end of it, corrupting the heap.

### Modifications:

- Size the allocation in bytes, starting from the 15KB initial allocation the [documentation](https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses) recommends, and retry on `ERROR_BUFFER_OVERFLOW` — the set of adapters can change between the sizing call and the filling call.
- Remove the corresponding skips in `UtilitiesTest.testEnumeratingDevices` and `SocketOptionProviderTest`.
- Running `SocketOptionProviderTest` for the first time on Windows showed that `testPassingInvalidSizeToSetComplexSocketOptionFails` needs a Windows-specific expectation. Winsock's `SO_RCVTIMEO` takes a `DWORD` rather than a `timeval`, so the `Int` the test passes is in fact large enough and `setsockopt` correctly accepts it. On Windows the test now passes a single byte, which is too small for any option, and asserts the `WSAEFAULT` that Winsock reports.

No behaviour change on any other platform; everything is behind `#if os(Windows)`.

### Result:

`System.enumerateDevices()` works on Windows, and 13 previously skipped tests run there.

Verified on a Windows ARM64 VM (Swift 6.3.2): a full unfiltered `swift test` passes — 2354 tests, 0 failures.