### PR TITLE
Add a dynamic resolver factory for reusable bootstraps

### DIFF
--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -827,6 +827,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     internal var _channelOptions: ChannelOptions.Storage
     private var connectTimeout: TimeAmount = TimeAmount.seconds(10)
     private var resolver: Optional<Resolver & Sendable>
+    private var resolverFactory: Optional<@Sendable (EventLoop) -> (Resolver & Sendable)>
     private var bindTarget: Optional<SocketAddress>
     private var enableMPTCP: Bool
 
@@ -863,6 +864,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
         self._channelInitializer = { channel in channel.eventLoop.makeSucceededFuture(()) }
         self.protocolHandlers = nil
         self.resolver = nil
+        self.resolverFactory = nil
         self.bindTarget = nil
         self.enableMPTCP = false
     }
@@ -930,7 +932,33 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     @preconcurrency
     public func resolver(_ resolver: (Resolver & Sendable)?) -> Self {
         self.resolver = resolver
+        self.resolverFactory = nil
         return self
+    }
+
+    /// Specifies a resolver factory to use for hostname connections.
+    ///
+    /// A fresh resolver is created for each call to ``connect(host:port:)``. This
+    /// is useful for resolvers that can only perform one resolution, while still
+    /// allowing the ``ClientBootstrap`` to be reused for multiple connections.
+    ///
+    /// - Parameter resolver: The dynamic resolver factory to use.
+    public func resolver(_ resolver: NIODynamicResolver) -> Self {
+        self.resolver = nil
+        self.resolverFactory = { eventLoop in
+            resolver.makeResolver(for: eventLoop)
+        }
+        return self
+    }
+
+    private func makeResolver(for eventLoop: EventLoop) -> Resolver & Sendable {
+        self.resolverFactory?(eventLoop)
+            ?? self.resolver
+            ?? GetaddrinfoResolver(
+                loop: eventLoop,
+                aiSocktype: .stream,
+                aiProtocol: .tcp
+            )
     }
 
     /// Enables multi-path TCP support.
