### PR TITLE
NIOFS: one-shot I/O を単一の thread-pool dispatch に統合

### DIFF
--- a/Sources/NIOFS/Array+FileSystem.swift
+++ b/Sources/NIOFS/Array+FileSystem.swift
@@ -28,9 +28,11 @@ extension Array where Element == UInt8 {
         maximumSizeAllowed: ByteCount,
         fileSystem: some FileSystemProtocol
     ) async throws {
-        let byteBuffer = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
-            try await handle.readToEnd(maximumSizeAllowed: maximumSizeAllowed)
-        }
+        let byteBuffer = try await ByteBuffer(
+            contentsOf: path,
+            maximumSizeAllowed: maximumSizeAllowed,
+            fileSystem: fileSystem
+        )
 
         self = Self(buffer: byteBuffer)
     }

--- a/Sources/NIOFS/ByteBuffer+FileSystem.swift
+++ b/Sources/NIOFS/ByteBuffer+FileSystem.swift
@@ -27,11 +27,19 @@ extension ByteBuffer {
         maximumSizeAllowed: ByteCount,
         fileSystem: some FileSystemProtocol
     ) async throws {
-        self = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
-            try await handle.readToEnd(
-                fromAbsoluteOffset: 0,
+        // Larger reads are deliberately chunked so that they don't monopolise an I/O worker.
+        if let fileSystem = fileSystem as? FileSystem, maximumSizeAllowed <= .mebibytes(64) {
+            self = try await fileSystem._readFileContents(
+                at: path,
                 maximumSizeAllowed: maximumSizeAllowed
             )
+        } else {
+            self = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
+                try await handle.readToEnd(
+                    fromAbsoluteOffset: 0,
+                    maximumSizeAllowed: maximumSizeAllowed
+                )
+            }
         }
     }
 

--- a/Sources/NIOFS/Convenience.swift
+++ b/Sources/NIOFS/Convenience.swift
@@ -79,8 +79,17 @@ extension Sequence<UInt8> where Self: Sendable {
         options: OpenOptions.Write = .newFile(replaceExisting: false),
         fileSystem: some FileSystemProtocol
     ) async throws -> Int64 {
-        try await fileSystem.withFileHandle(forWritingAt: path, options: options) { handle in
-            try await handle.write(contentsOf: self, toAbsoluteOffset: offset)
+        if let fileSystem = fileSystem as? FileSystem {
+            return try await fileSystem._writeFileContents(
+                to: path,
+                options: options
+            ) { sendableView in
+                sendableView._write(contentsOf: self, toAbsoluteOffset: offset)
+            }
+        } else {
+            return try await fileSystem.withFileHandle(forWritingAt: path, options: options) { handle in
+                try await handle.write(contentsOf: self, toAbsoluteOffset: offset)
+            }
         }
     }
 

--- a/Sources/NIOFS/FileSystem.swift
+++ b/Sources/NIOFS/FileSystem.swift
@@ -854,6 +854,77 @@ extension FileSystem {
         }
     }
 
+    internal func _readFileContents(
+        at path: NIOFilePath,
+        maximumSizeAllowed: ByteCount
+    ) async throws -> ByteBuffer {
+        let cancelled = ManagedAtomic(false)
+
+        return try await withTaskCancellationHandler {
+            try await self.threadPool.runIfActive {
+                let handle = try self._openFile(
+                    forReadingAt: path.underlying,
+                    options: OpenOptions.Read()
+                ).get()
+                let sendableView = handle.fileHandle.systemFileHandle.sendableView
+
+                let readResult: Result<ByteBuffer, Error> = Result {
+                    if cancelled.load(ordering: .acquiring) {
+                        throw CancellationError()
+                    }
+                    return try sendableView._readToEnd(
+                        fromAbsoluteOffset: 0,
+                        maximumSizeAllowed: maximumSizeAllowed,
+                        isCancelled: { cancelled.load(ordering: .acquiring) }
+                    )
+                }
+
+                try sendableView._close(materialize: true).get()
+                return try readResult.get()
+            }
+        } onCancel: {
+            cancelled.store(true, ordering: .releasing)
+        }
+    }
+
+    internal func _writeFileContents(
+        to path: NIOFilePath,
+        options: OpenOptions.Write,
+        write: @escaping @Sendable (SystemFileHandle.SendableView) -> Result<Int64, FileSystemError>
+    ) async throws -> Int64 {
+        let cancelled = ManagedAtomic(false)
+
+        return try await withTaskCancellationHandler {
+            try await self.threadPool.runIfActive {
+                let handle = try self._openFile(
+                    forWritingAt: path.underlying,
+                    options: options
+                ).get()
+                let sendableView = handle.fileHandle.systemFileHandle.sendableView
+
+                let writeResult: Result<Int64, Error> = Result {
+                    if cancelled.load(ordering: .acquiring) {
+                        throw CancellationError()
+                    }
+                    return try write(sendableView).get()
+                }
+
+                let materialize: Bool
+                switch writeResult {
+                case .success:
+                    materialize = true
+                case .failure:
+                    materialize = false
+                }
+
+                try sendableView._close(materialize: materialize).get()
+                return try writeResult.get()
+            }
+        } onCancel: {
+            cancelled.store(true, ordering: .releasing)
+        }
+    }
+
     /// Creates a directory at `fullPath`, potentially creating other directories along the way.
     private func _createDirectory(
         at fullPath: FilePath,

--- a/Sources/NIOFS/Internal/SystemFileHandle.swift
+++ b/Sources/NIOFS/Internal/SystemFileHandle.swift
@@ -1042,51 +1042,7 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
         length: ByteCount
     ) async throws -> ByteBuffer {
         try await self.threadPool.runIfActive { [sendableView] in
-            try sendableView._withUnsafeDescriptor { descriptor in
-                try descriptor.readChunk(
-                    fromAbsoluteOffset: offset,
-                    length: length.bytes
-                ).flatMapError { error in
-                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
-                        guard offset == 0 else {
-                            return .failure(
-                                FileSystemError(
-                                    code: .unsupported,
-                                    message: "File is unseekable.",
-                                    cause: nil,
-                                    location: .here()
-                                )
-                            )
-                        }
-
-                        return descriptor.readChunk(length: length.bytes).mapError { error in
-                            FileSystemError.read(
-                                usingSyscall: .read,
-                                error: error,
-                                path: sendableView.path,
-                                location: .here()
-                            )
-                        }
-                    } else {
-                        return .failure(
-                            FileSystemError.read(
-                                usingSyscall: .pread,
-                                error: error,
-                                path: sendableView.path,
-                                location: .here()
-                            )
-                        )
-                    }
-                }
-                .get()
-            } onUnavailable: {
-                FileSystemError(
-                    code: .closed,
-                    message: "Couldn't read chunk, the file '\(sendableView.path)' is closed.",
-                    cause: nil,
-                    location: .here()
-                )
-            }
+            try sendableView._readChunk(fromAbsoluteOffset: offset, length: length).get()
         }
     }
 
