### PR TITLE
[Windows] Report the WSAPoll selector's descriptor in its description

### DIFF
--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -420,7 +420,18 @@ extension Selector: CustomStringConvertible {
     @usableFromInline
     var description: String {
         func makeDescription() -> String {
-            "Selector { descriptor = \(self.selectorFD) }"
+            #if os(Windows)
+            // The WSAPoll backend has no descriptor standing for the selector itself, the way
+            // epoll and kqueue do. The read end of the wakeup socket pair has the same lifetime,
+            // so report that, and -1 once it has been closed, keeping the convention that -1
+            // means the selector is no longer usable.
+            let descriptor =
+                self.wakeupReadSocket == NIOBSDSocket.invalidHandle
+                ? -1 : Int(self.wakeupReadSocket)
+            #else
+            let descriptor = self.selectorFD
+            #endif
+            return "Selector { descriptor = \(descriptor) }"
         }
 
         if self.myThread.isCurrentSlow {

--- a/Tests/NIOPosixTests/EventLoopTest.swift
+++ b/Tests/NIOPosixTests/EventLoopTest.swift
@@ -2269,12 +2269,7 @@ final class MultiThreadedEventLoopGroupTests {
         }
     }
 
-    @Test(
-        .disabled(
-            if: System.isWindows,
-            "The WSAPoll selector has no epoll-style descriptor, so its debugDescription differs on Windows"
-        )
-    )
+    @Test
     func testStructuredConcurrencyMTELGStartStop() async throws {
         let loops = try await MultiThreadedEventLoopGroup.withEventLoopGroup(
             numberOfThreads: 3


### PR DESCRIPTION
### Motivation:

`Selector.description` prints `self.selectorFD`, which only the epoll, kqueue and io_uring backends ever assign. On Windows it therefore always reads `descriptor = -1` — the value that by convention means the selector has been closed — even while the selector is open and perfectly usable.

That made `MultiThreadedEventLoopGroupTests.testStructuredConcurrencyMTELGStartStop` unrunnable on Windows, since it asserts that a running event loop does *not* describe itself as having descriptor -1, and that a shut down one does.

### Modifications:

The WSAPoll backend has no single descriptor standing for the selector itself, but the read end of its wakeup socket pair has exactly the same lifetime: it is created in `initialiseState0` and reset to `NIOBSDSocket.invalidHandle` in `close0`, under the same `externalSelectorFDLock` that this description already takes. Report that on Windows, mapping the invalid handle to -1 so the established meaning of -1 is preserved.

Remove the corresponding skip.

The change is behind `#if os(Windows)`; other platforms keep printing `selectorFD` exactly as before.

### Result:

A running event loop on Windows now describes its selector accurately, and `testStructuredConcurrencyMTELGStartStop` runs there.

Verified on a Windows ARM64 VM (Swift 6.3.2): a full unfiltered `swift test` passes — 2354 tests, 0 failures.