### PR TITLE
NIOPosix: report WSAEWOULDBLOCK from Windows send/writev/recv as .wouldBlock

### DIFF
--- a/Sources/NIOPosix/BSDSocketAPIWindows.swift
+++ b/Sources/NIOPosix/BSDSocketAPIWindows.swift
@@ -294,7 +294,13 @@ extension NIOBSDSocket {
     ) throws -> IOResult<size_t> {
         let iResult: CInt = CNIOWindows_recv(s, buf, CInt(len), 0)
         if iResult == SOCKET_ERROR {
-            throw IOError(winsock: WSAGetLastError(), reason: "recv")
+            let error = WSAGetLastError()
+            // A non-blocking socket with nothing to read is not an error: report
+            // it the way the POSIX `syscall(blocking: true)` wrapper does.
+            if error == WSAEWOULDBLOCK {
+                return .wouldBlock(0)
+            }
+            throw IOError(winsock: error, reason: "recv")
         }
         return .processed(size_t(iResult))
     }
@@ -395,7 +401,14 @@ extension NIOBSDSocket {
     ) throws -> IOResult<size_t> {
         let iResult: CInt = CNIOWindows_send(s, buf, CInt(len), 0)
         if iResult == SOCKET_ERROR {
-            throw IOError(winsock: WSAGetLastError(), reason: "send")
+            let error = WSAGetLastError()
+            // A full send buffer on a non-blocking socket is not an error: report
+            // it the way the POSIX `syscall(blocking: true)` wrapper does, so the
+            // channel waits for writability instead of closing.
+            if error == WSAEWOULDBLOCK {
+                return .wouldBlock(0)
+            }
+            throw IOError(winsock: error, reason: "send")
         }
         return .processed(size_t(iResult))
     }
@@ -409,7 +422,16 @@ extension NIOBSDSocket {
         let ptr = UnsafeMutablePointer(mutating: iovecs.baseAddress)
         let result = WSASend(s, ptr, UInt32(iovecs.count), &bytesSent, 0, nil, nil)
         if result == SOCKET_ERROR {
-            throw IOError(winsock: WSAGetLastError(), reason: "WSASend")
+            let error = WSAGetLastError()
+            // A full send buffer on a non-blocking socket is not an error: report
+            // it the way the POSIX `syscall(blocking: true)` wrapper does, so the
+            // channel waits for writability instead of closing. Without this,
+            // any flush that outruns the socket's send buffer tears the channel
+            // down mid-stream.
+            if error == WSAEWOULDBLOCK {
+                return .wouldBlock(0)
+            }
+            throw IOError(winsock: error, reason: "WSASend")
         }
         return .processed(Int(bytesSent))
     }


### PR DESCRIPTION
### Motivation

On Windows, `NIOBSDSocket.send`, `.writev` (WSASend) and `.recv` throw an
`IOError` for **every** `SOCKET_ERROR`, including `WSAEWOULDBLOCK`. The POSIX
implementations map that to `.wouldBlock(0)` (via `syscall(blocking: true)`),
and the Windows `accept` / `connect` / `sendmmsg` wrappers already special-case
it — these three did not.

The consequence is that the first flush that outruns a non-blocking socket's
send buffer fails the write and tears the channel down mid-stream, instead of
waiting for writability. It only shows up once a write is big enough or a
burst long enough to fill the send buffer, which is why small traffic looks
fine.

Reproduced with a loopback WebSocket echo server on Windows ARM64
(Swift 6.3.3, swift-nio 2.101.3):

* 25 × 100 KiB frames, one flush per frame → the peer sees EOF partway
  through (21/25 buffers on one run, 3/25 on another); 4 × 100 KiB passes.
* Same bytes in a single flush → arrive byte-exact.
* A raw `ClientBootstrap` → `ServerBootstrap` harness shows the same split:
  flush-per-write loses the stream, one flush does not.

### Modifications

`NIOPosix/BSDSocketAPIWindows.swift`: `send`, `writev` and `recv` now return
`.wouldBlock(0)` when `WSAGetLastError()` is `WSAEWOULDBLOCK`, matching the
POSIX wrappers and the other Windows wrappers in the same file.

### Result

Writes that fill the send buffer suspend and resume on writability, as on
every other platform. The loopback repro above passes; a real client (a
WebSocket transport talking to a production server over TLS) goes from
"connection dies mid-burst" to clean.