@@ -1001,13 +1029,7 @@ public final class ClientBootstrap: NIOClientTCPBootstrapProtocol {
     /// - Returns: An `EventLoopFuture<Channel>` to deliver the `Channel` when connected.
     public func connect(host: String, port: Int) -> EventLoopFuture<Channel> {
         let loop = self.group.next()
-        let resolver =
-            self.resolver
-            ?? GetaddrinfoResolver(
-                loop: loop,
-                aiSocktype: .stream,
-                aiProtocol: .tcp
-            )
+        let resolver = self.makeResolver(for: loop)
         let enableMPTCP = self.enableMPTCP
         let channelInitializer = self.channelInitializer
         let channelOptions = self._channelOptions
@@ -1416,13 +1438,7 @@ extension ClientBootstrap {
                 PostRegistrationTransformationResult
             >
     ) async throws -> PostRegistrationTransformationResult {
-        let resolver =
-            self.resolver
-            ?? GetaddrinfoResolver(
-                loop: eventLoop,
-                aiSocktype: .stream,
-                aiProtocol: .tcp
-            )
+        let resolver = self.makeResolver(for: eventLoop)
 
         let enableMPTCP = self.enableMPTCP
         let bootstrapChannelInitializer = self.channelInitializer

--- a/Sources/NIOPosix/NIODynamicResolver.swift
+++ b/Sources/NIOPosix/NIODynamicResolver.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
+import NIOCore
+
+/// A factory for resolvers that can be used with ``ClientBootstrap``.
+///
+/// A resolver is normally a single-use object: it performs one pair of A and AAAA
+/// queries and is then discarded. ``NIODynamicResolver`` creates a new resolver for
+/// every hostname connection, which makes it safe to configure a reusable
+/// ``ClientBootstrap`` with a resolver that has single-use state.
+///
+/// The factory is called once when ``ClientBootstrap/connect(host:port:)`` starts a
+/// resolution. Concurrent connections each receive a different resolver instance.
+///
+/// - Important: The factory must return a resolver configured for the supplied event
+///   loop. The returned resolver must not be shared between connections.
+public final class NIODynamicResolver: Sendable {
+    private let resolverFactory: @Sendable (EventLoop) -> (Resolver & Sendable)
+
+    /// Create a dynamic resolver from a resolver factory.
+    ///
+    /// - Parameter resolverFactory: A closure that creates a fresh resolver for the
+    ///   event loop used by a connection.
+    public init<ResolverType: Resolver & Sendable>(
+        resolverFactory: @escaping @Sendable (EventLoop) -> ResolverType
+    ) {
+        self.resolverFactory = { eventLoop in
+            resolverFactory(eventLoop)
+        }
+    }
+
+    internal func makeResolver(for eventLoop: EventLoop) -> Resolver & Sendable {
+        self.resolverFactory(eventLoop)
+    }
+}
+
+#endif  // !os(WASI)

--- a/Tests/NIOPosixTests/NIODynamicResolverTest.swift
+++ b/Tests/NIOPosixTests/NIODynamicResolverTest.swift
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if !os(WASI)
+
+import NIOConcurrencyHelpers
+import NIOCore
+import XCTest
+
+@testable import NIOPosix
+
+private final class SingleUseTestResolver: Resolver, @unchecked Sendable {
+    private let loop: EventLoop
+    private let address: SocketAddress
+    private let queryCount = NIOLockedValueBox(0)
+
+    init(loop: EventLoop, address: SocketAddress) {
+        self.loop = loop
+        self.address = address
+    }
+
+    var numberOfQueries: Int {
+        self.queryCount.withLockedValue { $0 }
+    }
+
+    func initiateAQuery(host: String, port: Int) -> EventLoopFuture<[SocketAddress]> {
+        self.queryCount.withLockedValue { $0 += 1 }
+        return self.loop.makeSucceededFuture([self.address])
+    }
+
+    func initiateAAAAQuery(host: String, port: Int) -> EventLoopFuture<[SocketAddress]> {
+        self.queryCount.withLockedValue { $0 += 1 }
+        return self.loop.makeSucceededFuture([])
+    }
+
+    func cancelQueries() {}
+}
+
+final class NIODynamicResolverTest: XCTestCase {
+    func testCreatesFreshResolverForConcurrentConnections() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        let server = try ServerBootstrap(group: group)
+            .childChannelInitializer { channel in
+                channel.eventLoop.makeSucceededFuture(())
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try server.close().wait())
+        }
+
+        let address = try XCTUnwrap(server.localAddress)
+        let resolvers = NIOLockedValueBox<[SingleUseTestResolver]>([])
+        let dynamicResolver = NIODynamicResolver { eventLoop in
+            let resolver = SingleUseTestResolver(loop: eventLoop, address: address)
+            resolvers.withLockedValue { $0.append(resolver) }
+            return resolver
+        }
+
+        let bootstrap = ClientBootstrap(group: group)
+            .resolver(dynamicResolver)
+            .channelInitializer { channel in
+                channel.eventLoop.makeSucceededFuture(())
+            }
+
+        let connectionFutures = (0..<2).map { _ in
+            bootstrap.connect(host: "dynamic-resolver.test", port: address.port!)
+        }
+        let channels = try connectionFutures.map { try $0.wait() }
+        defer {
+            for channel in channels {
+                XCTAssertNoThrow(try channel.close().wait())
+            }
+        }
+
+        let createdResolvers = resolvers.withLockedValue { $0 }
+        XCTAssertEqual(createdResolvers.count, 2)
+        XCTAssertTrue(createdResolvers.allSatisfy { $0.numberOfQueries == 2 })
+    }
+}
+
+#endif  // !os(WASI)


### PR DESCRIPTION
Motivation:
ClientBootstrap currently stores one resolver instance, but DNS resolvers are generally single-use. Reusing a bootstrap with a single-use resolver makes it difficult to issue multiple hostname connections safely.

Modifications:
- Add NIODynamicResolver, which creates a fresh resolver for each hostname connection.
- Allow ClientBootstrap to use the dynamic resolver in both synchronous and async hostname-connect paths.
- Add a concurrent connection regression test proving that each connection receives its own resolver and A/AAAA query pair.

Result:
A reusable ClientBootstrap can safely create fresh resolver instances for concurrent hostname connections. The factory boundary avoids the shared mutable pairing problem identified in the earlier closed PR #2553.

Testing:
- swift test --filter NIODynamicResolverTest/testCreatesFreshResolverForConcurrentConnections
- swift test --parallel
- git diff --check

Closes #2434