### PR TITLE
Translate `SingleStepByteToMessageDecoderTest` to Swift Testing

### DIFF
--- a/Tests/NIOCoreTests/SingleStepByteToMessageDecoderTest.swift
+++ b/Tests/NIOCoreTests/SingleStepByteToMessageDecoderTest.swift
@@ -13,11 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import NIOEmbedded
-import XCTest
+import Testing
 
 @testable import NIOCore
 
-public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
+struct NIOSingleStepByteToMessageDecoderTests {
     private final class ByteToInt32Decoder: NIOSingleStepByteToMessageDecoder {
         typealias InboundOut = Int32
 
@@ -26,7 +26,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         }
 
         func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> InboundOut? {
-            XCTAssertTrue(seenEOF)
+            #expect(seenEOF)
             return try self.decode(buffer: &buffer)
         }
     }
@@ -39,7 +39,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         }
 
         func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> InboundOut? {
-            XCTAssertFalse(seenEOF)
+            #expect(!seenEOF)
             return try self.decode(buffer: &buffer)
         }
     }
@@ -58,7 +58,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         }
 
         func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> InboundOut? {
-            XCTAssertFalse(seenEOF)
+            #expect(!seenEOF)
             return try self.decode(buffer: &buffer)
         }
     }
@@ -75,7 +75,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
 
         func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> InboundOut? {
             self.decodeLastCalls += 1
-            XCTAssertEqual(1, self.decodeLastCalls)
+            #expect(1 == self.decodeLastCalls)
             self.lastBuffer = buffer
             return nil
         }
@@ -98,7 +98,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         }
     }
 