@@ -1095,6 +1051,157 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
         chunkLength size: ByteCount
     ) -> FileChunks {
         FileChunks(handle: self, chunkLength: size, range: range)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension SystemFileHandle.SendableView {
+    internal func _readChunk(
+        fromAbsoluteOffset offset: Int64,
+        length: ByteCount
+    ) -> Result<ByteBuffer, FileSystemError> {
+        self._withUnsafeDescriptorResult { descriptor in
+            descriptor.readChunk(
+                fromAbsoluteOffset: offset,
+                length: length.bytes
+            ).flatMapError { error in
+                if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
+                    guard offset == 0 else {
+                        return .failure(
+                            FileSystemError(
+                                code: .unsupported,
+                                message: "File is unseekable.",
+                                cause: nil,
+                                location: .here()
+                            )
+                        )
+                    }
+
+                    return descriptor.readChunk(length: length.bytes).mapError { error in
+                        FileSystemError.read(
+                            usingSyscall: .read,
+                            error: error,
+                            path: self.path,
+                            location: .here()
+                        )
+                    }
+                } else {
+                    return .failure(
+                        FileSystemError.read(
+                            usingSyscall: .pread,
+                            error: error,
+                            path: self.path,
+                            location: .here()
+                        )
+                    )
+                }
+            }
+        } onUnavailable: {
+            FileSystemError(
+                code: .closed,
+                message: "Couldn't read chunk, the file '\(self.path)' is closed.",
+                cause: nil,
+                location: .here()
+            )
+        }
+    }
+
+    internal func _readToEnd(
+        fromAbsoluteOffset offset: Int64,
+        maximumSizeAllowed: ByteCount,
+        isCancelled: () -> Bool
+    ) throws -> ByteBuffer {
+        let maximumSizeAllowed = maximumSizeAllowed == .unlimited ? .byteBufferCapacity : maximumSizeAllowed
+        let info = try self._info().get()
+        let fileSize = Int64(info.size)
+        let readSize = max(Int(fileSize - offset), 0)
+
+        if maximumSizeAllowed > .byteBufferCapacity {
+            throw FileSystemError(
+                code: .resourceExhausted,
+                message: """
+                    The maximum size allowed (\(maximumSizeAllowed)) is more than the maximum \
+                    amount of bytes that can be written to ByteBuffer \
+                    (\(ByteCount.byteBufferCapacity)). You can read the file in smaller chunks by \
+                    calling readChunks().
+                    """,
+                cause: nil,
+                location: .here()
+            )
+        }
+
+        if readSize > maximumSizeAllowed.bytes {
+            throw FileSystemError(
+                code: .resourceExhausted,
+                message: """
+                    There are more bytes to read (\(readSize)) than the maximum size allowed \
+                    (\(maximumSizeAllowed)). Read the file in chunks or increase the maximum size \
+                    allowed.
+                    """,
+                cause: nil,
+                location: .here()
+            )
+        }
+
+        let isSeekable = !(info.type == .fifo || info.type == .socket)
+        if isSeekable, fileSize > 0, readSize == 0 {
+            return ByteBuffer()
+        }
+
+        let singleShotReadLimit = 64 * 1024 * 1024
+        if isSeekable, fileSize > 0, readSize <= singleShotReadLimit {
+            if isCancelled() {
+                throw CancellationError()
+            }
+            return try self._readChunk(
+                fromAbsoluteOffset: offset,
+                length: .bytes(Int64(readSize))
+            ).get()
+        }
+
+        guard isSeekable || offset == 0 else {
+            throw FileSystemError(
+                code: .unsupported,
+                message: "File is unseekable.",
+                cause: nil,
+                location: .here()
+            )
+        }
+
+        var accumulator = ByteBuffer()
+        accumulator.reserveCapacity(readSize)
+
+        let chunkLength = ByteCount.mebibytes(8)
+        var readOffset = offset
+        while true {
+            if isCancelled() {
+                throw CancellationError()
+            }
+
+            let chunk = try self._readChunk(
+                fromAbsoluteOffset: isSeekable ? readOffset : 0,
+                length: chunkLength
+            ).get()
+            accumulator.writeImmutableBuffer(chunk)
+
+            if accumulator.readableBytes > maximumSizeAllowed.bytes {
+                throw FileSystemError(
+                    code: .resourceExhausted,
+                    message: """
+                        There are more bytes to read than the maximum size allowed \
+                        (\(maximumSizeAllowed)). Read the file in chunks or increase the maximum size \
+                        allowed.
+                        """,
+                    cause: nil,
+                    location: .here()
+                )
+            }
+
+            if chunk.readableBytes < chunkLength.bytes {
+                return accumulator
+            }
+            readOffset += Int64(chunk.readableBytes)
+        }
     }
 }
 
