### PR TITLE
Simplify imports in SocketAddresses.swift

### DIFF
--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -44,21 +44,14 @@ private typealias in_port_t = WinSDK.u_short
 private typealias sa_family_t = WinSDK.ADDRESS_FAMILY
 #elseif canImport(Darwin)
 import Darwin
-#elseif os(Linux) || os(Android)
+#elseif os(Linux) || os(Android) || os(FreeBSD) || os(OpenBSD)
 #if canImport(Glibc)
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
 #elseif canImport(Android)
 @preconcurrency import Android
-#endif
-import CNIOLinux
-#elseif os(FreeBSD)
-@preconcurrency import Glibc
-import CNIOFreeBSD
-#elseif os(OpenBSD)
-@preconcurrency import Glibc
-import CNIOOpenBSD
+#endif  // canImport(Glibc)
 #elseif canImport(WASILibc)
 @preconcurrency import WASILibc
 #else


### PR DESCRIPTION
Motivation:

The module map for glibc is broken which can lead libc symbols being attributed to the wrong module. In NIO, SocketAddresses.swift imports CNIOLinux (and friends) but, as far as I can tell, doesn't use any of their symbols directly. The result is that various libc symbols incorrectly get attributed to CNIOLinux and compilation can fail for downstream packages with member import visibility checks enabled.

See also: https://github.com/swiftlang/swift/issues/85427

Modifications:

- Remove the CNIO* imports from SocketAddresses.swift as they appear to be unused
- Simplify the imoport block

Result:

Can build grpc with member import visibility checks enabled.