-    func testDecoder() throws {
+    @Test func decoder() throws {
         let allocator = ByteBufferAllocator()
         let processor = NIOSingleStepByteToMessageProcessor(ByteToInt32Decoder())
         let messageReceiver: MessageReceiver<Int32> = MessageReceiver()
@@ -108,36 +108,36 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         let writerIndex = buffer.writerIndex
         buffer.moveWriterIndex(to: writerIndex - 1)
 
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertNil(messageReceiver.retrieveMessage())
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(messageReceiver.retrieveMessage() == nil)
 
         buffer.moveWriterIndex(to: writerIndex)
-        XCTAssertNoThrow(
-            try processor.process(
-                buffer: buffer.getSlice(at: writerIndex - 1, length: 1)!,
-                messageReceiver.receiveMessage
-            )
+        try processor.process(
+            buffer: buffer.getSlice(at: writerIndex - 1, length: 1)!,
+            messageReceiver.receiveMessage
         )
 
         var buffer2 = allocator.buffer(capacity: 32)
         buffer2.writeInteger(Int32(2))
         buffer2.writeInteger(Int32(3))
-        XCTAssertNoThrow(try processor.process(buffer: buffer2, messageReceiver.receiveMessage))
+        #expect(throws: Never.self) { try processor.process(buffer: buffer2, messageReceiver.receiveMessage) }
 
-        XCTAssertNoThrow(try processor.finishProcessing(seenEOF: true, messageReceiver.receiveMessage))
+        #expect(throws: Never.self) { try processor.finishProcessing(seenEOF: true, messageReceiver.receiveMessage) }
 
-        XCTAssertEqual(Int32(1), messageReceiver.retrieveMessage())
-        XCTAssertEqual(Int32(2), messageReceiver.retrieveMessage())
-        XCTAssertEqual(Int32(3), messageReceiver.retrieveMessage())
-        XCTAssertNil(messageReceiver.retrieveMessage())
+        #expect(Int32(1) == messageReceiver.retrieveMessage())
+        #expect(Int32(2) == messageReceiver.retrieveMessage())
+        #expect(Int32(3) == messageReceiver.retrieveMessage())
+        #expect(messageReceiver.retrieveMessage() == nil)
     }
 
-    func testMemoryIsReclaimedIfMostIsConsumed() throws {
+    @Test func memoryIsReclaimedIfMostIsConsumed() {
         let allocator = ByteBufferAllocator()
         let processor = NIOSingleStepByteToMessageProcessor(LargeChunkDecoder())
         let messageReceiver: MessageReceiver<ByteBuffer> = MessageReceiver()
         defer {
-            XCTAssertNoThrow(try processor.finishProcessing(seenEOF: false, messageReceiver.receiveMessage))
+            #expect(throws: Never.self) {
+                try processor.finishProcessing(seenEOF: false, messageReceiver.receiveMessage)
+            }
         }
 
         // We're going to send in 513 bytes. This will cause a chunk to be passed on, and will leave
@@ -146,13 +146,13 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         // will not be reclaimed.
         var buffer = allocator.buffer(capacity: 513)
         buffer.writeBytes(Array(repeating: 0x04, count: 513))
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
 
-        XCTAssertEqual(512, messageReceiver.retrieveMessage()!.readableBytes)
+        #expect(512 == messageReceiver.retrieveMessage()!.readableBytes)
 
-        XCTAssertEqual(processor._buffer!.capacity, 1024)
-        XCTAssertEqual(1, processor._buffer!.readableBytes)
-        XCTAssertEqual(512, processor._buffer!.readerIndex)
+        #expect(processor._buffer!.capacity == 1024)
+        #expect(1 == processor._buffer!.readableBytes)
+        #expect(512 == processor._buffer!.readerIndex)
 
         // Next we're going to send in another 513 bytes. This will cause another chunk to be passed
         // into our decoder buffer, which has a capacity of 1024 bytes, before we pass in another
@@ -163,12 +163,12 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         // reclaimed: While the capacity is more than 1024 bytes (2048 bytes), the reader index is
         // now at 1024. This means the buffer is exactly 50% consumed and not a tiny bit more, which
         // means no space will be reclaimed.
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(512, messageReceiver.retrieveMessage()!.readableBytes)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(512 == messageReceiver.retrieveMessage()!.readableBytes)
 
-        XCTAssertEqual(processor._buffer!.capacity, 2048)
-        XCTAssertEqual(2, processor._buffer!.readableBytes)
-        XCTAssertEqual(1024, processor._buffer!.readerIndex)
+        #expect(processor._buffer!.capacity == 2048)
+        #expect(2 == processor._buffer!.readableBytes)
+        #expect(1024 == processor._buffer!.readerIndex)
 
         // Finally we're going to send in another 513 bytes. This will cause another chunk to be
         // passed into our decoder buffer, which has a capacity of 2048 bytes. Since the buffer has
@@ -178,42 +178,44 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         // will lead to a reclaim. The resulting buffer will have a capacity of 2048 bytes (based
         // on its previous growth), with 3 readable bytes remaining.
 
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(512, messageReceiver.retrieveMessage()!.readableBytes)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(512 == messageReceiver.retrieveMessage()!.readableBytes)
 
-        XCTAssertEqual(processor._buffer!.capacity, 2048)
-        XCTAssertEqual(3, processor._buffer!.readableBytes)
-        XCTAssertEqual(0, processor._buffer!.readerIndex)
+        #expect(processor._buffer!.capacity == 2048)
+        #expect(3 == processor._buffer!.readableBytes)
+        #expect(0 == processor._buffer!.readerIndex)
     }
 
-    func testMemoryIsReclaimedIfLotsIsAvailable() throws {
+    @Test func memoryIsReclaimedIfLotsIsAvailable() {
         let allocator = ByteBufferAllocator()
         let processor = NIOSingleStepByteToMessageProcessor(OnceDecoder())
         let messageReceiver: MessageReceiver<ByteBuffer> = MessageReceiver()
         defer {
-            XCTAssertNoThrow(try processor.finishProcessing(seenEOF: false, messageReceiver.receiveMessage))
+            #expect(throws: Never.self) {
+                try processor.finishProcessing(seenEOF: false, messageReceiver.receiveMessage)
+            }
         }
 
         // We're going to send in 5119 bytes. This will be held.
         var buffer = allocator.buffer(capacity: 5119)
         buffer.writeBytes(Array(repeating: 0x04, count: 5119))
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(0, messageReceiver.count)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(0 == messageReceiver.count)
 
-        XCTAssertEqual(5119, processor._buffer!.readableBytes)
-        XCTAssertEqual(0, processor._buffer!.readerIndex)
+        #expect(5119 == processor._buffer!.readableBytes)
+        #expect(0 == processor._buffer!.readerIndex)
 
         // Now we're going to send in one more byte. This will cause a chunk to be passed on,
         // shrinking the held memory to 3072 bytes. However, memory will be reclaimed.
-        XCTAssertNoThrow(
+        #expect(throws: Never.self) {
             try processor.process(buffer: buffer.getSlice(at: 0, length: 1)!, messageReceiver.receiveMessage)
-        )
-        XCTAssertEqual(2048, messageReceiver.retrieveMessage()!.readableBytes)
-        XCTAssertEqual(3072, processor._buffer!.readableBytes)
-        XCTAssertEqual(0, processor._buffer!.readerIndex)
+        }
+        #expect(2048 == messageReceiver.retrieveMessage()!.readableBytes)
+        #expect(3072 == processor._buffer!.readableBytes)
+        #expect(0 == processor._buffer!.readerIndex)
     }
 
-    func testLeftOversMakeDecodeLastCalled() {
+    @Test func leftOversMakeDecodeLastCalled() {
         let allocator = ByteBufferAllocator()
         let decoder = PairOfBytesDecoder()
         let processor = NIOSingleStepByteToMessageProcessor(decoder)
@@ -222,62 +224,62 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         var buffer = allocator.buffer(capacity: 16)
         buffer.clear()
         buffer.writeStaticString("1")
-        XCTAssertEqual(processor.unprocessedBytes, 0)
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(processor.unprocessedBytes, 1)
+        #expect(processor.unprocessedBytes == 0)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(processor.unprocessedBytes == 1)
         buffer.clear()
         buffer.writeStaticString("23")
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(processor.unprocessedBytes, 1)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(processor.unprocessedBytes == 1)
         buffer.clear()
         buffer.writeStaticString("4567890x")
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(processor.unprocessedBytes, 1)
-        XCTAssertNoThrow(try processor.finishProcessing(seenEOF: false, messageReceiver.receiveMessage))
-        XCTAssertEqual(processor.unprocessedBytes, 1)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(processor.unprocessedBytes == 1)
+        #expect(throws: Never.self) { try processor.finishProcessing(seenEOF: false, messageReceiver.receiveMessage) }
+        #expect(processor.unprocessedBytes == 1)
 
-        XCTAssertEqual(
-            "12",
-            messageReceiver.retrieveMessage().map {
-                String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-            }
+        #expect(
+            "12"
+                == messageReceiver.retrieveMessage().map {
+                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
+                }
         )
-        XCTAssertEqual(
-            "34",
-            messageReceiver.retrieveMessage().map {
-                String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-            }
+        #expect(
+            "34"
+                == messageReceiver.retrieveMessage().map {
+                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
+                }
         )
-        XCTAssertEqual(
-            "56",
-            messageReceiver.retrieveMessage().map {
-                String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-            }
+        #expect(
+            "56"
+                == messageReceiver.retrieveMessage().map {
+                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
+                }
         )
-        XCTAssertEqual(
-            "78",
-            messageReceiver.retrieveMessage().map {
-                String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-            }
+        #expect(
+            "78"
+                == messageReceiver.retrieveMessage().map {
+                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
+                }
         )
-        XCTAssertEqual(
-            "90",
-            messageReceiver.retrieveMessage().map {
-                String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-            }
+        #expect(
+            "90"
+                == messageReceiver.retrieveMessage().map {
+                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
+                }
         )
-        XCTAssertNil(messageReceiver.retrieveMessage())
+        #expect(messageReceiver.retrieveMessage() == nil)
 
-        XCTAssertEqual(
-            "x",
-            decoder.lastBuffer.map {
-                String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-            }
+        #expect(
+            "x"
+                == decoder.lastBuffer.map {
+                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
+                }
         )
-        XCTAssertEqual(1, decoder.decodeLastCalls)
+        #expect(1 == decoder.decodeLastCalls)
     }
 
-    func testStructsWorkAsOSBTMDecoders() {
+    @Test func structsWorkAsOSBTMDecoders() {
         struct WantsOneThenTwoOSBTMDecoder: NIOSingleStepByteToMessageDecoder {
             typealias InboundOut = Int
 
@@ -295,7 +297,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
             }
 
             mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> InboundOut? {
-                XCTAssertTrue(seenEOF)
+                #expect(seenEOF)
                 if self.state > 0 {
                     self.state = 0
                     return buffer.readableBytes * -1
@@ -311,41 +313,41 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         var buffer = allocator.buffer(capacity: 16)
         buffer.clear()
         buffer.writeStaticString("1")
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
         buffer.clear()
         buffer.writeStaticString("23")
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
         buffer.clear()
         buffer.writeStaticString("4567890qwer")
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
 
-        XCTAssertEqual(1, messageReceiver.retrieveMessage())
-        XCTAssertEqual(2, messageReceiver.retrieveMessage())
-        XCTAssertEqual(3, messageReceiver.retrieveMessage())
-        XCTAssertEqual(4, messageReceiver.retrieveMessage())
-        XCTAssertNil(messageReceiver.retrieveMessage())
+        #expect(1 == messageReceiver.retrieveMessage())
+        #expect(2 == messageReceiver.retrieveMessage())
+        #expect(3 == messageReceiver.retrieveMessage())
+        #expect(4 == messageReceiver.retrieveMessage())
+        #expect(messageReceiver.retrieveMessage() == nil)
 
-        XCTAssertNoThrow(try processor.finishProcessing(seenEOF: true, messageReceiver.receiveMessage))
+        #expect(throws: Never.self) { try processor.finishProcessing(seenEOF: true, messageReceiver.receiveMessage) }
 
-        XCTAssertEqual(-4, messageReceiver.retrieveMessage())
-        XCTAssertNil(messageReceiver.retrieveMessage())
+        #expect(-4 == messageReceiver.retrieveMessage())
+        #expect(messageReceiver.retrieveMessage() == nil)
     }
 
-    func testDecodeLastIsInvokedOnceEvenIfNothingEverArrivedOnChannelClosed() {
-        class Decoder: NIOSingleStepByteToMessageDecoder {
+    @Test func decodeLastIsInvokedOnceEvenIfNothingEverArrivedOnChannelClosed() {
+        final class Decoder: NIOSingleStepByteToMessageDecoder {
             typealias InboundOut = ()
             var decodeLastCalls = 0
 
-            public func decode(buffer: inout ByteBuffer) throws -> InboundOut? {
-                XCTFail("did not expect to see decode called")
+            func decode(buffer: inout ByteBuffer) throws -> InboundOut? {
+                Issue.record("did not expect to see decode called")
                 return nil
             }
 
-            public func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> InboundOut? {
-                XCTAssertTrue(seenEOF)
+            func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> InboundOut? {
+                #expect(seenEOF)
                 self.decodeLastCalls += 1
-                XCTAssertEqual(1, self.decodeLastCalls)
-                XCTAssertEqual(0, buffer.readableBytes)
+                #expect(1 == self.decodeLastCalls)
+                #expect(0 == buffer.readableBytes)
                 return ()
             }
         }
@@ -354,16 +356,16 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         let processor = NIOSingleStepByteToMessageProcessor(decoder)
         let messageReceiver: MessageReceiver<()> = MessageReceiver()
 
-        XCTAssertEqual(0, messageReceiver.count)
+        #expect(0 == messageReceiver.count)
 
-        XCTAssertNoThrow(try processor.finishProcessing(seenEOF: true, messageReceiver.receiveMessage))
-        XCTAssertNotNil(messageReceiver.retrieveMessage())
-        XCTAssertNil(messageReceiver.retrieveMessage())
+        #expect(throws: Never.self) { try processor.finishProcessing(seenEOF: true, messageReceiver.receiveMessage) }
+        #expect(messageReceiver.retrieveMessage() != nil)
+        #expect(messageReceiver.retrieveMessage() == nil)
 
-        XCTAssertEqual(1, decoder.decodeLastCalls)
+        #expect(1 == decoder.decodeLastCalls)
     }
 
-    func testPayloadTooLarge() {
+    @Test func payloadTooLarge() {
         struct Decoder: NIOSingleStepByteToMessageDecoder {
             typealias InboundOut = Never
 
@@ -383,13 +385,13 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
 
         var buffer = allocator.buffer(capacity: max + 1)
         buffer.writeString(String(repeating: "*", count: max + 1))
-        XCTAssertThrowsError(try processor.process(buffer: buffer, messageReceiver.receiveMessage)) { error in
-            XCTAssertTrue(error is ByteToMessageDecoderError.PayloadTooLargeError)
+        #expect(throws: ByteToMessageDecoderError.PayloadTooLargeError.self) {
+            try processor.process(buffer: buffer, messageReceiver.receiveMessage)
         }
     }
 
-    func testPayloadTooLargeButHandlerOk() {
-        class Decoder: NIOSingleStepByteToMessageDecoder {
+    @Test func payloadTooLargeButHandlerOk() {
+        final class Decoder: NIOSingleStepByteToMessageDecoder {
             typealias InboundOut = String
 
             var decodeCalls = 0
@@ -412,14 +414,14 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
 
         var buffer = allocator.buffer(capacity: max + 1)
         buffer.writeString(String(repeating: "*", count: max + 1))
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertNoThrow(try processor.finishProcessing(seenEOF: false, messageReceiver.receiveMessage))
-        XCTAssertEqual(0, processor._buffer!.readableBytes)
-        XCTAssertGreaterThan(decoder.decodeCalls, 0)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(throws: Never.self) { try processor.finishProcessing(seenEOF: false, messageReceiver.receiveMessage) }
+        #expect(0 == processor._buffer!.readableBytes)
+        #expect(decoder.decodeCalls > 0)
     }
 
-    func testReentrancy() {
-        class ReentrantWriteProducingHandler: ChannelInboundHandler {
+    @Test func reentrancy() throws {
+        final class ReentrantWriteProducingHandler: ChannelInboundHandler {
             typealias InboundIn = ByteBuffer
             typealias InboundOut = String
             var processor: NIOSingleStepByteToMessageProcessor<OneByteStringDecoder>? = nil
@@ -435,7 +437,9 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
                         // Produce an extra write the first time we are called to test reentrancy
                         if self.produced == 1 {
                             let buf = ByteBuffer(string: "X")
-                            XCTAssertNoThrow(try (context.channel as! EmbeddedChannel).writeInbound(buf))
+                            #expect(throws: Never.self) {
+                                try (context.channel as! EmbeddedChannel).writeInbound(buf)
+                            }
                         }
                         context.fireChannelRead(Self.wrapInboundOut(message))
                     }
@@ -445,7 +449,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
             }
         }
 
-        class OneByteStringDecoder: NIOSingleStepByteToMessageDecoder {
+        final class OneByteStringDecoder: NIOSingleStepByteToMessageDecoder {
             typealias InboundOut = String
 
             func decode(buffer: inout ByteBuffer) throws -> String? {
@@ -453,7 +457,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
             }
 
             func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> String? {
-                XCTAssertTrue(seenEOF)
+                #expect(seenEOF)
                 return try self.decode(buffer: &buffer)
             }
         }
@@ -461,13 +465,13 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         let channel = EmbeddedChannel(handler: ReentrantWriteProducingHandler())
         var buffer = channel.allocator.buffer(capacity: 16)
         buffer.writeStaticString("a")
-        XCTAssertNoThrow(try channel.writeInbound(buffer))
-        XCTAssertNoThrow(XCTAssertEqual("X", try channel.readInbound()))
-        XCTAssertNoThrow(XCTAssertEqual("a", try channel.readInbound()))
-        XCTAssertNoThrow(XCTAssertTrue(try channel.finish().isClean))
+        #expect(throws: Never.self) { try channel.writeInbound(buffer) }
+        #expect("X" == (try channel.readInbound(as: String.self)))
+        #expect("a" == (try channel.readInbound(as: String.self)))
+        #expect(try channel.finish().isClean)
     }
 
-    func testWeDoNotCallShouldReclaimMemoryAsLongAsFramesAreProduced() {
+    @Test func weDoNotCallShouldReclaimMemoryAsLongAsFramesAreProduced() {
         struct TestByteToMessageDecoder: NIOSingleStepByteToMessageDecoder {
             typealias InboundOut = TestMessage
 
@@ -480,7 +484,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
             var reclaimHits = 0
 
             mutating func decode(buffer: inout ByteBuffer) throws -> TestMessage? {
-                XCTAssertEqual(self.decodeHits * 3, buffer.readerIndex)
+                #expect(self.decodeHits * 3 == buffer.readerIndex)
                 self.decodeHits += 1
                 guard buffer.readableBytes >= 3 else {
                     return nil
@@ -504,19 +508,19 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
 
         let buffer = ByteBuffer(repeating: 0, count: 3001)
         var callbackCount = 0
-        XCTAssertNoThrow(
+        #expect(throws: Never.self) {
             try processor.process(buffer: buffer) { _ in
                 callbackCount += 1
             }
-        )
+        }
 
-        XCTAssertEqual(callbackCount, 1000)
-        XCTAssertEqual(processor.decoder.decodeHits, 1001)
-        XCTAssertEqual(processor.decoder.reclaimHits, 1)
-        XCTAssertEqual(processor._buffer!.readableBytes, 1)
+        #expect(callbackCount == 1000)
+        #expect(processor.decoder.decodeHits == 1001)
+        #expect(processor.decoder.reclaimHits == 1)
+        #expect(processor._buffer!.readableBytes == 1)
     }
 
-    func testUnprocessedBytes() {
+    @Test func unprocessedBytes() {
         let allocator = ByteBufferAllocator()
         let processor = NIOSingleStepByteToMessageProcessor(LargeChunkDecoder())  // reads slices of 512 bytes
         let messageReceiver: MessageReceiver<ByteBuffer> = MessageReceiver()
@@ -524,42 +528,42 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         // We're going to send in 128 bytes. This will be held.
         var buffer = allocator.buffer(capacity: 128)
         buffer.writeBytes(Array(repeating: 0x04, count: 128))
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(0, messageReceiver.count)
-        XCTAssertEqual(processor.unprocessedBytes, 128)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(0 == messageReceiver.count)
+        #expect(processor.unprocessedBytes == 128)
 
         // Adding 513 bytes, will cause a message to be returned and an extra byte to be saved.
         buffer.clear()
         buffer.writeBytes(Array(repeating: 0x04, count: 513))
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(1, messageReceiver.count)
-        XCTAssertEqual(processor.unprocessedBytes, 129)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(1 == messageReceiver.count)
+        #expect(processor.unprocessedBytes == 129)
 
         // Adding 255 bytes, will cause 255 more bytes to be held.
         buffer.clear()
         buffer.writeBytes(Array(repeating: 0x04, count: 255))
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(1, messageReceiver.count)
-        XCTAssertEqual(processor.unprocessedBytes, 384)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(1 == messageReceiver.count)
+        #expect(processor.unprocessedBytes == 384)
 
         // Adding 128 bytes, will cause another message to be returned and the buffer to be empty.
         buffer.clear()
         buffer.writeBytes(Array(repeating: 0x04, count: 128))
-        XCTAssertNoThrow(try processor.process(buffer: buffer, messageReceiver.receiveMessage))
-        XCTAssertEqual(2, messageReceiver.count)
-        XCTAssertEqual(processor.unprocessedBytes, 0)
+        #expect(throws: Never.self) { try processor.process(buffer: buffer, messageReceiver.receiveMessage) }
+        #expect(2 == messageReceiver.count)
+        #expect(processor.unprocessedBytes == 0)
     }
 
     /// Tests re-entrancy by having a nested decoding operation empty the buffer and exit part way
     /// through the outer processing step
-    func testErrorDuringNestedDecoding() {
-        class ThrowingOnLastDecoder: NIOSingleStepByteToMessageDecoder {
+    @Test func errorDuringNestedDecoding() {
+        final class ThrowingOnLastDecoder: NIOSingleStepByteToMessageDecoder {
             /// `ByteBuffer` is the expected type passed in.
-            public typealias InboundIn = ByteBuffer
+            typealias InboundIn = ByteBuffer
             /// `ByteBuffer`s will be passed to the next stage.
-            public typealias InboundOut = ByteBuffer
+            typealias InboundOut = ByteBuffer
 
-            public init() {}
+            init() {}
 
             struct DecodeLastError: Error {}
 
@@ -576,7 +580,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
         let decoder = ThrowingOnLastDecoder()
         let b2mp = NIOSingleStepByteToMessageProcessor(decoder)
         var errorObserved = false
-        XCTAssertNoThrow(
+        #expect(throws: Never.self) {
             try b2mp.process(buffer: ByteBuffer(string: "1\n\n2\n3\n")) { line in
                 // We will throw an error to exit the decoding within the nested process call prematurely.
                 // Unless this is carefully handled we can be left in an inconsistent state which the outer call will encounter
@@ -586,7 +590,7 @@ public final class NIOSingleStepByteToMessageDecoderTest: XCTestCase {
                     errorObserved = true
                 }
             }
-        )
-        XCTAssertTrue(errorObserved)
+        }
+        #expect(errorObserved)
     }
 }

--- a/Tests/NIOCoreTests/SingleStepByteToMessageDecoderTest.swift
+++ b/Tests/NIOCoreTests/SingleStepByteToMessageDecoderTest.swift
@@ -112,10 +112,12 @@ struct NIOSingleStepByteToMessageDecoderTests {
         #expect(messageReceiver.retrieveMessage() == nil)
 
         buffer.moveWriterIndex(to: writerIndex)
-        try processor.process(
-            buffer: buffer.getSlice(at: writerIndex - 1, length: 1)!,
-            messageReceiver.receiveMessage
-        )
+        #expect(throws: Never.self) {
+            try processor.process(
+                buffer: buffer.getSlice(at: writerIndex - 1, length: 1)!,
+                messageReceiver.receiveMessage
+            )
+        }
 
         var buffer2 = allocator.buffer(capacity: 32)
         buffer2.writeInteger(Int32(2))

--- a/Tests/NIOCoreTests/SingleStepByteToMessageDecoderTest.swift
+++ b/Tests/NIOCoreTests/SingleStepByteToMessageDecoderTest.swift
@@ -240,44 +240,14 @@ struct NIOSingleStepByteToMessageDecoderTests {
         #expect(throws: Never.self) { try processor.finishProcessing(seenEOF: false, messageReceiver.receiveMessage) }
         #expect(processor.unprocessedBytes == 1)
 
-        #expect(
-            "12"
-                == messageReceiver.retrieveMessage().map {
-                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-                }
-        )
-        #expect(
-            "34"
-                == messageReceiver.retrieveMessage().map {
-                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-                }
-        )
-        #expect(
-            "56"
-                == messageReceiver.retrieveMessage().map {
-                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-                }
-        )
-        #expect(
-            "78"
-                == messageReceiver.retrieveMessage().map {
-                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-                }
-        )
-        #expect(
-            "90"
-                == messageReceiver.retrieveMessage().map {
-                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-                }
-        )
+        #expect("12" == messageReceiver.retrieveMessage().map { String(buffer: $0) })
+        #expect("34" == messageReceiver.retrieveMessage().map { String(buffer: $0) })
+        #expect("56" == messageReceiver.retrieveMessage().map { String(buffer: $0) })
+        #expect("78" == messageReceiver.retrieveMessage().map { String(buffer: $0) })
+        #expect("90" == messageReceiver.retrieveMessage().map { String(buffer: $0) })
         #expect(messageReceiver.retrieveMessage() == nil)
 
-        #expect(
-            "x"
-                == decoder.lastBuffer.map {
-                    String(decoding: $0.readableBytesView, as: Unicode.UTF8.self)
-                }
-        )
+        #expect("x" == decoder.lastBuffer.map { String(buffer: $0) })
         #expect(1 == decoder.decodeLastCalls)
     }
 


### PR DESCRIPTION
### Motivation

We want to extend `SingleStepByteToMessageDecoderTest` with tests for non-copyable decoders and typed throws. Instead of adding more XCTests, lets first move all existing tests to swift-testing.

### Changes

- Mechanical translation of `SingleStepByteToMessageDecoderTest` from XCTest to Swift Testing.

### Result

No behaviour change. We can write the new tests in Swift Testing.