@@ -1108,56 +1215,65 @@ extension SystemFileHandle: WritableFileHandleProtocol {
         toAbsoluteOffset offset: Int64
     ) async throws -> Int64 {
         try await self.threadPool.runIfActive { [sendableView] in
-            try sendableView._withUnsafeDescriptor { descriptor in
-                try descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
-                    .flatMapError { error in
-                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
-                            guard offset == 0 else {
-                                return .failure(
-                                    FileSystemError(
-                                        code: .unsupported,
-                                        message: "File is unseekable.",
-                                        cause: nil,
-                                        location: .here()
-                                    )
-                                )
-                            }
-
-                            return descriptor.write(contentsOf: bytes)
-                                .mapError { error in
-                                    FileSystemError.write(
-                                        usingSyscall: .write,
-                                        error: error,
-                                        path: sendableView.path,
-                                        location: .here()
-                                    )
-                                }
-                        } else {
-                            return .failure(
-                                FileSystemError.write(
-                                    usingSyscall: .pwrite,
-                                    error: error,
-                                    path: sendableView.path,
-                                    location: .here()
-                                )
-                            )
-                        }
-                    }
-                    .get()
-            } onUnavailable: {
-                FileSystemError(
-                    code: .closed,
-                    message: "Couldn't write bytes, the file '\(sendableView.path)' is closed.",
-                    cause: nil,
-                    location: .here()
-                )
-            }
+            try sendableView._write(contentsOf: bytes, toAbsoluteOffset: offset).get()
         }
     }
 
     public func resize(to size: ByteCount) async throws {
         try await self.threadPool.runIfActive { [sendableView] in
             try sendableView._resize(to: size).get()
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension SystemFileHandle.SendableView {
+    internal func _write(
+        contentsOf bytes: some Sequence<UInt8>,
+        toAbsoluteOffset offset: Int64
+    ) -> Result<Int64, FileSystemError> {
+        self._withUnsafeDescriptorResult { descriptor in
+            descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
+                .flatMapError { error in
+                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
+                        guard offset == 0 else {
+                            return .failure(
+                                FileSystemError(
+                                    code: .unsupported,
+                                    message: "File is unseekable.",
+                                    cause: nil,
+                                    location: .here()
+                                )
+                            )
+                        }
+
+                        return descriptor.write(contentsOf: bytes)
+                            .mapError { error in
+                                FileSystemError.write(
+                                    usingSyscall: .write,
+                                    error: error,
+                                    path: self.path,
+                                    location: .here()
+                                )
+                            }
+                    } else {
+                        return .failure(
+                            FileSystemError.write(
+                                usingSyscall: .pwrite,
+                                error: error,
+                                path: self.path,
+                                location: .here()
+                            )
+                        )
+                    }
+                }
+        } onUnavailable: {
+            FileSystemError(
+                code: .closed,
+                message: "Couldn't write bytes, the file '\(self.path)' is closed.",
+                cause: nil,
+                location: .here()
+            )
         }
     }
 }

--- a/Sources/NIOFS/String+FileSystem.swift
+++ b/Sources/NIOFS/String+FileSystem.swift
@@ -29,9 +29,11 @@ extension String {
         maximumSizeAllowed: ByteCount,
         fileSystem: some FileSystemProtocol
     ) async throws {
-        let byteBuffer = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
-            try await handle.readToEnd(maximumSizeAllowed: maximumSizeAllowed)
-        }
+        let byteBuffer = try await ByteBuffer(
+            contentsOf: path,
+            maximumSizeAllowed: maximumSizeAllowed,
+            fileSystem: fileSystem
+        )
 
         self = Self(buffer: byteBuffer)
     }

--- a/Sources/NIOFSFoundationCompat/Data+FileSystem.swift
+++ b/Sources/NIOFSFoundationCompat/Data+FileSystem.swift
@@ -35,9 +35,11 @@ extension Data {
         maximumSizeAllowed: ByteCount,
         fileSystem: some FileSystemProtocol
     ) async throws {
-        let byteBuffer = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
-            try await handle.readToEnd(maximumSizeAllowed: maximumSizeAllowed)
-        }
+        let byteBuffer = try await ByteBuffer(
+            contentsOf: path,
+            maximumSizeAllowed: maximumSizeAllowed,
+            fileSystem: fileSystem
+        )
 
         self = Data(buffer: byteBuffer)
     }

--- a/Sources/_NIOFileSystem/Array+FileSystem.swift
+++ b/Sources/_NIOFileSystem/Array+FileSystem.swift
@@ -28,9 +28,11 @@ extension Array where Element == UInt8 {
         maximumSizeAllowed: ByteCount,
         fileSystem: some FileSystemProtocol
     ) async throws {
-        let byteBuffer = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
-            try await handle.readToEnd(maximumSizeAllowed: maximumSizeAllowed)
-        }
+        let byteBuffer = try await ByteBuffer(
+            contentsOf: path,
+            maximumSizeAllowed: maximumSizeAllowed,
+            fileSystem: fileSystem
+        )
 
         self = Self(buffer: byteBuffer)
     }

--- a/Sources/_NIOFileSystem/ByteBuffer+FileSystem.swift
+++ b/Sources/_NIOFileSystem/ByteBuffer+FileSystem.swift
@@ -27,11 +27,19 @@ extension ByteBuffer {
         maximumSizeAllowed: ByteCount,
         fileSystem: some FileSystemProtocol
     ) async throws {
-        self = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
-            try await handle.readToEnd(
-                fromAbsoluteOffset: 0,
+        // Larger reads are deliberately chunked so that they don't monopolise an I/O worker.
+        if let fileSystem = fileSystem as? FileSystem, maximumSizeAllowed <= .mebibytes(64) {
+            self = try await fileSystem._readFileContents(
+                at: path,
                 maximumSizeAllowed: maximumSizeAllowed
             )
+        } else {
+            self = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
+                try await handle.readToEnd(
+                    fromAbsoluteOffset: 0,
+                    maximumSizeAllowed: maximumSizeAllowed
+                )
+            }
         }
     }
 

