### PR TITLE
[Windows] Delete UNIX domain socket paths that NIO created

### DIFF
--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -634,7 +634,9 @@ extension NIOBSDSocket {
                 (path.withCString(encodedAs: UTF16.self) {
                     CreateFileW(
                         $0,
-                        GENERIC_READ,
+                        // `DELETE` access is required to remove the path further down, via
+                        // `SetFileInformationByHandle`.
+                        GENERIC_READ | DWORD(DELETE),
                         DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE),
                         nil,
                         DWORD(OPEN_EXISTING),
@@ -643,14 +645,27 @@ extension NIOBSDSocket {
                     )
                 })
         else {
-            throw IOError(windows: DWORD(EBADF), reason: "CreateFileW")
+            // Nothing to clean up if the path does not exist. This mirrors the POSIX
+            // implementation, which treats `ENOENT` from `stat` as "already cleaned up".
+            let dwError = GetLastError()
+            if dwError == ERROR_FILE_NOT_FOUND || dwError == ERROR_PATH_NOT_FOUND {
+                return
+            }
+            throw IOError(windows: dwError, reason: "CreateFileW")
         }
         defer { CloseHandle(hFile) }
 
+        // `GetFileType` reports failure by returning `FILE_TYPE_UNKNOWN` *and* setting an error
         let ftFileType = GetFileType(hFile)
-        let dwError = GetLastError()
-        guard dwError == NO_ERROR, ftFileType != FILE_TYPE_DISK else {
-            throw IOError(windows: dwError, reason: "GetFileType")
+        if ftFileType == FILE_TYPE_UNKNOWN {
+            let dwError = GetLastError()
+            if dwError != NO_ERROR {
+                throw IOError(windows: dwError, reason: "GetFileType")
+            }
+        }
+        // A bound AF_UNIX path is a reparse point on disk; the reparse tag below identifies it.
+        guard ftFileType == FILE_TYPE_DISK else {
+            throw UnixDomainSocketPathWrongType()
         }
 
         var fiInformation: BY_HANDLE_FILE_INFORMATION =


### PR DESCRIPTION
### Motivation:

`cleanupUnixDomainSocket` could never delete a socket path on Windows. There were three reasons.

1. **A path that does not exist.** It threw `IOError(windows: EBADF)`, which puts an errno value into the Windows error domain. The POSIX code treats a missing path as already clean and returns.

2. **The file type check was inverted.** It rejected `FILE_TYPE_DISK`. On Windows a UNIX domain socket **is** a reparse point in the file system, so `GetFileType` reports exactly that. The check rejected the case the function exists for. The reparse tag, which the same function checks a few lines later, is what tells a socket from a normal file. The old `guard` also mixed the file type and the error state in one condition, so a rejected path was reported as `IOError(windows: 0)`. That reads as "The operation completed successfully".

3. **The handle had no delete access.** It was opened with `GENERIC_READ` only, so `SetFileInformationByHandle` failed with access denied.

Measured on a Windows ARM64 machine. The test binds an `AF_UNIX` socket, then asks NIO to clean the path up:

```
NIOUDS existedBefore=false existsAfterBind=false attrOK=true attrs=420 isReparse=true
NIOUDS cleanup threw UnixDomainSocketPathWrongType()   // reason 2
NIOUDS cleanup threw Access is denied.                 // then reason 3
NIOUDS cleanup succeeded                               // after both fixes
```

`existsAfterBind=false` is `FileManager` following the reparse point. `GetFileAttributesExW` reports `0x420`, which includes `FILE_ATTRIBUTE_REPARSE_POINT`.

### Modifications:

- Treat `ERROR_FILE_NOT_FOUND` and `ERROR_PATH_NOT_FOUND` as already clean, and return. This matches how POSIX handles `ENOENT`.
- Require `FILE_TYPE_DISK` instead of rejecting it. Check the `GetFileType` failure case separately, following its contract: failure is `FILE_TYPE_UNKNOWN` **and** an error is set. A path that exists but is not a socket now reports `UnixDomainSocketPathWrongType`, as on POSIX.
- Open the handle with `DELETE` access as well.

This file is Windows-only.

### Result:

NIO can now rebind a UNIX domain socket path that it used before on Windows. It also reports the same errors as the POSIX code for a missing path and for a wrong file type.

This is also what makes UNIX domain socket channel pairs usable in the tests. On a branch that enables them, `StreamChannelTest` goes from 1 passing test to 17.

Tested on a Windows ARM64 machine (Swift 6.3.2): builds on its own, and part of a larger branch where a full `swift test` passes (2360 tests, 0 failures).
