### PR TITLE
Map POLLHUP to readEOF in the WSAPoll selector so remote half-closure works on Windows

### DIFF
--- a/Sources/NIOPosix/SelectorWSAPoll.swift
+++ b/Sources/NIOPosix/SelectorWSAPoll.swift
@@ -67,7 +67,25 @@ extension SelectorEventSet {
             self.formUnion(.error)
         }
         if mapped & WinSDK.POLLHUP != 0 {
-            self.formUnion(.reset)
+            // WSAPoll has no `POLLRDHUP` equivalent. `POLLHUP` is the only hangup signal it
+            // produces and it is raised both when the peer shuts down its write side in an
+            // orderly fashion (FIN) and when the connection is aborted (RST). Reporting it as
+            // `.reset` would conflate the two: `SelectableEventLoop.handleEvent` treats `.reset`
+            // as terminal and unconditionally tears the whole `Channel` down, so a peer's FIN
+            // would close both directions and `allowRemoteHalfClosure` could never be honoured.
+            //
+            // Report `.readEOF` instead, which is what `epoll` synthesises from `EPOLLRDHUP`, and
+            // let the subsequent `recv` establish what actually happened: it returns 0 for an
+            // orderly FIN, which `readable0` turns into half-closure when the `Channel` allows it,
+            // and it fails with `WSAECONNRESET`/`WSAECONNABORTED` for an abortive teardown, which
+            // closes the `Channel` with the real error. The socket, not the poll bit, is the
+            // authority on which of the two occurred.
+            //
+            // This stays one-shot despite `POLLHUP` being reported regardless of the requested
+            // `events`: `BaseSocketChannel.readEOF0` removes `.readEOF` from the registration's
+            // interest and `whenReady0` intersects every event set with `registration.interested`,
+            // so later `POLLHUP` reports for the same socket are masked and cannot spin the loop.
+            self.formUnion(.readEOF)
         }
         if mapped & WinSDK.POLLNVAL != 0 {
             preconditionFailure("Invalid fd supplied.")


### PR DESCRIPTION
### Motivation

On Windows, `allowRemoteHalfClosure` is currently unimplementable: the WSAPoll selector can never produce `.readEOF`. WSAPoll has no `POLLRDHUP` equivalent, so `POLLHUP` is its only hangup signal and it fires for both an orderly peer FIN and an abortive RST. `SelectorWSAPoll` maps it to `.reset`, which `SelectableEventLoop.handleEvent` treats as terminal, so a peer's orderly FIN tears down a live channel that had deliberately half-closed its input.

Observed effect: the streamed-body failures in hummingbird-project/hummingbird#747 (tracked in #3697), and four `NIOSSLIntegrationTest` close-mode failures blocking Windows validation of apple/swift-nio-ssl#567. Instrumentation on a windows-2022 runner showed 8 `POLLHUP` deliveries of which 4 force-closed an open, active channel (`socketOpen=true active=true`); channels were registering interest in `.readEOF` (`interestedRaw` includes it) that the selector could never deliver. Not a duplicate of #3702: measured identical with and without the #3704 data-path fix.

### Modifications

Map `POLLHUP` to `.readEOF` instead of `.reset` in `SelectorEventSet.init(wsaPollEvents:)`, with a comment explaining why. This mirrors what epoll does with `EPOLLRDHUP` and makes `recv` the authority on what actually happened: 0 bytes = orderly FIN (half-closure honoured when the channel allows it); `WSAECONNRESET`/`WSAECONNABORTED` = genuine abort, closed with the real error. One functional line.

### Result

Measured on windows-2022 / Swift 6.3.3:

- swift-nio's own `testHalfCloseOwnOutput` goes from failing to passing; no new failures in the half-closure test runs.
- The four close-mode `NIOSSLIntegrationTest` failures on apple/swift-nio-ssl#567 all pass; that PR's full suite is green with this change (plus one Windows path-separator fix in a test regex on the nio-ssl side).
- The three timeout-dependent close-mode tests run ~5.0s, matching macOS, versus 0.018s when the channel was being torn down early.
- macOS sanity: the same tests pass locally; non-Windows platforms are untouched (the changed line is inside the WSAPoll-only selector).

Also validated stacked on #3704 (the two changes are in different areas and compose).

One caveat worth stating: Windows half-closure has no upstream CI guard today because `StreamChannelTest` is skipped on Windows (`NIOPosix` has no `PipeChannel` there), which is how this could ship undetected. We patched the harness to TCP-only on a probe branch to run the half-closure tests; a durable Windows guard likely wants that or a `PipeChannel` implementation, which is beyond this PR.