--- a/Sources/_NIOFileSystem/Convenience.swift
+++ b/Sources/_NIOFileSystem/Convenience.swift
@@ -79,8 +79,17 @@ extension Sequence<UInt8> where Self: Sendable {
         options: OpenOptions.Write = .newFile(replaceExisting: false),
         fileSystem: some FileSystemProtocol
     ) async throws -> Int64 {
-        try await fileSystem.withFileHandle(forWritingAt: path, options: options) { handle in
-            try await handle.write(contentsOf: self, toAbsoluteOffset: offset)
+        if let fileSystem = fileSystem as? FileSystem {
+            return try await fileSystem._writeFileContents(
+                to: path,
+                options: options
+            ) { sendableView in
+                sendableView._write(contentsOf: self, toAbsoluteOffset: offset)
+            }
+        } else {
+            return try await fileSystem.withFileHandle(forWritingAt: path, options: options) { handle in
+                try await handle.write(contentsOf: self, toAbsoluteOffset: offset)
+            }
         }
     }
 

--- a/Sources/_NIOFileSystem/FileSystem.swift
+++ b/Sources/_NIOFileSystem/FileSystem.swift
@@ -858,6 +858,77 @@ extension FileSystem {
         }
     }
 
+    internal func _readFileContents(
+        at path: FilePath,
+        maximumSizeAllowed: ByteCount
+    ) async throws -> ByteBuffer {
+        let cancelled = ManagedAtomic(false)
+
+        return try await withTaskCancellationHandler {
+            try await self.threadPool.runIfActive {
+                let handle = try self._openFile(
+                    forReadingAt: path,
+                    options: OpenOptions.Read()
+                ).get()
+                let sendableView = handle.fileHandle.systemFileHandle.sendableView
+
+                let readResult: Result<ByteBuffer, Error> = Result {
+                    if cancelled.load(ordering: .acquiring) {
+                        throw CancellationError()
+                    }
+                    return try sendableView._readToEnd(
+                        fromAbsoluteOffset: 0,
+                        maximumSizeAllowed: maximumSizeAllowed,
+                        isCancelled: { cancelled.load(ordering: .acquiring) }
+                    )
+                }
+
+                try sendableView._close(materialize: true).get()
+                return try readResult.get()
+            }
+        } onCancel: {
+            cancelled.store(true, ordering: .releasing)
+        }
+    }
+
+    internal func _writeFileContents(
+        to path: FilePath,
+        options: OpenOptions.Write,
+        write: @escaping @Sendable (SystemFileHandle.SendableView) -> Result<Int64, FileSystemError>
+    ) async throws -> Int64 {
+        let cancelled = ManagedAtomic(false)
+
+        return try await withTaskCancellationHandler {
+            try await self.threadPool.runIfActive {
+                let handle = try self._openFile(
+                    forWritingAt: path,
+                    options: options
+                ).get()
+                let sendableView = handle.fileHandle.systemFileHandle.sendableView
+
+                let writeResult: Result<Int64, Error> = Result {
+                    if cancelled.load(ordering: .acquiring) {
+                        throw CancellationError()
+                    }
+                    return try write(sendableView).get()
+                }
+
+                let materialize: Bool
+                switch writeResult {
+                case .success:
+                    materialize = true
+                case .failure:
+                    materialize = false
+                }
+
+                try sendableView._close(materialize: materialize).get()
+                return try writeResult.get()
+            }
+        } onCancel: {
+            cancelled.store(true, ordering: .releasing)
+        }
+    }
+
     /// Creates a directory at `fullPath`, potentially creating other directories along the way.
     private func _createDirectory(
         at fullPath: FilePath,

--- a/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
+++ b/Sources/_NIOFileSystem/Internal/SystemFileHandle.swift
@@ -1042,51 +1042,7 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
         length: ByteCount
     ) async throws -> ByteBuffer {
         try await self.threadPool.runIfActive { [sendableView] in
-            try sendableView._withUnsafeDescriptor { descriptor in
-                try descriptor.readChunk(
-                    fromAbsoluteOffset: offset,
-                    length: length.bytes
-                ).flatMapError { error in
-                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
-                        guard offset == 0 else {
-                            return .failure(
-                                FileSystemError(
-                                    code: .unsupported,
-                                    message: "File is unseekable.",
-                                    cause: nil,
-                                    location: .here()
-                                )
-                            )
-                        }
-
-                        return descriptor.readChunk(length: length.bytes).mapError { error in
-                            FileSystemError.read(
-                                usingSyscall: .read,
-                                error: error,
-                                path: sendableView.path,
-                                location: .here()
-                            )
-                        }
-                    } else {
-                        return .failure(
-                            FileSystemError.read(
-                                usingSyscall: .pread,
-                                error: error,
-                                path: sendableView.path,
-                                location: .here()
-                            )
-                        )
-                    }
-                }
-                .get()
-            } onUnavailable: {
-                FileSystemError(
-                    code: .closed,
-                    message: "Couldn't read chunk, the file '\(sendableView.path)' is closed.",
-                    cause: nil,
-                    location: .here()
-                )
-            }
+            try sendableView._readChunk(fromAbsoluteOffset: offset, length: length).get()
         }
     }
 
