### PR TITLE
Name the documented arguments the way the declarations name them

### DIFF
--- a/Sources/NIOFS/Internal/BufferedStream.swift
+++ b/Sources/NIOFS/Internal/BufferedStream.swift
@@ -386,7 +386,7 @@ extension BufferedStream {
         /// a `Result.failure`.
         ///
         /// - Parameters:
-        ///   - sequence: The element to write to the asynchronous stream.
+        ///   - element: The element to write to the asynchronous stream.
         ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
         ///   invoked during the call to ``write(_:onProduceMore:)``.
         internal func write(
@@ -444,7 +444,7 @@ extension BufferedStream {
         /// This method returns once more elements should be produced.
         ///
         /// - Parameters:
-        ///   - sequence: The element to write to the asynchronous stream.
+        ///   - element: The element to write to the asynchronous stream.
         internal func write(_ element: Element) async throws {
             try await self.write(contentsOf: CollectionOfOne(element))
         }

--- a/Sources/NIOFS/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFS/Internal/SystemFileHandle.swift
@@ -108,7 +108,7 @@ public final class SystemFileHandle: Sendable {
     /// - Parameters:
     ///   - descriptor: The open file descriptor.
     ///   - path: The path to the file used to open the descriptor.
-    ///   - executor: The executor which system calls will be performed on.
+    ///   - threadPool: The thread pool on which system calls will be performed.
     @_spi(Testing)
     public init(
         takingOwnershipOf descriptor: FileDescriptor,

--- a/Sources/NIOHTTP1/ByteCollectionUtils.swift
+++ b/Sources/NIOHTTP1/ByteCollectionUtils.swift
@@ -38,7 +38,7 @@ extension Sequence where Self.Element == UInt8 {
     /// This collection could be get from applying the `UTF8View`
     ///   property on the string protocol.
     ///
-    /// - Parameter bytes: The string constant in the form of a collection of `UInt8`
+    /// - Parameter to: The string constant in the form of a collection of `UInt8`
     /// - Returns: Whether the collection contains **EXACTLY** this array or no, but by ignoring case.
     internal func compareCaseInsensitiveASCIIBytes<T: Sequence>(to: T) -> Bool
     where T.Element == UInt8 {

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -530,7 +530,7 @@ extension ByteBuffer {
 
     /// Serializes this HTTP header block to bytes suitable for writing to the wire.
     ///
-    /// - Parameter buffer: A buffer to write the serialized bytes into. Will increment
+    /// - Parameter headers: The header block to serialize. Writing it will increment
     ///     the writer index of this buffer.
     mutating func write(headers: HTTPHeaders) {
         for header in headers.headers {

--- a/Sources/NIOPosix/ServerSocket.swift
+++ b/Sources/NIOPosix/ServerSocket.swift
@@ -76,7 +76,7 @@ class ServerSocket: BaseSocket, ServerSocketProtocol {
     /// Create a new instance.
     ///
     /// - Parameters:
-    ///   - descriptor: The _Unix file descriptor_ representing the bound socket.
+    ///   - socket: The _Unix file descriptor_ representing the bound socket.
     ///   - setNonBlocking: Set non-blocking mode on the socket.
     /// - Throws: An `IOError` if socket is invalid.
     init(socket: NIOBSDSocket.Handle, setNonBlocking: Bool = false) throws {

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -79,7 +79,7 @@ class Socket: BaseSocket, SocketProtocol {
     /// Create a new instance out of an already established socket.
     ///
     /// - Parameters:
-    ///   - descriptor: The existing socket descriptor.
+    ///   - socket: The existing socket descriptor.
     ///   - setNonBlocking: Set non-blocking mode on the socket.
     /// - Throws: An `IOError` if could not change the socket into non-blocking
     init(socket: NIOBSDSocket.Handle, setNonBlocking: Bool) throws {
@@ -109,7 +109,7 @@ class Socket: BaseSocket, SocketProtocol {
     /// file descriptor once it's not needed / used anymore.
     ///
     /// - Parameters:
-    ///   - descriptor: The file descriptor to wrap.
+    ///   - socket: The file descriptor to wrap.
     override init(socket: NIOBSDSocket.Handle) throws {
         try super.init(socket: socket)
     }

--- a/Sources/_NIOFileSystem/Internal/BufferedStream.swift
+++ b/Sources/_NIOFileSystem/Internal/BufferedStream.swift
@@ -386,7 +386,7 @@ extension BufferedStream {
         /// a `Result.failure`.
         ///
         /// - Parameters:
-        ///   - sequence: The element to write to the asynchronous stream.
+        ///   - element: The element to write to the asynchronous stream.
         ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
         ///   invoked during the call to ``write(_:onProduceMore:)``.
         internal func write(
@@ -444,7 +444,7 @@ extension BufferedStream {
         /// This method returns once more elements should be produced.
         ///
         /// - Parameters:
-        ///   - sequence: The element to write to the asynchronous stream.
+        ///   - element: The element to write to the asynchronous stream.
         internal func write(_ element: Element) async throws {
             try await self.write(contentsOf: CollectionOfOne(element))
         }

--- a/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
@@ -108,7 +108,7 @@ public final class SystemFileHandle: Sendable {
     /// - Parameters:
     ///   - descriptor: The open file descriptor.
     ///   - path: The path to the file used to open the descriptor.
-    ///   - executor: The executor which system calls will be performed on.
+    ///   - threadPool: The thread pool on which system calls will be performed.
     @_spi(Testing)
     public init(
         takingOwnershipOf descriptor: FileDescriptor,


### PR DESCRIPTION
### Motivation:

Eight doc comments name an argument that the declaration below them does not have, so DocC has nothing to bind the description to and quietly drops it. Nothing warns about this: Swift has no equivalent of `-Wdocumentation`, and DocC stays silent rather than complaining, so these sit until somebody reads the generated page and wonders where the description went

| file | the comment says | the declaration says |
|---|---|---|
| `NIOPosix/ServerSocket.swift` | `descriptor` | `socket` |
| `NIOPosix/Socket.swift` ×2 | `descriptor` | `socket` |
| `NIOHTTP1/ByteCollectionUtils.swift` | `bytes` | `to` |
| `NIOHTTP1/HTTPTypes.swift` | `buffer` | `headers` |
| `NIOFS/BufferedStream.swift` ×2 | `sequence` | `element` |
| `NIOFS/SystemFileHandle.swift` | `executor` | `threadPool` |

The socket ones are worth a word. Each of those files has a pair: a deprecated `init(descriptor:)` and its replacement `init(socket:)`, and the rename is recorded right there in `@available(*, deprecated, renamed: "init(socket:setNonBlocking:)")`. The replacement inherited the wording of the one it replaced, so the doc still says `descriptor`. The deprecated ones are correct and I left them alone

And the last two are the same defect in two copies of one module, `NIOFS` and `_NIOFileSystem`, which is what a verbatim copy of a file does to a mistake inside it. Fixing one and not the other would leave them out of sync, so both are in here

### Modifications:

Renamed the documented argument to the one in the declaration, eleven lines across eight files

One is slightly more than a rename: in `ByteBuffer.write(headers:)` the entry described the buffer the method is called on rather than its argument, so it now describes `headers` and keeps the note about the writer index

### Result:

The parameter descriptions reach the generated documentation. No API change, no behaviour change, comments only

btw these came out of a checker I wrote for exactly this, run over the tree and then read by hand one by one. Six of the things it flagged turned out to be my parser rather than your code, and those are fixed on my side rather than sent to you 🙌🏼

all of it on a MacBook Air M3, of course