### PR TITLE
Translate `ByteToMessageDecoderVerifierTest` to Swift Testing

### DIFF
--- a/Tests/NIOTestUtilsTests/ByteToMessageDecoderVerifierTest.swift
+++ b/Tests/NIOTestUtilsTests/ByteToMessageDecoderVerifierTest.swift
@@ -21,7 +21,7 @@ import Testing
 typealias VerificationError = ByteToMessageDecoderVerifier.VerificationError<String>
 
 struct ByteToMessageDecoderVerifierTests {
-    @Test func wrongResults() {
+    @Test func wrongResults() throws {
         struct AlwaysProduceY: ByteToMessageDecoder {
             typealias InboundOut = String
 
@@ -41,14 +41,13 @@ struct ByteToMessageDecoderVerifierTests {
             }
         }
 
-        let error = #expect(throws: VerificationError.self) {
+        let error = try #require(throws: VerificationError.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 stringInputOutputPairs: [("x", ["x"])],
                 decoderFactory: AlwaysProduceY.init
             )
         }
 
-        guard let error else { return }
         #expect(1 == error.inputs.count)
         switch error.errorCode {
         case .wrongProduction(let actual, let expected):
@@ -59,7 +58,7 @@ struct ByteToMessageDecoderVerifierTests {
         }
     }
 
-    @Test func noOutputWhenWeShouldHaveOutput() {
+    @Test func noOutputWhenWeShouldHaveOutput() throws {
         struct NeverProduce: ByteToMessageDecoder {
             typealias InboundOut = String
 
@@ -78,14 +77,13 @@ struct ByteToMessageDecoderVerifierTests {
             }
         }
 
-        let error = #expect(throws: VerificationError.self) {
+        let error = try #require(throws: VerificationError.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 stringInputOutputPairs: [("x", ["x"])],
                 decoderFactory: NeverProduce.init
             )
         }
 
-        guard let error else { return }
         #expect(1 == error.inputs.count)
         switch error.errorCode {
         case .underProduction(let expected):
@@ -95,7 +93,7 @@ struct ByteToMessageDecoderVerifierTests {
         }
     }
 
-    @Test func outputWhenWeShouldNotProduceOutput() {
+    @Test func outputWhenWeShouldNotProduceOutput() throws {
         struct ProduceTooEarly: ByteToMessageDecoder {
             typealias InboundOut = String
 
@@ -114,14 +112,13 @@ struct ByteToMessageDecoderVerifierTests {
             }
         }
 
-        let error = #expect(throws: VerificationError.self) {
+        let error = try #require(throws: VerificationError.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 stringInputOutputPairs: [("xxxxxx", ["Y"])],
                 decoderFactory: ProduceTooEarly.init
             )
         }
 
-        guard let error else { return }
         switch error.errorCode {
         case .overProduction(let actual):
             #expect("Y" == actual)
@@ -130,7 +127,7 @@ struct ByteToMessageDecoderVerifierTests {
         }
     }
 
-    @Test func leftovers() {
+    @Test func leftovers() throws {
         struct NeverDoAnything: ByteToMessageDecoder {
             typealias InboundOut = String
 
@@ -151,14 +148,13 @@ struct ByteToMessageDecoderVerifierTests {
             }
         }
 
-        let error = #expect(throws: VerificationError.self) {
+        let error = try #require(throws: VerificationError.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 stringInputOutputPairs: [("xxxxxx", [])],
                 decoderFactory: NeverDoAnything.init
             )
         }
 
-        guard let error else { return }
         switch error.errorCode {
         case .leftOversOnDeconstructingChannel(
             let inbound,

--- a/Tests/NIOTestUtilsTests/ByteToMessageDecoderVerifierTest.swift
+++ b/Tests/NIOTestUtilsTests/ByteToMessageDecoderVerifierTest.swift
@@ -14,14 +14,14 @@
 
 import NIOPosix
 import NIOTestUtils
-import XCTest
+import Testing
 
 @testable import NIOCore
 
 typealias VerificationError = ByteToMessageDecoderVerifier.VerificationError<String>
 
-class ByteToMessageDecoderVerifierTest: XCTestCase {
-    func testWrongResults() {
+struct ByteToMessageDecoderVerifierTests {
+    @Test func wrongResults() {
         struct AlwaysProduceY: ByteToMessageDecoder {
             typealias InboundOut = String
 
@@ -41,30 +41,25 @@ class ByteToMessageDecoderVerifierTest: XCTestCase {
             }
         }
 
-        XCTAssertThrowsError(
+        let error = #expect(throws: VerificationError.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 stringInputOutputPairs: [("x", ["x"])],
                 decoderFactory: AlwaysProduceY.init
             )
-        ) {
-            error in
-            switch error {
-            case let error as VerificationError:
-                XCTAssertEqual(1, error.inputs.count)
-                switch error.errorCode {
-                case .wrongProduction(let actual, let expected):
-                    XCTAssertEqual("Y", actual)
-                    XCTAssertEqual("x", expected)
-                default:
-                    XCTFail("unexpected error: \(error)")
-                }
-            default:
-                XCTFail("unexpected error: \(error)")
-            }
+        }
+
+        guard let error else { return }
+        #expect(1 == error.inputs.count)
+        switch error.errorCode {
+        case .wrongProduction(let actual, let expected):
+            #expect("Y" == actual)
+            #expect("x" == expected)
+        default:
+            Issue.record("unexpected error: \(error)")
         }
     }
 
-    func testNoOutputWhenWeShouldHaveOutput() {
+    @Test func noOutputWhenWeShouldHaveOutput() {
         struct NeverProduce: ByteToMessageDecoder {
             typealias InboundOut = String
 
@@ -83,29 +78,24 @@ class ByteToMessageDecoderVerifierTest: XCTestCase {
             }
         }
 
-        XCTAssertThrowsError(
+        let error = #expect(throws: VerificationError.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 stringInputOutputPairs: [("x", ["x"])],
                 decoderFactory: NeverProduce.init
             )
-        ) {
-            error in
-            switch error {
-            case let error as VerificationError:
-                XCTAssertEqual(1, error.inputs.count)
-                switch error.errorCode {
-                case .underProduction(let expected):
-                    XCTAssertEqual("x", expected)
-                default:
-                    XCTFail("unexpected error: \(error)")
-                }
-            default:
-                XCTFail("unexpected error: \(error)")
-            }
+        }
+
+        guard let error else { return }
+        #expect(1 == error.inputs.count)
+        switch error.errorCode {
+        case .underProduction(let expected):
+            #expect("x" == expected)
+        default:
+            Issue.record("unexpected error: \(error)")
         }
     }
 
-    func testOutputWhenWeShouldNotProduceOutput() {
+    @Test func outputWhenWeShouldNotProduceOutput() {
         struct ProduceTooEarly: ByteToMessageDecoder {
             typealias InboundOut = String
 
@@ -124,28 +114,23 @@ class ByteToMessageDecoderVerifierTest: XCTestCase {
             }
         }
 
-        XCTAssertThrowsError(
+        let error = #expect(throws: VerificationError.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 stringInputOutputPairs: [("xxxxxx", ["Y"])],
                 decoderFactory: ProduceTooEarly.init
             )
-        ) {
-            error in
-            switch error {
-            case let error as VerificationError:
-                switch error.errorCode {
-                case .overProduction(let actual):
-                    XCTAssertEqual("Y", actual)
-                default:
-                    XCTFail("unexpected error: \(error)")
-                }
-            default:
-                XCTFail("unexpected error: \(error)")
-            }
+        }
+
+        guard let error else { return }
+        switch error.errorCode {
+        case .overProduction(let actual):
+            #expect("Y" == actual)
+        default:
+            Issue.record("unexpected error: \(error)")
         }
     }
 
-    func testLeftovers() {
+    @Test func leftovers() {
         struct NeverDoAnything: ByteToMessageDecoder {
             typealias InboundOut = String
 
@@ -166,30 +151,25 @@ class ByteToMessageDecoderVerifierTest: XCTestCase {
             }
         }
 
-        XCTAssertThrowsError(
+        let error = #expect(throws: VerificationError.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 stringInputOutputPairs: [("xxxxxx", [])],
                 decoderFactory: NeverDoAnything.init
             )
-        ) {
-            error in
-            switch error {
-            case let error as VerificationError:
-                switch error.errorCode {
-                case .leftOversOnDeconstructingChannel(
-                    let inbound,
-                    let outbound,
-                    pendingOutbound: let pending
-                ):
-                    XCTAssertEqual(0, outbound.count)
-                    XCTAssertEqual(["leftover"], inbound.map { $0.tryAs(type: String.self) })
-                    XCTAssertEqual(0, pending.count)
-                default:
-                    XCTFail("unexpected error: \(error)")
-                }
-            default:
-                XCTFail("unexpected error: \(error)")
-            }
+        }
+
+        guard let error else { return }
+        switch error.errorCode {
+        case .leftOversOnDeconstructingChannel(
+            let inbound,
+            let outbound,
+            pendingOutbound: let pending
+        ):
+            #expect(0 == outbound.count)
+            #expect(["leftover"] == inbound.map { $0.tryAs(type: String.self) })
+            #expect(0 == pending.count)
+        default:
+            Issue.record("unexpected error: \(error)")
         }
     }
 }


### PR DESCRIPTION
### Motivation

We want to extend `ByteToMessageDecoderVerifierTest` with tests that verify non-copyable decoders. Instead of adding more XCTests, lets first move all existing tests to swift-testing.

### Changes

- Mechanical translation of `ByteToMessageDecoderVerifierTest` from XCTest to Swift Testing.

### Result

No behaviour change. We can write the new tests in Swift Testing.