@@ -1095,6 +1051,157 @@ extension SystemFileHandle: ReadableFileHandleProtocol {
         chunkLength size: ByteCount
     ) -> FileChunks {
         FileChunks(handle: self, chunkLength: size, range: range)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension SystemFileHandle.SendableView {
+    internal func _readChunk(
+        fromAbsoluteOffset offset: Int64,
+        length: ByteCount
+    ) -> Result<ByteBuffer, FileSystemError> {
+        self._withUnsafeDescriptorResult { descriptor in
+            descriptor.readChunk(
+                fromAbsoluteOffset: offset,
+                length: length.bytes
+            ).flatMapError { error in
+                if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
+                    guard offset == 0 else {
+                        return .failure(
+                            FileSystemError(
+                                code: .unsupported,
+                                message: "File is unseekable.",
+                                cause: nil,
+                                location: .here()
+                            )
+                        )
+                    }
+
+                    return descriptor.readChunk(length: length.bytes).mapError { error in
+                        FileSystemError.read(
+                            usingSyscall: .read,
+                            error: error,
+                            path: self.path,
+                            location: .here()
+                        )
+                    }
+                } else {
+                    return .failure(
+                        FileSystemError.read(
+                            usingSyscall: .pread,
+                            error: error,
+                            path: self.path,
+                            location: .here()
+                        )
+                    )
+                }
+            }
+        } onUnavailable: {
+            FileSystemError(
+                code: .closed,
+                message: "Couldn't read chunk, the file '\(self.path)' is closed.",
+                cause: nil,
+                location: .here()
+            )
+        }
+    }
+
+    internal func _readToEnd(
+        fromAbsoluteOffset offset: Int64,
+        maximumSizeAllowed: ByteCount,
+        isCancelled: () -> Bool
+    ) throws -> ByteBuffer {
+        let maximumSizeAllowed = maximumSizeAllowed == .unlimited ? .byteBufferCapacity : maximumSizeAllowed
+        let info = try self._info().get()
+        let fileSize = Int64(info.size)
+        let readSize = max(Int(fileSize - offset), 0)
+
+        if maximumSizeAllowed > .byteBufferCapacity {
+            throw FileSystemError(
+                code: .resourceExhausted,
+                message: """
+                    The maximum size allowed (\(maximumSizeAllowed)) is more than the maximum \
+                    amount of bytes that can be written to ByteBuffer \
+                    (\(ByteCount.byteBufferCapacity)). You can read the file in smaller chunks by \
+                    calling readChunks().
+                    """,
+                cause: nil,
+                location: .here()
+            )
+        }
+
+        if readSize > maximumSizeAllowed.bytes {
+            throw FileSystemError(
+                code: .resourceExhausted,
+                message: """
+                    There are more bytes to read (\(readSize)) than the maximum size allowed \
+                    (\(maximumSizeAllowed)). Read the file in chunks or increase the maximum size \
+                    allowed.
+                    """,
+                cause: nil,
+                location: .here()
+            )
+        }
+
+        let isSeekable = !(info.type == .fifo || info.type == .socket)
+        if isSeekable, fileSize > 0, readSize == 0 {
+            return ByteBuffer()
+        }
+
+        let singleShotReadLimit = 64 * 1024 * 1024
+        if isSeekable, fileSize > 0, readSize <= singleShotReadLimit {
+            if isCancelled() {
+                throw CancellationError()
+            }
+            return try self._readChunk(
+                fromAbsoluteOffset: offset,
+                length: .bytes(Int64(readSize))
+            ).get()
+        }
+
+        guard isSeekable || offset == 0 else {
+            throw FileSystemError(
+                code: .unsupported,
+                message: "File is unseekable.",
+                cause: nil,
+                location: .here()
+            )
+        }
+
+        var accumulator = ByteBuffer()
+        accumulator.reserveCapacity(readSize)
+
+        let chunkLength = ByteCount.mebibytes(8)
+        var readOffset = offset
+        while true {
+            if isCancelled() {
+                throw CancellationError()
+            }
+
+            let chunk = try self._readChunk(
+                fromAbsoluteOffset: isSeekable ? readOffset : 0,
+                length: chunkLength
+            ).get()
+            accumulator.writeImmutableBuffer(chunk)
+
+            if accumulator.readableBytes > maximumSizeAllowed.bytes {
+                throw FileSystemError(
+                    code: .resourceExhausted,
+                    message: """
+                        There are more bytes to read than the maximum size allowed \
+                        (\(maximumSizeAllowed)). Read the file in chunks or increase the maximum size \
+                        allowed.
+                        """,
+                    cause: nil,
+                    location: .here()
+                )
+            }
+
+            if chunk.readableBytes < chunkLength.bytes {
+                return accumulator
+            }
+            readOffset += Int64(chunk.readableBytes)
+        }
     }
 }
 
