### PR TITLE
[Windows] Read SO_ERROR as a winsock error

### DIFF
--- a/Sources/NIOCore/IO.swift
+++ b/Sources/NIOCore/IO.swift
@@ -25,6 +25,41 @@ import typealias WinSDK.DWORD
 import typealias WinSDK.WCHAR
 import typealias WinSDK.WORD
 
+import let WinSDK.WSAEACCES
+import let WinSDK.WSAEADDRINUSE
+import let WinSDK.WSAEADDRNOTAVAIL
+import let WinSDK.WSAEAFNOSUPPORT
+import let WinSDK.WSAEALREADY
+import let WinSDK.WSAEBADF
+import let WinSDK.WSAECANCELLED
+import let WinSDK.WSAECONNABORTED
+import let WinSDK.WSAECONNREFUSED
+import let WinSDK.WSAECONNRESET
+import let WinSDK.WSAEDESTADDRREQ
+import let WinSDK.WSAEFAULT
+import let WinSDK.WSAEHOSTUNREACH
+import let WinSDK.WSAEINPROGRESS
+import let WinSDK.WSAEINTR
+import let WinSDK.WSAEINVAL
+import let WinSDK.WSAEISCONN
+import let WinSDK.WSAELOOP
+import let WinSDK.WSAEMFILE
+import let WinSDK.WSAEMSGSIZE
+import let WinSDK.WSAENAMETOOLONG
+import let WinSDK.WSAENETDOWN
+import let WinSDK.WSAENETRESET
+import let WinSDK.WSAENETUNREACH
+import let WinSDK.WSAENOBUFS
+import let WinSDK.WSAENOPROTOOPT
+import let WinSDK.WSAENOTCONN
+import let WinSDK.WSAENOTEMPTY
+import let WinSDK.WSAENOTSOCK
+import let WinSDK.WSAEOPNOTSUPP
+import let WinSDK.WSAEPROTONOSUPPORT
+import let WinSDK.WSAEPROTOTYPE
+import let WinSDK.WSAETIMEDOUT
+import let WinSDK.WSAEWOULDBLOCK
+
 internal func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
     DWORD((s << 10) | p)
 }
