### PR TITLE
[Windows] Stop skipping the event loop tick metrics tests

### DIFF
--- a/Tests/NIOPosixTests/EventLoopMetricsDelegateTests.swift
+++ b/Tests/NIOPosixTests/EventLoopMetricsDelegateTests.swift
@@ -34,15 +34,6 @@ final class RecorderDelegate: NIOEventLoopMetricsDelegate, Sendable {
 }
 
 final class EventLoopMetricsDelegateTests: XCTestCase {
-    override func setUpWithError() throws {
-        #if os(Windows)
-        // These tests assert on event-loop tick counts, but the WSAPoll selector
-        // wakes far more often than epoll/kqueue, so the counts are unreliable
-        // (and flaky) on Windows.
-        throw XCTSkip("Event-loop tick-count metrics are unreliable on the WSAPoll selector")
-        #endif
-    }
-
     func testMetricsDelegateNotCalledWhenNoEvents() throws {
         let delegate = RecorderDelegate()
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1, metricsDelegate: delegate)


### PR DESCRIPTION
### Motivation:

`EventLoopMetricsDelegateTests` is skipped in its entirety on Windows, on the grounds that the WSAPoll selector wakes far more often than epoll or kqueue and so the tick counts are unreliable and flaky.

Measuring it does not bear that out.

### Modifications:

Remove the skip. No source changes are needed.

Evidence gathered on a Windows ARM64 VM (Swift 6.3.2):

- `testMetricsDelegateTickInfo` observes `ticks=2`, `numberOfTasks` per tick `[2, 1]`. That is **identical** to what the same instrumentation reports on macOS, and it is the low end of the `2...5` range the test allows, so there are three spare ticks of headroom rather than a count pressed up against the limit.
- Both tests pass in isolation across four consecutive runs, and in three separate full unfiltered runs of the entire test suite (2354 tests, 0 failures each).

For completeness, while investigating I did find one real asymmetry, which turns out not to affect these tests: `whenReady0` converts its timeout with `Int32(clamping: timeAmount.nanoseconds / 1_000_000)`, so a sub-millisecond timeout truncates to `0` where epoll arms a nanosecond-precision `timerfd` and kqueue uses a `timespec`. Probing it showed the cost is at most one extra poll (a 500µs sleep scheduled from inside an idle loop produced 1 extra tick, not a spin), and these tests use 100ms and 1s delays so they never encounter it. Worth knowing about, but not a correctness problem and out of scope here.

### Result:

Two more tests run on Windows.