@@ -1108,56 +1215,65 @@ extension SystemFileHandle: WritableFileHandleProtocol {
         toAbsoluteOffset offset: Int64
     ) async throws -> Int64 {
         try await self.threadPool.runIfActive { [sendableView] in
-            try sendableView._withUnsafeDescriptor { descriptor in
-                try descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
-                    .flatMapError { error in
-                        if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
-                            guard offset == 0 else {
-                                return .failure(
-                                    FileSystemError(
-                                        code: .unsupported,
-                                        message: "File is unseekable.",
-                                        cause: nil,
-                                        location: .here()
-                                    )
-                                )
-                            }
-
-                            return descriptor.write(contentsOf: bytes)
-                                .mapError { error in
-                                    FileSystemError.write(
-                                        usingSyscall: .write,
-                                        error: error,
-                                        path: sendableView.path,
-                                        location: .here()
-                                    )
-                                }
-                        } else {
-                            return .failure(
-                                FileSystemError.write(
-                                    usingSyscall: .pwrite,
-                                    error: error,
-                                    path: sendableView.path,
-                                    location: .here()
-                                )
-                            )
-                        }
-                    }
-                    .get()
-            } onUnavailable: {
-                FileSystemError(
-                    code: .closed,
-                    message: "Couldn't write bytes, the file '\(sendableView.path)' is closed.",
-                    cause: nil,
-                    location: .here()
-                )
-            }
+            try sendableView._write(contentsOf: bytes, toAbsoluteOffset: offset).get()
         }
     }
 
     public func resize(to size: ByteCount) async throws {
         try await self.threadPool.runIfActive { [sendableView] in
             try sendableView._resize(to: size).get()
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension SystemFileHandle.SendableView {
+    internal func _write(
+        contentsOf bytes: some Sequence<UInt8>,
+        toAbsoluteOffset offset: Int64
+    ) -> Result<Int64, FileSystemError> {
+        self._withUnsafeDescriptorResult { descriptor in
+            descriptor.write(contentsOf: bytes, toAbsoluteOffset: offset)
+                .flatMapError { error in
+                    if let errno = error as? Errno, errno == .illegalSeek || errno == .noSuchAddressOrDevice {
+                        guard offset == 0 else {
+                            return .failure(
+                                FileSystemError(
+                                    code: .unsupported,
+                                    message: "File is unseekable.",
+                                    cause: nil,
+                                    location: .here()
+                                )
+                            )
+                        }
+
+                        return descriptor.write(contentsOf: bytes)
+                            .mapError { error in
+                                FileSystemError.write(
+                                    usingSyscall: .write,
+                                    error: error,
+                                    path: self.path,
+                                    location: .here()
+                                )
+                            }
+                    } else {
+                        return .failure(
+                            FileSystemError.write(
+                                usingSyscall: .pwrite,
+                                error: error,
+                                path: self.path,
+                                location: .here()
+                            )
+                        )
+                    }
+                }
+        } onUnavailable: {
+            FileSystemError(
+                code: .closed,
+                message: "Couldn't write bytes, the file '\(self.path)' is closed.",
+                cause: nil,
+                location: .here()
+            )
         }
     }
 }

--- a/Sources/_NIOFileSystem/String+FileSystem.swift
+++ b/Sources/_NIOFileSystem/String+FileSystem.swift
@@ -29,9 +29,11 @@ extension String {
         maximumSizeAllowed: ByteCount,
         fileSystem: some FileSystemProtocol
     ) async throws {
-        let byteBuffer = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
-            try await handle.readToEnd(maximumSizeAllowed: maximumSizeAllowed)
-        }
+        let byteBuffer = try await ByteBuffer(
+            contentsOf: path,
+            maximumSizeAllowed: maximumSizeAllowed,
+            fileSystem: fileSystem
+        )
 
         self = Self(buffer: byteBuffer)
     }

--- a/Sources/_NIOFileSystemFoundationCompat/Data+FileSystem.swift
+++ b/Sources/_NIOFileSystemFoundationCompat/Data+FileSystem.swift
@@ -35,9 +35,11 @@ extension Data {
         maximumSizeAllowed: ByteCount,
         fileSystem: some FileSystemProtocol
     ) async throws {
-        let byteBuffer = try await fileSystem.withFileHandle(forReadingAt: path) { handle in
-            try await handle.readToEnd(maximumSizeAllowed: maximumSizeAllowed)
-        }
+        let byteBuffer = try await ByteBuffer(
+            contentsOf: path,
+            maximumSizeAllowed: maximumSizeAllowed,
+            fileSystem: fileSystem
+        )
 
         self = Data(buffer: byteBuffer)
     }

--- a/Tests/NIOFSIntegrationTests/ConvenienceTests.swift
+++ b/Tests/NIOFSIntegrationTests/ConvenienceTests.swift
@@ -12,8 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
 import NIOCore
 import NIOFS
+import NIOPosix
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -25,6 +27,227 @@ final class ConvenienceTests: XCTestCase {
     }
 
     static let fs = FileSystem.shared
+
+    func testOneShotReadSizesAndRepeatedReads() async throws {
+        try await Self.fs.withTemporaryDirectory { _, directoryPath in
+            for size in [0, 1024, 1024 * 1024] {
+                let path = NIOFilePath(FilePath(directoryPath).appending("file-\(size)"))
+                let expected = (0..<size).map { UInt8(truncatingIfNeeded: $0) }
+                try await expected.write(toFileAt: path)
+
+                for _ in 0..<3 {
+                    let actual = try await ByteBuffer(
+                        contentsOf: path,
+                        maximumSizeAllowed: .bytes(Int64(size + 1))
+                    )
+                    XCTAssertEqual(actual, ByteBuffer(bytes: expected))
+                }
+            }
+        }
+    }
+
+    func testOneShotReadNonexistentFile() async throws {
+        let path = try await Self.fs.temporaryFilePath()
+        await XCTAssertThrowsFileSystemErrorAsync {
+            try await ByteBuffer(contentsOf: path, maximumSizeAllowed: .bytes(1024))
+        } onError: { error in
+            XCTAssertEqual(error.code, .notFound)
+        }
+    }
+
+    func testOneShotReadMaximumSizeFailureClosesDescriptor() async throws {
+        try await Self.fs.withTemporaryDirectory { _, directoryPath in
+            let path = NIOFilePath(FilePath(directoryPath).appending("too-large"))
+            try await [UInt8](repeating: 1, count: 1024).write(toFileAt: path)
+
+            await XCTAssertThrowsFileSystemErrorAsync {
+                try await ByteBuffer(contentsOf: path, maximumSizeAllowed: .bytes(1023))
+            } onError: { error in
+                XCTAssertEqual(error.code, .resourceExhausted)
+            }
+        }
+    }
+
+    func testOneShotReadPermissionFailure() async throws {
+        try await Self.fs.withTemporaryDirectory { _, directoryPath in
+            let path = NIOFilePath(FilePath(directoryPath).appending("unreadable"))
+            try await [1, 2, 3].write(toFileAt: path)
+            try await Self.fs.withFileHandle(
+                forReadingAndWritingAt: path,
+                options: .modifyFile(createIfNecessary: false)
+            ) { handle in
+                try await handle.replacePermissions([])
+            }
+
+            do {
+                _ = try await ByteBuffer(contentsOf: path, maximumSizeAllowed: .bytes(3))
+                throw XCTSkip("The current user can read files without read permissions")
+            } catch let skip as XCTSkip {
+                throw skip
+            } catch let error as FileSystemError {
+                XCTAssertEqual(error.code, .permissionDenied)
+            }
+        }
+    }
+
+    func testOneShotWriteCreateOverwriteAndOffset() async throws {
+        try await Self.fs.withTemporaryDirectory { _, directoryPath in
+            let path = NIOFilePath(FilePath(directoryPath).appending("output"))
+            let initial = [UInt8](repeating: 1, count: 1024 * 1024)
+            let initialCount = try await initial.write(toFileAt: path)
+            XCTAssertEqual(initialCount, Int64(initial.count))
+
+            let replacement: [UInt8] = [2, 3, 4, 5]
+            let replacementCount = try await replacement.write(
+                toFileAt: path,
+                options: .newFile(replaceExisting: true)
+            )
+            XCTAssertEqual(replacementCount, Int64(replacement.count))
+
+            let offsetCount = try await [8, 9].write(
+                toFileAt: path,
+                absoluteOffset: 2,
+                options: .modifyFile(createIfNecessary: false)
+            )
+            XCTAssertEqual(offsetCount, 2)
+
+            let actual = try await ByteBuffer(contentsOf: path, maximumSizeAllowed: .bytes(16))
+            XCTAssertEqual(actual, ByteBuffer(bytes: [2, 3, 8, 9]))
+        }
+    }
+
+    func testOneShotEmptyWrite() async throws {
+        try await Self.fs.withTemporaryDirectory { _, directoryPath in
+            let path = NIOFilePath(FilePath(directoryPath).appending("empty"))
+            let written = try await [UInt8]().write(toFileAt: path)
+            XCTAssertEqual(written, 0)
+
+            let actual = try await ByteBuffer(contentsOf: path, maximumSizeAllowed: .bytes(0))
+            XCTAssertEqual(actual.readableBytes, 0)
+        }
+    }
+
+    func testOneShotWriteFailureDoesNotMaterializeFile() async throws {
+        try await Self.fs.withTemporaryDirectory { _, directoryPath in
+            let path = NIOFilePath(
+                FilePath(directoryPath).appending("missing").appending("output")
+            )
+
+            await XCTAssertThrowsFileSystemErrorAsync {
+                try await [1, 2, 3].write(toFileAt: path)
+            } onError: { error in
+                XCTAssertEqual(error.code, .notFound)
+            }
+
+            let info = try await Self.fs.info(forFileAt: path)
+            XCTAssertNil(info)
+        }
+    }
+
+    func testOneShotReadsAtHighConcurrency() async throws {
+        try await Self.fs.withTemporaryDirectory { _, directoryPath in
+            let path = NIOFilePath(FilePath(directoryPath).appending("input"))
+            let expected = [UInt8](repeating: 0x5a, count: 4096)
+            try await expected.write(toFileAt: path)
+
+            try await withThrowingTaskGroup(of: ByteBuffer.self) { group in
+                for _ in 0..<512 {
+                    group.addTask {
+                        try await ByteBuffer(contentsOf: path, maximumSizeAllowed: .bytes(4096))
+                    }
+                }
+
+                for try await actual in group {
+                    XCTAssertEqual(actual, ByteBuffer(bytes: expected))
+                }
+            }
+        }
+    }
+
+    func testCancelledQueuedOneShotReadDoesNotLeakDescriptor() async throws {
+        let pool = NIOThreadPool(numberOfThreads: 1)
+        pool.start()
+        let fileSystem = FileSystem(threadPool: pool)
+        let workerStarted = self.expectation(description: "thread-pool worker is occupied")
+        let releaseWorker = DispatchSemaphore(value: 0)
+        pool.submit { state in
+            XCTAssertEqual(state, .active)
+            workerStarted.fulfill()
+            releaseWorker.wait()
+        }
+        await self.fulfillment(of: [workerStarted])
+
+        do {
+            try await Self.fs.withTemporaryDirectory { _, directoryPath in
+                let path = NIOFilePath(FilePath(directoryPath).appending("input"))
+                try await [1, 2, 3].write(toFileAt: path)
+
+                let task = Task {
+                    try await ByteBuffer(
+                        contentsOf: path,
+                        maximumSizeAllowed: .bytes(3),
+                        fileSystem: fileSystem
+                    )
+                }
+                task.cancel()
+                releaseWorker.signal()
+
+                do {
+                    _ = try await task.value
+                    XCTFail("Cancelled read unexpectedly succeeded")
+                } catch is CancellationError {
+                    // Expected.
+                }
+            }
+        } catch {
+            releaseWorker.signal()
+            try await pool.shutdownGracefully()
+            throw error
+        }
+
+        try await pool.shutdownGracefully()
+    }
+
+    func testCancelledQueuedOneShotWriteDoesNotMaterializeFile() async throws {
+        let pool = NIOThreadPool(numberOfThreads: 1)
+        pool.start()
+        let fileSystem = FileSystem(threadPool: pool)
+        let workerStarted = self.expectation(description: "thread-pool worker is occupied")
+        let releaseWorker = DispatchSemaphore(value: 0)
+        pool.submit { state in
+            XCTAssertEqual(state, .active)
+            workerStarted.fulfill()
+            releaseWorker.wait()
+        }
+        await self.fulfillment(of: [workerStarted])
+
+        do {
+            try await Self.fs.withTemporaryDirectory { _, directoryPath in
+                let path = NIOFilePath(FilePath(directoryPath).appending("output"))
+                let task = Task {
+                    try await [1, 2, 3].write(toFileAt: path, fileSystem: fileSystem)
+                }
+                task.cancel()
+                releaseWorker.signal()
+
+                do {
+                    _ = try await task.value
+                    XCTFail("Cancelled write unexpectedly succeeded")
+                } catch is CancellationError {
+                    // Expected.
+                }
+
+                let info = try await Self.fs.info(forFileAt: path)
+                XCTAssertNil(info)
+            }
+        } catch {
+            releaseWorker.signal()
+            try await pool.shutdownGracefully()
+            throw error
+        }
+
+        try await pool.shutdownGracefully()
+    }
 
     func testWriteStringToFile() async throws {
         let path = try await Self.fs.temporaryFilePath()


### PR DESCRIPTION
## 概要

NIOFS の one-shot read と同期 `Sequence<UInt8>` write は、これまで `open`、実データ I/O、`close` を別々の `NIOThreadPool` ジョブとして実行していました。この構成では dispatch のオーバーヘッドが増えるだけでなく、高並行時に多数の `open` が read/write と close より先に処理され、同時に保持する file descriptor 数が呼び出し側の並行数まで増える可能性があります。

この変更では、具体的な `FileSystem` を使う bounded whole-file read と同期 sequence write について、`open -> I/O -> close` を1つの blocking worker ジョブに統合します。

## 設計

- `SystemFileHandle.SendableView` に同期 read/write プリミティブを抽出しました。
- concrete `FileSystem` 専用の内部 fast path から、descriptor の全ライフサイクルを1つの `runIfActive` 内で実行します。
- 任意の同期 `Sequence<UInt8>` は eager copy せず、従来どおり I/O worker 上で列挙します。
- transactional write の materialize/discard、close error の優先順位、offset、short read/write、permission、symlink の意味は維持します。
- queued cancellation と syscall 実行中の cancellation の境界を維持し、成功した `open` は必ず同じ worker ジョブ内で close します。
- custom `FileSystemProtocol` は従来の汎用経路を維持します。
- 既存実装が公平性のため chunking していた 64 MiB 超の read は、引き続き chunked 経路を使います。
- 公開 API の変更はありません。

## dispatch 数

release build で `NIOThreadPool._submit` を一時的に計測しました。

| 操作 | 変更前 | 変更後 |
|---|---:|---:|
| empty whole-file read | 4回/操作 | 1回/操作 |
| 1 KiB whole-file read | 4回/操作 | 1回/操作 |
| 1 KiB synchronous sequence write | 3回/操作 | 1回/操作 |

## 性能測定

Apple M2、macOS 26.1、Swift 6.2.1、2-thread `NIOThreadPool`、warm cache で、baseline と変更後を交互に5回ずつ実行した中央値です。各 worker は専用ファイルを使っています。

| 操作 | サイズ | 並行数 | throughput | p95 | process CPU |
|---|---:|---:|---:|---:|---:|
| read | 1 KiB | 1 | +60.9% | -40.4% | -41.5% |
| read | 1 KiB | 128 | +26.3% | -19.4% | -20.7% |
| read | 1 MiB | 1 | +32.4% | -28.1% | -29.2% |
| read | 1 MiB | 128 | +130.9% | -60.8% | -41.6% |
| write | 1 KiB | 1 | +50.2% | -41.1% | -35.9% |
| write | 1 KiB | 128 | +28.7% | -27.3% | -12.7% |
| write | 1 MiB | 1 | +0.1% | +1.0% | -11.9% |
| write | 1 MiB | 128 | +22.0% | -12.7% | -3.2% |

1 MiB・単一 caller の write は実質的に throughput neutral でした。

## file descriptor

1 KiB、2-thread pool の高並行測定では、ピーク descriptor 数が次のように変化しました。

| caller concurrency | 変更前 | 変更後 |
|---:|---:|---:|
| 32 | 33 | 2〜3 |
| 128 | 129 | 2〜3 |
| 512 | 513 | 3 |
| 1,024 | 1,025 | 3 |
| 2,048 | 2,049 | 3 |

子プロセスの descriptor limit を256にして512 readを同時実行した場合、変更前は各 repetition で259件失敗し、変更後は0件でした。

## 巨大ファイルの公平性

128 MiB read を1つの worker ジョブにまとめる試作では、2つの連続 read が2-thread poolを占有し、小さい read を長時間待たせることが分かりました。そのため最終実装では、64 MiBを超える許容量の read を既存の chunked 経路に残しました。

2つの連続128 MiB readと、128回の1 KiB readを混在させた測定では、小 read のp95は変更前15.7〜24.3 ms、変更後3.7〜6.9 msでした。巨大 read の scheduling point を維持しつつ、小 read 自体の dispatch 数を減らした結果です。

## テスト

以下を追加しました。

- 0 B、1 KiB、1 MiB の readと反復 read
- nonexistent file、permission、maximum-size error
- create、replace/truncate、absolute offset write
- empty write
- 失敗した transactional write がファイルを materialize しないこと
- 512 concurrent reads
- queued read/write cancellation と resource cleanup

実行結果:

- `swift format lint --strict`: 成功
- `git diff --check`: 成功
- `NIOFSIntegrationTests.ConvenienceTests`: 17 passed
- `NIOFSTests`: 137 passed、3 platform skips
- `swift test --disable-sandbox`: 全体成功

macOS/arm64 以外の runtime 測定と、再現性のある cold-cache 測定は行っていません。

Addresses #3582.