@@ -74,20 +109,74 @@ public struct IOError: Swift.Error {
 
     /// The `errno` that was set for the operation.
     ///
-    /// - Warning: On Windows an `IOError` may instead carry a `windows`- or `winsock`-domain
-    ///   error code, for which there is no corresponding `errno`. Reading `errnoCode` in that
-    ///   case is a programmer error and traps with `fatalError`; inspect the error's domain
-    ///   before accessing this property on Windows.
+    /// On Windows, an `IOError` may carry a `winsock`-domain error code instead. Those codes
+    /// have the same meanings as their `errno` counterparts -- `WSAEMSGSIZE` means what
+    /// `EMSGSIZE` means -- so they are translated here, which keeps error handling written
+    /// against `errno` working on Windows. A `winsock` code with no `errno` counterpart, and a
+    /// `windows`-domain code, are returned unchanged; Windows CRT `errno` values do not exceed
+    /// 140 while Winsock and Win32 codes are far larger, so such a value cannot be mistaken for
+    /// an `errno`.
     public var errnoCode: CInt {
         switch self.error {
         case .errno(let code):
             return code
         #if os(Windows)
-        default:
-            fatalError("IOError domain is not `errno`")
+        case .winsock(let code):
+            return Self.errnoForWinsockError(code) ?? code
+        case .windows(let code):
+            return CInt(bitPattern: code)
         #endif
         }
     }
+
+    #if os(Windows)
+    /// The `errno` equivalent of a Winsock error code, if it has one.
+    ///
+    /// The codes are paired by meaning, which for this range of Winsock errors is the same as
+    /// pairing them by name.
+    private static func errnoForWinsockError(_ code: CInt) -> CInt? {
+        switch code {
+        case WSAEINTR: return EINTR
+        case WSAEBADF: return EBADF
+        case WSAEACCES: return EACCES
+        case WSAEFAULT: return EFAULT
+        case WSAEINVAL: return EINVAL
+        case WSAEMFILE: return EMFILE
+        // Note that the Windows CRT, unlike other platforms, gives `EWOULDBLOCK` and `EAGAIN`
+        // distinct values. Winsock reports would-block as `WSAEWOULDBLOCK`, so that is the one
+        // to pair it with.
+        case WSAEWOULDBLOCK: return EWOULDBLOCK
+        case WSAEINPROGRESS: return EINPROGRESS
+        case WSAEALREADY: return EALREADY
+        case WSAENOTSOCK: return ENOTSOCK
+        case WSAEDESTADDRREQ: return EDESTADDRREQ
+        case WSAEMSGSIZE: return EMSGSIZE
+        case WSAEPROTOTYPE: return EPROTOTYPE
+        case WSAENOPROTOOPT: return ENOPROTOOPT
+        case WSAEPROTONOSUPPORT: return EPROTONOSUPPORT
+        case WSAEOPNOTSUPP: return EOPNOTSUPP
+        case WSAEAFNOSUPPORT: return EAFNOSUPPORT
+        case WSAEADDRINUSE: return EADDRINUSE
+        case WSAEADDRNOTAVAIL: return EADDRNOTAVAIL
+        case WSAENETDOWN: return ENETDOWN
+        case WSAENETUNREACH: return ENETUNREACH
+        case WSAENETRESET: return ENETRESET
+        case WSAECONNABORTED: return ECONNABORTED
+        case WSAECONNRESET: return ECONNRESET
+        case WSAENOBUFS: return ENOBUFS
+        case WSAEISCONN: return EISCONN
+        case WSAENOTCONN: return ENOTCONN
+        case WSAETIMEDOUT: return ETIMEDOUT
+        case WSAECONNREFUSED: return ECONNREFUSED
+        case WSAELOOP: return ELOOP
+        case WSAENAMETOOLONG: return ENAMETOOLONG
+        case WSAEHOSTUNREACH: return EHOSTUNREACH
+        case WSAENOTEMPTY: return ENOTEMPTY
+        case WSAECANCELLED: return ECANCELED
+        default: return nil
+        }
+    }
+    #endif
 
     #if os(Windows)
     public init(windows code: DWORD, reason: String) {

--- a/Sources/NIOPosix/BaseSocketChannel.swift
+++ b/Sources/NIOPosix/BaseSocketChannel.swift
@@ -1148,7 +1148,7 @@ class BaseSocketChannel<SocketType: BaseSocketProtocol>: SelectableChannel, Chan
                     // we have a socket error, let's forward
                     // this path will be executed on Linux (EPOLLERR) & Darwin (ev.fflags != 0) for
                     // stream sockets, and most (but not all) errors on datagram sockets
-                    error = IOError(errnoCode: result, reason: "connection reset (error set)")
+                    error = IOError(socketError: result, reason: "connection reset (error set)")
                 } else {
                     // we don't have a socket error, this must be connection reset without an error then
                     // this path should only be executed on Linux (EPOLLHUP, no EPOLLERR)

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -29,6 +29,20 @@ typealias IOVector = WSABUF
 typealias IOVector = iovec
 #endif
 
+extension IOError {
+    /// Creates an `IOError` from an error code read out of a socket, as `SO_ERROR` produces.
+    ///
+    /// Winsock reports those in its own error domain rather than as an `errno`, so the two need
+    /// to be distinguished at the point the value is read.
+    init(socketError code: CInt, reason: String) {
+        #if os(Windows)
+        self.init(winsock: code, reason: reason)
+        #else
+        self.init(errnoCode: code, reason: reason)
+        #endif
+    }
+}
+
 // TODO: scattering support
 class Socket: BaseSocket, SocketProtocol {
     typealias SocketType = Socket
@@ -150,7 +164,10 @@ class Socket: BaseSocket, SocketProtocol {
     func finishConnect() throws {
         let result: Int32 = try getOption(level: .socket, name: .so_error)
         if result != 0 {
-            throw IOError(errnoCode: result, reason: "finishing a non-blocking connect failed")
+            throw IOError(
+                socketError: result,
+                reason: "finishing a non-blocking connect failed"
+            )
         }
     }
 

--- a/Sources/NIOPosix/SocketChannel.swift
+++ b/Sources/NIOPosix/SocketChannel.swift
@@ -892,6 +892,10 @@ final class DatagramChannel: BaseSocketChannel<Socket>, @unchecked Sendable {
 
     private func shouldCloseOnErrnoCode(_ errnoCode: CInt) -> Bool {
         switch errnoCode {
+        // ECONNREFUSED can happen on linux if the previous sendto(...) failed.
+        // See also:
+        // -    https://bugzilla.redhat.com/show_bug.cgi?id=1375
+        // -    https://lists.gt.net/linux/kernel/39575
         case ECONNREFUSED, ENOMEM:
             // These are errors we may be able to recover from.
             return false
@@ -900,37 +904,28 @@ final class DatagramChannel: BaseSocketChannel<Socket>, @unchecked Sendable {
         }
     }
 
-    private func shouldCloseOnError(_ error: IOError.Error) -> Bool {
-        switch error {
-        // ECONNREFUSED can happen on linux if the previous sendto(...) failed.
-        // See also:
-        // -    https://bugzilla.redhat.com/show_bug.cgi?id=1375
-        // -    https://lists.gt.net/linux/kernel/39575
-        case .errno(let code):
-            return self.shouldCloseOnErrnoCode(code)
-        #if os(Windows)
-        default:
-            return true
-        #endif
-        }
+    private func shouldCloseOnError(_ error: IOError) -> Bool {
+        // Reading `errnoCode` rather than matching on the error's domain matters on Windows, where
+        // this error usually carries a Winsock code: `errnoCode` reports the `errno` that
+        // corresponds to it, so the comparisons above hold there too.
+        self.shouldCloseOnErrnoCode(error.errnoCode)
     }
 
     override func shouldCloseOnReadError(_ err: Error) -> Bool {
         guard let err = err as? IOError else { return true }
-        return self.shouldCloseOnError(err.error)
+        return self.shouldCloseOnError(err)
     }
 
     override func error() -> ErrorResult {
         // Assume we can get the error from the socket.
         do {
-            let errnoCode: CInt = try self.socket.getOption(level: .socket, name: .so_error)
-            if self.shouldCloseOnErrnoCode(errnoCode) {
+            let socketError: CInt = try self.socket.getOption(level: .socket, name: .so_error)
+            let error = IOError(socketError: socketError, reason: "so_error")
+            if self.shouldCloseOnError(error) {
                 self.reset()
                 return .fatal
             } else {
-                self.pipeline.syncOperations.fireErrorCaught(
-                    IOError(errnoCode: errnoCode, reason: "so_error")
-                )
+                self.pipeline.syncOperations.fireErrorCaught(error)
                 return .nonFatal
             }
         } catch {

--- a/Tests/NIOCoreTests/IOErrorTest.swift
+++ b/Tests/NIOCoreTests/IOErrorTest.swift
@@ -17,6 +17,10 @@ import XCTest
 
 @testable import NIOCore
 
+#if os(Windows)
+import WinSDK
+#endif
+
 class IOErrorTest: XCTestCase {
     func testMemoryLayoutBelowThreshold() {
         XCTAssert(MemoryLayout<IOError>.size <= 24)
@@ -26,4 +30,45 @@ class IOErrorTest: XCTestCase {
     func testDeprecatedAPIStillFunctional() {
         XCTAssertNoThrow(IOError(errnoCode: 1, function: "anyFunc"))
     }
+
+    #if os(Windows)
+    func testWinsockErrorsReportTheEquivalentErrno() {
+        // A representative sample rather than the whole table: the ones NIO itself compares
+        // against when classifying errors.
+        let equivalents: [(CInt, CInt)] = [
+            (WSAEMSGSIZE, EMSGSIZE),
+            (WSAEHOSTUNREACH, EHOSTUNREACH),
+            (WSAEAFNOSUPPORT, EAFNOSUPPORT),
+            (WSAECONNREFUSED, ECONNREFUSED),
+            (WSAECONNRESET, ECONNRESET),
+            (WSAEBADF, EBADF),
+            (WSAEINVAL, EINVAL),
+            (WSAEWOULDBLOCK, EWOULDBLOCK),
+        ]
+        for (winsock, expected) in equivalents {
+            XCTAssertEqual(
+                IOError(winsock: winsock, reason: "test").errnoCode,
+                expected,
+                "winsock error \(winsock) should report errno \(expected)"
+            )
+        }
+    }
+
+    func testWinsockErrorWithoutAnErrnoEquivalentIsReportedUnchanged() {
+        // `WSAEDISCON` has no `errno` counterpart, so it is passed through. It cannot be
+        // confused with an `errno`, which never exceeds 140 on Windows.
+        let error = IOError(winsock: WSAEDISCON, reason: "test")
+        XCTAssertEqual(error.errnoCode, WSAEDISCON)
+        XCTAssertGreaterThan(error.errnoCode, 140)
+    }
+
+    func testWindowsDomainErrorIsReportedUnchanged() {
+        let error = IOError(windows: DWORD(ERROR_FILE_NOT_FOUND), reason: "test")
+        XCTAssertEqual(error.errnoCode, ERROR_FILE_NOT_FOUND)
+    }
+
+    func testErrnoDomainErrorIsUnaffected() {
+        XCTAssertEqual(IOError(errnoCode: ENOENT, reason: "test").errnoCode, ENOENT)
+    }
+    #endif
 }


### PR DESCRIPTION
### Motivation:

_Depends on #3700, which is the first commit on this branch. Please review only the last commit, or wait until that is merged._

On Windows, `SO_ERROR` reports a Winsock error code, not an errno. Three places read it and put the value into an errno `IOError`. The codes then made no sense. `ChannelTests.testConnectWithECONNREFUSEDGetsTheRightError` saw 10061 (`WSAECONNREFUSED`) where it expected 107 (`ECONNREFUSED`).

There is a second effect. `SocketChannel.error()` compares that value with `ECONNREFUSED` and `ENOMEM` to decide if the error **can be recovered**. On Windows the comparison never matched, so every such error was treated as fatal and reset the channel.

### Modifications:

- Add `IOError(socketError:reason:)`. It records the value in the domain it belongs to: winsock on Windows, errno elsewhere. Use it in `Socket.finishConnect`, `BaseSocketChannel` and `SocketChannel.error()`.
- Classify the error through `IOError.errnoCode`. On Windows that reports the matching errno (#3700), so the comparisons work on every platform. The `#if os(Windows)` branch in `shouldCloseOnError` is no longer needed.

The comment about `ECONNREFUSED` on Linux moves next to the cases it describes, so it is not lost.

### Result:

Connect failures report the correct error on Windows, and a recoverable socket error is no longer treated as fatal there.

This fixes `ChannelTests.testConnectWithECONNREFUSEDGetsTheRightError`. That test runs once `ChannelTests` is enabled on Windows, which another PR does.

Tested on a Windows ARM64 machine (Swift 6.3.2): builds, `NIOPosix` still builds on macOS, and part of a larger branch where a full `swift test` passes (2360 tests, 0 failures).
