### PR TITLE
[Windows] Implement sendmmsg

### DIFF
--- a/Sources/CNIOWindows/include/CNIOWindows.h
+++ b/Sources/CNIOWindows/include/CNIOWindows.h
@@ -93,8 +93,6 @@ NIO(sendto)(SOCKET s, const void *buf, int len, int flags, const SOCKADDR *to,
   return sendto(s, buf, len, flags, to, tolen);
 }
 
-int NIO(sendmmsg)(SOCKET s, NIO(mmsghdr) *msgvec, unsigned int vlen, int flags);
-
 int NIO(recvmmsg)(SOCKET s, NIO(mmsghdr) *msgvec, unsigned int vlen, int flags,
                   struct timespec *timeout);
 

--- a/Sources/CNIOWindows/shim.c
+++ b/Sources/CNIOWindows/shim.c
@@ -21,12 +21,6 @@
 #include <stdio.h>
 #include <winbase.h>
 
-int CNIOWindows_sendmmsg(SOCKET s, CNIOWindows_mmsghdr *msgvec, unsigned int vlen,
-                         int flags) {
-  assert(!"sendmmsg not implemented");
-  abort();
-}
-
 int CNIOWindows_recvmmsg(SOCKET s, CNIOWindows_mmsghdr *msgvec,
                          unsigned int vlen, int flags,
                          struct timespec *timeout) {

--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -376,7 +376,7 @@ extension NIOBSDSocket {
         var pfnWSASendMsg: LPFN_WSASENDMSG?
         var cbBytesReturned: DWORD = 0
         if WinSDK.WSAIoctl(
-            s,
+            Handle,
             SIO_GET_EXTENSION_FUNCTION_POINTER,
             &InBuffer,
             DWORD(MemoryLayout.stride(ofValue: InBuffer)),

--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -346,12 +346,37 @@ extension NIOBSDSocket {
         msgHdr lpMsg: UnsafePointer<msghdr>,
         flags dwFlags: CInt
     ) throws -> IOResult<size_t> {
+        let WSASendMsg = try Self.lookupWSASendMsg(socket: Handle)
+
+        let lpMsg: LPWSAMSG = UnsafeMutablePointer<WSAMSG>(mutating: lpMsg)
+        var NumberOfBytesSent: DWORD = 0
+        // FIXME(compnerd) is the socket guaranteed to not be overlapped?
+        if WSASendMsg(
+            Handle,
+            lpMsg,
+            DWORD(dwFlags),
+            &NumberOfBytesSent,
+            nil,
+            nil
+        ) == SOCKET_ERROR {
+            throw IOError(winsock: WSAGetLastError(), reason: "sendmsg")
+        }
+        return .processed(size_t(NumberOfBytesSent))
+    }
+
+    /// Resolves the `WSASendMsg` extension function for the given socket.
+    ///
+    /// Winsock does not export `WSASendMsg` for direct linking, it has to be looked up per
+    /// socket through `WSAIoctl`.
+    private static func lookupWSASendMsg(
+        socket s: NIOBSDSocket.Handle
+    ) throws -> LPFN_WSASENDMSG {
         // TODO(compnerd) see comment above
         var InBuffer = WSAID_WSASENDMSG
         var pfnWSASendMsg: LPFN_WSASENDMSG?
         var cbBytesReturned: DWORD = 0
         if WinSDK.WSAIoctl(
-            Handle,
+            s,
             SIO_GET_EXTENSION_FUNCTION_POINTER,
             &InBuffer,
             DWORD(MemoryLayout.stride(ofValue: InBuffer)),
@@ -370,21 +395,7 @@ extension NIOBSDSocket {
                 reason: "sendmsg"
             )
         }
-
-        let lpMsg: LPWSAMSG = UnsafeMutablePointer<WSAMSG>(mutating: lpMsg)
-        var NumberOfBytesSent: DWORD = 0
-        // FIXME(compnerd) is the socket guaranteed to not be overlapped?
-        if WSASendMsg(
-            Handle,
-            lpMsg,
-            DWORD(dwFlags),
-            &NumberOfBytesSent,
-            nil,
-            nil
-        ) == SOCKET_ERROR {
-            throw IOError(winsock: WSAGetLastError(), reason: "sendmsg")
-        }
-        return .processed(size_t(NumberOfBytesSent))
+        return WSASendMsg
     }
 
     @inline(never)
@@ -475,7 +486,41 @@ extension NIOBSDSocket {
     )
         throws -> IOResult<Int>
     {
-        .processed(Int(CNIOWindows_sendmmsg(socket, msgvec, vlen, flags)))
+        // Winsock has no `sendmmsg`, so send the messages one at a time, in the same way the
+        // Darwin shim does. The `WSASendMsg` extension function is resolved once for the whole
+        // batch rather than once per message.
+        guard vlen > 0 else {
+            return .processed(0)
+        }
+        let WSASendMsg = try Self.lookupWSASendMsg(socket: socket)
+
+        for i in 0..<Int(vlen) {
+            var dwNumberOfBytesSent: DWORD = 0
+            // FIXME(compnerd) is the socket guaranteed to not be overlapped?
+            let iResult = withUnsafeMutablePointer(to: &msgvec[i].msg_hdr) { lpMsg in
+                WSASendMsg(socket, lpMsg, DWORD(flags), &dwNumberOfBytesSent, nil, nil)
+            }
+
+            if iResult == SOCKET_ERROR {
+                let error = WSAGetLastError()
+                guard i > 0 else {
+                    // Nothing was sent at all. Report a blocking socket as such, which is what
+                    // the POSIX implementation's `syscall(blocking: true)` wrapper does, and
+                    // report anything else as an error.
+                    if error == WSAEWOULDBLOCK {
+                        return .wouldBlock(0)
+                    }
+                    throw IOError(winsock: error, reason: "sendmmsg")
+                }
+                // Earlier messages were sent successfully, so report a short send and leave the
+                // caller to retry the rest, as the Darwin shim does.
+                return .processed(i)
+            }
+
+            msgvec[i].msg_len = CUnsignedInt(dwNumberOfBytesSent)
+        }
+
+        return .processed(Int(vlen))
     }
 
     // NOTE: this should return a `ssize_t`, however, that is not a standard

--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -369,7 +369,7 @@ extension NIOBSDSocket {
     /// Winsock does not export `WSASendMsg` for direct linking, it has to be looked up per
     /// socket through `WSAIoctl`.
     private static func lookupWSASendMsg(
-        socket s: NIOBSDSocket.Handle
+        socket Handle: NIOBSDSocket.Handle
     ) throws -> LPFN_WSASENDMSG {
         // TODO(compnerd) see comment above
         var InBuffer = WSAID_WSASENDMSG


### PR DESCRIPTION
### Motivation:

On Windows, `CNIOWindows_sendmmsg` was only a stub. It called `abort()`.

NIO uses `sendmmsg` when a datagram channel has several writes pending. So any such write stopped the whole test process. This blocked the UDP tests and the raw socket tests.

### Modifications:

Windows has no `sendmmsg`. This sends one message at a time with `WSASendMsg`. The Darwin shim does the same with `sendmsg`.

- The code is in Swift, not in the C shim. The Windows `sendmsg` already calls `WSASendMsg` from Swift.
- The `WSASendMsg` pointer is looked up once per batch, not once per message.
- If the first message would block, the result is `.wouldBlock(0)`. If a later message fails, the result is a short send. This matches what the POSIX code does.
- The unused C stub is deleted.

### Result:

Datagram writes work on Windows, and `DatagramChannelTests` no longer stops the test process.

Tested on a Windows ARM64 machine (Swift 6.3.2). A full `swift test` passes: 2354 tests, 0 failures.
