### PR TITLE
Remove unused `SelectorLifecycleState.closing`

### DIFF
--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -26,7 +26,6 @@ import WinSDK
 @usableFromInline
 internal enum SelectorLifecycleState: Sendable {
     case open
-    case closing
     case closed
 }
 


### PR DESCRIPTION
### Motivation

`SelectorLifecycleState.closing` is never used in code.

### Changes

- Remove `SelectorLifecycleState.closing`

### Result

Easier code.
